### PR TITLE
Fixed MAAT number in caseworker and advocate views

### DIFF
--- a/app/views/advocates/claims/_defendant_fields.html.haml
+++ b/app/views/advocates/claims/_defendant_fields.html.haml
@@ -23,7 +23,7 @@
   %br
   = f.check_box :order_for_judicial_apportionment
   %br
-  = f.label :maat_reference
+  = f.label :maat_reference, t('maat_reference_number')
   %br
   = f.text_field :maat_reference
   %p

--- a/app/views/case_workers/claims/_claim.html.haml
+++ b/app/views/case_workers/claims/_claim.html.haml
@@ -21,7 +21,7 @@
         %dd
           #{claim.case_workers.map(&:email).join(', ')}
         %dt
-          MATT no
+          #{t('maat_reference_number')}
         %dd
           #{claim.defendants.map(&:maat_reference).join(', ')}
         %dt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,4 @@ en:
   documents:
     form:
       upload: "Choose file to upload"
+  maat_reference_number: "MAAT Reference"


### PR DESCRIPTION
so it's always upper case and spelt correctly
the label text is now sourced from locales
