### PR TITLE
Redetermination and written reasons

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -4,8 +4,8 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   include DocTypes
 
   respond_to :html
-  before_action :set_claim, only: [:show, :edit, :update, :transition_state, :destroy]
-  before_action :set_doctypes, only: [:show, :transition_state]
+  before_action :set_claim, only: [:show, :edit, :update, :destroy]
+  before_action :set_doctypes, only: [:show]
   before_action :set_context, only: [:index, :outstanding, :authorised ]
   before_action :set_financial_summary, only: [:index, :outstanding, :authorised]
   before_action :set_search_options, only: [:index]
@@ -92,16 +92,6 @@ class Advocates::ClaimsController < Advocates::ApplicationController
     else
       render_edit_with_resources
     end
-  end
-
-  def transition_state
-    @messages = @claim.messages.most_recent_first
-    begin
-      @claim.update_model_and_transition_state(claim_params)
-    rescue StateMachine::InvalidTransition => err
-    end
-    @message = @claim.messages.build
-    render action: :show
   end
 
   def destroy

--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -45,7 +45,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def set_claims
-    @claims = tab == 'allocated' ? Claim.caseworker_dashboard_under_assessment : Claim.submitted_or_redetermination
+    @claims = tab == 'allocated' ? Claim.caseworker_dashboard_under_assessment : Claim.submitted_or_redetermination_or_awaiting_written_reasons
     @claims = @claims.order(submitted_at: :asc)
 
     search_claims

--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -45,7 +45,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def set_claims
-    @claims = tab == 'allocated' ? Claim.caseworker_dashboard_under_assessment : Claim.submitted
+    @claims = tab == 'allocated' ? Claim.caseworker_dashboard_under_assessment : Claim.submitted_or_redetermination
     @claims = @claims.order(submitted_at: :asc)
 
     search_claims

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -86,7 +86,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         when 'allocated'
           Claim.caseworker_dashboard_under_assessment
         when 'unallocated'
-          Claim.submitted
+          Claim.submitted_or_redetermination
         when 'completed'
           Claim.caseworker_dashboard_completed
       end

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -86,7 +86,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         when 'allocated'
           Claim.caseworker_dashboard_under_assessment
         when 'unallocated'
-          Claim.submitted_or_redetermination
+          Claim.submitted_or_redetermination_or_awaiting_written_reasons
         when 'completed'
           Claim.caseworker_dashboard_completed
       end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -36,7 +36,8 @@ class MessagesController < ApplicationController
       :claim_id,
       :attachment,
       :subject,
-      :body
+      :body,
+      :request_redetermination
     )
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -37,7 +37,7 @@ class MessagesController < ApplicationController
       :attachment,
       :subject,
       :body,
-      :request_redetermination
+      :claim_action
     )
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -37,7 +37,8 @@ class MessagesController < ApplicationController
       :attachment,
       :subject,
       :body,
-      :claim_action
+      :claim_action,
+      :written_reasons_submitted
     )
   end
 end

--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -16,7 +16,7 @@ module CaseWorkers::ClaimsHelper
   end
 
   def unallocated_claims_count
-    Claim.submitted.count
+    Claim.submitted_or_redetermination.count
   end
 
   def claim_position_and_count

--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -16,7 +16,7 @@ module CaseWorkers::ClaimsHelper
   end
 
   def unallocated_claims_count
-    Claim.submitted_or_redetermination.count
+    Claim.submitted_or_redetermination_or_awaiting_written_reasons.count
   end
 
   def claim_position_and_count

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,13 +12,13 @@ class Ability
     if persona.is_a? Advocate
       if persona.admin?
         can [:index, :outstanding, :authorised, :new, :create], Claim
-        can [:show, :edit, :update, :transition_state, :confirmation, :destroy], Claim, chamber_id: persona.chamber_id
+        can [:show, :edit, :update, :confirmation, :destroy], Claim, chamber_id: persona.chamber_id
         can [:show, :download], Document, chamber_id: persona.chamber_id
         can [:index, :new, :create], Advocate
         can [:show, :edit, :update, :destroy], Advocate, chamber_id: persona.chamber_id
       else
         can [:index, :outstanding, :authorised, :new, :create], Claim
