### PR TITLE
Rspec profiling

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -10,7 +10,6 @@ class Advocates::ClaimsController < Advocates::ApplicationController
 
   def index
     claims = @context.claims.order(created_at: :desc)
-
     params[:search_field] ||= 'Defendant'
 
     if params[:search].present?
@@ -23,14 +22,12 @@ class Advocates::ClaimsController < Advocates::ApplicationController
           claims.search(:defendant_name, params[:search])
       end
     end
-
     @claims = claims
-
-    @draft_claims     = claims.advocate_dashboard_draft
-    @rejected_claims  = claims.advocate_dashboard_rejected
-    @submitted_claims = claims.advocate_dashboard_submitted
-    @part_paid_claims = claims.advocate_dashboard_part_paid
-    @completed_claims = claims.advocate_dashboard_completed
+    @draft_claims = @claims.select(&:advocate_dashboard_draft?)
+    @rejected_claims = @claims.select(&:advocate_dashboard_rejected?)
+    @submitted_claims = @claims.select(&:advocate_dashboard_submitted?)
+    @part_paid_claims = @claims.select(&:advocate_dashboard_part_paid?)
+    @completed_claims = @claims.select(&:advocate_dashboard_completed?)
   end
 
   def outstanding

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -156,6 +156,18 @@ class Claim < ActiveRecord::Base
 
   end
 
+  # responds to methods like claim.advocate_dashboard_submitted? which correspond to the constant ADVOCATE_DASHBOARD_REJECTED_STATES in Claims::StateMachine
+  def method_missing(method, *args)
+    if Claims::StateMachine.has_state?(method)
+      Claims::StateMachine.is_in_state?(method, self)
+    else
+      super
+    end
+  end
+
+
+
+
   def self.attrs_blank?(attributes)
     attributes['quantity'].blank? && attributes['rate'].blank? && attributes['amount'].blank?
   end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -2,6 +2,32 @@ module Claims::StateMachine
   ARCHIVE_VALIDITY = 180.days
   STANDARD_VALIDITY = 21.days
 
+  ADVOCATE_DASHBOARD_DRAFT_STATES         = [ 'draft' ]
+  ADVOCATE_DASHBOARD_REJECTED_STATES      = [ 'rejected' ]
+  ADVOCATE_DASHBOARD_SUBMITTED_STATES     = [ 'allocated', 'submitted', 'awaiting_info_from_court', 'awaiting_further_info' ]
+  ADVOCATE_DASHBOARD_PART_PAID_STATES     = [ 'part_paid', 'appealed', 'parts_rejected' ]
+  ADVOCATE_DASHBOARD_COMPLETED_STATES     = [ 'completed', 'refused' ]
+
+
+  # will return true if there is a constant defined in this class with the same name in upper case as method with the trailing question mark removed
+  def self.has_state?(method)
+    return false unless method =~ /\?$/
+    const_defined?("#{method.to_s.chop.upcase}_STATES")
+  end
+
+
+  def self.is_in_state?(method, claim)
+    begin
+      konstant_name = "Claims::StateMachine::#{method.to_s.chop.upcase}_STATES".constantize
+      konstant_name.include?(claim.state)
+    rescue NameError
+      return false
+    end
+
+  end
+
+
+
   def self.included(klass)
     klass.state_machine :state,                      initial: :draft do
       after_transition on: :submit,                  do: :set_submission_date!
@@ -83,11 +109,11 @@ module Claims::StateMachine
     klass.scope :non_draft, -> { klass.where(state: ['allocated', 'appealed', 'awaiting_further_info', 'awaiting_info_from_court', 'completed',
          'deleted', 'paid', 'part_paid', 'parts_rejected', 'refused', 'rejected', 'submitted']) }
 
-    klass.scope :advocate_dashboard_draft,      -> { klass.where(state: 'draft') }
-    klass.scope :advocate_dashboard_rejected,   -> { klass.where(state: 'rejected') }
-    klass.scope :advocate_dashboard_submitted,  -> { klass.where(state: ['allocated', 'submitted', 'awaiting_info_from_court', 'awaiting_further_info']) }
-    klass.scope :advocate_dashboard_part_paid,  -> { klass.where(state: ['part_paid', 'appealed', 'parts_rejected']) }
-    klass.scope :advocate_dashboard_completed,  -> { klass.where(state: ['completed', 'refused' ]) }
+    klass.scope :advocate_dashboard_draft,      -> { klass.where(state: ADVOCATE_DASHBOARD_DRAFT_STATES ) }
+    klass.scope :advocate_dashboard_rejected,   -> { klass.where(state: ADVOCATE_DASHBOARD_REJECTED_STATES ) }
+    klass.scope :advocate_dashboard_submitted,  -> { klass.where(state: ADVOCATE_DASHBOARD_SUBMITTED_STATES ) }
+    klass.scope :advocate_dashboard_part_paid,  -> { klass.where(state: ADVOCATE_DASHBOARD_PART_PAID_STATES ) }
+    klass.scope :advocate_dashboard_completed,  -> { klass.where(state: ADVOCATE_DASHBOARD_COMPLETED_STATES ) }
 
   end
 

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -18,24 +18,33 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
     end
   end
 
