### PR TITLE
Remove "parts rejected" and "appealed" states.

### DIFF
--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -16,6 +16,6 @@ module CaseWorkers::ClaimsHelper
   end
 
   def unallocated_claims_count
-    Claim.submitted.count # doesn't include appealed claims
+    Claim.submitted.count
   end
 end

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -20,7 +20,6 @@ STATES_TO_ADD_EVIDENCE_FOR = ['allocated',
                               'completed',
                               'paid',
                               'part_paid',
-                              'parts_rejected',
                               'awaiting_further_info',
                               'awaiting_info_from_court']
 

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -21,14 +21,12 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
   describe 'GET #index' do
     before(:each) do
       @allocated_claim                = build_claim_in_state(:allocated)
-      @appealed_claim                 = build_claim_in_state(:appealed)
       @archived_pending_delete_claim  = build_claim_in_state(:archived_pending_delete)
       @awaiting_further_info_claim    = build_claim_in_state(:awaiting_further_info)
       @awaiting_info_from_court_claim = build_claim_in_state(:awaiting_info_from_court)
       @completed_claim                = build_claim_in_state(:completed)
       @draft_claim                    = build_claim_in_state(:draft)
       @part_paid_claim                = build_claim_in_state(:part_paid)
-      @parts_rejected_claim           = build_claim_in_state(:parts_rejected)
       @refused_claim                  = build_claim_in_state(:refused)
       @rejected_claim                 = build_claim_in_state(:rejected)
       @submitted_claim                = build_claim_in_state(:submitted)
@@ -38,9 +36,9 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
       allow_any_instance_of(Claims::FinancialSummary).to receive(:total_outstanding_claim_value).and_return( 1323.44 )
     end
 
-    let(:full_collection)  { [  @allocated_claim, @appealed_claim, @archived_pending_delete_claim,
+    let(:full_collection)  { [  @allocated_claim, @archived_pending_delete_claim,
                                 @awaiting_further_info_claim, @awaiting_info_from_court_claim, @completed_claim,
-                                @draft_claim, @part_paid_claim, @parts_rejected_claim, @refused_claim,
+                                @draft_claim, @part_paid_claim, @refused_claim,
                                 @rejected_claim, @submitted_claim ] }
 
     context 'advocate' do
@@ -59,9 +57,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
                                                               @submitted_claim,
                                                               @awaiting_info_from_court_claim,
                                                               @awaiting_further_info_claim)
-        expect(assigns(:part_paid_claims)).to contain_claims( @part_paid_claim,
-                                                              @appealed_claim,
-                                                              @parts_rejected_claim)
+        expect(assigns(:part_paid_claims)).to contain_claims( @part_paid_claim)
         expect(assigns(:completed_claims)).to contain_claims( @completed_claim, @refused_claim )
       end
     end
@@ -86,9 +82,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
                                                               @submitted_claim,
                                                               @awaiting_info_from_court_claim,
                                                               @awaiting_further_info_claim)
-        expect(assigns(:part_paid_claims)).to contain_claims( @part_paid_claim,
-                                                              @appealed_claim,
-                                                              @parts_rejected_claim)
+        expect(assigns(:part_paid_claims)).to contain_claims( @part_paid_claim )
         expect(assigns(:completed_claims)).to contain_claims( @completed_claim, @refused_claim )
       end
     end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -99,10 +99,6 @@ FactoryGirl.define do
       after(:create) { |c| c.submit!; c.allocate!; }
     end
 
-    factory :appealed_claim do
-      after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.pay_part!; c.reject_parts!; c.appeal! }
-    end
-
     factory :archived_pending_delete_claim do
       after(:create) { |c| c.archive_pending_delete! }
     end
@@ -125,10 +121,6 @@ FactoryGirl.define do
 
     factory :part_paid_claim do
       after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.pay_part! }
-    end
-
-    factory :parts_rejected_claim do
-      after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.pay_part!; c.reject_parts!  }
     end
 
     factory :refused_claim do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe Claim, type: :model do
 
   context 'State Machine meta states magic methods' do
     let(:claim)       { FactoryGirl.build :claim }
-    let(:all_states)  { [  'allocated', 'appealed', 'archived_pending_delete', 'awaiting_further_info', 'awaiting_info_from_court', 'completed',
-                           'deleted', 'draft', 'paid', 'part_paid', 'parts_rejected', 'refused', 'rejected', 'submitted' ] }
+    let(:all_states)  { [  'allocated', 'archived_pending_delete', 'awaiting_further_info', 'awaiting_info_from_court', 'completed',
+                           'deleted', 'draft', 'paid', 'part_paid', 'refused', 'rejected', 'submitted' ] }
 
     context 'advocate_dashboard_draft?' do
       before(:each)     { allow(claim).to receive(:state).and_return('draft') }
@@ -132,14 +132,14 @@ RSpec.describe Claim, type: :model do
 
     context 'advocate_dashboard_part_paid' do
       it 'should respond true' do
-        [ 'part_paid', 'appealed', 'parts_rejected' ].each do |state|
+        [ 'part_paid' ].each do |state|
           allow(claim).to receive(:state).and_return(state)
           expect(claim.advocate_dashboard_part_paid?).to be true
         end
       end
 
       it 'should respond false to anything else' do
-        (all_states - [ 'part_paid', 'appealed', 'parts_rejected' ]).each do |claim_state|
+        (all_states - [ 'part_paid' ]).each do |claim_state|
           allow(claim).to receive(:state).and_return(claim_state)
           expect(claim.advocate_dashboard_part_paid?).to be false
         end


### PR DESCRIPTION
Unused states and transitions for "parts rejected" and "appealed." Removed in preparation for new state(s) around claim redetermination and written reason.
