### PR TITLE
Changed deployment db tasks and run.sh behaviour

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
 set -e
 
+if [ "$DOCKER_STATE" = "none" ]; then
+  SLEEP_TIME=0
+else
+  if [ "$RUN_MIGRATE_OR_SEED" = "True" ]; then
+    # if DOCKER_STATE is none, no need to wait
+    if [ "$DOCKER_STATE" = "none" ]; then
+        SLEEP_TIME=0
+    fi
+  else
+    DOCKER_STATE=none
+    SLEEP_TIME=2m
+  fi
+fi
+
 case ${DOCKER_STATE} in
 migrate)
-    echo "running migrate"
     bundle exec rake db:migrate
     ;;
 seed)
-    echo "running seed"
-    bundle exec rake db:drop
-    bundle exec rake db:create
-    bundle exec rake db:migrate
-    bundle exec rake db:seed
-    bundle exec rake claims:demo_data
+    # db:reload  a bespoke task, see lib/tasks/db.rake
+    bundle exec rake db:reload
     ;;
 esac
+if [ -n "$SLEEP_TIME" ]; then
+  sleep $SLEEP_TIME
+fi
 exec bundle exec unicorn -p 80


### PR DESCRIPTION
- previous version did not cope with multiple nodes in the autoscaling
  group due to contention on the DB
- added new environment variable `RUN_MIGRATE_OR_SEED`
- added delays on non master node to avoid contention
- db tasks only executed on salt master
- used bespoke rake tasks provided by developers
