### PR TITLE
Refactor API endpoints to use UUIDs

### DIFF
--- a/app/interfaces/api/v1/advocates/claim.rb
+++ b/app/interfaces/api/v1/advocates/claim.rb
@@ -39,7 +39,7 @@ module API
               optional :trial_cracked_at_third, type: String, values: Settings.trial_cracked_at_third, desc: "The third in which this case was cracked."
             end
 
-            def build_arguements
+            def build_arguments
               user = User.advocates.find_by(email: params[:advocate_email])
               if user.blank?
                 raise API::V1::ArgumentError, 'advocate_email is invalid'
@@ -65,7 +65,7 @@ module API
                   trial_cracked_at:         params[:trial_cracked_at],
                   trial_cracked_at_third:   params[:trial_cracked_at_third],
                   offence_id:               params[:offence_id],
-                  court_id:                 params[:court_id], 
+                  court_id:                 params[:court_id],
                 }
               end
             end
@@ -79,23 +79,24 @@ module API
 
           post do
             begin
-              arguements = build_arguements
+              arguments = build_arguments
             rescue => error
-              arguements_error = ErrorResponse.new(error)
-              status arguements_error.status
-              return arguements_error.body
+              arguments_error = ErrorResponse.new(error)
+              status arguments_error.status
+              return arguments_error.body
             end
 
-            claim = ::Claim.create(arguements)
+            claim = ::Claim.create(arguments)
 
             if !claim.errors.empty?
-                    error = ErrorResponse.new(claim)
+              error = ErrorResponse.new(claim)
               status error.status
               return error.body
             end
 
             status 201
-            api_response = { 'id' => claim.id }.merge!(declared(params))
+
+            api_response = { 'id' => claim.reload.uuid }.merge!(declared(params))
 
             api_response
           end
@@ -108,17 +109,17 @@ module API
 
           post '/validate' do
             begin
-                arguements = build_arguements
+                arguments = build_arguments
             rescue => error
-              arguements_error = ErrorResponse.new(error)
-              status arguements_error.status
-              return arguements_error.body
+              arguments_error = ErrorResponse.new(error)
+              status arguments_error.status
+              return arguments_error.body
             end
 
-            claim = ::Claim.new(arguements)
+            claim = ::Claim.new(arguments)
 
             if !claim.valid?
-                    error = ErrorResponse.new(claim)
+              error = ErrorResponse.new(claim)
               status error.status
               return error.body
             end

--- a/app/interfaces/api/v1/advocates/date_attended.rb
+++ b/app/interfaces/api/v1/advocates/date_attended.rb
@@ -1,7 +1,7 @@
 module API
   module V1
 
-    
+
     class Error < StandardError; end
     class ArgumentError < Error; end
 
@@ -18,14 +18,14 @@ module API
 
           helpers do
             params :date_attended_creation do
-              requires :fee_id, type: Integer, desc: 'The ID of the corresponding Fee.'
+              requires :fee_id, type: String, desc: 'The ID of the corresponding Fee.'
               requires :date, type: DateTime, desc: 'The date, or first date in the date-range, applicable to this Fee (YYYY/MM/DD)'
               optional :date_to, type: DateTime, desc: 'The last date your date-range (YYYY/MM/DD)'
             end
 
             def args
               {
-                fee_id: params[:fee_id],
+                fee_id: ::Fee.find_by(uuid: params[:fee_id]).try(:id),
                 date: params[:date],
                 date_to: params[:date_to]
               }

--- a/app/interfaces/api/v1/advocates/date_attended.rb
+++ b/app/interfaces/api/v1/advocates/date_attended.rb
@@ -40,7 +40,9 @@ module API
           end
 
           post do
-            ::DateAttended.create!(args)
+            date_attended = ::DateAttended.create!(args)
+            api_response = { 'id' => date_attended.reload.uuid }.merge!(declared(params))
+            api_response
           end
 
 

