### PR TITLE
Remove /rails path from Dockerfile and related script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,5 @@
 FROM ministryofjustice/ruby:2-webapp-onbuild
 
-ENV APP_HOME /rails
-
-ADD ./ /rails
 ADD ./docker/run.sh $APP_HOME/run.sh
 RUN chmod 777 $APP_HOME/run.sh
 WORKDIR $APPHOME

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -e
-echo "inside run.sh"
-cd /rails
 
 case ${DOCKER_STATE} in
 migrate)


### PR DESCRIPTION
The base image we are building on already puts things under /usr/src/app
so let's just use that.

And I think this was causing problems with asset paths and where the
asset manifests were being written to/read from

The `cd` in the script is not needed because the WORKDIR in the dockerfile sets the initial working directory for processes run in the docker image.
