### PR TITLE
Set initial value of 3 hours for devise inactivity session timeout

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 3.hours
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false


### PR DESCRIPTION
This value can be tweaked based on testing and user feedback.
