### PR TITLE
fix bug whereby table headers appear out of line

### DIFF
--- a/app/views/advocates/claims/_claims.html.haml
+++ b/app/views/advocates/claims/_claims.html.haml
@@ -36,10 +36,12 @@
           = claim.defendants.map(&:name).join(', ')
         %td
           = claim.cms_number
-        %td
-          = claim.submitted_at.strftime('%d/%m/%Y') unless claim.submitted_at.nil?
-        %td
-          = claim.paid_at.strftime('%d/%m/%Y') unless claim.paid_at.nil?
+        - if claims.map(&:state).uniq != ['draft']
+          %td
+            = claim.submitted_at.strftime('%d/%m/%Y') unless claim.submitted_at.nil?
+        - if claims.map(&:state).uniq != ['draft'] && claims.map(&:state).uniq != ['rejected'] && claims.map(&:state).uniq != ['submitted','allocated']
+          %td
+            = claim.paid_at.strftime('%d/%m/%Y') unless claim.paid_at.nil?
         %td.currency
           = number_to_currency(claim.total)
         - if claims.map(&:state).uniq == ['part_paid'] || claims.map(&:state).uniq == ['completed']


### PR DESCRIPTION
This was caused by conditional logic on table headers not
being applied to table cells.
