### PR TITLE
Provide framework for archiving / deleting old claims

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -296,6 +296,15 @@ class Claim < ActiveRecord::Base
     VatRate.pretty_rate(self.vat_date)
   end
 
+  def last_state_transition
+    claim_state_transitions.order(created_at: :asc).last
+  end
+
+  def last_state_transition_time
+    last_state_transition.created_at
+  end
+
+
   def opened_for_redetermination?
     return true if self.redetermination?
 
@@ -342,11 +351,6 @@ class Claim < ActiveRecord::Base
   def last_redetermination
     self.redeterminations.select(&:valid?).last
   end
-
-  def last_state_transition
-    last_transition = claim_state_transitions.order(created_at: :asc).last
-  end
-
 
   def set_scheme
     rep_order = self.earliest_representation_order

--- a/app/models/timed_transitions/batch_transitioner.rb
+++ b/app/models/timed_transitions/batch_transitioner.rb
@@ -1,0 +1,15 @@
+
+module TimedTransitions
+  class BatchTransitioner
+
+
+    def run
+      claims = Transitioner.candidate_claims
+      claims.each do |claim| 
+        transitioner = Transitioner.new(claim)
+        transitioner.run
+      end
+    end
+
+  end
+end

--- a/app/models/timed_transitions/specification.rb
+++ b/app/models/timed_transitions/specification.rb
@@ -1,0 +1,14 @@
+module TimedTransitions
+
+  class Specification
+
+    attr_reader :current_state, :number_of_days, :method
+
+    def initialize(current_state, number_of_days, method)
+      @current_state  = current_state
+      @number_of_days = number_of_days
+      @method         = method
+    end
+
+  end
+end

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -1,0 +1,49 @@
+module TimedTransitions
+  class Transitioner
+
+    @@timed_transition_specifications = {
+      authorised:               Specification.new(:authorised, 60, :archive),
+      part_authorised:          Specification.new(:part_authorised, 60, :archive),
+      refused:                  Specification.new(:refused, 60, :archive),
+      rejected:                 Specification.new(:rejected, 60, :archive),
+      archived_pending_delete:  Specification.new(:archived_pending_delete, 60, :destroy)
+    }
+
+    # generates sql to retrieve all claims in a state from which a timed transition can be made.
+    #
+    def self.candidate_claims
+      Claim.where('state in (?)', candidate_states)
+    end
+
+
+    def self.candidate_states
+      @@timed_transition_specifications.keys
+    end
+
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def run
+      specification = @@timed_transition_specifications[@claim.state.to_sym]
+      if @claim.last_state_transition_time < specification.number_of_days.days.ago
+        send(specification.method)
+      end
+    end
+
+
+    private
+
+    def archive
+      @claim.archive_pending_delete!
+    end
+
+
+    def destroy
+      @claim.destroy
+    end 
+
+
+  end
+end

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -16,7 +16,7 @@ namespace :claims do
 
 
   desc 'archives or deletes stale claims'
-  taks :archive_stale => :environment do
+  task :archive_stale => :environment do
     TimedTransition::BatchTransitioner.new.run
   end
 end

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -13,5 +13,11 @@ namespace :claims do
     DemoData::ClaimGenerator.new.run
     Rake::Task['db:data:dump'].invoke
   end
+
+
+  desc 'archives or deletes stale claims'
+  taks :archive_stale => :environment do
+    TimedTransition::BatchTransitioner.new.run
+  end
 end
 

