### PR TITLE
modify translator to handle gov_uk_date_fields error

### DIFF
--- a/app/presenters/error_message_translator.rb
+++ b/app/presenters/error_message_translator.rb
@@ -36,7 +36,13 @@ class ErrorMessageTranslator
 
   private
 
+  # needed for GovUkDateField error handling (at least)
+  def format_error(error)
+    error.gsub(/\s+/,'_').downcase
+  end
+
   def get_messages(translations, key, error)
+    error = format_error(error)
     if key_refers_to_numbered_submodel?(key)  && submodel_key_exists?(translations, key)
       translation_subset, submodel_key = extract_last_submodel_attribute(translations, key)
       get_messages(translation_subset, submodel_key, error)

--- a/app/validators/claim_date_validator.rb
+++ b/app/validators/claim_date_validator.rb
@@ -23,7 +23,7 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be more than 5 years old
   def validate_trial_fixed_notice_at
     if @record.case_type  && @record.case_type.requires_cracked_dates?
-      validate_presence(:trial_fixed_notice_at, "blank_#{snake_case_type}_date") 
+      validate_presence(:trial_fixed_notice_at, "blank_#{snake_case_type}_date")
       validate_not_after(Date.today, :trial_fixed_notice_at, "check_#{snake_case_type}_date")
       validate_not_before(Settings.earliest_permitted_date, :trial_fixed_notice_at, "check_#{snake_case_type}_date")
       validate_not_before(earliest_rep_order, :trial_fixed_notice_at, "check_#{snake_case_type}_date")
@@ -37,7 +37,7 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be before trial_fixed_notice_at
   def validate_trial_fixed_at
     if @record.case_type  && @record.case_type.requires_cracked_dates?
-      validate_presence(:trial_fixed_at, "blank_#{snake_case_type}_date") 
+      validate_presence(:trial_fixed_at, "blank_#{snake_case_type}_date")
       validate_not_after(Date.today, :trial_fixed_at, "check_#{snake_case_type}_date")
       validate_not_before(Settings.earliest_permitted_date, :trial_fixed_at, "check_#{snake_case_type}_date")
       validate_not_before(earliest_rep_order, :trial_fixed_at, "check_#{snake_case_type}_date")
@@ -52,7 +52,7 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be before the trial fixed/warned issued
   def validate_trial_cracked_at
     if @record.case_type && @record.case_type.requires_cracked_dates?
-      validate_presence(:trial_cracked_at, "blank_#{snake_case_type}_date") 
+      validate_presence(:trial_cracked_at, "blank_#{snake_case_type}_date")
       validate_not_after(Date.today, :trial_cracked_at, "check_#{snake_case_type}_date")
       validate_not_before(Settings.earliest_permitted_date, :trial_cracked_at, "check_#{snake_case_type}_date")
       validate_not_before(earliest_rep_order, :trial_cracked_at, "check_#{snake_case_type}_date")
@@ -65,8 +65,8 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be before first rep order date
   # cannot be more than 5 years in the past
   def validate_first_day_of_trial
-    if @record.case_type && @record.case_type.requires_trial_dates? 
-      validate_presence(:first_day_of_trial, "blank") 
+    if @record.case_type && @record.case_type.requires_trial_dates?
+      validate_presence(:first_day_of_trial, "blank")
       validate_not_after(@record.trial_concluded_at, :first_day_of_trial, "blank")
       validate_not_before(earliest_rep_order, :first_day_of_trial, "blank")
       validate_not_before(Settings.earliest_permitted_date, :first_day_of_trial, "blank")
@@ -78,7 +78,7 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be before the first rep order was granted
   # cannot be more than 5 years in sthe past
   def validate_trial_concluded_at
-    if @record.case_type && @record.case_type.requires_trial_dates? 
+    if @record.case_type && @record.case_type.requires_trial_dates?
       validate_presence(:trial_concluded_at, "blank")
       validate_not_before(@record.first_day_of_trial, :trial_concluded_at, "blank")
       validate_not_before(earliest_rep_order, :trial_concluded_at, "blank")

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -75,6 +75,10 @@ case_number:
 first_day_of_trial:
   _seq: 60
   blank:
+    long: Enter a date for the first day of trial
+    short: Enter a date
+    api: Enter a date for the first day of trial
+  invalid_date:
     long: Enter a valid date for the first day of trial
     short: Enter a valid date
     api: Enter a valid date for the first day of trial