-  describe "GET #index" do
+  describe 'GET #index' do
     before(:each) do
-      @allocated_claim                = FactoryGirl.create :allocated_claim, advocate: advocate
-      @appealed_claim                 = FactoryGirl.create :appealed_claim, advocate: advocate
-      @archived_pending_delete_claim  = FactoryGirl.create :archived_pending_delete_claim, advocate: advocate
-      @awaiting_further_info_claim    = FactoryGirl.create :awaiting_further_info_claim, advocate: advocate
-      @awaiting_info_from_court_claim = FactoryGirl.create :awaiting_info_from_court_claim, advocate: advocate
-      @completed_claim                = FactoryGirl.create :completed_claim, advocate: advocate
-      @draft_claim                    = FactoryGirl.create :draft_claim, advocate: advocate
-      @part_paid_claim                = FactoryGirl.create :part_paid_claim, advocate: advocate
-      @parts_rejected_claim           = FactoryGirl.create :parts_rejected_claim, advocate: advocate
-      @refused_claim                  = FactoryGirl.create :refused_claim, advocate: advocate
-      @rejected_claim                 = FactoryGirl.create :rejected_claim, advocate: advocate
-      @submitted_claim                = FactoryGirl.create :submitted_claim, advocate: advocate
+      @allocated_claim                = build_claim_in_state(:allocated)
+      @appealed_claim                 = build_claim_in_state(:appealed)
+      @archived_pending_delete_claim  = build_claim_in_state(:archived_pending_delete)
+      @awaiting_further_info_claim    = build_claim_in_state(:awaiting_further_info)
+      @awaiting_info_from_court_claim = build_claim_in_state(:awaiting_info_from_court)
+      @completed_claim                = build_claim_in_state(:completed)
+      @draft_claim                    = build_claim_in_state(:draft)
+      @part_paid_claim                = build_claim_in_state(:part_paid)
+      @parts_rejected_claim           = build_claim_in_state(:parts_rejected)
+      @refused_claim                  = build_claim_in_state(:refused)
+      @rejected_claim                 = build_claim_in_state(:rejected)
+      @submitted_claim                = build_claim_in_state(:submitted)
     end
 
+    let(:full_collection)  { [  @allocated_claim, @appealed_claim, @archived_pending_delete_claim, 
+                                @awaiting_further_info_claim, @awaiting_info_from_court_claim, @completed_claim,
+                                @draft_claim, @part_paid_claim, @parts_rejected_claim, @refused_claim, 
+                                @rejected_claim, @submitted_claim ] }
+
     context 'advocate' do
-      it 'should categorise the claims' do
+      it 'should categorise the claims for the advocate' do
+        query_result = double 'QueryResult'
+        expect(controller.current_user).to receive(:claims).and_return(query_result)
+        allow(query_result).to receive(:order).and_return(full_collection)
+
         get :index
 
         expect(response).to have_http_status(:success)
@@ -53,56 +62,28 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
     end
 
     context 'advocate admin' do
-      let(:other_chamber)                   { create(:chamber) }
+
       let(:advocate_admin)                  { create(:advocate, :admin, chamber_id: advocate.chamber.id) }
-      let(:advocate_in_same_chamber)        { create(:advocate, chamber_id: advocate.chamber.id) }
-      let(:advocate_in_different_chamber)   { create(:advocate, :admin, chamber_id: other_chamber.id) }
 
