### PR TITLE
Make all the claims report tables consistant

### DIFF
--- a/app/views/case_workers/admin/allocations/new.html.haml
+++ b/app/views/case_workers/admin/allocations/new.html.haml
@@ -92,7 +92,7 @@
 
     = f.submit params[:tab] == 'allocated' ? 'Re-allocate' : 'Allocate', class: 'button'
 
-  %table
+  %table.claims_table
     %thead
       %th
         = link_to 'Select all', '#', class: 'select-all', data: { 'all-checked' => 'false' }


### PR DESCRIPTION
Only the case worker admin allocation/re-alloccate page needed to be changed.
<img width="1062" alt="screen shot 2015-10-06 at 21 47 58" src="https://cloud.githubusercontent.com/assets/3441519/10322769/2f34877c-6c77-11e5-96a5-31db966b2950.png">
