### PR TITLE
add search by defendant to caseworker dashboard

### DIFF
--- a/app/assets/stylesheets/imports.scss
+++ b/app/assets/stylesheets/imports.scss
@@ -16,3 +16,4 @@
 @import "form";
 @import "dynamic-offence-list";
 @import "admin";
+@import "search-options";

--- a/app/assets/stylesheets/search-options.scss
+++ b/app/assets/stylesheets/search-options.scss
@@ -1,0 +1,12 @@
+#search-options{
+  display:block;
+  clear: both;
+  padding:15px;
+  background-color: $grey-3;
+  margin-bottom: 1em;
+  input[type="text"]{
+    width:75%;
+    margin-right: 1em;
+    font-size: 1em;
+  }
+}

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -4,7 +4,8 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   before_action :set_claim, only: [:show]
 
   def index
-    @claims = @claims.find_by_maat_reference(params[:search]) if params[:search].present?
+    @claims = @claims.find_by_maat_reference(params[:search_maat]) if params[:search_maat].present?
+    @claims = @claims.find_by_defendant_name(params[:search_defendant]) if params[:search_defendant].present?
     @claims = @claims.order("#{sort_column} #{sort_direction}")
   end
 

--- a/app/views/case_workers/claims/_search_options.html.haml
+++ b/app/views/case_workers/claims/_search_options.html.haml
@@ -1,0 +1,7 @@
+= form_tag case_workers_claims_path, method: :get do
+  = hidden_field_tag :tab, params[:tab]
+  = hidden_field_tag :sort, params[:sort]
+  = hidden_field_tag :direction, params[:direction]
+  = text_field_tag :search_maat, params[:search_maat], placeholder: 'MAAT reference no.'
+  = text_field_tag :search_defendant, params[:search_defendant], placeholder: 'Defendant'
+  = submit_tag 'Search', class: 'button'

