### PR TITLE
Fix case worker unallocation bug

### DIFF
--- a/app/models/case_worker.rb
+++ b/app/models/case_worker.rb
@@ -14,7 +14,7 @@ class CaseWorker < ActiveRecord::Base
 
   has_one :user, as: :persona, inverse_of: :persona, dependent: :destroy
   has_many :case_worker_claims, dependent: :destroy
-  has_many :claims, through: :case_worker_claims
+  has_many :claims, through: :case_worker_claims, after_remove: :unallocate!
 
   default_scope { includes(:user) }
 
@@ -26,4 +26,10 @@ class CaseWorker < ActiveRecord::Base
   delegate :first_name, to: :user
   delegate :last_name, to: :user
   delegate :name, to: :user
+
+  protected
+
+  def unallocate!(record)
+    record.submit! if record.allocated? && (record.case_workers - [self]).none?
+  end
 end

--- a/app/models/case_worker_claim.rb
+++ b/app/models/case_worker_claim.rb
@@ -16,8 +16,6 @@ class CaseWorkerClaim < ActiveRecord::Base
   after_create :generate_message_statuses
   after_create :set_claim_allocated!
 
-  after_destroy :set_claim_submitted!
-
   private
 
   def generate_message_statuses
@@ -30,9 +28,5 @@ class CaseWorkerClaim < ActiveRecord::Base
 
   def set_claim_allocated!
     claim.allocate! if claim.submitted?
-  end
-
-  def set_claim_submitted!
-    claim.submit! if claim.allocated? && claim.case_workers.none?
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -699,13 +699,13 @@ RSpec.describe Claim, type: :model do
     subject { create(:submitted_claim) }
     let(:case_worker) { create(:case_worker) }
 
-    it 'set the claim to "allocated" when assigned to case worker' do
+    it 'moves to "allocated" state when assigned to case worker' do
       subject.case_workers << case_worker
       expect(subject.reload).to be_allocated
     end
   end
 
-  describe 'move claim to "submitted" when case worker removed' do
+  describe 'moves to "submitted" state when case worker removed' do
     subject { create(:submitted_claim) }
     let(:case_worker) { create(:case_worker) }
     let(:other_case_worker) { create(:case_worker) }


### PR DESCRIPTION
User #after_remove callback to fix case worker unallocation bug - claim is transitioned to "submitted" if no assigned case workers remain for the claim and the claim was in an "allocated" state. 
