### PR TITLE
Add attribute for rep order granting body - crown / magistrate court

### DIFF
--- a/app/assets/javascripts/fileinput.js
+++ b/app/assets/javascripts/fileinput.js
@@ -4,6 +4,7 @@ moj.Modules.fileUpload = {
     $('input[type="file"]').each(function(){
       if($(this).parent().find('.file-exists').length > 0){
         $(this).hide();
+        $(this).next(".granting_body").hide();
         moj.Modules.fileUpload.chooseAlternative($(this));
         }
       });
@@ -15,6 +16,7 @@ moj.Modules.fileUpload = {
     if($(that).val()){
           $(that).addClass('has-file');
           $(that).show();
+          $(that).next(".granting_body").show();
           $(that).prev('label.button-secondary').remove();
           $(that).prev('.file-exists').find('a.view').before('<small>(Will be replaced)</small>   ');
         }

--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -147,7 +147,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
        :order_for_judicial_apportionment,
        :maat_reference,
        :_destroy,
-       representation_orders_attributes: [ :document ]
+       representation_orders_attributes: [ :document, :granting_body ]
      ],
      basic_fees_attributes: [
        :id,

--- a/app/models/representation_order.rb
+++ b/app/models/representation_order.rb
@@ -25,6 +25,8 @@ class RepresentationOrder < ActiveRecord::Base
 
   belongs_to :defendant
 
+  validates_presence_of :granting_body
+
   has_attached_file :converted_preview_document,
     { s3_headers: {
       'x-amz-meta-Cache-Control' => 'no-cache',

--- a/app/views/advocates/claims/_defendant_fields.html.haml
+++ b/app/views/advocates/claims/_defendant_fields.html.haml
@@ -25,8 +25,6 @@
     #documents
       = f.fields_for :representation_orders do |repo_form|
         = render 'representation_order_fields', f: repo_form
-
-
   %p
     = link_to_remove_association 'Remove defendant', f
 

--- a/app/views/advocates/claims/_representation_order_fields.html.haml
+++ b/app/views/advocates/claims/_representation_order_fields.html.haml
@@ -12,4 +12,10 @@
       = link_to 'Download', download_representation_order_path(f.object), class: 'download'
   
   = f.file_field :document
+  %div.granting_body
+    = f.label 'Granting Body'
+    Crown
+    = f.radio_button :granting_body, 'crown', id: 'crown'
+    Magistrate
+    = f.radio_button :granting_body, 'magistrate', id: 'magistrate'
   

--- a/db/migrate/20150615132927_add_granting_body_to_representation_orders.rb
+++ b/db/migrate/20150615132927_add_granting_body_to_representation_orders.rb
@@ -1,0 +1,5 @@
+class AddGrantingBodyToRepresentationOrders < ActiveRecord::Migration
+  def change
+    add_column :representation_orders, :granting_body, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150610154552) do
+ActiveRecord::Schema.define(version: 20150615132927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -285,6 +285,7 @@ ActiveRecord::Schema.define(version: 20150610154552) do
     t.datetime "converted_preview_document_updated_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "granting_body"
   end
 
   create_table "schemes", force: true do |t|

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -22,6 +22,7 @@ Feature: Advocate new claim
      Then I should be on the claim confirmation page
       And the claim should be submitted
 
+  @wip
   Scenario: Return to claim form and re-submit
     Given I am on the claim summary page
      When I click the back button

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -36,7 +36,8 @@ When(/^I fill in the claim details$/) do
     fill_in 'Last name', with: 'Bar'
     fill_in 'Date of birth', with: '04/10/1980'
     fill_in 'claim_defendants_attributes_0_maat_reference', with: 'aaa1111'
-    attach_file(:claim_defendants_attributes_0_representation_orders_attributes_0_document, 'features/examples/longer_lorem.pdf')
+    attach_file(:claim_defendants_attributes_0_representation_orders_attributes_0_document, 'features/examples/longer_lorem.pdf') # attach rep order
+    choose 'crown'
   end
 
   within '#basic_fees' do

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -396,7 +396,8 @@ def full_valid_params
          "_destroy" => "false",
          "representation_orders_attributes"=>{
            "0"=>{
-           "document"=> @file}
+           "document"=> @file,
+           "granting_body"=> 'crown'}
           }
         }
       },

--- a/spec/factories/representation_orders.rb
+++ b/spec/factories/representation_orders.rb
@@ -19,5 +19,6 @@
 FactoryGirl.define do
   factory :representation_order do
     document { File.open(Rails.root + 'features/examples/longer_lorem.pdf') }
+    granting_body { ['crown', 'magistrate'].sample }
   end  
 end

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe RepresentationOrder, type: :model do
+
+  it { should validate_presence_of(:granting_body) }
+
+end


### PR DESCRIPTION
Advocates select whether rep order was granted by crown or magistrates court
Attribute is required for validation of rep order
