### PR TITLE
add api key regenerate feature

### DIFF
--- a/app/controllers/advocates/admin/chambers_controller.rb
+++ b/app/controllers/advocates/admin/chambers_controller.rb
@@ -1,10 +1,15 @@
 class Advocates::Admin::ChambersController < Advocates::Admin::ApplicationController
 
-  before_action :set_chamber, only: [:show, :edit, :update]
+  before_action :set_chamber, only: [:show, :edit, :update, :regenerate_api_key]
 
   def show; end
 
   def edit; end
+
+  def regenerate_api_key
+    @chamber.regenerate_api_key!
+    redirect_to advocates_admin_chamber_path(@chamber), notice: 'API key successfully updated'
+  end
 
   def update
     if @chamber.update(chamber_params)
@@ -24,8 +29,10 @@ class Advocates::Admin::ChambersController < Advocates::Admin::ApplicationContro
     params.require(:chamber).permit(
      :name,
      :supplier_number,
-     :vat_registered
+     :vat_registered,
+     :api_key
     )
   end
+
 
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -12,7 +12,7 @@ class Ability
     if persona.is_a? Advocate
       if persona.admin?
         can [:create], ClaimIntention
-        can [:show, :edit, :update], Chamber, id: persona.chamber_id
+        can [:show, :edit, :update, :regenerate_api_key], Chamber, id: persona.chamber_id
         can [:index, :outstanding, :authorised, :archived, :new, :create], Claim
         can [:show, :edit, :update, :confirmation, :clone_rejected, :destroy], Claim, chamber_id: persona.chamber_id
         can [:show, :download], Document, chamber_id: persona.chamber_id

--- a/app/models/chamber.rb
+++ b/app/models/chamber.rb
@@ -29,6 +29,10 @@ class Chamber < ActiveRecord::Base
   validates :supplier_number, presence: true, uniqueness: { case_sensitive: false }
   validates :api_key, presence: true
 
+  def regenerate_api_key!
+    update_column(:api_key, SecureRandom.uuid)
+  end
+
 private
 
   def set_api_key

--- a/app/views/advocates/admin/chambers/show.html.haml
+++ b/app/views/advocates/admin/chambers/show.html.haml
@@ -13,7 +13,11 @@
 
 %p
   = label_tag :api_key, "#{t('.api_key')}:", class: "form-label"
-  = @chamber.api_key
+  .grid-row
+    .column-third#api-key
+      = @chamber.api_key
+    .column-two-thirds
+      = button_to 'Generate new key', regenerate_api_key_advocates_admin_chamber_path(@chamber), method: :patch, data: { confirm: "Are you sure?\n\nImportant: the new key will need to be used for all API calls and JSON file claim imports for this chamber." }, class: 'button'
 
 - if can? :edit, @chamber
   = link_to 'Edit', edit_advocates_admin_chamber_path(@chamber), class: 'button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,9 @@ Rails.application.routes.draw do
         patch 'update_password', on: :member
       end
 
-      resources :chambers, only: [:show, :edit, :update]
+      resources :chambers, only: [:show, :edit, :update] do
+       patch :regenerate_api_key, on: :member
+      end
     end
 
   end

--- a/features/advocate_admin_edit_chamber.feature
+++ b/features/advocate_admin_edit_chamber.feature
@@ -1,0 +1,18 @@
+Feature: Chamber Administration
+  Background:
+    As an advocate admin I want to be able to manage the chamber details I am an admin for.
+
+Scenario: Generate a new API key for chamber
+    Given I am a signed in advocate admin
+     When I visit the Manage chamber page
+      And I click "Generate new key"
+     Then I should be redirected to the Manage chamber page
+      And I should see a new api key
+
+Scenario: Edit supplier number
+    Given I am a signed in advocate admin
+     When I visit the Edit chamber page
+      And I fill in supplier number with "C9999"
+      And I click "Save"
+     Then I should be redirected to the Manage chamber page
+      And I should see a supplier of "C9999"

--- a/features/step_definitions/advocate_admin_edit_chamber_steps.rb
+++ b/features/step_definitions/advocate_admin_edit_chamber_steps.rb
@@ -1,0 +1,29 @@
+
+When(/^I visit the Edit chamber page$/) do
+  visit edit_advocates_admin_chamber_path(@advocate.chamber)
+  expect(page.current_path).to eq(edit_advocates_admin_chamber_path(@advocate.chamber))
+end
+
+When(/^I fill in supplier number with "(.*?)"$/) do |supplier_number|
+  fill_in 'chamber_supplier_number', with: supplier_number
+end
+
+Then(/^I should see a supplier of "(.*?)"$/) do |supplier_number|
+  expect(page).to have_content(supplier_number)
+end
+
+
+When(/^I visit the Manage chamber page$/) do
+  visit advocates_admin_chamber_path(@advocate.chamber)
+  @api_key = find('#api-key').text
+end
+
+Then(/^I should be redirected to the Manage chamber page$/) do
+  expect(page.current_path).to eq(advocates_admin_chamber_path(@advocate.chamber))
+end
+
+Then(/^I should see a new api key$/) do
+  expect(page).to have_selector('#api-key')
+  new_api_key = find('#api-key').text
+  expect(new_api_key).to_not eql @api_key
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -92,14 +92,14 @@ describe Ability do
     end
 
     context 'cannot manage their chamber' do
-      [:show, :edit, :update].each do |action|
+      [:show, :edit, :update, :regenerate_api_key].each do |action|
         it { should_not be_able_to(action, chamber) }
       end
     end
 
     context 'cannot manage other chambers' do
       let(:other_chamber) { create(:chamber) }
-      [:show, :edit, :update].each do |action|
+      [:show, :edit, :update, :regenerate_api_key].each do |action|
         it { should_not be_able_to(action, other_chamber) }
       end
     end
@@ -134,14 +134,14 @@ describe Ability do
     end
 
     context 'can manage their chamber' do
-      [:show, :edit, :update].each do |action|
+      [:show, :edit, :update, :regenerate_api_key].each do |action|
         it { should be_able_to(action, chamber) }
       end
     end
 
     context 'cannot manage other chambers' do
       let(:other_chamber) { create(:chamber) }
-      [:show, :edit, :update].each do |action|
+      [:show, :edit, :update, :regenerate_api_key].each do |action|
         it { should_not be_able_to(action, other_chamber) }
       end
     end

--- a/spec/models/chamber_spec.rb
+++ b/spec/models/chamber_spec.rb
@@ -38,4 +38,13 @@ RSpec.describe Chamber, type: :model do
     end
   end
 
+  context '.regenerate_api_key' do
+    let(:chamber) { FactoryGirl.create(:chamber) }
+
+    it 'should create a new api_key' do
+      old_api_key = chamber.api_key
+      expect{ chamber.regenerate_api_key! }.to change{ chamber.api_key }.from(old_api_key)
+    end
+  end
+
 end


### PR DESCRIPTION
this provides a regeneration of api key capability for advocate admins of a chamber
