### PR TITLE
Soft delete claims

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -68,12 +68,8 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   end
 
   def destroy
-    if @claim.draft?
-      @claim.destroy
-      respond_with @claim, { location: advocates_claims_url, notice: 'Claim deleted' }
-    else
-      redirect_to advocates_claims_url, alert: 'Cannot destroy non-draft claim'
-    end
+    @claim.archive_pending_delete!
+    respond_with @claim, { location: advocates_claims_url, notice: 'Claim deleted' }
   end
 
   private

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -32,7 +32,7 @@ class Claim < ActiveRecord::Base
              :expenses,
              :fee_types,
              :messages,
-             offence: :offence_class)
+             offence: :offence_class).not_deleted
   end
 
   scope :outstanding, -> { where("state = 'submitted' or state = 'allocated'") }

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -70,10 +70,16 @@ module Claims::StateMachine
     end
 
     klass.state_machine.states.map(&:name).each do |s|
-      klass.scope s, -> { klass.where(state: s) }
+      if s == :archived_pending_delete
+        klass.scope s, -> { klass.unscope(:where).where(state: s) }
+      else
+        klass.scope s, -> { klass.where(state: s) }
+      end
     end
 
-    klass.scope :non_draft, -> { klass.where.not(state: 'draft') }
+    klass.scope :not_deleted, -> { klass.where.not(state: 'archived_pending_delete') }
+    klass.scope :non_draft, -> { klass.where(state: ['allocated', 'appealed', 'awaiting_further_info', 'awaiting_info_from_court', 'completed',
+         'deleted', 'paid', 'part_paid', 'parts_rejected', 'refused', 'rejected', 'submitted']) }
   end
 
   private

--- a/app/views/advocates/claims/_claims.html.haml
+++ b/app/views/advocates/claims/_claims.html.haml
@@ -42,6 +42,5 @@
           - if claim.editable?
             |
             = link_to 'Edit', edit_advocates_claim_path(claim)
-          - if claim.draft?
-            |
-            = link_to 'Delete', advocates_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }
+          |
+          = link_to 'Delete', advocates_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -269,28 +269,18 @@ RSpec.describe Advocates::ClaimsController, type: :controller do
   describe "DELETE #destroy" do
     before { delete :destroy, id: subject }
 
-    context 'draft claim' do
-      subject { create(:claim) }
+    subject { create(:claim) }
 
-      it 'destroys the claim' do
-        expect(Claim.count).to eq(0)
-      end
-
-      it 'redirects to advocates root url' do
-        expect(response).to redirect_to(advocates_claims_url)
-      end
+    it 'deletes the claim' do
+      expect(Claim.count).to eq(0)
     end
 
-    context 'non-draft claim' do
-      subject { create(:submitted_claim) }
+    it "sets the claim's state to 'archived_pending_delete'" do
+      expect(subject.reload).to be_archived_pending_delete
+    end
 
-      it 'does not destroy the claim' do
-        expect(Claim.first).to eq(subject)
-      end
-
-      it 'redirects to advocates root url' do
-        expect(response).to redirect_to(advocates_claims_url)
-      end
+    it 'redirects to advocates root url' do
+      expect(response).to redirect_to(advocates_claims_url)
     end
   end
 end

--- a/spec/models/claims/state_machine_scopes_spec.rb
+++ b/spec/models/claims/state_machine_scopes_spec.rb
@@ -1,15 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe Claims::StateMachine, type: :model do
-  subject { create(:claim) }
-
   describe 'all available states are scoped' do
+    subject { create(:claim) }
+
     let(:states) { subject.class.state_machine.states.map(&:name) }
 
     it 'and accessible' do
       states.each do |state|
         subject.update_column(:state, state.to_s)
         expect(subject.class.send(state)).to match_array(subject)
+      end
+    end
+  end
+
+  describe 'custom scopes' do
+    let!(:draft_claim) { create(:claim) }
+    let!(:submitted_claim) { create(:submitted_claim) }
+    let!(:allocated_claim) { create(:allocated_claim) }
+    let!(:deleted_claim) { create(:archived_pending_delete_claim) }
+
+    describe '.non_draft' do
+      it 'only returns non-draft claims' do
+        expect(Claim.non_draft).to match_array([allocated_claim, submitted_claim])
+      end
+    end
+
+    describe '.not_deleted' do
+      it 'does not include deleted claims' do
+        expect(Claim.not_deleted).to match_array([draft_claim, allocated_claim, submitted_claim])
       end
     end
   end


### PR DESCRIPTION
Claims are transitioned to an archived_pending_delete state when deleted. These claims will no display in the advocates or case worker dashboards.
