### PR TITLE
Caseworker claim allocation ordering

### DIFF
--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -10,7 +10,7 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
   def edit; end
 
   def allocate
-    @claims = Claim.non_draft
+    @claims = Claim.non_draft.order(created_at: :asc)
   end
 
   def new

--- a/features/claim_allocation.feature
+++ b/features/claim_allocation.feature
@@ -18,3 +18,9 @@ Feature: Claim allocation
       And I allocate claims
      When I remove the caseworker
      Then the claims should not be assigned to any case workers
+
+  Scenario: Newly submitted claims are added to the bottom of the allocation list
+    Given a new claim has been submitted
+     When I visit the case worker allocation page
+     Then I should see the new claim at the bottom of the list
+

--- a/features/step_definitions/claim_allocation_steps.rb
+++ b/features/step_definitions/claim_allocation_steps.rb
@@ -55,3 +55,11 @@ Then(/^the claims should be in an allocated state$/) do
   expect(@allocated_claim_1.reload).to be_allocated
   expect(@allocated_claim_2.reload).to be_allocated
 end
+
+Given(/^a new claim has been submitted$/) do
+  @claim = create(:submitted_claim)
+end
+
+Then(/^I should see the new claim at the bottom of the list$/) do
+  expect(all("input[type='checkbox']").last[:id]).to eq("case_worker_claim_ids_#{@claim.id}")
+end

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController, type: :controller do
     end
 
     it 'assigns @claims' do
-      expect(assigns(:claims)).to eq(Claim.non_draft)
+      expect(assigns(:claims)).to eq(Claim.non_draft.order(created_at: :asc))
     end
 
     it 'renders the template' do


### PR DESCRIPTION
Claim allocation places newest submitted claims at the bottom of the list.
