### PR TITLE
Clone rejected claims

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.2.3'
 
+gem 'amoeba',                 '~> 3.0.0'
 gem 'auto_strip_attributes',  '~> 2.0'
 gem 'aws-sdk-v1',             '1.64.0'
 gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    amoeba (3.0.0)
+      activerecord (>= 3.2.6)
     annotate (2.6.10)
       activerecord (>= 3.2, <= 4.3)
       rake (~> 10.4)
@@ -469,6 +471,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  amoeba (~> 3.0.0)
   annotate
   auto_strip_attributes (~> 2.0)
   awesome_print

--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -4,7 +4,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   include DocTypes
 
   respond_to :html
-  before_action :set_claim, only: [:show, :edit, :update, :destroy]
+  before_action :set_claim, only: [:show, :edit, :update, :clone_rejected, :destroy]
   before_action :set_doctypes, only: [:show]
   before_action :set_context, only: [:index, :outstanding, :authorised, :archived ]
   before_action :set_financial_summary, only: [:index, :outstanding, :authorised]
@@ -77,6 +77,15 @@ class Advocates::ClaimsController < Advocates::ApplicationController
       submit_if_required_and_redirect
     else
       render_edit_with_resources
+    end
+  end
+
+  def clone_rejected
+    begin
+      draft = @claim.clone_rejected_to_new_draft
+      redirect_to edit_advocates_claim_url(draft), notice: 'Draft created'
+    rescue
+      redirect_to advocates_claims_url, alert: 'Can only clone rejected claims'
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,7 +13,7 @@ class Ability
       if persona.admin?
         can [:create], ClaimIntention
         can [:index, :outstanding, :authorised, :archived, :new, :create], Claim
-        can [:show, :edit, :update, :confirmation, :destroy], Claim, chamber_id: persona.chamber_id
+        can [:show, :edit, :update, :confirmation, :clone_rejected, :destroy], Claim, chamber_id: persona.chamber_id
         can [:show, :download], Document, chamber_id: persona.chamber_id
         can [:destroy], Document do |document|
           if document.advocate_id.nil?
@@ -29,7 +29,7 @@ class Ability
       else
         can [:create], ClaimIntention
         can [:index, :outstanding, :authorised, :archived, :new, :create], Claim
-        can [:show, :edit, :update, :confirmation, :destroy], Claim, advocate_id: persona.id
+        can [:show, :edit, :update, :confirmation, :clone_rejected, :destroy], Claim, advocate_id: persona.id
         can [:show, :download], Document, advocate_id: persona.id
         can [:destroy], Document do |document|
           if document.advocate_id.nil?

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -49,6 +49,7 @@ class Claim < ActiveRecord::Base
   extend Claims::Search
   include Claims::Calculations
   include Claims::UserMessages
+  include Claims::Cloner
 
   include NumberCommaParser
   numeric_attributes :fees_total, :expenses_total, :total, :vat_amount

--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -1,5 +1,4 @@
 module Claims::Calculations
-
   def calculate_fees_total(category=nil)
     fees.reload
     if category.blank?
@@ -10,7 +9,8 @@ module Claims::Calculations
   end
 
   def calculate_expenses_total
-    expenses.reload.map(&:amount).sum
+    # #reload prevents cloning
+    Expense.where(claim_id: self.id).map(&:amount).sum
   end
 
   def calculate_total
@@ -28,5 +28,4 @@ module Claims::Calculations
   def update_total
     update_column(:total, calculate_total)
   end
-
 end

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -13,6 +13,7 @@ module Claims::Cloner
       klass.amoeba do
         enable
         nullify :uuid
+        clone [:dates_attended]
       end
     end
 

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -1,0 +1,65 @@
+module Claims::Cloner
+  extend ActiveSupport::Concern
+
+  included do |klass|
+    klass.amoeba do
+      enable
+      nullify :submitted_at
+      nullify :uuid
+      clone [:fees, :documents, :defendants, :expenses]
+    end
+
+    Fee.class_eval do |klass|
+      klass.amoeba do
+        enable
+        nullify :uuid
+      end
+    end
+
+    Defendant.class_eval do |klass|
+      klass.amoeba do
+        enable
+        nullify :uuid
+        clone [:representation_orders]
+      end
+    end
+
+    Expense.class_eval do |klass|
+      klass.amoeba do
+        enable
+        nullify :uuid
+        clone [:dates_attended]
+      end
+    end
+
+    RepresentationOrder.class_eval do |klass|
+      klass.amoeba do
+        enable
+        nullify :uuid
+      end
+    end
+
+    Document.class_eval do |klass|
+      klass.amoeba do
+        enable
+        nullify :uuid
+      end
+    end
+
+    DateAttended.class_eval do |klass|
+      klass.amoeba do
+        enable
+        nullify :uuid
+      end
+    end
+  end
+
+  def clone_rejected_to_new_draft
+    raise 'Can only clone claims in state "rejected"' unless rejected?
+
+    draft = amoeba_dup
+    draft.state = 'draft'
+    draft.save!
+    draft
+  end
+end

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -14,14 +14,13 @@
 #
 
 class Defendant < ActiveRecord::Base
