### PR TITLE
Error message copy changes

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -91,9 +91,9 @@ class Claim < ActiveRecord::Base
   has_paper_trail on: [:update], ignore: [:created_at, :updated_at]
 
   # ensure submodel validations bubble up to claim errrors
-  validates_associated :defendants, message: 'One or more defendants are invalid'
-  validates_associated :fees,       message: 'One or more fees are invalid'
-  validates_associated :expenses,   message: 'One or more expenses are invalid'
+  validates_associated :defendants, message: 'There is a problem with one or more defendants'
+  validates_associated :fees,       message: 'There is a problem with one or more fees'
+  validates_associated :expenses,   message: 'There is a problem with one or more expenses'
 
   # advocate-relevant scopes
   scope :outstanding, -> { where(state: %w( submitted allocated )) }
@@ -130,7 +130,6 @@ class Claim < ActiveRecord::Base
 
 
   after_initialize :instantiate_basic_fees
-
 
   before_save :calculate_vat
 

--- a/app/validators/claim_textfield_validator.rb
+++ b/app/validators/claim_textfield_validator.rb
@@ -61,7 +61,7 @@ class ClaimTextfieldValidator < BaseClaimValidator
   # must have a format of capital letter followed by 8 digits
   def validate_case_number
     validate_presence(:case_number, "Case number cannot be blank, you must enter a case number")
-    validate_pattern(:case_number, /^[A-Z]{1}\d{8}$/, "Case number must be in format A12345678 (i.e. 1 capital Letter followed by exactly 8 digits)") unless @record.case_number.blank?
+    validate_pattern(:case_number, /^[A-Z]{1}\d{8}$/, "Case number must be in format A12345678") unless @record.case_number.blank?
   end
 
 # must be present

--- a/app/views/advocates/admin/advocates/_form.html.haml
+++ b/app/views/advocates/admin/advocates/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for [:advocates, :admin, @advocate] do |f|
   - if @advocate.errors.any?
     .validation-summary
-      %h3.heading-small= "#{pluralize(@advocate.errors.count, t('.error'))} #{t('.prohibited_save')}"
+      %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@advocate.errors.count, t('.error'))}"
       %ul
         - @advocate.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/advocates/admin/advocates/change_password.html.haml
+++ b/app/views/advocates/admin/advocates/change_password.html.haml
@@ -4,7 +4,6 @@
 = form_for [:advocates, :admin, @advocate], url: update_password_advocates_admin_advocate_path do |f|
   - if @advocate.user.errors.any?
     .validation-summary
-      / %h3.heading-small= "#{pluralize(@advocate.user.errors.count, t('.error'))} #{t('.prohibited_save')}"
       %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@advocate.user.errors.count, t('.error'))}"
       %ul
         - @advocate.user.errors.full_messages.each do |msg|

--- a/app/views/advocates/admin/advocates/change_password.html.haml
+++ b/app/views/advocates/admin/advocates/change_password.html.haml
@@ -4,7 +4,8 @@
 = form_for [:advocates, :admin, @advocate], url: update_password_advocates_admin_advocate_path do |f|
   - if @advocate.user.errors.any?
     .validation-summary
-      %h3.heading-small= "#{pluralize(@advocate.user.errors.count, t('.error'))} #{t('.prohibited_save')}"
+      / %h3.heading-small= "#{pluralize(@advocate.user.errors.count, t('.error'))} #{t('.prohibited_save')}"
+      %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@advocate.user.errors.count, t('.error'))}"
       %ul
         - @advocate.user.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/advocates/admin/advocates/change_password.html.haml
+++ b/app/views/advocates/admin/advocates/change_password.html.haml
@@ -4,7 +4,7 @@
 = form_for [:advocates, :admin, @advocate], url: update_password_advocates_admin_advocate_path do |f|
   - if @advocate.user.errors.any?
     .validation-summary
-      %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@advocate.user.errors.count, t('.error'))}"
+      %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@advocate.user.errors.count, 'error')}"
       %ul
         - @advocate.user.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/advocates/certifications/new.html.haml
+++ b/app/views/advocates/certifications/new.html.haml
@@ -5,7 +5,7 @@
 
     - if @certification.errors.any?
       .validation-summary
-        %h3.heading-small= "This claim certification has #{pluralize(@certification.errors.count, t('.error'))}"
+        %h3.heading-small= "This claim certification has #{pluralize(@certification.errors.count, 'error')}"
         %ul
           - @certification.errors.full_messages.each do |msg|
             %li= msg

