### PR TITLE
Remove claim counts

### DIFF
--- a/app/views/geckoboard_api/widgets/claims.jbuilder
+++ b/app/views/geckoboard_api/widgets/claims.jbuilder
@@ -5,7 +5,7 @@ json.item do
       text: 'Rejected'
     },
     {
-      value: @reporter.authorised_in_part[:count],
+      value: @reporter.authorised_in_part[:percentage],
       text: 'Part authorised'
     },
     {

--- a/app/views/geckoboard_api/widgets/claims.jbuilder
+++ b/app/views/geckoboard_api/widgets/claims.jbuilder
@@ -1,15 +1,15 @@
 json.item do
   json.array! [
     {
-      value: "#{@reporter.rejected[:percentage].round(2)}% (#{@reporter.rejected[:count]})",
+      value: @reporter.rejected[:percentage],
       text: 'Rejected'
     },
     {
-      value: "#{@reporter.authorised_in_part[:percentage].round(2)}% (#{@reporter.authorised_in_part[:count]})",
+      value: @reporter.authorised_in_part[:count],
       text: 'Part authorised'
     },
     {
-      value: "#{@reporter.authorised_in_full[:percentage].round(2)}% (#{@reporter.authorised_in_full[:count]})",
+      value: @reporter.authorised_in_full[:percentage],
       text: 'Authorised'
     }
   ]


### PR DESCRIPTION
Revert back to showing only percentages due to Geckoboard RAG widget being unable to process non-float values.
