### PR TITLE
change case allocation tabs

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -67,6 +67,8 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
           Claim.caseworker_dashboard_under_assessment
         when 'unallocated'
           Claim.submitted
+        when 'completed'
+          Claim.caseworker_dashboard_completed
       end
     else
       @claims = case tab
@@ -80,7 +82,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
 
   def tab
     if current_user.persona.admin?
-      %w(allocated unallocated).include?(params[:tab]) ? params[:tab] : 'allocated'
+      %w(allocated unallocated completed).include?(params[:tab]) ? params[:tab] : 'allocated'
     else
       %w(current completed).include?(params[:tab]) ? params[:tab] : 'current'
     end

--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -4,7 +4,11 @@ module CaseWorkers::ClaimsHelper
   end
 
   def completed_claims_count
-    current_user.claims.caseworker_dashboard_completed.count
+    if current_user.persona.admin?
+      Claim.caseworker_dashboard_completed.count
+    else
+      current_user.claims.caseworker_dashboard_completed.count
+    end
   end
 
   def allocated_claims_count

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -110,9 +110,6 @@ module Claims::StateMachine
       end
     end
 
-
-
-    # klass.scope :not_deleted, -> { klass.where.not(state: 'archived_pending_delete') }
     klass.scope :non_draft, -> { klass.where(state: ['allocated', 'appealed', 'awaiting_further_info', 'awaiting_info_from_court', 'completed',
          'deleted', 'paid', 'part_paid', 'parts_rejected', 'refused', 'rejected', 'submitted']) }
 

--- a/app/views/case_workers/claims/_nav_tabs.html.haml
+++ b/app/views/case_workers/claims/_nav_tabs.html.haml
@@ -5,10 +5,9 @@
         = link_to "Allocated claims (#{allocated_claims_count})", case_workers_claims_path(params.merge(tab: 'allocated'))
       %li{class: ('active' if params[:tab] == 'unallocated')}
         = link_to "Unallocated claims (#{unallocated_claims_count})", case_workers_claims_path(params.merge(tab: 'unallocated'))
-      %li{class: ('active' if controller.controller_name == 'case_workers')}
-        = link_to "Case Workers (#{CaseWorker.count})", case_workers_admin_case_workers_path
     - else
       %li{class: ( 'active' if params[:tab] == 'current' || (params[:tab].blank? && controller.controller_name == 'claims')) }
         = link_to "Current claims (#{current_claims_count})", case_workers_claims_path(params.merge(tab: 'current'))
-      %li{class: ('active' if params[:tab] == 'completed')}
-        = link_to "Completed claims (#{completed_claims_count})", case_workers_claims_path(params.merge(tab: 'completed'))
+
+    %li{class: ('active' if params[:tab] == 'completed')}
+      = link_to "Completed claims (#{completed_claims_count})", case_workers_claims_path(params.merge(tab: 'completed'))

--- a/app/views/layouts/_user.html.haml
+++ b/app/views/layouts/_user.html.haml
@@ -1,6 +1,8 @@
 = content_for :after_header do
   #user_links
     %strong
+      - if current_user.persona.admin?
+        = link_to "Case Workers (#{CaseWorker.count})", case_workers_admin_case_workers_path
       = link_to current_user.name, '#'
       = link_to user_message_statuses_path do
         %span#message_count

--- a/features/caseworker_admin_claims_list.feature
+++ b/features/caseworker_admin_claims_list.feature
@@ -15,3 +15,18 @@ Feature: Caseworker claims list
      When I visit my dashboard
      Then I should see the unallocated claims
       And I should see the claims sorted by oldest first
+
+  Scenario: View completed claims
+    Given I am a signed in case worker admin
+      And there are completed claims
+     When I visit my dashboard
+     Then I should see the completed claims
+      And I should see the claims sorted by oldest first
+
+Scenario: View case workers
+    Given I am a signed in case worker admin
+      And 2 case workers exist
+     When I visit my dashboard
+     Then I should see a case worker link including count
+     When I click the case worker link
+      And I should be taken to the case worker admin page

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -39,8 +39,6 @@ end
 
 # NOTE: this step requires server to be running as it is js-reliant (i.e. cocoon)
 When(/^I add (\d+) dates? attended for one of my "(.*?)" fees$/) do |number, fee_type |
-
-  save_and_open_page
   div_id = fee_type.downcase == "fixed" ? 'fees' : 'basic_fees'
 
   number.to_i.times do

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -17,6 +17,10 @@ Given(/^there are unallocated claims$/) do
   @claims = create_list(:submitted_claim, 5)
 end
 
+Given(/^there are completed claims$/) do
+  @claims = create_list(:completed_claim, 5)
+end
+
 Then(/^I should see the allocated claims$/) do
   click_on "Allocated claims (#{@claims.count})"
   expect(page).to have_content("Allocated claims (#{@claims.count})")
@@ -26,6 +30,25 @@ Then(/^I should see the unallocated claims$/) do
   click_on "Unallocated claims (#{@claims.count})"
   expect(page).to have_content("Unallocated claims (#{@claims.count})")
 end
+
+Then(/^I should see the completed claims$/) do
+  click_on "Completed claims (#{@claims.count})"
+  expect(page).to have_content("Completed claims (#{@claims.count})")
+end
+
+# logging in creates an additional case worker (hence +1)
+Then(/^I should see a case worker link including count$/) do
+  expect(page).to have_selector('a', text: "Case Workers (#{@case_workers.count+1})")
+end
+
+Then(/^I click the case worker link$/) do
+  find('a', text: "Case Worker").click
+end
+
+Then(/^I should be taken to the case worker admin page$/) do
+  expect(page).to have_selector('h1', text: "Case workers")
+end
+
 
 Given(/^I have (\d+) "(.*?)" claims involving defendant "(.*?)" amongst others$/) do |number,state,defendant_name|
   claims = create_list("#{state}_claim".to_sym, number.to_i)


### PR DESCRIPTION
the admin dashboard needs to show completed claims
as a tab and the case workers as a link in the top
right navigation area.
