### PR TITLE
fix api and modify fee validator

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -50,7 +50,8 @@ class Fee < ActiveRecord::Base
   end
 
   def self.new_blank(claim, fee_type)
-    Fee.new(claim: claim, fee_type: fee_type, quantity: 0, amount: 0)
+    quantity = (fee_type.code == 'BAF' ? 1 : 0)
+    Fee.new(claim: claim, fee_type: fee_type, quantity: quantity, amount: 0)
   end
 
   def self.new_collection_from_form_params(claim, form_params)

--- a/app/validators/fee_validator.rb
+++ b/app/validators/fee_validator.rb
@@ -34,7 +34,6 @@ class FeeValidator < BaseClaimValidator
     if @record.claim.case_type.try(:is_fixed_fee?)
       validate_numericality(:quantity, 0, 0, 'You cannot claim a basic fee for this case type')
     else
-      # TODO - this causes problems for API and logic error whereby amount cannot be 0 if quantity is 1
       validate_numericality(:quantity, 1, 1, 'Quantity for basic fee must be exactly one')
     end
   end

--- a/app/validators/fee_validator.rb
+++ b/app/validators/fee_validator.rb
@@ -34,6 +34,7 @@ class FeeValidator < BaseClaimValidator
     if @record.claim.case_type.try(:is_fixed_fee?)
       validate_numericality(:quantity, 0, 0, 'You cannot claim a basic fee for this case type')
     else
+      # TODO - this causes problems for API and logic error whereby amount cannot be 0 if quantity is 1
       validate_numericality(:quantity, 1, 1, 'Quantity for basic fee must be exactly one')
     end
   end
@@ -92,7 +93,7 @@ class FeeValidator < BaseClaimValidator
     if @record.amount < 0
       add_error(:amount, 'Fee amount cannot be negative')
     elsif @record.quantity > 0 && @record.amount == 0
-      add_error(:amount, 'Fee amount cannot be zero or blank if a fee quantity has been specified, please enter the relevant amount')
+      add_error(:amount, 'Fee amount cannot be zero or blank if a fee quantity has been specified, please enter the relevant amount') unless @record.fee_type.code == 'BAF'
     elsif @record.quantity == 0 && @record.amount > 0
       add_error(:amount, 'Fee amounts cannot be specified if the fee quantity is zero')
     # TODO: on analysis with BA decided to allow decimals for all fees

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -1,6 +1,12 @@
 @stub_s3_upload
 
 Feature: Advocate new claim
+
+  Scenario: New claim instantiates Basic Fee Type (BAF) to quantity of 1
+   Given I am a signed in advocate
+     And I am on the new claim page
+    Then I should see a Basic Fee quantity of exactly one
+
   Scenario: Fill in claim form and submit to LAA
     Given I am a signed in advocate
       And There are fee schemes in place
@@ -164,6 +170,12 @@ Scenario Outline: Add fees with dates attended then remove fee
        And I select a Case Type of "Trial"
        And I submit to LAA
       Then There should not be any Fixed Fees saved
+
+  Scenario: New claim instantiates Basic Fee Type (BAF) to quantity of 1
+     Given I am a signed in advocate
+       # And There are fee schemes in place
+       And I am on the new claim page
+      Then I should see a Basic Fee quantity of exactly one
 
   Scenario: Edit existing non-Fixed case type to be Fixed
     Given I am a signed in advocate

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -13,7 +13,7 @@ Given(/^I am on the new claim page$/) do
   create(:court, name: 'some court')
   create(:offence_class, description: 'A: Homicide and related grave offences')
   create(:offence, description: 'Murder')
-  create(:fee_type, :basic, description: 'Basic Fee')
+  create(:fee_type, :basic, description: 'Basic Fee', code: 'BAF')
   create(:fee_type, :basic, description: 'Other Basic Fee')
   create(:fee_type, :basic, description: 'Basic Fee with dates attended required', code: 'SAF')
   create(:fee_type, :fixed, description: 'Fixed Fee example')
@@ -26,11 +26,6 @@ Given(/^There are fee schemes in place$/) do
   Scheme.find_or_create_by(name: 'AGFS Fee Scheme 7', start_date: Date.parse('01/04/2011'), end_date: Date.parse('02/10/2011'))
   Scheme.find_or_create_by(name: 'AGFS Fee Scheme 8', start_date: Date.parse('03/10/2011'), end_date: Date.parse('31/03/2012'))
   Scheme.find_or_create_by(name: 'AGFS Fee Scheme 9', start_date: Date.parse('01/04/2012'), end_date: nil)
-end
-
-Given(/^there are case types in place$/) do
-  create(:case_type, name: 'Contempt')
-  create(:case_type, name: 'Fixed Fee')
 end
 
 Given(/^There are case types in place$/) do
@@ -336,6 +331,10 @@ end
 Then(/^I should( not)? be able to view "(.*?)"$/i) do |have, content|
   to_or_not_to = have.nil? ? 'to' : have.gsub(/\s+/,'').downcase == 'not' ? 'to_not' : 'to'
   expect(page).method(to_or_not_to).call have_content(content)
+end
+
+Then(/^I should see a Basic Fee quantity of exactly one$/) do
+  expect(page).to have_field('claim_basic_fees_attributes_0_quantity', with: 1)
 end
 
 Given(/^I fill in an Initial Fee$/) do

