### PR TITLE
amend defendant search to include middle name

### DIFF
--- a/app/models/claims/search.rb
+++ b/app/models/claims/search.rb
@@ -3,7 +3,8 @@ module Claims::Search
   QUERY_MAPPINGS_FOR_SEARCH = {
     defendant_name: {
       joins: :defendants,
-      query: "lower(defendants.first_name || ' ' || defendants.last_name) ILIKE :term"
+      query: "lower(defendants.first_name || ' ' || defendants.last_name) ILIKE :term " +
+             "OR lower(defendants.first_name || ' ' || defendants.middle_name || ' ' || defendants.last_name) ILIKE :term"
     },
     advocate_name: {
       joins: { advocate: :user },

--- a/features/advocate_claims_list.feature
+++ b/features/advocate_claims_list.feature
@@ -65,20 +65,26 @@ Feature: Advocate claims list
       And I search by the advocate name "John Smith"
      Then I should only see the 4 claims for the advocate "John Smith"
 
-  Scenario Outline: Search claims by defendant name
+  Scenario Outline: Search claims by defendant name (with optional middlename)
     Given I am a signed in advocate
       And There are fee schemes in place
       And I have 2 claims involving defendant "Joe Bloggs" amongst others
       And I have 3 claims involving defendant "Fred Bloggs" amongst others
+      And I have 1 claims involving defendant "Fred Joe Bloggs" amongst others
+      And I have 1 claims involving defendant "Joe Fred Bloggs" amongst others
      When I visit the advocates dashboard
       And I search by the name <defendant_name>
      Then I should only see the <number> claims involving defendant <defendant_name>
 
      Examples:
-        | defendant_name | number |
-        | "Joe Bloggs"   | 2      |
-        | "Fred Bloggs"  | 3      |
-        | "Bloggs"       | 5      |
+        | defendant_name    | number  |
+        | "Joe Bloggs"      | 4       |
+        | "Fred Bloggs"     | 5       |
+        | "Joe"             | 4       |
+        | "Bloggs"          | 7       |
+        | "Fred Joe Bloggs" | 1       |
+        | "Joe Fred Bloggs" | 1       |
+
 
   Scenario: No search by advocate name for non-admin
     Given I am a signed in advocate

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -165,11 +165,12 @@ end
 Given(/^I have (\d+) claims involving defendant "(.*?)" amongst others$/) do |number,defendant_name|
   @claims = create_list(:draft_claim, number.to_i, advocate: @advocate)
   @claims.each do |claim|
-    create(:defendant, claim: claim, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name)
+    create(:defendant, claim: claim, first_name: Faker::Name.first_name, middle_name: Faker::Name.first_name, last_name: Faker::Name.last_name)
   end
   @claims = create_list(:submitted_claim, number.to_i, advocate: @advocate)
   @claims.each do |claim|
-    create(:defendant, claim: claim, first_name: defendant_name.split.first, last_name: defendant_name.split.last)
+    middle_names = defendant_name.split.delete_if.with_index { |name,idx| name if idx == 0 || idx == defendant_name.split.count-1 }.join(' ')
+    create(:defendant, claim: claim, first_name: defendant_name.split.first, middle_name: middle_names, last_name: defendant_name.split.last)
   end
 end
 


### PR DESCRIPTION
This came out of user testing. The functionality
makes specifying the middle name(s) optional in that
a search for "Joe Bloggs" will find "Joe Bloggs",
"Joe Fred Bloggs", "Joe Fred Bob Bloggs", etc.
