### PR TITLE
Confirmation dialog for "Clear form" button on claim form

### DIFF
--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -212,4 +212,4 @@
       = f.submit t('.submit_to_laa'), class: 'button'
       - if @claim.draft?
         = f.submit t('.save_to_drafts'), class: 'button'
-      = link_to t('.clear_form'), new_advocates_claim_path, class: 'button'
+      = link_to t('.clear_form'), new_advocates_claim_path, class: 'button', data: { confirm: 'Are you sure you want to clear this form?' }


### PR DESCRIPTION
Clear form button pops up dialog asking "Are you sure you want to clear this form?" before proceeding.
