### PR TITLE
Consolidate advocates dashboard search with dropdown

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -79,10 +79,10 @@ class Claim < ActiveRecord::Base
   has_many :defendants,               dependent: :destroy,          inverse_of: :claim
   has_many :documents,                dependent: :destroy,          inverse_of: :claim
   has_many :messages,                 dependent: :destroy,          inverse_of: :claim
-  
+
   has_many :basic_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'BASIC'") }, class_name: 'Fee'
   has_many :non_basic_fees, -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'BASIC'") }, class_name: 'Fee'
-  
+
   default_scope do
     includes(:advocate,
              :case_workers,

--- a/app/views/advocates/claims/_search_form.html.haml
+++ b/app/views/advocates/claims/_search_form.html.haml
@@ -1,0 +1,4 @@
+= form_tag advocates_claims_path, method: :get do
+  = text_field_tag :search, params[:search], placeholder: 'Search...'
+  = select_tag :search_field, options_for_select(@search_options, params[:search_field])
+  = submit_tag 'Search', class: 'button'

--- a/app/views/advocates/claims/_search_options.html.haml
+++ b/app/views/advocates/claims/_search_options.html.haml
@@ -1,5 +1,0 @@
-= form_tag advocates_claims_path, method: :get do
-  - if current_user.persona.admin?
-    = text_field_tag :search_advocate, params[:search_advocate], placeholder: 'Advocate'
-  = text_field_tag :search_defendant, params[:search_defendant], placeholder: 'Defendant'
-  = submit_tag 'Search', id: 'search', class: 'button'

--- a/app/views/advocates/claims/index.html.haml
+++ b/app/views/advocates/claims/index.html.haml
@@ -10,7 +10,7 @@
   = render partial: 'financial_summary', locals: { financial_summary: @financial_summary }
 
 #search-options
-  = render partial: 'search_options'
+  = render partial: 'search_form'
 
 #claim-accordion
   %h2 Draft (#{@draft_claims.count})

--- a/features/advocate_claims_list.feature
+++ b/features/advocate_claims_list.feature
@@ -73,26 +73,10 @@ Feature: Advocate claims list
         | "Fred Bloggs"  | 3      |
         | "Bloggs"       | 5      |
 
- Scenario Outline: Search claims by advocate and defendant name
-  Given I am a signed in advocate admin
-    And signed in advocate's chamber has 2 claims for advocate "Fred Dibna" with defendant "Fred Bloggs"
-    And signed in advocate's chamber has 3 claims for advocate "Joe Adlott" with defendant "Joe Bloggs"
-   When I visit the advocates dashboard
-    And I enter advocate name of <advocate_name>
-    And I enter defendant name of <defendant_name>
-    And I hit search button
-   Then I should only see the <claim_count> claims involving defendant <defendant_name>
-
-   Examples:
-      | advocate_name | defendant_name | claim_count |
-      | "Fred Dibna"  | "Joe Bloggs"   | 0           |
-      | "Fred Dibna"  | "Fred Bloggs"  | 2           |
-      | "Joe Adlott"  | "Joe Bloggs"   | 3           |
-
   Scenario: No search by advocate name for non-admin
     Given I am a signed in advocate
      When I visit the advocates dashboard
-     Then I should not see the advocate search field
+     Then I should not see the advocate search option
 
   Scenario Outline: Claims section titles
     Given I am a signed in advocate

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -122,21 +122,25 @@ Then(/^I should see my chamber's (\d+) "(.*?)" claims$/) do |number, state|
 end
 
 When(/^I search by the advocate name "(.*?)"$/) do |name|
-  fill_in 'search_advocate', with: name
-  click_button 'search'
+  select 'Advocate', from: 'search_field'
+  fill_in 'search', with: name
+  click_button 'Search'
 end
 
 Then(/^I should only see the (\d+) claims for the advocate "(.*?)"$/) do |number, name|
   expect(page).to have_content(name, count: number.to_i)
 end
 
-Then(/^I should not see the advocate search field$/) do
-  expect(page).to_not have_selector('#search_advocate')
+Then(/^I should not see the advocate search option$/) do
+  within '#search_field' do
+    expect(page).to_not have_content('Advocate')
+  end
 end
 
 When(/^I search by the defendant name "(.*?)"$/) do |name|
-  fill_in 'search_defendant', with: name
-  click_button 'search'
+  select 'Defendant', from: 'search_field'
+  fill_in 'search', with: name
+  click_button 'Search'
 end
 
 Then(/^I should only see the (\d+) claims involving defendant "(.*?)"$/) do |number, name|
@@ -185,16 +189,13 @@ Given(/^signed in advocate's chamber has (\d+) claims for advocate "(.*?)" with 
   end
 end
 
-When(/^I enter advocate name of "(.*?)"$/) do |name|
-  fill_in 'search_advocate', with: name
-end
-
-When(/^I enter defendant name of "(.*?)"$/) do |name|
-  fill_in 'search_defendant', with: name
+When(/^I enter the search term "(.*?)"$/) do |name|
+  select 'All', from: 'search_field'
+  fill_in 'search', with: name
 end
 
 When (/^I hit search button$/) do
-  click_button 'search'
+  click_button 'Search'
 end
 
 Given(/^I have (\d+) claims of each state$/) do | claims_per_state |


### PR DESCRIPTION
Replace multiple search fields on advocates dashboard with dropdown to constrain search,
