### PR TITLE
add invalid date translation missing from defendant dob

### DIFF
--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -232,7 +232,7 @@ defendant:
       long: "Check the date of birth for of the #{defendant}"
       short: Check the date of birth
       api: "Check the date of birth for the defendant"
-    invalid:
+    invalid_date:
       long: "Enter a valid date of birth for the #{defendant}"
       short: Enter a valid date
       api: "Enter a valid date of birth for the defendant"


### PR DESCRIPTION
Adds a translation for the GovUkDateFields gem on defendant date of birth that i missed in previous PR
