### PR TITLE
Build assets in the container at docker-build time

### DIFF
--- a/docker/rails/Dockerfile
+++ b/docker/rails/Dockerfile
@@ -9,4 +9,7 @@ WORKDIR /rails
 
 EXPOSE 80
 
+#SECRET_TOKEN set here because otherwise devise blows up during the precompile.
+RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=blah
+
 CMD /rails/run.sh


### PR DESCRIPTION
We need the assets in the container so that we have a working manifest.json packaged with the app else the templates can't know what that hash of the files are.

To generate assets properly we need to put rails into production environment. The only thing I'm not too hapy with here is having to specify SECRET_KEY_BASE - or more specifically how do we keep up to date with any other new required environment variables
