### PR TITLE
Remove max fee quantity validation

### DIFF
--- a/app/validators/fee_validator.rb
+++ b/app/validators/fee_validator.rb
@@ -87,7 +87,7 @@ class FeeValidator < BaseClaimValidator
   end
 
   def validate_any_quantity
-    add_error(:quantity, 'invalid') if @record.quantity < 0 || @record.quantity > 100
+    add_error(:quantity, 'invalid') if @record.quantity < 0 || @record.quantity > 99999
   end
 
   def validate_amount
@@ -107,8 +107,7 @@ class FeeValidator < BaseClaimValidator
     # NOTE: this should be combinable with other non_baf logic
     # ignore for fixed fees (no baf required)
     # ignore if from the api (because basic fee instantiation sets
-    # the BAF to 1 and amount to 0 as part of claim creation
-    # however we could test if action is an update)
+    # the BAF to 1 and amount to 0 via claim creation endpoint)
     unless @record.claim.case_type.try(:is_fixed_fee?) || (@record.claim.try(:api_draft?) && @record.new_record?)
       add_error(:amount, 'baf_invalid') if @record.amount <= 0
     end

--- a/app/views/advocates/claims/_basic_fee_fields.html.haml
+++ b/app/views/advocates/claims/_basic_fee_fields.html.haml
@@ -7,7 +7,7 @@
           = raw t('.basic_fee_prompt_text')
     %td
       %a{name: "basic_fee_#{@basic_fee_count}_quantity"}
-      = f.number_field :quantity, value: number_with_precision_or_blank(f.object.quantity), class: 'quantity', min: 0, max: 999, maxlength: 3
+      = f.number_field :quantity, value: number_with_precision_or_blank(f.object.quantity), class: 'quantity', min: 0, max: 99999, maxlength: 5
       = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
     %td
       %a{name: "basic_fee_#{@basic_fee_count}_amount"}

--- a/app/views/advocates/claims/_fixed_fee_fields.html.haml
+++ b/app/views/advocates/claims/_fixed_fee_fields.html.haml
@@ -6,7 +6,7 @@
       = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_fee_type")
     %td
       %a{name: "fixed_fee_#{@fixed_fee_count}_quantity"}
-      = f.number_field :quantity, class: 'quantity', min: 0, max: 999, maxlength: 3
+      = f.number_field :quantity, class: 'quantity', min: 0, max: 99999, maxlength: 5
       = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_quantity")
     %td
       %a{name: "fixed_fee_#{@fixed_fee_count}_amount"}

--- a/app/views/advocates/claims/_misc_fee_fields.html.haml
+++ b/app/views/advocates/claims/_misc_fee_fields.html.haml
@@ -7,7 +7,7 @@
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
     %td
       %a{name: "misc_fee_#{@misc_fee_count}_quantity"}
-      = f.number_field :quantity, class: 'quantity', min: 0, max: 999, maxlength: 3
+      = f.number_field :quantity, class: 'quantity', min: 0, max: 99999, maxlength: 5
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_quantity")
     %td
       %a{name: "misc_fee_#{@misc_fee_count}_amount"}

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -424,7 +424,7 @@ basic_fee:
       api: Enter a valid amount for pages of prosecution evidence fees
     invalid:
       long: Enter a valid amount for the basic fee
-      short: Enter a valid quantity
+      short: Enter a valid amount
       api: Enter a valid amount for the basic fee
 
 #################################################################################

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -453,9 +453,9 @@ misc_fee:
   quantity:
     _seq: 30
     invalid:
-      long: 'Enter a quantity for the #{misc_fee}'
-      short: Enter a quantity
-      api: Enter a quantity for the miscellaneous fee
+      long: 'Enter a valid quantity for the #{misc_fee}'
+      short: Enter a valid quantity
+      api: Enter a valid quantity for the miscellaneous fee
 
 #################################################################################
 #                                                                               #
@@ -483,9 +483,9 @@ fixed_fee:
   quantity:
     _seq: 30
     invalid:
-      long: 'Enter a quantity for the #{fixed_fee}'
-      short: Enter a quantity
-      api: Enter a quantity for the fixed fee
+      long: 'Enter a valid quantity for the #{fixed_fee}'
+      short: Enter a valid quantity
+      api: Enter a valid quantity for the fixed fee
 
 #################################################################################
 #                                                                               #

--- a/features/unhappy_paths.feature
+++ b/features/unhappy_paths.feature
@@ -42,8 +42,8 @@ Scenario Outline: Attempt to submit claim to LAA without specifying required tex
     | field_id                                   | error_message                                      |
     | "claim_case_number"                        | "Enter a case number"                              |
     | "claim_defendants_attributes_0_first_name" | "Enter a first name for the first defendant"       |
-    | "claim_basic_fees_attributes_0_quantity"   | "Enter a quantity of 1 for basic fee"       |
-    | "claim_misc_fees_attributes_0_quantity"    | "Enter a quantity for the first miscellaneous fee" |
+    | "claim_basic_fees_attributes_0_quantity"   | "Enter a quantity of 1 for basic fee"              |
+    | "claim_misc_fees_attributes_0_quantity"    | "Enter a valid quantity for the first miscellaneous fee" |
     | "claim_expenses_attributes_0_quantity"     | "Enter a quantity for the first expense"           |
 
     # TODO: unhappy paths for representation order details

--- a/spec/validators/date_validation_helpers.rb
+++ b/spec/validators/date_validation_helpers.rb
@@ -55,7 +55,7 @@ module RspecDateValidationHelpers
 
   def should_be_valid_if_equal_to_value(record, field, value)
     record.send("#{field}=", value)
-    expect(record.send(:valid?)).to be true
     expect(record.errors[field]).to be_empty
+    expect(record.send(:valid?)).to be true
   end
 end

--- a/spec/validators/fee_validator_spec.rb
+++ b/spec/validators/fee_validator_spec.rb
@@ -53,6 +53,7 @@ describe FeeValidator do
   end
 
   describe 'quantity' do
+
     context 'basic fee (BAF)' do
       expected_error_message = 'baf_qty1'
       it { should_be_valid_if_equal_to_value(baf_fee, :quantity, 1) }
@@ -140,6 +141,16 @@ describe FeeValidator do
         end
         it { should_error_if_equal_to_value(pcm_fee, :quantity, 1, 'pcm_invalid') }
         it { should_error_if_equal_to_value(pcm_fee, :quantity, -1, 'pcm_invalid') }
+      end
+    end
+
+    context 'any other fee' do
+      it { should_error_if_equal_to_value(fee, :quantity, -1, 'invalid') }
+      it { should_be_valid_if_equal_to_value(fee, :quantity, 99999) }
+      it { should_error_if_equal_to_value(fee, :quantity, 100000,    'invalid') }
+
+      it 'should not allow zero if amount is not zero' do
+        should_error_if_equal_to_value(fee, :quantity, 0, 'invalid')
       end
     end
   end


### PR DESCRIPTION
default max quantity for a fee (if not specified elsewhere for specific fee types) was 100.  This causes a bug for Page of Prosecution Evidence, at least, which can be almost any number. default max amended to 99999
