### PR TITLE
fix logger fail and test for 405 response from each api endpoint

### DIFF
--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -5,7 +5,7 @@ class API::Logger < Grape::Middleware::Base
   end
 
   def after
-    log_api_response(@app_response.status, JSON.parse(@app_response.body.first))
+    log_api_response(@app_response.status)
     @app_response # this must return @app_response or nil
   end
 
@@ -15,8 +15,15 @@ class API::Logger < Grape::Middleware::Base
     log_api('api-request', { method: method, path: path, data: data })
   end
 
-  def log_api_response(status, response_body)
+  def log_api_response(status)
     log_api('api-response', { status: status, response_body: response_body })
+  end
+
+  def response_body
+    begin
+      JSON.parse(@app_response.body.first)
+    rescue JSON::ParserError
+    end
   end
 
   def log_api(api_type, data)

--- a/spec/api/v1/claims/claim_spec.rb
+++ b/spec/api/v1/claims/claim_spec.rb
@@ -7,6 +7,9 @@ describe API::V1::Advocates::Claim do
   VALIDATE_CLAIM_ENDPOINT = "/api/advocates/claims/validate"
   CREATE_CLAIM_ENDPOINT = "/api/advocates/claims"
 
+  ALL_CLAIM_ENDPOINTS = [VALIDATE_CLAIM_ENDPOINT, CREATE_CLAIM_ENDPOINT]
+  FORBIDDEN_CLAIM_VERBS = [:get, :put, :patch, :delete]
+
   let!(:current_advocate) { create(:advocate) }
   let!(:offence)          { create(:offence)}
   let!(:court)            { create(:court)}
@@ -22,6 +25,19 @@ describe API::V1::Advocates::Claim do
                           :offence_id => offence.id,
                           :court_id => court.id,
                           :prosecuting_authority => 'cps'} }
+
+  context 'All claim API endpoints' do
+    ALL_CLAIM_ENDPOINTS.each do |endpoint| # for each endpoint
+      context 'when sent a non-permitted verb' do
+        FORBIDDEN_CLAIM_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it 'should return a status of 405' do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
 
   describe "POST /api/advocates/claims/validate" do
 

--- a/spec/api/v1/claims/date_attended_spec.rb
+++ b/spec/api/v1/claims/date_attended_spec.rb
@@ -8,9 +8,25 @@ describe API::V1::Advocates::DateAttended do
   CREATE_DATE_ATTENDED_ENDPOINT = "/api/advocates/dates_attended"
   VALIDATE_DATE_ATTENDED_ENDPOINT = "/api/advocates/dates_attended/validate"
 
+  ALL_DATES_ATTENDED_ENDPOINTS = [VALIDATE_DATE_ATTENDED_ENDPOINT, CREATE_DATE_ATTENDED_ENDPOINT]
+  FORBIDDEN_DATES_ATTENDED_VERBS = [:get, :put, :patch, :delete]
+
   let!(:fee)                            { create(:fee, id: 1) }
   let!(:valid_date_attended_params)     { {fee_id: fee.id, date: '10 May 2015', date_to: '12 May 2015'} }
   let!(:invalid_date_attended_params)   { {} }
+
+  context 'All dates_attended API endpoints' do
+    ALL_DATES_ATTENDED_ENDPOINTS.each do |endpoint| # for each endpoint
+      context 'when sent a non-permitted verb' do
+        FORBIDDEN_DATES_ATTENDED_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it 'should return a status of 405' do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
 
   describe 'POST api/advocates/dates_attended' do
 

--- a/spec/api/v1/claims/defendant_spec.rb
+++ b/spec/api/v1/claims/defendant_spec.rb
@@ -8,10 +8,26 @@ describe API::V1::Advocates::Defendant do
   CREATE_DEFENDANT_ENDPOINT = "/api/advocates/defendants"
   VALIDATE_DEFENDANT_ENDPOINT = "/api/advocates/defendants/validate"
 
