### PR TITLE
Remove indictment number

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -43,7 +43,6 @@ class Claim < ActiveRecord::Base
   validates :advocate_category,       presence: true,     inclusion: { in: ADVOCATE_CATEGORIES }
   validates :prosecuting_authority,   presence: true,     inclusion: { in: PROSECUTING_AUTHORITIES }
   validates :advocate_category,       presence: true,     inclusion: { in: ADVOCATE_CATEGORIES }
-  validates :indictment_number,       presence: true
   validates :estimated_trial_length,  numericality: { greater_than_or_equal_to: 0 }
   validates :actual_trial_length,     numericality: { greater_than_or_equal_to: 0 }
 

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -23,10 +23,6 @@
 
       = f.collection_select :prosecuting_authority, Claim::PROSECUTING_AUTHORITIES, :to_s, :upcase, { prompt: true }, { class: 'select2' }
 
-      = f.label :indictment_number
-
-      = f.text_field :indictment_number
-
       = f.label :court
 
       = f.collection_select :court_id, Court.all, :id, :name, { prompt: true }, { class: 'select2' }

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -17,7 +17,6 @@ end
 When(/^I fill in the claim details$/) do
   select('Guilty', from: 'claim_case_type')
   select('CPS', from: 'claim_prosecuting_authority')
-  fill_in 'Indictment number', with: '123456'
   select('some court', from: 'claim_court_id')
   fill_in 'Case number', with: '123456'
   select('A: Homicide and related grave offences', from: 'claim_offence_class_id')

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -178,7 +178,6 @@ RSpec.describe Advocates::ClaimsController, type: :controller do
              case_number: '12345',
              advocate_category: 'qc_alone',
              prosecuting_authority: 'cps',
-             indictment_number: '12345'
           }
         end
 

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -6,7 +6,6 @@ FactoryGirl.define do
     case_type 'trial'
     offence
     advocate_category 'qc_alone'
-    sequence(:indictment_number) { |n| "12345-#{n}" }
     prosecuting_authority 'cps'
     sequence(:cms_number) { |n| "CMS-#{Time.now.year}-#{rand(100..199)}-#{n}" }
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Claim, type: :model do
   it { should validate_presence_of(:case_number) }
   it { should validate_presence_of(:prosecuting_authority) }
   it { should validate_inclusion_of(:prosecuting_authority).in_array(%w( cps )) }
-  it { should validate_presence_of(:indictment_number) }
 
   it { should validate_presence_of(:case_type) }
   it { should validate_inclusion_of(:case_type).in_array(%w( guilty trial retrial cracked_retrial )) }


### PR DESCRIPTION
User research has tentativley determined that the indictment number
is not needed but in case it is required at a later date the DB
migrations and controller params aspects have been
left in place.
