### PR TITLE
Fixes unsafe use of #html_safe in ClaimPresenter

### DIFF
--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -2,7 +2,17 @@ class ClaimPresenter < BasePresenter
   presents :claim
 
   def defendant_names
-    claim.defendants.order('id ASC').map(&:name).join(',<br>').html_safe
+    defendant_names = claim.defendants.order('id ASC').map(&:name)
+
+    h.capture do
+      defendant_names.each do |name|
+        h.concat(name)
+        unless name == defendant_names.last
+          h.concat(',')
+          h.concat(h.tag :br)
+        end
+      end
+    end
   end
 
   def submitted_at(options={})
@@ -79,7 +89,14 @@ class ClaimPresenter < BasePresenter
   end
 
   def representation_order_details
-    claim.defendants.map(&:representation_order_details).flatten.join('<br/>').html_safe
+    rep_order_details = claim.defendants.map(&:representation_order_details).flatten
+
+    h.capture do
+      rep_order_details.each do |details|
+        h.concat(details)
+        h.concat(h.tag :br) unless details == rep_order_details.last
+      end
+    end
   end
 
   def assessment_date

--- a/spec/presenters/claim_presenter_spec.rb
+++ b/spec/presenters/claim_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ClaimPresenter do
   after { Timecop.return }
 
   it '#defendant_names' do
-    expect(subject.defendant_names).to eql("#{@first_defendant.name},<br>John Robert Smith,<br>Adam Smith")
+    expect(subject.defendant_names).to eql("#{@first_defendant.name},<br />John Robert Smith,<br />Adam Smith")
   end
 
   it '#submitted_at' do
@@ -143,7 +143,7 @@ RSpec.describe ClaimPresenter do
         defendant_2.representation_orders =[ FactoryGirl.build(:representation_order, representation_order_date: Date.new(2015,3,1), granting_body: "Magistrates' Court", maat_reference: 'xyz4321') ]
       end
       claim.defendants = [ defendant_1, defendant_2 ]
-      expect(subject.representation_order_details).to eq( "Crown Court 01/03/2015 1234abc<br/>Magistrates' Court 13/08/2015 abc1234<br/>Magistrates' Court 01/03/2015 xyz4321" )
+      expect(subject.representation_order_details).to eq( "Crown Court 01/03/2015 1234abc<br />Magistrates&#39; Court 13/08/2015 abc1234<br />Magistrates&#39; Court 01/03/2015 xyz4321" )
     end
   end
 


### PR DESCRIPTION
Script injection execution fixed in #defendant_names and #representation_order_details presenter methods.
