### PR TITLE
fix flicker in cukes search tests

### DIFF
--- a/features/advocate_claims_list.feature
+++ b/features/advocate_claims_list.feature
@@ -68,10 +68,11 @@ Feature: Advocate claims list
   Scenario Outline: Search claims by defendant name (with optional middlename)
     Given I am a signed in advocate
       And There are fee schemes in place
-      And I have 2 claims involving defendant "Joe Bloggs" amongst others
-      And I have 3 claims involving defendant "Fred Bloggs" amongst others
-      And I have 1 claims involving defendant "Fred Joe Bloggs" amongst others
-      And I have 1 claims involving defendant "Joe Fred Bloggs" amongst others
+      And I have 2 claims involving defendant "Joe Bloggs"
+      And I have 3 claims involving defendant "Fred Bloggs"
+      And I have 1 claims involving defendant "Fred Joe Bloggs"
+      And I have 1 claims involving defendant "Joe Fred Bloggs"
+      And I have 2 claims involving defendant "Someone Else"
      When I visit the advocates dashboard
       And I search by the name <defendant_name>
      Then I should only see the <number> claims involving defendant <defendant_name>

--- a/features/caseworker_claims_list.feature
+++ b/features/caseworker_claims_list.feature
@@ -46,10 +46,11 @@ Feature: Caseworker claims list
 
   Scenario Outline: Search current and completed claims by defendant name
     Given I am signed in and on the case worker dashboard
-      And I have 2 "allocated" claims involving defendant "Joe Bloggs" amongst others
-      And I have 3 "allocated" claims involving defendant "Fred Bloggs" amongst others
-      And I have 2 "completed" claims involving defendant "Joe Bloggs" amongst others
-      And I have 3 "completed" claims involving defendant "Fred Bloggs" amongst others
+      And I have 2 "allocated" claims involving defendant "Joe Bloggs"
+      And I have 3 "allocated" claims involving defendant "Fred Bloggs"
+      And I have 2 "completed" claims involving defendant "Joe Bloggs"
+      And I have 3 "completed" claims involving defendant "Fred Bloggs"
+      And I have 2 "completed" claims involving defendant "Someone Else"
      When I visit my dashboard
       And I search claims by defendant name <defendant_name>
      Then I should only see <number> "Current" claims

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -163,11 +163,7 @@ Given(/^my chamber has (\d+) claims for advocate "(.*?)"$/) do |number, advocate
   @claims.each { |claim| claim.update_column(:advocate_id, claim_advocate.id) }
 end
 
-Given(/^I have (\d+) claims involving defendant "(.*?)" amongst others$/) do |number,defendant_name|
-  @claims = create_list(:draft_claim, number.to_i, advocate: @advocate)
-  @claims.each do |claim|
-    create(:defendant, claim: claim, first_name: Faker::Name.first_name, middle_name: Faker::Name.first_name, last_name: Faker::Name.last_name)
-  end
+Given(/^I have (\d+) claims involving defendant "(.*?)"$/) do |number,defendant_name|
   @claims = create_list(:submitted_claim, number.to_i, advocate: @advocate)
   @claims.each do |claim|
     middle_names = defendant_name.split.delete_if.with_index { |name,idx| name if idx == 0 || idx == defendant_name.split.count-1 }.join(' ')

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -41,12 +41,7 @@ Then(/^I should see an admin link$/) do
   expect(find('h1')).to have_content('Case workers')
 end
 
-Given(/^I have (\d+) "(.*?)" claims involving defendant "(.*?)" amongst others$/) do |number,state,defendant_name|
-  claims = create_list("#{state}_claim".to_sym, number.to_i)
-  claims.each do |claim|
-    create(:defendant, claim: claim, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name)
-  end
-  @case_worker.claims << claims
+Given(/^I have (\d+) "(.*?)" claims involving defendant "(.*?)"$/) do |number,state,defendant_name|
   claims = create_list("#{state}_claim".to_sym, number.to_i)
   claims.each do |claim|
     create(:defendant, claim: claim, first_name: defendant_name.split.first, last_name: defendant_name.split.last)


### PR DESCRIPTION
two cukes had the potential to create additional
::Faker names which could match the Names being
searched for by the test. This has been removed.
