### PR TITLE
only paper_trail :state on claim model

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -89,7 +89,7 @@ class Claim < ActiveRecord::Base
 
   has_one  :certification
 
-  has_paper_trail on: [:update], ignore: [:created_at, :updated_at, :original_submission_date, :last_submitted_at, :evidence_checklist_ids]
+  has_paper_trail on: [:update], only: [:state]
 
   # advocate-relevant scopes
   scope :outstanding, -> { where(state: %w( submitted allocated )) }

--- a/features/claim_messages.feature
+++ b/features/claim_messages.feature
@@ -16,6 +16,18 @@ Feature: Claim messages
       And I leave a message
      Then I should see my message at the bottom of the message list
 
+  Scenario: Only updates to state are tracked by papertrail
+    Given I am a signed in advocate
+      And There are case types in place
+      And I am on the new claim page
+      And I fill in the claim details
+      And I save to drafts
+    When I edit the claim and save to draft
+      And I view the claim
+    Then I should not see any dates in the message history field
+      And I should see 'no messages found' in the claim history
+
+
   Scenario: View messages as an advocate
     Given I am a signed in advocate
       And I have a submitted claim with messages

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -49,7 +49,7 @@ Given(/^my chamber has (\d+) "(.*?)" claims$/) do |number, state|
   claims.each do |claim|
     claim.update_column(:advocate_id, advocate.id)
     claim.fees << create(:fee, :random_values, claim: claim, fee_type: create(:fee_type))
-    if claim.state == 'completed'
+    if claim.state == 'authorised'
       claim.assessment.update(fees: claim.total)
     elsif claim.state == 'part_authorised'
       claim.assessment.update(fees: claim.total / 2)     # arbitrarily authorise half the total for part-authorised
@@ -58,7 +58,6 @@ Given(/^my chamber has (\d+) "(.*?)" claims$/) do |number, state|
 end
 
 Given(/^my chamber has (\d+) "(.*?)" claims for advocate "(.*?)"$/) do |number, state, advocate_name|
-
   # add advocate to my chamber
   advocate = create_advocate_with_full_name(advocate_name)
   chamber = @advocate.chamber

--- a/features/step_definitions/claim_messages_steps.rb
+++ b/features/step_definitions/claim_messages_steps.rb
@@ -41,3 +41,17 @@ Given(/^I have a submitted claim with messages$/) do
   @messages = create_list(:message, 5, claim_id: @claim.id)
   @messages.each { |m| m.update_column(:sender_id, create(:advocate).user.id) }
 end
+
+When(/^I edit the claim and save to draft$/) do
+  claim = Claim.last
+  visit "/advocates/claims/#{claim.id}/edit"
+  click_on 'Save to drafts'
+end
+
+Then(/^I should not see any dates in the message history field$/) do
+  expect(page.all('div.event-date').count).to eq 0
+end
+
+Then(/^I should see 'no messages found' in the claim history$/) do
+  expect(page).to have_content('No messages found')
+end


### PR DESCRIPTION
- claim message histories had empty entries
- this was because attributes were being tracked by paper_trail that were not then used to generate messages (but they were present in versions, which is used to create the timeline)
