### PR TITLE
add default date and time formats

### DIFF
--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -75,7 +75,7 @@
             %dt
               Hearing
             %dd
-              15/04/2 7
+              27/04/2015
             %dt
               Advocate
             %dd

--- a/config/initializers/date_time.rb
+++ b/config/initializers/date_time.rb
@@ -1,0 +1,8 @@
+# Date
+Date::DATE_FORMATS[:default] = Settings.date_format
+
+# Time
+DateTime::DATE_FORMATS[:default] = Settings.date_time_format
+
+# Time
+Time::DATE_FORMATS[:default] = Settings.date_time_format

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,12 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  date:
+    formats:
+      default: "%d/%m/%Y"
+  datetime:
+    formats:
+      default: "%d/%m/%Y %H:%M"
   dictionary:
     errors:
       blank: &blank "can't be blank"


### PR DESCRIPTION
This has already been applied through constants in the settings.yml
file but this provides a catchall for other dates.
