### PR TITLE
Repurpose forgot password

### DIFF
--- a/app/controllers/advocates/admin/advocates_controller.rb
+++ b/app/controllers/advocates/admin/advocates_controller.rb
@@ -17,9 +17,15 @@ class Advocates::Admin::AdvocatesController < Advocates::Admin::ApplicationContr
   end
 
   def create
-    @advocate = Advocate.new(advocate_params.merge(chamber_id: current_user.persona.chamber.id))
+    new_advocate_params = advocate_params
+    temporary_password = SecureRandom.uuid
+    new_advocate_params['user_attributes']['password'] = temporary_password
+    new_advocate_params['user_attributes']['password_confirmation'] = temporary_password
+
+    @advocate = Advocate.new(new_advocate_params.merge(chamber_id: current_user.persona.chamber.id))
 
     if @advocate.save
+      @advocate.user.send_reset_password_instructions
       redirect_to advocates_admin_advocates_url, notice: 'Advocate successfully created'
     else
       render :new
@@ -68,4 +74,5 @@ class Advocates::Admin::AdvocatesController < Advocates::Admin::ApplicationContr
       user_attributes: [:id, :email, :password, :password_confirmation, :current_password, :first_name, :last_name]
     )
   end
+
 end

--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -22,9 +22,15 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
   end
 
   def create
-    @case_worker = CaseWorker.new(case_worker_params)
+    new_case_worker_params = case_worker_params
+    temporary_password = SecureRandom.uuid
+    new_case_worker_params['user_attributes']['password'] = temporary_password
+    new_case_worker_params['user_attributes']['password_confirmation'] = temporary_password
+
+    @case_worker = CaseWorker.new(new_case_worker_params)
 
     if @case_worker.save
+      @case_worker.user.send_reset_password_instructions
       redirect_to case_workers_admin_case_workers_url, notice: 'Case worker successfully created'
     else
       render :new

--- a/app/views/advocates/admin/advocates/_form.html.haml
+++ b/app/views/advocates/admin/advocates/_form.html.haml
@@ -22,11 +22,11 @@
      
        
 
-      - if @advocate.new_record?
-        = user_fields.label t(".password"), class: "form-label"
-        = user_fields.password_field :password, class: "form-control"
-        = user_fields.label t(".password_confirmation"), class: "form-label"
-        = user_fields.password_field :password_confirmation, class: "form-control"
+      / - if @advocate.new_record?
+      /   = user_fields.label t(".password"), class: "form-label"
+      /   = user_fields.password_field :password, class: "form-control"
+      /   = user_fields.label t(".password_confirmation"), class: "form-label"
+      /   = user_fields.password_field :password_confirmation, class: "form-control"
 
     %fieldset.user-form
       = f.label t(".supplier_number"), class: "form-label"

--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -15,12 +15,6 @@
       = user_fields.label :email, class: "form-label"
       = user_fields.email_field :email, class: "form-control"
 
-      - if @case_worker.new_record?
-        = user_fields.label :password, class: "form-label"
-        = user_fields.password_field :password, class: "form-control"
-        = user_fields.label :password_confirmation, class: "form-label"
-        = user_fields.password_field :password_confirmation, class: "form-control"
-
     %fieldset.user-form
       %div.form-group
         %label.form-label

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -13,5 +13,3 @@
 	<p>If you didn't request this, please ignore this email.</p>
 	<p>Your password won't change until you access the link above and create a new one.</p>
 <% end %>
-
-

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,17 @@
-<p>Hello <%= @resource.email %>!</p>
+<% if @resource.sign_in_count == 0 %>
+	<p>Hello <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+	<p>You have been registered as a new user for Advocate Defense Payments.  Please click on the link below and reset your password.</p>
+	<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+	<p>If you didn't request this, please ignore this email.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<% else %>
+	<p>Hello <%= @resource.email %>!</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+	<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+	<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+	<p>If you didn't request this, please ignore this email.</p>
+	<p>Your password won't change until you access the link above and create a new one.</p>
+<% end %>
+
+

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,11 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.default_url_options = { host: 'localhost' }
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,11 +18,11 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "Advocate Defense Payments - Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Advocate Defense Payments - Change your password"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "Advocate Defense Payments - Unlock your account"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/features/new_user.feature
+++ b/features/new_user.feature
@@ -1,0 +1,8 @@
+Feature: User is added by advocate or caseworker admin
+
+Scenario: New advocate user
+  Given I am a signed in advocate admin
+    And I am on the new user page
+  When I fill in the details
+    And click submit
+  Then I see confirmation that a new user has been created

--- a/features/new_user.feature
+++ b/features/new_user.feature
@@ -2,7 +2,16 @@ Feature: User is added by advocate or caseworker admin
 
 Scenario: New advocate user
   Given I am a signed in advocate admin
