### PR TITLE
fix broken claims rake task

### DIFF
--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -45,14 +45,14 @@ namespace :claims do
   end
 
   def add_fees_expenses_and_defendant(claim)
-    rand(1..10).times { claim.fees << FactoryGirl.create(:fee, :random_values, claim_id: claim.id, fee_type_id: FeeType.all.sample(1)[0].id) }
-    rand(1..10).times { claim.expenses << FactoryGirl.create(:expense, :random_values, claim_id: claim.id, expense_type_id: ExpenseType.all.sample(1)[0].id) }
-    claim.defendants << FactoryGirl.create(:defendant, claim_id: claim.id)
+    rand(1..10).times { claim.fees << FactoryGirl.create(:fee, :random_values, claim: claim, fee_type: FeeType.all.sample) }
+    rand(1..10).times { claim.expenses << FactoryGirl.create(:expense, :random_values, claim: claim, expense_type: ExpenseType.all.sample) }
+    claim.defendants << FactoryGirl.create(:defendant, claim: claim)
   end
 
   def add_document(claim)
     file = File.open("./features/examples/longer_lorem.pdf")
-    Document.create!(claim_id: claim.id, document_type_id: 1, document: file, document_content_type: 'application/pdf', advocate: Advocate.find(1) )
+    Document.create!(claim: claim, document_type: DocumentType.all.sample, document: file, document_content_type: 'application/pdf', advocate: Advocate.find(1) )
   end
 
   def parse_states_from_string(states_delimited_string)
@@ -94,7 +94,6 @@ namespace :claims do
       claims_per_state.times do
           
           claim = FactoryGirl.create("#{s}_claim".to_sym, advocate: advocate, court: Court.all.sample, offence: Offence.all.sample)
-
           puts("   - created #{s} claim for advocate #{advocate.first_name} #{advocate.last_name}")
           add_fees_expenses_and_defendant(claim)
           add_document(claim)


### PR DESCRIPTION
The archived_pending_delete state, at least, caused a nilclass failure
for claim creation. This has been fixed and task improved to use objects
where possible rather than object id passing.
