### PR TITLE
reduce the chances of admin creating new user with wrong email

### DIFF
--- a/app/controllers/advocates/admin/advocates_controller.rb
+++ b/app/controllers/advocates/admin/advocates_controller.rb
@@ -21,7 +21,7 @@ class Advocates::Admin::AdvocatesController < Advocates::Admin::ApplicationContr
 
   def create
     @advocate = Advocate.new(params_with_temporary_password.merge(chamber_id: current_user.persona.chamber.id))
-
+    
     if @advocate.save
       @advocate.user.send_reset_password_instructions
       redirect_to advocates_admin_advocates_url, notice: 'Advocate successfully created'
@@ -64,7 +64,7 @@ class Advocates::Admin::AdvocatesController < Advocates::Admin::ApplicationContr
      :role,
      :apply_vat,
      :supplier_number,
-      user_attributes: [:id, :email, :password, :password_confirmation, :current_password, :first_name, :last_name]
+     user_attributes: [:id, :email, :email_confirmation, :password, :password_confirmation, :current_password, :first_name, :last_name]
     )
   end
 

--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -74,7 +74,7 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
      :days_worked_3,
      :days_worked_4,
      :approval_level,
-     user_attributes: [:id, :email, :current_password, :password, :password_confirmation, :first_name, :last_name],
+     user_attributes: [:id, :email, :email_confirmation, :current_password, :password, :password_confirmation, :first_name, :last_name],
      claim_ids: []
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,8 @@ class User < ActiveRecord::Base
   has_many :user_message_statuses, dependent: :destroy
 
   validates :first_name, :last_name, presence: true
+  validates :email, confirmation: true
+  attr_accessor :email_confirmation
 
   delegate :claims, to: :persona
 
@@ -53,4 +55,5 @@ class User < ActiveRecord::Base
   def sortable_name
     [last_name, first_name] * ' '
   end
+
 end

--- a/app/views/advocates/admin/advocates/_form.html.haml
+++ b/app/views/advocates/admin/advocates/_form.html.haml
@@ -14,19 +14,13 @@
       = user_fields.text_field :last_name, class: "form-control"
       = user_fields.label t(".email"), class: "form-label"
       = user_fields.email_field :email, class: "form-control"
+      = user_fields.label t(".email_confirmation"), class: "form-label"
+      = user_fields.email_field :email_confirmation, class: "form-control"
       
       = f.label :apply_vat, class: "form-label"
       %div.form-group.inline
         =f.collection_radio_buttons(:apply_vat, [true, false], :to_s, :to_s) do |b|
           - b.label(class: 'block-label') { b.radio_button + (b.value.to_s == 'true' ? 'Yes' : 'No') }
-     
-       
-
-      / - if @advocate.new_record?
-      /   = user_fields.label t(".password"), class: "form-label"
-      /   = user_fields.password_field :password, class: "form-control"
-      /   = user_fields.label t(".password_confirmation"), class: "form-label"
-      /   = user_fields.password_field :password_confirmation, class: "form-control"
 
     %fieldset.user-form
       = f.label t(".supplier_number"), class: "form-label"
@@ -38,7 +32,3 @@
           - b.label(class: "block-label") { b.radio_button + b.value.humanize }
 
   = f.submit 'Save', class: "button"
-
-
-
-

--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -3,17 +3,19 @@
     .validation-summary
       %h3.heading-small= "This case worker has #{pluralize(@case_worker.errors.count, 'error')}"
       %ul
-        - @case_worker.errors.full_messages.each do |msg|
+        - @case_worker.errors._full_messages.each do |msg|
           %li= msg
 
   = f.fields_for :user do |user_fields|
     %fieldset.user-form
-      = user_fields.label :first_name, class: "form-label"
+      = user_fields.label t('.first_name'), class: "form-label"
       = user_fields.text_field :first_name, class: "form-control"
-      = user_fields.label :last_name, class: "form-label"
+      = user_fields.label t('.last_name'), class: "form-label"
       = user_fields.text_field :last_name, class: "form-control"
-      = user_fields.label :email, class: "form-label"
+      = user_fields.label t('.email'), class: "form-label"
       = user_fields.email_field :email, class: "form-control"
+      = user_fields.label t('.email_confirmation'), class: "form-label"
+      = user_fields.email_field :email_confirmation, class: "form-control"
 
     %fieldset.user-form
       %div.form-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
   datetime:
     formats:
       default: "%d/%m/%Y %H:%M"
+
   dictionary:
     errors:
       blank: &blank "cannot be blank"
@@ -37,29 +38,36 @@ en:
       view: &view 'View'
     models:
       advocate: &advocate 'Advocate'
+      case_worker: &case_worker 'Case worker'
     attributes:
       users:
         role: &role 'Role'
         email: &email 'Email'
+        email_confirmation: &email_confirmation 'Email confirmation'
         password: &password 'Password'
         password_confirmation: &password_confirmation 'Password confirmation'
         first_name: &first_name 'First name'
         middle_name: &middle_name 'Middle name'
         lasst_name: &last_name 'Last name'
