### PR TITLE
must save claim before validating total > 0

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -354,15 +354,18 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   end
 
   def create_and_submit
-    @claim.force_validation = true
-    @claim.save
-    # TODO: use @claim.save return value instead of @claim.valid? ?
-    if @claim.valid?
-      @claim.documents.each { |d| d.update_column(:advocate_id, @claim.advocate_id) }
-      redirect_to new_advocates_claim_certification_path(@claim)
-    else
-      render_new_with_resources
+    Claim.transaction do
+      @claim.save
+      @claim.force_validation = true
+      # TODO: use @claim.save return value instead of @claim.valid? ?
+      if @claim.valid?
+        @claim.documents.each { |d| d.update_column(:advocate_id, @claim.advocate_id) }
+        redirect_to new_advocates_claim_certification_path(@claim) and return
+      else
+        raise ActiveRecord::Rollback
+      end
     end
+    render_new_with_resources
   end
 
 end

--- a/app/validators/claim_textfield_validator.rb
+++ b/app/validators/claim_textfield_validator.rb
@@ -27,7 +27,7 @@ class ClaimTextfieldValidator < BaseClaimValidator
 
   def validate_total
     unless @record.source == 'api'
-      validate_numericality(:total, 0.01, nil, "The total being claimed for must be greater than £0.00")
+      validate_numericality(:total, 0.01, nil, "Total value claimed must be greater than £0.00")
     end
   end
 

--- a/app/validators/claim_textfield_validator.rb
+++ b/app/validators/claim_textfield_validator.rb
@@ -10,7 +10,7 @@ class ClaimTextfieldValidator < BaseClaimValidator
     :estimated_trial_length,
     :actual_trial_length,
     :trial_cracked_at_third,
-    # :total
+    :total
     ]
   end
 
@@ -25,22 +25,11 @@ class ClaimTextfieldValidator < BaseClaimValidator
 
   private
 
-  #
-  # TODO: removed as is causing odd behaviour due to the save
-  #       if total needs to be validated it must be done in an
-  #       after save hook or by alternative means.
-  #
-  # def validate_total
-  #   if @record.persisted? && @record.source != 'api'
-  #     validate_numericality(:total, 0.01, nil, "The total being claimed for must be greater than £0.00")
-  #   else
-  #     curr_force_validation = @record.force_validation?
-  #     @record.force_validation = false # prevent this validation being called reursively
-  #     @record.save # trigger total update
-  #     validate_numericality(:total, 0.01, nil, "The total being claimed for must be greater than £0.00")
-  #     @record.force_validation = curr_force_validation # ensure the force validation returned to previous state
-  #   end
-  # end
+  def validate_total
+    unless @record.source == 'api'
+      validate_numericality(:total, 0.01, nil, "The total being claimed for must be greater than £0.00")
+    end
+  end
 
   # ALWAYS required/mandatory
   def validate_advocate

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -20,15 +20,14 @@ Feature: Advocate new claim
       And I should see the claim totals
       And the claim should be in a "submitted" state
 
-  # TODO: reintroduce once a suitable way of validating this is found
-  # Scenario: Try to submit a zero value claim
-  #   Given I am a signed in advocate
-  #     And There are fee schemes in place
-  #     And There are case types in place
-  #     And I am on the new claim page
-  #    When I fill in the claim details but add no fees or expenses
-  #     And I submit to LAA
-  #    Then I should see errors
+  Scenario: Try to submit a zero value claim
+    Given I am a signed in advocate
+      And There are fee schemes in place
+      And There are case types in place
+      And I am on the new claim page
+     When I fill in the claim details but add no fees or expenses
+      And I submit to LAA
+     Then I should see errors
 
   Scenario: Fill in claim form and submit invalid or incomplete claim to LAA
     Given I am a signed in advocate

--- a/features/api_new_claim.feature
+++ b/features/api_new_claim.feature
@@ -2,6 +2,7 @@ Feature: API new claim
 
   Background: the API creation of a draft claim applies validation, unlike claim creation in the web app, but subsequent saving as draft in the web app for an API claim should not.
 
+  # failing because validation on total is applied to draft claims before fees/expenses are created
   Scenario: New claim via API is saved as draft, again, in web app without errors
     Given I am a signed in advocate
       And I create a draft claim marked as from API

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -1184,10 +1184,10 @@ RSpec.describe Claim, type: :model do
        "commit"=>"Submit to LAA"}
       claim = Claim.new(params['claim'])
       claim.creator = advocate
+      expect(claim.save).to be true
       claim.force_validation = true
       result = claim.valid?
       ap claim.errors if result == false
-      expect(claim.save).to be true
       expect(claim.expenses).to have(1).member
       expect(claim.expenses_total).to eq 40.0
     end

