### PR TITLE
Exclude certain associations from claim cloning

### DIFF
--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -7,6 +7,13 @@ module Claims::Cloner
       nullify :last_submitted_at
       nullify :original_submission_date
       nullify :uuid
+      exclude_association :messages
+      exclude_association :case_worker_claims
+      exclude_association :case_workers
+      exclude_association :claim_state_transitions
+      exclude_association :versions
+      exclude_association :fees
+      exclude_association :expenses
       clone [:fees, :documents, :defendants, :expenses]
     end
 

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -12,8 +12,9 @@ module Claims::Cloner
       exclude_association :case_workers
       exclude_association :claim_state_transitions
       exclude_association :versions
-      exclude_association :fees
-      exclude_association :expenses
+      exclude_association :basic_fees
+      exclude_association :fixed_fees
+      exclude_association :misc_fees
       clone [:fees, :documents, :defendants, :expenses]
     end
 
@@ -69,6 +70,7 @@ module Claims::Cloner
     draft = amoeba_dup
     draft.state = 'draft'
     draft.save!
+
     draft
   end
 end

--- a/app/models/concerns/document_attachment.rb
+++ b/app/models/concerns/document_attachment.rb
@@ -40,6 +40,6 @@ module DocumentAttachment
   end
 
   def add_converted_preview_document
-    self.converted_preview_document = self.pdf_tmpfile
+    self.converted_preview_document = self.pdf_tmpfile if self.converted_preview_document_file_name.nil?
   end
 end


### PR DESCRIPTION
Excludes associations such as versions and messages from being cloned. Fixes duplication of fees/expenses when cloning.
