### PR TITLE
remove expenses' "old" date attribute in lieu of dates_attended

### DIFF
--- a/app/interfaces/api/v1/advocates/expense.rb
+++ b/app/interfaces/api/v1/advocates/expense.rb
@@ -19,7 +19,6 @@ module API
           helpers do
             params :expense_creation do
               requires :claim_id, type: String, desc: "Unique identifier for the claim associated with this defendant."
-              requires :date, type: DateTime, desc: "Date on which this expense was incurred (YYYY/MM/DD)."
               requires :expense_type_id, type: Integer, desc: "Reference to the parent expense type."
               requires :quantity, type: Integer, desc: "Quantity of expenses of this type and rate."
               requires :rate, type: Float, desc: "Rate for each expense."
@@ -29,7 +28,6 @@ module API
             def args
               {
                 claim_id: ::Claim.find_by(uuid: params[:claim_id]).try(:id),
-                date: params[:date],
                 expense_type_id: params[:expense_type_id],
                 quantity: params[:quantity],
                 rate: params[:rate],

--- a/db/migrate/20150807120316_remove_date_from_expenses.rb
+++ b/db/migrate/20150807120316_remove_date_from_expenses.rb
@@ -1,0 +1,5 @@
+class RemoveDateFromExpenses < ActiveRecord::Migration
+  def change
+    remove_column :expenses, :date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150807085212) do
+ActiveRecord::Schema.define(version: 20150807120316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -190,7 +190,6 @@ ActiveRecord::Schema.define(version: 20150807085212) do
   create_table "expenses", force: true do |t|
     t.integer  "expense_type_id"
     t.integer  "claim_id"
-    t.datetime "date"
     t.string   "location"
     t.integer  "quantity"
     t.decimal  "rate"

--- a/spec/api/v1/claims/expense_spec.rb
+++ b/spec/api/v1/claims/expense_spec.rb
@@ -13,7 +13,7 @@ describe API::V1::Advocates::Expense do
 
   let!(:claim)                      {  create(:claim).reload }
   let!(:expense_type)               {  create(:expense_type) }
-  let!(:valid_params)       { {claim_id: claim.uuid, expense_type_id: expense_type.id, rate: 1, quantity: 2, date: '10 May 2015', location: 'London' }  }
+  let!(:valid_params)       { {claim_id: claim.uuid, expense_type_id: expense_type.id, rate: 1, quantity: 2, location: 'London' }  }
   let!(:invalid_params)     { {claim_id: claim.uuid }                                                                             }
 
   context 'All expense API endpoints' do
@@ -59,7 +59,7 @@ describe API::V1::Advocates::Expense do
         it 'returns 400 and an appropriate error message in the response body' do
           response = post_to_create_endpoint(invalid_params)
           expect(response.status).to eq 400
-          expect(response.body).to eq "{\"error\":\"date is missing, expense_type_id is missing, quantity is missing, rate is missing\"}"
+          expect(response.body).to eq "{\"error\":\"expense_type_id is missing, quantity is missing, rate is missing\"}"
         end
       end
 
@@ -84,7 +84,7 @@ describe API::V1::Advocates::Expense do
       it 'returns 400' do
         response = post_to_validate_endpoint(invalid_params)
         expect(response.status).to eq 400
-        expect(response.body).to eq "{\"error\":\"date is missing, expense_type_id is missing, quantity is missing, rate is missing\"}"
+        expect(response.body).to eq "{\"error\":\"expense_type_id is missing, quantity is missing, rate is missing\"}"
       end
     end
 

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -18,7 +18,6 @@ FactoryGirl.define do
   factory :expense do
     expense_type
     claim
-    date { Faker::Date.between(12.days.ago, Date.today) }
     location Faker::Address.city
     quantity 1
     rate "9.99"


### PR DESCRIPTION
an old attribute for date existed on expenses and is
no longer needed. It was never acutally viewable in views
either.
