### PR TITLE
Update claim remark without state transition triggering

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -254,7 +254,7 @@ class Claim < ActiveRecord::Base
   def update_model_and_transition_state(params)
     new_state = params.delete('state_for_form')
     self.update(params)
-    self.state_for_form = new_state
+    self.state_for_form = new_state unless self.state_for_form == new_state || new_state.blank?
   end
 
   private

--- a/features/claim_status.feature
+++ b/features/claim_status.feature
@@ -25,6 +25,16 @@ Scenario Outline: Update claim status
       | "Rejected"  		| "" 		 	 | "Rejected remark" 	   |
       | "Awaiting info from court"      | ""       | "Awaiting info from Court remark" |
 
+Scenario: Update claim remark without updating status
+  Given I am a signed in case worker
+    And claims have been assigned to me
+   When I visit my dashboard
+    And I view status details for a claim
+    And I enter remark "Test remark"
+    And I press update button
+    And I should see "enabled" remark "Test remark"
+    And the claim state should be allocated
+
 Scenario Outline: View claim status
     Given I am a signed in advocate
       And I have 3 allocated claims whos status is <status> with amount assessed of <amount> and remark of <remark>

--- a/features/step_definitions/claim_status_steps.rb
+++ b/features/step_definitions/claim_status_steps.rb
@@ -63,3 +63,7 @@ end
 Then(/^I should see an image tag with source "(.*?)" against that claim$/) do |image_source|
 	expect(find('.status-indicator')['src'].include?(image_source)).to eql(true)
 end
+
+When(/^the claim state should be allocated$/) do
+  expect(Claim.all.pluck(:state).uniq).to eq(['allocated'])
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -231,6 +231,20 @@ RSpec.describe Claim, type: :model do
       #then
       expect(claim.reload.state).to eq 'part_paid'
     end
+
+    it 'should not transition when "state_for_form" is the same as the claim\'s state' do
+      claim = FactoryGirl.create :paid_claim
+      claim_params = {"state_for_form"=>"paid", "amount_assessed"=>"88.55", "additional_information"=>""}
+      claim.update_model_and_transition_state(claim_params)
+      expect(claim.reload.state).to eq('paid')
+    end
+
+    it 'should not transition when "state_for_form" is blank' do
+      claim = FactoryGirl.create :paid_claim
+      claim_params = {"state_for_form"=>"", "amount_assessed"=>"88.55", "additional_information"=>""}
+      claim.update_model_and_transition_state(claim_params)
+      expect(claim.reload.state).to eq('paid')
+    end
   end
 
   context 'amount_assessed validation' do


### PR DESCRIPTION
Do not transition state if state for form value passed is the same as current state or blank.
