### PR TITLE
Add grape swagger root url envvar

### DIFF
--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -1,3 +1,3 @@
 GrapeSwaggerRails.options.url      = "/api/v1/advocates/swagger_doc"
-GrapeSwaggerRails.options.app_url  = ENV["GRAPE_SWAGGER_ROOT_URL"]
+GrapeSwaggerRails.options.app_url  = ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000'
 GrapeSwaggerRails.options.app_name = 'ADP API'

--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -1,3 +1,3 @@
 GrapeSwaggerRails.options.url      = "/api/v1/advocates/swagger_doc"
-GrapeSwaggerRails.options.app_url  = 'http://localhost:3000'
+GrapeSwaggerRails.options.app_url  = ENV["GRAPE_SWAGGER_ROOT_URL"]
 GrapeSwaggerRails.options.app_name = 'ADP API'


### PR DESCRIPTION
I believe this can be safely deployed and requires no profile changes
for devs as it falls back to using http://localhost:3000. Otherwise devs can add
`export GRAPE_SWAGGER_ROOT_URL='http://localhost:3000'`

servers will require appropriate env vars as below:
`export GRAPE_SWAGGER_ROOT_URL='https://dev-adp.dsd.io'`
`export GRAPE_SWAGGER_ROOT_URL='https://staging-adp.dsd.io'`
`export GRAPE_SWAGGER_ROOT_URL='https://demo-adp.dsd.io'`