--- a/spec/models/timed_state_transitions/batch_transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/batch_transitioner_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+
+module TimedTransitions
+
+  describe BatchTransitioner do 
+
+    before(:each) do
+      Timecop.freeze 61.days.ago do
+        @old_draft     = FactoryGirl.create :claim
+        @old_auth      = FactoryGirl.create :authorised_claim
+        @old_part_auth = FactoryGirl.create :part_authorised_claim
+        @old_refused   = FactoryGirl.create :refused_claim
+        @old_rejected  = FactoryGirl.create :rejected_claim
+        @old_archived  = FactoryGirl.create :archived_pending_delete_claim
+      end
+
+      Timecop.freeze 59.days.ago do
+        @new_draft     = FactoryGirl.create :claim
+        @new_auth      = FactoryGirl.create :authorised_claim
+        @new_part_auth = FactoryGirl.create :part_authorised_claim
+        @new_refused   = FactoryGirl.create :refused_claim
+        @new_rejected  = FactoryGirl.create :rejected_claim
+        @new_archived  = FactoryGirl.create :archived_pending_delete_claim
+      end
+    end
+   
+    it 'should transition those that need to be transitioned and not others' do
+      BatchTransitioner.new.run
+      
+      expect(@new_draft.state).to eq 'draft'
+      expect(@new_auth.state).to eq 'authorised'
+      expect(@new_part_auth.state).to eq 'part_authorised'
+      expect(@new_refused.state).to eq 'refused'
+      expect(@new_rejected.state).to eq 'rejected'
+      expect(@new_archived.state).to eq 'archived_pending_delete'
+
+      expect(@old_draft.reload.state).to eq 'draft'
+      expect(@old_auth.reload.state).to eq 'archived_pending_delete'
+      expect(@old_part_auth.reload.state).to eq 'archived_pending_delete'
+      expect(@old_refused.reload.state).to eq 'archived_pending_delete'
+      expect(@old_rejected.reload.state).to eq 'archived_pending_delete'
+      
+      expect {
+        @old_archived.reload
+      }.to raise_error ActiveRecord::RecordNotFound
+
+
+    end
+
+  end
+end

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+
+module TimedTransitions
+
+  describe Transitioner do 
+
+    let(:claim)           { double Claim }
+
+    describe '.candidate_states' do
+      it 'should return an array of source states for timed transitions' do
+        expect(Transitioner.candidate_states).to eq (
+          [ :authorised, 
+            :part_authorised, 
+            :refused, 
+            :rejected,
+            :archived_pending_delete
+          ] )
+      end
+    end
+
+
+    describe '.candidate_claims' do
+      it 'should generate the correct sql' do
+        expect(Transitioner.candidate_claims.to_sql).to eq( 
+          %q<SELECT "claims".* FROM "claims" WHERE (state in ('authorised','part_authorised','refused','rejected','archived_pending_delete'))>)
+      end
+    end
+
+
+    describe '.process' do
+      it 'should not call archive if last state change less than 60 days ago' do
+        claim = double Claim
+        expect(claim).to receive(:last_state_transition_time).and_return(59.days.ago)
+        expect(claim).to receive(:state).and_return('authorised')
+        transitioner = Transitioner.new(claim)
+        expect(transitioner).not_to receive(:archive)
+        transitioner.run
+      end
+
+      it 'should call archive if last state change more than 60 days ago' do
+        expect(claim).to receive(:last_state_transition_time).and_return(61.days.ago)
+        expect(claim).to receive(:state).and_return('authorised')
+        transitioner = Transitioner.new(claim)
+        expect(transitioner).to receive(:archive)
+        transitioner.run
+      end
+
+      it 'should not call destroy if last state change less than 60 days ago' do
+        expect(claim).to receive(:last_state_transition_time).and_return(59.days.ago)
+        expect(claim).to receive(:state).and_return('archived_pending_delete')
+        transitioner = Transitioner.new(claim)
+        expect(transitioner).not_to receive(:destroy)
+        transitioner.run
+      end
+
+      it 'should call destroy if last state change more than 60 days ago' do
+        expect(claim).to receive(:last_state_transition_time).and_return(61.days.ago)
+        expect(claim).to receive(:state).and_return('archived_pending_delete')
+        transitioner = Transitioner.new(claim)
+        expect(transitioner).to receive(:destroy)
+        transitioner.run
+      end
+    end
+
+
+    describe '#archive' do
+      it 'shoudl call archive pending delete on the claim' do
+        transitioner = Transitioner.new(claim)
+        expect(claim).to receive(:archive_pending_delete!)
+        transitioner.send(:archive)
+      end
+    end
+
+    describe '#destroy' do
+      it 'should call destroy on the claim' do
+        transitioner = Transitioner.new(claim)
+        expect(claim).to receive(:destroy)
+        transitioner.send(:destroy)
+      end
+    end
+
+
+  end
+
+end


### PR DESCRIPTION
rake task and supporting classes to move claims that have been in specified states for 60 days to archived pending delete, and delete those in archived pending delete for more than 60 days.

Configured by changing the @@timed_transition_specifications class variable in TimedTransitions::Transitioner
