### PR TITLE
remove newest sort link from case worker dashboard

### DIFF
--- a/app/views/case_workers/claims/index.html.haml
+++ b/app/views/case_workers/claims/index.html.haml
@@ -16,8 +16,6 @@
     %ul
       %li{class: ('active' if params[:sort].blank? && params[:direction].blank?) || (params[:sort] == 'submitted_at' && params[:direction] == 'asc')}
         = link_to 'Oldest', case_workers_claims_path(params.merge(sort: 'submitted_at', direction: 'asc'))
-      %li{class: ('active' if params[:sort] == 'submitted_at' && params[:direction] == 'desc')}
-        = link_to 'Newest', case_workers_claims_path(params.merge(sort: 'submitted_at', direction: 'desc'))
       %li{class: ('active' if params[:sort] == 'total' && params[:direction] == 'desc')}
         = link_to 'Value - Highest first', case_workers_claims_path(params.merge(sort: 'total', direction: 'desc'))
       %li{class: ('active' if params[:sort] == 'total' && params[:direction] == 'asc')}

--- a/features/caseworker_claims_list.feature
+++ b/features/caseworker_claims_list.feature
@@ -8,7 +8,7 @@ Feature: Caseworker claims list
       And claims have been assigned to me
      When I visit my dashboard
      Then I should see only my claims
-      And the claims should be sorted by oldest first
+      And I should see the claims sorted by oldest first
 
   Scenario: View completed claims
     Given I am a signed in case worker
@@ -16,12 +16,12 @@ Feature: Caseworker claims list
      When I visit my dashboard
       And I click on the Completed Claims tab
      Then I should see only my claims
-      And the claims should be sorted by oldest first
+      And I should see the claims sorted by oldest first
 
-  Scenario: Sort current claims by newest first
+  Scenario: Sort current claims by oldest first
     Given I am signed in and on the case worker dashboard
-     When I sort the the claims by newest first
-     Then I should see the claims sorted by newest first
+     When I sort the claims by oldest first
+     Then I should see the claims sorted by oldest first
 
   Scenario: Sort current claims by highest value
     Given I am signed in and on the case worker dashboard

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -35,27 +35,22 @@ Then(/^I should see only my claims$/) do
   end
 end
 
-Then(/^the claims should be sorted by oldest first$/) do
-  claim_dom_ids = @claims.sort_by(&:submitted_at).map { |c| "claim_#{c.id}" }
-  expect(page.body).to match(/.*#{claim_dom_ids.join('.*')}.*/m)
-end
-
 Given(/^I am signed in and on the case worker dashboard$/) do
   steps <<-STEPS
     Given I am a signed in case worker
       And claims have been assigned to me
      When I visit my dashboard
      Then I should see only my claims
-      And the claims should be sorted by oldest first
+      And I should see the claims sorted by oldest first
   STEPS
 end
 
-When(/^I sort the the claims by newest first$/) do
-  click_on 'Newest'
+When(/^I sort the claims by oldest first$/) do
+  click_on 'Oldest'
 end
 
-Then(/^I should see the claims sorted by newest first$/) do
-  claim_dom_ids = @claims.sort_by(&:submitted_at).reverse.map { |c| "claim_#{c.id}" }
+Then(/^I should see the claims sorted by oldest first$/) do
+  claim_dom_ids = @claims.sort_by(&:submitted_at).map { |c| "claim_#{c.id}" }
   expect(page.body).to match(/.*#{claim_dom_ids.join('.*')}.*/m)
 end
 


### PR DESCRIPTION
claims submitted logest ago are a priority and user feedback from
case worker senior stakeholders requested removal of the newest
sort option.
