### PR TITLE
Remove restriction for user to be signed in when submitting feedback

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,9 +1,21 @@
 class FeedbackController < ApplicationController
+  skip_load_and_authorize_resource only: [:new, :create]
+
   def new
     @feedback = Feedback.new
   end
 
   def create
-    redirect_to root_path_url_for_user, notice: 'Feedback submitted'
+    redirect_to redirect_after_create_url, notice: 'Feedback submitted'
+  end
+
+  private
+
+  def redirect_after_create_url
+    if current_user
+      root_path_url_for_user
+    else
+      new_user_session_url
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,6 @@ class Ability
 
     can [:create, :download_attachment], Message
     can [:index, :update], UserMessageStatus
-    can [:new, :create], Feedback
 
     if persona.is_a? Advocate
       if persona.admin?

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -4,10 +4,11 @@ class Feedback
 
   attr_accessor :text, :email, :referrer, :user_agent, :comment, :rating
 
-  RATINGS = { 5 => 'Very satisfied',
+  RATINGS = {
+    5 => 'Very satisfied',
     4 => 'Satisfied',
     3 => 'Neither satisfied nor dissatisfied',
     2 => 'Dissatisfied',
-    1 => 'Very dissatisfied'}
-
+    1 => 'Very dissatisfied'
+  }
 end

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe FeedbackController, type: :controller do
-  let(:advocate) { create(:advocate) }
-
-  before do
-    sign_in advocate.user
-  end
-
   describe "GET #new" do
     before do
       get :new
@@ -26,12 +20,24 @@ RSpec.describe FeedbackController, type: :controller do
   end
 
   describe "POST #create" do
-    before do
-      post :create
+    context 'when user signed in' do
+      let(:advocate) { create(:advocate) }
+
+      before do
+        sign_in advocate.user
+      end
+
+      it "redirects to the users home" do
+        post :create
+        expect(response).to redirect_to(advocates_root_url)
+      end
     end
 
-    it "redirects to the users home" do
-      expect(response).to redirect_to(advocates_root_url)
+    context 'when no user signed in' do
+      it "redirects to the sign in page" do
+        post :create
+        expect(response).to redirect_to(new_user_session_url)
+      end
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -11,8 +11,6 @@ describe Ability do
     it { should_not be_able_to(:index, UserMessageStatus) }
     it { should_not be_able_to(:update, UserMessageStatus.new) }
     it { should_not be_able_to(:create, Document.new) }
-    it { should_not be_able_to(:new, Feedback.new) }
-    it { should_not be_able_to(:create, Feedback.new) }
   end
 
   context 'when a signed in user' do
@@ -22,8 +20,6 @@ describe Ability do
     it { should be_able_to(:download_attachment, Message.new) }
     it { should be_able_to(:index, UserMessageStatus) }
     it { should be_able_to(:update, UserMessageStatus.new) }
-    it { should be_able_to(:new, Feedback.new) }
-    it { should be_able_to(:create, Feedback.new) }
   end
 
   context 'advocate' do


### PR DESCRIPTION
Feedback can be submitted by non-signed in users. Signed in users are redirected to their "home" page (dashboard) after submitting feedback. Non signed in users are redirected to the sign in page after submitting feedback.
