### PR TITLE
Redetermination and written reasons filtering on allocations page.

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -63,7 +63,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def filter_claims
-    if ['fixed_fee', 'cracked', 'trial', 'guilty_plea'].include?(params[:filter])
+    if %w( fixed_fee cracked trial guilty_plea redetermination awaiting_written_reasons ).include?(params[:filter])
       @claims = @claims.send(params[:filter].to_sym)
     end
 

--- a/app/views/case_workers/admin/allocations/new.html.haml
+++ b/app/views/case_workers/admin/allocations/new.html.haml
@@ -38,6 +38,18 @@
 
       != "&nbsp";
 
+      = label_tag do
+        = radio_button_tag :filter, 'redetermination', params[:filter] == 'redetermination'
+        Redetermination
+
+      != "&nbsp";
+
+      = label_tag do
+        = radio_button_tag :filter, 'awaiting_written_reasons', params[:filter] == 'awaiting_written_reasons'
+        Awaiting written reasons
+
+      != "&nbsp";
+
       = hidden_field_tag :high_value, params[:high_value]
       = hidden_field_tag :tab, params[:tab]
 

--- a/features/claim_allocation.feature
+++ b/features/claim_allocation.feature
@@ -40,15 +40,11 @@ Feature: Claim allocation
      Then I should only see <quantity> "<type>" claims after filtering
 
     Examples:
-      | type        | quantity  |
-      | all         | 10        |
-      | fixed_fee   | 10        |
-      | cracked     | 10        |
-      | trial       | 10        |
-      | guilty_plea | 10        |
-
-  @wip @focus @javascript @webmock_allow_net_connect @failing-environment-specific
-  Scenario: Select all rows
-    When I visit the allocation page
-     And I click "Select all"
-    Then all the claims should be selected
+      | type                     | quantity  |
+      | all                      | 10        |
+      | fixed_fee                | 10        |
+      | cracked                  | 10        |
+      | trial                    | 10        |
+      | guilty_plea              | 10        |
+      | redetermination          | 10        |
+      | awaiting_written_reasons | 10        |

--- a/features/step_definitions/claim_allocation_steps.rb
+++ b/features/step_definitions/claim_allocation_steps.rb
@@ -61,20 +61,6 @@ Then(/^the first (\d+) claims should no longer be displayed$/) do |quantity|
   end
 end
 
-Then(/^all the claims should be selected$/) do
-  count = 0
-  all('input[type="checkbox"]').each do |input|
-    expect(input).to be_checked
-    count += 1
-  end
-
-  expect(@claims.count).to eq(count)
-
-  within '.claim-count' do
-    expect(page).to have_content(/#{count} claims?/)
-  end
-end
-
 Given(/^there are (\d+) "(.*?)" claims?$/) do |quantity, type|
   Claim.destroy_all
 
@@ -92,6 +78,10 @@ Given(/^there are (\d+) "(.*?)" claims?$/) do |quantity, type|
       create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Cracked Trial').id)
     when 'guilty_plea'
       create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Guilty plea').id)
+    when 'redetermination'
+      create_list(:redetermination_claim, number)
+    when 'awaiting_written_reasons'
+      create_list(:awaiting_written_reasons_claim, number)
   end
 end
 


### PR DESCRIPTION
Two additional filtering options on caseworker admin allocations page:
- Redetermination
- Awaiting written reasons
