### PR TITLE
Remove cracked trial validation

### DIFF
--- a/app/validators/claim_date_validator.rb
+++ b/app/validators/claim_date_validator.rb
@@ -23,7 +23,7 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be more than 5 years old
   def validate_trial_fixed_notice_at
     if @record.case_type  && @record.case_type.requires_cracked_dates?
-      validate_presence(:trial_fixed_notice_at, "blank_#{snake_case_type}_date") 
+      validate_presence(:trial_fixed_notice_at, "blank_#{snake_case_type}_date")
       validate_not_after(Date.today, :trial_fixed_notice_at, "check_#{snake_case_type}_date")
       validate_not_before(Settings.earliest_permitted_date, :trial_fixed_notice_at, "check_#{snake_case_type}_date")
       validate_not_before(earliest_rep_order, :trial_fixed_notice_at, "check_#{snake_case_type}_date")
@@ -31,14 +31,13 @@ class ClaimDateValidator < BaseClaimValidator
   end
 
   # required when case type is cracked, cracked before retrieal
-  # cannot be in the future
+  # REMOVED as trial may never have occured - cannot be in the future
   # cannot be before earliest rep order
   # cannot be more than 5 years old
   # cannot be before trial_fixed_notice_at
   def validate_trial_fixed_at
     if @record.case_type  && @record.case_type.requires_cracked_dates?
-      validate_presence(:trial_fixed_at, "blank_#{snake_case_type}_date") 
-      validate_not_after(Date.today, :trial_fixed_at, "check_#{snake_case_type}_date")
+      validate_presence(:trial_fixed_at, "blank_#{snake_case_type}_date")
       validate_not_before(Settings.earliest_permitted_date, :trial_fixed_at, "check_#{snake_case_type}_date")
       validate_not_before(earliest_rep_order, :trial_fixed_at, "check_#{snake_case_type}_date")
       validate_not_before(@record.trial_fixed_notice_at, :trial_fixed_at, "check_#{snake_case_type}_date")
@@ -52,7 +51,7 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be before the trial fixed/warned issued
   def validate_trial_cracked_at
     if @record.case_type && @record.case_type.requires_cracked_dates?
-      validate_presence(:trial_cracked_at, "blank_#{snake_case_type}_date") 
+      validate_presence(:trial_cracked_at, "blank_#{snake_case_type}_date")
       validate_not_after(Date.today, :trial_cracked_at, "check_#{snake_case_type}_date")
       validate_not_before(Settings.earliest_permitted_date, :trial_cracked_at, "check_#{snake_case_type}_date")
       validate_not_before(earliest_rep_order, :trial_cracked_at, "check_#{snake_case_type}_date")
@@ -65,8 +64,8 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be before first rep order date
   # cannot be more than 5 years in the past
   def validate_first_day_of_trial
-    if @record.case_type && @record.case_type.requires_trial_dates? 
-      validate_presence(:first_day_of_trial, "blank") 
+    if @record.case_type && @record.case_type.requires_trial_dates?
+      validate_presence(:first_day_of_trial, "blank")
       validate_not_after(@record.trial_concluded_at, :first_day_of_trial, "blank")
       validate_not_before(earliest_rep_order, :first_day_of_trial, "blank")
       validate_not_before(Settings.earliest_permitted_date, :first_day_of_trial, "blank")
@@ -78,7 +77,7 @@ class ClaimDateValidator < BaseClaimValidator
   # cannot be before the first rep order was granted
   # cannot be more than 5 years in sthe past
   def validate_trial_concluded_at
-    if @record.case_type && @record.case_type.requires_trial_dates? 
+    if @record.case_type && @record.case_type.requires_trial_dates?
       validate_presence(:trial_concluded_at, "blank")
       validate_not_before(@record.first_day_of_trial, :trial_concluded_at, "blank")
       validate_not_before(earliest_rep_order, :trial_concluded_at, "blank")

--- a/spec/validators/claim_date_validator_spec.rb
+++ b/spec/validators/claim_date_validator_spec.rb
@@ -53,7 +53,6 @@ describe ClaimDateValidator do
   context 'trial fixed at' do
     context 'cracked trial claim' do
       it { should_error_if_not_present(cracked_trial_claim, :trial_fixed_at, 'blank_cracked_trial_date') }
-      it { should_error_if_in_future(cracked_trial_claim, :trial_fixed_at, 'check_cracked_trial_date') }
       it { should_error_if_not_too_far_in_the_past(cracked_trial_claim, :trial_fixed_at, 'check_cracked_trial_date') }
       it { should_error_if_earlier_than_earliest_repo_date(cracked_trial_claim, :trial_fixed_at, 'check_cracked_trial_date') }
       it { should_error_if_earlier_than_other_date(cracked_trial_claim, :trial_fixed_at, :trial_fixed_notice_at, 'check_cracked_trial_date') }
@@ -61,7 +60,6 @@ describe ClaimDateValidator do
 
     context 'cracked before retrial' do
       it { should_error_if_not_present(cracked_before_retrial_claim, :trial_fixed_at, 'blank_cracked_before_retrial_date') }
-      it { should_error_if_in_future(cracked_before_retrial_claim, :trial_fixed_at, 'check_cracked_before_retrial_date') }
       it { should_error_if_not_too_far_in_the_past(cracked_before_retrial_claim, :trial_fixed_at, 'check_cracked_before_retrial_date') }
       it { should_error_if_earlier_than_earliest_repo_date(cracked_before_retrial_claim, :trial_fixed_at, 'check_cracked_before_retrial_date') }
       it { should_error_if_earlier_than_other_date(cracked_before_retrial_claim, :trial_fixed_at, :trial_fixed_notice_at, 'check_cracked_before_retrial_date') }


### PR DESCRIPTION
   remove cracked trial trial date validation to prevent future dates

```
business analyst requested as was causing issues since
cracked trials may have cracked before the trial (which is then
in the future).
```
