### PR TITLE
Replace placeholder text with values for claim detail view

### DIFF
--- a/app/assets/javascripts/advocates/claims/fee_section_display.js
+++ b/app/assets/javascripts/advocates/claims/fee_section_display.js
@@ -54,13 +54,13 @@ adp.feeSectionDisplay = {
 
   applyFixedFeeState : function(state) {
     if (state) {
-      adp.feeSectionDisplay.applyWarning('Initial and Miscellaneous fees exist that will be removed if you save this claim as a Fixed Fee!!', state);
+      adp.feeSectionDisplay.applyWarning('Initial and Miscellaneous fees exist that will be removed if you save this claim as a Fixed Fee!', state);
       adp.feeSectionDisplay.$basicFeesSet.slideUp();
       adp.feeSectionDisplay.$miscFeesSet.slideUp();
       adp.feeSectionDisplay.$fixedFeesSet.slideDown();
 
     } else {
-      adp.feeSectionDisplay.applyWarning('Fixed fees exist that will be removed if you save this non-fixed-fee case type claim!!', state);
+      adp.feeSectionDisplay.applyWarning('Fixed fees exist that will be removed if you save this non-fixed-fee case type claim!', state);
       adp.feeSectionDisplay.$basicFeesSet.slideDown();
       adp.feeSectionDisplay.$miscFeesSet.slideDown();
       adp.feeSectionDisplay.$fixedFeesSet.slideUp();

--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -18,6 +18,18 @@ class ClaimPresenter < BasePresenter
     claim.paid_at.strftime(format) unless claim.paid_at.nil?
   end
 
+  def retrial
+    claim.case_type.match(/retrial/i) ? 'Yes' : 'No'
+  end
+
+  def any_judicial_apportionments
+    claim.defendants.map(&:order_for_judicial_apportionment).include?(true) ? 'Yes' : 'No'
+  end
+
+  def trial_concluded
+    claim.trial_concluded_at.blank? ? 'not specified' : claim.trial_concluded_at.strftime(Settings.date_format)
+  end
+
   def total
     h.number_to_currency(claim.total)
   end

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -60,22 +60,22 @@
             - if claim.court
               = claim.court.name
           %dt
-            =t('.prosecuting_auth')
+            = t('.prosecuting_auth')
           %dd
-            CPS
+            = claim.prosecuting_authority.titleize
           %dt
-            =t('.q.retrial')
+            = t('.q.retrial')
           %dd
-            No
+            = claim.retrial
           %dt
             =t('.j_a')
           %dd
-            No
+            = claim.any_judicial_apportionments
           - if controller.action_name == 'show' || controller.action_name == 'update'
             %dt
-              Hearing
+              Trial Concluded
             %dd
-              27/04/2015
+              = claim.trial_concluded
             %dt
               Advocate
             %dd

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -9,6 +9,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   # inflect.irregular 'person', 'people'
   # inflect.uncountable %w( fish sheep )
   inflect.irregular 'date_attended', 'dates_attended'
+  inflect.acronym 'CPS'
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,7 +327,7 @@ en:
       offence_class: Offence class
       prosecuting_auth: Prosecuting authority
       q:
-        retrial: "Retrial?"
+        retrial: "Retrial"
       reporders: Representation order(s)
       submit_date: Case submitted
 

--- a/spec/presenters/claim_presenter_spec.rb
+++ b/spec/presenters/claim_presenter_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe ClaimPresenter do
   before do
     Timecop.freeze(Time.current)
     @first_defendant = claim.defendants.first
-    create(:defendant, first_name: 'John', middle_name: 'Robert', last_name: 'Smith', claim: claim)
-    create(:defendant, first_name: 'Adam', middle_name: '', last_name: 'Smith', claim: claim)
+    create(:defendant, first_name: 'John', middle_name: 'Robert', last_name: 'Smith', claim: claim, order_for_judicial_apportionment: false)
+    create(:defendant, first_name: 'Adam', middle_name: '', last_name: 'Smith', claim: claim, order_for_judicial_apportionment: false)
   end
 
   after { Timecop.return }
@@ -29,7 +29,35 @@ RSpec.describe ClaimPresenter do
     expect(subject.paid_at).to eql(Time.current.strftime('%d/%m/%Y'))
     expect(subject.paid_at(include_time: false)).to eql(Time.current.strftime('%d/%m/%Y'))
     expect(subject.paid_at(include_time: true)).to eql(Time.current.strftime('%d/%m/%Y %H:%M'))
-    expect{ subject.paid_at(rubbish: false) }.to raise_error(ArgumentError)
+    expect{subject.paid_at(rubbish: false) }.to raise_error(ArgumentError)
+  end
+
+  describe '#retrial' do
+
+    it 'returns yes for case types like retrial' do
+      claim.case_type = 'retrial'
+      expect(subject.retrial).to eql 'Yes'
+    end
+
+    it 'returns no for case types NOT like retrial' do
+      claim.case_type = 'contempt'
+      expect(subject.retrial).to eql 'No'
+    end
+
+  end
+
+  describe '#any_judicial_apportionments' do
+
+    it "returns yes if any defendants have an order for judicial apportionment" do
+      @first_defendant.update_attribute(:order_for_judicial_apportionment,true)
+      expect(subject.any_judicial_apportionments).to eql 'Yes'
+    end
+
+    it "returns no if no defendants have an order for judicial apportionment" do
+      @first_defendant.update_attribute(:order_for_judicial_apportionment,false)
+      expect(subject.any_judicial_apportionments).to eql 'No'
+    end
+
   end
 
   # TODO: do currency converters need internationalisation??


### PR DESCRIPTION
some placeholder text in the claim detail view (read-only)
has been hanging around for a while. This needed modifying
bsed on feedback from users

could still lockdown this view with some request/view spec.