-        can [:show, :edit, :update, :transition_state, :confirmation, :destroy], Claim, advocate_id: persona.id
+        can [:show, :edit, :update, :confirmation, :destroy], Claim, advocate_id: persona.id
         can [:show, :download], Document, advocate_id: persona.id
       end
     elsif persona.is_a? CaseWorker

--- a/app/models/case_worker_claim.rb
+++ b/app/models/case_worker_claim.rb
@@ -27,6 +27,6 @@ class CaseWorkerClaim < ActiveRecord::Base
   end
 
   def set_claim_allocated!
-    claim.allocate! if claim.submitted? || claim.redetermination?
+    claim.allocate! if claim.submitted? || claim.redetermination? || claim.awaiting_written_reasons?
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -79,7 +79,7 @@ class Claim < ActiveRecord::Base
   has_many :basic_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'BASIC'").order(fee_type_id: :asc) }, class_name: 'Fee'
   has_many :fixed_fees,     -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'FIXED'") }, class_name: 'Fee'
   has_many :misc_fees,      -> { joins(fee_type: :fee_category).where("fee_categories.abbreviation = 'MISC'") }, class_name: 'Fee'
-  
+
   has_many :determinations
   has_one  :assessment
   has_many :redeterminations
@@ -246,6 +246,13 @@ class Claim < ActiveRecord::Base
 
     transition = claim_state_transitions.order(created_at: :asc).last
     transition && transition.from == 'redetermination'
+  end
+
+  def written_reasons_outstanding?
+    return true if self.awaiting_written_reasons?
+
+    transition = claim_state_transitions.order(created_at: :asc).last
+    transition && transition.from == 'awaiting_written_reasons'
   end
 
   private

--- a/app/views/advocates/claims/show.html.haml
+++ b/app/views/advocates/claims/show.html.haml
@@ -1,4 +1,4 @@
--present(@claim) do |claim| 
+-present(@claim) do |claim|
   %p
     = link_to t('link.back'), advocates_claims_path, class: 'button'
     - if claim.editable?

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -1,6 +1,11 @@
 <% if @message.persisted? %>
   $('.message-notification').text('<%=j @notification[:notice].html_safe %>');
   $('.timeline .days > li > ul:first-child').prepend('<%=j render "shared/message", message: @message %>');
+  $('.no-messages').hide();
+
+  <% unless Claim::VALID_STATES_FOR_REDETERMINATION.include?(@message.claim.state) %>
+    $('.redetermination-checkbox').hide();
+  <% end %>
 <% else %>
   $('.message-error').text('<%=j @notification[:alert].html_safe %>');
 <% end %>

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -6,6 +6,10 @@
   <% unless Claim::VALID_STATES_FOR_REDETERMINATION.include?(@message.claim.state) %>
     $('.claim-action-dropdown').hide();
   <% end %>
+
+  <% unless @message.claim.written_reasons_outstanding? %>
+    $('.written-reasons-checkbox').hide();
+  <% end %>
 <% else %>
   $('.message-error').text('<%=j @notification[:alert].html_safe %>');
 <% end %>

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -4,7 +4,7 @@
   $('.no-messages').hide();
 
   <% unless Claim::VALID_STATES_FOR_REDETERMINATION.include?(@message.claim.state) %>
-    $('.redetermination-checkbox').hide();
+    $('.claim-action-dropdown').hide();
   <% end %>
 <% else %>
   $('.message-error').text('<%=j @notification[:alert].html_safe %>');

--- a/app/views/shared/_claim_status.html.haml
+++ b/app/views/shared/_claim_status.html.haml
@@ -3,6 +3,10 @@
     %p
       Opened for redetermination on #{@claim.claim_state_transitions.where(to: 'redetermination').last.created_at} (see messages/notes for further details).
 
+  - if claim.written_reasons_outstanding?
+    %p
+      Awaiting written reasons.
+
   = form_for(claim, url: case_workers_claim_path(claim)) do |f|
     %fieldset#claim-status
       = f.label :status, "Update status (current status: '#{claim.state}')"

--- a/app/views/shared/_claim_status.html.haml
+++ b/app/views/shared/_claim_status.html.haml
@@ -3,12 +3,6 @@
     %p
       Opened for redetermination on #{@claim.claim_state_transitions.where(to: 'redetermination').last.created_at} (see messages/notes for further details).
 
