### PR TITLE
Fix ping.json

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -2,14 +2,12 @@ class PingController  < ApplicationController
   respond_to :json
 
   def index
-    Rails.logger.silence do
       respond_with(
         {
           'Build Number' => ENV['BUILD_NUMBER'] || "Not Avaialble",
-          'Build Date'   => ENV['BUILD_ID'] || 'Not Available',
+          'Build Date'   => ENV['BUILD_DATE'] || 'Not Available',
           'Commit SHA'   => ENV['GIT_COMMIT'] || 'Not Available'
         }
       )
-    end
   end
 end

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,6 +5,7 @@ set -e
 echo "DEBUG:run.sh:BUILD_NUMBER:${BUILD_NUMBER}"
 echo "DEBUG:run.sh:GIT_COMMIT:${GIT_COMMIT}"
 echo "DEBUG:run.sh:BUILD_ID:${BUILD_ID}"
+echo "DEBUG:run.sh:BUILD_DATE:${BUILD_DATE}"
 
 case ${DOCKER_STATE} in
 migrate)


### PR DESCRIPTION
Code had been copied from another project and did not work.
Variable BUILD_ID no longer contains build timestamp, therefore using shell on Jenkins server to get it.