--- a/spec/validators/claim_date_validator_spec.rb
+++ b/spec/validators/claim_date_validator_spec.rb
@@ -6,15 +6,21 @@ describe ClaimDateValidator do
   let(:cracked_before_retrial_case_type)  { FactoryGirl.build :case_type, :requires_cracked_dates, name: "Cracked before retrial" }
   let(:contempt_case_type)                { FactoryGirl.build :case_type, :requires_trial_dates,    name: 'Contempt'}
 
-  let(:claim)                             { FactoryGirl.create :claim, force_validation: true }
+  let(:claim)                             { FactoryGirl.create :claim }
   let(:cracked_trial_claim) do
-    claim = FactoryGirl.create :claim, force_validation: true, case_type: cracked_case_type
+    claim = FactoryGirl.create :claim, case_type: cracked_case_type
     nulify_fields_on_record(claim, :trial_fixed_notice_at, :trial_fixed_at, :trial_cracked_at)
   end
 
   let(:cracked_before_retrial_claim) do
-    claim = FactoryGirl.create :claim, force_validation: true, case_type: cracked_before_retrial_case_type
+    claim = FactoryGirl.create :claim, case_type: cracked_before_retrial_case_type
     nulify_fields_on_record(claim, :trial_fixed_notice_at, :trial_fixed_at, :trial_cracked_at)
+  end
+
+  before do
+    claim.force_validation = true
+    cracked_trial_claim.force_validation = true
+    cracked_before_retrial_claim.force_validation = true
   end
 
   context 'trial_fixed_notice_at' do
@@ -81,7 +87,8 @@ describe ClaimDateValidator do
   end
 
   context 'first day of trial' do
-    let(:contempt_claim_with_nil_first_day) { nulify_fields_on_record(FactoryGirl.create(:claim, force_validation: true, case_type: contempt_case_type), :first_day_of_trial) }
+    let(:contempt_claim_with_nil_first_day) { nulify_fields_on_record(FactoryGirl.create(:claim, case_type: contempt_case_type), :first_day_of_trial) }
+    before { contempt_claim_with_nil_first_day.force_validation = true }
 
     it { should_error_if_not_present(contempt_claim_with_nil_first_day, :first_day_of_trial, "Please enter a valid date for first day of trial")  }
     it { should_errror_if_later_than_other_date(claim, :first_day_of_trial, :trial_concluded_at, "First day of trial must not be after date trial concluded") }
@@ -90,7 +97,8 @@ describe ClaimDateValidator do
   end
 
   context 'trial_concluded_at' do
-    let(:contempt_claim_with_nil_concluded_at) { nulify_fields_on_record(FactoryGirl.create(:claim, force_validation: true, case_type: contempt_case_type), :trial_concluded_at) }
+    let(:contempt_claim_with_nil_concluded_at) { nulify_fields_on_record(FactoryGirl.create(:claim, case_type: contempt_case_type), :trial_concluded_at) }
+    before { contempt_claim_with_nil_concluded_at.force_validation = true }
 
     it { should_error_if_not_present(contempt_claim_with_nil_concluded_at, :trial_concluded_at, "Please enter a valid date for date trial concluded") }
     it { should_error_if_earlier_than_other_date(claim, :trial_concluded_at, :first_day_of_trial, "Date trial concluded must not be before first day of trial") }

--- a/spec/validators/claim_textfield_validator_spec.rb
+++ b/spec/validators/claim_textfield_validator_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 describe ClaimTextfieldValidator do
 
-  let(:claim)                       { FactoryGirl.create :claim, force_validation: true }
+  let(:claim)                       { FactoryGirl.create :claim }
   let(:guilty_plea)                 { FactoryGirl.build :case_type, name: 'Guilty plea'}
   let(:contempt)                    { FactoryGirl.build :case_type, :requires_trial_dates, name: 'Contempt' }
   let(:breach_of_crown_court_order) { FactoryGirl.build :case_type, name: 'Breach of Crown Court order'}
   let(:cracked_before_retrial)      { FactoryGirl.build :case_type, name: 'Cracked before retrial'}
 
   before(:each) do
+    claim.force_validation = true
     claim.estimated_trial_length = 1
     claim.actual_trial_length = 2
   end
@@ -87,7 +88,6 @@ context '#perform_validation?' do
 
   context 'advocate' do
     it 'should error if not present, regardless' do
-      claim.force_validation=true
       claim.advocate = nil
       should_error_with(claim, :advocate, "Advocate cannot be blank, you must provide an advocate")
     end
@@ -95,7 +95,6 @@ context '#perform_validation?' do
 
   context 'creator' do
     it 'should error if not present, regardless' do
-      claim.force_validation=true
       claim.creator = nil
       should_error_with(claim, :creator, "Creator cannot be blank, you must provide an creator")
     end


### PR DESCRIPTION
- save claim before forcing validation to update claim total
- wrap this all in a transaction so that save is undone if claim is then invalid
- do not apply validation for total on claims which come via the API because, in this case, the claim is created and saved before any fees or expenses
