### PR TITLE
Fix fixed fee logic

### DIFF
--- a/app/assets/javascripts/advocates/claims/fee_section_display.js
+++ b/app/assets/javascripts/advocates/claims/fee_section_display.js
@@ -76,7 +76,7 @@ adp.feeSectionDisplay = {
 
     $warning.remove();
 
-    if (isFixedFee && (feeExists('.basic-fee-group') || feeExists('.misc-fee-group'))) {
+    if (isFixedFee && (feeExists('.basic-fee-group'))) {
       adp.feeSectionDisplay.$caseTypeSelect.after(warningMsg);
     } else if (!isFixedFee && feeExists('.fixed-fee-group')) {
       adp.feeSectionDisplay.$caseTypeSelect.after(warningMsg);
@@ -86,7 +86,7 @@ adp.feeSectionDisplay = {
 
   applyFixedFeeState : function(state) {
     if (state) {
-      adp.feeSectionDisplay.applyWarning('Initial and Miscellaneous fees exist that will be removed if you save this claim as a Fixed Fee!', state);
+      adp.feeSectionDisplay.applyWarning('Initial fees exist that will be removed if you save this claim as a Fixed Fee!', state);
       adp.feeSectionDisplay.$basicFeesSet.slideUp();
       adp.feeSectionDisplay.$fixedFeesSet.slideDown();
 

--- a/app/assets/javascripts/advocates/claims/fee_section_display.js
+++ b/app/assets/javascripts/advocates/claims/fee_section_display.js
@@ -86,12 +86,12 @@ adp.feeSectionDisplay = {
 
   applyFixedFeeState : function(state) {
     if (state) {
-      adp.feeSectionDisplay.applyWarning('Initial fees exist that will be removed if you save this claim as a Fixed Fee!', state);
+      adp.feeSectionDisplay.applyWarning('Initial fees exist that will be removed if you save this claim as a Fixed Fee', state);
       adp.feeSectionDisplay.$basicFeesSet.slideUp();
       adp.feeSectionDisplay.$fixedFeesSet.slideDown();
 
     } else {
-      adp.feeSectionDisplay.applyWarning('Fixed fees exist that will be removed if you save this non-fixed-fee case type claim!', state);
+      adp.feeSectionDisplay.applyWarning('Fixed fees exist that will be removed if you save this non-fixed-fee case type claim', state);
       adp.feeSectionDisplay.$basicFeesSet.slideDown();
       adp.feeSectionDisplay.$miscFeesSet.slideDown();
       adp.feeSectionDisplay.$fixedFeesSet.slideUp();

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -95,13 +95,14 @@ form {
 }
 .reminder {
   display: block;
-  padding: 15px;
+  padding: 5px;
   border:1px solid  $ministry-of-justice;
 }
 
 .warning {
-  padding: 5px;
-  color: orange;
+  display: block;
+  padding: 15px;
+  color: red;
 }
 
 .field_with_errors{

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -346,7 +346,6 @@ class Claim < ActiveRecord::Base
   def destroy_all_invalid_fee_types
     if case_type.present? && case_type.is_fixed_fee?
       basic_fees.map(&:clear) unless basic_fees.empty?
-      misc_fees.destroy_all   unless misc_fees.empty?
     else
       fixed_fees.destroy_all unless fixed_fees.empty?
     end

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -157,7 +157,7 @@ Scenario Outline: Add fees with dates attended then remove fee
      Then I should be redirected to the claim confirmation page
       And I should see the claim totals accounting for the miscellaneous fee
 
-  Scenario: Fixed Fee case type does not save Initial/Misc Fees
+  Scenario: Fixed Fee case type does not save Initial Fees
      Given I am a signed in advocate
        And There are fee schemes in place
        And There are case types in place
@@ -167,7 +167,7 @@ Scenario Outline: Add fees with dates attended then remove fee
        And I select a Case Type of "Fixed fee"
        And I submit to LAA
       Then There should not be any Initial Fees saved
-       And There should not be any Miscellaneous Fees Saved
+       And There should be a Miscellaneous Fee Saved
 
   Scenario: Non-Fixed Fee case type does not save Fixed Fees
      Given I am a signed in advocate
@@ -189,4 +189,4 @@ Scenario Outline: Add fees with dates attended then remove fee
       And I select a Case Type of "Fixed fee"
       And I submit to LAA
      Then There should not be any Initial Fees saved
-      And There should not be any Miscellaneous Fees Saved
+      And There should be a Miscellaneous Fee Saved

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -330,9 +330,14 @@ Then(/^There should not be any Initial Fees saved$/) do
   expect(Claim.last.calculate_fees_total(:basic).to_f).to eql(0.0)
 end
 
-Then(/^There should not be any Miscellaneous Fees Saved$/) do
-  expect(Claim.last.misc_fees.size).to eql(0)
+# Then(/^There should not be any Miscellaneous Fees Saved$/) do
+#   expect(Claim.last.misc_fees.size).to eql(0)
+# end
+
+Then(/^There should be a Miscellaneous Fee Saved$/) do
+  expect(Claim.last.misc_fees.size).to eql(1)
 end
+
 
 Then(/^There should not be any Fixed Fees saved$/) do
   expect(Claim.last.fixed_fees.size).to eql(0)

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -376,12 +376,12 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
               expect(claim.basic_fees.size).to eq 4
               expect(claim.basic_fees.map(&:amount).sum).to eql 0.00
 
-              # miscellaneous fees are destroyed implicitly by claim model for fixed-fee case types
-              expect(claim.misc_fees.size).to eq 0
+              # miscellaneous fees are NOT destroyed implicitly by claim model for fixed-fee case types
+              expect(claim.misc_fees.size).to eq 1
               expect(claim.fixed_fees.size).to eq 1
               expect(claim.fixed_fees.map(&:amount).sum).to eql 2500.00
 
-              expect(claim.reload.fees_total).to eq 2500.00
+              expect(claim.reload.fees_total).to eq 2750.00
             end
           end
 

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -871,7 +871,7 @@ RSpec.describe Claim, type: :model do
       expect(claim_with_all_fee_types.misc_fees.size).to eql 1
     end
 
-    it 'clears basic fees and but does NOT destroy miscelllaneous fees for Fixed Fee case types' do
+    it 'clears basic fees and but does NOT destroy miscellaneous fees for Fixed Fee case types' do
       claim_with_all_fee_types.case_type = CaseType.find_or_create_by!(name: 'Fixed fee', is_fixed_fee: true)
       claim_with_all_fee_types.save
       expect(claim_with_all_fee_types.basic_fees.map(&:amount).sum.to_f).to eql 0.0

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -871,12 +871,12 @@ RSpec.describe Claim, type: :model do
       expect(claim_with_all_fee_types.misc_fees.size).to eql 1
     end
 
-    it 'clears basic fees and destroys miscelllaneous fees for Fixed Fee case types' do
+    it 'clears basic fees and but does NOT destroy miscelllaneous fees for Fixed Fee case types' do
       claim_with_all_fee_types.case_type = CaseType.find_or_create_by!(name: 'Fixed fee', is_fixed_fee: true)
       claim_with_all_fee_types.save
       expect(claim_with_all_fee_types.basic_fees.map(&:amount).sum.to_f).to eql 0.0
       expect(claim_with_all_fee_types.fixed_fees.size).to eql 1
-      expect(claim_with_all_fee_types.misc_fees.size).to eql 0
+      expect(claim_with_all_fee_types.misc_fees.size).to eql 1
     end
 
   end


### PR DESCRIPTION
previous fixed fe logic was not fully backed out and causes a bug
whereby miscellaneous fees cannot be saved against a claim 
with a case type that is considered a fixed fee.
