### PR TITLE
Fix to prevent tests relying on specific record ids

### DIFF
--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -27,7 +27,7 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
     add_breadcrumb @case_worker.name, case_workers_admin_case_worker_path(@case_worker)
     add_breadcrumb 'Allocate', allocate_case_workers_admin_case_worker_path(@case_worker)
 
-    @claims = Claim.unscope(:includes).includes([:defendants, :advocate, :court, :case_workers]).non_draft.order(created_at: :asc)
+    @claims = Claim.unscope(:includes).includes( [ {:defendants => :representation_orders}, :advocate, :court, :case_workers ] ).non_draft.order(created_at: :asc)
   end
 
   def new

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -18,7 +18,7 @@ Given(/^I am on the new claim page$/) do
   create(:fee_type, :basic, description: 'Basic Fee')
   create(:fee_type, :basic, description: 'Other Basic Fee')
   create(:expense_type, name: 'Travel')
-  create(:document_type, id: 1, description: 'Representation Order')
+  create(:document_type, description: 'Representation Order')
   visit new_advocates_claim_path
 end
 
@@ -69,7 +69,9 @@ When(/^I fill in the claim details$/) do
   end
 
   within 'table#evidence-checklist' do
-    check 'claim_document_type_ids_1'
+    element = find('td label', text: "Representation Order")
+    checkbox_id = element[:for]
+    check checkbox_id
   end
 
   select 'Other', from: 'claim_documents_attributes_0_document_type_id'


### PR DESCRIPTION
Tests were occasionally failing because a record was being created with a specific id so that the element could later be paid on the page, but if a record with that id already existed in the DB, the test failed.  This fix does it another way.
