### PR TITLE
Add 'gamma' environment to list of environments for RailsHost

### DIFF
--- a/lib/rails_host.rb
+++ b/lib/rails_host.rb
@@ -1,6 +1,6 @@
 class RailsHost
 
-  VALID_ENVS = %w{ dev demo staging api-sandbox }
+  VALID_ENVS = %w{ dev demo staging api-sandbox gamma }
 
 
   def self.env


### PR DESCRIPTION
VALID_ENVS updated to include 'gamma'
