### PR TITLE
Methods for checking presence of read/unread messages on claims

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -48,6 +48,7 @@ class Claim < ActiveRecord::Base
   include Claims::StateMachine
   extend Claims::Search
   include Claims::Calculations
+  include Claims::UserMessages
 
   include NumberCommaParser
   numeric_attributes :fees_total, :expenses_total, :total, :vat_amount

--- a/app/models/claims/user_messages.rb
+++ b/app/models/claims/user_messages.rb
@@ -1,0 +1,39 @@
+module Claims::UserMessages
+  def read_messages
+    user_messages_relation.where('user_message_statuses.read = ?', true)
+  end
+
+  def unread_messages
+    user_messages_relation.where('user_message_statuses.read = ?', false)
+  end
+
+  def has_read_messages?
+    read_messages.any?
+  end
+
+  def has_unread_messages?
+    unread_messages.any?
+  end
+
+  def has_unread_messages_for?(user)
+    unread_messages_for(user).any?
+  end
+
+  def has_read_messages_for?(user)
+    read_messages_for(user).any?
+  end
+
+  def unread_messages_for(user)
+    user_messages_relation.where('user_message_statuses.read = ? AND user_message_statuses.user_id = ?', false, user.id)
+  end
+
+  def read_messages_for(user)
+    user_messages_relation.where('user_message_statuses.read = ? AND user_message_statuses.user_id = ?', true, user.id)
+  end
+
+  private
+
+  def user_messages_relation
+    messages.joins(:user_message_statuses)
+  end
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -883,7 +883,7 @@ RSpec.describe Claim, type: :model do
     end
   end
 
-  
+
   describe '.total_greater_than_or_equal_to' do
     let(:not_greater_than_400) do
       claims = []
@@ -1024,22 +1024,4 @@ RSpec.describe Claim, type: :model do
       end
     end
   end
-
-  
 end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spec/models/claims/user_messages_spec.rb
+++ b/spec/models/claims/user_messages_spec.rb
@@ -1,0 +1,243 @@
+require 'rails_helper'
+
+RSpec.describe Claims::UserMessages, type: :model do
+  let!(:claim) { create(:submitted_claim) }
+
+  describe '#has_unread_messages?' do
+    context 'when unread messages present' do
+      before { create(:message, claim: claim) }
+
+      it 'has unread messages' do
+        expect(claim).to have_unread_messages
+      end
+    end
+
+    context 'when no unread messages present' do
+      before do
+        create(:message)
+        UserMessageStatus.first.update_column(:read, true)
+      end
+
+      it 'does not have unread messages' do
+        expect(claim).to_not have_unread_messages
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not have unread messages' do
+        expect(claim).to_not have_unread_messages
+      end
+    end
+  end
+
+  describe '#has_read_messages?' do
+    context 'when read messages present' do
+      before do
+        create(:message, claim: claim)
+        UserMessageStatus.first.update_column(:read, true)
+      end
+
+      it 'has read messages' do
+        expect(claim).to have_read_messages
+      end
+    end
+
+    context 'when no read messages present' do
+      before do
+        create(:message)
+      end
+
+      it 'does not have read messages' do
+        expect(claim).to_not have_read_messages
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not have read messages' do
+        expect(claim).to_not have_read_messages
+      end
+    end
+  end
+
+  describe '#unread_messages' do
+    let(:message_1) { create(:message, claim: claim) }
+    let(:message_2) { create(:message, claim: claim) }
+
+    context 'when unread messages present' do
+      before do
+        message_2.user_message_statuses.each { |status| status.update_column(:read, true) }
+      end
+
+      it 'returns unread messages' do
+        expect(claim.unread_messages).to match_array([message_1])
+      end
+    end
+
+    context 'when no unread messages present' do
+      before do
+        UserMessageStatus.all.each do |status|
+          status.update_column(read: true)
+        end
+      end
+
+      it 'does not return any messages' do
+        expect(claim.unread_messages).to be_empty
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not return any messages' do
+        expect(claim.unread_messages).to be_empty
+      end
+    end
+  end
+
+  describe '#read_messages' do
+    let(:message_1) { create(:message, claim: claim) }
+    let(:message_2) { create(:message, claim: claim) }
+
+    context 'when read messages present' do
+      before do
+        message_2.user_message_statuses.each { |status| status.update_column(:read, true) }
+      end
+
+      it 'returns read messages' do
+        expect(claim.read_messages).to match_array([message_2])
+      end
+    end
+
+    context 'when no read messages present' do
+      it 'does not return any messages' do
+        expect(claim.read_messages).to be_empty
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not return any messages' do
+        expect(claim.read_messages).to be_empty
+      end
+    end
+  end
+
+  describe '#unread_messages_for' do
+    let(:user) { claim.advocate.user }
+    let(:message_1) { create(:message, claim: claim) }
+    let(:message_2) { create(:message, claim: claim) }
+
+    context 'when unread messages present' do
+      before do
+        message_2.user_message_statuses.where(user_id: user.id).each { |status| status.update_column(:read, true) }
+      end
+
+      it 'returns unread messages for user' do
+        expect(claim.unread_messages_for(user)).to match_array([message_1])
+      end
+    end
+
+    context 'when no unread messages present' do
+      before do
+        UserMessageStatus.where(user_id: user.id).each do |status|
+          status.update_column(read: true)
+        end
+      end
+
+      it 'does not return any messages' do
+        expect(claim.unread_messages_for(user)).to be_empty
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not return any messages' do
+        expect(claim.unread_messages_for(user)).to be_empty
+      end
+    end
+  end
+
+  describe '#read_messages_for' do
+    let(:user) { claim.advocate.user }
+    let(:message_1) { create(:message, claim: claim) }
+    let(:message_2) { create(:message, claim: claim) }
+
+    context 'when read messages present' do
+      before do
+        message_2.user_message_statuses.where(user_id: user.id).each { |status| status.update_column(:read, true) }
+      end
+
+      it 'returns read messages' do
+        expect(claim.read_messages).to match_array([message_2])
+      end
+    end
+
+    context 'when no read messages present' do
+      it 'does not return any messages' do
+        expect(claim.read_messages).to be_empty
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not return any messages' do
+        expect(claim.read_messages).to be_empty
+      end
+    end
+  end
+
+  describe '#has_unread_messages_for?' do
+    let(:user) { claim.advocate.user }
+
+    context 'when unread messages present' do
+      before { create(:message, claim: claim) }
+
+      it 'has unread messages' do
+        expect(claim).to have_unread_messages_for(user)
+      end
+    end
+
+    context 'when no unread messages present' do
+      before do
+        create(:message)
+        UserMessageStatus.first.update_column(:read, true)
+      end
+
+      it 'does not have unread messages' do
+        expect(claim).to_not have_unread_messages_for(user)
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not have unread messages' do
+        expect(claim).to_not have_unread_messages_for(user)
+      end
+    end
+  end
+
+  describe '#has_read_messages_for?' do
+    let(:user) { claim.advocate.user }
+
+    context 'when read messages present' do
+      before do
+        create(:message, claim: claim)
+        UserMessageStatus.first.update_column(:read, true)
+      end
+
+      it 'has read messages' do
+        expect(claim).to have_read_messages_for(user)
+      end
+    end
+
+    context 'when no read messages present' do
+      before do
+        create(:message)
+      end
+
+      it 'does not have read messages' do
+        expect(claim).to_not have_read_messages_for(user)
+      end
+    end
+
+    context 'when no messages present' do
+      it 'does not have read messages' do
+        expect(claim).to_not have_read_messages_for(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Convenience methods to check and get messages on claims, optionally per user.
