### PR TITLE
Modify standard json date format check

### DIFF
--- a/app/interfaces/api/custom_validations/date_format.rb
+++ b/app/interfaces/api/custom_validations/date_format.rb
@@ -1,7 +1,13 @@
 class StandardJsonFormat < Grape::Validations::Base
   def validate_param!(attr_name, params)
-    unless params[attr_name] =~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
-      fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "is not in standard JSON date format (YYYY-MM-DD)"
+
+    #
+    # regex pattern: "sortable" e.g.
+    #   match     - 2015-05-21
+    #   match     - 2015-05-21T14:00:00
+    #
+    unless params[attr_name] =~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$/
+      fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "is not in an acceptable date format (YYYY-MM-DD[T00:00:00])"
     end
   end
 end

--- a/spec/api/v1/claims/claim_spec.rb
+++ b/spec/api/v1/claims/claim_spec.rb
@@ -67,7 +67,7 @@ describe API::V1::Advocates::Claim do
       expect(json[0]['error']).to include("Case number cannot be blank, you must enter a case number")
     end
 
-    it 'returns 400 and JSON error when dates are not in standard JSON format' do
+    it 'returns 400 and JSON error when dates are not in acceptable format' do
       claim_params[:first_day_of_trial] = '01-01-2015'
       claim_params[:trial_concluded_at] = '09-01-2015'
       claim_params[:trial_fixed_notice_at] = '01-01-2015'
@@ -76,7 +76,7 @@ describe API::V1::Advocates::Claim do
       post_to_validate_endpoint
       expect(last_response.status).to eq(400)
       json = JSON.parse(last_response.body)
-      expect(json).to eq [{"error"=>"first_day_of_trial is not in standard JSON date format (YYYY-MM-DD)"}, {"error"=>"trial_concluded_at is not in standard JSON date format (YYYY-MM-DD)"}, {"error"=>"trial_fixed_notice_at is not in standard JSON date format (YYYY-MM-DD)"}, {"error"=>"trial_fixed_at is not in standard JSON date format (YYYY-MM-DD)"}, {"error"=>"trial_cracked_at is not in standard JSON date format (YYYY-MM-DD)"}]
+      expect(json).to eq [{"error"=>"first_day_of_trial is not in an acceptable date format (YYYY-MM-DD[T00:00:00])"}, {"error"=>"trial_concluded_at is not in an acceptable date format (YYYY-MM-DD[T00:00:00])"}, {"error"=>"trial_fixed_notice_at is not in an acceptable date format (YYYY-MM-DD[T00:00:00])"}, {"error"=>"trial_fixed_at is not in an acceptable date format (YYYY-MM-DD[T00:00:00])"}, {"error"=>"trial_cracked_at is not in an acceptable date format (YYYY-MM-DD[T00:00:00])"}]
     end
 
   end

--- a/spec/api/v1/claims/date_attended_spec.rb
+++ b/spec/api/v1/claims/date_attended_spec.rb
@@ -128,13 +128,13 @@ describe API::V1::Advocates::DateAttended do
       expect(response.body).to eq "[{\"error\":\"Attended item can't be blank\"}]"
     end
 
-    it 'returns 400 and JSON error when dates are not in standard JSON format' do
+    it 'returns 400 and JSON error when dates are not in acceptable format' do
       invalid_params = valid_params
       invalid_params[:date] = '10-05-2015'
       invalid_params[:date_to] = '12-05-2015'
       response = post_to_validate_endpoint(invalid_params)
       expect(response.status).to eq 400
-      expect(response.body).to eq "[{\"error\":\"date is not in standard JSON date format (YYYY-MM-DD)\"},{\"error\":\"date_to is not in standard JSON date format (YYYY-MM-DD)\"}]"
+      expect(response.body).to eq "[{\"error\":\"date is not in an acceptable date format (YYYY-MM-DD[T00:00:00])\"},{\"error\":\"date_to is not in an acceptable date format (YYYY-MM-DD[T00:00:00])\"}]"
     end
 
   end

--- a/spec/api/v1/claims/defendant_spec.rb
+++ b/spec/api/v1/claims/defendant_spec.rb
@@ -117,12 +117,12 @@ describe API::V1::Advocates::Defendant do
       expect(invalid_response.body).to eq "[{\"error\":\"Claim cannot be blank\"}]"
     end
 
-    it 'returns 400 and JSON error when dates are not in standard JSON format' do
+    it 'returns 400 and JSON error when dates are not in acceptable format' do
       invalid_params = valid_params
       invalid_params[:date_of_birth] = '10-05-1980'
       response = post_to_validate_endpoint(invalid_params)
       expect(response.status).to eq 400
-      expect(response.body).to eq "[{\"error\":\"date_of_birth is not in standard JSON date format (YYYY-MM-DD)\"}]"
+      expect(response.body).to eq "[{\"error\":\"date_of_birth is not in an acceptable date format (YYYY-MM-DD[T00:00:00])\"}]"
     end
 
   end

--- a/spec/api/v1/claims/representation_order_spec.rb
+++ b/spec/api/v1/claims/representation_order_spec.rb
@@ -120,12 +120,12 @@ describe API::V1::Advocates::RepresentationOrder do
       expect(response.body).to eq "[{\"error\":\"Defendant can't be blank\"}]"
     end
 
-    it 'returns 400 and JSON error when dates are not in standard JSON format' do
+    it 'returns 400 and JSON error when dates are not in acceptable format' do
       invalid_params = valid_params
       invalid_params[:representation_order_date] = '10-06-2015'
       response = post_to_validate_endpoint(invalid_params)
       expect(response.status).to eq 400
-      expect(response.body).to eq "[{\"error\":\"representation_order_date is not in standard JSON date format (YYYY-MM-DD)\"}]"
+      expect(response.body).to eq "[{\"error\":\"representation_order_date is not in an acceptable date format (YYYY-MM-DD[T00:00:00])\"}]"
     end
 
   end


### PR DESCRIPTION
this small change enforces a date format which can optionally include a time element following the ISO 8601 standard. The time element is stripped off by a date parser in all current instances but this allows API consumer clients to use certain date casting functions when passing dates to us without it raising an error. 

API Consumers must now provide a format of either YYYY-MM-DD or YYYY-MM-DDT00:00:00
