### PR TITLE
Turn off autocomplete for sign in form and password field

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,13 +1,13 @@
 %h1.page-title
   = "Sign in"
 
-= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }) do |f|
   %div.form-group
     = f.label :email, class: "form-label"
     = f.input_field :email, autofocus: true, class: "form-control"
   %div.form-group
     = f.label :password, class:"form-label"
-    = f.input_field :password,  class: "form-control"
+    = f.input_field :password, autocomplete: 'off', class: "form-control"
 
   -#%div.form-group
     -# f.input :remember_me, as: :boolean if devise_mapping.rememberable?


### PR DESCRIPTION
Depending on browser this will remove the prompt to save password after successful sign in. Disables autocomplete of email field too.
