### PR TITLE
improved reliability of docker run.sh

### DIFF
--- a/docker/rails/run.sh
+++ b/docker/rails/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 echo "inside run.sh"
 cd /rails
 
@@ -6,11 +7,11 @@ case ${DOCKER_STATE} in
 migrate)
     echo "running migrate"
     bundle exec rake db:migrate
-    ;;
+    ;;  
 seed)
     echo "running seed"
     bundle exec rake db:migrate
     bundle exec rake db:seed
     ;;
 esac
-bundle exec unicorn -p 80
+exec bundle exec unicorn -p 80


### PR DESCRIPTION
added set -e so that if the script fails it doesn't carry on

executing unicorn within the same process using exec. This doesn't have much effect other than removing a 'bash' process from running container with a single child process of unicorn