--- a/app/views/case_workers/claims/index.html.haml
+++ b/app/views/case_workers/claims/index.html.haml
@@ -9,6 +9,9 @@
       Current claims
       (#{@claims.count})
 
+#search-options
+  = render partial: 'search_options'
+
 #list-controls
   %nav
     %h3
@@ -21,12 +24,6 @@
       %li{class: ('active' if params[:sort] == 'total' && params[:direction] == 'asc')}
         = link_to 'Value - Lowest first', case_workers_claims_path(params.merge(sort: 'total', direction: 'asc'))
 
-    = form_tag case_workers_claims_path, method: :get do
-      = hidden_field_tag :tab, params[:tab]
-      = hidden_field_tag :sort, params[:sort]
-      = hidden_field_tag :direction, params[:direction]
-      = text_field_tag :search, params[:search], placeholder: 'MAAT reference no.'
-      = submit_tag 'Search', class: 'button'
 %ul.case-data-headings
   %li
     %h3

--- a/features/advocate_claims_list.feature
+++ b/features/advocate_claims_list.feature
@@ -59,17 +59,19 @@ Feature: Advocate claims list
       And I search by the advocate name "John Smith"
      Then I should only see the 4 claims for the advocate "John Smith"
 
-  Scenario: Search claims by defendant name
+  Scenario Outline: Search claims by defendant name
     Given I am a signed in advocate
       And I have 2 claims involving defendant "Joe Bloggs" amongst others
       And I have 3 claims involving defendant "Fred Bloggs" amongst others
      When I visit the advocates dashboard
-      And I search by the defendant name "Joe Bloggs"
-     Then I should only see the 2 claims involving defendant "Joe Bloggs"
-      And I search by the defendant name "Fred Bloggs"
-     Then I should only see the 3 claims involving defendant "Fred Bloggs"
-      And I search by the defendant name "Bloggs"
-     Then I should only see the 5 claims involving defendant "Bloggs"
+      And I search by the defendant name <defendant_name>
+     Then I should only see the <number> claims involving defendant <defendant_name>
+
+     Examples:
+        | defendant_name | number |
+        | "Joe Bloggs"   | 2      |
+        | "Fred Bloggs"  | 3      |
+        | "Bloggs"       | 5      |
 
  Scenario Outline: Search claims by advocate and defendant name
   Given I am a signed in advocate admin

--- a/features/caseworker_claims_list.feature
+++ b/features/caseworker_claims_list.feature
@@ -25,12 +25,12 @@ Feature: Caseworker claims list
 
   Scenario: Sort current claims by highest value
     Given I am signed in and on the case worker dashboard
-     When I sort the the claims by highest value first
+     When I sort the claims by highest value first
      Then I should see the claims sorted by highest value first
 
   Scenario: Sort current claims by lowest value
     Given I am signed in and on the case worker dashboard
-     When I sort the the claims by lowest value first
+     When I sort the claims by lowest value first
      Then I should see the claims sorted by lowest value first
 
   Scenario: Current claims count
@@ -41,3 +41,32 @@ Feature: Caseworker claims list
     Given I am signed in and on the case worker dashboard
      When I search for a claim by MAAT reference
      Then I should only see claims matching the MAAT reference
+
+  Scenario Outline: Search Current claims by defendant name
+    Given I am signed in and on the case worker dashboard
+      And I have 2 "allocated" claims involving defendant "Joe Bloggs" amongst others
+      And I have 3 "allocated" claims involving defendant "Fred Bloggs" amongst others
+     When I visit my dashboard
+      And I search claims by defendant name <defendant_name>
+     Then I should only see <number> <state_name> claims
+
+     Examples:
+        | defendant_name | number | state_name |
+        | "Joe Bloggs"   | 2      | "Current"  |
+        | "Fred Bloggs"  | 3      | "Current"  |
+        | "Bloggs"       | 5      | "Current"  |
+
+  Scenario Outline: Search Completed claims by defendant name
+    Given I am signed in and on the case worker dashboard
+      And I have 2 "completed" claims involving defendant "Joe Bloggs" amongst others
+      And I have 3 "completed" claims involving defendant "Fred Bloggs" amongst others
+     When I visit my dashboard
+      And I click on the Completed Claims tab
+      And I search claims by defendant name <defendant_name>
+     Then I should only see <number> <state_name> claims
+
+     Examples:
+        | defendant_name | number | state_name  |
+        | "Joe Bloggs"   | 2      | "Completed" |
+        | "Fred Bloggs"  | 3      | "Completed" |
+        | "Bloggs"       | 5      | "Completed" |

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -133,7 +133,6 @@ When(/^I search by the defendant name "(.*?)"$/) do |name|
 end
 
 Then(/^I should only see the (\d+) claims involving defendant "(.*?)"$/) do |number, name|
-  # expect(page).to have_content(name, count: number.to_i)
   expect(page).to have_content(name, count: number.to_i)
 end
 

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
 
   describe "GET #index" do
     let(:tab) { nil }
-    let(:search) { nil }
-    before { get :index, tab: tab, search: search }
+    let(:maat_search_param) { nil }
+    let(:defendant_search_param) { nil }
+    before { get :index, tab: tab, search_maat: maat_search_param, search_defendant: defendant_search_param }
 
     it "returns http success" do
       expect(response).to have_http_status(:success)
@@ -36,13 +37,24 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
       end
     end
 
-    context 'search' do
-      let(:search) { '12345' }
+    context 'search by maat' do
+      let(:maat_search_param) { '12345' }
       before do
-        create(:defendant, claim_id: case_worker.claims.first.id, maat_reference: '12345')
+        create(:defendant, claim: case_worker.claims.first, maat_reference: '12345')
       end
 
       it 'finds the claims with MAAT reference "12345"' do
+        expect(assigns(:claims)).to eq([case_worker.claims.first])
+      end
+    end
+
+    context 'search by defendant' do
+      let(:defendant_search_param) { 'Joe Bloggs' }
+      before do
+        create(:defendant, claim: case_worker.claims.first, first_name: 'Joe', last_name: 'Bloggs')
+      end
+
+      it 'finds the claims with specified defendant' do
         expect(assigns(:claims)).to eq([case_worker.claims.first])
       end
     end


### PR DESCRIPTION
User requirement to enable case workers to search for their allocated
and completed claims by defendant name.
