### PR TITLE
quantity of hours for travel time should not be integer

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -6,7 +6,7 @@
 #  expense_type_id :integer
 #  claim_id        :integer
 #  location        :string
-#  quantity        :integer
+#  quantity        :float
 #  rate            :decimal(, )
 #  amount          :decimal(, )
 #  created_at      :datetime

--- a/app/models/json_template.rb
+++ b/app/models/json_template.rb
@@ -155,6 +155,7 @@ class JsonTemplate
         text: 'string',
         date: 'string',
         decimal: 1.1,
+        float: 1.1
       }
     end
 

--- a/db/migrate/20151119175237_change_quantity_format_in_expenses.rb
+++ b/db/migrate/20151119175237_change_quantity_format_in_expenses.rb
@@ -1,0 +1,9 @@
+class ChangeQuantityFormatInExpenses < ActiveRecord::Migration
+  def up
+    change_column :expenses, :quantity, :float
+  end
+
+  def down
+    change_column :expenses, :quantity, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151115214327) do
+ActiveRecord::Schema.define(version: 20151119175237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -240,7 +240,7 @@ ActiveRecord::Schema.define(version: 20151115214327) do
     t.integer  "expense_type_id"
     t.integer  "claim_id"
     t.string   "location"
-    t.integer  "quantity"
+    t.float    "quantity"
     t.decimal  "rate"
     t.decimal  "amount"
     t.datetime "created_at"

--- a/features/step_definitions/claim_evidence_checklist_steps.rb
+++ b/features/step_definitions/claim_evidence_checklist_steps.rb
@@ -12,5 +12,6 @@ Then(/^I visit the claim show page$/) do
 end
 
 Then(/^I should see a list item for "(.*?)" evidence$/) do |text|
+  save_and_open_page
   expect(page).to have_selector('li', text: text)
 end

--- a/spec/api/v1/claims/expense_spec.rb
+++ b/spec/api/v1/claims/expense_spec.rb
@@ -90,7 +90,7 @@ describe API::V1::Advocates::Expense do
 
       context "unexpected error" do
         it "should return 400 and JSON error array of error message" do
-          params[:quantity] = 1000000000000000000000000
+          params[:location] = 1000000000000000000000000
           post_to_create_endpoint
           expect(last_response.status).to eq(400)
           json = JSON.parse(last_response.body)

--- a/spec/api/v1/claims/expense_spec.rb
+++ b/spec/api/v1/claims/expense_spec.rb
@@ -90,7 +90,7 @@ describe API::V1::Advocates::Expense do
 
       context "unexpected error" do
         it "should return 400 and JSON error array of error message" do
-          params[:location] = 1000000000000000000000000
+          allow_any_instance_of(Expense).to receive(:save!).and_raise(RangeError, "out of range for ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer")
           post_to_create_endpoint
           expect(last_response.status).to eq(400)
           json = JSON.parse(last_response.body)


### PR DESCRIPTION
- users commented that when they set travel time to float it is not persisted (always rounded to int)
- bug caused by the fact quantity is set as integer in the schema
- changed to :float
