### PR TITLE
Json importer api token

### DIFF
--- a/app/controllers/advocates/json_document_importers_controller.rb
+++ b/app/controllers/advocates/json_document_importers_controller.rb
@@ -2,11 +2,11 @@ class Advocates::JsonDocumentImportersController < ApplicationController
 
   skip_before_filter :verify_authenticity_token, :only => :create
   skip_load_and_authorize_resource only: [:create]
-  before_action :set_schema
+  before_action :set_schema, :get_api_key
   respond_to :js, :html
 
   def create
-    @json_document_importer = JsonDocumentImporter.new(json_document_importer_params.merge(schema: @schema))
+    @json_document_importer = JsonDocumentImporter.new(json_document_importer_params.merge(schema: @schema, api_key: @api_key))
     if @json_document_importer.valid?
       @json_document_importer.import!
       respond_to do |format|
@@ -28,6 +28,10 @@ class Advocates::JsonDocumentImportersController < ApplicationController
 
   def json_document_importer_params
     params.require(:json_document_importer).permit(:json_file)
+  end
+
+  def get_api_key
+    @api_key = current_user.persona.chamber.api_key
   end
 
 end

--- a/app/interfaces/api/v1/api_helper.rb
+++ b/app/interfaces/api/v1/api_helper.rb
@@ -38,8 +38,8 @@ module API
 
       def self.find_creator_by_email(email)
         user = User.advocates.find_by(email: email)
-        if user.blank? || !user.persona.admin?
-          raise API::V1::ArgumentError, 'Creator email is invalid or does not have administrator privileges'
+        if user.blank?
+          raise API::V1::ArgumentError, 'Creator email is invalid'
         else
           @advocate = user.persona
         end

--- a/app/models/json_template.rb
+++ b/app/models/json_template.rb
@@ -157,7 +157,9 @@ class JsonTemplate
     end
 
     def get_route_params(const)
-      API::V1::Advocates.const_get(const).endpoints.first.routes.first.route_params
+      route_params = API::V1::Advocates.const_get(const).endpoints.first.routes.first.route_params
+      route_params.delete("api_key")
+      route_params
     end
 
   end

--- a/spec/api/v1/claims/claim_spec.rb
+++ b/spec/api/v1/claims/claim_spec.rb
@@ -84,14 +84,7 @@ describe API::V1::Advocates::Claim do
     it "should return 400 and JSON error array when creator email is invalid" do
       valid_params[:creator_email] = "non_existent_admin@bigblackhole.com"
       post_to_validate_endpoint
-      expect_error_response("Creator email is invalid or does not have administrator privileges")
-    end
-
-     it "should return 400 and JSON error array when creator does not have admin role" do
-      vendor.update!(role: 'advocate')
-      valid_params[:creator_email] = "non_existent_admin@bigblackhole.com"
-      post_to_validate_endpoint
-      expect_error_response("Creator email is invalid or does not have administrator privileges")
+      expect_error_response("Creator email is invalid")
     end
 
     it "should return 400 and JSON error array when advocate email is invalid" do

--- a/spec/examples/cms_export_with_nulls.json
+++ b/spec/examples/cms_export_with_nulls.json
@@ -1,6 +1,7 @@
 [
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,

--- a/spec/examples/cms_exported_claim.json
+++ b/spec/examples/cms_exported_claim.json
@@ -1,6 +1,7 @@
 [
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,

--- a/spec/examples/invalid_cms_exported_claim.json
+++ b/spec/examples/invalid_cms_exported_claim.json
@@ -2,6 +2,7 @@
 [
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "case_type_id": 1,
       "indictment_number": "12345678",
       "first_day_of_trial": "2015-06-01",

--- a/spec/examples/json_schema_fail.json
+++ b/spec/examples/json_schema_fail.json
@@ -2,6 +2,7 @@
 [
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,

--- a/spec/examples/multiple_cms_export_with_errors.json
+++ b/spec/examples/multiple_cms_export_with_errors.json
@@ -2,6 +2,7 @@
 [
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,
       "indictment_number": "12345678",
@@ -66,6 +67,7 @@
   },
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,
@@ -131,6 +133,7 @@
   },
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,
@@ -196,6 +199,7 @@
   },
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,

--- a/spec/examples/multiple_cms_export_with_errors_2.json
+++ b/spec/examples/multiple_cms_export_with_errors_2.json
@@ -5,6 +5,7 @@
 [
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,
       "indictment_number": "12345678",
@@ -69,6 +70,7 @@
   },
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "case_type_id": 1,
       "indictment_number": "12345678",
       "first_day_of_trial": "2015-06-01",
@@ -132,6 +134,7 @@
   },
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,
@@ -195,6 +198,7 @@
   },
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,

