### PR TITLE
"Save draft" and "Submit to LAA" on buttons

### DIFF
--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -92,5 +92,5 @@
 
 
     %p
-      = f.submit 'Submit', class: 'button'
+      = f.submit (@claim.new_record? ? 'Save draft' : 'Save'), class: 'button'
       = link_to 'Back', advocates_claims_path, class: 'button'

--- a/app/views/advocates/claims/summary.html.haml
+++ b/app/views/advocates/claims/summary.html.haml
@@ -21,5 +21,5 @@
         %li= msg
   = f.hidden_field :advocate_id, value: @claim.advocate_id
   = hidden_field_tag :summary, true
-  = f.submit 'Submit', class: 'button'
+  = f.submit 'Submit to LAA', class: 'button'
   = link_to 'Back', edit_advocates_claim_path(@claim), class: 'button'

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -67,7 +67,7 @@ Then(/^the Offence category does contain "(.*?)"$/) do |valid_offence_category|
 end
 
 When(/^I submit the form$/) do
-  click_on 'Submit'
+  find('input[name="commit"]').click
 end
 
 Then(/^I should be redirected to the claim summary page$/) do


### PR DESCRIPTION
New claim form displays "Save draft" and "Submit to LAA" on buttons
