### PR TITLE
enable filtering before quantity allocation

### DIFF
--- a/app/views/case_workers/admin/allocations/new.html.haml
+++ b/app/views/case_workers/admin/allocations/new.html.haml
@@ -86,7 +86,7 @@
   %p
     - unless params[:tab] == 'allocated'
       = number_field_tag :quantity_to_allocate, nil, { placeholder: params[:tab] == 'allocated' ? 'Number to re-allocate' : 'Number to allocate', min: 0 }
-
+      = hidden_field_tag :filter, params[:filter] if params[:filter]
     = f.grouped_collection_select :case_worker_id, Location.all, :case_workers, :name, :id, :name, { prompt: 'Select case worker' }, { class: 'select2 extra-margin', style: 'display: inline-block; width: 200px;' }
 
     = f.submit params[:tab] == 'allocated' ? 'Re-allocate' : 'Allocate', class: 'button'
@@ -117,7 +117,7 @@
             %td
               = b.check_box
             %td
-              = b.label do
+              = b.label(class: "case-number") do
                 = claim.case_number
             %td
               = b.label do

--- a/features/claim_allocation.feature
+++ b/features/claim_allocation.feature
@@ -48,3 +48,17 @@ Feature: Claim allocation
       | guilty_plea              | 10        |
       | redetermination          | 10        |
       | awaiting_written_reasons | 10        |
+
+  Scenario: Filter then allocate
+    Given There are case types in place
+      And there are 2 "cracked" claims
+      And there are 2 "fixed_fee" claims
+      And I visit the allocation page
+      And I filter by "fixed_fee"
+      And I should only see 2 "fixed_fee" claims after filtering
+    When I enter 1 in the quantity text field
+      And I select a case worker
+      And I click Allocate
+    Then the first 1 claims in the list should be allocated to the case worker
+      And the first 1 claims should no longer be displayed
+      


### PR DESCRIPTION
- previously filter param was not passed to create when quantity allocation was attempted
- this is now in a hidden field
- the test for quantity allocation was also altered to ensure claims were being allocated from the filtered list
- to achieve this, @claims_to_allocate is set after filtering, before a quantity is submitted, based on what the user sees on screen.
