### PR TITLE
Added libreoffice package to docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,11 @@ FROM ministryofjustice/ruby:2-webapp-onbuild
 
 ADD ./docker/run.sh $APP_HOME/run.sh
 RUN chmod 777 $APP_HOME/run.sh
+RUN apt-get update &&  \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install libreoffice && \
+    apt-get clean && \
+    rm /var/lib/apt/lists/*_*
+
 WORKDIR $APPHOME
 
 EXPOSE 80


### PR DESCRIPTION
This change adds the libreoffice package to the docker container.
libreoffice is required by the libreconv gem used in the application to convert to PDF.