--- a/app/interfaces/api/v1/advocates/defendant.rb
+++ b/app/interfaces/api/v1/advocates/defendant.rb
@@ -1,7 +1,7 @@
 module API
   module V1
 
-    
+
     class Error < StandardError; end
     class ArgumentError < Error; end
 
@@ -18,7 +18,7 @@ module API
 
           helpers do
             params :defendant_creation do
-              requires :claim_id, type: Integer, desc: "Unique identifier for the claim associated with this defendant."
+              requires :claim_id, type: String, desc: "Unique identifier for the claim associated with this defendant."
               requires :first_name, type: String, desc: "First name of the defedant."
               optional :middle_name, type: String, desc: "Middle name of the defendant."
               requires :last_name, type: String, desc: "Last name of the defendant."
@@ -28,7 +28,7 @@ module API
 
             def args
               {
-                claim_id: params[:claim_id],
+                claim_id: ::Claim.find_by(uuid: params[:claim_id]).try(:id),
                 first_name: params[:first_name],
                 middle_name: params[:middle_name],
                 last_name: params[:last_name],
@@ -58,7 +58,7 @@ module API
           post '/validate' do
             defendant = ::Defendant.new(args)
             if !defendant.valid?
-                    error = ErrorResponse.new(defendant)
+              error = ErrorResponse.new(defendant)
               status error.status
               return error.body
             end

--- a/app/interfaces/api/v1/advocates/defendant.rb
+++ b/app/interfaces/api/v1/advocates/defendant.rb
@@ -46,7 +46,9 @@ module API
           end
 
           post do
-            ::Defendant.create!(args)
+            defendant = ::Defendant.create!(args)
+            api_response = { 'id' => defendant.reload.uuid }.merge!(declared(params))
+            api_response
           end
 
           desc "Validate a defendant."

--- a/app/interfaces/api/v1/advocates/expense.rb
+++ b/app/interfaces/api/v1/advocates/expense.rb
@@ -1,7 +1,7 @@
 module API
   module V1
 
-    
+
     class Error < StandardError; end
     class ArgumentError < Error; end
 
@@ -18,7 +18,7 @@ module API
 
           helpers do
             params :expense_creation do
-              requires :claim_id, type: Integer, desc: "Unique identifier for the claim associated with this defendant."
+              requires :claim_id, type: String, desc: "Unique identifier for the claim associated with this defendant."
               requires :date, type: DateTime, desc: "Date on which this expense was incurred (YYYY/MM/DD)."
               requires :expense_type_id, type: Integer, desc: "Reference to the parent expense type."
               requires :quantity, type: Integer, desc: "Quantity of expenses of this type and rate."
@@ -28,7 +28,7 @@ module API
 
             def args
               {
-                claim_id: params[:claim_id],
+                claim_id: ::Claim.find_by(uuid: params[:claim_id]).try(:id),
                 date: params[:date],
                 expense_type_id: params[:expense_type_id],
                 quantity: params[:quantity],
@@ -59,7 +59,7 @@ module API
             expense = ::Expense.new(args)
 
             if !expense.valid?
-                    error = ErrorResponse.new(expense)
+              error = ErrorResponse.new(expense)
               status error.status
               return error.body
             end

--- a/app/interfaces/api/v1/advocates/expense.rb
+++ b/app/interfaces/api/v1/advocates/expense.rb
@@ -46,7 +46,9 @@ module API
           end
 
           post do
-            ::Expense.create!(args)
+            expense = ::Expense.create!(args)
+            api_response = { 'id' => expense.reload.uuid }.merge!(declared(params))
+            api_response
           end
 
           desc "Validate an expense."

--- a/app/interfaces/api/v1/advocates/fee.rb
+++ b/app/interfaces/api/v1/advocates/fee.rb
@@ -41,7 +41,9 @@ module API
           end
 
           post do
-            ::Fee.create!(args)
+            fee = ::Fee.create!(args)
+            api_response = { 'id' => fee.reload.uuid }.merge!(declared(params))
+            api_response
           end
 
 

--- a/app/interfaces/api/v1/advocates/fee.rb
+++ b/app/interfaces/api/v1/advocates/fee.rb
@@ -17,7 +17,7 @@ module API
 
           helpers do
             params :fee_creation do
-              requires :claim_id, type: Integer, desc: 'The unique identifier for the corresponding claim.'
+              requires :claim_id, type: String, desc: 'The unique identifier for the corresponding claim.'
               requires :fee_type_id, type: Integer, desc: 'The unique identifier for the corresponding FeeType'
               requires :quantity, type: Integer, desc: 'The number of Fees being claimed for of this FeeType and Rate'
               requires :amount, type: Float, desc: 'Total value.'
@@ -25,7 +25,7 @@ module API
 
             def args
               {
-                claim_id: params[:claim_id],
+                claim_id: ::Claim.find_by(uuid: params[:claim_id]).try(:id),
                 fee_type_id: params[:fee_type_id],
                 quantity: params[:quantity],
                 amount: params[:amount]
@@ -55,7 +55,7 @@ module API
             fee = ::Fee.new(args)
 
             if !fee.valid?
-                    error = ErrorResponse.new(fee)
+              error = ErrorResponse.new(fee)
               status error.status
               return error.body
             end

--- a/app/interfaces/api/v1/advocates/representation_order.rb
+++ b/app/interfaces/api/v1/advocates/representation_order.rb
@@ -41,7 +41,9 @@ module API
           end
 
           post do
-            ::RepresentationOrder.create!(args)
+            representation_order = ::RepresentationOrder.create!(args)
+            api_response = { 'id' => representation_order.reload.uuid }.merge!(declared(params))
+            api_response
           end
 
 

--- a/app/interfaces/api/v1/advocates/representation_order.rb
+++ b/app/interfaces/api/v1/advocates/representation_order.rb
@@ -17,7 +17,7 @@ module API
 
           helpers do
             params :representation_order_creation do
-              requires :defendant_id, type: Integer, desc: 'ID of the defendant'
+              requires :defendant_id, type: String, desc: 'ID of the defendant'
               requires :granting_body, type: String, desc: "The court which granted this representation order (Crown Court or Magistrate's Court)"
               requires :maat_reference, type: String, desc: "The unique identifier for this representation order"
               requires :representation_order_date, type: Date, desc: "The date on which this representation order was granted (YYYY/MM/DD)"
@@ -25,7 +25,7 @@ module API
 
             def args
               {
-                defendant_id: params[:defendant_id],
+                defendant_id: ::Defendant.find_by(uuid: params[:defendant_id]).try(:id),
                 granting_body: params[:granting_body],
                 maat_reference: params[:maat_reference],
                 representation_order_date: params[:representation_order_date]
@@ -55,7 +55,7 @@ module API
             representation_order = ::RepresentationOrder.new(args)
 
             if !representation_order.valid?
-                    error = ErrorResponse.new(representation_order)
+              error = ErrorResponse.new(representation_order)
               status error.status
               return error.body
             end
@@ -63,13 +63,8 @@ module API
             status 200
             { valid: true }
           end
-
         end
-
-
       end
-
     end
-
   end
 end

--- a/spec/api/v1/claims/claim_spec.rb
+++ b/spec/api/v1/claims/claim_spec.rb
@@ -69,7 +69,7 @@ describe API::V1::Advocates::Claim do
       expect(json_response['id']).not_to be_nil
 
       expect{ post_to_create_endpoint }.to change { Claim.count }.by(1)
-      expect(Claim.find(json_response['id']).id).to eq(json_response['id'])
+      expect(Claim.find_by(uuid: json_response['id']).uuid).to eq(json_response['id'])
     end
 
     it "returns 400 and an error when advocate email is invalid" do

--- a/spec/api/v1/claims/date_attended_spec.rb
+++ b/spec/api/v1/claims/date_attended_spec.rb
@@ -9,7 +9,7 @@ describe API::V1::Advocates::DateAttended do
   VALIDATE_DATE_ATTENDED_ENDPOINT = "/api/advocates/dates_attended/validate"
 
   let!(:fee)                            { create(:fee, id: 1) }
-  let!(:valid_date_attended_params)     { {fee_id: fee.id, date: '10 May 2015', date_to: '12 May 2015'} }
+  let!(:valid_date_attended_params)     { {fee_id: fee.reload.uuid, date: '10 May 2015', date_to: '12 May 2015'} }
   let!(:invalid_date_attended_params)   { {} }
 
   describe 'POST api/advocates/dates_attended' do

--- a/spec/api/v1/claims/defendant_spec.rb
+++ b/spec/api/v1/claims/defendant_spec.rb
@@ -9,8 +9,8 @@ describe API::V1::Advocates::Defendant do
   VALIDATE_DEFENDANT_ENDPOINT = "/api/advocates/defendants/validate"
 
   let!(:claim)                     {  create(:claim).reload }
-  let!(:valid_defendant_params)    { {claim_id: claim.uuid, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
-  let!(:invalid_defendant_params)  { {claim_id: claim.uuid} }
+  let!(:valid_params)    { {claim_id: claim.uuid, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
+  let!(:invalid_params)  { {claim_id: claim.uuid} }
   let!(:invalid_claim_id_params)   { {claim_id: SecureRandom.uuid, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
 
   describe 'POST api/advocates/defendants' do
@@ -22,16 +22,24 @@ describe API::V1::Advocates::Defendant do
     context 'when defendant params are valid' do
 
       it 'returns 201 and creates a new defendant record' do
-        response = post_to_create_endpoint(valid_defendant_params)
+        response = post_to_create_endpoint(valid_params)
         expect(response.status).to eq 201
       end
 
+      it 'returns JSON with UUIDs instead of IDs' do
+        response = post_to_create_endpoint(valid_params)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['id']).not_to be_nil
+        expect(Defendant.find_by(uuid: json_response['id']).uuid).to eq(json_response['id'])
+        expect(Defendant.find_by(uuid: json_response['id']).claim.uuid).to eq(json_response['claim_id'])
+      end
     end
 
     context 'when defendant params are invalid' do
 
       it 'returns 400 and an appropriate error message in the response body' do
-        response = post_to_create_endpoint(invalid_defendant_params)
+        response = post_to_create_endpoint(invalid_params)
         expect(response.status).to eq 400
         expect(response.body).to eq "{\"error\":\"first_name is missing, last_name is missing, date_of_birth is missing\"}"
       end
@@ -47,12 +55,12 @@ describe API::V1::Advocates::Defendant do
     end
 
     it 'returns 200 when the params are valid' do
-      response = post_to_validate_endpoint(valid_defendant_params)
+      response = post_to_validate_endpoint(valid_params)
       expect(response.status).to eq 200
     end
 
     it 'with MISSING PARAMS returns 400 and an appropriate error message' do
-      invalid_response = post_to_validate_endpoint(invalid_defendant_params)
+      invalid_response = post_to_validate_endpoint(invalid_params)
       expect(invalid_response.status).to eq 400
       expect(invalid_response.body).to eq "{\"error\":\"first_name is missing, last_name is missing, date_of_birth is missing\"}"
     end

--- a/spec/api/v1/claims/defendant_spec.rb
+++ b/spec/api/v1/claims/defendant_spec.rb
@@ -8,10 +8,10 @@ describe API::V1::Advocates::Defendant do
   CREATE_DEFENDANT_ENDPOINT = "/api/advocates/defendants"
   VALIDATE_DEFENDANT_ENDPOINT = "/api/advocates/defendants/validate"
 
-  let!(:claim)                     {  create(:claim) }
-  let!(:valid_defendant_params)    { {claim_id: claim.id, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
-  let!(:invalid_defendant_params)  { {claim_id: claim.id} }
-  let!(:invalid_claim_id_params)   { {claim_id: 10000000, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
+  let!(:claim)                     {  create(:claim).reload }
+  let!(:valid_defendant_params)    { {claim_id: claim.uuid, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
+  let!(:invalid_defendant_params)  { {claim_id: claim.uuid} }
+  let!(:invalid_claim_id_params)   { {claim_id: SecureRandom.uuid, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "10 May 1980"} }
 
   describe 'POST api/advocates/defendants' do
 
@@ -47,23 +47,21 @@ describe API::V1::Advocates::Defendant do
     end
 
     it 'returns 200 when the params are valid' do
-        response = post_to_validate_endpoint(valid_defendant_params)
-        expect(response.status).to eq 200
+      response = post_to_validate_endpoint(valid_defendant_params)
+      expect(response.status).to eq 200
     end
 
     it 'with MISSING PARAMS returns 400 and an appropriate error message' do
-        invalid_response = post_to_validate_endpoint(invalid_defendant_params)
-        expect(invalid_response.status).to eq 400
-        expect(invalid_response.body).to eq "{\"error\":\"first_name is missing, last_name is missing, date_of_birth is missing\"}"
+      invalid_response = post_to_validate_endpoint(invalid_defendant_params)
+      expect(invalid_response.status).to eq 400
+      expect(invalid_response.body).to eq "{\"error\":\"first_name is missing, last_name is missing, date_of_birth is missing\"}"
     end
 
     it 'with INVALID CLAIM ID returns 400 and an appropriate error message' do
-        invalid_response = post_to_validate_endpoint(invalid_claim_id_params)
-        expect(invalid_response.status).to eq 400
-        expect(invalid_response.body).to eq "[{\"error\":\"Claim can't be blank\"}]"
+      invalid_response = post_to_validate_endpoint(invalid_claim_id_params)
+      puts invalid_response.body
+      expect(invalid_response.status).to eq 400
+      expect(invalid_response.body).to eq "[{\"error\":\"Claim can't be blank\"}]"
     end
-
-
   end
-
 end

--- a/spec/api/v1/claims/expense_spec.rb
+++ b/spec/api/v1/claims/expense_spec.rb
@@ -8,10 +8,10 @@ describe API::V1::Advocates::Expense do
   CREATE_EXPENSE_ENDPOINT = "/api/advocates/expenses"
   VALIDATE_EXPENSE_ENDPOINT = "/api/advocates/expenses/validate"
 
-  let!(:claim)                      {  create(:claim)                                                                                     }
-  let!(:expense_type)               {  create(:expense_type)                                                                              }
-  let!(:valid_expense_params)       { {claim_id: claim.id, expense_type_id: expense_type.id, rate: 1, quantity: 2, date: '10 May 2015', location: 'London' }  }
-  let!(:invalid_expense_params)     { {claim_id: claim.id }                                                                             }
+  let!(:claim)                      {  create(:claim).reload }
+  let!(:expense_type)               {  create(:expense_type) }
+  let!(:valid_expense_params)       { {claim_id: claim.uuid, expense_type_id: expense_type.id, rate: 1, quantity: 2, date: '10 May 2015', location: 'London' }  }
+  let!(:invalid_expense_params)     { {claim_id: claim.uuid }                                                                             }
 
   describe 'POST api/advocates/expenses' do
 

--- a/spec/api/v1/claims/expense_spec.rb
+++ b/spec/api/v1/claims/expense_spec.rb
@@ -10,8 +10,8 @@ describe API::V1::Advocates::Expense do
 
   let!(:claim)                      {  create(:claim).reload }
   let!(:expense_type)               {  create(:expense_type) }
-  let!(:valid_expense_params)       { {claim_id: claim.uuid, expense_type_id: expense_type.id, rate: 1, quantity: 2, date: '10 May 2015', location: 'London' }  }
-  let!(:invalid_expense_params)     { {claim_id: claim.uuid }                                                                             }
+  let!(:valid_params)       { {claim_id: claim.uuid, expense_type_id: expense_type.id, rate: 1, quantity: 2, date: '10 May 2015', location: 'London' }  }
+  let!(:invalid_params)     { {claim_id: claim.uuid }                                                                             }
 
   describe 'POST api/advocates/expenses' do
 
@@ -22,8 +22,17 @@ describe API::V1::Advocates::Expense do
     context 'when expense params are valid' do
 
       it 'returns 201 and creates a new expense record' do
-        response = post_to_create_endpoint(valid_expense_params)
+        response = post_to_create_endpoint(valid_params)
         expect(response.status).to eq 201
+      end
+
+      it 'returns JSON with UUIDs instead of IDs' do
+        response = post_to_create_endpoint(valid_params)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['id']).not_to be_nil
+        expect(Expense.find_by(uuid: json_response['id']).uuid).to eq(json_response['id'])
+        expect(Expense.find_by(uuid: json_response['id']).claim.uuid).to eq(json_response['claim_id'])
       end
 
     end
@@ -32,7 +41,7 @@ describe API::V1::Advocates::Expense do
 
       context 'because required values are missing' do
         it 'returns 400 and an appropriate error message in the response body' do
-          response = post_to_create_endpoint(invalid_expense_params)
+          response = post_to_create_endpoint(invalid_params)
           expect(response.status).to eq 400
           expect(response.body).to eq "{\"error\":\"date is missing, expense_type_id is missing, quantity is missing, rate is missing\"}"
         end
@@ -50,14 +59,14 @@ describe API::V1::Advocates::Expense do
 
     context 'when params are valid' do
       it 'returns 200' do
-        response = post_to_validate_endpoint(valid_expense_params)
+        response = post_to_validate_endpoint(valid_params)
         expect(response.status).to eq 200
       end
     end
 
     context 'when params are invalid' do
       it 'returns 400' do
-        response = post_to_validate_endpoint(invalid_expense_params)
+        response = post_to_validate_endpoint(invalid_params)
         expect(response.status).to eq 400
         expect(response.body).to eq "{\"error\":\"date is missing, expense_type_id is missing, quantity is missing, rate is missing\"}"
       end

--- a/spec/api/v1/claims/fee_spec.rb
+++ b/spec/api/v1/claims/fee_spec.rb
@@ -9,9 +9,9 @@ describe API::V1::Advocates::Fee do
   VALIDATE_FEE_ENDPOINT = "/api/advocates/fees/validate"
 
   let!(:fee_type)            { create(:fee_type, id: 1) }
-  let!(:claim)               { create(:claim) }
-  let!(:valid_fee_params)    { {claim_id: claim.id, fee_type_id: fee_type.id, quantity: 3, amount: 10.00 } }
-  let!(:invalid_fee_params)  { {claim_id: claim.id} }
+  let!(:claim)               { create(:claim).reload }
+  let!(:valid_fee_params)    { {claim_id: claim.uuid, fee_type_id: fee_type.id, quantity: 3, amount: 10.00 } }
+  let!(:invalid_fee_params)  { {claim_id: claim.uuid } }
 
   describe 'POST api/advocates/fees' do
 
@@ -29,7 +29,7 @@ describe API::V1::Advocates::Fee do
       it 'creates a new fee record with all provided attributes' do
         response = post_to_create_endpoint
         fee = Fee.last
-        expect(fee.claim).to eq claim
+        expect(fee.claim.id).to eq claim.id
         expect(fee.fee_type).to eq fee_type
         expect(fee.quantity).to eq 3
         expect(fee.amount).to eq 10.00

--- a/spec/api/v1/claims/fee_spec.rb
+++ b/spec/api/v1/claims/fee_spec.rb
@@ -10,29 +10,38 @@ describe API::V1::Advocates::Fee do
 
   let!(:fee_type)            { create(:fee_type, id: 1) }
   let!(:claim)               { create(:claim).reload }
-  let!(:valid_fee_params)    { {claim_id: claim.uuid, fee_type_id: fee_type.id, quantity: 3, amount: 10.00 } }
-  let!(:invalid_fee_params)  { {claim_id: claim.uuid } }
+  let!(:valid_params)    { {claim_id: claim.uuid, fee_type_id: fee_type.id, quantity: 3, amount: 10.00 } }
+  let!(:invalid_params)  { {claim_id: claim.uuid } }
 
   describe 'POST api/advocates/fees' do
 
-    def post_to_create_endpoint
-      post CREATE_FEE_ENDPOINT, valid_fee_params, format: :json
+    def post_to_create_endpoint(params)
+      post CREATE_FEE_ENDPOINT, params, format: :json
     end
 
     context 'when fee params are valid' do
 
       it 'returns status of 201' do
-        response = post_to_create_endpoint
+        response = post_to_create_endpoint(valid_params)
         expect(response.status).to eq 201
       end
 
       it 'creates a new fee record with all provided attributes' do
-        response = post_to_create_endpoint
+        response = post_to_create_endpoint(valid_params)
         fee = Fee.last
         expect(fee.claim.id).to eq claim.id
         expect(fee.fee_type).to eq fee_type
         expect(fee.quantity).to eq 3
         expect(fee.amount).to eq 10.00
+      end
+
+      it 'returns JSON with UUIDs instead of IDs' do
+        response = post_to_create_endpoint(valid_params)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['id']).not_to be_nil
+        expect(Fee.find_by(uuid: json_response['id']).uuid).to eq(json_response['id'])
+        expect(Fee.find_by(uuid: json_response['id']).claim.uuid).to eq(json_response['claim_id'])
       end
 
     end
@@ -46,12 +55,12 @@ describe API::V1::Advocates::Fee do
     end
 
     it 'returns 200 when the params are valid' do
-        response = post_to_validate_endpoint(valid_fee_params)
+        response = post_to_validate_endpoint(valid_params)
         expect(response.status).to eq 200
     end
 
     it 'returns 400 when the params are invalid' do
-        invalid_response = post_to_validate_endpoint(invalid_fee_params)
+        invalid_response = post_to_validate_endpoint(invalid_params)
         expect(invalid_response.status).to eq 400
     end
 

--- a/spec/api/v1/claims/representation_order_spec.rb
+++ b/spec/api/v1/claims/representation_order_spec.rb
@@ -10,8 +10,8 @@ describe API::V1::Advocates::RepresentationOrder do
 
   let!(:claim) { create(:claim) }
   let!(:defendant) { create(:defendant, claim: claim).reload }
-  let!(:valid_representation_order_params)    { {granting_body: "Magistrate's Court", defendant_id: defendant.uuid, representation_order_date: '10 June 2015', maat_reference: 'maatmaatmaat' } }
-  let!(:invalid_representation_order_params)  { {} }
+  let!(:valid_params)    { {granting_body: "Magistrate's Court", defendant_id: defendant.uuid, representation_order_date: '10 June 2015', maat_reference: 'maatmaatmaat' } }
+  let!(:invalid_params)  { {} }
 
   describe 'POST api/advocates/representation_orders' do
 
@@ -22,12 +22,12 @@ describe API::V1::Advocates::RepresentationOrder do
     context 'when representation_order params are valid' do
 
       it 'returns status of 201' do
-        response = post_to_create_endpoint(valid_representation_order_params)
+        response = post_to_create_endpoint(valid_params)
         expect(response.status).to eq 201
       end
 
       it 'creates a new representation_order record with all provided attributes' do
-        post_to_create_endpoint(valid_representation_order_params)
+        post_to_create_endpoint(valid_params)
         representation_order = RepresentationOrder.last
         expect(representation_order.granting_body).to eq "Magistrate's Court"
         expect(representation_order.defendant_id).to eq Defendant.find_by(uuid: defendant.uuid).id
@@ -35,17 +35,26 @@ describe API::V1::Advocates::RepresentationOrder do
         expect(representation_order.maat_reference).to eq 'MAATMAATMAAT'
       end
 
+      it 'returns JSON with UUIDs instead of IDs' do
+        response = post_to_create_endpoint(valid_params)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['id']).not_to be_nil
+        expect(RepresentationOrder.find_by(uuid: json_response['id']).uuid).to eq(json_response['id'])
+        expect(RepresentationOrder.find_by(uuid: json_response['id']).defendant.uuid).to eq(json_response['defendant_id'])
+      end
+
     end
 
     context 'when params are invalid' do
 
       it 'returns status of 400' do
-        response = post_to_create_endpoint(invalid_representation_order_params)
+        response = post_to_create_endpoint(invalid_params)
         expect(response.status).to eq 400
       end
 
       it 'the response body contains an appropriate error message' do
-        response = post_to_create_endpoint(invalid_representation_order_params)
+        response = post_to_create_endpoint(invalid_params)
         expect(response.body).to eq "{\"error\":\"defendant_id is missing, granting_body is missing, maat_reference is missing, representation_order_date is missing\"}"
       end
 
@@ -62,7 +71,7 @@ describe API::V1::Advocates::RepresentationOrder do
     context 'when params are valid' do
 
       it 'returns status 200' do
-        response = post_to_validate_endpoint(valid_representation_order_params)
+        response = post_to_validate_endpoint(valid_params)
         expect(response.status).to eq 200
       end
 
@@ -71,12 +80,12 @@ describe API::V1::Advocates::RepresentationOrder do
     context 'when params are invalid' do
 
       it 'returns status 400' do
-        response = post_to_validate_endpoint(invalid_representation_order_params)
+        response = post_to_validate_endpoint(invalid_params)
         expect(response.status).to eq 400
       end
 
       it 'the response body contains and appropriate error message' do
-        response = post_to_validate_endpoint(invalid_representation_order_params)
+        response = post_to_validate_endpoint(invalid_params)
         expect(response.body).to eq "{\"error\":\"defendant_id is missing, granting_body is missing, maat_reference is missing, representation_order_date is missing\"}"
       end
 

--- a/spec/api/v1/claims/representation_order_spec.rb
+++ b/spec/api/v1/claims/representation_order_spec.rb
@@ -8,7 +8,9 @@ describe API::V1::Advocates::RepresentationOrder do
   CREATE_REPRESENTATION_ORDER_ENDPOINT = "/api/advocates/representation_orders"
   VALIDATE_REPRESENTATION_ORDER_ENDPOINT = "/api/advocates/representation_orders/validate"
 
-  let!(:valid_representation_order_params)    { {granting_body: "Magistrate's Court", defendant_id: 1, representation_order_date: '10 June 2015', maat_reference: 'maatmaatmaat' } }
+  let!(:claim) { create(:claim) }
+  let!(:defendant) { create(:defendant, claim: claim).reload }
+  let!(:valid_representation_order_params)    { {granting_body: "Magistrate's Court", defendant_id: defendant.uuid, representation_order_date: '10 June 2015', maat_reference: 'maatmaatmaat' } }
   let!(:invalid_representation_order_params)  { {} }
 
   describe 'POST api/advocates/representation_orders' do
@@ -28,7 +30,7 @@ describe API::V1::Advocates::RepresentationOrder do
         post_to_create_endpoint(valid_representation_order_params)
         representation_order = RepresentationOrder.last
         expect(representation_order.granting_body).to eq "Magistrate's Court"
-        expect(representation_order.defendant_id).to eq 1
+        expect(representation_order.defendant_id).to eq Defendant.find_by(uuid: defendant.uuid).id
         expect(representation_order.representation_order_date.to_s).to eq  "10/06/2015 00:00"
         expect(representation_order.maat_reference).to eq 'MAATMAATMAAT'
       end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -43,7 +43,6 @@
 
 FactoryGirl.define do
   factory :claim do
-
     court
     scheme      { random_scheme }
     case_number { Faker::Number.number(10) }


### PR DESCRIPTION
API endpoints updated to use UUIDs for ID params (claims, defendants etc).