--- a/spec/examples/multiple_cms_exported_claims.json
+++ b/spec/examples/multiple_cms_exported_claims.json
@@ -1,6 +1,7 @@
 [
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,
@@ -66,6 +67,7 @@
   },
   {
     "claim": {
+      "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
       "case_number": "A12345678",
       "case_type_id": 1,

--- a/spec/models/json_document_importer_spec.rb
+++ b/spec/models/json_document_importer_spec.rb
@@ -9,18 +9,18 @@ describe JsonDocumentImporter do
   let(:file_in_wrong_format)              { double 'erroneous_file_selection', tempfile: './features/examples/shorter_lorem.pdf', content_type: 'application/pdf' }
   let(:schema_validation_fail)            { double 'invalid_json_file', tempfile: './spec/examples/json_schema_fail.json', content_type: 'application/json'}
   let(:export_with_nulls)                 { double 'cms_export_with_nulls', tempfile: './spec/examples/cms_export_with_nulls.json', content_type: 'application/json'}
-  let(:importer)                          { JsonDocumentImporter.new(json_file: cms_exported_claim, schema: schema) }
-  let(:invalid_importer)                  { JsonDocumentImporter.new(json_file: invalid_cms_exported_claim, schema: schema) }
-  let(:multiple_claim_importer)           { JsonDocumentImporter.new(json_file: multiple_cms_exported_claims, schema: schema) }
-  let(:wrong_format_importer)             { JsonDocumentImporter.new(json_file: file_in_wrong_format, schema: schema) }
-  let(:schema_validation_fail_importer)   { JsonDocumentImporter.new(json_file: schema_validation_fail, schema: schema) }
-  let(:importer_with_nulls)               { JsonDocumentImporter.new(json_file: export_with_nulls, schema: schema) }
-  let(:claim_params)                      { {:source=>"json_import", "advocate_email"=>"advocate@example.com", "case_number"=>"A12345678", "case_type_id"=>1, "indictment_number"=>"12345678", "first_day_of_trial"=>"2015-06-01", "estimated_trial_length"=>3, "actual_trial_length"=>3, "trial_concluded_at"=>"2015-06-03", "advocate_category"=>"QC", "offence_id"=>1, "court_id"=>1, "cms_number"=>"12345678", "additional_information"=>"string", "apply_vat"=>true, "trial_fixed_notice_at"=>"2015-06-01", "trial_fixed_at"=>"2015-06-01", "trial_cracked_at"=>"2015-06-01"} }
-  let(:defendant_params)                  { {"first_name"=>"case", "last_name"=>"system", "date_of_birth"=>"1979-12-10", "order_for_judicial_apportionment"=>true, "claim_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7"} }
-  let(:rep_order_params)                  { {"granting_body"=>"Crown Court", "maat_reference"=>"1234567891", "representation_order_date"=>"2015-05-01", "defendant_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7"} }
-  let(:fee_params)                        { {"fee_type_id"=>2, "quantity"=>1, "amount"=>1.1, "claim_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7"} }
-  let(:expense_params)                    { {"expense_type_id"=>1, "quantity"=>1, "rate"=>1.1, "location"=>"London", "claim_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7"} }
-  let(:date_attended_params)              { {"attended_item_type"=>/Fee|Expense/, "date"=>"2015-06-01", "date_to"=>"2015-06-01", "attended_item_id"=>"1234"} }
+  let(:importer)                          { JsonDocumentImporter.new(json_file: cms_exported_claim, schema: schema, api_key: 'test_key') }
+  let(:invalid_importer)                  { JsonDocumentImporter.new(json_file: invalid_cms_exported_claim, schema: schema, api_key: 'test_key') }
+  let(:multiple_claim_importer)           { JsonDocumentImporter.new(json_file: multiple_cms_exported_claims, schema: schema, api_key: 'test_key') }
+  let(:wrong_format_importer)             { JsonDocumentImporter.new(json_file: file_in_wrong_format, schema: schema, api_key: 'test_key') }
+  let(:schema_validation_fail_importer)   { JsonDocumentImporter.new(json_file: schema_validation_fail, schema: schema, api_key: 'test_key') }
+  let(:importer_with_nulls)               { JsonDocumentImporter.new(json_file: export_with_nulls, schema: schema, api_key: 'test_key') }
+  let(:claim_params)                      { {:source=>"json_import", "creator_email"=>"advocateadmin@example.com", "advocate_email"=>"advocate@example.com", "case_number"=>"A12345678", "case_type_id"=>1, "indictment_number"=>"12345678", "first_day_of_trial"=>"2015-06-01", "estimated_trial_length"=>3, "actual_trial_length"=>3, "trial_concluded_at"=>"2015-06-03", "advocate_category"=>"QC", "offence_id"=>1, "court_id"=>1, "cms_number"=>"12345678", "additional_information"=>"string", "apply_vat"=>true, "trial_fixed_notice_at"=>"2015-06-01", "trial_fixed_at"=>"2015-06-01", "trial_cracked_at"=>"2015-06-01", api_key: 'test_key'} }
+  let(:defendant_params)                  { {"first_name"=>"case", "last_name"=>"system", "date_of_birth"=>"1979-12-10", "order_for_judicial_apportionment"=>true, "claim_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7", api_key: 'test_key'} }
+  let(:rep_order_params)                  { {"granting_body"=>"Crown Court", "maat_reference"=>"1234567891", "representation_order_date"=>"2015-05-01", "defendant_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7", api_key: 'test_key'} }
+  let(:fee_params)                        { {"fee_type_id"=>2, "quantity"=>1, "amount"=>1.1, "claim_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7", api_key: 'test_key'} }
+  let(:expense_params)                    { {"expense_type_id"=>1, "quantity"=>1, "rate"=>1.1, "location"=>"London", "claim_id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7", api_key: 'test_key'} }
+  let(:date_attended_params)              { {"attended_item_type"=>/Fee|Expense/, "date"=>"2015-06-01", "date_to"=>"2015-06-01", "attended_item_id"=>"1234", api_key: 'test_key'} }
   let(:successful_claim_response)         { double 'api_response', code: 201, body: {"id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7"}.to_json }
   let(:successful_defendant_response)     { double 'api_response', code: 201, body: {"id"=>"642ec639-5037-4d64-a3aa-27c377e51ea7"}.to_json }
   let(:successful_rep_order_response)     { double 'api_response', code: 201 }
@@ -29,7 +29,7 @@ describe JsonDocumentImporter do
   let(:successful_date_attended_response) { double 'api_response', code: 201 }
   let(:failed_claim_creation)             { double 'api_error_response', code: 400, body: [{"error"=>"Advocate email is invalid"}].to_json }
   let(:failed_claim_creation2)            { double 'api_error_response', code: 400, body: [{"error"=>"Case type cannot be blank, you must select a case type"}, {"error"=>"Court cannot be blank, you must select a court"}, {"error"=>"Case number cannot be blank, you must enter a case number"}, {"error"=>"Advocate category cannot be blank, you must select an appropriate advocate category"}, {"error"=>"Offence Category cannot be blank, you must select an offence category"}].to_json }
-  let(:failed_defendant_creation)         { double 'api_error_response', code: 400, body: [{"error"=> "Claim cannot be blank"}].to_json }
+  let(:failed_defendant_creation)         { double 'api_error_response', code: 400, body: [{"error"=> "Claim cannot be blank"}].to_json } 
 
   context 'parses a json document and' do
 


### PR DESCRIPTION
- The API key is now taken from current_user.persona.chamber in the json_document_importers_controller
- I have removed validation against the creator having admin rights (because regular advocates should be able to create claims, in their CMS, and submit via the API).
- Some adjustments to the example docs and specs were required.
