### PR TITLE
Defendant names in claims list on advocates

### DIFF
--- a/app/views/advocates/claims/_claims.html.haml
+++ b/app/views/advocates/claims/_claims.html.haml
@@ -7,6 +7,8 @@
         %th
           Advocate name
       %th
+        Defendents
+      %th
         CMS Number
       %th
         Submission date
@@ -21,6 +23,8 @@
         - if current_user.persona.admin?
           %td
             = claim.advocate.name
+        %td
+          = claim.defendants.map(&:name).join(', ')
         %td
           = claim.cms_number
         %td


### PR DESCRIPTION
Comma separated defendant names for claims on advocates dashboard.
