### PR TITLE
Selects/dropdowns only filter from beginning of string

### DIFF
--- a/app/assets/javascripts/advocates/claims/select2.js
+++ b/app/assets/javascripts/advocates/claims/select2.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var adp = adp || {};
+
+adp.select2 = {
+  init : function() {
+    $('.select2').select2({
+      matcher: adp.select2.startOfMatcher
+    });
+  },
+  startOfMatcher : function(term, text) {
+    return text.toUpperCase().indexOf(term.toUpperCase()) == 0;
+  }
+};

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,7 +28,6 @@ var moj = moj || {};
 
 moj.Modules.devs.init = function(){};
 
-
 $('#claim-accordion h2').each(function(){
   $(this).next('section').hide();
   $(this).click(function(){
@@ -40,7 +39,8 @@ $('#claim-accordion h2:first-of-type').addClass('open').next('section').show();
 function initialise(){
   $('#footer').css('margin-top',$(document).height() - ($('#global-header').height() + $('.outer-block:eq(1)').height()  ) - $('#footer').height());
   moj.Modules.CookieMessage.init();
-  $('.select2').select2();
+
+  adp.select2.init();
   adp.newClaim.init();
   adp.crackedTrial.init();
   adp.claimCompletion.init();

--- a/app/views/advocates/claims/_offence_select.html.haml
+++ b/app/views/advocates/claims/_offence_select.html.haml
@@ -1,3 +1,3 @@
 = label_tag t('.offence_class')
 
-= collection_select :offence_class, :description, offences, :id, :offence_class, options = { prompt: t('.select_offence_class'), selected: offences.count == 1 ? offences.first : nil }, html_options = { class: 'select2' }
+= collection_select :offence_class, :description, offences, :id, :offence_class, options = { prompt: t('.select_offence_class'), selected: offences.count == 1 ? offences.first : nil }, html_options = { class: 'select2', disabled: offences.count == 1 }

--- a/app/views/offences/index.js.erb
+++ b/app/views/offences/index.js.erb
@@ -3,7 +3,9 @@
   $('.offence-class-select').hide();
 <% else %>
   $('.offence-class-select').html('<%=j render partial: "advocates/claims/offence_select", locals: { offences: @offences } %>');
-  $('.offence-class-select select').select2();
+  $('.offence-class-select select').select2({
+    matcher: adp.select2.startOfMatcher
+  });
   adp.newClaim.attachToOffenceClassSelect();
   $('.offence-class-select').slideDown();
 <% end %>


### PR DESCRIPTION
Selects/dropdowns only filter from beginning of string.

Offence category now displays second dropdown, offence class, as disabled if only one option available.
