### PR TITLE
reduce amount of evidence attached to demo data claims

### DIFF
--- a/db/seeds/seed_helper.rb
+++ b/db/seeds/seed_helper.rb
@@ -1,7 +1,7 @@
 module SeedHelper
 
   def self.find_or_create_caseworker!(attrs)
-    if User.find_by(first_name: attrs[:first_name], last_name: attrs[:last_name], email: attrs[:email].downcase,).blank?
+    if User.find_by(first_name: attrs[:first_name], last_name: attrs[:last_name], email: attrs[:email].downcase).blank?
       # puts "+creating case worker #{attrs[:first_name]}, #{attrs[:last_name]}, #{attrs[:email]}"
       user = User.create!(
         first_name: attrs[:first_name],


### PR DESCRIPTION
travis CI and deply were taking a long time and could be
costing significant amounts in network traffic.