-  - if current_user.persona.is_a?(Advocate)
-    - if Claim::VALID_STATES_FOR_REDETERMINATION.include?(@claim.state)
-      = form_for(@claim, url: transition_state_advocates_claim_path(@claim)) do |f|
-        = f.hidden_field :state_for_form, value: 'redetermination'
-        = f.submit 'Request redetermination', class: 'button', id: 'button'
-
   = form_for(claim, url: case_workers_claim_path(claim)) do |f|
     %fieldset#claim-status
       = f.label :status, "Update status (current status: '#{claim.state}')"
@@ -56,5 +50,6 @@
       = f.label :additional_information, "Remarks"
       = f.text_area :additional_information, disabled: disabled
 
-      %p
-      = f.submit 'Update', class: 'button', id: 'button'
+      - if current_user.persona.is_a?(CaseWorker)
+        %p
+        = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_messages.html.haml
+++ b/app/views/shared/_messages.html.haml
@@ -1,15 +1,13 @@
 %section#messages
   .timeline
-    %h4
-      Communication tool
-      %ul.days
-        %li
-          %ul
-            - if @messages.none?
-              %span
-                No messages found
-            - else
-              = render partial: 'shared/message', collection: @messages
+    %ul.days
+      %li
+        %ul
+          - if @messages.none?
+            %span.no-messages
+              No messages found
+          - else
+            = render partial: 'shared/message', collection: @messages
 
     = simple_form_for @message, remote: true, authenticity_token: true  do |f|
       .message-notification
@@ -18,5 +16,13 @@
       = f.input :claim_id, value: @claim.id, as: :hidden
       = f.input :subject, placeholder: 'Subject', label: false
       = f.input :body, placeholder: 'Message', label: false
+
+      - if Claim::VALID_STATES_FOR_REDETERMINATION.include?(@claim.state)
+        .redetermination-checkbox
+          = f.label :request_redetermination do
+            = f.check_box :request_redetermination
+            Request redetermination
+
       = f.input :attachment, as: :file, label: false
+
       = f.submit 'Post', class: 'button'

--- a/app/views/shared/_messages.html.haml
+++ b/app/views/shared/_messages.html.haml
@@ -17,10 +17,14 @@
       = f.input :subject, placeholder: 'Subject', label: false
       = f.input :body, placeholder: 'Message', label: false
 
-      - if Claim::VALID_STATES_FOR_REDETERMINATION.include?(@claim.state)
+      - if current_user.persona.is_a?(Advocate) && Claim::VALID_STATES_FOR_REDETERMINATION.include?(@claim.state)
         .claim-action-dropdown
           = f.label :claim_action
           = f.collection_select :claim_action, ['Apply for redetermination', 'Request written reasons'], :to_s, :to_s, { prompt: true }, { class: 'select2' }
+
+      - if current_user.persona.is_a?(CaseWorker) && @claim.written_reasons_outstanding?
+        .written-reasons-checkbox
+          = f.input :written_reasons_submitted, as: :boolean
 
       = f.input :attachment, as: :file, label: false
 

--- a/app/views/shared/_messages.html.haml
+++ b/app/views/shared/_messages.html.haml
@@ -18,10 +18,9 @@
       = f.input :body, placeholder: 'Message', label: false
 
       - if Claim::VALID_STATES_FOR_REDETERMINATION.include?(@claim.state)
-        .redetermination-checkbox
-          = f.label :request_redetermination do
-            = f.check_box :request_redetermination
-            Request redetermination
+        .claim-action-dropdown
+          = f.label :claim_action
+          = f.collection_select :claim_action, ['Apply for redetermination', 'Request written reasons'], :to_s, :to_s, { prompt: true }, { class: 'select2' }
 
       = f.input :attachment, as: :file, label: false
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,6 @@ Rails.application.routes.draw do
       get 'confirmation', on: :member
       get 'outstanding', on: :collection
       get 'authorised', on: :collection
-      patch 'transition_state', on: :member
     end
 
     namespace :admin do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,8 +52,8 @@ ActiveRecord::Schema.define(version: 20150813163440) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "location_id"
-    t.string   "approval_level", default: "Low"
     t.string   "days_worked"
+    t.string   "approval_level", default: "Low"
   end
 
   add_index "case_workers", ["location_id"], name: "index_case_workers_on_location_id", using: :btree