--- a/lib/api_test_client.rb
+++ b/lib/api_test_client.rb
@@ -95,6 +95,10 @@ private
     end
   end
 
+  def id_from_json(json,key='id')
+    JSON.parse(json)[key] rescue 0
+  end
+
   #
   # don't raise exceptions but, instead, return the
   # response for analysis.
@@ -120,18 +124,21 @@ private
   end
 
   def clean_up
-      @messages << "cleaning up"
+      puts "smoke test: cleaning up"
+      # @messages << "cleaning up"
       claim = Claim.find_by(uuid: @claim_id)
       if claim
-        claim.destroy!
-        @messages << "claim destroyed"
-      else
-        @message << "claim NOT found for destruction!!"
+        if claim.destroy
+          # @messages << "claim destroyed"
+          puts "smoke test: claim destroyed"
+        else
+          # @message << "claim NOT found for destruction!!"
+          puts "smoke test: claim NOT found for destruction!!"
+        end
       end
   end
 
   def post_to_advocate_endpoint(resource, payload, prefix=nil)
-
     endpoint = RestClient::Resource.new([api_root_url, prefix || ADVOCATE_PREFIX, resource].join('/'))
     endpoint.post(payload, { :content_type => :json, :accept => :json } ) do |response, request, result|
       if response.code.to_s =~ /^2/
@@ -143,7 +150,6 @@ private
       end
       response
     end
-
   end
 
   def test_claim_creation_endpoints
@@ -152,30 +158,30 @@ private
     response = post_to_advocate_endpoint('claims', claim_data)
     return if failure
 
-    @claim_id = JSON.parse(response)['id']
+    @claim_id = id_from_json(response)
 
     # add a defendant
     response = post_to_advocate_endpoint('defendants', defendant_data(@claim_id))
 
     # add representation order
-    defendant_id = JSON.parse(response)['id']
+    defendant_id = id_from_json(response)
     response = post_to_advocate_endpoint('representation_orders', representation_order_data(defendant_id))
 
     # add fee
     response = post_to_advocate_endpoint('fees', fee_data(@claim_id))
 
     # add date attended to fee
-    attended_item_id = JSON.parse(response)['id']
+    attended_item_id = id_from_json(response)
     response = post_to_advocate_endpoint('dates_attended', date_attended_data(attended_item_id,"fee"))
 
     # add expense
     response = post_to_advocate_endpoint('expenses', expense_data(@claim_id))
 
     # add date attended to expense
-    attended_item_id = JSON.parse(response)['id']
+    attended_item_id = id_from_json(response)
     response = post_to_advocate_endpoint('dates_attended', date_attended_data(attended_item_id,"expense"))
 
-    # destroy all data created
+  ensure
     clean_up
 
   end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -780,8 +780,9 @@ RSpec.describe Claim, type: :model do
       claim_2 = FactoryGirl.create :claim, case_type_id: ct_fixed_2.id
       claim_3 = FactoryGirl.create :claim, case_type_id: ct_basic_1.id
       claim_4 = FactoryGirl.create :claim, case_type_id: ct_basic_2.id
-
-      expect(Claim.fixed_fee).to eq( [ claim_1, claim_2 ])
+      expect(Claim.fixed_fee.count).to eq 2
+      expect(Claim.fixed_fee).to include claim_1
+      expect(Claim.fixed_fee).to include claim_2
     end
   end
 

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Fee, type: :model do
       expect(fee.amount).to eq 0
       expect(fee).to be_new_record
     end
+
+    context 'for the BAF basic fee' do
+      it 'should be called as part of claim instatiation and assign 1 as quantity for BAF fee types' do
+        baf_fee_type = FactoryGirl.create :fee_type, :basic, code: 'BAF'
+        claim = FactoryGirl.build :claim
+        fee = claim.basic_fees.first
+        expect(fee.fee_type.code).to eql 'BAF'
+        expect(fee.amount).to eq 0.00
+        expect(fee.quantity).to eq 1
+        expect(fee).to be_new_record
+      end
+    end
   end
 
 

--- a/spec/validators/fee_validator_spec.rb
+++ b/spec/validators/fee_validator_spec.rb
@@ -24,6 +24,7 @@ describe FeeValidator do
     end
     context 'quantity greater than zero' do
       it { should_be_valid_if_equal_to_value(daf_fee, :amount, 450.00) }
+      it { should_be_valid_if_equal_to_value(baf_fee, :amount, 0.00) }
       it { should_error_if_equal_to_value(daf_fee, :amount, nil, 'Fee amount cannot be zero or blank if a fee quantity has been specified, please enter the relevant amount') }
       it { should_error_if_equal_to_value(daf_fee, :amount, 0.00, 'Fee amount cannot be zero or blank if a fee quantity has been specified, please enter the relevant amount') }
       it { should_error_if_equal_to_value(daf_fee, :amount, -320, 'Fee amount cannot be negative') }


### PR DESCRIPTION
The fee validator was causing problems with the API, basic fee instantiation 
and was not reflecting all possible business scenario logic for PCMH fee types.

Includes:
  -refactor of fee_validator
  -instantiate basic fee type quantity to one
  -short circuit amount/quantity validation for BAF fees
  -specs and cukes for above
  -fixes API create claim endpoints
  -fixes smoke test

does not include:
- modifying of fee creation API endpoint to update
  basic fees, not create new ones.
