### PR TITLE
Use paperclip.io_adapters to find path to pdf duplicate

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -51,7 +51,7 @@ class Document < ActiveRecord::Base
   end
 
   def path_to_pdf_duplicate
-    document.path.split('.')[0] + '.pdf'
+    Paperclip.io_adapters.for(self.document).path.split('.')[0] + '.pdf'
   end
 
   def has_pdf_duplicate?

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Document, type: :model do
     subject { create(:document) }
 
     it 'returns the path to .pdf copy of attachment' do
-      expect(subject.path_to_pdf_duplicate).to match /public\/assets\/test\/images\/\d*\/\d*\/\d*\/longer_lorem.pdf/
+      expect(File.exist?(subject.path_to_pdf_duplicate)).to eq true
     end
   end
 


### PR DESCRIPTION
evidence 'view' link isn't shown on Heroku / AWS because it depends on document#has_pdf_duplicate, which was written using document#path, in error.  Changed to use Paperclip.io_adapters and this works locally.  All tests passing.
