### PR TITLE
Apply select2 to offence select

### DIFF
--- a/app/assets/javascripts/advocates/claims/new_claim.js
+++ b/app/assets/javascripts/advocates/claims/new_claim.js
@@ -1,4 +1,4 @@
-"user strict";
+"use strict";
 
 var cbo = cbo || {}
 
@@ -9,7 +9,8 @@ cbo.newClaim = {
   init : function() {
     cbo.newClaim.$offenceSelect = $('#claim_offence_id');
     cbo.newClaim.$offenceClassSelect = $('#claim_offence_class_id');
-    cbo.newClaim.$offenceSelect.children('optgroup').hide();
+
+    $(cbo.newClaim.$offenceSelect.children('optgroup').select2("container")).removeClass("show-optgroup").addClass("hide-optgroup");
     cbo.newClaim.$offenceClassSelect.change(function(){
       cbo.newClaim.cascadeOffenceClassChange();
     });
@@ -17,9 +18,9 @@ cbo.newClaim = {
   cascadeOffenceClassChange : function() {
     offenceClassLabel = cbo.newClaim.$offenceClassSelect.find('option:selected').text();
     if (offenceClassLabel){
-      cbo.newClaim.$offenceSelect.children('optgroup').hide();
+      $(cbo.newClaim.$offenceSelect.children('optgroup').select2("container")).removeClass("show-optgroup").addClass("hide-optgroup");
       cbo.newClaim.$offenceSelect.val("");
-      cbo.newClaim.$offenceSelect.children('optgroup[label="' + offenceClassLabel + '"]').show();
+      $(cbo.newClaim.$offenceSelect.children('optgroup[label="' + offenceClassLabel + '"]').select2("container")).removeClass("hide-optgroup").addClass("show-optgroup");
     }
   }
   

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -12,4 +12,6 @@
 @import "design-patterns/alpha-beta";
 @import "design-patterns/buttons";
 
+@import "new_claim";
+
 @import "layout";

--- a/app/assets/stylesheets/new_claim.css.scss
+++ b/app/assets/stylesheets/new_claim.css.scss
@@ -1,0 +1,14 @@
+/*
+*  select2 prevents function of normal jQuery .hide()
+*  and .show() functions - these classes are used as a
+*  workaround.
+*
+*/
+
+.hide-optgroup {
+	display: none!important;
+}
+
+.show-optgroup {
+	display: block!important;
+}

--- a/app/views/advocates/claims/_dynamic_offence_fields.html.haml
+++ b/app/views/advocates/claims/_dynamic_offence_fields.html.haml
@@ -17,4 +17,4 @@
                               :id,
                               :description,
                               options = { prompt:  ' -- Please select offence category (based on class above) -- ' },
-                              html_options = {  style: 'width: 75%;' }
+                              html_options = {  class: 'select2', style: 'width: 75%;' }


### PR DESCRIPTION
Tweak of previous javascript to apply a workaround that enables use of 
select2 library with cascading offence class and offence category relationship.
