### PR TITLE
Fix api uuid pg bug

### DIFF
--- a/app/interfaces/api/v1/advocates/defendant.rb
+++ b/app/interfaces/api/v1/advocates/defendant.rb
@@ -23,10 +23,6 @@ module API
             end
 
             def build_arguments
-
-              # explicit test for UUID that is not in correct format to avoid PG error
-              raise API::V1::ArgumentError, 'malformed UUID' unless ApiHelper.uuid_valid?(params[:claim_id])
-
               {
                 claim_id:       ::Claim.find_by(uuid: params[:claim_id]).try(:id),
                 first_name:     params[:first_name],

--- a/app/interfaces/api/v1/advocates/defendant.rb
+++ b/app/interfaces/api/v1/advocates/defendant.rb
@@ -23,6 +23,10 @@ module API
             end
 
             def build_arguments
+
+              # explicit test for UUID that is not in correct format to avoid PG error
+              raise API::V1::ArgumentError, 'malformed UUID' unless ApiHelper.uuid_valid?(params[:claim_id])
+
               {
                 claim_id:       ::Claim.find_by(uuid: params[:claim_id]).try(:id),
                 first_name:     params[:first_name],

--- a/app/interfaces/api/v1/api_helper.rb
+++ b/app/interfaces/api/v1/api_helper.rb
@@ -57,6 +57,12 @@ module API
       end
 
       # --------------------
+      def self.uuid_valid?(uuid)
+        return true if uuid =~ /\A[\da-f]{32}\z/i
+        return true if uuid =~ /\A(urn:uuid:)?[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}\z/i
+      end
+
+      # --------------------
       def self.create_resource(model_object, params, api_response, arg_builder_proc)
 
         model_instance = validate_resource(model_object, api_response, arg_builder_proc)

--- a/app/interfaces/api/v1/api_helper.rb
+++ b/app/interfaces/api/v1/api_helper.rb
@@ -28,7 +28,12 @@ module API
             @model = object
             build_error_response
           else
-            @body = error_messages.push({ error: object.message })
+            # temp workaround til rails 4.2 upgrade which should fix malformed UUID error and raise ActiveRecord::RecordNotFound
+            if object.inspect.include? 'PG::InvalidTextRepresentation: ERROR:  invalid input syntax for uuid:'
+              @body = error_messages.push({ error: "malformed UUID" })
+            else
+              @body = error_messages.push({ error: object.message })
+            end
             @status = 400
           end
 
@@ -54,12 +59,6 @@ module API
              raise "unable to build error response as no errors were found"
            end
         end
-      end
-
-      # --------------------
-      def self.uuid_valid?(uuid)
-        return true if uuid =~ /\A[\da-f]{32}\z/i
-        return true if uuid =~ /\A(urn:uuid:)?[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}\z/i
       end
 
       # --------------------

--- a/spec/api/v1/claims/date_attended_spec.rb
+++ b/spec/api/v1/claims/date_attended_spec.rb
@@ -98,6 +98,15 @@ describe API::V1::Advocates::DateAttended do
         end
       end
 
+      context "malformed attended_item_id UUID" do
+        it "should be temporarily handled explicitly (until rails 4.2 upgrade)" do
+          valid_params[:attended_item_id] = 'any-old-rubbish'
+          response = post_to_create_endpoint(valid_params)
+          expect(response.status).to eq(400)
+          expect(response.body).to eq "[{\"error\":\"malformed UUID\"}]"
+        end
+      end
+
     end
 
   end

--- a/spec/api/v1/claims/defendant_spec.rb
+++ b/spec/api/v1/claims/defendant_spec.rb
@@ -74,7 +74,7 @@ describe API::V1::Advocates::Defendant do
       end
 
       context "malformed claim UUID" do
-        it "should be handled by ActiveRecord not PG" do
+        it "should be temporarily handled explicitly (until rails 4.2 upgrade)" do
           valid_params[:claim_id] = 'any-old-rubbish'
           response = post_to_create_endpoint(valid_params)
           expect(response.status).to eq(400)

--- a/spec/api/v1/claims/defendant_spec.rb
+++ b/spec/api/v1/claims/defendant_spec.rb
@@ -72,6 +72,16 @@ describe API::V1::Advocates::Defendant do
           expect(json[0]['error']).to include("PG::StringDataRightTruncation: ERROR:  value too long for type character varying(255)")
         end
       end
+
+      context "malformed claim UUID" do
+        it "should be handled by ActiveRecord not PG" do
+          valid_params[:claim_id] = 'any-old-rubbish'
+          response = post_to_create_endpoint(valid_params)
+          expect(response.status).to eq(400)
+          expect(response.body).to eq "[{\"error\":\"malformed UUID\"}]"
+        end
+      end
+
     end
 
   end

--- a/spec/api/v1/claims/expense_spec.rb
+++ b/spec/api/v1/claims/expense_spec.rb
@@ -82,6 +82,15 @@ describe API::V1::Advocates::Expense do
         end
       end
 
+      context "malformed claim UUID" do
+        it "should be temporarily handled explicitly (until rails 4.2 upgrade)" do
+          valid_params[:claim_id] = 'any-old-rubbish'
+          response = post_to_create_endpoint(valid_params)
+          expect(response.status).to eq(400)
+          expect(response.body).to eq "[{\"error\":\"malformed UUID\"}]"
+        end
+      end
+
     end
 
   end

--- a/spec/api/v1/claims/fee_spec.rb
+++ b/spec/api/v1/claims/fee_spec.rb
@@ -101,6 +101,15 @@ describe API::V1::Advocates::Fee do
         end
       end
 
+      context "malformed claim UUID" do
+        it "should be temporarily handled explicitly (until rails 4.2 upgrade)" do
+          valid_params[:claim_id] = 'any-old-rubbish'
+          response = post_to_create_endpoint(valid_params)
+          expect(response.status).to eq(400)
+          expect(response.body).to eq "[{\"error\":\"malformed UUID\"}]"
+        end
+      end
+
     end
 
   end


### PR DESCRIPTION
This relates to a possible BUG in rails 4.1.8 working against postgres DB using the UUID extensions whereby a malformed UUID raises an unfriendly PG error rather that a ActiveRecord::RecordNotFound
error. This may be fixed in Rails 4.2, which we may eventually upgrade too.

reference: https://github.com/rails/rails/issues/11902
