### PR TITLE
"Return to claim" goes back to claim form

### DIFF
--- a/app/views/advocates/certifications/new.html.haml
+++ b/app/views/advocates/certifications/new.html.haml
@@ -12,7 +12,7 @@
 
 
 
-    %p 
+    %p
       By ticking a box, you are confirming you are the Trial Advocate (in cases where legal aid was granted on or after 5th May 2015) or Instructed Advocate and that you are entitled to submit a claim in respect of this case. If our records indicate that you are not the Trial or Instructed Advocate, this may result in the claim being rejected without payment
 
     %p Please ensure you only tick the relevant box.
@@ -23,10 +23,10 @@
 
     =f.check_box :main_hearing
     =f.label :main_hearing, 'I attended the Main Hearing (1st day of trial)'
-     
-     
+
+
     %h3 All other claims:
-     
+
     %p I certify that I am the Instructed Advocate as:
     = f.check_box :notified_court
     = f.label :notified_court, 'I notified the court, in writing before the PCMH that I was the Instructed Advocate. <br/>A copy of the letter is attached.'.html_safe
@@ -34,29 +34,29 @@
     %p
     = f.check_box :attended_pcmh
     = f.label :attended_pcmh, 'I attended the PCMH (where the client was arraigned) and no other advocate wrote to the court prior to this to advice that they were the Instructed Advocate.'
-     
+
     %p
     = f.check_box :attended_first_hearing
     = f.label :attended_first_hearing, 'I attended the first hearing after the PCMH and no other advocate attended the PCMH or wrote to the court prior to this to advise that they were the Instructed Advocate.'
-    
+
     %p
     = f.check_box :previous_advocate_notified_court
-    = f.label :previous_advocate_notified_court, 'The previous Instructed Advocate notified the court in writing that they were no longer acting in this case and I was then instructed.'    
+    = f.label :previous_advocate_notified_court, 'The previous Instructed Advocate notified the court in writing that they were no longer acting in this case and I was then instructed.'
 
     %p
     = f.check_box :fixed_fee_case
     = f.label :fixed_fee_case, 'The case was a fixed fee (with a case number beginning with an S or A) and I attended the main hearing.'
-     
+
 
     %p All of the above options are in accordance with relevant provision of any secondary legislation arising from the Legal Aid, Sentencing and Punishment of Offenders Act 2012.
-     
-    %br 
+
+    %br
 
     %p You are also confirming that you:
-     
+
     %ul
       %li certify that where you have represented more than one defendant in a matter, only one claim has been, and will be made, for all those defendants together, including where one defendant has transferred representation to another advocate.
-      
+
       %li certify that no interim, hardship or staged payment has been received by you or any other advocate on any case number within this matter other than the one under which this claim is made unless fully detailed (case number, court and advocate supplier number under which payment was made) within this claim.
 
       %li certify that where there is a joined indictment, then all matters dealt with by you, as the Instructed Advocate, within that joined indictment are included in this claim.
@@ -87,5 +87,4 @@
     %p
 
     = f.submit "Certify and submit claim", class: "button"
-    = f.submit "Return to claim", class: 'button'
-
+    = link_to 'Return to claim', edit_advocates_claim_path(@claim), class: 'button'


### PR DESCRIPTION
Clicking "Return to claim" from certification returns user to claim form
