### PR TITLE
Archive button to archive completed claims

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -240,6 +240,10 @@ class Claim < ActiveRecord::Base
     draft?
   end
 
+  def archivable?
+    VALID_STATES_FOR_ARCHIVAL.include?(self.state)
+  end
+
   def perform_validation?
     self.force_validation? || self.validation_required?
   end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -12,6 +12,7 @@ module Claims::StateMachine
   CASEWORKER_DASHBOARD_UNALLOCATED_STATES       = %w( submitted redetermination awaiting_written_reasons )
   CASEWORKER_DASHBOARD_ARCHIVED_STATES          = %w( authorised part_authorised rejected refused archived_pending_delete)
   VALID_STATES_FOR_REDETERMINATION              = %w( authorised part_authorised refused )
+  VALID_STATES_FOR_ARCHIVAL                     = %w( authorised part_authorised refused rejected )
   NON_DRAFT_STATES                              = %w( allocated deleted authorised part_authorised refused rejected submitted )
   AUTHORISED_STATES                             = ADVOCATE_DASHBOARD_PART_AUTHORISED_STATES + ADVOCATE_DASHBOARD_COMPLETED_STATES
 

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -1,19 +1,19 @@
 %div.grid-row.claim-header
   %div.column-third
     %span.normal
-      = "Case number:"
+      = 'Case number:'
     %div.bold-xlarge
       = claim.case_number.blank? ? 'not-provided' : claim.case_number
   %div.column-two-thirds
     %div.left
       %span.normal
-        = "Status:"
+        = 'Status:'
       %div{class: "medium status #{claim.state}"}
         = claim.state.humanize
     - if current_user.persona.is_a?(CaseWorker)
       %div.right
         %span.normal
-          = "Other claims:"
+          = 'Other claims:'
         %div.normal.other-claims
           - if claim_ids.present? && claim_ids.include?(@claim.id)
             = claim_position_and_count
@@ -22,10 +22,12 @@
     - if current_user.persona.is_a?(Advocate)
       - if claim.editable?
         %div.right
-          = link_to "Edit this claim", edit_advocates_claim_path(claim), class: 'button'
-          = link_to "Delete draft", advocates_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button-secondary'
-      - if claim.rejected?
+          = link_to 'Edit this claim', edit_advocates_claim_path(claim), class: 'button'
+          = link_to 'Delete draft', advocates_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button-secondary'
+      - if claim.archivable?
         %div.right
-          = button_to 'Create draft and resubmit', clone_rejected_advocates_claim_path(claim), method: 'patch', class: 'button'
+          - if claim.rejected?
+            = button_to 'Create draft and resubmit', clone_rejected_advocates_claim_path(claim), method: 'patch', class: 'button', form: { style: 'display: inline-block;' }
+          = link_to 'Archive', advocates_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button-secondary'
 %div.bold-medium.claim-detail-header
-  = "Claim details"
+  = 'Claim details'

--- a/features/archive_claim.feature
+++ b/features/archive_claim.feature
@@ -1,0 +1,31 @@
+Feature: Archive claim
+  Background:
+    As an advocate I want to be able to archive my completed claims
+
+    Given I am a signed in advocate
+
+    Scenario Outline: Archive claims in valid states
+      Given I am on the detail page for a <state> claim
+       Then I should see the archive button
+       When I click on the archive button
+       Then the claim should be archived
+        And I should see the claim on the archive page
+
+      Examples:
+        | state                      |
+        | "refused"                  |
+        | "part_authorised"          |
+        | "rejected"                 |
+        | "authorised"               |
+
+    Scenario Outline: Archive claims in valid states
+      Given I am on the detail page for a <state> claim
+       Then I should not see the archive button
+        And I should not see the claim on the archive page
+
+      Examples:
+        | state                      |
+        | "allocated"                |
+        | "awaiting_written_reasons" |
+        | "redetermination"          |
+        | "draft"                    |

--- a/features/step_definitions/archive_claim_steps.rb
+++ b/features/step_definitions/archive_claim_steps.rb
@@ -1,0 +1,24 @@
+Then(/^I should( not)? see the archive button$/) do |negation|
+  does = negation.nil? ? 'to' : negation.gsub(/\s+/,'').downcase == 'not' ? 'to_not' : 'to'
+  within '.main-content' do
+    expect(page).method(does).call have_selector('a', text: /\AArchive\z/)
+  end
+end
+
+When(/^I click on the archive button$/) do
+  within '.main-content' do
+    click_on 'Archive'
+  end
+end
+
+Then(/^the claim should be archived$/) do
+  claim = Claim.last
+  expect(claim).to be_archived_pending_delete
+end
+
+Then(/^I should( not)? see the claim on the archive page$/) do |negation|
+  claim = Claim.last
+  does = negation.nil? ? 'to' : negation.gsub(/\s+/,'').downcase == 'not' ? 'to_not' : 'to'
+  visit archived_advocates_claims_path
+  expect(page).method(does).call have_content(claim.case_number)
+end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -664,6 +664,22 @@ RSpec.describe Claim, type: :model do
     end
   end
 
+  describe '#archivable?' do
+    it 'should not be archivable from states: allocated, archived_pending_delete, awaiting_written_reasons, draft, redetermination' do
+      %w( allocated awaiting_written_reasons draft redetermination ).each do |state|
+        claim = create("#{state}_claim".to_sym)
+        expect(claim.archivable?).to eq(false)
+      end
+    end
+
+    it 'should be archivable from states: refused, rejected, part authorised, authorised' do
+      %w( refused rejected part_authorised authorised ).each do |state|
+        claim = create("#{state}_claim".to_sym)
+        expect(claim.archivable?).to eq(true)
+      end
+    end
+  end
+
   describe '#validation_required?' do
 
     let(:claim) { FactoryGirl.create(:claim, source: 'web') }


### PR DESCRIPTION
"Archive" button to allow advocates to manually archive "completed" claims, i.e. authorised, part authorised, rejected and refused states.