--- a/app/views/advocates/certifications/new.html.haml
+++ b/app/views/advocates/certifications/new.html.haml
@@ -5,7 +5,7 @@
 
     - if @certification.errors.any?
       .validation-summary
-        %h3.heading-small= "#{pluralize(@certification.errors.count, 'Error')} Prohibitied Save"
+        %h3.heading-small= "This claim certification has #{pluralize(@certification.errors.count, t('.error'))}"
         %ul
           - @certification.errors.full_messages.each do |msg|
             %li= msg

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -5,13 +5,13 @@
 
     - if @claim.errors.any?
       .validation-summary
-        %h2.heading-small= "#{pluralize(@claim.errors.count, t('.error'))} #{t('.prohibited_save')}"
-        .form-hint
-          scroll down to view detailed errors against individual fields
+        %h2.heading-small= "#{t('.prohibited_save')} #{pluralize(@claim.errors.count, t('.error'))}"
         %ul
           - @claim.errors.full_messages.each do |message|
             %li
               = message
+        %span.form-hint
+          = t('.form_error_hint')
     %fieldset
       %legend.bold-medium
         = t('.case_advocate_offence')

--- a/app/views/case_workers/admin/allocations/new.html.haml
+++ b/app/views/case_workers/admin/allocations/new.html.haml
@@ -78,8 +78,7 @@
   - if @allocation.errors.any?
     .validation-summary
       %h2.heading-small
-        = "#{pluralize(@allocation.errors.count, 'error')}"
-        prohibited save
+        = "This case worker allocation has #{pluralize(@allocation.errors.count, t('.error'))}"
       %ul
         - @allocation.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/admin/allocations/new.html.haml
+++ b/app/views/case_workers/admin/allocations/new.html.haml
@@ -78,7 +78,7 @@
   - if @allocation.errors.any?
     .validation-summary
       %h2.heading-small
-        = "This case worker allocation has #{pluralize(@allocation.errors.count, t('.error'))}"
+        = "This claim allocation has #{pluralize(@allocation.errors.count, 'error')}"
       %ul
         - @allocation.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for [:case_workers, :admin, @case_worker] do |f|
   - if @case_worker.errors.any?
     .validation-summary
-      %h3.heading-small= "#{pluralize(@case_worker.errors.count, 'error')} prohibited this case worker from being saved:"
+      %h3.heading-small= "This case worker has #{pluralize(@case_worker.errors.count, 'error')}"
       %ul
         - @case_worker.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/admin/case_workers/allocate.html.haml
+++ b/app/views/case_workers/admin/case_workers/allocate.html.haml
@@ -6,7 +6,7 @@
 = form_for [:case_workers, :admin, @case_worker] do |f|
   - if @case_worker.errors.any?
     .validation-summary
-      %h2.heading-small= "This case worker allocation has #{pluralize(@case_worker.errors.count, 'error')}"
+      %h2.heading-small= "This claim allocation has #{pluralize(@case_worker.errors.count, 'error')}"
       %ul
         - @case_worker.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/admin/case_workers/allocate.html.haml
+++ b/app/views/case_workers/admin/case_workers/allocate.html.haml
@@ -6,7 +6,7 @@
 = form_for [:case_workers, :admin, @case_worker] do |f|
   - if @case_worker.errors.any?
     .validation-summary