-      before(:each) do
-        @allocated_claim_2                = FactoryGirl.create :allocated_claim, advocate: advocate_in_same_chamber
-        @appealed_claim_2                 = FactoryGirl.create :appealed_claim, advocate: advocate_in_same_chamber
-        @archived_pending_delete_claim_2  = FactoryGirl.create :archived_pending_delete_claim, advocate: advocate_in_same_chamber
-        @awaiting_further_info_claim_2    = FactoryGirl.create :awaiting_further_info_claim, advocate: advocate_in_same_chamber
-        @awaiting_info_from_court_claim_2 = FactoryGirl.create :awaiting_info_from_court_claim, advocate: advocate_in_same_chamber
-        @completed_claim_2                = FactoryGirl.create :completed_claim, advocate: advocate_in_same_chamber
-        @draft_claim_2                    = FactoryGirl.create :draft_claim, advocate: advocate_in_same_chamber
-        @part_paid_claim_2                = FactoryGirl.create :part_paid_claim, advocate: advocate_in_same_chamber
-        @parts_rejected_claim_2           = FactoryGirl.create :parts_rejected_claim, advocate: advocate_in_same_chamber
-        @refused_claim_2                  = FactoryGirl.create :refused_claim, advocate: advocate_in_same_chamber
-        @rejected_claim_2                 = FactoryGirl.create :rejected_claim, advocate: advocate_in_same_chamber
-        @submitted_claim_2                = FactoryGirl.create :submitted_claim, advocate: advocate_in_same_chamber
-
-        @allocated_claim_3                = FactoryGirl.create :allocated_claim, advocate: advocate_in_different_chamber
-        @appealed_claim_3                 = FactoryGirl.create :appealed_claim, advocate: advocate_in_different_chamber
-        @archived_pending_delete_claim_3  = FactoryGirl.create :archived_pending_delete_claim, advocate: advocate_in_different_chamber
-        @awaiting_further_info_claim_3    = FactoryGirl.create :awaiting_further_info_claim, advocate: advocate_in_different_chamber
-        @awaiting_info_from_court_claim_3 = FactoryGirl.create :awaiting_info_from_court_claim, advocate: advocate_in_different_chamber
-        @completed_claim_3                = FactoryGirl.create :completed_claim, advocate: advocate_in_different_chamber
-        @draft_claim_3                    = FactoryGirl.create :draft_claim, advocate: advocate_in_different_chamber
-        @part_paid_claim_3                = FactoryGirl.create :part_paid_claim, advocate: advocate_in_different_chamber
-        @parts_rejected_claim_3           = FactoryGirl.create :parts_rejected_claim, advocate: advocate_in_different_chamber
-        @refused_claim_3                  = FactoryGirl.create :refused_claim, advocate: advocate_in_different_chamber
-        @rejected_claim_3                 = FactoryGirl.create :rejected_claim, advocate: advocate_in_different_chamber
-        @submitted_claim_3                = FactoryGirl.create :submitted_claim, advocate: advocate_in_different_chamber
-
+      it 'should categorise claims for the chamber' do
         sign_in advocate_admin.user
-      end
-
-      it 'should categorise claims from the same chamber and exclude those from another chamber' do
+        query_result = double 'QueryResult'
+        expect(controller.current_user.persona.chamber).to receive(:claims).and_return(query_result)
+        allow(query_result).to receive(:order).and_return(full_collection)
+      
         get :index
 
         expect(response).to have_http_status(:success)
-
-        expect(assigns(:draft_claims)).to contain_claims( @draft_claim, @draft_claim_2 )
-        expect(assigns(:rejected_claims)).to contain_claims( @rejected_claim, @rejected_claim_2 )
-        expect(assigns(:submitted_claims)).to contain_claims( @allocated_claim, @allocated_claim_2,
-                                                              @submitted_claim, @submitted_claim_2,
-                                                              @awaiting_info_from_court_claim, @awaiting_info_from_court_claim_2,
-                                                              @awaiting_further_info_claim, @awaiting_further_info_claim_2)
-        expect(assigns(:part_paid_claims)).to contain_claims( @part_paid_claim, @part_paid_claim_2,
-                                                              @appealed_claim, @appealed_claim_2,
-                                                              @parts_rejected_claim, @parts_rejected_claim_2)
-        expect(assigns(:completed_claims)).to contain_claims( @completed_claim, @completed_claim_2, @refused_claim, @refused_claim_2 )
+        expect(assigns(:draft_claims)).to contain_claims( @draft_claim )
+        expect(assigns(:rejected_claims)).to contain_claims( @rejected_claim )
+        expect(assigns(:submitted_claims)).to contain_claims( @allocated_claim,
+                                                              @submitted_claim,
+                                                              @awaiting_info_from_court_claim,
+                                                              @awaiting_further_info_claim)
+        expect(assigns(:part_paid_claims)).to contain_claims( @part_paid_claim,
+                                                              @appealed_claim,
+                                                              @parts_rejected_claim)
+        expect(assigns(:completed_claims)).to contain_claims( @completed_claim, @refused_claim )
       end
     end
 
@@ -474,5 +455,14 @@ def valid_claim_fee_params
      "apply_vat" => "0"
    }
 end
+
+
+
+def build_claim_in_state(state)
+  claim = FactoryGirl.build :unpersisted_claim
+  allow(claim).to receive(:state).and_return(state.to_s)
+  claim
+end
+
 
 

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -55,6 +55,12 @@ FactoryGirl.define do
       end
     end
 
