### PR TITLE
Consistent table copy

### DIFF
--- a/app/assets/stylesheets/claims-table.scss
+++ b/app/assets/stylesheets/claims-table.scss
@@ -7,9 +7,8 @@
         background-color: $grey-4;
       }
       &.rejected{
-        background-color: #FAEBEC;
         td:first-child{
-          border-left: 5px solid #DF3034;
+          border-left: 10px solid #DF3034;
         }
       }
     }

--- a/app/views/advocates/claims/_defendant_fields.html.haml
+++ b/app/views/advocates/claims/_defendant_fields.html.haml
@@ -26,3 +26,5 @@
 
   %p
     = link_to_remove_association t('.remove_defendant'), f
+
+  %hr

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -78,7 +78,7 @@
           = validation_error_message(@claim, :trial_concluded_at)
 
     %fieldset
-      %legend
+      %legend.bold-medium
         = t('.defendants')
       #defendants
         = f.fields_for :defendants do |defendant|

--- a/app/views/advocates/claims/_representation_order_fields.html.haml
+++ b/app/views/advocates/claims/_representation_order_fields.html.haml
@@ -1,5 +1,4 @@
 .nested-fields
-  %br
   %h4
     = t('.representation_order')
 

--- a/app/views/advocates/claims/_search_form.html.haml
+++ b/app/views/advocates/claims/_search_form.html.haml
@@ -3,7 +3,7 @@
     %div.form-inputs
       - path_to_use = defined?(archived) && archived ? archived_advocates_claims_path : advocates_claims_path
       = form_tag path_to_use, method: :get do
-        = text_field_tag :search, params[:search], placeholder: 'Search e.g. Defendant name, Advocate name', class: "form-control-3-4"
+        = text_field_tag :search, params[:search], placeholder: 'eg defendant name, advocate name', class: "form-control-3-4"
         = submit_tag t('common.search'), class: 'button button-secondary'
   %div.column-half
     &nbsp;

--- a/app/views/case_workers/admin/allocations/new.html.haml
+++ b/app/views/case_workers/admin/allocations/new.html.haml
@@ -100,13 +100,13 @@
       %th
         Advocate
       %th
-        Defendant(s)
+        = t('.defendants')
       %th
         Type
       %th
-        Submission date
+        = t('.submitted_date')
       %th
-        Value
+        = t('.claim_total')
       - if params[:tab] == 'allocated'
         %th
           Allocated to

--- a/app/views/case_workers/admin/case_workers/allocate.html.haml
+++ b/app/views/case_workers/admin/case_workers/allocate.html.haml
@@ -15,7 +15,7 @@
       %thead
         %tr
           %th
-            Defendant
+            Defendant(s)
           %th
             Case number
           %th

--- a/app/views/case_workers/claims/_search_form.html.haml
+++ b/app/views/case_workers/claims/_search_form.html.haml
@@ -6,7 +6,7 @@
         = hidden_field_tag :tab, params[:tab]
         = hidden_field_tag :sort, params[:sort]
         = hidden_field_tag :direction, params[:direction]
-        = text_field_tag :search, params[:search], placeholder: 'e.g. MAAT Reference, Defendant name, Case worker name or email', class: 'form-control-3-4'
+        = text_field_tag :search, params[:search], placeholder: 'eg MAAT reference, defendant name, case worker name or email', class: 'form-control-3-4'
         = submit_tag t('common.search'), class: 'button button-secondary'
   %div.column-half
     &nbsp;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,10 +208,10 @@ en:
         no_claims_found: 'No claims found'
         advocate: *advocate
         messages: 'Messages'
-        defendants: 'Defendants'
+        defendants: 'Defendant(s)'
         case_number: 'Case number'
-        submission_date: 'Submitted date'
-        authorised_date: 'Authorised date'
+        submission_date: 'Date submitted'
+        authorised_date: 'Date authorised'
         total: 'Claimed'
         assessed: 'Assessed'
         status: 'Status'
@@ -414,6 +414,11 @@ en:
           password: *password
           password_confirmation: *password_confirmation
           submit: 'Change password'
+      allocations:
+        new:
+          submitted_date: 'Date submitted'
+          claim_total: 'Claim total'
+          defendants: Defendant(s)
     claims:
       archived:
         archived_claims: Archived claims
@@ -430,12 +435,12 @@ en:
       claims_list:
         no_claims_found: 'No claims found'
       claims:
-        case_number: Case Number
+        case_number: Case number
         advocate: Advocate
-        defendants: Defendants
+        defendants: Defendant(s)
         total: Claimed
         status: Status
-        submission_date: Submitted date
+        submission_date: Date submitted
         messages: Messages
   devise:
     shared:


### PR DESCRIPTION
Apply consistent copy in tables
- same headings across tables
- sentence case on headings
- search field placeholder text
- rejected claim colouring change
