### PR TITLE
Add meta tag to make iOS safari not render numbers as telephone numbers

### DIFF
--- a/app/views/layouts/advocate.html.haml
+++ b/app/views/layouts/advocate.html.haml
@@ -1,5 +1,6 @@
 - @disable_logo_link  = true
 - content_for :head do
+  %meta{:name =>"format-detection", :content => "telephone=no"}
   = stylesheet_link_tag "advocates/application", media: "all"
 
 - content_for :body_end do

--- a/app/views/layouts/advocate.html.haml
+++ b/app/views/layouts/advocate.html.haml
@@ -1,6 +1,6 @@
 - @disable_logo_link  = true
 - content_for :head do
-  %meta{:name =>"format-detection", :content => "telephone=no"}
+  %meta{:name =>"format-detection", :content => "telephone=no"}/
   = stylesheet_link_tag "advocates/application", media: "all"
 
 - content_for :body_end do

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,6 @@
 - @disable_logo_link  = true
 - content_for :head do
+  %meta{:name =>"format-detection", :content => "telephone=no"}
   = stylesheet_link_tag "application", media: "all"
 
 - content_for :body_end do

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,6 @@
 - @disable_logo_link  = true
 - content_for :head do
-  %meta{:name =>"format-detection", :content => "telephone=no"}
+  %meta{:name =>"format-detection", :content => "telephone=no"}/
   = stylesheet_link_tag "application", media: "all"
 
 - content_for :body_end do

--- a/app/views/layouts/case_worker.html.haml
+++ b/app/views/layouts/case_worker.html.haml
@@ -1,5 +1,6 @@
 - @disable_logo_link  = true
 - content_for :head do
+  %meta{:name =>"format-detection", :content => "telephone=no"}
   = stylesheet_link_tag "case_workers/application", media: "all"
 
 - content_for :body_end do

--- a/app/views/layouts/case_worker.html.haml
+++ b/app/views/layouts/case_worker.html.haml
@@ -1,6 +1,6 @@
 - @disable_logo_link  = true
 - content_for :head do
-  %meta{:name =>"format-detection", :content => "telephone=no"}
+  %meta{:name =>"format-detection", :content => "telephone=no"}/
   = stylesheet_link_tag "case_workers/application", media: "all"
 
 - content_for :body_end do


### PR DESCRIPTION
We can still convert telephone numbers to display and work as telephone numbers but we have to explicitly define them as such.
reference: https://developer.apple.com/library/safari/featuredarticles/iPhoneURLScheme_Reference/PhoneLinks/PhoneLinks.html
