### PR TITLE
Extend expiration of reset password tokens to 7 days

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -189,7 +189,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 7.days
 
   # ==> Configuration for :encryptable
   # Allow you to use another encryption algorithm besides bcrypt (default). You can use


### PR DESCRIPTION
Reset password tokens valid for 7 days.