@@ -105,8 +109,12 @@ trial_concluded_at:
   _seq: 90
   blank:
     long: Enter the date on which the trial concluded
-    short: Enter a valid date
+    short: Enter a date
     api: Enter the date on which the trial concluded
+  invalid_date:
+    long: 'Enter a valid date for trial concluded'
+    short: Enter a valid date
+    api: 'Enter a valid date for trial concluded'
 
 trial_fixed_notice_at:
   _seq: 110
@@ -126,6 +134,10 @@ trial_fixed_notice_at:
     long: 'Check the date for "Notice of 1st fixed/warned issued"'
     short: Check this date
     api: 'Check the date for "Notice of 1st fixed/warned issued"'
+  invalid_date:
+    long: 'Enter a valid date for the "Notice of 1st fixed/warned issued"'
+    short: Enter a valid date
+    api: 'Enter a valid date for the "Notice of 1st fixed/warned issued"'
 
 trial_fixed_at:
   _seq: 120
@@ -145,6 +157,10 @@ trial_fixed_at:
     long: Check the date for "1st fixed/warned trial"
     short: Check this date
     api: Check the date for "1st fixed/warned trial"
+  invalid_date:
+      long: 'Enter a valid date for the "1st fixed/warned trial"'
+      short: Enter a valid date
+      api: 'Enter a valid date for the "1st fixed/warned trial"'
 
 trial_cracked_at:
   _seq: 130
@@ -164,6 +180,10 @@ trial_cracked_at:
     long: Check the date for "Case cracked"
     short: Check this date
     api: Check the date for "Case cracked"
+  invalid_date:
+    long: 'Enter a valid date for "Case cracked"'
+    short: Enter a valid date
+    api: 'Enter a valid date for "Case cracked"'
 
 trial_cracked_at_third:
   _seq: 140
@@ -212,6 +232,11 @@ defendant:
       long: "Check the date of birth for of the #{defendant}"
       short: Check the date of birth
       api: "Check the date of birth for the defendant"
+    invalid:
+      long: "Enter a valid date of birth for the #{defendant}"
+      short: Enter a valid date
+      api: "Enter a valid date of birth for the defendant"
+
 
   representation_orders:
     _seq: 200
@@ -247,6 +272,10 @@ representation_order:
       long: 'Enter a valid representation order date for the #{representation_order} of the #{defendant}'
       short: Enter a valid date
       api: 'Enter a valid representation order date for the representation order of the defendant'
+    invalid_date:
+      long: 'Enter a valid date for the representation order date of the #{representation_order} of the #{defendant}'
+      short: Enter a valid date
+      api: 'Enter a valid date for the representation order date of the representation order of the defendant'
 
   maat_reference:
     _seq: 30
@@ -531,6 +560,10 @@ date_attended:
       long: 'The #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{expense} is more than 5 years ago'
       short: Enter a date less than 5 years ago
       api: The date attended (from) must be less than 5 years ago
+    invalid_date:
+      long: 'Enter a valid date for the #{date_attended} (from) of the #{basic_fee}#{fixed_fee}#{misc_fee}#{expense}'
+      short: Enter a valid date
+      api: 'Enter a valid date for the date attended (from)'
 
   date_to:
     _seq: 20
@@ -542,3 +575,7 @@ date_attended:
       long: 'The #{date_attended} (to) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{expense} is invalid'
       short: Enter a date that is not in the future
       api: The date attended (to) cannot be in the future
+    invalid_date:
+      long: 'Enter a valid date for the #{date_attended} (to) of the #{basic_fee}#{fixed_fee}#{misc_fee}#{expense}'
+      short: Enter a valid date
+      api: 'Enter a valid date for the date attended (to)'

--- a/spec/api/v1/claims/date_attended_spec.rb
+++ b/spec/api/v1/claims/date_attended_spec.rb
@@ -101,6 +101,14 @@ describe API::V1::Advocates::DateAttended do
         end
       end
 
+      context 'malformed date format' do
+          it 'rejects malformed dates' do
+            valid_params[:date] = '2015-05-32'
+            post_to_create_endpoint
+            expect_error_response("Enter a valid date for the date attended (from)",1)
+          end
+      end
+
     end
 
   end


### PR DESCRIPTION
the gov_uk_date_fields gem raises an "Invalid date"
error for dates that are illegal e.g 32/1/2015. This needed
separate handling.