-
   auto_strip_attributes :first_name, :last_name, squish: true, nullify: true
 
   belongs_to :claim
 
   has_many  :representation_orders, dependent: :destroy, inverse_of: :defendant
   validates_associated :representation_orders, message: 'There is a problem with one or more defendant representation orders'
-  
+
   # validates :representation_order, presence: {message: 'Representation order cannot be blank'}
   validates_with DefendantValidator
   validates_with DefendantSubModelValidator

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -53,6 +53,8 @@ class Document < ActiveRecord::Base
   private
 
   def documents_count
+    return true if self.form_id.nil?
+
     count = Document.where(form_id: self.form_id).count
 
     if count >= Settings.max_document_upload_count

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -45,7 +45,7 @@ class Expense < ActiveRecord::Base
     claim.update_total
   end
 
-   def perform_validation?
+  def perform_validation?
     claim && claim.perform_validation?
   end
 end

--- a/app/validators/expense_validator.rb
+++ b/app/validators/expense_validator.rb
@@ -2,9 +2,9 @@ class ExpenseValidator < BaseClaimValidator
 
   def self.fields
     [
-    :expense_type,
-    :quantity,
-    :rate
+      :expense_type,
+      :quantity,
+      :rate
     ]
   end
 

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -19,9 +19,13 @@
             = claim_position_and_count
             - unless last_claim?
               = next_claim_link 'Next claim &gt;'.html_safe, class: 'next-claim'
-    - if claim.editable? && current_user.persona.is_a?(Advocate)
-      %div.right
-        = link_to "Edit this claim", edit_advocates_claim_path(claim), class: 'button'
-        = link_to "Delete draft", advocates_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button-secondary'
+    - if current_user.persona.is_a?(Advocate)
+      - if claim.editable?
+        %div.right
+          = link_to "Edit this claim", edit_advocates_claim_path(claim), class: 'button'
+          = link_to "Delete draft", advocates_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button-secondary'
+      - if claim.rejected?
+        %div.right
+          = button_to 'Create draft and resubmit', clone_rejected_advocates_claim_path(claim), method: 'patch', class: 'button'
 %div.bold-medium.claim-detail-header
   = "Claim details"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,10 +54,11 @@ Rails.application.routes.draw do
     post '/advocates/json_importer' => 'json_document_importer#create'
 
     resources :claims do
-      get 'confirmation', on: :member
-      get 'outstanding',  on: :collection
-      get 'authorised',   on: :collection
-      get 'archived',     on: :collection
+      get 'confirmation',     on: :member
+      get 'outstanding',      on: :collection
+      get 'authorised',       on: :collection
+      get 'archived',         on: :collection
+      patch 'clone_rejected', to: 'claims#clone_rejected', on: :member
 
       resource :certification, only: [:new, :create]
     end

--- a/features/rejected_claim_to_draft.feature
+++ b/features/rejected_claim_to_draft.feature
@@ -1,0 +1,27 @@
+Feature: Rejected claim to new draft
+  Background:
+    As an advocate I want to be able to re-submit rejected claims by creating a
+    new draft.
+
+    Given I am a signed in advocate
+
+    Scenario Outline: No link to create draft from non-rejected claim
+      Given I am on the detail page for a <state> claim
+       Then I should not see the "Create draft and resubmit" link
+
+      Examples:
+        | state                      |
+        | "submitted"                |
+        | "allocated"                |
+        | "refused"                  |
+        | "part_authorised"          |
+        | "authorised"               |
+        | "draft"                    |
+        | "redetermination"          |
+        | "awaiting_written_reasons" |
+
+    Scenario: Create draft from rejected claim
+      Given I am on the detail page for a rejected claim with case number 'T12345678'
+       When I click "Create draft and resubmit"
+       Then I should be redirected to the edit page of a draft claim
+        And the draft claim should have case number 'T12345678'

