### PR TITLE
Add missing transition

### DIFF
--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -15,7 +15,7 @@ module Claims::StateMachine
          :deleted, :draft, :paid, :part_paid, :parts_rejected, :refused, :rejected, :submitted
 
       event :allocate do
-        transition [:submitted] => :allocated
+        transition [:submitted, :awaiting_info_from_court] => :allocated
       end
 
       event :appeal do

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Claims::StateMachine, type: :model do
       it { expect{ subject.draft! }.to    change{ subject.state }.to('draft') }
     end
 
+    describe 'from awaiting_further_info_from_court' do
+      before { subject.submit!; subject.allocate!; subject.await_info_from_court! }
+      it { expect{ subject.allocate! }.to change{ subject.state }.to('allocated') }
+    end
+
     describe 'from draft' do
       it { expect{ subject.submit! }.to change{ subject.state }.to('submitted') }
       it { expect{ subject.archive_pending_delete! }.to change{ subject.state }.to('archived_pending_delete') }


### PR DESCRIPTION
I didn't add a transition to allow a claim to be put back to allocated
once the court has supplied the requested information.  Fixed.