+  ALL_DEFENDANT_ENDPOINTS = [VALIDATE_DEFENDANT_ENDPOINT, CREATE_DEFENDANT_ENDPOINT]
+  FORBIDDEN_DEFENDANT_VERBS = [:get, :put, :patch, :delete]
+
   let!(:claim)                     {  create(:claim) }
   let!(:valid_defendant_params)    { {claim_id: claim.id, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
   let!(:invalid_defendant_params)  { {claim_id: claim.id} }
   let!(:invalid_claim_id_params)   { {claim_id: 10000000, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
+
+  context 'All defendant API endpoints' do
+    ALL_DEFENDANT_ENDPOINTS.each do |endpoint| # for each endpoint
+      context 'when sent a non-permitted verb' do
+        FORBIDDEN_DEFENDANT_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it 'should return a status of 405' do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
 
   describe 'POST api/advocates/defendants' do
 

--- a/spec/api/v1/claims/dropdown_data_spec.rb
+++ b/spec/api/v1/claims/dropdown_data_spec.rb
@@ -17,6 +17,22 @@ describe API::V1::DropdownData do
   FEE_TYPE_ENDPOINT       = "/api/fee_types"
   EXPENSE_TYPE_ENDPOINT   = "/api/expense_types"
 
+  ALL_DROPDOWN_ENDPOINTS       = [CASE_TYPE_ENDPOINT, COURT_ENDPOINT, ADVOCATE_CATEGORY_ENDPOINT, PROSECUTING_AUTHORITY_ENDPOINT, CRACKED_THIRD_ENDPOINT, GRANTING_BODY_ENDPOINT, OFFENCE_CLASS_ENDPOINT, OFFENCE_ENDPOINT, FEE_CATEGORY_ENDPOINT, FEE_TYPE_ENDPOINT, EXPENSE_TYPE_ENDPOINT]
+  FORBIDDEN_DROPDOWN_VERBS     = [:post, :put, :patch, :delete]
+
+  context 'All dropdown data API endpoints' do
+    ALL_DROPDOWN_ENDPOINTS.each do |endpoint| # for each endpoint
+      context 'when sent a non-permitted verb' do
+        FORBIDDEN_DROPDOWN_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it 'should return a status of 405' do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
+
   context 'GET api/case_types' do
 
     it 'should return a status of 200' do
@@ -30,6 +46,7 @@ describe API::V1::DropdownData do
     end
 
   end
+
 
   context 'GET api/courts' do
 

--- a/spec/api/v1/claims/expense_spec.rb
+++ b/spec/api/v1/claims/expense_spec.rb
@@ -8,10 +8,26 @@ describe API::V1::Advocates::Expense do
   CREATE_EXPENSE_ENDPOINT = "/api/advocates/expenses"
   VALIDATE_EXPENSE_ENDPOINT = "/api/advocates/expenses/validate"
 
+  ALL_EXPENSE_ENDPOINTS = [VALIDATE_EXPENSE_ENDPOINT, CREATE_EXPENSE_ENDPOINT]
+  FORBIDDEN_EXPENSE_VERBS = [:get, :put, :patch, :delete]
+
   let!(:claim)                      {  create(:claim)                                                                                     }
   let!(:expense_type)               {  create(:expense_type)                                                                              }
   let!(:valid_expense_params)       { {claim_id: claim.id, expense_type_id: expense_type.id, rate: 1, quantity: 2, date: '10 May 2015', location: 'London' }  }
-  let!(:invalid_expense_params)     { {claim_id: claim.id }                                                                             }
+  let!(:invalid_expense_params)     { {claim_id: claim.id }                                                                         }
+
+  context 'All expense API endpoints' do
+    ALL_EXPENSE_ENDPOINTS.each do |endpoint| # for each endpoint
+      context 'when sent a non-permitted verb' do
+        FORBIDDEN_EXPENSE_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it 'should return a status of 405' do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
 
   describe 'POST api/advocates/expenses' do
 

--- a/spec/api/v1/claims/fee_spec.rb
+++ b/spec/api/v1/claims/fee_spec.rb
@@ -8,10 +8,26 @@ describe API::V1::Advocates::Fee do
   CREATE_FEE_ENDPOINT = "/api/advocates/fees"
   VALIDATE_FEE_ENDPOINT = "/api/advocates/fees/validate"
 
+  ALL_FEE_ENDPOINTS = [VALIDATE_FEE_ENDPOINT, CREATE_FEE_ENDPOINT]
+  FORBIDDEN_FEE_VERBS = [:get, :put, :patch, :delete]
+
   let!(:fee_type)            { create(:fee_type, id: 1) }
   let!(:claim)               { create(:claim) }
   let!(:valid_fee_params)    { {claim_id: claim.id, fee_type_id: fee_type.id, quantity: 3, amount: 10.00 } }
   let!(:invalid_fee_params)  { {claim_id: claim.id} }
+
+  context 'All fee API endpoints' do
+    ALL_FEE_ENDPOINTS.each do |endpoint| # for each endpoint
+      context 'when sent a non-permitted verb' do
+        FORBIDDEN_FEE_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it 'should return a status of 405' do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
 
   describe 'POST api/advocates/fees' do
 

--- a/spec/api/v1/claims/representation_order_spec.rb
+++ b/spec/api/v1/claims/representation_order_spec.rb
@@ -8,8 +8,24 @@ describe API::V1::Advocates::RepresentationOrder do
   CREATE_REPRESENTATION_ORDER_ENDPOINT = "/api/advocates/representation_orders"
   VALIDATE_REPRESENTATION_ORDER_ENDPOINT = "/api/advocates/representation_orders/validate"
 
+  ALL_REP_ORDER_ENDPOINTS = [VALIDATE_REPRESENTATION_ORDER_ENDPOINT, CREATE_REPRESENTATION_ORDER_ENDPOINT]
+  FORBIDDEN_REP_ORDER_VERBS = [:get, :put, :patch, :delete]
+
   let!(:valid_representation_order_params)    { {granting_body: "Magistrate's Court", defendant_id: 1, representation_order_date: '10 June 2015', maat_reference: 'maatmaatmaat' } }
   let!(:invalid_representation_order_params)  { {} }
+
+  context 'All representation_order API endpoints' do
+    ALL_REP_ORDER_ENDPOINTS.each do |endpoint| # for each endpoint
+      context 'when sent a non-permitted verb' do
+        FORBIDDEN_REP_ORDER_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it 'should return a status of 405' do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
 
   describe 'POST api/advocates/representation_orders' do
 


### PR DESCRIPTION
JSON.parse, in the logger, was failing when a 405 status was returned because there is no response body in those cases.
