### PR TITLE
Allow guard to focus on specific, tagged tests.

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,27 +1,49 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-## Uncomment and set this to only include directories you want to watch
-# directories %w(app lib config test spec features)
-
-## Uncomment to clear the screen before every task
+require "guard/rspec/dsl"
 clearing :on
 
-## Guard internally checks for changes in the Guardfile and exits.
-## If you want Guard to automatically start up again, run guard in a
-## shell loop, e.g.:
-##
-##  $ while bundle exec guard; do echo "Restarting Guard..."; done
-##
-## Note: if you are using the `directories` clause above and you are not
-## watching the project directory ('.'), then you will want to move
-## the Guardfile to a watched dir and symlink it back, e.g.
-#
-#  $ mkdir config
-#  $ mv Guardfile config/
-#  $ ln -s config/Guardfile .
-#
-# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+def watch_cucumber
+  watch(%r{^features/.+\.feature$})
+  watch(%r{^features/support/.+$})          { "features" }
+
+  watch(%r{^features/step_definitions/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "features"
+  end
+end
+
+def watch_rspec
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.("routing/#{m[1]}_routing"),
+      rspec.spec.("controllers/#{m[1]}_controller"),
+      rspec.spec.("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.("features/#{m[1]}") }
+end
 
 guard :bundler do
   require 'guard/bundler'
@@ -36,36 +58,13 @@ guard :bundler do
 end
 
 group :features do
-
   guard 'cucumber',
     cli: '--profile default',
     all_on_start: true,
     binstubs: true do
-      watch(%r{^features/.+\.feature$})
-      watch(%r{^features/support/.+$})          { "features" }
-
-      watch(%r{^features/step_definitions/(.+)_steps\.rb$}) do |m|
-        Dir[File.join("**/#{m[1]}.feature")][0] || "features"
-      end
-    end
-
+    watch_cucumber
+  end
 end
-
-# Guard-Rails supports a lot options with default values:
-# daemon: false                        # runs the server as a daemon.
-# debugger: false                      # enable ruby-debug gem.
-# environment: 'development'           # changes server environment.
-# force_run: false                     # kills any process that's holding the listen port before attempting to (re)start Rails.
-# pid_file: 'tmp/pids/[RAILS_ENV].pid' # specify your pid_file.
-# host: 'localhost'                    # server hostname.
-# port: 3000                           # server port number.
-# root: '/spec/dummy'                  # Rails' root path.
-# server: thin                         # webserver engine.
-# start_on_start: true                 # will start the server when starting Guard.
-# timeout: 30                          # waits untill restarting the Rails server, in seconds.
-# zeus_plan: server                    # custom plan in zeus, only works with `zeus: true`.
-# zeus: false                          # enables zeus gem.
-# CLI: 'rails server'                  # customizes runner command. Omits all options except `pid_file`!
 
 guard 'rails' do
   watch('Gemfile.lock')
@@ -73,62 +72,24 @@ guard 'rails' do
 end
 
 group :spec do
-
-  # Note: The cmd option is now required due to the increasing number of ways
-  #       rspec may be run, below are examples of the most common uses.
-  #  * bundler: 'bundle exec rspec'
-  #  * bundler binstubs: 'bin/rspec'
-  #  * spring: 'bin/rspec' (This will use spring if running and you have
-  #                          installed the spring binstubs per the docs)
-  #  * zeus: 'zeus rspec' (requires the server to be started separately)
-  #  * 'just' rspec: 'rspec'
-
   guard :rspec,
     cmd: "bin/rspec",
     all_on_start: true,
     all_after_pass: true  do
-      require "guard/rspec/dsl"
-      dsl = Guard::RSpec::Dsl.new(self)
-
-      # Feel free to open issues for suggestions and improvements
-
-      # RSpec files
-      rspec = dsl.rspec
-      watch(rspec.spec_helper) { rspec.spec_dir }
-      watch(rspec.spec_support) { rspec.spec_dir }
-      watch(rspec.spec_files)
-
-      # Ruby files
-      ruby = dsl.ruby
-      dsl.watch_spec_files_for(ruby.lib_files)
-
-      # Rails files
-      rails = dsl.rails(view_extensions: %w(erb haml slim))
-      dsl.watch_spec_files_for(rails.app_files)
-      dsl.watch_spec_files_for(rails.views)
-
-      watch(rails.controllers) do |m|
-        [
-          rspec.spec.("routing/#{m[1]}_routing"),
-          rspec.spec.("controllers/#{m[1]}_controller"),
-          rspec.spec.("acceptance/#{m[1]}")
-        ]
-      end
-
-      # Rails config changes
-      watch(rails.spec_helper)     { rspec.spec_dir }
-      watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
-      watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
-
-      # Capybara features specs
-      watch(rails.view_dirs)     { |m| rspec.spec.("features/#{m[1]}") }
-
-      # Turnip features and steps
-      watch(%r{^spec/acceptance/(.+)\.feature$})
-      watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-        Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-      end
-    end
-
+    watch_rspec
+  end
 end
 
+group :focus do
+
+    guard 'cucumber',
+      cli: '--profile focus',
+      binstubs: true do
+        watch_cucumber
+      end
+
+    guard :rspec,
+      cmd: "bin/rspec --tag focus" do
+        watch_rspec
+      end
+end

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -2,7 +2,9 @@
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
 std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+focus_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags @focus"
 %>
 default: <%= std_opts %> features
+focus: <%= focus_opts %> features
 wip: --tags @wip:3 --wip features
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip


### PR DESCRIPTION
I use guard alot as my local CI server.  This allows me to keep its
scope focused on only the section of code I am developing while I am
developing it.  Afterwards, I can descope the run and let it test
everything.

Decided against Zeus. 