--- a/features/step_definitions/rejected_claim_to_draft_steps.rb
+++ b/features/step_definitions/rejected_claim_to_draft_steps.rb
@@ -1,0 +1,24 @@
+Given(/^I am on the detail page for a "(.*?)" claim$/) do |state|
+  claim = create("#{state}_claim".to_sym, advocate: @advocate)
+  visit advocates_claim_path(claim)
+end
+
+Then(/^I should not see the "(.*?)" link$/) do |link_text|
+  expect(current_path).to eq(advocates_claim_path(Claim.last))
+  expect(page).to_not have_content(link_text)
+end
+
+Given(/^I am on the detail page for a rejected claim with case number '(.+)'$/) do |case_number|
+  rejected_claim = create(:rejected_claim, advocate: @advocate, case_number: case_number)
+  visit advocates_claim_path(rejected_claim)
+end
+
+Then(/^I should be redirected to the edit page of a draft claim$/) do
+  expect(Claim.last).to be_draft
+  expect(current_path).to eq(edit_advocates_claim_path(Claim.last))
+end
+
+Then(/^the draft claim should have case number '(.+)'$/) do |case_number|
+  expect(Claim.last.case_number).to eq(case_number)
+  expect(page).to have_selector("input[value='#{case_number}']")
+end

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
             advocate_category: 'QC',
             expenses_attributes:
               [
-                { 
+                {
                   expense_type_id: expense_type.id,
                   location: "London",
                   quantity: 1,
@@ -495,6 +495,41 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
           'first_day_of_trial_mm' => '11',
           'first_day_of_trial_dd' => '4' }, commit: 'Submit to LAA'
         expect(assigns(:claim).first_day_of_trial).to eq Date.new(2015, 11, 4)
+      end
+    end
+  end
+
+  describe "PATCH #clone_rejected" do
+    context 'from rejected claim' do
+      subject { create(:rejected_claim, advocate: advocate) }
+
+      before do
+        patch :clone_rejected, id: subject
+      end
+
+      it 'creates a draft from the rejected claim' do
+        expect(Claim.last).to be_draft
+        expect(Claim.last.case_number).to eq(subject.case_number)
+      end
+
+      it 'redirects to the draft\'s edit page' do
+        expect(response).to redirect_to(edit_advocates_claim_url(Claim.last))
+      end
+    end
+
+    context 'from non-rejected claim' do
+      subject { create(:submitted_claim, advocate: advocate) }
+
+      before do
+        patch :clone_rejected, id: subject
+      end
+
+      it 'redirects to advocates dashboard' do
+        expect(response).to redirect_to(advocates_claims_url)
+      end
+
+      it 'does not create a draft claim' do
+        expect(Claim.last).to_not be_draft
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -35,7 +35,7 @@ describe Ability do
     end
 
     context 'can manage their own claims' do
-      [:show, :edit, :update, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: advocate)) }
       end
     end
@@ -43,7 +43,7 @@ describe Ability do
     context 'cannot manage claims by another advocate' do
       let(:other_advocate) { create(:advocate) }
 
-      [:show, :edit, :update, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
         it { should_not be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end
@@ -105,7 +105,7 @@ describe Ability do
     end
 
     context 'can manage their own claims' do
-      [:show, :edit, :update, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: advocate)) }
       end
     end
@@ -113,7 +113,7 @@ describe Ability do
     context 'can manage claims by another advocate in the same chamber' do
       let(:other_advocate) { create(:advocate, chamber: chamber) }
 
