### PR TITLE
fix 'moving Add Date Attended Buttons'- bug where buttons would appea…

### DIFF
--- a/app/views/advocates/claims/_fee_fields.html.haml
+++ b/app/views/advocates/claims/_fee_fields.html.haml
@@ -8,9 +8,9 @@
   %td.amount
     &nbsp; 
   %td
-    = f.fields_for :dates_attended do |date_attended|
-      = render 'date_attended_fields', f: date_attended
     = link_to_add_association 'Add Date Attended', f, :dates_attended, class: 'button-secondary', data: {'association-insertion-method' => 'after', 'association-insertion-traversal' => 'closest', 'association-insertion-node' => 'tr'}
-
   %td
     = link_to_remove_association 'Remove', f
+    
+  = f.fields_for :dates_attended do |date_attended|
+    = render 'date_attended_fields', f: date_attended


### PR DESCRIPTION
…r in wrong place
- It would seem that the extra rows for attendance dates were being inserted in the wrong place, pushing the Add Date Attended buttons out of the table
- I moved the lines which render the _date_attended_fields partial to the end of the _fee_fields partial and this seems to have worked
