### PR TITLE
status updates - fix redetermination bug and advocate copy

### DIFF
--- a/app/models/case_worker.rb
+++ b/app/models/case_worker.rb
@@ -12,6 +12,7 @@
 #
 
 class CaseWorker < ActiveRecord::Base
+
   auto_strip_attributes :role, :approval_level, squish: true, nullify: true
 
   ROLES = %w{ admin case_worker }

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -61,8 +61,8 @@ module Claims::StateMachine
       after_transition on: :redetermine,              do: [:remove_case_workers!, :set_last_submission_date!]
       after_transition on: :await_written_reasons,    do: [:remove_case_workers!, :set_last_submission_date!]
       after_transition on: :archive_pending_delete,   do: :set_valid_until!
-      before_transition on: [:reject, :refuse], do: :set_amount_assessed_zero!
-      before_transition any => any,  do: :set_paper_trail_event!
+      before_transition on: [:reject, :refuse],       do: :set_amount_assessed_zero!
+      before_transition any => any,                   do: :set_paper_trail_event!
 
       event :redetermine do
         transition VALID_STATES_FOR_REDETERMINATION.map(&:to_sym) => :redetermination

--- a/app/presenters/state_change_presenter.rb
+++ b/app/presenters/state_change_presenter.rb
@@ -5,7 +5,7 @@ class StateChangePresenter < BasePresenter
   def change
     version.changeset.each do |attribute, changes|
       new_state = changes.last
-      return "#{state_change_descriptions[new_state]} - #{version.created_at.strftime('%H:%M')}"
+      return "#{state_change_descriptions[new_state][current_user_persona]}"
     end
   end
 
@@ -13,15 +13,19 @@ private
 
   def state_change_descriptions
     {
-      'redetermiation'                => 'Redetermination requested',
-      'awaiting_written_reasons'      => 'Written reasons requested',
-      'submitted'                     => 'Claim submitted',
-      'allocated'                     => 'Claim allocated',
-      'authorised'                    => 'Claim authorised',
-      'part_autorised'                => 'Claim part authorised',
-      'rejected'                      => 'Claim rejected',
-      'refused'                       => 'Claim refused'
+      'redetermination'               => {"CaseWorker" => "A redetermination requested",   "Advocate" => "You requested redetermination"},
+      'awaiting_written_reasons'      => {"CaseWorker" => "Written reasons requested",     "Advocate" => "You requested written reasons"},
+      'submitted'                     => {"CaseWorker" => "Claim submitted",               "Advocate" => "Your claim has been submitted"},
+      'allocated'                     => {"CaseWorker" => "Claim allocated",               "Advocate" => "Your claim has been allocated"},
+      'authorised'                    => {"CaseWorker" => "Claim authorised",              "Advocate" => "Your claim has been authorised"},
+      'part_autorised'                => {"CaseWorker" => "Claim part authorised",         "Advocate" => "Your claim has been part-authorised"},
+      'rejected'                      => {"CaseWorker" => "Claim rejected",                "Advocate" => "Your claim has been rejected"},
+      'refused'                       => {"CaseWorker" => "Claim refused",                 "Advocate" => "Your claim has been refused"}
     }
+  end
+
+  def current_user_persona
+    @view.current_user.persona.class.to_s
   end
 
 end

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -61,4 +61,6 @@
         .event
           %ul
             %li
-              = state_change.change
+              %strong
+                = state_change.change
+              = " - #{history_item.created_at.strftime('%H:%M')}"

--- a/features/claim_messages.feature
+++ b/features/claim_messages.feature
@@ -28,3 +28,9 @@ Feature: Claim messages
      When I visit that claim's "advocate" detail page
       And I leave a message
      Then I should see my message at the bottom of the message list
+
+  Scenario: Advocate cannot leave messages on completed claims
+    Given I am a signed in advocate
+      And I have a rejected claim
+    When I visit that claim's "advocate" detail page
+      Then I should not be able to leave a message

--- a/features/claim_redetermination.feature
+++ b/features/claim_redetermination.feature
@@ -22,12 +22,12 @@ Feature: Claim redetermination
      Then I should not see a control in the messages section to request a redetermination
 
     Examples:
-      | state                           |
-      | draft_claim                     |
-      | submitted_claim                 |
-      | allocated_claim                 |
-      | rejected_claim                  |
-      | redetermination_claim           |
+      | state                     |
+      | draft                     |
+      | submitted                 |
+      | allocated                 |
+      | rejected                  |
+      | redetermination           |
 
   Scenario: Re-open claim for redetermination
     Given I am a signed in advocate

--- a/features/step_definitions/claim_messages_steps.rb
+++ b/features/step_definitions/claim_messages_steps.rb
@@ -41,3 +41,7 @@ Given(/^I have a submitted claim with messages$/) do
   @messages = create_list(:message, 5, claim_id: @claim.id)
   @messages.each { |m| m.update_column(:sender_id, create(:advocate).user.id) }
 end
+
+Then(/^I should not be able to leave a message$/) do
+  
+end

--- a/features/step_definitions/claim_redetermination_steps.rb
+++ b/features/step_definitions/claim_redetermination_steps.rb
@@ -1,5 +1,5 @@
 Given(/^I have a (.+) claim$/) do |state|
-  @claim = create(state.to_sym, advocate: @advocate)
+  @claim = create("#{state}_claim".to_sym, advocate: @advocate)
 end
 
 Given(/^the claim has a case worker assigned to it$/) do

--- a/spec/presenters/state_change_presenter_spec.rb
+++ b/spec/presenters/state_change_presenter_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe StateChangePresenter do
   let(:subject)    { StateChangePresenter.new(claim.versions.last, view) }
 
   describe "#change" do
+
+
     it 'returns a human readable string describing a state change' do
-      expect(subject.change).to eq "Claim allocated - #{subject.created_at.strftime('%H:%M')}"
+      allow(subject).to receive(:current_user_persona).and_return('CaseWorker')
+      expect(subject.change).to eq "Claim allocated"
     end
   end
 


### PR DESCRIPTION
-Fixed the bug where state changes to 'redetermination' were not displayed correctly in the claim history.
-Made the status updates bold
-Changed the advocate copy for status updates to be more user-focused.