+    factory :unpersisted_claim do
+      court         { FactoryGirl.build :court }
+      advocate      { FactoryGirl.build :advocate, chamber: FactoryGirl.build(:chamber) }
+      offence       { FactoryGirl.build :offence, offence_class: FactoryGirl.build(:offence_class) }
+    end
+
     factory :invalid_claim do
       case_type 'invalid case type'
     end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -54,6 +54,101 @@ RSpec.describe Claim, type: :model do
   it { should have_many(:document_type_claims) }
   it { should have_many(:document_types) }
 
+
+
+  context 'State Machine meta states magic methods' do
+    let(:claim)       { FactoryGirl.build :claim }
+    let(:all_states)  { [  'allocated', 'appealed', 'archived_pending_delete', 'awaiting_further_info', 'awaiting_info_from_court', 'completed',
+                           'deleted', 'draft', 'paid', 'part_paid', 'parts_rejected', 'refused', 'rejected', 'submitted' ] }
+
+    context 'advocate_dashboard_draft?' do
+      before(:each)     { allow(claim).to receive(:state).and_return('draft') }
+
+      it 'should respond true in draft' do
+        allow(claim).to receive(:state).and_return('draft')
+        expect(claim.advocate_dashboard_draft?).to be true
+      end
+
+      it 'should respond false to anything else' do
+        (all_states - ['draft']).each do |state|
+          allow(claim).to receive(:state).and_return(state)
+          expect(claim.advocate_dashboard_draft?).to be false
+        end
+      end
+    end
+
+    context 'advocate_dashboard_rejected?' do
+      before(:each)     { allow(claim).to receive(:state).and_return('rejected') }
+      it 'should respond true' do
+        allow(claim).to receive(:state).and_return('rejected')
+        expect(claim.advocate_dashboard_rejected?).to be true
+      end
+
+      it 'should respond false to anything else' do
+        (all_states - ['rejected']).each do |state|
+          allow(claim).to receive(:state).and_return(state)
+          expect(claim.advocate_dashboard_rejected?).to be false
+        end
+      end
+    end
+
+    context 'advocate_dashboard_submitted?' do
+      it 'should respond true' do
+        [ 'allocated', 'submitted', 'awaiting_info_from_court', 'awaiting_further_info' ].each do |claim_state|
+          allow(claim).to receive(:state).and_return(claim_state)
+          expect(claim.advocate_dashboard_submitted?).to be true
+        end
+      end
+
+      it 'should respond false to anything else' do
+        (all_states - [ 'allocated', 'submitted', 'awaiting_info_from_court', 'awaiting_further_info' ]).each do |claim_state|
+          allow(claim).to receive(:state).and_return(claim_state)
+          expect(claim.advocate_dashboard_submitted?).to be false
+        end
+      end
+    end
+
+    context 'advocate_dashboard_part_paid' do
+      it 'should respond true' do
+        [ 'part_paid', 'appealed', 'parts_rejected' ].each do |state|
+          allow(claim).to receive(:state).and_return(state)
+          expect(claim.advocate_dashboard_part_paid?).to be true
+        end
+      end
+
+      it 'should respond false to anything else' do
+        (all_states - [ 'part_paid', 'appealed', 'parts_rejected' ]).each do |claim_state|
+          allow(claim).to receive(:state).and_return(claim_state)
+          expect(claim.advocate_dashboard_part_paid?).to be false
+        end
+      end
+    end
+
+    context 'advocate_dashboard_completed_states' do
+      it 'should respond true' do
+        [ 'completed', 'refused' ].each do |state|
+          allow(claim).to receive(:state).and_return(state)
+          expect(claim.advocate_dashboard_completed?).to be true
+        end
+      end
+
+      it 'should respond false to anything else' do
+        (all_states - [ 'completed', 'refused' ]).each do |claim_state|
+          allow(claim).to receive(:state).and_return(claim_state)
+          expect(claim.advocate_dashboard_completed?).to be false
+        end
+      end
+    end
+
+    context 'unrecognised state' do
+      it 'should raise NoMethodError' do
+        expect {
+          claim.other_unknown_state?
+        }.to raise_error NoMethodError, /undefined method `other_unknown_state\?'/
+      end
+    end
+  end
+
   describe 'validations' do
 
     context 'draft' do


### PR DESCRIPTION
- Allow claims to respond to methods like advocate_dashboard_draft?, advocate_dashboard_rejected?
- Ensure claims controller selects categories of claims from the correct context instead of re-reading from the database
- make claims controller specs use unpersisted models in order to speed things up
