### PR TITLE
Case worker claim allocation

### DIFF
--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -10,7 +10,7 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
   def edit; end
 
   def allocate
-    @claims = Claim.all
+    @claims = Claim.non_draft
   end
 
   def new
@@ -30,6 +30,7 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
 
   def update
     if @case_worker.update(case_worker_params)
+      @case_worker.claims.each { |claim| claim.allocate! if claim.submitted? }
       redirect_to case_workers_admin_case_workers_url, notice: 'Case worker successfully updated'
     else
       render :edit

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -5,7 +5,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   def index
     @claims = case tab
       when 'current'
-        current_user.claims.submitted
+        current_user.claims.allocated
       when 'completed'
         current_user.claims.completed
     end

--- a/app/models/advocate.rb
+++ b/app/models/advocate.rb
@@ -6,7 +6,7 @@ class Advocate < ActiveRecord::Base
   has_one :user, as: :persona, inverse_of: :persona, dependent: :destroy
   has_many :claims, dependent: :destroy
 
-  default_scope { includes(:user) }
+  default_scope { includes(:user, :chamber) }
 
   validates :user, presence: true
   validates :chamber, :first_name, :last_name, presence: true

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -91,4 +91,8 @@ class Claim < ActiveRecord::Base
   def update_total
     update_column(:total, fees_total + expenses_total)
   end
+
+  def description
+    "#{court.code}-#{case_number} #{advocate.name} (#{advocate.chamber.name})"
+  end
 end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -72,6 +72,8 @@ module Claims::StateMachine
     klass.state_machine.states.map(&:name).each do |s|
       klass.scope s, -> { klass.where(state: s) }
     end
+
+    klass.scope :non_draft, -> { klass.where.not(state: 'draft') }
   end
 
   private

--- a/app/views/case_workers/admin/case_workers/allocate.html.haml
+++ b/app/views/case_workers/admin/case_workers/allocate.html.haml
@@ -10,6 +10,6 @@
 
   = f.label :claim_ids, 'Claims'
   %br
-  = f.collection_select :claim_ids, @claims, :id, :case_number, { prompt: true }, { multiple: true, style: 'width: 100%;' }
+  = f.collection_select :claim_ids, @claims, :id, :description, { prompt: true }, { multiple: true, style: 'width: 100%;' }
   %br
   = f.submit

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -6,8 +6,8 @@ end
 
 Given(/^claims have been assigned to me$/) do
   case_worker = CaseWorker.first
-  @claims = create_list(:submitted_claim, 5)
-  @other_claims = create_list(:submitted_claim, 3)
+  @claims = create_list(:allocated_claim, 5)
+  @other_claims = create_list(:allocated_claim, 3)
   @claims.each_with_index { |claim, index| claim.update_column(:total, index + 1) }
   @claims.each { |claim| claim.case_workers << case_worker }
   create(:defendant, maat_reference: 'AA1245', claim_id: @claims.first.id)

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController, type: :controller do
     end
 
     it 'assigns @claims' do
-      expect(assigns(:claims)).to eq(Claim.all)
+      expect(assigns(:claims)).to eq(Claim.non_draft)
     end
 
     it 'renders the template' do

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CaseWorkers::ClaimsController, type: :controller do
   let!(:case_worker) { create(:case_worker) }
-  let!(:claims) { create_list(:submitted_claim, 5) }
+  let!(:claims) { create_list(:allocated_claim, 5) }
   let!(:other_claim) { create(:submitted_claim) }
 
   before do
@@ -23,8 +23,8 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
     end
 
     context 'current claims' do
-      it 'assigns submitted @claims' do
-        expect(assigns(:claims)).to eq(case_worker.claims.submitted.order(:submitted_at, :id))
+      it 'assigns allocated @claims' do
+        expect(assigns(:claims)).to eq(case_worker.claims.allocated)
       end
     end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -197,4 +197,14 @@ RSpec.describe Claim, type: :model do
       end
     end
   end
+
+  describe '#description' do
+    let(:expected_output) do
+      "#{subject.court.code}-#{subject.case_number} #{subject.advocate.name} (#{subject.advocate.chamber.name})"
+    end
+
+    it 'returns a formatted description string containing claim information' do
+      expect(subject.description).to eq(expected_output)
+    end
+  end
 end


### PR DESCRIPTION
Allocate claims to case workers via a multi-select displaying basic claim information (court code/case number, advocate name).
