### PR TITLE
add dummy case workers to demo data

### DIFF
--- a/spec/factories/case_workers.rb
+++ b/spec/factories/case_workers.rb
@@ -11,7 +11,8 @@
 FactoryGirl.define do
   factory :case_worker do
     after(:build) do |case_worker|
-      case_worker.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.email, password: 'password', password_confirmation: 'password')
+      case_worker.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, password: 'password', password_confirmation: 'password')
+      case_worker.user.email = "#{case_worker.first_name}.#{case_worker.last_name}@laa.gov.uk"
     end
 
     location


### PR DESCRIPTION
This enables tests for allocation tool to have numerous
case workers to allocate to. NOTE that this may be
replaced with a seed file of real case workers.
