### PR TITLE
fix broken sign out in swagger nav bar

### DIFF
--- a/app/assets/javascripts/adp_swagger_application.js
+++ b/app/assets/javascripts/adp_swagger_application.js
@@ -1,8 +1,5 @@
 //
-// to provide grape swagger rails use of certain rails methods,
-// particulalry link_to with methid: delete, we need
-// swagger to have jquery_ujs. However, since grape swagger rails
-// already includes jquery and does not require other application
-// js, we do not wan tto include apd's application.js here
+// To provide grape swagger rails use of certain rails methods
+// without adding all of ADP's application.js
 //
 //= require jquery_ujs

--- a/app/assets/javascripts/adp_swagger_application.js
+++ b/app/assets/javascripts/adp_swagger_application.js
@@ -1,0 +1,8 @@
+//
+// to provide grape swagger rails use of certain rails methods,
+// particulalry link_to with methid: delete, we need
+// swagger to have jquery_ujs. However, since grape swagger rails
+// already includes jquery and does not require other application
+// js, we do not wan tto include apd's application.js here
+//
+//= require jquery_ujs

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -254,8 +254,8 @@
     ga('send', 'pageview');
   </script>
 
-  <!-- including jquery twice cause an error in swagger the impact of which is unclear but we do not need this js anyway -->
-  <%#= javascript_include_tag "application" %>
+  <!-- do NOT include ADPs application,js as it including jquery twice causes a jquery error in swagger, the impact of which is unclear, but we do not need this js anyway execpt jquery_ujs -->
+  <%= javascript_include_tag "adp_swagger_application" %>
 
 </body>
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,4 +4,4 @@
 Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( adp_swagger_application.js )


### PR DESCRIPTION
sign out requires Unobtrusive javascript to create
the delete method but previous branch removed application.js
since it is otherwise unrequired. applied separate
js file that requires jquery_ujs only for use by grape swagger
page to fix.
