### PR TITLE
Start claim and casing issues in the navigation

### DIFF
--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -164,12 +164,12 @@
       <% if user_signed_in? %>
         <nav id="primary-nav" role="navigation">
           <% if current_user.persona.is_a?(Advocate) %>
-            <%= link_to "#{current_user.persona.admin? ? 'All' : 'Your'} Claims", '/advocates' %>
+            <%= link_to "#{current_user.persona.admin? ? 'All' : 'Your'} claims", '/advocates' %>
             <%= link_to "Archive", '/advocates/claims/archived', title: "View archived claims"   %>
             <% if Rails.host.api_sandbox? %>
               <%= link_to "API Documentation", '/api_landing' %>
             <% end %>
-            <%= link_to "New Claim", '/advocates/claims/new', title: "Start a new claim" %>
+            <%= link_to t('link.add_claim'), '/advocates/claims/new', title: "Start a new claim" %>
             <% if current_user.persona.admin? %>
               <%= link_to 'Admin', '/advocates/admin/advocates' %>
             <% end %>

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -1,22 +1,22 @@
 - if user_signed_in?
   %nav#primary-nav{:role =>'navigation'}
     - if current_user.persona.is_a?(Advocate)
-      = link_to "#{current_user.persona.admin? ? 'All' : 'Your'} Claims", advocates_root_path
+      = link_to "#{current_user.persona.admin? ? 'All' : 'Your'} claims", advocates_root_path
       = link_to "Archive", archived_advocates_claims_path, title: "View archived claims"
       - if Rails.host.api_sandbox?
         = link_to "API Documentation", api_landing_page_path
-      = link_to "New Claim", new_advocates_claim_path, title: "Start a new claim"
+      = link_to t('link.add_claim'), new_advocates_claim_path, title: "Start a new claim"
       - if current_user.persona.admin?
         = link_to 'Admin', advocates_admin_advocates_path
     - elsif current_user.persona.is_a?(CaseWorker)
       - if current_user.persona.admin?
-        = link_to 'Your Claims', case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current'))
+        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current'))
         = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived'))
         = link_to "Allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search).merge(tab: 'unallocated'))
         = link_to "Re-allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search).merge(tab: 'allocated'))
         = link_to 'Admin', case_workers_admin_case_workers_path
       - else
-        = link_to 'Your Claims', case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current'))
+        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current'))
         = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived'))
     - else
       = "Error"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,7 +149,7 @@ en:
     or: or
     search: Search
   link:
-    add_claim: Start a Claim
+    add_claim: Start a claim
     back: Back
     file_another_claim: File another claim
     remove_rep_order: Remove representation order

--- a/features/caseworker_admin_claims_list.feature
+++ b/features/caseworker_admin_claims_list.feature
@@ -6,10 +6,10 @@ Feature: Caseworker claims list
    Given I am a signed in case worker admin
      And claims have been assigned to me
     When I visit my dashboard
-     And I click "Your Claims"
+     And I click "Your claims"
     Then I should see only my claims
      And I should see the claims sorted by oldest first
-  
+
   Scenario: View all archived claims
    Given I am a signed in case worker admin
      And there are archived claims

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -57,25 +57,25 @@ Then(/^I should be redirected to the advocates root url$/) do
 end
 
 Then(/^I should see the advocates correct working primary navigation$/) do
-  step "I should see the advocates Your Claims link and it should work"
+  step "I should see the advocates Your claims link and it should work"
   step "I should see the advocates Archive link and it should work"
-  step "I should see the advocates New Claim link and it should work"
+  step "I should see the advocates Start a claim link and it should work"
 end
 
 Then(/^I should see the admin advocates correct working primary navigation$/) do
-  step "I should see the admin advocates All Claims link and it should work"
+  step "I should see the admin advocates All claims link and it should work"
   step "I should see the advocates Archive link and it should work"
-  step "I should see the advocates New Claim link and it should work"
+  step "I should see the advocates Start a claim link and it should work"
   step "I should see the advocates Admin link and it should work"
 end
 
-Then(/^I should see the advocates Your Claims link and it should work$/) do
-  find('#primary-nav').click_link('Your Claims')
+Then(/^I should see the advocates Your claims link and it should work$/) do
+  find('#primary-nav').click_link('Your claims')
   expect(find('.page-title')).to have_content('Your Claims')
 end
 
-Then(/^I should see the admin advocates All Claims link and it should work$/) do
-  find('#primary-nav').click_link('All Claims')
+Then(/^I should see the admin advocates All claims link and it should work$/) do
+  find('#primary-nav').click_link('All claims')
   expect(find('.page-title')).to have_content('All Claims')
 end
 
@@ -84,8 +84,8 @@ Then(/^I should see the advocates Archive link and it should work$/) do
   expect(find('h1')).to have_content('Archived Claims')
 end
 
-Then(/^I should see the advocates New Claim link and it should work$/) do
-  find('#primary-nav').click_link('New Claim')
+Then(/^I should see the advocates Start a claim link and it should work$/) do
+  find('#primary-nav').click_link('Start a claim')
   expect(find('h1')).to have_content('Claim for Advocate Graduated Fees')
 end
 
@@ -95,20 +95,20 @@ Then(/^I should see the advocates Admin link and it should work$/) do
 end
 
 Then(/^I should see the caseworkers correct working primary navigation$/) do
-  step "I should see the caseworkers Your Claims link and it should work"
+  step "I should see the caseworkers Your claims link and it should work"
   step "I should see the caseworkers Archive link and it should work"
 end
 
 Then(/^I should see the admin caseworkers correct working primary navigation$/) do
-  step "I should see the admin caseworkers Your Claims link and it should work"
+  step "I should see the admin caseworkers Your claims link and it should work"
   step "I should see the admin caseworkers Archive link and it should work"
   step "I should see the admin caseworkers Allocation link and it should work"
   step "I should see the admin caseworkers Re-allocation link and it should work"
   step "I should see the admin caseworkers Admin link and it should work"
 end
 
-Then(/^I should see the caseworkers Your Claims link and it should work$/) do
-  find('#primary-nav').click_link('Your Claims')
+Then(/^I should see the caseworkers Your claims link and it should work$/) do
+  find('#primary-nav').click_link('Your claims')
   expect(find('h1.page-title')).to have_content('Your Claims')
 end
 
@@ -117,8 +117,8 @@ Then(/^I should see the caseworkers Archive link and it should work$/) do
   expect(find('h1.page-title')).to have_content('Archived Claims')
 end
 
-Then(/^I should see the admin caseworkers Your Claims link and it should work$/) do
-  find('#primary-nav').click_link('Your Claims')
+Then(/^I should see the admin caseworkers Your claims link and it should work$/) do
+  find('#primary-nav').click_link('Your claims')
   expect(find('h1.page-title')).to have_content('Your Claims')
 end
 


### PR DESCRIPTION
Changed the "Start" button text from "Start a New Claim" to "Start a claim". Changed the advocates link "New Claims" link to be consistent with the button and renamed it to "Start a claim". Also fixed issues around capitals being used in the navigation. 
