### PR TITLE
Change filtering of claims on case worker allocation page

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -63,10 +63,19 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def filter_claims
-    if %w( fixed_fee cracked trial guilty_plea redetermination awaiting_written_reasons ).include?(params[:filter])
-      @claims = @claims.send(params[:filter].to_sym)
-    end
+    filter_by_state_and_type
+    filter_by_value
+  end
 
+  def filter_by_state_and_type
+    if %w( redetermination awaiting_written_reasons ).include?(params[:filter])
+      @claims = @claims.send(params[:filter].to_sym)
+    elsif %w( fixed_fee cracked trial guilty_plea ).include?(params[:filter])
+      @claims = @claims.where{state << %w( redetermination awaiting_written_reasons )}.send(params[:filter].to_sym)
+    end
+  end
+
+  def filter_by_value
     if params[:claim_value].present? && params[:claim_value] == 'high'
       @claims = @claims.total_greater_than_or_equal_to(Settings.high_value_claim_threshold)
     elsif params[:claim_value].present? && params[:claim_value] == 'low'

--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -68,10 +68,11 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def filter_by_state_and_type
-    if %w( redetermination awaiting_written_reasons ).include?(params[:filter])
-      @claims = @claims.send(params[:filter].to_sym)
-    elsif %w( fixed_fee cracked trial guilty_plea ).include?(params[:filter])
-      @claims = @claims.where{state << %w( redetermination awaiting_written_reasons )}.send(params[:filter].to_sym)
+    case params[:filter]
+      when 'redetermination', 'awaiting_written_reasons'
+        @claims = @claims.send(params[:filter].to_sym)
+      when 'fixed_fee', 'cracked', 'trial', 'guilty_plea'
+        @claims = @claims.where{state << %w( redetermination awaiting_written_reasons )}.send(params[:filter].to_sym)
     end
   end
 

--- a/features/claim_allocation.feature
+++ b/features/claim_allocation.feature
@@ -4,7 +4,7 @@ Feature: Claim allocation
 
     Given I am a signed in case worker admin
       And 2 case workers exist
-      And 10 submitted claims exist
+      And 5 submitted claims exist
 
   Scenario: Allocate claims to case worker
      When I visit the allocation page
@@ -41,21 +41,38 @@ Feature: Claim allocation
     Then I should see all claims
 
   Scenario Outline: Filtering claims
-      And There are case types in place
-    Given there are <quantity> "<type>" claims
+     Given There are case types in place
+       And there are <quantity> "<type>" claims
      When I visit the allocation page
       And I filter by "<type>"
      Then I should only see <quantity> "<type>" claims after filtering
 
     Examples:
       | type                     | quantity  |
-      | all                      | 10        |
-      | fixed_fee                | 10        |
-      | cracked                  | 10        |
-      | trial                    | 10        |
-      | guilty_plea              | 10        |
-      | redetermination          | 10        |
-      | awaiting_written_reasons | 10        |
+      | all                      | 5         |
+      | fixed_fee                | 2         |
+      | cracked                  | 2         |
+      | trial                    | 2         |
+      | guilty_plea              | 2         |
+      | redetermination          | 2         |
+      | awaiting_written_reasons | 2         |
+
+  Scenario Outline: Filtering by fixed_fee, cracked, trial, guilty_plea should not show redetermination or awaiting_written_reason claims
+    Given There are case types in place
+      And there are <quantity> "<type>" claims
+      And there are 2 "redetermination" claims
+      And there are 2 "awaiting_written_reasons" claims
+     When I visit the allocation page
+      And I filter by "<type>"
+     Then I should only see <quantity> "<type>" claims after filtering
+      And I should not see any redetermination or awaiting_written_reasons claims
+
+    Examples:
+      | type          | quantity |
+      | fixed_fee     | 2        |
+      | cracked       | 2        |
+      | trial         | 2        |
+      | guilty_plea   | 2        |
 
   Scenario: Filter then allocate
     Given There are case types in place
@@ -64,9 +81,9 @@ Feature: Claim allocation
       And I visit the allocation page
       And I filter by "fixed_fee"
       And I should only see 2 "fixed_fee" claims after filtering
-    When I enter 1 in the quantity text field
+     When I enter 1 in the quantity text field
       And I select a case worker
       And I click Allocate
-    Then the first 1 claims in the list should be allocated to the case worker
+     Then the first 1 claims in the list should be allocated to the case worker
       And the first 1 claims should no longer be displayed
 

--- a/features/step_definitions/claim_allocation_steps.rb
+++ b/features/step_definitions/claim_allocation_steps.rb
@@ -100,55 +100,57 @@ When(/^I filter by "(.*?)"$/) do |filter|
 end
 
 Then(/^I should only see (\d+) "(.*?)" claims? after filtering$/) do |quantity, type|
-  number = quantity.to_i
-
   claims = type == 'all' ? Claim.all : Claim.send(type.to_sym)
+  claims.each { |claim| expect(page).to have_selector("#claim_#{claim.id}") }
 
-  claims.each do |claim|
-    expect(page).to have_selector("#claim_#{claim.id}")
-  end
-
-  expect(claims.count).to eq(number)
+  expect(claims.count).to eq(quantity.to_i)
 
   within '.claim-count' do
-    expect(page).to have_content(/#{number} claims?/)
+    expect(page).to have_content(/#{quantity} claims?/)
   end
 end
 
 Given(/^high value claims exist$/) do
-  @claims[0..4].each do |claim|
+  @claims[0..2].each do |claim|
     claim.update_column(:total, Settings.high_value_claim_threshold)
   end
 end
 
 Given(/^low value claims exist$/) do
-  @claims[5..9].each do |claim|
+  @claims[3...5].each do |claim|
     claim.update_column(:total, Settings.high_value_claim_threshold - 100 )
   end
 end
 
 Then(/^I should only see high value claims$/) do
-  @claims[0..4].each do |claim|
+  @claims[0..2].each do |claim|
     expect(page).to have_selector("#claim_#{claim.id}")
   end
 
   within '.claim-count' do
-    expect(page).to have_content(/5 claims/)
+    expect(page).to have_content(/3 claims/)
   end
 end
 
 Then(/^I should only see low value claims$/) do
-  @claims[5..9].each do |claim|
+  @claims[3...5].each do |claim|
     expect(page).to have_selector("#claim_#{claim.id}")
   end
 
   within '.claim-count' do
-    expect(page).to have_content(/5 claims/)
+    expect(page).to have_content(/2 claims/)
   end
 end
 
 Then(/^I should see all claims$/) do
   @claims.each do |claim|
     expect(page).to have_selector("#claim_#{claim.id}")
+  end
+end
+
+Then(/^I should not see any redetermination or awaiting_written_reasons claims$/) do
+  claims = Claim.redetermination + Claim.awaiting_written_reasons
+  claims.each do |claim|
+    expect(page).to_not have_selector("#claim_#{claim.id}")
   end
 end


### PR DESCRIPTION
Filtering by fixed_fee, cracked, trial, guilty_plea does not show redetermination or awaiting_written_reason claims.
