### PR TITLE
Sticky start claim button

### DIFF
--- a/app/assets/javascripts/modules/advocates/claims/StickySection.js
+++ b/app/assets/javascripts/modules/advocates/claims/StickySection.js
@@ -1,0 +1,31 @@
+moj.Modules.StickySection = {
+  el: '.sticky-section',
+  $sectionWrapper : {},
+
+  isElementInViewport: function(){
+    var rect = this.$sectionWrapper[0].getBoundingClientRect();
+
+    return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
+    );
+  },
+
+  init: function() {
+    this.$sectionWrapper = $(this.el);
+    if (!this.$sectionWrapper.length) {
+      return;
+    }
+
+    this.toggleFixedPanel();
+    $(window).on('scroll', $.proxy(this.toggleFixedPanel, this));
+  },
+
+  toggleFixedPanel: function() {
+    this.$sectionWrapper
+      .find('p')
+      .toggleClass('fixed-panel-bar', !$.proxy(this.isElementInViewport, this)());
+  }
+};

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -146,3 +146,17 @@ form {
   margin-bottom: 0;
   padding-bottom: 0;
 }
+
+.controller-claims {
+  .fixed-panel-bar {
+    @include outer-block;
+    @include flex(1 0 auto);
+    width: 100%;
+    position: fixed;
+    bottom: 0;
+    background-color: #fff;
+    margin-bottom: 0;
+    padding-top: 15px;
+    border-top: 1px solid $border-colour;
+  }
+}

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -235,8 +235,9 @@
           = validation_error_message(@claim, :additional_information)
         .column-half
           &nbsp;
-    %p
-      = f.submit t('.submit_to_laa'), class: 'button left'
-      - if @claim.draft?
-        = f.submit t('.save_to_drafts'), class: 'button button-secondary left'
-      = link_to t('.clear_form'), new_advocates_claim_path, class: 'button button-secondary right', data: { confirm: 'Are you sure you want to clear this form?' }
+    .sticky-section
+      %p
+        = f.submit t('.submit_to_laa'), class: 'button left'
+        - if @claim.draft?
+          = f.submit t('.save_to_drafts'), class: 'button button-secondary left'
+        = link_to t('.clear_form'), new_advocates_claim_path, class: 'button button-secondary right', data: { confirm: 'Are you sure you want to clear this form?' }


### PR DESCRIPTION
The "Submit to LAA", "Save to Draft" and "Clear Form" buttons should now follows users up and down the Start a new claim page.
