### PR TITLE
omit these atts from versioning

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -88,7 +88,7 @@ class Claim < ActiveRecord::Base
 
   has_one  :certification
 
-  has_paper_trail on: [:update], ignore: [:created_at, :updated_at]
+  has_paper_trail on: [:update], ignore: [:created_at, :updated_at, :submitted_at, :evidence_checklist_ids]
 
   # ensure submodel validations bubble up to claim errrors
   validates_associated :defendants, message: 'There is a problem with one or more defendants'


### PR DESCRIPTION
We do not need to version changes to :evidence_checklist_ids because these will not change after submission (evidence will be added via the messaging tool) and we do not need to version the claims during their creation (prior to submission).

We do not need to track :submitted_at because state change is already versioned.
