### PR TITLE
Eager load claim associations

### DIFF
--- a/app/models/advocate.rb
+++ b/app/models/advocate.rb
@@ -6,6 +6,8 @@ class Advocate < ActiveRecord::Base
   has_one :user, as: :persona, inverse_of: :persona, dependent: :destroy
   has_many :claims, dependent: :destroy
 
+  default_scope { includes(:user) }
+
   validates :user, presence: true
   validates :first_name, :last_name, presence: true
 

--- a/app/models/case_worker.rb
+++ b/app/models/case_worker.rb
@@ -6,6 +6,8 @@ class CaseWorker < ActiveRecord::Base
   has_many :case_worker_claims, dependent: :destroy
   has_many :claims, through: :case_worker_claims
 
+  default_scope { includes(:user) }
+
   validates :user, presence: true
 
   accepts_nested_attributes_for :user

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -21,6 +21,17 @@ class Claim < ActiveRecord::Base
   has_many :defendants,               dependent: :destroy,          inverse_of: :claim
   has_many :documents,                dependent: :destroy,          inverse_of: :claim
 
+  default_scope do
+    includes(:advocate,
+             :case_workers,
+             :court,
+             :defendants,
+             :documents,
+             :expenses,
+             :fee_types,
+             offence: :offence_class)
+  end
+
   validates :offence,                 presence: true
   validates :advocate,                presence: true
   validates :court,                   presence: true

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -2,6 +2,8 @@ class Fee < ActiveRecord::Base
   belongs_to :claim
   belongs_to :fee_type
 
+  default_scope { includes(:fee_type) }
+
   validates :amount, :quantity, :rate, presence: true, numericality: true
 
   after_save do


### PR DESCRIPTION
Load times were slow even for a compartiviely small number of records.
~60 claims triggered ~600 db reads. This _should_ be all the required
includes ensure efficient loading. Himal has reviewed in person already.
