### PR TITLE
Fix paths in the Dockerfile - should have been done in #74

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,13 +3,13 @@ FROM ministryofjustice/ruby:2-webapp-onbuild
 ENV APP_HOME /rails
 
 ADD ./ /rails
-ADD ./docker/rails/run.sh /rails/run.sh
-RUN chmod 777 /rails/run.sh
-WORKDIR /rails
+ADD ./docker/run.sh $APP_HOME/run.sh
+RUN chmod 777 $APP_HOME/run.sh
+WORKDIR $APPHOME
 
 EXPOSE 80
 
 #SECRET_TOKEN set here because otherwise devise blows up during the precompile.
 RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here
 
-CMD /rails/run.sh
+CMD $APP_HOME/run.sh


### PR DESCRIPTION
In #74 we moved the dockerfile from docker/rails/ to docker/ but forgot to update some paths – without this the jenkins jobs fail and we cant build our containers.
