### PR TITLE
Casual message date and design changes

### DIFF
--- a/app/assets/stylesheets/message.scss
+++ b/app/assets/stylesheets/message.scss
@@ -29,7 +29,6 @@ Styling for Claims Messaging
     padding: 5px;
     margin-bottom: 1em;
     .single-date{
-      border-top: 1px solid $border-colour;
       text-align: center;
       legend{
         text-align: center;
@@ -193,6 +192,9 @@ Styling for Claims Messaging
       margin-bottom: 5px;
       margin-right: 1em;
       text-align: right;
+      strong{
+        font-weight: bold;
+      }
       table{
         @extend .claims_table;
         td{

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,4 +30,15 @@ module ApplicationHelper
   def signed_in_user_profile_path
     eval("#{current_user.persona.class.to_s.underscore.pluralize}_admin_#{current_user.persona.class.to_s.underscore}_path(#{current_user.persona_id})")
   end
+
+  def casual_date(date)
+    if Date.parse(date) == Date.today
+      "Today"
+    elsif Date.parse(date) == Date.yesterday
+      "Yesterday"
+    else
+      date
+    end
+  end
+
 end

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -44,7 +44,9 @@
       &nbsp;
     .column-third
       .event
-        = "#{history_item.event} - #{history_item.created_at.strftime('%H:%M')}"
+        %strong
+          = history_item.event
+        = "- #{history_item.created_at.strftime('%H:%M')}"
         %table
           - history_item.changeset.each do |attribute, changes|
             %tr

--- a/app/views/shared/_message_list.html.haml
+++ b/app/views/shared/_message_list.html.haml
@@ -6,8 +6,8 @@
     - claim.history_items_by_date.each do |date, history_items|
       %fieldset.single-date
         %legend.visuallyhidden
-          = date
+          = casual_date(date)
         .event-date
-          = date
+          = casual_date(date)
         - history_items.each do |history_item|
           = render partial: 'shared/message', locals: {history_item: history_item }


### PR DESCRIPTION
Removed keylines between the dates and made the status change message bold. At the moment its just assessments made but @EdwardAndress is working on the state change messages and will make those bold as part of his changes.
![screen shot 2015-10-29 at 12 28 14](https://cloud.githubusercontent.com/assets/3441519/10818317/8e183c3e-7e38-11e5-9876-e971d157be17.png)
