### PR TITLE
ensure demo data includes unallocated claims

### DIFF
--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -32,8 +32,6 @@ module Claims::StateMachine
     end
   end
 
-
-
   def self.included(klass)
     klass.state_machine :state,                      initial: :draft do
       after_transition on: :submit,                  do: :set_submission_date!

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -138,7 +138,7 @@ namespace :claims do
           add_documentary_evidence(claim,2)
 
           # all states but those below require allocation to case worker
-          unless [:draft,:archived_pending_delete].include?(s)
+          unless [:draft,:archived_pending_delete,:submitted].include?(s)
             case_worker.claims << claim
             puts "     - allocating to #{case_worker.user.email}"
           end


### PR DESCRIPTION
previous rake task allocated submitted claims erroneously.
