### PR TITLE
remove seed data from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,3 @@ deploy:
   run:
     - "rake db:clear"
     - "rake db:migrate"
-    - "rake db:seed"


### PR DESCRIPTION
seed data is not necessary for travis CI tests and
slows build.
