### PR TITLE
add trial concluded date to claims

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -156,6 +156,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
      :first_day_of_trial,
      :estimated_trial_length,
      :actual_trial_length,
+     :trial_concluded_at,
      :advocate_category,
      :additional_information,
      :prosecuting_authority,

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -15,6 +15,7 @@
 #  first_day_of_trial     :date
 #  estimated_trial_length :integer          default(0)
 #  actual_trial_length    :integer          default(0)
+#  trial_concluded_at     :date
 #  fees_total             :decimal(, )      default(0.0)
 #  expenses_total         :decimal(, )      default(0.0)
 #  total                  :decimal(, )      default(0.0)

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -44,6 +44,9 @@
       %span.auto-width
         = f.label t('.actual_length')
         = f.number_field :actual_trial_length
+      %span.auto-width
+        = f.label t('.trial_concluded_at')
+        = f.date_field :trial_concluded_at
 
     %fieldset
       %legend

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,7 @@ en:
         first_day_of_trial: 'First day of trial'
         estimated_length: 'Estimated trial length'
         actual_length: 'Actual trial length'
+        trial_concluded_at: 'Trial concluded on'
         defendants: 'Defendants'
         add_another_defendant: 'Add Another Defendant'
         section_two: 'Section 2:'

--- a/db/migrate/20150701104143_add_trial_concluded_at_to_claims.rb
+++ b/db/migrate/20150701104143_add_trial_concluded_at_to_claims.rb
@@ -1,0 +1,5 @@
+class AddTrialConcludedAtToClaims < ActiveRecord::Migration
+  def change
+    add_column :claims, :trial_concluded_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150625125502) do
+ActiveRecord::Schema.define(version: 20150701104143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 20150625125502) do
     t.text     "notes"
     t.text     "evidence_notes"
     t.string   "evidence_checklist_ids"
+    t.date     "trial_concluded_at"
   end
 
   add_index "claims", ["advocate_id"], name: "index_claims_on_advocate_id", using: :btree

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -453,6 +453,7 @@ def valid_claim_fee_params
      "first_day_of_trial" => "2015-05-13",
      "estimated_trial_length" => "2",
      "actual_trial_length" => "2",
+     "trial_concluded_at" => "2015-05-15",
      "evidence_checklist_ids" => ["1", "5", ""],
      "defendants_attributes"=>
       {"0"=>

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -15,6 +15,7 @@
 #  first_day_of_trial     :date
 #  estimated_trial_length :integer          default(0)
 #  actual_trial_length    :integer          default(0)
+#  trial_concluded_at     :date
 #  fees_total             :decimal(, )      default(0.0)
 #  expenses_total         :decimal(, )      default(0.0)
 #  total                  :decimal(, )      default(0.0)

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -15,6 +15,7 @@
 #  first_day_of_trial     :date
 #  estimated_trial_length :integer          default(0)
 #  actual_trial_length    :integer          default(0)
+#  trial_concluded_at     :date
 #  fees_total             :decimal(, )      default(0.0)
 #  expenses_total         :decimal(, )      default(0.0)
 #  total                  :decimal(, )      default(0.0)


### PR DESCRIPTION
First day of trial, estimated and actual trial length
further requires an additional user-requested field to store
the date the trial concluded.