-      [:show, :edit, :update, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
         it { should be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end
@@ -121,7 +121,7 @@ describe Ability do
     context 'cannot manage claims by another advocate in a different chamber' do
       let(:other_advocate) { create(:advocate) }
 
-      [:show, :edit, :update, :confirmation, :destroy].each do |action|
+      [:show, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
         it { should_not be_able_to(action, Claim.new(advocate: other_advocate)) }
       end
     end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe Claims::Cloner, type: :model do
+  let!(:rejected_claim) do
+    rejected_claim = create(:rejected_claim)
+    rejected_claim.expenses << create(:expense)
+    rejected_claim.expenses.each do |expense|
+      expense.dates_attended << create(:date_attended)
+    end
+    rejected_claim.documents << create(:document)
+    rejected_claim
+  end
+
+  describe '#clone_rejected_to_new_draft' do
+    let!(:cloned_claim) { rejected_claim.clone_rejected_to_new_draft }
+
+    it 'cannot be used to clone non-rejected claims' do
+      [
+        create(:draft_claim),
+        create(:submitted_claim),
+        create(:allocated_claim),
+        create(:authorised_claim),
+        create(:part_authorised_claim),
+        create(:refused_claim),
+        create(:redetermination_claim),
+        create(:awaiting_written_reasons_claim)
+      ].each do |claim|
+        expect{ claim.clone_rejected_to_new_draft }.to raise_error
+      end
+    end
+
+    it 'creates a draft claim' do
+      expect(cloned_claim).to be_draft
+    end
+
+    it 'does not clone the submitted_at date' do
+      expect(cloned_claim.submitted_at).to be_nil
+    end
+
+    it 'does not clone the uuid' do
+      expect(cloned_claim.reload.uuid).to_not eq(rejected_claim.uuid)
+    end
+
+    it 'does not clone the uuids of fees' do
+      expect(cloned_claim.fees.map(&:reload).map(&:uuid)).to_not match_array(rejected_claim.fees.map(&:reload).map(&:uuid))
+    end
+
+    it 'does not clone the uuids of expenses' do
+      expect(cloned_claim.expenses.map(&:reload).map(&:uuid)).to_not match_array(rejected_claim.expenses.map(&:reload).map(&:uuid))
+    end
+
+    it 'does not clone the uuids of documents' do
+      expect(cloned_claim.documents.map(&:reload).map(&:uuid)).to_not match_array(rejected_claim.documents.map(&:reload).map(&:uuid))
+    end
+
+    it 'does not clone the uuids of defendants' do
+      expect(cloned_claim.defendants.map(&:reload).map(&:uuid)).to_not match_array(rejected_claim.defendants.map(&:reload).map(&:uuid))
+    end
+
+    it 'does not clone the uuids of representation orders' do
+      cloned_claim_uuids = cloned_claim.defendants.map(&:reload).map { |d| d.representation_orders.map(&:reload).map(&:uuid ) }.flatten
+      rejected_claim_uuids = rejected_claim.defendants.map(&:reload).map { |d| d.representation_orders.map(&:reload).map(&:uuid ) }.flatten
+      expect(cloned_claim_uuids).to_not match_array(rejected_claim_uuids)
+    end
+
+    it 'does not clone the uuids of dates attended' do
+      expect(cloned_claim.expenses.map(&:reload).map { |e| e.dates_attended.map(&:reload).map(&:uuid ) }.flatten).to_not
+        match_array(rejected_claim.expenses.map(&:reload).map { |e| e.dates_attended.map(&:reload).map(&:uuid ) }.flatten)
+    end
+
+    it 'clones the fees' do
+      expect(cloned_claim.fees.count).to eq(rejected_claim.fees.count)
+
+      cloned_claim.fees.each_with_index do |fee, index|
+        expect(fee.amount).to eq(rejected_claim.fees[index].amount)
+      end
+    end
+
+    it 'clones the expenses' do
+      expect(cloned_claim.reload.expenses.count).to eq(rejected_claim.expenses.count)
+    end
+
+    it 'clones the expenses\' dates attended' do
+      expect(cloned_claim.expenses.map { |e| e.dates_attended.count }).to eq(rejected_claim.expenses.map { |e| e.dates_attended.count })
+    end
+
+    it 'clones the defendants' do
+      expect(cloned_claim.defendants.count).to eq(rejected_claim.defendants.count)
+      expect(cloned_claim.defendants.map(&:name)).to eq(rejected_claim.defendants.map(&:name))
+    end
+
+    it 'clones the defendant\'s representation orders' do
+      expect(cloned_claim.defendants.map { |d| d.representation_orders.count }).to eq(rejected_claim.defendants.map { |d| d.representation_orders.count })
+    end
+
+    it 'clones the documents' do
+      expect(cloned_claim.documents.count).to eq(1)
+      expect(cloned_claim.documents.count).to eq(rejected_claim.documents.count)
+    end
+  end
+end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe Claims::Cloner, type: :model do
     end
 
     it 'does not clone the uuids of dates attended' do
-      expect(cloned_claim.expenses.map(&:reload).map { |e| e.dates_attended.map(&:reload).map(&:uuid ) }.flatten).to_not
-        match_array(rejected_claim.expenses.map(&:reload).map { |e| e.dates_attended.map(&:reload).map(&:uuid ) }.flatten)
+      cloned_claim_uuids = cloned_claim.expenses.map(&:reload).map { |e| e.dates_attended.map(&:reload).map(&:uuid ) }.flatten
+      rejected_claim_uuids = rejected_claim.expenses.map(&:reload).map { |e| e.dates_attended.map(&:reload).map(&:uuid ) }.flatten
+      expect(cloned_claim_uuids).to_not match_array(rejected_claim_uuids)
     end
 
     it 'clones the fees' do


### PR DESCRIPTION
Ability to create new draft claim from rejected claim. New draft creates copies of fees, expenses (with dates attended), defendants (including representation orders) and documents.