--- a/features/claim_redetermination.feature
+++ b/features/claim_redetermination.feature
@@ -3,11 +3,11 @@ Feature: Claim redetermination
     As an advocate I want to be able to re-open a claim for redetermination.
     As a case worker I want to be able to review claims submitted for redetermination.
 
-  Scenario Outline: Redetermination button visible
+  Scenario Outline: Redetermination control visible
     Given I am a signed in advocate
       And I have a <state> claim
      When I visit the claims's detail page
-     Then I should see a button to re-open the claim for redetermination
+     Then I should see a control in the messages section to request a redetermination
 
     Examples:
       | state           |
@@ -15,11 +15,11 @@ Feature: Claim redetermination
       | part_paid_claim |
       | refused_claim   |
 
-  Scenario Outline: Redetermination button NOT visible
+  Scenario Outline: Redetermination control NOT visible
     Given I am a signed in advocate
       And I have a <state> claim
      When I visit the claims's detail page
-     Then I should not see a button to re-open the claim for redetermination
+     Then I should not see a control in the messages section to request a redetermination
 
     Examples:
       | state                           |
@@ -37,7 +37,7 @@ Feature: Claim redetermination
     Given I am a signed in advocate
       And I have a paid_claim claim
      When I visit the claims's detail page
-      And I click on "Request redetermination"
+      And I check "Request redetermination" and send a message
      Then the claim should be in the redetermination state
       And a notice should be present in the claim status panel
 

--- a/features/claim_redetermination.feature
+++ b/features/claim_redetermination.feature
@@ -36,9 +36,11 @@ Feature: Claim redetermination
   Scenario: Re-open claim for redetermination
     Given I am a signed in advocate
       And I have a paid_claim claim
+      And the claim has a case worker assigned to it
      When I visit the claims's detail page
-      And I check "Request redetermination" and send a message
+      And I select "Apply for redetermination" and send a message
      Then the claim should be in the redetermination state
+      And the claim should no longer have case workers assigned
       And a notice should be present in the claim status panel
 
   Scenario Outline: Handle redetermination claims

--- a/features/claim_redetermination.feature
+++ b/features/claim_redetermination.feature
@@ -39,15 +39,15 @@ Feature: Claim redetermination
       And the claim has a case worker assigned to it
      When I visit the claims's detail page
       And I select "Apply for redetermination" and send a message
-     Then the claim should be in the redetermination state
+     Then the claim should be in the "redetermination" state
       And the claim should no longer have case workers assigned
-      And a notice should be present in the claim status panel
+      And a redetermination notice should be present in the claim status panel
 
   Scenario Outline: Handle redetermination claims
     Given I am a signed in case worker
       And a redetermined claim is assigned to me
      When I visit the claim's case worker detail page
-     Then a notice should be present in the claim status panel
+     Then a redetermination notice should be present in the claim status panel
       And when I select a state of "<form_state>" and update the claim
      Then the claim should be in the "<state>" state
       And the claim should no longer be open for redetermination
@@ -59,3 +59,22 @@ Feature: Claim redetermination
       | Rejected                  | rejected                 |
       | Refused                   | refused                  |
       | Awaiting info from court  | awaiting_info_from_court |
+
+  Scenario: Request written reasons for claim
+    Given I am a signed in advocate
+      And I have a paid_claim claim
+      And the claim has a case worker assigned to it
+     When I visit the claims's detail page
+      And I select "Request written reasons" and send a message
+     Then the claim should be in the "awaiting_written_reasons" state
+      And the claim should no longer have case workers assigned
+      And a written reasons notice should be present in the claim status panel
+
+  Scenario: Handle written reasons for claim
+    Given I am a signed in case worker
+      And a written reasons claim is assigned to me
+     When I visit the claim's case worker detail page
+     Then a written reasons notice should be present in the claim status panel
+      And when I check "Written reasons submitted" and send a message
+     Then the claim should be in the state previous to the written reasons request
+      And the claim should no longer awaiting written reasons

