### PR TITLE
Ensure offence select2 is blanked when class changed.

### DIFF
--- a/app/assets/javascripts/advocates/claims/new_claim.js
+++ b/app/assets/javascripts/advocates/claims/new_claim.js
@@ -16,10 +16,10 @@ cbo.newClaim = {
     });
   },
   cascadeOffenceClassChange : function() {
-    offenceClassLabel = cbo.newClaim.$offenceClassSelect.find('option:selected').text();
+    var offenceClassLabel = cbo.newClaim.$offenceClassSelect.find('option:selected').text();
     if (offenceClassLabel){
       $(cbo.newClaim.$offenceSelect.children('optgroup').select2("container")).removeClass("show-optgroup").addClass("hide-optgroup");
-      cbo.newClaim.$offenceSelect.val("");
+      cbo.newClaim.$offenceSelect.select2("val", "");
       $(cbo.newClaim.$offenceSelect.children('optgroup[label="' + offenceClassLabel + '"]').select2("container")).removeClass("hide-optgroup").addClass("show-optgroup");
     }
   }


### PR DESCRIPTION
Another minor javascript tweak that i missed from previous select2 enabling
of the offence select list. This tweak ensures if user changes class after
selecting an offence then offence is nulled.
