### PR TITLE
Update cloner to nullify claim submission timestamps

### DIFF
--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -4,7 +4,8 @@ module Claims::Cloner
   included do |klass|
     klass.amoeba do
       enable
-      nullify :submitted_at
+      nullify :last_submitted_at
+      nullify :original_submission_date
       nullify :uuid
       clone [:fees, :documents, :defendants, :expenses]
     end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -36,8 +36,12 @@ RSpec.describe Claims::Cloner, type: :model do
       expect(cloned_claim).to be_draft
     end
 
-    it 'does not clone the submitted_at date' do
-      expect(cloned_claim.submitted_at).to be_nil
+    it 'does not clone last_submitted_at' do
+      expect(cloned_claim.last_submitted_at).to be_nil
+    end
+
+    it 'does not clone original_submission_date' do
+      expect(cloned_claim.original_submission_date).to be_nil
     end
 
     it 'does not clone the uuid' do


### PR DESCRIPTION
Update claim cloner to nullify last_submitted_at and original_submission_date when cloning draft.
