### PR TITLE
Remove passing of claim ids and claim count

### DIFF
--- a/app/views/case_workers/claims/_caseworker_claims.html.haml
+++ b/app/views/case_workers/claims/_caseworker_claims.html.haml
@@ -21,7 +21,7 @@
         %tr
           %td
           %td
-            = link_to claim.case_number , case_workers_claim_path(claim, claim_ids: @claims.map(&:id), claim_count: @claims.try(:count)),{:class => 'js-test-case-number-link'}
+            = link_to claim.case_number , case_workers_claim_path(claim),{:class => 'js-test-case-number-link'}
           %td
             = claim.advocate.user.name
           %td

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -58,14 +58,12 @@ end
 Then(/^I should see only my claims$/) do
   @claims.each do | claim |
     expect(find('#claims-list')).to have_link(claim.case_number,
-          :href => case_workers_claim_path(claim,
-          claim_ids: @claims.map(&:id), claim_count: @claims.try(:count)))
+          href: case_workers_claim_path(claim))
   end
 
   @other_claims.each do | other_claim |
     expect(find('#claims-list')).to_not have_link(other_claim.case_number,
-          :href => case_workers_claim_path(other_claim,
-          claim_ids: @other_claims.map(&:id), claim_count: @other_claims.try(:count)))
+          href: case_workers_claim_path(other_claim))
   end
 end
 
@@ -87,8 +85,7 @@ end
 Then(/^I should see the claims sorted by oldest first$/) do
   @claims.sort_by(&:submitted_at).each do | claim |
     expect(find('#claims-list')).to have_link(claim.case_number,
-          :href => case_workers_claim_path(claim,
-          claim_ids: @claims.map(&:id), claim_count: @claims.try(:count)))
+          href: case_workers_claim_path(claim))
   end
 end
 

--- a/features/view_claim_evidence.feature
+++ b/features/view_claim_evidence.feature
@@ -25,7 +25,7 @@ Feature: Viewing and downloading claim evidence
       And click on a link to view some evidence
     Then I see "longer_lorem.pdf" in my browser
 
-  @javascript
+  @javascript @webmock_allow_localhost_connect
   Scenario: Caseworker views a document in a new tab
     Given I am signed in and on the case worker dashboard
       And I have been assigned claims with evidence attached


### PR DESCRIPTION
claim_ids param passing in case workers controller no longer necessary.
