### PR TITLE
Submit redeterminations from messaging feature

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -4,8 +4,8 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   include DocTypes
 
   respond_to :html
-  before_action :set_claim, only: [:show, :edit, :update, :transition_state, :destroy]
-  before_action :set_doctypes, only: [:show, :transition_state]
+  before_action :set_claim, only: [:show, :edit, :update, :destroy]
+  before_action :set_doctypes, only: [:show]
   before_action :set_context, only: [:index, :outstanding, :authorised ]
   before_action :set_financial_summary, only: [:index, :outstanding, :authorised]
   before_action :set_search_options, only: [:index]
@@ -92,16 +92,6 @@ class Advocates::ClaimsController < Advocates::ApplicationController
     else
       render_edit_with_resources
     end
-  end
-
-  def transition_state
-    @messages = @claim.messages.most_recent_first
-    begin
-      @claim.update_model_and_transition_state(claim_params)
-    rescue StateMachine::InvalidTransition => err
-    end
-    @message = @claim.messages.build
-    render action: :show
   end
 
   def destroy

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -36,7 +36,8 @@ class MessagesController < ApplicationController
       :claim_id,
       :attachment,
       :subject,
-      :body
+      :body,
+      :request_redetermination
     )
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,13 +12,13 @@ class Ability
     if persona.is_a? Advocate
       if persona.admin?
         can [:index, :outstanding, :authorised, :new, :create], Claim
-        can [:show, :edit, :update, :transition_state, :confirmation, :destroy], Claim, chamber_id: persona.chamber_id
+        can [:show, :edit, :update, :confirmation, :destroy], Claim, chamber_id: persona.chamber_id
         can [:show, :download], Document, chamber_id: persona.chamber_id
         can [:index, :new, :create], Advocate
         can [:show, :edit, :update, :destroy], Advocate, chamber_id: persona.chamber_id
       else
         can [:index, :outstanding, :authorised, :new, :create], Claim
-        can [:show, :edit, :update, :transition_state, :confirmation, :destroy], Claim, advocate_id: persona.id
+        can [:show, :edit, :update, :confirmation, :destroy], Claim, advocate_id: persona.id
         can [:show, :download], Document, advocate_id: persona.id
       end
     elsif persona.is_a? CaseWorker

--- a/app/views/advocates/claims/show.html.haml
+++ b/app/views/advocates/claims/show.html.haml
@@ -1,4 +1,4 @@
--present(@claim) do |claim| 
+-present(@claim) do |claim|
   %p
     = link_to t('link.back'), advocates_claims_path, class: 'button'
     - if claim.editable?

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -1,6 +1,11 @@
 <% if @message.persisted? %>
   $('.message-notification').text('<%=j @notification[:notice].html_safe %>');
   $('.timeline .days > li > ul:first-child').prepend('<%=j render "shared/message", message: @message %>');
+  $('.no-messages').hide();
+
+  <% unless Claim::VALID_STATES_FOR_REDETERMINATION.include?(@message.claim.state) %>
+    $('.redetermination-checkbox').hide();
+  <% end %>
 <% else %>
   $('.message-error').text('<%=j @notification[:alert].html_safe %>');
 <% end %>

--- a/app/views/shared/_claim_status.html.haml
+++ b/app/views/shared/_claim_status.html.haml
@@ -3,12 +3,6 @@
     %p
       Opened for redetermination on #{@claim.claim_state_transitions.where(to: 'redetermination').last.created_at} (see messages/notes for further details).
 
-  - if current_user.persona.is_a?(Advocate)
-    - if Claim::VALID_STATES_FOR_REDETERMINATION.include?(@claim.state)
-      = form_for(@claim, url: transition_state_advocates_claim_path(@claim)) do |f|
-        = f.hidden_field :state_for_form, value: 'redetermination'
-        = f.submit 'Request redetermination', class: 'button', id: 'button'
-
   = form_for(claim, url: case_workers_claim_path(claim)) do |f|
     %fieldset#claim-status
       = f.label :status, "Update status (current status: '#{claim.state}')"
@@ -56,5 +50,6 @@
       = f.label :additional_information, "Remarks"
       = f.text_area :additional_information, disabled: disabled
 
-      %p
-      = f.submit 'Update', class: 'button', id: 'button'
+      - if current_user.persona.is_a?(CaseWorker)
+        %p
+        = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_messages.html.haml
+++ b/app/views/shared/_messages.html.haml
@@ -1,15 +1,13 @@
 %section#messages
   .timeline
-    %h4
-      Communication tool
-      %ul.days
-        %li
-          %ul
-            - if @messages.none?
-              %span
-                No messages found
-            - else
-              = render partial: 'shared/message', collection: @messages
+    %ul.days
+      %li
+        %ul
+          - if @messages.none?
+            %span.no-messages
+              No messages found
+          - else
+            = render partial: 'shared/message', collection: @messages
 
     = simple_form_for @message, remote: true, authenticity_token: true  do |f|
       .message-notification
