### PR TITLE
Transition claim to "allocated" state when assigned to case worker

### DIFF
--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -51,7 +51,6 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
 
   def update
     if @case_worker.update(case_worker_params)
-      @case_worker.claims.each { |claim| claim.allocate! if claim.submitted? }
       redirect_to case_workers_admin_case_workers_url, notice: 'Case worker successfully updated'
     else
       render :edit

--- a/app/models/case_worker_claim.rb
+++ b/app/models/case_worker_claim.rb
@@ -14,6 +14,7 @@ class CaseWorkerClaim < ActiveRecord::Base
   belongs_to :claim
 
   after_create :generate_message_statuses
+  after_create :set_claim_allocated!
 
   private
 
@@ -23,5 +24,9 @@ class CaseWorkerClaim < ActiveRecord::Base
     messages.each do |message|
       UserMessageStatus.create!(user_id: user.id, message_id: message.id)
     end
+  end
+
+  def set_claim_allocated!
+    claim.allocate! if claim.submitted?
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -626,4 +626,13 @@ RSpec.describe Claim, type: :model do
 
   end
 
+  describe 'allocate claim when assigning to case worker' do
+    subject { create(:submitted_claim) }
+    let(:case_worker) { create(:case_worker) }
+
+    it 'set the claim to "allocated" when assigned to case worker' do
+      subject.case_workers << case_worker
+      expect(subject.reload).to be_allocated
+    end
+  end
 end


### PR DESCRIPTION
Fixes bug by handling allocated state transition with a callback on CaseWorkerClaim rather than in the CaseWorkerController#allocated action.
