### PR TITLE
Message presenter

### DIFF
--- a/app/presenters/claim_history_presenter.rb
+++ b/app/presenters/claim_history_presenter.rb
@@ -1,7 +1,7 @@
 class ClaimHistoryPresenter < BasePresenter
   presents :claim
 
-  def history_and_messages
+  def history_items_by_date
     unique_formatted_dates.inject({}) do |hash, date_string|
       arr = select_by_date_string(versions, date_string) + select_by_date_string(messages, date_string) + select_by_date_string(assessments, date_string) + select_by_date_string(redetermination_versions, date_string)
       hash[date_string] = arr.flatten.sort_by { |e| e.created_at } if arr.any?

--- a/app/presenters/state_change_presenter.rb
+++ b/app/presenters/state_change_presenter.rb
@@ -1,0 +1,29 @@
+class StateChangePresenter < BasePresenter
+
+  presents :version
+
+  def new_state?
+    true
+  end
+
+  def change
+    version.changeset.each do |attribute, changes|
+      new_state = changes.last
+      return "#{descriptions[new_state]} - #{version.created_at.strftime('%H:%M')}"
+    end
+  end
+
+  def descriptions
+    {
+      'redetermiation'                => 'Redetermination requested',
+      'awaiting_written_reasons'      => 'Written reasons requested',
+      'submitted'                     => 'Claim submitted',
+      'allocated'                     => 'Claim allocated',
+      'authorised'                    => 'Claim authorised',
+      'part_autorised'                => 'Claim part authorised',
+      'rejected'                      => 'Claim rejected',
+      'refused'                       => 'Claim refused'
+    }
+  end
+
+end

--- a/app/presenters/state_change_presenter.rb
+++ b/app/presenters/state_change_presenter.rb
@@ -2,18 +2,16 @@ class StateChangePresenter < BasePresenter
 
   presents :version
 
-  def new_state?
-    true
-  end
-
   def change
     version.changeset.each do |attribute, changes|
       new_state = changes.last
-      return "#{descriptions[new_state]} - #{version.created_at.strftime('%H:%M')}"
+      return "#{state_change_descriptions[new_state]} - #{version.created_at.strftime('%H:%M')}"
     end
   end
 