--- a/features/step_definitions/claim_redetermination_steps.rb
+++ b/features/step_definitions/claim_redetermination_steps.rb
@@ -6,16 +6,19 @@ When(/^I visit the claims's detail page$/) do
   visit advocates_claim_path(@claim)
 end
 
-Then(/^I should (not )?see a button to re\-open the claim for redetermination$/) do |negate|
+Then(/^I should (not )?see a control in the messages section to request a redetermination$/) do |negate|
   if negate.present?
-    expect(page).to_not have_selector(:link_or_button, 'Request redetermination')
+    expect(page).to_not have_selector('#message_request_redetermination')
   else
-    expect(page).to have_selector(:link_or_button, 'Request redetermination')
+    expect(page).to have_selector('#message_request_redetermination')
   end
 end
 
-When(/^I click on "(.*?)"$/) do |link_or_button_text|
-  click_on link_or_button_text
+When(/^I check "(.*?)" and send a message$/) do |checkbox_text|
+  check checkbox_text
+  fill_in 'message_subject', with: 'Redetermination request'
+  fill_in 'message_body', with: 'lorem ipsum'
+  click_button 'Post'
 end
 
 Then(/^the claim should be in the redetermination state$/) do

--- a/features/step_definitions/claim_redetermination_steps.rb
+++ b/features/step_definitions/claim_redetermination_steps.rb
@@ -2,20 +2,25 @@ Given(/^I have a (.+) claim$/) do |state|
   @claim = create(state.to_sym, advocate: @advocate)
 end
 
+Given(/^the claim has a case worker assigned to it$/) do
+  case_worker = create(:case_worker)
+  @claim.case_workers << case_worker
+end
+
 When(/^I visit the claims's detail page$/) do
   visit advocates_claim_path(@claim)
 end
 
 Then(/^I should (not )?see a control in the messages section to request a redetermination$/) do |negate|
   if negate.present?
-    expect(page).to_not have_selector('#message_request_redetermination')
+    expect(page).to_not have_selector('#message_claim_action')
   else
-    expect(page).to have_selector('#message_request_redetermination')
+    expect(page).to have_selector('#message_claim_action')
   end
 end
 
-When(/^I check "(.*?)" and send a message$/) do |checkbox_text|
-  check checkbox_text
+When(/^I select "(.*?)" and send a message$/) do |option_text|
+  select option_text, from: 'message_claim_action'
   fill_in 'message_subject', with: 'Redetermination request'
   fill_in 'message_body', with: 'lorem ipsum'
   click_button 'Post'
@@ -24,6 +29,11 @@ end
 Then(/^the claim should be in the redetermination state$/) do
   @claim.reload
   expect(@claim.state).to eq('redetermination')
+end
+
+Then(/^the claim should no longer have case workers assigned$/) do
+  @claim.reload
+  expect(@claim.case_workers).to be_empty
 end
 
 Then(/^a notice should be present in the claim status panel$/) do

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -444,10 +444,6 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
     end
   end
 
-  describe "PATCH #transition_state" do
-
-  end
-
   describe "DELETE #destroy" do
     before { delete :destroy, id: subject }
 

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
     end
 
     it 'assigns @claims' do
-      expect(assigns(:claims)).to eq(Claim.submitted_or_redetermination.order(submitted_at: :asc))
+      expect(assigns(:claims)).to eq(Claim.submitted_or_redetermination_or_awaiting_written_reasons.order(submitted_at: :asc))
     end
 
     it 'assigns @allocation' do

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
     end
 
     it 'assigns @claims' do
-      expect(assigns(:claims)).to eq(Claim.submitted.order(submitted_at: :asc))
+      expect(assigns(:claims)).to eq(Claim.submitted_or_redetermination.order(submitted_at: :asc))
     end
 
     it 'assigns @allocation' do

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -131,6 +131,10 @@ FactoryGirl.define do
       after(:create) { |c|  c.submit!; c.allocate!; set_amount_assessed(c); c.pay!; c.redetermine! }
     end
 
+    factory :awaiting_written_reasons_claim do
+      after(:create) { |c|  c.submit!; c.allocate!; set_amount_assessed(c); c.pay!; c.await_written_reasons! }
+    end
+
     factory :part_paid_claim do
       after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.pay_part! }
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -30,7 +30,7 @@ describe Ability do
     end
 
     context 'can manage their own claims' do
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: advocate)) }
       end
     end
@@ -38,7 +38,7 @@ describe Ability do
     context 'cannot manage claims by another advocate' do
       let(:other_advocate) { create(:advocate) }
 
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should_not be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end
@@ -74,7 +74,7 @@ describe Ability do
     end
 
     context 'can manage their own claims' do
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: advocate)) }
       end
     end
