### PR TITLE
Display case worker name

### DIFF
--- a/app/views/case_workers/admin/case_workers/index.html.haml
+++ b/app/views/case_workers/admin/case_workers/index.html.haml
@@ -6,7 +6,7 @@
 %ul#assignee-list
   - @case_workers.each do |case_worker|
     %li{id: dom_id(case_worker)}
-      = link_to "#{case_worker.email} (#{case_worker.role.humanize})", case_workers_admin_case_worker_path(case_worker)
+      = link_to "#{case_worker.name} - #{case_worker.email} (#{case_worker.role.humanize})", case_workers_admin_case_worker_path(case_worker)
       %ul.actions
         %li
           = link_to 'Allocate claims', allocate_case_workers_admin_case_worker_path(case_worker)

--- a/app/views/case_workers/admin/case_workers/show.html.haml
+++ b/app/views/case_workers/admin/case_workers/show.html.haml
@@ -1,3 +1,5 @@
 = render 'case_workers/claims/nav_tabs'
 
-%h1= @case_worker.name
+%h1
+  = @case_worker.name
+  (#{@case_worker.email}) - #{@case_worker.role.humanize}


### PR DESCRIPTION
Display the case worker firstname nd lastname alongside email on the case workers management page.
