### PR TITLE
Add body class using the controllers name

### DIFF
--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -94,7 +94,7 @@
   </script>
 </head>
 
-<body class="swagger-section" <%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
+<body class="swagger-section #{'controller-'' + controller.controller_name}">
   <script type="text/javascript">document.body.className = 'js-enabled ' + document.body.className;</script>
 
   <div id="skiplink-container">

--- a/app/views/layouts/advocate.html.haml
+++ b/app/views/layouts/advocate.html.haml
@@ -3,6 +3,9 @@
   %meta{:name =>"format-detection", :content => "telephone=no"}/
   = stylesheet_link_tag "advocates/application", media: "all"
 
+- content_for :body_classes do
+  = "controller-" + controller.controller_name
+
 - content_for :body_end do
   %script
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,6 +3,9 @@
   %meta{:name =>"format-detection", :content => "telephone=no"}/
   = stylesheet_link_tag "application", media: "all"
 
+- content_for :body_classes do
+  = "controller-" + controller.controller_name
+
 - content_for :body_end do
   %script
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/views/layouts/case_worker.html.haml
+++ b/app/views/layouts/case_worker.html.haml
@@ -3,6 +3,9 @@
   %meta{:name =>"format-detection", :content => "telephone=no"}/
   = stylesheet_link_tag "case_workers/application", media: "all"
 
+- content_for :body_classes do
+  = "controller-" + controller.controller_name
+
 - content_for :body_end do
   %script
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -36,5 +39,5 @@
 
 - content_for :footer_support_links do
   = render partial: 'layouts/footer'
-  
+
 = render template: 'layouts/moj_internal_template'


### PR DESCRIPTION
adds a class to the body element eg. controller-claims would be used for pages generated by the claims controller.

We can use this to target JS and CSS to page specific functionality
