### PR TITLE
Remove formatting on expense rates in claim summary

### DIFF
--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -71,7 +71,7 @@
                 %td
                   = expense.quantity
                 %td
-                  = '%.2f' % expense.rate
+                  = expense.rate
                 %td
                   = expense.amount
 


### PR DESCRIPTION
Formatting raises exception when expense rate is nil
