### PR TITLE
Separate fixed misc fee sections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,3 @@ DEPENDENCIES
   unicorn-rails (= 2.2.0)
   webmock (~> 1.21.0)
   webrick (~> 1.3)
-
-BUNDLED WITH
-   1.10.5

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,8 +34,9 @@ function initialise(){
   $('.select2').select2();
   adp.newClaim.init();
   adp.crackedTrial.init();
-  adp.feeCalculator.init('fees');
-  adp.feeCalculator.init('basic_fees');
+  adp.feeCalculator.init('basic-fees');
+  adp.feeCalculator.init('fixed-fees');
+  adp.feeCalculator.init('misc-fees');
   adp.feeCalculator.init('expenses');
   moj.Modules.fileUpload.init();
   moj.Modules.judicialApportionment.init();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -40,7 +40,7 @@ function initialise(){
   moj.Modules.fileUpload.init();
   moj.Modules.judicialApportionment.init();
   moj.Modules.amountAssessed.init();
-  $('#fees, #expenses, #documents').on('cocoon:after-insert', function(e,insertedItem) {
+  $('#fixed-fees, #misc-fees, #expenses, #documents').on('cocoon:after-insert', function(e,insertedItem) {
     $(insertedItem).find('.select2').select2();
   });
   moj.Modules.selectAll.init();

--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -202,7 +202,39 @@ class Advocates::ClaimsController < Advocates::ApplicationController
           :_destroy
         ]
      ],
-     non_basic_fees_attributes: [
+     # non_basic_fees_attributes: [
+     #   :id,
+     #   :claim_id,
+     #   :fee_type_id,
+     #   :fee_id,
+     #   :quantity,
+     #   :rate,
+     #   :_destroy,
+     #   dates_attended_attributes: [
+     #      :id,
+     #      :fee_id,
+     #      :date,
+     #      :date_to,
+     #      :_destroy
+     #    ]
+     #  ],
+      fixed_fees_attributes: [
+       :id,
+       :claim_id,
+       :fee_type_id,
+       :fee_id,
+       :quantity,
+       :rate,
+       :_destroy,
+       dates_attended_attributes: [
+          :id,
+          :fee_id,
+          :date,
+          :date_to,
+          :_destroy
+        ]
+      ],
+      misc_fees_attributes: [
        :id,
        :claim_id,
        :fee_type_id,
@@ -238,7 +270,8 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   end
 
   def build_nested_resources
-    [:defendants, :non_basic_fees, :expenses, :documents].each do |association|
+    # [:defendants, :non_basic_fees, :fixed_fees, :misc_fees, :expenses, :documents].each do |association|
+    [:defendants, :fixed_fees, :misc_fees, :expenses, :documents].each do |association|
       build_nested_resource(@claim, association)
     end
 

--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -202,22 +202,6 @@ class Advocates::ClaimsController < Advocates::ApplicationController
           :_destroy
         ]
      ],
-     # non_basic_fees_attributes: [
-     #   :id,
-     #   :claim_id,
-     #   :fee_type_id,
-     #   :fee_id,
-     #   :quantity,
-     #   :rate,
-     #   :_destroy,
-     #   dates_attended_attributes: [
-     #      :id,
-     #      :fee_id,
-     #      :date,
-     #      :date_to,
-     #      :_destroy
-     #    ]
-     #  ],
       fixed_fees_attributes: [
        :id,
        :claim_id,
@@ -270,7 +254,6 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   end
 
   def build_nested_resources
-    # [:defendants, :non_basic_fees, :fixed_fees, :misc_fees, :expenses, :documents].each do |association|
     [:defendants, :fixed_fees, :misc_fees, :expenses, :documents].each do |association|
       build_nested_resource(@claim, association)
     end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -76,7 +76,6 @@ class Claim < ActiveRecord::Base
   has_many :messages,                 dependent: :destroy,          inverse_of: :claim
 
   has_many :basic_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'BASIC'") }, class_name: 'Fee'
-  # has_many :non_basic_fees, -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'BASIC'") }, class_name: 'Fee'
   has_many :fixed_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'FIXED'") }, class_name: 'Fee'
   has_many :misc_fees,      -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'MISC'") }, class_name: 'Fee'
 
@@ -98,11 +97,11 @@ class Claim < ActiveRecord::Base
   scope :authorised,  -> { where(state: 'paid') }
 
   # Trial type scopes
-  scope :cracked, -> { where(case_type: ['cracked_trial', 'cracked_before_retrial']) }
-  scope :trial, -> { where(case_type: ['trial', 'retrial']) }
+  scope :cracked,     -> { where(case_type: ['cracked_trial', 'cracked_before_retrial']) }
+  scope :trial,       -> { where(case_type: ['trial', 'retrial']) }
   scope :guilty_plea, -> { where(case_type: ['guilty_plea']) }
 
-  scope :fixed_fee, -> { joins(fee_types: :fee_category).where('fee_categories.abbreviation = ?', 'FIXED').uniq }
+  scope :fixed_fee,   -> { joins(fee_types: :fee_category).where('fee_categories.abbreviation = ?', 'FIXED').uniq }
 
   scope :total_greater_than_or_equal_to, -> (value) { where { total >= value } }
 
@@ -124,7 +123,6 @@ class Claim < ActiveRecord::Base
   validate :evidence_checklist_ids_all_numeric_strings
 
   accepts_nested_attributes_for :basic_fees,        reject_if:  :all_blank,  allow_destroy: true
-  # accepts_nested_attributes_for :non_basic_fees,    reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
   accepts_nested_attributes_for :fixed_fees,        reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
   accepts_nested_attributes_for :misc_fees,         reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
   accepts_nested_attributes_for :expenses,          reject_if: :all_blank,  allow_destroy: true

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -75,12 +75,11 @@ class Claim < ActiveRecord::Base
   has_many :documents,                dependent: :destroy,          inverse_of: :claim
   has_many :messages,                 dependent: :destroy,          inverse_of: :claim
 
-  has_many :basic_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'BASIC'") }, class_name: 'Fee'
+  has_many :basic_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'BASIC'").order(fee_type_id: :asc) }, class_name: 'Fee'
   has_many :fixed_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'FIXED'") }, class_name: 'Fee'
   has_many :misc_fees,      -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'MISC'") }, class_name: 'Fee'
 
-
-  default_scope do
+ default_scope do
     includes(:advocate,
              :case_workers,
              :court,

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -76,9 +76,9 @@ class Claim < ActiveRecord::Base
   has_many :messages,                 dependent: :destroy,          inverse_of: :claim
 
   has_many :basic_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'BASIC'") }, class_name: 'Fee'
-  has_many :non_basic_fees, -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'BASIC'") }, class_name: 'Fee'
-  has_many :fixed_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'FIXED'") }, class_name: 'Fee'
-  has_many :misc_fees,      -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'MISC'") }, class_name: 'Fee'
+  # has_many :non_basic_fees, -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'BASIC'") }, class_name: 'Fee'
+  has_many :fixed_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'FIXED'") }, class_name: 'Fee'
+  has_many :misc_fees,      -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'MISC'") }, class_name: 'Fee'
 
 
   default_scope do
@@ -124,7 +124,7 @@ class Claim < ActiveRecord::Base
   validate :evidence_checklist_ids_all_numeric_strings
 
   accepts_nested_attributes_for :basic_fees,        reject_if:  :all_blank,  allow_destroy: true
-  accepts_nested_attributes_for :non_basic_fees,    reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
+  # accepts_nested_attributes_for :non_basic_fees,    reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
   accepts_nested_attributes_for :fixed_fees,        reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
   accepts_nested_attributes_for :misc_fees,         reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
   accepts_nested_attributes_for :expenses,          reject_if: :all_blank,  allow_destroy: true

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -77,6 +77,8 @@ class Claim < ActiveRecord::Base
 
   has_many :basic_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'BASIC'") }, class_name: 'Fee'
   has_many :non_basic_fees, -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'BASIC'") }, class_name: 'Fee'
+  has_many :fixed_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'FIXED'") }, class_name: 'Fee'
+  has_many :misc_fees,      -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation != 'MISC'") }, class_name: 'Fee'
 
 
   default_scope do
@@ -123,6 +125,8 @@ class Claim < ActiveRecord::Base
 
   accepts_nested_attributes_for :basic_fees,        reject_if:  :all_blank,  allow_destroy: true
   accepts_nested_attributes_for :non_basic_fees,    reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
+  accepts_nested_attributes_for :fixed_fees,        reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
+  accepts_nested_attributes_for :misc_fees,         reject_if:  proc { |attributes|attrs_blank?(attributes) },  allow_destroy: true
   accepts_nested_attributes_for :expenses,          reject_if: :all_blank,  allow_destroy: true
   accepts_nested_attributes_for :defendants,        reject_if: :all_blank,  allow_destroy: true
   accepts_nested_attributes_for :documents,         reject_if: :all_blank,  allow_destroy: true

--- a/app/models/fee_category.rb
+++ b/app/models/fee_category.rb
@@ -15,18 +15,20 @@ class FeeCategory < ActiveRecord::Base
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :abbreviation, presence: true, uniqueness: {case_sensitive: false}
 
-  scope :non_basic, -> { where('abbreviation != ?', 'BASIC').order(:name) }
+  scope :non_basic, -> { where('abbreviation != ?', 'BASIC').order(:name) } #may not need any longer
+  scope :fixed,     -> { where('abbreviation = ?', 'FIXED').order(:name) }
+  scope :misc,      -> { where('abbreviation = ?', 'MISC').order(:name) }
 
-  def self.basic 
+  def self.basic
     FeeCategory.where('abbreviation = ?', 'BASIC').first
   end
 
-  def self.misc 
+  def self.misc
     FeeCategory.where('abbreviation = ?', 'MISC').first
   end
 
 
-  def self.fixed 
+  def self.fixed
     FeeCategory.where('abbreviation = ?', 'FIXED').first
   end
 

--- a/app/models/fee_category.rb
+++ b/app/models/fee_category.rb
@@ -15,31 +15,30 @@ class FeeCategory < ActiveRecord::Base
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :abbreviation, presence: true, uniqueness: {case_sensitive: false}
 
-  scope :non_basic, -> { where('abbreviation != ?', 'BASIC').order(:name) } #may not need any longer
-  scope :fixed,     -> { where('abbreviation = ?', 'FIXED').order(:name) }
-  scope :misc,      -> { where('abbreviation = ?', 'MISC').order(:name) }
-
+  # NOTE: there is only one category of each type so SCOPES (that always return a relation)
+  #       are less useful here.
   def self.basic
-    FeeCategory.where('abbreviation = ?', 'BASIC').first
+    FeeCategory.find_by(abbreviation: 'BASIC')
   end
 
   def self.misc
-    FeeCategory.where('abbreviation = ?', 'MISC').first
+    FeeCategory.find_by(abbreviation: 'MISC')
   end
-
 
   def self.fixed
-    FeeCategory.where('abbreviation = ?', 'FIXED').first
+    FeeCategory.find_by(abbreviation: 'FIXED')
   end
-
-  def self.non_basic
-    FeeCategory.where('abbreviation != ?', 'BASIC')
-  end
-
 
   def is_basic?
     self.abbreviation == 'BASIC'
   end
 
+  def is_misc?
+    self.abbreviation == 'MISC'
+  end
+
+  def is_fixed?
+    self.abbreviation == 'FIXED'
+  end
 
 end

--- a/app/views/advocates/claims/_fixed_fee_fields.html.haml
+++ b/app/views/advocates/claims/_fixed_fee_fields.html.haml
@@ -1,17 +1,17 @@
-%tbody.misc-fee-group
+%tbody.fixed-fee-group
   %tr.nested-fields
     %td
-      = f.grouped_collection_select :fee_type_id, FeeCategory.non_basic.includes(:fee_types), :fee_types, :name, :id, :description, {prompt: true}, {class: 'select2'}
+      = f.collection_select :fee_type_id, FeeType.fixed, :id, :description, {prompt: true}, {class: 'select2'}
     %td
       = f.number_field :quantity, class: 'quantity'
     %td
       = f.number_field :rate, value: number_with_precision(f.object.rate, precision: 2), class: 'rate'
     %td.amount
       = number_to_currency(f.object.amount)
-    %td.add-misc-fee-date-attended
+    %td.add-fixed-fee-date-attended
       = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'button-secondary', data: {'association-insertion-method' => 'after', 'association-insertion-traversal' => 'closest', 'association-insertion-node' => 'tr'}
-    %td.remove-misc-fee
-      = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group' }
+    %td.remove-fixed-fee
+      = link_to_remove_association t('.remove'), f, { wrapper_class: 'fixed-fee-group' }
 
   = f.fields_for :dates_attended do |date_attended|
     = render 'date_attended_fields', f: date_attended

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -87,8 +87,8 @@
 
     %fieldset
       %legend
-        = t('.fixed_and_misc_fees')
-      #fees
+        = t('.fixed_fees')
+      #fixed-fees
         %table.table
           %thead
             %tr
@@ -102,10 +102,32 @@
                 = t('.amount')
               %th
               %th
-          = f.fields_for :non_basic_fees do |fee|
-            = render 'fee_fields', f: fee
+          = f.fields_for :fixed_fees do |fee|
+            = render 'fixed_fee_fields', f: fee
 
-        = link_to_add_association t('.add_another_fee'), f, :fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
+        = link_to_add_association t('.add_another_fee'), f, :fixed_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
+
+    %fieldset
+      %legend
+        = t('.misc_fees')
+      #misc-fees
+        %table.table
+          %thead
+            %tr
+              %th
+                = t('.fee_type')
+              %th
+                = t('.quantity')
+              %th
+                = t('.rate')
+              %th
+                = t('.amount')
+              %th
+              %th
+          = f.fields_for :misc_fees do |fee|
+            = render 'misc_fee_fields', f: fee
+
+        = link_to_add_association t('.add_another_fee'), f, :misc_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
 
     %fieldset
       %legend

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -87,28 +87,6 @@
 
     %fieldset
       %legend
-        = t('.fixed_fees')
-      #fixed-fees
-        %table.table
-          %thead
-            %tr
-              %th
-                = t('.fee_type')
-              %th
-                = t('.quantity')
-              %th
-                = t('.rate')
-              %th
-                = t('.amount')
-              %th
-              %th
-          = f.fields_for :fixed_fees do |fee|
-            = render 'fixed_fee_fields', f: fee
-
-        = link_to_add_association t('.add_fixed_fee'), f, :fixed_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
-
-    %fieldset
-      %legend
         = t('.misc_fees')
       #misc-fees
         %table.table
@@ -128,6 +106,28 @@
             = render 'misc_fee_fields', f: fee
 
         = link_to_add_association t('.add_misc_fee'), f, :misc_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
+
+    %fieldset
+      %legend
+        = t('.fixed_fees')
+      #fixed-fees
+        %table.table
+          %thead
+            %tr
+              %th
+                = t('.fee_type')
+              %th
+                = t('.quantity')
+              %th
+                = t('.rate')
+              %th
+                = t('.amount')
+              %th
+              %th
+          = f.fields_for :fixed_fees do |fee|
+            = render 'fixed_fee_fields', f: fee
+
+        = link_to_add_association t('.add_fixed_fee'), f, :fixed_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
 
     %fieldset
       %legend

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -65,7 +65,7 @@
     %fieldset
       %legend
         = t('.basic_fees')
-      #basic_fees
+      #basic-fees
         %p
           = t('.quantity_and_rate_prompt')
         %table.table
@@ -105,7 +105,7 @@
           = f.fields_for :fixed_fees do |fee|
             = render 'fixed_fee_fields', f: fee
 
-        = link_to_add_association t('.add_another_fee'), f, :fixed_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
+        = link_to_add_association t('.add_fixed_fee'), f, :fixed_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
 
     %fieldset
       %legend
@@ -127,7 +127,7 @@
           = f.fields_for :misc_fees do |fee|
             = render 'misc_fee_fields', f: fee
 
-        = link_to_add_association t('.add_another_fee'), f, :misc_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
+        = link_to_add_association t('.add_misc_fee'), f, :misc_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
 
     %fieldset
       %legend

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -83,7 +83,7 @@
                 = t('.amount')
               %th
             = f.fields_for :basic_fees do |basic_fee|
-              = render 'basic_fee_fields', f: basic_fee, basic_fees: f.object.basic_fees
+              = render 'basic_fee_fields', f: basic_fee
 
     %fieldset
       %legend
@@ -102,8 +102,8 @@
                 = t('.amount')
               %th
               %th
-          = f.fields_for :misc_fees do |fee|
-            = render 'misc_fee_fields', f: fee
+          = f.fields_for :misc_fees do |misc_fee|
+            = render 'misc_fee_fields', f: misc_fee
 
         = link_to_add_association t('.add_misc_fee'), f, :misc_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
 
@@ -124,8 +124,8 @@
                 = t('.amount')
               %th
               %th
-          = f.fields_for :fixed_fees do |fee|
-            = render 'fixed_fee_fields', f: fee
+          = f.fields_for :fixed_fees do |fixed_fee|
+            = render 'fixed_fee_fields', f: fixed_fee
 
         = link_to_add_association t('.add_fixed_fee'), f, :fixed_fees, class: 'button-secondary', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}
 

--- a/app/views/advocates/claims/_misc_fee_fields.html.haml
+++ b/app/views/advocates/claims/_misc_fee_fields.html.haml
@@ -1,0 +1,17 @@
+%tbody.misc-fee-group
+  %tr.nested-fields
+    %td
+      = f.collection_select :fee_type_id, FeeType.misc, :id, :description, {prompt: true}, {class: 'select2'}
+    %td
+      = f.number_field :quantity, class: 'quantity'
+    %td
+      = f.number_field :rate, value: number_with_precision(f.object.rate, precision: 2), class: 'rate'
+    %td.amount
+      = number_to_currency(f.object.amount)
+    %td.add-misc-fee-date-attended
+      = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'button-secondary', data: {'association-insertion-method' => 'after', 'association-insertion-traversal' => 'closest', 'association-insertion-node' => 'tr'}
+    %td.remove-misc-fee
+      = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group' }
+
+  = f.fields_for :dates_attended do |date_attended|
+    = render 'date_attended_fields', f: date_attended

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,7 +210,7 @@ en:
         last_name: *last_name
         date_of_birth: 'Date of birth'
         order_for_judicial_apportionment: 'Order for judicial apportionment'
-        add_another_rep_order: 'Add another representation order'
+        add_another_rep_order: 'Add Another Representation Order'
         remove_defendant: 'Remove defendant'
       document_fields:
         document_type: 'Document type'
@@ -267,10 +267,10 @@ en:
         quantity_modifier: 'Modifier'
         rate: 'Rate'
         amount: 'Amount'
-        fixed_and_misc_fees: 'Fixed and Miscellaneous Fees'
         fixed_fees: 'Fixed Fees'
         misc_fees: 'Miscellaneous Fees'
-        add_another_fee: 'Add Another Fee'
+        add_fixed_fee: 'Add Another Fixed Fee'
+        add_misc_fee: 'Add Another Miscellaneous Fee'
         expenses: 'Expenses'
         expense_type: 'Expense Type'
         location: 'Location'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,6 +268,8 @@ en:
         rate: 'Rate'
         amount: 'Amount'
         fixed_and_misc_fees: 'Fixed and Miscellaneous Fees'
+        fixed_fees: 'Fixed Fees'
+        misc_fees: 'Miscellaneous Fees'
         add_another_fee: 'Add Another Fee'
         expenses: 'Expenses'
         expense_type: 'Expense Type'

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -3,7 +3,7 @@
 Feature: Advocate new claim
   Scenario: Fill in claim form and submit to LAA
     Given I am a signed in advocate
-      And There are fee schemes in place 
+      And There are fee schemes in place
       And I am on the new claim page
      When I fill in the claim details
       And I submit to LAA
@@ -36,13 +36,13 @@ Feature: Advocate new claim
   Scenario: Add mulitple rep orders for a single defendant
     Given I am a signed in advocate
       And I am on the new claim page
-     When I click Add another representation order
+     When I click Add Another Representation Order
      Then I see 2 fields for adding a rep order
 
   Scenario: Add too many rep orders for a single defendant and remove one
     Given I am a signed in advocate
       And I am on the new claim page
-     When I click Add another representation order
+     When I click Add Another Representation Order
       And I then choose to remove the additional rep order
      Then I see 1 field for adding a rep order
 

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -126,3 +126,23 @@ Feature: Advocate new claim
       And I submit to LAA
      Then I should be redirected to the claim confirmation page
       And I should see the claim totals accounting for modifier
+
+  Scenario: Add Fixed Fee type
+    Given I am a signed in advocate
+      And There are fee schemes in place
+      And I am on the new claim page
+     When I fill in the claim details
+      And I add a fixed fee
+      And I submit to LAA
+     Then I should be redirected to the claim confirmation page
+      And I should see the claim totals accounting for the fixed fee
+
+  Scenario: Add Miscellaneous Fee type
+    Given I am a signed in advocate
+      And There are fee schemes in place
+      And I am on the new claim page
+     When I fill in the claim details
+      And I add a miscellaneous fee
+      And I submit to LAA
+     Then I should be redirected to the claim confirmation page
+      And I should see the claim totals accounting for the miscellaneous fee

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -27,8 +27,8 @@ Given(/^There are fee schemes in place$/) do
   Scheme.find_or_create_by(name: 'AGFS Fee Scheme 9', start_date: Date.parse('01/04/2012'), end_date: nil)
 end
 
-When(/^I click Add another representation order$/) do
-  page.all('a.button-secondary.add_fields').select {|link| link.text == "Add another representation order"}.first.click
+When(/^I click Add Another Representation Order$/) do
+  page.all('a.button-secondary.add_fields').select {|link| link.text == "Add Another Representation Order"}.first.click
 end
 
 Then(/^I see (\d+) fields? for adding a rep order$/) do |number|
@@ -104,7 +104,7 @@ When(/^I fill in the claim details$/) do
     choose 'Crown Court'
   end
 
-  within '#basic_fees' do
+  within '#basic-fees' do
     fill_in 'claim_basic_fees_attributes_0_quantity', with: 1
     fill_in 'claim_basic_fees_attributes_0_rate', with: 0.5
     fill_in 'claim_basic_fees_attributes_1_quantity', with: 1
@@ -269,7 +269,7 @@ Then(/^the case number should reflect the change$/) do
 end
 
 When(/^I fill in an additional fee type that is subjected to a modifer$/) do
-  within '#basic_fees' do
+  within '#basic-fees' do
     fill_in 'claim_basic_fees_attributes_2_quantity', with: 6
     fill_in 'claim_basic_fees_attributes_2_rate', with: 1
   end

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -17,6 +17,8 @@ Given(/^I am on the new claim page$/) do
   create(:fee_type, :basic, description: 'Other Basic Fee')
   create(:fee_type, :basic, description: 'Basic Fee with Modifer', quantity_modifier: -4)
   create(:fee_type, :basic, description: 'Basic Fee with dates attended required', quantity_modifier: -2, code: 'SAF')
+  create(:fee_type, :fixed, description: 'Fixed Fee example')
+  create(:fee_type, :misc,  description: 'Miscellaneous Fee example')
   create(:expense_type, name: 'Travel')
   visit new_advocates_claim_path
 end
@@ -279,4 +281,28 @@ Then(/^I should see the claim totals accounting for modifier$/) do
   expect(page).to have_content("Fees total: £3.00")
   expect(page).to have_content("Expenses total: £40.00")
   expect(page).to have_content("Total: £43.00")
+end
+
+When(/^I add a fixed fee$/) do
+    within '#fixed-fees' do
+      fill_in 'claim_fixed_fees_attributes_0_quantity', with: 1
+      fill_in 'claim_fixed_fees_attributes_0_rate', with: 100.01
+      select 'Fixed Fee example', from: 'claim_fixed_fees_attributes_0_fee_type_id'
+    end
+end
+
+Then(/^I should see the claim totals accounting for the fixed fee$/) do
+  expect(page).to have_content("Fees total: £101.01")
+end
+
+When(/^I add a miscellaneous fee$/) do
+    within '#misc-fees' do
+      fill_in 'claim_misc_fees_attributes_0_quantity', with: 1
+      fill_in 'claim_misc_fees_attributes_0_rate', with: 200.01
+      select 'Miscellaneous Fee example', from: 'claim_misc_fees_attributes_0_fee_type_id'
+    end
+end
+
+Then(/^I should see the claim totals accounting for the miscellaneous fee$/) do
+  expect(page).to have_content("Fees total: £201.01")
 end

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -68,13 +68,13 @@ When(/^I add (\d+) dates? attended for one of my "(.*?)" fees$/) do |number, fee
 end
 
 When(/^I remove the fee$/) do
-  within('#fees') do
+  within('#fixed-fees') do
     page.all('a', text: "Remove").first.click
   end
 end
 
 Then(/^the dates attended are also removed$/) do
-  expect(within('#fees') { page.all('tr.extra-data.nested-fields') }.count).to eq 0
+  expect(within('#fixed-fees') { page.all('tr.extra-data.nested-fields') }.count).to eq 0
 end
 
 When(/^I fill in the claim details$/) do

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -150,11 +150,12 @@ end
 
   # add 1 to 6 fixed/misc fees, some with dates
   def add_fixed_misc_fees(claim, fee_count=nil)
-    fee_count = fee_count.nil? ? rand(2..8) : fee_count
+    fee_count = fee_count.nil? ? rand(1..6) : fee_count
     fee_count.times do
       fee_type = rand(2) == 1 ? FeeType.misc.sample : FeeType.fixed.sample
       fee = FactoryGirl.create(:fee, :random_values, claim: claim, fee_type: fee_type)
       FactoryGirl.create(:date_attended, fee: fee) unless rand(2) == 0
+      puts "            + creating fee of category #{fee.fee_type.fee_category.abbreviation} and type #{fee.fee_type.description}"
     end
   end
 
@@ -177,8 +178,8 @@ end
     add_fixed_misc_fees(claim)
     add_expenses(claim)
 
-    #attempt to force ~33%% of claims to have random values over 20k threshold
-    push_fees_over_threshold(claim) if rand(3) == 1
+    #attempt to force ~25%% of claims to have random values over 20k threshold
+    push_fees_over_threshold(claim) if rand(4) == 1
 
     add_defendants(claim)
     add_documentary_evidence(claim, rand(1..2)) # WARNING: adding evidence can significantly slow travis and deploy process and eat network trvis (i.e. cost??)

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -313,9 +313,15 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
             expect(claim.basic_fees.detect{ |f| f.fee_type_id == basic_fee_type_4.id }.amount.to_f ).to eq 125.0
             expect(claim.basic_fees.detect{ |f| f.fee_type_id == basic_fee_type_2.id }).to be_blank
 
-            expect(claim.non_basic_fees.size).to eq 2
-            expect(claim.non_basic_fees.detect{ |f| f.fee_type_id == misc_fee_type_2.id }.amount.to_f ).to eq 250.0
-            expect(claim.non_basic_fees.detect{ |f| f.fee_type_id == fixed_fee_type_1.id }.amount.to_f ).to eq 2500.0
+            # expect(claim.non_basic_fees.size).to eq 2
+            # expect(claim.non_basic_fees.detect{ |f| f.fee_type_id == misc_fee_type_2.id }.amount.to_f ).to eq 250.0
+            # expect(claim.non_basic_fees.detect{ |f| f.fee_type_id == fixed_fee_type_1.id }.amount.to_f ).to eq 2500.0
+
+            expect(claim.fixed_fees.size).to eq 1
+            expect(claim.fixed_fees.detect{ |f| f.fee_type_id == fixed_fee_type_1.id }.amount.to_f ).to eq 2500.0
+
+            expect(claim.misc_fees.size).to eq 1
+            expect(claim.misc_fees.detect{ |f| f.fee_type_id == misc_fee_type_2.id }.amount.to_f ).to eq 250.0
 
             expect(claim.reload.fees_total).to eq 12_875.45
           end
@@ -330,7 +336,9 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
             expect(response.body).to have_content("Prosecuting authority can't be blank")
             claim = assigns(:claim)
             expect(claim.basic_fees.size).to eq 4
-            expect(claim.non_basic_fees.size).to eq 2
+            # expect(claim.non_basic_fees.size).to eq 2
+            expect(claim.fixed_fees.size).to eq 1
+            expect(claim.misc_fees.size).to eq 1
 
             bf1 = claim.basic_fees.detect{ |f| f.description == 'Basic Fee Type 1' }
             expect(bf1.quantity).to eq 10
@@ -495,10 +503,18 @@ def valid_claim_fee_params
         "2"=>{"quantity" => "1", "rate" => "9000.45", "fee_type_id" => basic_fee_type_3.id.to_s},
         "3"=>{"quantity" => "5", "rate" => "25", "fee_type_id" => basic_fee_type_4.id.to_s}
         },
-     "non_basic_fees_attributes"=>
+     # "non_basic_fees_attributes"=>
+     #  {
+     #    "0"=>{"fee_type_id" => misc_fee_type_2.id.to_s, "quantity" => "2", "rate" => "125", "_destroy" => "false"},
+     #    "1"=>{"fee_type_id" => fixed_fee_type_1.id.to_s, "quantity" => "250", "rate" => "10", "_destroy" => "false"}
+     #  },
+      "fixed_fees_attributes"=>
       {
-        "0"=>{"fee_type_id" => misc_fee_type_2.id.to_s, "quantity" => "2", "rate" => "125", "_destroy" => "false"},
-        "1"=>{"fee_type_id" => fixed_fee_type_1.id.to_s, "quantity" => "250", "rate" => "10", "_destroy" => "false"}
+        "0"=>{"fee_type_id" => fixed_fee_type_1.id.to_s, "quantity" => "250", "rate" => "10", "_destroy" => "false"}
+      },
+      "misc_fees_attributes"=>
+      {
+        "1"=>{"fee_type_id" => misc_fee_type_2.id.to_s, "quantity" => "2", "rate" => "125", "_destroy" => "false"},
       },
      "expenses_attributes"=>
      {

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
         let(:invalid_claim_params)      { valid_claim_fee_params.reject{ |k,v| k == 'prosecuting_authority'} }
 
         context 'valid params' do
-          it 'should create a claim with all basic fees and the specified non-basic fees' do
+          it 'should create a claim with all basic fees and the specified miscellaneous and fixed fees' do
             post :create, claim: claim_params
             claim = assigns(:claim)
 
@@ -312,10 +312,6 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
             expect(claim.basic_fees.detect{ |f| f.fee_type_id == basic_fee_type_3.id }.amount.to_f ).to eq 9000.45
             expect(claim.basic_fees.detect{ |f| f.fee_type_id == basic_fee_type_4.id }.amount.to_f ).to eq 125.0
             expect(claim.basic_fees.detect{ |f| f.fee_type_id == basic_fee_type_2.id }).to be_blank
-
-            # expect(claim.non_basic_fees.size).to eq 2
-            # expect(claim.non_basic_fees.detect{ |f| f.fee_type_id == misc_fee_type_2.id }.amount.to_f ).to eq 250.0
-            # expect(claim.non_basic_fees.detect{ |f| f.fee_type_id == fixed_fee_type_1.id }.amount.to_f ).to eq 2500.0
 
             expect(claim.fixed_fees.size).to eq 1
             expect(claim.fixed_fees.detect{ |f| f.fee_type_id == fixed_fee_type_1.id }.amount.to_f ).to eq 2500.0
@@ -329,14 +325,13 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
 
         context 'invalid params' do
           render_views
-          it 'should redisplay the page with error messages and all the entered data in basic and non basic fees' do
+          it 'should redisplay the page with error messages and all the entered data in basic, miscellaneous and fixed fees' do
             post :create, claim: invalid_claim_params, commit: 'Submit to LAA'
             expect(response.status).to eq 200
             expect(response).to render_template(:new)
             expect(response.body).to have_content("Prosecuting authority can't be blank")
             claim = assigns(:claim)
             expect(claim.basic_fees.size).to eq 4
-            # expect(claim.non_basic_fees.size).to eq 2
             expect(claim.fixed_fees.size).to eq 1
             expect(claim.misc_fees.size).to eq 1
 
@@ -503,11 +498,6 @@ def valid_claim_fee_params
         "2"=>{"quantity" => "1", "rate" => "9000.45", "fee_type_id" => basic_fee_type_3.id.to_s},
         "3"=>{"quantity" => "5", "rate" => "25", "fee_type_id" => basic_fee_type_4.id.to_s}
         },
-     # "non_basic_fees_attributes"=>
-     #  {
-     #    "0"=>{"fee_type_id" => misc_fee_type_2.id.to_s, "quantity" => "2", "rate" => "125", "_destroy" => "false"},
-     #    "1"=>{"fee_type_id" => fixed_fee_type_1.id.to_s, "quantity" => "250", "rate" => "10", "_destroy" => "false"}
-     #  },
       "fixed_fees_attributes"=>
       {
         "0"=>{"fee_type_id" => fixed_fee_type_1.id.to_s, "quantity" => "250", "rate" => "10", "_destroy" => "false"}

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -218,18 +218,14 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-
   it { should accept_nested_attributes_for(:basic_fees) }
-  # it { should accept_nested_attributes_for(:non_basic_fees) }
   it { should accept_nested_attributes_for(:fixed_fees) }
   it { should accept_nested_attributes_for(:misc_fees) }
   it { should accept_nested_attributes_for(:expenses) }
   it { should accept_nested_attributes_for(:defendants) }
   it { should accept_nested_attributes_for(:documents) }
 
-
   subject { create(:claim) }
-
 
   describe '.earliest_representation_order' do
     let(:claim)         { FactoryGirl.build :unpersisted_claim }

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Claim, type: :model do
 
 
   it { should accept_nested_attributes_for(:basic_fees) }
-  it { should accept_nested_attributes_for(:non_basic_fees) }
+  # it { should accept_nested_attributes_for(:non_basic_fees) }
   it { should accept_nested_attributes_for(:fixed_fees) }
   it { should accept_nested_attributes_for(:misc_fees) }
   it { should accept_nested_attributes_for(:expenses) }
@@ -231,7 +231,7 @@ RSpec.describe Claim, type: :model do
   subject { create(:claim) }
 
 
-  describe 'earliest_representation_order' do
+  describe '.earliest_representation_order' do
     let(:claim)         { FactoryGirl.build :unpersisted_claim }
     let(:early_date)    { 2.years.ago.to_date }
 
@@ -251,13 +251,13 @@ RSpec.describe Claim, type: :model do
       # when I get the earliest rep order
       rep_order = claim.earliest_representation_order
 
-      # it should have a date of 
+      # it should have a date of
       expect(rep_order.representation_order_date).to eq early_date
     end
   end
 
 
-  describe 'is_allocated_to_case_worker' do
+  describe '.is_allocated_to_case_worker' do
     let(:case_worker_1)        { FactoryGirl.create :case_worker }
     let(:case_worker_2)        { FactoryGirl.create :case_worker }
 
@@ -273,7 +273,7 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  describe '#update_model_and_transition_state' do
+  describe '.update_model_and_transition_state' do
     it 'should update the model then transition state to prevent state transition validation errors' do
       # given
       claim = FactoryGirl.create :allocated_claim
@@ -356,7 +356,7 @@ RSpec.describe Claim, type: :model do
       @bft3 = FactoryGirl.create :fee_type, :basic,  description: 'BBBB', id: 6
     end
 
-    describe '#instantiate_basic_fees' do
+    describe '.instantiate_basic_fees' do
       it 'should create a fee record for every basic fee type' do
         # Given three basic fee types and some other non-basic fee types
         # when I instantiate a new claim
@@ -374,7 +374,7 @@ RSpec.describe Claim, type: :model do
       end
     end
 
-    describe '#basic_fees' do
+    describe '.basic_fees' do
       it 'should return a fee for every basic fee sorted in order of fee type id (i.e. seeded data order)' do
         # Given three basic fee types and some other non-basic fee types and a claim
         claim = FactoryGirl.build :claim

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -221,6 +221,8 @@ RSpec.describe Claim, type: :model do
 
   it { should accept_nested_attributes_for(:basic_fees) }
   it { should accept_nested_attributes_for(:non_basic_fees) }
+  it { should accept_nested_attributes_for(:fixed_fees) }
+  it { should accept_nested_attributes_for(:misc_fees) }
   it { should accept_nested_attributes_for(:expenses) }
   it { should accept_nested_attributes_for(:defendants) }
   it { should accept_nested_attributes_for(:documents) }


### PR DESCRIPTION
fixed fees only apply to fixed fees case/claim types
which are to be applied in a future ticket. This
lays the groundwork for that ticket.

includes:
- remove non basic fee logic (model scopes, partials)
- add separate scopes and partials for fixed/misc fees
- amend specs in line with changes
- add cukes