+
   activerecord:
     models:
       advocate: *advocate
+      case_worker: *case_worker
       claim: 'Claim'
       defendant: 'Defendant'
     attributes:
       advocate:
         role: *role
         supplier_number: 'Supplier number'
+      case_worker:
+        role: *role
       user:
         email: *email
         password: *password
         first_name: *first_name
         last_name: *last_name
+        email_confirmation: *email_confirmation
       claim:
         advocate: *advocate
         offence: 'Offence'
@@ -77,10 +85,17 @@ en:
             supplier_number:
               blank: cannot be blank
               invalid: 'must be 5 alhpa-numeric characters'
+        case_worker:
+          attributes:
+            role:
+              blank: Role cannot be blank
         user:
           attributes:
             email:
               blank: *blank
+            email_confirmation:
+              confirmation: 'and email must match'
+              blank: You must enter an email confirmation
             password:
               blank: cannot be blank
             password_confirmation:
@@ -157,6 +172,7 @@ en:
           error: 'error'
           prohibited_save: 'This advocate has'
           email: *email
+          email_confirmation: *email_confirmation
           password: *password
           password_confirmation: *password_confirmation
           first_name: *first_name
@@ -391,7 +407,7 @@ en:
       net_total: Net total
       vat_amount: VAT Amount
 
-
+# en.case_workers
   case_workers:
     admin:
       case_workers:
@@ -402,6 +418,11 @@ en:
           approval_limit: Approval limit
           location: Location
           working_days: Working days
+        form:
+          first_name: *first_name
+          last_name: *last_name
+          email: *email
+          email_confirmation: *email_confirmation
         change_password:
           error: 'error'
           prohibited_save: 'This case worker password change has'

--- a/features/new_user.feature
+++ b/features/new_user.feature
@@ -8,6 +8,13 @@ Scenario: New advocate user
   Then I see confirmation that a new "Advocate" user has been created
     And an email is sent to the new user
 
+Scenario: New advocate with mismatching email_confirmation
+  Given I am a signed in advocate admin
+    And I am on the new "advocate" page
+  When I fill in the "advocate" details but email and email_confirmation do not match
+    And click save
+  Then I see an error message
+
 Scenario: New caseworker user
   Given I am a signed in case worker admin
     And I am on the new "case_worker" page
@@ -15,3 +22,10 @@ Scenario: New caseworker user
     And click save
   Then I see confirmation that a new "Case worker" user has been created
     And an email is sent to the new user
+
+Scenario: New caseworker with mismatching email_confirmation
+  Given I am a signed in case worker admin
+    And I am on the new "case_worker" page
+  When I fill in the "case_worker" details but email and email_confirmation do not match
+    And click save
+  Then I see an error message

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -7,6 +7,25 @@ When(/^I fill in the "(.*?)" details$/) do |persona|
   fill_in "#{persona}_user_attributes_first_name", with: 'Harold'
   fill_in "#{persona}_user_attributes_last_name", with: 'Hughes'
   fill_in "#{persona}_user_attributes_email", with: 'harold.hughes@example.com'
+  fill_in "#{persona}_user_attributes_email_confirmation", with: 'harold.hughes@example.com'
+  case persona
+  when 'advocate'
+    choose(('advocate[apply_vat]').first)
+    fill_in 'advocate_supplier_number', with: '31425'
+    choose(("#{persona}[role]").first)
+  when 'case_worker'
+    check('case_worker[days_worked_0]')
+    choose('case_worker_approval_level_high')
+    choose('case_worker[location_id]')
+    choose('case_worker_role_case_worker')
+  end
+end
+
+When(/^I fill in the "(.*?)" details but email and email_confirmation do not match$/) do |persona|
+  fill_in "#{persona}_user_attributes_first_name", with: 'Harold'
+  fill_in "#{persona}_user_attributes_last_name", with: 'Hughes'
+  fill_in "#{persona}_user_attributes_email", with: 'harold.hughes@example.com'
+  fill_in "#{persona}_user_attributes_email_confirmation", with: 'another_email@example.com'
   case persona
   when 'advocate'
     choose(('advocate[apply_vat]').first)
@@ -34,4 +53,8 @@ Then(/^an email is sent to the new user$/) do
   expect(ActionMailer::Base.deliveries.length).to eq 1
   expect(ActionMailer::Base.deliveries.first.to).to eq ["harold.hughes@example.com"]
   expect(ActionMailer::Base.deliveries.first.subject).to eq "Advocate Defence Payments - Change your password"
+end
+
+Then(/^I see an error message$/) do
+  expect(page).to have_content "Email confirmation and email must match"
 end


### PR DESCRIPTION
- Force admin user to enter a new users email address twice
- This will reduce the chances of them creating a user with the wrong email address
- And an email being sent out to the wrong person
