### PR TITLE
only advocates change state to :await_written_reasons or :redetermine

### DIFF
--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -13,9 +13,12 @@ class ClaimPresenter < BasePresenter
   end
 
   def valid_transitions_for_detail_form
-    valid_transitions(include_submitted: false)
+    if claim.state == "allocated"
+      valid_transitions(include_submitted: false)
+    else
+      nil
+    end
   end
-
 
   def humanized_state
     claim.state.humanize

--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -13,7 +13,7 @@ class ClaimPresenter < BasePresenter
   end
 
   def valid_transitions_for_detail_form
-    if claim.state == "allocated"
+    if claim.state == "allocated" && !written_reasons_outstanding?
       valid_transitions(include_submitted: false)
     else
       nil

--- a/app/views/shared/_claim_status.html.haml
+++ b/app/views/shared/_claim_status.html.haml
@@ -7,7 +7,7 @@
     %p
       Awaiting written reasons.
 
-  - if current_user.persona.is_a?(CaseWorker) && claim.valid_transitions_for_detail_form.size > 0
+  - if current_user.persona.is_a?(CaseWorker) && claim.valid_transitions_for_detail_form
     = render partial: 'shared/determinations_form', locals: { claim: claim }
   - else
     = render partial: 'shared/determinations_table', locals: { claim: claim }

--- a/features/claim_status.feature
+++ b/features/claim_status.feature
@@ -14,7 +14,6 @@ Scenario Outline: Update claim status
       And I enter fees assessed of <fees> and expenses assessed of <expenses>
       And I press update button
      Then I should be able to update the status from <status> 
-      And I should see an option select for claim status
     
    Examples:
       | status             | fees     | expenses | total     |

--- a/features/step_definitions/claim_status_steps.rb
+++ b/features/step_definitions/claim_status_steps.rb
@@ -76,7 +76,7 @@ Then(/^I should see the current status set to "(.*)"$/) do |state|
 end
 
 Then(/^I should be able to update the status from "(.*)"$/) do |state|
-  expect(page).to have_content("Update status (current status: '#{state}')")
+  expect(page).to have_content("Current status: #{state}")
 end
 
 Then(/^I should see an option select for claim status$/) do


### PR DESCRIPTION
Addressing this bug report from Alistair:
- Case workers are getting options to request written information and to apply for redetermination.
- Test case
- Create a claim and get it to the point where the advocate has requested redetermination.
- Login as a case worker admin and allocate that claim.
- Login as caseworker and edit that claim
- You should see the 4 status options (refused, rejected,part-auth, auth).
- Choose "refused"(i suspect the same applies for other status types too) and click the "Update" button.
- The page submits and everything shows it been updated to the selected status except the case worker now sees two status options (redetermination and apply for written reasons) that were only previously available to advocates.

It doesn't seem to be an issue in staging so its something we have introduced recently
