### PR TITLE
Exclude inapplicable states from search

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -103,15 +103,18 @@ class Advocates::ClaimsController < Advocates::ApplicationController
 
   def search
     params[:search_field] ||= 'Defendant'
+    @claims = @claims.search(*search_option_mappings[params[:search_field]], params[:search])
+  end
 
-    @claims = case params[:search_field]
-      when 'All'
-        @claims.search(:advocate_name, :defendant_name, params[:search])
-      when 'Advocate'
-        @claims.search(:advocate_name, params[:search])
-      when 'Defendant'
-        @claims.search(:defendant_name, params[:search])
-    end
+  def search_option_mappings
+    option_mappings = {
+      'All'       => [:defendant_name],
+      'Advocate'  => [:advocate_name],
+      'Defendant' => [:defendant_name]
+    }
+
+    option_mappings['All'] << :advocate_name if current_user.persona.admin?
+    option_mappings
   end
 
   def set_state_claims

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -48,7 +48,6 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
     }
 
     option_mappings['All'] << :case_worker_name_or_email if current_user.persona.admin?
-
     option_mappings
   end
 

--- a/app/models/claims/search.rb
+++ b/app/models/claims/search.rb
@@ -1,4 +1,5 @@
 module Claims::Search
+
   QUERY_MAPPINGS_FOR_SEARCH = {
     defendant_name: {
       joins: :defendants,
@@ -23,6 +24,6 @@ module Claims::Search
     sql = options.inject([]) { |r, o| r << "(#{QUERY_MAPPINGS_FOR_SEARCH[o][:query]})" }.join(' OR ')
     relation = options.inject(all) { |r, o| r = r.joins(QUERY_MAPPINGS_FOR_SEARCH[o][:joins]) }
 
-    relation.where(sql, term: "%#{term.downcase}%")
+    relation.where(sql, term: "%#{term.downcase}%").where(state: Claims::StateMachine.advocate_dashboard_states)
   end
 end

--- a/app/models/claims/search.rb
+++ b/app/models/claims/search.rb
@@ -24,6 +24,6 @@ module Claims::Search
     sql = options.inject([]) { |r, o| r << "(#{QUERY_MAPPINGS_FOR_SEARCH[o][:query]})" }.join(' OR ')
     relation = options.inject(all) { |r, o| r = r.joins(QUERY_MAPPINGS_FOR_SEARCH[o][:joins]) }
 
-    relation.where(sql, term: "%#{term.downcase}%").where(state: Claims::StateMachine.advocate_dashboard_states)
+    relation.where(sql, term: "%#{term.downcase}%").where(state: Claims::StateMachine.dashboard_displayable_states)
   end
 end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -8,7 +8,7 @@ module Claims::StateMachine
   ADVOCATE_DASHBOARD_PART_PAID_STATES     = [ 'part_paid', 'appealed', 'parts_rejected' ]
   ADVOCATE_DASHBOARD_COMPLETED_STATES     = [ 'completed', 'refused', 'paid' ]
 
-  def self.advocate_dashboard_states
+  def self.dashboard_displayable_states
     ADVOCATE_DASHBOARD_DRAFT_STATES +
     ADVOCATE_DASHBOARD_REJECTED_STATES +
     ADVOCATE_DASHBOARD_SUBMITTED_STATES +

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -8,6 +8,13 @@ module Claims::StateMachine
   ADVOCATE_DASHBOARD_PART_PAID_STATES     = [ 'part_paid', 'appealed', 'parts_rejected' ]
   ADVOCATE_DASHBOARD_COMPLETED_STATES     = [ 'completed', 'refused', 'paid' ]
 
+  def self.advocate_dashboard_states
+    ADVOCATE_DASHBOARD_DRAFT_STATES +
+    ADVOCATE_DASHBOARD_REJECTED_STATES +
+    ADVOCATE_DASHBOARD_SUBMITTED_STATES +
+    ADVOCATE_DASHBOARD_PART_PAID_STATES +
+    ADVOCATE_DASHBOARD_COMPLETED_STATES
+  end
 
   # will return true if there is a constant defined in this class with the same name in upper case as method with the trailing question mark removed
   def self.has_state?(method)


### PR DESCRIPTION
current searches do not limit the claims according to state. 
Consequently the search "summary" count includes claims 
in states not currently displayed.