@@ -82,7 +82,7 @@ describe Ability do
     context 'can manage claims by another advocate in the same chamber' do
       let(:other_advocate) { create(:advocate, chamber: chamber) }
 
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end
@@ -90,7 +90,7 @@ describe Ability do
     context 'cannot manage claims by another advocate in a different chamber' do
       let(:other_advocate) { create(:advocate) }
 
-      [:show, :edit, :update, :transition_state, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :destroy].each do |action|
         it { should_not be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Claim, type: :model do
       claim = FactoryGirl.create :allocated_claim
       claim.assessment = Assessment.new
       claim_params = {
-        "state_for_form"=>"part_paid", 
+        "state_for_form"=>"part_paid",
         "assessment_attributes" => {
           "id" => claim.assessment.id,
           "fees" => "66.22",
@@ -1016,21 +1016,42 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  
+  describe '#written_reasons_outstanding?' do
+    let(:claim) { create(:claim) }
+
+    before do
+      claim.submit!
+      claim.allocate!
+      claim.refuse!
+    end
+
+    context 'when transitioned to awaiting_written_reasons' do
+      before do
+        claim.await_written_reasons!
+      end
+
+      it 'should be in an awaiting_written_reasons state' do
+        expect(claim).to be_awaiting_written_reasons
+      end
+
+      it 'should be awaiting_written_reasons' do
+        expect(claim.written_reasons_outstanding?).to eq(true)
+      end
+    end
+
+    context 'when transitioned to allocated' do
+      before do
+        claim.await_written_reasons!
+        claim.allocate!
+      end
+
+      it 'should be in an allocated state' do
+        expect(claim).to be_allocated
+      end
+
+      it 'should have written_reasons_outstanding before being allocated' do
+        expect(claim.written_reasons_outstanding?).to eq(true)
+      end
+    end
+  end
 end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spec/models/claims/state_machine_scopes_spec.rb
+++ b/spec/models/claims/state_machine_scopes_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Claims::StateMachine, type: :model do
     let!(:allocated_claim) { create(:allocated_claim) }
     let!(:deleted_claim) { create(:archived_pending_delete_claim) }
     let!(:redetermination_claim) { create(:redetermination_claim) }
+    let!(:awaiting_written_reasons_claim) { create(:awaiting_written_reasons_claim) }
 
     describe '.non_draft' do
       it 'only returns non-draft claims' do
@@ -27,9 +28,9 @@ RSpec.describe Claims::StateMachine, type: :model do
       end
     end
 
-    describe '.submitted_or_redetermination' do
-      it 'only returns submitted or redetermination claims' do
-        expect(Claim.submitted_or_redetermination).to match_array([submitted_claim, redetermination_claim])
+    describe '.submitted_or_redetermination_or_awaiting_written_reasons' do
+      it 'only returns submitted or redetermination or awaiting_written_reasons claims' do
+        expect(Claim.submitted_or_redetermination_or_awaiting_written_reasons).to match_array([submitted_claim, redetermination_claim, awaiting_written_reasons_claim])
       end
     end
   end

--- a/spec/models/claims/state_machine_scopes_spec.rb
+++ b/spec/models/claims/state_machine_scopes_spec.rb
@@ -19,10 +19,17 @@ RSpec.describe Claims::StateMachine, type: :model do
     let!(:submitted_claim) { create(:submitted_claim) }
     let!(:allocated_claim) { create(:allocated_claim) }
     let!(:deleted_claim) { create(:archived_pending_delete_claim) }
+    let!(:redetermination_claim) { create(:redetermination_claim) }
 
     describe '.non_draft' do
       it 'only returns non-draft claims' do
         expect(Claim.non_draft).to match_array([allocated_claim, submitted_claim])
+      end
+    end
+
+    describe '.submitted_or_redetermination' do
+      it 'only returns submitted or redetermination claims' do
+        expect(Claim.submitted_or_redetermination).to match_array([submitted_claim, redetermination_claim])
       end
     end
   end


### PR DESCRIPTION
Remove redetermination request button from claim status and move to messaging feature as a dropdown with options:
- Apply for redetermination
- Request written reasons

Transitioning a claim to redetermination or awaiting_written_reasons removes allocated case workers and places the claim back in the 'unallocated' tab for case worker admins. Written reasons checkbox for case workers on messages, transitions claim back to original state (before request for written reasons was made).
