### PR TITLE
Fix "Evidence is displayed in a new tab" scenario.

### DIFF
--- a/app/views/case_workers/claims/_evidence_list.html.haml
+++ b/app/views/case_workers/claims/_evidence_list.html.haml
@@ -1,4 +1,4 @@
-%section 
+%section
   %ol#evidence-list
     - @doc_types.each do |doc_type|
       %li
@@ -6,7 +6,5 @@
         - if @claim.has_doctype?(doc_type)
           - document = @claim.doc_of_type(doc_type)
           .item-controls
-            %a.view
-              = link_to 'View', document_path(document), target: '_blank'
-            %a.download
-              = link_to 'Download', download_document_path(document)
+            = link_to 'View', document_path(document), target: '_blank', class: 'view'
+            = link_to 'Download', download_document_path(document), class: 'download'

--- a/features/step_definitions/view_provider_evidence_steps.rb
+++ b/features/step_definitions/view_provider_evidence_steps.rb
@@ -13,6 +13,7 @@ Then(/^I see links to view\/download each document submitted with the claim$/) d
 end
 
 When(/^click on a link to (download|view) some evidence$/) do |link|
+  find('h2', text: 'Evidence list').click
   first('.item-controls').click_link(link.titlecase)
 end
 


### PR DESCRIPTION
Scenario was broken due to accordion section not being open ("View" link not visible).
