### PR TITLE
remove unused Timecop from fee presenter spec

### DIFF
--- a/spec/presenters/fee_presenter_spec.rb
+++ b/spec/presenters/fee_presenter_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe FeePresenter do
 
-  before { Timecop.freeze(Time.current) }
-  after { Timecop.return }
-
-  let(:frozen_time)   { Time.current }
   let(:claim)         { create(:claim) }
   let(:fee_type)      { create(:fee_type, description: 'Basic fee type C') }
   let(:fee)           { create(:fee, quantity: 4, rate: 5.40, claim: claim, fee_type: fee_type) }


### PR DESCRIPTION
just forgot to remove Timecop from a spec where i had been using it during development
