### PR TITLE
remove irrelevant columns from advocate claims sections

### DIFF
--- a/app/views/advocates/claims/_claims.html.haml
+++ b/app/views/advocates/claims/_claims.html.haml
@@ -12,10 +12,12 @@
         Defendants
       %th
         CMS Number
-      %th
-        Submission date
-      %th
-        Paid date
+      - if claims.map(&:state).uniq != ['draft']
+        %th
+          Submission date
+      - if claims.map(&:state).uniq != ['draft'] && claims.map(&:state).uniq != ['rejected'] && claims.map(&:state).uniq != ['submitted','allocated']
+        %th
+          Paid date
       %th.currency
         Claim total
       - if claims.map(&:state).uniq == ['part_paid'] || claims.map(&:state).uniq == ['completed']

--- a/features/advocate_claims_list.feature
+++ b/features/advocate_claims_list.feature
@@ -106,3 +106,16 @@ Feature: Advocate claims list
       | "Submitted to LAA" |
       | "Part paid"        |
       | "Completed"        |
+
+  Scenario Outline: Only relevant columns visible
+    Given I am a signed in advocate
+      And I have 1 claims of each state
+     When I visit the advocates dashboard
+     Then I should NOT see column <column_name> under section id <section_id>
+
+    Examples:
+      | column_name       | section_id  |
+      | "Submission date" | "draft"     |
+      | "Paid date"       | "draft"     |
+      | "Paid date"       | "rejected"  |
+      | "Paid date"       | "submitted" |

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -189,3 +189,17 @@ end
 When (/^I hit search button$/) do
   click_button 'search'
 end
+
+Given(/^I have (\d+) claims of each state$/) do | claims_per_state |
+  # create n claims for all states except deleted and archived_pending_delete
+  states = Claim.state_machine.states.map(&:name)
+  states = states.map { |s| if s != :deleted && s != :archived_pending_delete then  s; end; }.compact
+  states.each do | state |
+    claims = create_list("#{state}_claim".to_sym, claims_per_state.to_i, advocate: @advocate)
+  end
+end
+
+Then(/^I should NOT see column "(.*?)" under section id "(.*?)"$/) do |column_name, section_id|
+  node = find("section##{section_id}").find('.claims_table')
+  expect(node).not_to have_selector('th', text: column_name)
+end


### PR DESCRIPTION
certain columns displayed in the advocate dashboard's
claims index are irrelevant for certain claim states.
These should be removed/not displayed.
