### PR TITLE
Remove duplicate mention for Webrick for :test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,6 @@ group :test do
   gem 'simplecov-multi',            require: false
   gem 'timecop',                    '~> 0.7.4'
   gem 'webmock',                    '~> 1.21.0'
-  gem 'webrick',        '~> 1.3'
 end
 
 group :doc do


### PR DESCRIPTION
running Bundle install gives this warning:

```
Your Gemfile lists the gem webrick (~> 1.3) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```

This was introduced in PR #464 https://github.com/ministryofjustice/advocate-defence-payments/pull/464/files#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R63

@EdwardAndress - I'm assigning it to you encase there was a particular reason that we might need to be aware of.
