### PR TITLE
determinations are created before assessment is made; use updated_at

### DIFF
--- a/app/models/claims/financial_summary.rb
+++ b/app/models/claims/financial_summary.rb
@@ -9,7 +9,7 @@ class Claims::FinancialSummary
 
   def authorised_claims
     @context.claims.any_authorised.joins(:determinations)
-      .where('determinations.created_at >= ?', Time.now.beginning_of_week).group('claims.id')
+      .where('determinations.updated_at >= ?', Time.now.beginning_of_week).group('claims.id')
   end
 
   def total_outstanding_claim_value


### PR DESCRIPTION
- authorised claims were not appearing in financial summary
- the #authorised_claims method was selecting claims based on when the determination was created
- but actually, determinations are created before assessment is made (for the form?)
- select claims based on when the determination was updated instead
