### PR TITLE
Indicate in claim detail summary whether VAT applies to claim

### DIFF
--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -68,3 +68,8 @@
   %p
     Claim total:
     = number_to_currency(@claim.total)
+
+  - if @claim.apply_vat?
+    %p
+      %strong
+        VAT applies to claim


### PR DESCRIPTION
Displays "VAT applies to claim" in claim detail summary when a claim has been submitted with VAT selected.
