### PR TITLE
Define permissions for advocate claims

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require cocoon
 //= require_tree .
 
+moj.Modules.devs.init = function(){} 
 
 $('#claims-list dd, dt').not('.quickview').each(function() {
   $(this).hide();

--- a/app/controllers/advocates/application_controller.rb
+++ b/app/controllers/advocates/application_controller.rb
@@ -1,13 +1,10 @@
 class Advocates::ApplicationController < ApplicationController
-
-	before_action :authenticate_advocate!
+  load_and_authorize_resource
 	layout 'advocate'
 
   private
 
-  def authenticate_advocate!
-    unless user_signed_in? && current_user.persona.is_a?(Advocate)
-      redirect_to root_url, alert: 'Must be signed in as an advocate'
-    end
+  rescue_from CanCan::AccessDenied do |exception|
+    redirect_to root_url, alert: t('requires_advocate_authorisation')
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,12 +5,12 @@ class Ability
     persona = user.persona rescue nil
 
     if persona.is_a? Advocate
+        can :create, [Claim, Document]
+        can :landing, Claim
+        can [:update, :read, :destroy, :download,
+             :summary, :confirmation, :outstanding], [Claim, Document], chamber_id: persona.chamber_id
       if persona.admin?
-        can :manage, :all
-      else
-        can :manage, Claim
-        can :create, Document
-        can [:update, :read, :destroy, :download], Document, chamber_id: persona.chamber_id
+        # Placeholder for Advocate admin
       end
     elsif persona.is_a? CaseWorker
       if persona.admin?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -13,6 +13,8 @@ class Claim < ActiveRecord::Base
   belongs_to :advocate
   belongs_to :scheme
 
+  delegate   :chamber_id, to: :advocate
+
   has_many :case_worker_claims,       dependent: :destroy
   has_many :case_workers,             through: :case_worker_claims
   has_many :fees,                     dependent: :destroy,          inverse_of: :claim

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  requires_advocate_authorisation: 'You must be signed in as an advocate or advocate admin'
   number:
     currency:
        format:

--- a/features/advocate_claims_financial_summary.feature
+++ b/features/advocate_claims_financial_summary.feature
@@ -5,7 +5,7 @@ Feature: Advocate Claims Financial Summary
   Scenario: View summary of outstanding claims as an advocate
     Given I am a signed in advocate
       And I have claims
-     When I visit the advocates dashboard
+      When I visit the advocates dashboard
      Then I should see my total value of outstanding claims
 
   Scenario: View summary of outstanding claims as an advocate admin

--- a/features/claims_authorisation.feature
+++ b/features/claims_authorisation.feature
@@ -1,0 +1,66 @@
+Feature: claims are only accessible to the correct authorised users
+  As an anonymous user
+  I cannot do anything at all with any claim
+
+  As an advocate admin
+  I am able to mange claims from my chambers and should not be able to manage claims
+  from other chambers.
+
+  As an advocate
+  I am able to read claims from my chambers and should not be able to do ANYTHING to
+  claims from other chambers or other advocates within my chambers.
+
+  As a case worker
+  I am able to mange any claim
+
+  Scenario: The general public cannot access any claims
+    Given an "advocate" user account exists
+    When a claim exists that belongs to the advocate
+    Then an anonymous user cannot access the claim
+
+  Scenario: The advocate who uploaded the claim can access it
+    Given an "advocate" user account exists
+    And that advocate signs in
+    When a claim exists that belongs to the advocate
+    Then the advocate can access the claim
+
+  Scenario: An advocate admin from the same chamber as the advocate who uploaded the claim can manage it
+    Given an "advocate" user account exists
+    And 1 "advocate admin" user account exists who works for the same chamber
+    When a claim exists that belongs to the advocate
+    And that advocate admin signs in
+    Then the advocate admin can manage the claim
+
+  Scenario: An advocate admin from a different chamber from the advocate who uploaded the claim cannot manage it
+    Given an "advocate" user account exists
+    And 1 "advocate admin" user account exists who works for different chambers
+    When a claim exists that belongs to the advocate
+    And that advocate admin signs in
+    Then the advocate admin cannot manage the claim
+
+  Scenario: An advocate admin from a different chamber from the advocate who uploaded the claim cannot manage it
+    Given an "advocate" user account exists
+    And 1 "advocate admin" user account exists who works for different chambers
+    When a claim exists that belongs to the advocate
+    And that advocate admin signs in
+    Then the advocate admin cannot manage the claim
+
+  Scenario: Advocates from the same chamber can access each others claims
+    Given 2 "advocate" user accounts exist who work for the same chamber
+    When a claim exists that belongs to the 1st advocate
+    And the 2nd advocate signs in
+    Then that advocate can access the claim
+
+  Scenario: Advocates from different chambers cannot access each others claims
+    Given 2 "advocate" user accounts exist who work for different chambers
+    When a claim exists that belongs to the 1st advocate
+    And the 2nd advocate signs in
+    Then that advocate cannot access the claim
+
+  Scenario: Case worker can access all claims
+    Given 2 "advocate" user accounts exist who work for different chambers
+    And a "case worker" user account exists
+    When a claim exists that belongs to the 1st advocate
+    When a claim exists that belongs to the 2nd advocate
+    And that case worker signs in
+    Then the case worker can access all claims

--- a/features/document_security.feature
+++ b/features/document_security.feature
@@ -8,7 +8,6 @@ Feature: Documents are only accessible to the correct authorised users
     When a document exists that belongs to the advocate
     Then an anonymous user cannot access the document
 
-  @focus
   Scenario: The advocate who uploaded the document can access it
     Given an "advocate" user account exists
     And that advocate signs in

--- a/features/sign_in.feature
+++ b/features/sign_in.feature
@@ -7,8 +7,7 @@ Feature: Sign in
 
   Scenario: Sign in as an advocate admin
     Given an "advocate admin" user account exists
-     When I visit the user sign in page
-      And I enter my email, password and click log in
+    When that advocate admin signs in
      Then I should be redirected to the advocates landing url
 
   Scenario: Sign in as a case worker

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -1,14 +1,12 @@
 Given(/^I have claims$/) do
-  advocate = Advocate.first
-  @claims = create_list(:submitted_claim, 5)
+  @claims = create_list(:submitted_claim, 5, advocate: @advocate)
   @other_claims = create_list(:submitted_claim, 3)
   @claims.each_with_index { |claim, index| claim.update_column(:total, index + 1) }
-  @claims.each { |claim| claim.update_column(:advocate_id, advocate.id) }
   create(:defendant, maat_reference: 'AA1245', claim_id: @claims.first.id)
   create(:defendant, maat_reference: 'BB1245', claim_id: @claims.second.id)
 end
-When(/^I visit the advocates dashboard$/) do
 
+When(/^I visit the advocates dashboard$/) do
   visit advocates_claims_path
 end
 

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -1,9 +1,3 @@
-Given(/^I am a signed in advocate$/) do
-  @advocate = create(:advocate)
-  visit new_user_session_path
-  sign_in(@advocate.user, 'password')
-end
-
 Given(/^I am on the new claim page$/) do
   create(:court, name: 'some court')
   create(:offence_class, description: 'A: Homicide and related grave offences')

--- a/features/step_definitions/claim_steps.rb
+++ b/features/step_definitions/claim_steps.rb
@@ -1,0 +1,29 @@
+When(/^a claim exists that belongs to the(?: (\d+)\w+)? advocate$/) do |cardinality|
+  card = cardinality.nil? ? 0 : cardinality.to_i - 1
+  @claim = create(:claim, advocate: @advocates[card])
+end
+
+Then(/^an anonymous user cannot access the claim$/) do
+  click 'Sign out' rescue nil
+  visit advocates_claim_url(@claim)
+  expect(page.current_url).to eq(root_url)
+  expect(page).to have_content(/must be signed in/i)
+end
+
+Then(/^(?:the|that) (?:advocate(?: admin)?) can (?:access|manage) the claim$/) do
+  visit edit_advocates_claim_url(@claim)
+  expect(page).to have_content(/Edit claim/)
+end
+
+Then(/^(?:the|that) (?:advocate(?: admin)?) cannot (?:access|manage) the claim$/) do
+  visit edit_advocates_claim_url(@claim)
+  expect(page).not_to have_content(/Edit claim/)
+end
+
+Then(/^the case worker can access all claims$/) do
+  expected_copy = 'Edit claim'
+  Claim.all.each do |claim|
+    visit edit_advocates_claim_url(claim)
+    expect(page).to have_content(/#{expected_copy}/)
+  end
+end

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -4,7 +4,7 @@ def make_accounts(role, number = 1)
     when 'advocate'
       @advocates = create_list(:advocate, number)
     when 'advocate admin'
-      create(:advocate, :admin)
+      @advocate_admins = create_list(:advocate, number, :admin)
     when 'case worker'
       @case_workers = create_list(:case_worker, number)
     when 'case worker admin'
@@ -17,18 +17,27 @@ Given(/an? "(.*?)" user account exists$/) do |role|
   make_accounts(role)
 end
 
-Given(/^(\d+) "(.*?)" user accounts exist who work for (the same|different) chambers?$/) do |number, role, chambers|
+Given(/^(\d+) "(.*?)" user accounts? exists? who works? for (the same|different) chambers?$/) do |number, role, chambers|
   make_accounts(role, number.to_i)
   if chambers == 'the same'
     the_chamber = create(:chamber)
-    @advocates.each { |a| a.chamber = the_chamber; a.save }
+    @advocates.each { |a| a.chamber = the_chamber; a.save } if @advocates
+    @advocate_admins.each { |a| a.chamber = the_chamber; a.save } if @advocate_admins
   else
-    @advocates.each { |a| a.chamber = create(:chamber); a.save }
+    @advocates.each { |a| a.chamber = create(:chamber); a.save } if @advocates
+    @advocate_admins.each { |a| a.chamber = create(:chamber); a.save } if @advocate_admins
   end
 end
 
 When(/^I visit the user sign in page$/) do
   visit new_user_session_path
+end
+
+Given(/^(?:the|that)(?: (\d+)\w+)? advocate admin signs in$/) do |cardinality|
+  card = cardinality.nil? ? 1 : cardinality
+  @user = @advocate_admins[card.to_i-1].user
+  step "I visit the user sign in page"
+  step "I enter my email, password and click log in"
 end
 
 Given(/^(?:the|that)(?: (\d+)\w+)? advocate signs in$/) do |cardinality|
@@ -47,7 +56,7 @@ end
 
 When(/^I enter my email, password and click log in$/) do
   fill_in 'Email', with: (@user || User.first).email
-  fill_in 'Password', with: @password
+  fill_in 'Password', with: @password || 'password'
   click_on 'Log in'
   expect(page).to have_content('Sign out')
 end
@@ -64,3 +73,12 @@ end
 Then(/^I should be redirected to the advocates landing url$/) do
   expect(current_url).to eq(advocates_landing_url)
 end
+
+Given(/^I am a signed in advocate$/) do
+  step %Q{an "advocate" user account exists}
+  @advocate = @advocates.first
+  @user     = @advocate.user
+  step "I visit the user sign in page"
+  step "I enter my email, password and click log in"
+end
+

--- a/features/view_provider_evidence.feature
+++ b/features/view_provider_evidence.feature
@@ -21,7 +21,7 @@ Feature: Using provider evidence to process a claim
       And click on a link to view some evidence
     Then I see "longer_lorem.pdf" in my browser
 
-  @focus @javascript @webmock_allow_net_connect @failing-environment-specific
+  @javascript @webmock_allow_net_connect @failing-environment-specific
   Scenario: Evidence is displayed in a new tab
     Given I am signed in and on the case worker dashboard
       And I have been assigned claims with evidence attached

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe Advocates::ClaimsController, type: :controller do
-  let(:advocate) { create(:advocate) }
+RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
+  let!(:advocate) { create(:advocate) }
 
   before { sign_in advocate.user }
 
@@ -26,10 +26,10 @@ RSpec.describe Advocates::ClaimsController, type: :controller do
 
     context 'advocate' do
       before do
-        create(:claim, advocate: advocate)
-        create(:submitted_claim, advocate: advocate)
-        create(:completed_claim, advocate: advocate)
-        create(:rejected_claim, advocate: advocate)
+        create(:claim,            advocate: advocate)
+        create(:submitted_claim,  advocate: advocate)
+        create(:completed_claim,  advocate: advocate)
+        create(:rejected_claim,   advocate: advocate)
       end
 
       it 'assigns @submitted_claims' do
@@ -103,7 +103,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller do
   end
 
   describe "GET #show" do
-    subject { create(:claim) }
+    subject { create(:claim, advocate: advocate) }
 
     before { get :show, id: subject }
 
@@ -137,7 +137,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller do
   end
 
   describe "GET #edit" do
-    subject { create(:claim) }
+    subject { create(:claim, advocate: advocate) }
 
     before { get :edit, id: subject }
 
@@ -205,7 +205,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller do
   end
 
   describe "PUT #update" do
-    subject { create(:claim) }
+    subject { create(:claim, advocate: advocate) }
 
     context 'when valid' do
       context 'and draft' do
@@ -258,7 +258,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller do
   end
 
   describe "DELETE #destroy" do
-    subject { create(:claim) }
+    subject { create(:claim, advocate: advocate) }
 
     before { delete :destroy, id: subject }
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Claim, type: :model do
   it { should belong_to(:advocate) }
+  it { should delegate_method(:chamber_id).to(:advocate) }
+
   it { should belong_to(:court) }
   it { should belong_to(:offence) }
   it { should belong_to(:scheme) }


### PR DESCRIPTION
This was being doing by before filters in the individual controllers.
This changes that to use CanCan, instead.
