### PR TITLE
to turn api off by commenting out relevant routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   root to: 'high_voltage/pages#show', id: 'home'
 
-  namespace :api, format: :json do
-    namespace :advocates do
-      resources :claims
-    end
-  end
+  #namespace :api, format: :json do
+  #  namespace :advocates do
+  #    resources :claims
+  #  end
+  #end
 
   devise_for :users
 

--- a/spec/controllers/api/advocates/claims_controller_spec.rb
+++ b/spec/controllers/api/advocates/claims_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Api::Advocates::ClaimsController, type: :controller do
+RSpec.describe Api::Advocates::ClaimsController, type: :controller, api_turned_off: true do
   let(:new_claim)          { build(:claim)                         }
   let(:invalid_new_claim)  { build(:invalid_claim)                 }
   let(:params)             { {claim: new_claim.attributes}         }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.filter_run_excluding api_turned_off: true
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
I've investigated a few feature switching gems and will look into them some more - but maybe this is OK for now?
