### PR TITLE
Claim summary for the advocate dashboard

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -4,18 +4,17 @@ class Advocates::ClaimsController < Advocates::ApplicationController
 
 
   def index
-    claims = if current_user.persona.admin?
-      current_user.persona.chamber.claims.order(created_at: :desc)
-    else
-      current_user.claims.order(created_at: :desc)
-    end
+    # parent can be a chamber or an advocate
+    parent = current_user.persona.admin? ? current_user.persona.chamber : current_user
 
+    claims = parent.claims.order(created_at: :desc)
     claims = claims.find_by_advocate_name(params[:search]) if params[:search].present?
 
     @submitted_claims = claims.submitted
     @allocated_claims = claims.allocated
     @completed_claims = claims.completed
     @draft_claims = claims.draft
+    @claims_summary  = Claims::Summary.new(parent)
   end
 
   def show; end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -32,6 +32,9 @@ class Claim < ActiveRecord::Base
              offence: :offence_class)
   end
 
+  scope :outstanding, -> { where("state = 'submitted' or state = 'allocated'") }
+  scope :authorised, -> { where(state: 'paid') }
+
   validates :offence,                 presence: true
   validates :advocate,                presence: true
   validates :court,                   presence: true

--- a/app/models/claims/summary.rb
+++ b/app/models/claims/summary.rb
@@ -1,0 +1,23 @@
+class Claims::Summary
+
+  def initialize(parent)
+    @parent = parent
+  end
+
+  def outstanding_claims
+    @parent.claims.outstanding
+  end
+
+  def authorised_claims
+    @parent.claims.authorised
+  end
+
+  def total_outstanding_claim_value
+    outstanding_claims.sum(:total)
+  end
+
+  def total_authorised_claim_value
+    authorised_claims.sum(:total)
+  end
+
+end

--- a/app/views/advocates/claims/_summary.html.haml
+++ b/app/views/advocates/claims/_summary.html.haml
@@ -1,0 +1,9 @@
+%br Total Outstanding Claims:
+
+#outstanding_claims
+  = number_to_currency(claims_summary.total_outstanding_claim_value)
+
+%br Total Authorised Claims:
+
+#authorised_claims
+  = number_to_currency(claims_summary.total_authorised_claim_value)

--- a/app/views/advocates/claims/index.html.haml
+++ b/app/views/advocates/claims/index.html.haml
@@ -3,6 +3,9 @@
 %p
   = link_to 'Add Claim', new_advocates_claim_path, class: 'button'
 
+#summary
+  = render partial: 'summary', locals: { claims_summary: @claims_summary }
+
 - if current_user.persona.admin?
   %p
     = form_tag advocates_claims_path, method: :get do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20150511152610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pgcrypto"
 
   create_table "advocates", force: true do |t|
     t.string   "role"

--- a/features/advocate_claims_summary.feature
+++ b/features/advocate_claims_summary.feature
@@ -1,0 +1,27 @@
+Feature: Advocate claims Summary
+  Background:
+    As an advocate I want to see a financial summary of my claims.
+
+  Scenario: View summary of outstanding claims as an advocate
+    Given I am a signed in advocate
+      And I have claims
+     When I visit the advocates dashboard
+     Then I should see my total value of outstanding claims
+
+  Scenario: View summary of outstanding claims as an advocate admin
+    Given I am a signed in advocate admin
+      And my chamber has claims
+     When I visit the advocates dashboard
+     Then I should see the total value of outstanding claims for my chamber
+
+  Scenario: View summary of authorised claims as an advocate
+    Given I am a signed in advocate
+      And I have claims
+     When I visit the advocates dashboard
+     Then I should see my total value of authorised claims
+
+  Scenario: View summary of authorised claims as an advocate admin
+    Given I am a signed in advocate admin
+      And my chamber has claims
+     When I visit the advocates dashboard
+     Then I should see the total value of authorised claims for my chamber

--- a/features/step_definitions/claims_summary_steps.rb
+++ b/features/step_definitions/claims_summary_steps.rb
@@ -1,0 +1,16 @@
+Then(/^I should see my total value of outstanding claims$/) do
+  expect(page).to have_css("#summary #outstanding_claims")
+end
+
+Then(/^I should see the total value of outstanding claims for my chamber$/) do
+  expect(page).to have_css("#summary #outstanding_claims")
+end
+
+Then(/^I should see my total value of authorised claims$/) do
+  expect(page).to have_css("#summary #authorised_claims")
+end
+
+Then(/^I should see the total value of authorised claims for my chamber$/) do
+  expect(page).to have_css("#summary #authorised_claims")
+end
+

--- a/spec/models/claims/summary_spec.rb
+++ b/spec/models/claims/summary_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Claims::Summary, type: :model do
+  let!(:submitted_claim) { create(:claim, state: 'submitted', total: 103.56) }
+  let!(:allocated_claim) { create(:claim, state: 'allocated', total: 56.21) }
+  let!(:paid_claim) { create(:claim, state: 'paid', total: 89) }
+  let(:advocate) { create(:advocate) }
+
+  context 'by advocate' do
+
+    subject { Claims::Summary.new(advocate) }
+
+    before do
+      advocate.claims << [submitted_claim, allocated_claim, paid_claim]
+    end
+
+    describe '#total_outstanding_claim_value' do
+      it 'calculates the value of outstanding claims' do
+        expect(subject.total_outstanding_claim_value).to eq(159.77)
+      end
+    end
+
+    describe '#total_authorised_claim_value' do
+      it 'calculates the value of authorised claims' do
+        expect(subject.total_authorised_claim_value).to eq(89)
+      end
+    end
+
+  end
+
+  context 'by Chambers' do
+    let!(:chamber) { create(:chamber) }
+    let(:another_advocate) { create(:advocate, chamber: chamber) }
+
+    let!(:another_submitted_claim) { create(:claim, state: 'submitted', total: 33.56) }
+    let!(:another_allocated_claim) { create(:claim, state: 'allocated', total: 66.21) }
+    let!(:another_paid_claim) { create(:claim, state: 'paid', total: 29.6) }
+
+    before do
+      advocate.chamber = chamber
+      advocate.save
+
+      advocate.claims << [submitted_claim, allocated_claim, paid_claim]
+      another_advocate.claims << [another_submitted_claim, another_allocated_claim, another_paid_claim]
+    end
+
+    subject { Claims::Summary.new(chamber) }
+
+    describe '.total_outstanding_claim_value' do
+      it 'calculates the value of outstanding claims' do
+        expect(subject.total_outstanding_claim_value).to eq(259.54)
+      end
+    end
+
+    describe '.total_authorised_claim_value' do
+      it 'calculates the value of authorised claims' do
+        expect(subject.total_authorised_claim_value).to eq(118.6)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
A summary screen for the advocate dashboard that displays the total
value of outstanding and authorised claims.

If you are viewing the dashboard as an admin the summary is calculated
for your chamber otherwise it shows a summary for your user.
- add model specs for ClaimSummary
- add ClaimSummary model and views
- add cukes