-  def descriptions
+private
+
+  def state_change_descriptions
     {
       'redetermiation'                => 'Redetermination requested',
       'awaiting_written_reasons'      => 'Written reasons requested',

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -1,4 +1,5 @@
-- if message.is_a? Message
+- if history_item.is_a? Message
+  - message = history_item
   .grid-row{id: dom_id(message) }
     - if message.sender.persona.is_a?(Advocate)
       .column-two-thirds
@@ -37,33 +38,27 @@
                 (#{message.sender.persona.class.to_s.humanize})
               .column-half.sent
                 = message.created_at
-- elsif message.is_a?(PaperTrail::Version) && message.item_type == 'Determination'
+- elsif history_item.is_a?(PaperTrail::Version) && history_item.item_type == 'Determination'
   .grid-row.history
     .column-two-thirds
       &nbsp;
     .column-third
       .event
-        = message.event
+        = "#{history_item.event} - #{history_item.created_at.strftime('%H:%M')}"
         %table
-          - message.changeset.each do |attribute, changes|
+          - history_item.changeset.each do |attribute, changes|
             %tr
               %td
                 #{attribute.humanize}:
               %td
                 #{number_to_currency(changes.last)}
-- elsif message.is_a?(PaperTrail::Version) && message.item_type == 'Claim'
-  .grid-row.history
-    .column-quarter
-      &nbsp;
-    .column-three-quarter
-      .event
-        %ul
-          - message.changeset.each do |attribute, changes|
+- elsif history_item.is_a?(PaperTrail::Version) && history_item.event == 'State change'
+  - present(history_item, StateChangePresenter) do |state_change|
+    .grid-row.history
+      .column-quarter
+        &nbsp;
+      .column-three-quarter
+        .event
+          %ul
             %li
-              - if changes.first.present? && changes.last.present?
-                Changed
-                "#{attribute.humanize}"
-                from
-                "#{changes.first}"
-                to
-                "#{changes.last}"
+              = state_change.change

--- a/app/views/shared/_message_list.html.haml
+++ b/app/views/shared/_message_list.html.haml
@@ -1,13 +1,13 @@
 - present(@message.claim, ClaimHistoryPresenter) do |claim|
-  - if claim.history_and_messages.none?
+  - if claim.history_items_by_date.none?
     %span.no-messages
       No messages found
   - else
-    - claim.history_and_messages.each do |date, events|
+    - claim.history_items_by_date.each do |date, history_items|
       %fieldset.single-date
         %legend.visuallyhidden
           = date
         .event-date
           = date
-        - events.each do |event|
-          = render partial: 'shared/message', locals: {message: event }
+        - history_items.each do |history_item|
+          = render partial: 'shared/message', locals: {history_item: history_item }

--- a/features/step_definitions/claim_history_steps.rb
+++ b/features/step_definitions/claim_history_steps.rb
@@ -12,7 +12,7 @@ Then(/^I should see the state change to submitted reflected in the history$/) do
   within '#messages' do
     within '.messages-list' do
       history = all('.event').last
-      expect(history).to have_content(/Changed "State" from "draft" to "submitted"/)
+      expect(history).to have_content(/Claim submitted/)
     end
   end
 end
@@ -37,7 +37,7 @@ Then(/^I should see the state change to authorised reflected in the history$/) d
   within '#messages' do
     within '.messages-list' do
       history = all('.event').last
-      expect(history).to have_content(/Changed "State" from "allocated" to "authorised"/)
+      expect(history).to have_content(/Claim authorised/)
     end
   end
 end

--- a/spec/presenters/assessment_presenter_spec.rb
+++ b/spec/presenters/assessment_presenter_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-describe AssessmentPresenter do
+RSpec.describe AssessmentPresenter do
   
-  let(:assessment)              { FactoryGirl.create :assessment, fees: 1452.33, expenses: 2455.77 }
-  let(:presenter)               { AssessmentPresenter.new(assessment, view) }
+  let(:assessment)  { FactoryGirl.create :assessment, fees: 1452.33, expenses: 2455.77 }
+  let(:subject)     { AssessmentPresenter.new(assessment, view) }
   
   context 'currency fields' do
   
     it 'should format currency amount' do
-      expect(presenter.fees_total).to eq '£1,452.33'
-      expect(presenter.expenses_total).to eq '£2,455.77'
-      expect(presenter.total).to eq '£3,908.10'
+      expect(subject.fees_total).to eq '£1,452.33'
+      expect(subject.expenses_total).to eq '£2,455.77'
+      expect(subject.total).to eq '£3,908.10'
     end
   end
 

--- a/spec/presenters/claim_history_presenter_spec.rb
+++ b/spec/presenters/claim_history_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ClaimHistoryPresenter do
   let(:claim) { create :claim }
   subject { ClaimHistoryPresenter.new(claim, view) }
 
-  describe '#history_and_messages' do
+  describe '#history_items_by_date' do
     let(:first_message) do
       Timecop.travel(Time.zone.local(2015, 9, 21, 13, 0, 0)) do
         create(:message, claim: claim, body: 'Hello world')
@@ -68,7 +68,7 @@ RSpec.describe ClaimHistoryPresenter do
 
     it 'returns a claims message and history hash in chronological order' do
       claim.reload
-      expect(subject.history_and_messages).to eq(expected_hash)
+      expect(subject.history_items_by_date).to eq(expected_hash)
     end
   end
 end

--- a/spec/presenters/state_change_presenter_spec.rb
+++ b/spec/presenters/state_change_presenter_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe StateChangePresenter do
+
+  let(:claim)      { create(:allocated_claim) }
+  let(:subject)    { StateChangePresenter.new(claim.versions.last, view) }
+
+  describe "#change" do
+    it 'returns a human readable string describing a state change' do
+      expect(subject.change).to eq "Claim allocated - #{subject.created_at.strftime('%H:%M')}"
+    end
+  end
+
+end


### PR DESCRIPTION
- The way status updates were displayed was a little unslightly
- Some logic was required to deal with the full range of possible state changes
- This is contained within the StateChangePresenter (the branch name is now incorrect but the commit message clarifies my intent)
