### PR TITLE
Changes to run.sh relating to ping.json variables

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -e
 
-[ -e ping_data.sh ] && source ping_data.sh
-echo "DEBUG:run.sh:BUILD_NUMBER:${BUILD_NUMBER}"
-echo "DEBUG:run.sh:GIT_COMMIT:${GIT_COMMIT}"
-echo "DEBUG:run.sh:BUILD_ID:${BUILD_ID}"
-echo "DEBUG:run.sh:BUILD_DATE:${BUILD_DATE}"
-
 case ${DOCKER_STATE} in
 migrate)
     echo "running migrate"


### PR DESCRIPTION
  Variables consumed by ping.json are passed directly
  within the Dockerfile (added on the fly by the Jenkins build job).
