### PR TITLE
Remove lorem ispsum entries from seed data

### DIFF
--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -5,9 +5,9 @@ namespace :claims do
     FileUtils.rm_rf('./features/examples/000')
   end
 
-  desc "Create submitted claims with random fees, random expenses and one defendant"
+  desc "Create submitted claims with random fees, expenses, offence and one defendant"
   task :submitted, [:number] => :environment do |task, args|
-    args[:number].to_i.times { FactoryGirl.create(:submitted_claim, court_id: random_court_id) }
+    args[:number].to_i.times { FactoryGirl.create(:submitted_claim, court: Court.all.sample, offence: Offence.all.sample) }
     claims = Claim.last(args[:number])
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
@@ -15,9 +15,9 @@ namespace :claims do
     end
   end
 
-  desc "Create draft claims with random fees, random expenses and one defendant"
+  desc "Create draft claims with random fees, expenses, offence and one defendant"
   task :draft, [:number] => :environment do |task, args|
-    args[:number].to_i.times { FactoryGirl.create(:claim, court_id: random_court_id) }
+    args[:number].to_i.times { FactoryGirl.create(:claim, court: Court.all.sample, offence: Offence.all.sample) }
     claims = Claim.last(args[:number])
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
@@ -25,9 +25,9 @@ namespace :claims do
     end
   end
 
-  desc "Create claims allocated to caseworker@example.com, with random fees, random expenses and one defendant"
+  desc "Create claims allocated to caseworker@example.com, with random fees, expenses, offence and one defendant"
   task :allocated, [:number] => :environment do |task, args|
-    args[:number].to_i.times { FactoryGirl.create(:submitted_claim, court_id: random_court_id) }
+    args[:number].to_i.times { FactoryGirl.create(:submitted_claim, court: Court.all.sample, offence: Offence.all.sample ) }
     claims = Claim.last(args[:number])
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
@@ -36,9 +36,9 @@ namespace :claims do
     end
   end
 
-  desc "Create completed claims, with random fees, random expenses and one defendant"
+  desc "Create completed claims, with random fees, expenses, offence and one defendant"
   task :completed, [:number] => :environment do |task, args|
-    args[:number].to_i.times { FactoryGirl.create(:completed_claim, court_id: random_court_id) }
+    args[:number].to_i.times { FactoryGirl.create(:completed_claim, court: Court.all.sample, offence: Offence.all.sample) }
     claims = Claim.last(args[:number])
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
@@ -49,10 +49,6 @@ namespace :claims do
 
   desc "Create draft, submitted, allocated and completed claims with random fees, random expenses and one defendant"
   task :all_states, [:number] => [:submitted, :draft, :allocated, :completed] do |task, args|
-  end
-
-  def random_court_id
-    Court.all.sample(1)[0].id
   end
 
   def add_fees_expenses_and_defendant(claim)

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -12,6 +12,7 @@ namespace :claims do
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
       add_document(claim)
+      report_created(:submitted, claim)
     end
   end
 
@@ -22,6 +23,7 @@ namespace :claims do
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
       add_document(claim)
+      report_created(:draft, claim)
     end
   end
 
@@ -32,7 +34,8 @@ namespace :claims do
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
       add_document(claim)
-      allocate(claim, 'caseworker@example.com')
+      allocate_claim(claim, 'caseworker@example.com')
+      report_created(:allocated, claim)
     end
   end
 
@@ -43,12 +46,17 @@ namespace :claims do
     claims.each do |claim|
       add_fees_expenses_and_defendant(claim)
       add_document(claim)
-      allocate(claim, 'caseworker@example.com')
+      allocate_claim(claim, 'caseworker@example.com')
+      report_created(:completed, claim)
     end
   end
 
   desc "Create draft, submitted, allocated and completed claims with random fees, random expenses and one defendant"
   task :all_states, [:number] => [:submitted, :draft, :allocated, :completed] do |task, args|
+  end
+
+  def report_created(claim_type, claim)
+    printf("Created %s claim: %s\n", claim_type.to_s, [claim.id, claim.state].join(', '))
   end
 
   def add_fees_expenses_and_defendant(claim)
@@ -62,7 +70,7 @@ namespace :claims do
     Document.create!(claim_id: claim.id, document_type_id: 1, document: file, document_content_type: 'application/msword' )
   end
 
-  def allocate(claim, caseworker_email)
+  def allocate_claim(claim, caseworker_email)
     caseworker = User.find_by(email: caseworker_email).persona
     caseworker.claims << claim
   end

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
 
     context 'current claims' do
       it 'assigns submitted @claims' do
-        expect(assigns(:claims)).to eq(case_worker.claims.submitted)
+        expect(assigns(:claims)).to eq(case_worker.claims.submitted.order(:submitted_at, :id))
       end
     end
 

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -14,13 +14,12 @@ FactoryGirl.define do
     end
 
     factory :submitted_claim do
-      state 'submitted'
-      submitted_at { Time.now }
+      after(:create) { |claim| claim.submit! }
     end
 
     factory :completed_claim do
-      state 'completed'
-      submitted_at { Time.now }
+      after(:create) { |claim| claim.submit! }
+      after(:create) { |claim| claim.complete! }
     end
   end
 


### PR DESCRIPTION
...ion

factory girl generated random strings were being seeded by the rake claims tasks.
These were removed and "real" offence data used for seeding claims demo data.