-      %h2.heading-small= "#{pluralize(@case_worker.errors.count, 'error')} prohibited this allocation from being saved:"
+      %h2.heading-small= "This case worker allocation has #{pluralize(@case_worker.errors.count, 'error')}"
       %ul
         - @case_worker.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -4,7 +4,7 @@
 = form_for [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path do |f|
   - if @case_worker.user.errors.any?
     .validation-summary
-      %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@case_worker.user.errors.count, t('.error'))}"
+      %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@case_worker.user.errors.count, 'error')}"
       %ul
         - @case_worker.user.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -4,7 +4,7 @@
 = form_for [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path do |f|
   - if @case_worker.user.errors.any?
     .validation-summary
-      %h3.heading-small= "T#{t('.prohibited_save')} #{pluralize(@case_worker.user.errors.count, t('.error'))}"
+      %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@case_worker.user.errors.count, t('.error'))}"
       %ul
         - @case_worker.user.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -4,7 +4,7 @@
 = form_for [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path do |f|
   - if @case_worker.user.errors.any?
     .validation-summary
-      %h3.heading-small= "#{pluralize(@case_worker.user.errors.count, t('.error'))} #{t('.prohibited_save')}"
+      %h3.heading-small= "T#{t('.prohibited_save')} #{pluralize(@case_worker.user.errors.count, t('.error'))}"
       %ul
         - @case_worker.user.errors.full_messages.each do |msg|
           %li= msg

--- a/app/views/case_workers/claims/show.html.haml
+++ b/app/views/case_workers/claims/show.html.haml
@@ -3,13 +3,13 @@
   %p
     - if @claim.errors.any?
       .validation-summary
-        %h4.heading-small= "#{pluralize(@claim.errors.count, 'error')} prohibited this claim from being saved"
+        %h4.heading-small= "This claim has #{pluralize(@claim.errors.count, t('.error'))}"
         %ul
           - @claim.errors.full_messages.each do |msg|
             %li= msg
     - elsif params[:errors] # passed from redirect in update action
       .validation-summary
-        %h4.heading-small= "#{pluralize(params[:errors].count, 'error')} prohibited this claim from being saved"
+        %h4.heading-small= "This claim has #{pluralize(params[:errors].count, t('.error'))}"
         %ul
           - params[:errors].each do |msg|
             %li= msg

--- a/app/views/case_workers/claims/show.html.haml
+++ b/app/views/case_workers/claims/show.html.haml
@@ -3,13 +3,13 @@
   %p
     - if @claim.errors.any?
       .validation-summary
-        %h4.heading-small= "This claim has #{pluralize(@claim.errors.count, t('.error'))}"
+        %h4.heading-small= "This claim has #{pluralize(@claim.errors.count, 'error')}"
         %ul
           - @claim.errors.full_messages.each do |msg|
             %li= msg
     - elsif params[:errors] # passed from redirect in update action
       .validation-summary
-        %h4.heading-small= "This claim has #{pluralize(params[:errors].count, t('.error'))}"
+        %h4.heading-small= "This claim has #{pluralize(params[:errors].count, 'error')}"
         %ul
           - params[:errors].each do |msg|
             %li= msg

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -4,7 +4,7 @@
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
   - if resource.errors.any?
     .validation-summary
-      %h2.heading-small= "#{pluralize(resource.errors.count, 'error')} prohibited this #{resource_name} from being saved"
+      %h2.heading-small= "This #{resource_name} has #{pluralize(resource.errors.count, t('.error'))}"
       %ul
         - resource.errors.each do |attribute, message|
           %li

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -4,7 +4,7 @@
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
   - if resource.errors.any?
     .validation-summary
-      %h2.heading-small= "This #{resource_name} has #{pluralize(resource.errors.count, t('.error'))}"
+      %h2.heading-small= "This #{resource_name} has #{pluralize(resource.errors.count, 'error')}"
       %ul
         - resource.errors.each do |attribute, message|
           %li

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -4,7 +4,7 @@
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   - if resource.errors.any?
     .validation-summary
-      %h2.heading-small= "#{pluralize(resource.errors.count, 'error')} prohibited this #{resource_name} from being saved"
+      %h2.heading-small= "This #{resource_name} has #{pluralize(resource.errors.count, 'error')}"
       %ul
         - resource.errors.each do |attribute, message|
           %li

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -56,5 +56,5 @@ en:
       not_found: "not found"
       not_locked: "was not locked"
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
-        other: "%{count} errors prohibited this %{resource} from being saved:"
+        one: "This %{resource} has 1 error"
+        other: "This %{resource} has %{count} errors"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,7 +172,7 @@ en:
           edit_advocate: 'Edit Advocate'
         form:
           error: 'error'
-          prohibited_save: 'prohibited this advocate from being saved:'
+          prohibited_save: 'This advocate has'
           email: *email
           password: *password
           password_confirmation: *password_confirmation
@@ -183,7 +183,7 @@ en:
           submit: 'Create Advocate'
         change_password:
           error: 'error'
-          prohibited_save: 'prohibited this advocate from being saved:'
+          prohibited_save: 'This advocate password change has'
           current_password: Current password
           password: *password
           password_confirmation: *password_confirmation
@@ -258,7 +258,8 @@ en:
         view_details: 'View Details'
       form:
         error: 'error'
-        prohibited_save: 'prohibited this claim from being saved:'
+        form_error_hint: 'Check below for more detail'
+        prohibited_save: 'This claim has'
         case_advocate_offence: 'Case, Instructed Advocate & Offence'
         advocate: *advocate
         scheme: 'Scheme'
@@ -351,7 +352,7 @@ en:
       case_workers:
         change_password:
           error: 'error'
-          prohibited_save: 'prohibited this case worker from being saved:'
+          prohibited_save: 'This case worker password change has'
           current_password: Current password
           password: *password
           password_confirmation: *password_confirmation

--- a/features/step_definitions/advocate_edit_claim_steps.rb
+++ b/features/step_definitions/advocate_edit_claim_steps.rb
@@ -8,5 +8,5 @@ end
 
 Then(/^I should be redirected back and errors displayed$/) do 
   expect(page.current_path).to eq(advocates_claim_path(@claim))
-  expect(page).to have_content(/\d+ errors? prohibited this claim from being saved:/)
+  expect(page).to have_content(/This claim has \d+ errors?/)
 end

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -177,7 +177,7 @@ end
 
 Then(/^I should be redirected back to the claim form with error$/) do
   expect(page).to have_content('Claim for Advocate Graduated Fees')
-  expect(page).to have_content(/\d+ errors? prohibited this claim from being saved:/)
+  expect(page).to have_content(/This claim has \d+ errors?/)
   expect(page).to have_content("Advocate cannot be blank")
 end
 
@@ -275,11 +275,11 @@ Then(/^the claim should be in a "(.*?)" state$/) do |state|
 end
 
 Then(/^I should see errors$/) do
-  expect(page).to have_content(/\d+ errors? prohibited this claim from being saved/)
+  expect(page).to have_content(/This claim has \d+ errors?/)
 end
 
 Then(/^I should not see errors$/) do
-  expect(page).not_to have_content(/\d+ errors? prohibited this claim from being saved/)
+  expect(page).not_to have_content(/This claim has \d+ errors?/)
 end
 
 Then(/^no claim should be submitted$/) do

--- a/features/step_definitions/claim_document_upload_steps.rb
+++ b/features/step_definitions/claim_document_upload_steps.rb
@@ -38,7 +38,7 @@ Given(/^I am on the new claim page and have attached invalid documents$/) do
 end
 
 When(/^the page should have validation errors$/) do
-  expect(page).to have_content(/\d+ errors? prohibited this claim from being saved/)
+  expect(page).to have_content(/This claim has \d+ errors?/)
 end
 
 Then(/^the attached files should still be visible$/) do

--- a/features/unhappy_paths.feature
+++ b/features/unhappy_paths.feature
@@ -41,9 +41,9 @@ Scenario Outline: Attempt to submit claim to LAA without specifying required tex
 
     | field_id                                   | error_message                                                |
     | "claim_case_number"                        | "Case number cannot be blank, you must enter a case number"  |
-    | "claim_defendants_attributes_0_first_name" | "One or more defendants are invalid"                         |
-    | "claim_basic_fees_attributes_0_quantity"   | "One or more fees are invalid"                               |
-    | "claim_expenses_attributes_0_quantity"     | "One or more expenses are invalid"                           |
+    | "claim_defendants_attributes_0_first_name" | "There is a problem with one or more defendants"             |
+    | "claim_basic_fees_attributes_0_quantity"   | "There is a problem with one or more fees"                   |
+    | "claim_expenses_attributes_0_quantity"     | "There is a problem with one or more expenses"               |
 
     # TODO: unhappy paths for representation order details
 

--- a/spec/validators/claim_textfield_validator_spec.rb
+++ b/spec/validators/claim_textfield_validator_spec.rb
@@ -126,7 +126,7 @@ context '#perform_validation?' do
     invalid_formats.each do |invalid_format|
       it "should error if invalid format #{invalid_format}" do
         claim.case_number = invalid_format
-        should_error_with(claim, :case_number,"Case number must be in format A12345678 (i.e. 1 capital Letter followed by exactly 8 digits)")
+        should_error_with(claim, :case_number,"Case number must be in format A12345678")
       end
     end
   end


### PR DESCRIPTION
This changes:
- the header text of the error summary for all resource (claim/advocate/caseworker) forms
- adds and repositions the form error hint at footer of claim error summary
- minor individual error message changes
