### PR TITLE
Require an S3 bucket name to be set for Paperclip in production envs.

### DIFF
--- a/config/aws.yml
+++ b/config/aws.yml
@@ -5,6 +5,7 @@ default: &default
 
 production:
   <<: *default
+  bucket: <%= ENV.fetch('adp_bucket_name') %>
 
 development:
   <<: *default


### PR DESCRIPTION
We can sort of have a sane default for develop and test, but on
production we require this to be set as the app shouldn't run without
this set correctly
