### PR TITLE
Modified run.sh to improve rake tasks names and to fix contention on multinode stacks

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,26 +1,78 @@
 #!/bin/bash
-set -e
+# last modified 12-09-2015
+set -ex
 
-if [ "$DOCKER_STATE" = "none" ]; then
-  SLEEP_TIME=0
-else
-  if [ "$RUN_MIGRATE_OR_SEED" != "True" ]; then
-      SLEEP_TIME=5m
+echo "DEBUG: run.sh starts here"
+
+echo "DEBUG: DOCKER_STATE = $DOCKER_STATE"
+
+# check the variable LOCK passed from the upstart script
+echo "DEBUG: checking for LOCK"
+
+# if LOCK is set it takes precedence
+if [ -z ${LOCK+x} ]; then
+  echo "DEBUG: LOCK is not set; DOCKER_STATE: $DOCKER_STATE"
+  # if LOCK is not set, let's check RUN_MIGRATE_OR_SEED
+  # compatible with salt master version
+  echo "DEBUG:run.sh:checking RUN_MIGRATE_OR_SEED"
+  if [ -z ${RUN_MIGRATE_OR_SEED+x} ]; then
+    echo "DEBUG: RUN_MIGRATE_OR_SEED is not set; DOCKER_STATE: $DOCKER_STATE"
+    # neither is set, set to none
+    echo "WARN: neither LOCK nor RUN_MIGRATE_OR_SEED set"
+    DOCKER_STATE=none
+  else
+    echo "DEBUG: RUN_MIGRATE_OR_SEED is SET $RUN_MIGRATE_OR_SEED"
+    if [ "$RUN_MIGRATE_OR_SEED" = "True" ]; then
+      echo "DEBUG:run.sh:leaving DOCKER_STATE alone"
+    else
       DOCKER_STATE=none
+      echo "DEBUG:run.sh:forcing DOCKER_STATE to none"
+    fi
+  fi
+else
+  if [ "$LOCK" = "" ]; then
+    echo "DEBUG: LOCK set but empty; DOCKER_STATE: $DOCKER_STATE"
+  else
+    if [ $LOCK -eq 1 ]; then
+      echo "DEBUG: LOCK acquired; DOCKER_STATE: $DOCKER_STATE"
+    else
+      if [ $LOCK -eq 0 ]; then
+        echo "DEBUG: LOCK not acquired; do nothing - DOCKER_STATE: $DOCKER_STATE"
+        DOCKER_STATE=none
+      else
+        echo "DEBUG: LOCK value not recognized: $LOCK - DOCKER_STATE: $DOCKER_STATE"
+      fi
+    fi
   fi
 fi
 
+set +x
+echo "**********************************************"
+echo "DEBUG: after IFs, DOCKER_STATE = $DOCKER_STATE"
+echo "**********************************************"
+set -x
+
 case ${DOCKER_STATE} in
 migrate)
+    echo "executing rake db:migrate"
     bundle exec rake db:migrate
     ;;
 seed)
+    # db:seed
+    echo "executing rake db:seed"
+    bundle exec rake db:seed
+    ;;
+reload)
     # db:reload  a bespoke task, see lib/tasks/db.rake
+    echo "executing rake db:reload"
     bundle exec rake db:reload
     ;;
+reseed)
+    # db:clear
+    echo "executing rake db:reseed"
+    bundle exec rake db:reseed
+    ;;
 esac
-if [ -n "$SLEEP_TIME" ]; then
-  sleep $SLEEP_TIME
-fi
 
+echo "launching unicorn"
 exec bundle exec unicorn -p 80 -c config/unicorn.rb


### PR DESCRIPTION
- changed the list of rake tasks that are passed to the container
- made changes due to the fact that in newer stacks there is no longer a salt-master
- made changes for new variable LOCK passed to the container from the upstart script
- If neither LOCK nor RUN_MIGRATE_OR_SEED is set, default task to none