@@ -18,5 +16,13 @@
       = f.input :claim_id, value: @claim.id, as: :hidden
       = f.input :subject, placeholder: 'Subject', label: false
       = f.input :body, placeholder: 'Message', label: false
+
+      - if Claim::VALID_STATES_FOR_REDETERMINATION.include?(@claim.state)
+        .redetermination-checkbox
+          = f.label :request_redetermination do
+            = f.check_box :request_redetermination
+            Request redetermination
+
       = f.input :attachment, as: :file, label: false
+
       = f.submit 'Post', class: 'button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,6 @@ Rails.application.routes.draw do
       get 'confirmation', on: :member
       get 'outstanding', on: :collection
       get 'authorised', on: :collection
-      patch 'transition_state', on: :member
     end
 
     namespace :admin do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,8 +52,8 @@ ActiveRecord::Schema.define(version: 20150813163440) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "location_id"
-    t.string   "approval_level", default: "Low"
     t.string   "days_worked"
+    t.string   "approval_level", default: "Low"
   end
 
   add_index "case_workers", ["location_id"], name: "index_case_workers_on_location_id", using: :btree

--- a/features/claim_redetermination.feature
+++ b/features/claim_redetermination.feature
@@ -3,11 +3,11 @@ Feature: Claim redetermination
     As an advocate I want to be able to re-open a claim for redetermination.
     As a case worker I want to be able to review claims submitted for redetermination.
 
-  Scenario Outline: Redetermination button visible
+  Scenario Outline: Redetermination control visible
     Given I am a signed in advocate
       And I have a <state> claim
      When I visit the claims's detail page
-     Then I should see a button to re-open the claim for redetermination
+     Then I should see a control in the messages section to request a redetermination
 
     Examples:
       | state           |
@@ -15,11 +15,11 @@ Feature: Claim redetermination
       | part_paid_claim |
       | refused_claim   |
 
-  Scenario Outline: Redetermination button NOT visible
+  Scenario Outline: Redetermination control NOT visible
     Given I am a signed in advocate
       And I have a <state> claim
      When I visit the claims's detail page
-     Then I should not see a button to re-open the claim for redetermination
+     Then I should not see a control in the messages section to request a redetermination
 
     Examples:
       | state                           |
@@ -37,7 +37,7 @@ Feature: Claim redetermination
     Given I am a signed in advocate
       And I have a paid_claim claim
      When I visit the claims's detail page
-      And I click on "Request redetermination"
+      And I check "Request redetermination" and send a message
      Then the claim should be in the redetermination state
       And a notice should be present in the claim status panel
 

--- a/features/step_definitions/claim_redetermination_steps.rb
+++ b/features/step_definitions/claim_redetermination_steps.rb
@@ -6,16 +6,19 @@ When(/^I visit the claims's detail page$/) do
   visit advocates_claim_path(@claim)
 end
 
-Then(/^I should (not )?see a button to re\-open the claim for redetermination$/) do |negate|
+Then(/^I should (not )?see a control in the messages section to request a redetermination$/) do |negate|
   if negate.present?
-    expect(page).to_not have_selector(:link_or_button, 'Request redetermination')
+    expect(page).to_not have_selector('#message_request_redetermination')
   else
-    expect(page).to have_selector(:link_or_button, 'Request redetermination')
+    expect(page).to have_selector('#message_request_redetermination')
   end
 end
 
-When(/^I click on "(.*?)"$/) do |link_or_button_text|
-  click_on link_or_button_text
+When(/^I check "(.*?)" and send a message$/) do |checkbox_text|
+  check checkbox_text
+  fill_in 'message_subject', with: 'Redetermination request'
+  fill_in 'message_body', with: 'lorem ipsum'
+  click_button 'Post'
 end
 
 Then(/^the claim should be in the redetermination state$/) do

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -444,10 +444,6 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
     end
   end
 
-  describe "PATCH #transition_state" do
-
-  end
-
   describe "DELETE #destroy" do
     before { delete :destroy, id: subject }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -30,7 +30,7 @@ describe Ability do
     end
 
     context 'can manage their own claims' do
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: advocate)) }
       end
     end
@@ -38,7 +38,7 @@ describe Ability do
     context 'cannot manage claims by another advocate' do
       let(:other_advocate) { create(:advocate) }
 
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should_not be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end
@@ -74,7 +74,7 @@ describe Ability do
     end
 
     context 'can manage their own claims' do
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: advocate)) }
       end
     end
@@ -82,7 +82,7 @@ describe Ability do
     context 'can manage claims by another advocate in the same chamber' do
       let(:other_advocate) { create(:advocate, chamber: chamber) }
 
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end
@@ -90,7 +90,7 @@ describe Ability do
     context 'cannot manage claims by another advocate in a different chamber' do
       let(:other_advocate) { create(:advocate) }
 
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should_not be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end


### PR DESCRIPTION
Remove redetermination request button from claim status and move to messaging feature.