-    And I am on the new user page
-  When I fill in the details
-    And click submit
-  Then I see confirmation that a new user has been created
+    And I am on the new "advocate" page
+  When I fill in the "advocate" details
+    And click save
+  Then I see confirmation that a new "Advocate" user has been created
+    And an email is sent to the new user
+
+Scenario: New caseworker user
+  Given I am a signed in case worker admin
+    And I am on the new "case_worker" page
+  When I fill in the "case_worker" details
+    And click save
+  Then I see confirmation that a new "Case worker" user has been created
+    And an email is sent to the new user

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -1,0 +1,20 @@
+Given(/^I am on the new user page$/) do
+  visit '/advocates/admin/advocates/new'
+end
+
+When(/^I fill in the details$/) do
+  fill_in 'advocate_user_attributes_first_name', with: 'Harold'
+  fill_in 'advocate_user_attributes_last_name', with: 'Hughes'
+  fill_in 'advocate_user_attributes_email', with: 'harold.hughes@example.com'
+  choose(('advocate[apply_vat]').first)
+  fill_in 'advocate_supplier_number', with: '31425'
+  choose(('advocate[role]').first)
+end
+
+When(/^click submit$/) do
+  click_on 'Save'
+end
+
+Then(/^I see confirmation that a new user has been created$/) do
+  expect(page).to have_content 'Advocate successfully created'
+end

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -1,20 +1,36 @@
-Given(/^I am on the new user page$/) do
-  visit '/advocates/admin/advocates/new'
+Given(/^I am on the new "(.*?)" page$/) do |persona|
+  personas = persona.pluralize
+  visit "/#{personas}/admin/#{personas}/new"
 end
 
-When(/^I fill in the details$/) do
-  fill_in 'advocate_user_attributes_first_name', with: 'Harold'
-  fill_in 'advocate_user_attributes_last_name', with: 'Hughes'
-  fill_in 'advocate_user_attributes_email', with: 'harold.hughes@example.com'
-  choose(('advocate[apply_vat]').first)
-  fill_in 'advocate_supplier_number', with: '31425'
-  choose(('advocate[role]').first)
+When(/^I fill in the "(.*?)" details$/) do |persona|
+  fill_in "#{persona}_user_attributes_first_name", with: 'Harold'
+  fill_in "#{persona}_user_attributes_last_name", with: 'Hughes'
+  fill_in "#{persona}_user_attributes_email", with: 'harold.hughes@example.com'
+  case persona
+  when 'advocate'
+    choose(('advocate[apply_vat]').first)
+    fill_in 'advocate_supplier_number', with: '31425'
+    choose(("#{persona}[role]").first)
+  when 'case_worker'
+    check('case_worker[days_worked_0]')
+    choose('case_worker_approval_level_high')
+    choose('case_worker[location_id]')
+    choose('case_worker_role_case_worker')
+  end
 end
 
-When(/^click submit$/) do
+When(/^click save$/) do
+  ActionMailer::Base.delivery_method = :test
+  ActionMailer::Base.perform_deliveries = true
   click_on 'Save'
 end
 
-Then(/^I see confirmation that a new user has been created$/) do
-  expect(page).to have_content 'Advocate successfully created'
+Then(/^I see confirmation that a new "(.*?)" user has been created$/) do |persona|
+  expect(page).to have_content "#{persona} successfully created"
+end
+
+Then(/^an email is sent to the new user$/) do
+  expect(ActionMailer::Base.deliveries.length).to eq 1
+  expect(ActionMailer::Base.deliveries.first.to).to eq ["harold.hughes@example.com"]
 end

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -33,4 +33,5 @@ end
 Then(/^an email is sent to the new user$/) do
   expect(ActionMailer::Base.deliveries.length).to eq 1
   expect(ActionMailer::Base.deliveries.first.to).to eq ["harold.hughes@example.com"]
+  expect(ActionMailer::Base.deliveries.first.subject).to eq "Advocate Defense Payments - Change your password"
 end

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -163,12 +163,12 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController, type: :controller do
     context 'when invalid' do
       it 'does not create a case worker' do
         expect {
-          post :create, case_worker: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'xxx', role: 'case_worker' }
+          post :create, case_worker: { role: 'case_worker', user_attributes: {email: 'invalidemail'} }
         }.to_not change(User, :count)
       end
 
       it 'renders the new template' do
-        post :create, case_worker: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'xxx', role: 'case_worker' }
+        post :create, case_worker: { role: 'case_worker', user_attributes: {email: 'invalidemail'} }
         expect(response).to render_template(:new)
       end
     end


### PR DESCRIPTION
- The reset password mechanism has been repurposed to send out an email to new users.
- There is now no longer the option for an admin user to set the password for a new user.
- New users are assigned a temporary, random, password using SecureRandom.uuid
- The mailer uses the same template for both forgotten password new user scenarios.
- There is a logical switch inside the template to determine what the email contains.
- The subject is defined in locales/en.yml and is generic to suit both scenarios.
