### PR TITLE
Add fee calculations

### DIFF
--- a/app/assets/javascripts/modules/advocates/claims/FeeCalculator.js
+++ b/app/assets/javascripts/modules/advocates/claims/FeeCalculator.js
@@ -1,13 +1,13 @@
 moj.Modules.FeeCalculator = {
-  el: '#expenses',
+  el: '#expenses, #basic-fees, #misc-fees, #fixed-fees',
 
   init : function() {
     this.addChangeEvent();
   },
 
-  calculateAmount: function(rate, quantity, modifier) {
+  calculateAmount: function(rate, quantity) {
     var r = rate || 0;
-    var q = (quantity || 0) + (modifier || 0);
+    var q = quantity || 0;
     q = q < 0 ? 0 : q;
     var t = (r * q).toFixed(2);
     t = t < 0 ? 0 : t;
@@ -20,9 +20,8 @@ moj.Modules.FeeCalculator = {
     $(this.el).on('change', '.quantity, .rate', function(e) {
       var wrapper  = $(e.target).closest('.nested-fields');
       var quantity = parseFloat(wrapper.find('.quantity').val());
-      var modifier = parseFloat(wrapper.find('.quantity-modifier').text());
       var rate     = parseFloat(wrapper.find('.rate').val());
-      var total = self.calculateAmount(rate,quantity,modifier);
+      var total = self.calculateAmount(rate,quantity);
       if (isNaN(total) ){
         wrapper.find('.amount').text(' ');
       }

--- a/app/assets/javascripts/modules/advocates/claims/FeeSectionDisplay.js
+++ b/app/assets/javascripts/modules/advocates/claims/FeeSectionDisplay.js
@@ -57,7 +57,7 @@ moj.Modules.FeeSectionDisplay = {
       // if there is 1 or more amount input elements with value attribute containing digits 1 to 9
       return $(container).find('.amount')
         .filter( function (index, el) {
-          return /[1-9]/.test($(el).val());
+          return /[1-9]/.test($(el).text());
         }).length > 0;
     }
 

--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -223,7 +223,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
        :fee_type_id,
        :fee_id,
        :quantity,
-       :amount,
+       :rate,
        :_destroy,
        dates_attended_attributes: [
           :id,
@@ -243,7 +243,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
        :fee_type_id,
        :fee_id,
        :quantity,
-       :amount,
+       :rate,
        :_destroy,
        dates_attended_attributes: [
           :id,
@@ -263,7 +263,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
        :fee_type_id,
        :fee_id,
        :quantity,
-       :amount,
+       :rate,
        :_destroy,
        dates_attended_attributes: [
           :id,

--- a/app/interfaces/api/v1/advocates/expense.rb
+++ b/app/interfaces/api/v1/advocates/expense.rb
@@ -16,9 +16,9 @@ module API
               # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
               optional :api_key, type: String,          desc: "REQUIRED: The API authentication key of the chamber"
               optional :claim_id, type: String,         desc: "REQUIRED: Unique identifier for the claim associated with this defendant."
-              optional :expense_type_id, type: Integer, desc: "REQUIRED: Reference to the parent expense type."
-              optional :quantity, type: Integer,        desc: "REQUIRED: Quantity of expenses of this type and rate."
-              optional :rate, type: Float,              desc: "REQUIRED: Rate for each expense."
+              optional :expense_type_id, type: Integer, desc: "REQUIRED: The unique identifier for the corresponding expense type."
+              optional :quantity, type: Float,          desc: "REQUIRED: The number of expenses of this type that are being claimed (quantity x rate will equal amount). rounded to nearest quarter."
+              optional :rate, type: Float,              desc: "REQUIRED: The currency value per unit/quantity of the expense (quantity x rate will equal amount)."
               optional :location, type:  String,        desc: "OPTIONAL: Location (e.g. of hotel) where applicable."
             end
 

--- a/app/interfaces/api/v1/advocates/fee.rb
+++ b/app/interfaces/api/v1/advocates/fee.rb
@@ -19,9 +19,9 @@ module API
               # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
               optional :api_key, type: String,      desc: "REQUIRED: The API authentication key of the chamber"
               optional :claim_id, type: String,     desc: 'REQUIRED: The unique identifier for the corresponding claim.'
-              optional :fee_type_id, type: Integer, desc: 'REQUIRED: The unique identifier for the corresponding FeeType'
-              optional :quantity, type: Integer,    desc: 'REQUIRED: The number of Fees being claimed for of this FeeType and Rate'
-              optional :amount, type: Float,        desc: 'REQUIRED: Total value.'
+              optional :fee_type_id, type: Integer, desc: 'REQUIRED: The unique identifier for the corresponding fee type'
+              optional :quantity, type: Integer,    desc: 'REQUIRED: The number of fees of this fee type that are being claimed (quantity x rate will equal amount)'
+              optional :rate, type: Float,          desc: 'REQUIRED: The currency value per unit/quantity of the fee (quantity x rate will equal amount).'
             end
 
             # NOTE: explicit error raising because claim_id's presence is not validated by model due to instatiation issues # TODO review in code review
@@ -39,7 +39,7 @@ module API
                 claim_id: claim_id,
                 fee_type_id: params[:fee_type_id],
                 quantity: params[:quantity],
-                amount: params[:amount]
+                rate: params[:rate]
               }
             end
 

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -30,7 +30,8 @@ class Fee < ActiveRecord::Base
 
   before_validation do
     self.quantity = 0 if self.quantity.blank?
-    self.amount = 0 if self.amount.blank?
+    self.rate = 0 if self.rate.blank?
+    self.amount = calculate_amount(quantity, rate)
   end
 
   after_save do
@@ -45,6 +46,10 @@ class Fee < ActiveRecord::Base
 
   def perform_validation?
     claim && claim.perform_validation?
+  end
+
+  def calculate_amount (quantity, rate)
+    quantity*rate
   end
 
   def self.new_blank(claim, fee_type)

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -31,7 +31,7 @@ class Fee < ActiveRecord::Base
   before_validation do
     self.quantity = 0 if self.quantity.blank?
     self.rate = 0 if self.rate.blank?
-    self.amount = calculate_amount(quantity, rate)
+    self.amount = self.calculated_amount
   end
 
   after_save do
@@ -48,8 +48,8 @@ class Fee < ActiveRecord::Base
     claim && claim.perform_validation?
   end
 
-  def calculate_amount (quantity, rate)
-    quantity*rate
+  def calculated_amount
+    self.quantity * self.rate
   end
 
   def self.new_blank(claim, fee_type)
@@ -97,6 +97,7 @@ class Fee < ActiveRecord::Base
 
   def clear
     self.quantity = nil;
+    self.rate = nil;
     self.amount = nil;
     # explicitly destroy child relations
     self.dates_attended.destroy_all unless self.dates_attended.empty?

--- a/app/presenters/fee_presenter.rb
+++ b/app/presenters/fee_presenter.rb
@@ -6,6 +6,11 @@ class FeePresenter < BasePresenter
     fee.dates_attended.order(date: :asc).map(&:to_s).join(', ')
   end
 
+
+ def rate
+    '%.2f' % fee.rate
+ end
+
  def amount
     h.number_to_currency(fee.amount)
  end

--- a/app/validators/fee_validator.rb
+++ b/app/validators/fee_validator.rb
@@ -91,6 +91,10 @@ class FeeValidator < BaseClaimValidator
   end
 
   def validate_rate
+    # TODO: this return should be removed once those claims (on gamma/beta-testing) created prior to rate being reintroduced
+    #       have been deleted/archived.
+    return if @record.is_before_rate_reintroduced?
+
     fee_code = @record.fee_type.try(:code)
     case fee_code
       when 'BAF'

--- a/app/views/advocates/claims/_basic_fee_fields.html.haml
+++ b/app/views/advocates/claims/_basic_fee_fields.html.haml
@@ -10,11 +10,13 @@
       = f.number_field :quantity, value: number_with_precision_or_blank(f.object.quantity), class: 'quantity', min: 0, max: 99999, maxlength: 5
       = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
     %td
-      %a{name: "basic_fee_#{@basic_fee_count}_amount"}
+      %a{name: "basic_fee_#{@basic_fee_count}_rate"}
       %div.pound-wrapper
-        = f.label :amount, '£', class: 'pound-sign bold-xsmall'
-        = f.text_field :amount, value: number_with_precision(f.object.amount, precision: 2), class: 'amount', size: 10, maxlength: 8
-      = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_amount")
+        = f.label :rate, '£', class: 'pound-sign bold-xsmall'
+        = f.text_field :rate, value: number_with_precision(f.object.rate, precision: 2), class: 'rate', size: 10, maxlength: 8
+      = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_rate")
+    %td.amount
+      = number_to_currency(f.object.amount)
     %td.add-basic-fee-date-attended
       - if f.object.fee_type.has_dates_attended?
         = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'button-secondary', data: {'association-insertion-method' => 'after', 'association-insertion-traversal' => 'closest', 'association-insertion-node' => 'tr'}

--- a/app/views/advocates/claims/_fixed_fee_fields.html.haml
+++ b/app/views/advocates/claims/_fixed_fee_fields.html.haml
@@ -9,11 +9,13 @@
       = f.number_field :quantity, class: 'quantity', min: 0, max: 99999, maxlength: 5
       = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_quantity")
     %td
-      %a{name: "fixed_fee_#{@fixed_fee_count}_amount"}
+      %a{name: "fixed_fee_#{@misc_fee_count}_rate"}
       %div.pound-wrapper
-        = f.label :amount, '£', class: 'pound-sign bold-xsmall'
-        = f.text_field :amount, value: number_with_precision(f.object.amount, precision: 2), class: 'amount', size: 10, maxlength: 8
-      = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_amount")
+        = f.label :rate, '£', class: 'pound-sign bold-xsmall'
+        = f.text_field :rate, value: number_with_precision(f.object.rate, precision: 2), class: 'rate', size: 10, maxlength: 8
+      = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_rate")
+    %td.amount
+      = number_to_currency(f.object.amount)
     %td.add-fixed-fee-date-attended
       = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'button-secondary', data: {'association-insertion-method' => 'after', 'association-insertion-traversal' => 'closest', 'association-insertion-node' => 'tr'}
     %td.remove-fixed-fee

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -100,6 +100,8 @@
               %th
                 = t('.quantity')
               %th
+                = t('.rate')
+              %th
                 = t('.amount')
               %th
             = f.fields_for :basic_fees do |basic_fee_fields|
@@ -117,6 +119,8 @@
                 = t('.fee_type')
               %th
                 = t('.quantity')
+              %th
+                = t('.rate')
               %th
                 = t('.amount')
               %th
@@ -138,6 +142,8 @@
                 = t('.fee_type')
               %th
                 = t('.quantity')
+              %th
+                = t('.rate')
               %th
                 = t('.amount')
               %th

--- a/app/views/advocates/claims/_misc_fee_fields.html.haml
+++ b/app/views/advocates/claims/_misc_fee_fields.html.haml
@@ -10,11 +10,13 @@
       = f.number_field :quantity, class: 'quantity', min: 0, max: 99999, maxlength: 5
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_quantity")
     %td
-      %a{name: "misc_fee_#{@misc_fee_count}_amount"}
+      %a{name: "misc_fee_#{@misc_fee_count}_rate"}
       %div.pound-wrapper
-        = f.label :amount, '£', class: 'pound-sign bold-xsmall'
-        = f.text_field :amount, value: number_with_precision(f.object.amount, precision: 2), class: 'amount', size: 10, maxlength: 8
-      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_amount")
+        = f.label :rate, '£', class: 'pound-sign bold-xsmall'
+        = f.text_field :rate, value: number_with_precision(f.object.rate, precision: 2), class: 'rate', size: 10, maxlength: 8
+      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_rate")
+    %td.amount
+      = number_to_currency(f.object.amount)
     %td.add-misc-fee-date-attended
       = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'button-secondary', data: {'association-insertion-method' => 'after', 'association-insertion-traversal' => 'closest', 'association-insertion-node' => 'tr'}
     %td.remove-misc-fee

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -16,6 +16,8 @@
             %th
               = t('.quantity')
             %th
+              = t('.rate')
+            %th
               = t('.amount')
         %tbody
           - claim.fees.select(&:present?).each do |fee_object|
@@ -31,6 +33,8 @@
                   = fee.fee_type.description
                 %td
                   = fee.quantity
+                %td
+                  = fee.rate
                 %td
                   = fee.amount
       .totals

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -336,96 +336,96 @@ basic_fee:
       short: Enter a valid quantity
       api: Enter a valid quantity for the basic fee
 
-  amount:
+  rate:
     _seq: 20
     baf_invalid:
-      long: Enter a valid amount for the basic fee
-      short: Enter a valid amount
-      api: Enter a valid amount for the basic fee
+      long: Enter a valid rate for the basic fee
+      short: Enter a valid rate
+      api: Enter a valid rate for the basic fee
     daf_zero:
-      long: Enter a valid amount for daily attendance fees (3-40 days)
-      short: Enter a valid amount
-      api: Enter a valid amount for daily attendance fees (3-40 days)
+      long: Enter a valid rate for daily attendance fees (3-40 days)
+      short: Enter a valid rate
+      api: Enter a valid rate for daily attendance fees (3-40 days)
     daf_invalid:
-      long: Enter a valid amount for daily attendance fees (3-40 days)
-      short: Enter a valid amount
-      api: Enter a valid amount for daily attendance fees (3-40 days)
+      long: Enter a valid rate for daily attendance fees (3-40 days)
+      short: Enter a valid rate
+      api: Enter a valid rate for daily attendance fees (3-40 days)
     dah_zero:
-      long: Enter a valid amount for daily attendance fees (41-50 days)
-      short: Enter a valid amount
-      api: Enter a valid amount for daily attendance fees (41-50 days)
+      long: Enter a valid rate for daily attendance fees (41-50 days)
+      short: Enter a valid rate
+      api: Enter a valid rate for daily attendance fees (41-50 days)
     dah_invalid:
-      long: Enter a valid amount for daily attendance fees (41-50 days)
-      short: Enter a valid amount
-      api: Enter a valid amount for daily attendance fees (41-50 days)
+      long: Enter a valid rate for daily attendance fees (41-50 days)
+      short: Enter a valid rate
+      api: Enter a valid rate for daily attendance fees (41-50 days)
     daj_zero:
-      long: Enter a valid amount for daily attendance fees (51+ days)
-      short: Enter a valid amount
-      api: Enter a valid amount for daily attendance fees (51+ days)
+      long: Enter a valid rate for daily attendance fees (51+ days)
+      short: Enter a valid rate
+      api: Enter a valid rate for daily attendance fees (51+ days)
     daj_invalid:
-      long: Enter a valid amount for daily attendance fees (51+ days)
-      short: Enter a valid amount
-      api: Enter a valid amount for daily attendance fees (51+ days)
+      long: Enter a valid rate for daily attendance fees (51+ days)
+      short: Enter a valid rate
+      api: Enter a valid rate for daily attendance fees (51+ days)
     saf_zero:
-      long: Enter a valid amount for standard appearance fees
-      short: Enter a valid amount
-      api: Enter a valid amount for standard appearance fees
+      long: Enter a valid rate for standard appearance fees
+      short: Enter a valid rate
+      api: Enter a valid rate for standard appearance fees
     saf_invalid:
-      long: Enter a valid amount for standard appearance fees
-      short: Enter a valid amount
-      api: Enter a valid amount for standard appearance fees
+      long: Enter a valid rate for standard appearance fees
+      short: Enter a valid rate
+      api: Enter a valid rate for standard appearance fees
     pcm_zero:
-      long: Enter a valid amount for plea and case management hearing fees
-      short: Enter a valid amount
-      api: Enter a valid amount for plea and case management hearing fees
+      long: Enter a valid rate for plea and case management hearing fees
+      short: Enter a valid rate
+      api: Enter a valid rate for plea and case management hearing fees
     pcm_invalid:
-      long: Enter a valid amount for plea and case management hearing fees
-      short: Enter a valid amount
-      api: Enter a valid amount for plea and case management hearing fees
+      long: Enter a valid rate for plea and case management hearing fees
+      short: Enter a valid rate
+      api: Enter a valid rate for plea and case management hearing fees
     cav_zero:
-      long: Enter a valid amount for conference and views fees
-      short: Enter a valid amount
-      api: Enter a valid amount for conference and views fees
+      long: Enter a valid rate for conference and views fees
+      short: Enter a valid rate
+      api: Enter a valid rate for conference and views fees
     cav_invalid:
-      long: Enter a valid amount for conference and views fees
-      short: Enter a valid amount
-      api: Enter a valid amount for conference and views fees
+      long: Enter a valid rate for conference and views fees
+      short: Enter a valid rate
+      api: Enter a valid rate for conference and views fees
     ndr_zero:
-      long: Enter a valid amount for number of defendants uplift fees
-      short: Enter a valid amount
-      api: Enter a valid amount for number of defendants uplift fees
+      long: Enter a valid rate for number of defendants uplift fees
+      short: Enter a valid rate
+      api: Enter a valid rate for number of defendants uplift fees
     ndr_invalid:
-      long: Enter a valid amount for number of defendants uplift fees
-      short: Enter a valid amount
-      api: Enter a valid amount for number of defendants uplift fees
+      long: Enter a valid rate for number of defendants uplift fees
+      short: Enter a valid rate
+      api: Enter a valid rate for number of defendants uplift fees
     noc_zero:
-      long: Enter a valid amount for number of cases uplift fees
-      short: Enter a valid amount
-      api: Enter a valid amount for number of cases uplift fees
+      long: Enter a valid rate for number of cases uplift fees
+      short: Enter a valid rate
+      api: Enter a valid rate for number of cases uplift fees
     noc_invalid:
-      long: Enter a valid amount for number of cases uplift fees
-      short: Enter a valid amount
-      api: Enter a valid amount for number of cases uplift fees
+      long: Enter a valid rate for number of cases uplift fees
+      short: Enter a valid rate
+      api: Enter a valid rate for number of cases uplift fees
     npw_zero:
-      long: Enter a valid amount for number of prosecution witnesses fees
-      short: Enter a valid amount
-      api: Enter a valid amount for number of prosecution witnesses fees
+      long: Enter a valid rate for number of prosecution witnesses fees
+      short: Enter a valid rate
+      api: Enter a valid rate for number of prosecution witnesses fees
     npw_invalid:
-      long: Enter a valid amount for number of prosecution witnesses fees
-      short: Enter a valid amount
-      api: Enter a valid amount for number of prosecution witnesses fees
+      long: Enter a valid rate for number of prosecution witnesses fees
+      short: Enter a valid rate
+      api: Enter a valid rate for number of prosecution witnesses fees
     ppe_zero:
-      long: Enter a valid amount for pages of prosecution evidence fees
-      short: Enter a valid amount
-      api: Enter a valid amount for pages of prosecution evidence fees
+      long: Enter a valid rate for pages of prosecution evidence fees
+      short: Enter a valid rate
+      api: Enter a valid rate for pages of prosecution evidence fees
     ppe_invalid:
-      long: Enter a valid amount for pages of prosecution evidence fees
-      short: Enter a valid amount
-      api: Enter a valid amount for pages of prosecution evidence fees
+      long: Enter a valid rate for pages of prosecution evidence fees
+      short: Enter a valid rate
+      api: Enter a valid rate for pages of prosecution evidence fees
     invalid:
-      long: Enter a valid amount for the basic fee
-      short: Enter a valid amount
-      api: Enter a valid amount for the basic fee
+      long: Enter a valid rate for the basic fee
+      short: Enter a valid rate
+      api: Enter a valid rate for the basic fee
 
 #################################################################################
 #                                                                               #
@@ -443,12 +443,12 @@ misc_fee:
       short: Choose a fee type
       api: Choose a type for the miscellaneous fee
 
-  amount:
+  rate:
     _seq: 20
     invalid:
-      long: 'Enter an amount for the #{misc_fee}'
-      short: Enter an amount
-      api: Enter an amount for the miscellaneous fee
+      long: 'Enter a rate for the #{misc_fee}'
+      short: Enter a rate
+      api: Enter a rate for the miscellaneous fee
 
   quantity:
     _seq: 30
@@ -473,12 +473,12 @@ fixed_fee:
       short: Choose a fee type
       api: Choose a type for the fixed fee
 
-  amount:
+  rate:
     _seq: 20
     invalid:
-      long: 'Enter an amount for the #{fixed_fee}'
-      short: Enter an amount
-      api: Enter an amount for the fixed fee
+      long: 'Enter a rate for the #{fixed_fee}'
+      short: Enter a rate
+      api: Enter a rate for the fixed fee
 
   quantity:
     _seq: 30

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -316,17 +316,17 @@ basic_fee:
       short: Enter 1
       api: Enter a quantity of 1 for basic fee
     daf_qty_mismatch:
-      long: The number of daily attendance fees does not fit the actual trial length
+      long: The number of daily attendance fees (3-40 days) does not fit the actual trial length
       short: Enter a number that fits the actual trial length
-      api: The number of daily attendance fees does not fit the actual trial length
+      api: The number of daily attendance fees (3-40 days) does not fit the actual trial length
     dah_qty_mismatch:
-      long: The number of daily attendance fees does not fit the actual trial length
+      long: The number of daily attendance fees (41-50 days) does not fit the actual trial length
       short: Enter a number that fits the actual trial length
-      api: The number of daily attendance fees does not fit the actual trial length
+      api: The number of daily attendance fees (41-50 days) does not fit the actual trial length
     daj_qty_mismatch:
-      long: The number of daily attendance fees does not fit the actual trial length
+      long: The number of daily attendance fees (51+ days) does not fit the actual trial length
       short: Enter a number that fits the actual trial length
-      api: The number of daily attendance fees does not fit the actual trial length
+      api: The number of daily attendance fees (51+ days) does not fit the actual trial length
     pcm_invalid:
       long: The quantity for plea and case management hearing must be less than or equal to 3
       short: Enter a number less than or equal to 3

--- a/db/migrate/20151130155527_add_rate_to_fees.rb
+++ b/db/migrate/20151130155527_add_rate_to_fees.rb
@@ -1,0 +1,5 @@
+class AddRateToFees < ActiveRecord::Migration
+  def change
+    add_column :fees, :rate, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151126143208) do
+ActiveRecord::Schema.define(version: 20151130155527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -288,6 +288,7 @@ ActiveRecord::Schema.define(version: 20151126143208) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.uuid     "uuid",        default: "uuid_generate_v4()"
+    t.decimal  "rate"
   end
 
   add_index "fees", ["claim_id"], name: "index_fees_on_claim_id", using: :btree

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -152,9 +152,9 @@ When(/^I fill in the claim details(.*)$/) do |details|
   unless details == ' but add no fees or expenses' # preceeding space is required for match
     within '#basic-fees' do
       fill_in 'claim_basic_fees_attributes_0_quantity', with: 1
-      fill_in 'claim_basic_fees_attributes_0_amount', with: 50
+      fill_in 'claim_basic_fees_attributes_0_rate', with: 50
       fill_in 'claim_basic_fees_attributes_1_quantity', with: 1
-      fill_in 'claim_basic_fees_attributes_1_amount', with: 50
+      fill_in 'claim_basic_fees_attributes_1_rate', with: 50
     end
 
     within '#expenses' do
@@ -321,7 +321,7 @@ end
 When(/^I add a fixed fee$/) do
     within '#fixed-fees' do
       fill_in 'claim_fixed_fees_attributes_0_quantity', with: 1
-      fill_in 'claim_fixed_fees_attributes_0_amount', with: 100.00
+      fill_in 'claim_fixed_fees_attributes_0_rate', with: 100.00
       select 'Fixed Fee example', from: 'claim_fixed_fees_attributes_0_fee_type_id'
     end
 end
@@ -333,7 +333,7 @@ end
 When(/^I add a miscellaneous fee$/) do
     within '#misc-fees' do
       fill_in 'claim_misc_fees_attributes_0_quantity', with: 1
-      fill_in 'claim_misc_fees_attributes_0_amount', with: 200.00
+      fill_in 'claim_misc_fees_attributes_0_rate', with: 200.00
       select 'Miscellaneous Fee example', from: 'claim_misc_fees_attributes_0_fee_type_id'
     end
 end
@@ -381,7 +381,7 @@ end
 Given(/^I fill in an Initial Fee$/) do
   within '#basic-fees' do
     fill_in 'claim_basic_fees_attributes_0_quantity', with: 2
-    fill_in 'claim_basic_fees_attributes_0_amount', with: 1.5
+    fill_in 'claim_basic_fees_attributes_0_rate', with: 0.75
   end
 end
 
@@ -389,7 +389,7 @@ Given(/^I fill in a Miscellaneous Fee$/) do
   within '#misc-fees' do
     select 'Miscellaneous Fee example', from: 'claim_misc_fees_attributes_0_fee_type_id'
     fill_in 'claim_misc_fees_attributes_0_quantity', with: 2
-    fill_in 'claim_misc_fees_attributes_0_amount', with: 3.00
+    fill_in 'claim_misc_fees_attributes_0_rate', with: 1.50
   end
 end
 
@@ -397,7 +397,7 @@ Given(/^I fill in a Fixed Fee$/) do
   within '#fixed-fees' do
     select 'Fixed Fee example', from: 'claim_fixed_fees_attributes_0_fee_type_id'
     fill_in 'claim_fixed_fees_attributes_0_quantity', with: 2
-    fill_in 'claim_fixed_fees_attributes_0_amount', with: 3.00
+    fill_in 'claim_fixed_fees_attributes_0_rate', with: 1.50
   end
 end
 
@@ -405,7 +405,7 @@ Given(/^I fill in a Fixed Fee using select2$/) do
   within '#fixed-fees' do
     # select2 'Fixed Fee example', from: 'claim_fixed_fees_attributes_0_fee_type_id' # does not work
     fill_in 'claim_fixed_fees_attributes_0_quantity', with: 2
-    fill_in 'claim_fixed_fees_attributes_0_amount', with: 3.00
+    fill_in 'claim_fixed_fees_attributes_0_rate', with: 1.50
   end
 end
 

--- a/lib/api_test_client.rb
+++ b/lib/api_test_client.rb
@@ -275,7 +275,7 @@ private
       "claim_id": claim_uuid,
       "fee_type_id": fee_type_id,
       "quantity": 1,
-      "amount": 2.1,
+      "rate": 2.1,
     }
   end
 
@@ -289,7 +289,7 @@ private
       "claim_id": claim_uuid,
       "fee_type_id": fee_type_id,
       "quantity": 2,
-      "amount": 3.1,
+      "rate": 1.55,
     }
   end
 

--- a/lib/demo_data/basic_fee_generator.rb
+++ b/lib/demo_data/basic_fee_generator.rb
@@ -17,10 +17,10 @@ module DemoData
 
     private
 
-    def update_basic_fee(basic_fee_code, quantity, amount)
+    def update_basic_fee(basic_fee_code, quantity, rate)
       fee = @claim.basic_fees.find_by(fee_type_id: basic_fee_type_by_code(basic_fee_code))
       raise "fee code #{basic_fee_code} does not match any known basic fees" if fee.fee_type_id.nil?
-      fee.update(quantity: quantity, amount: amount)
+      fee.update(quantity: quantity, rate: rate)
       @codes_added << basic_fee_code
     end
 
@@ -38,22 +38,22 @@ module DemoData
     def add_daf
       return unless @claim.case_type.requires_trial_dates? && @claim.actual_trial_length > 0
       quantity = @claim.case_type.requires_trial_dates? ? [@claim.actual_trial_length,39].min - 2 : 1
-      amount   = @claim.case_type.requires_trial_dates? ? 10 * @claim.actual_trial_length - 2 : 250
-      update_basic_fee('DAF', quantity, amount)
+      rate   = @claim.case_type.requires_trial_dates? ? 10 * @claim.actual_trial_length - 2 : 250
+      update_basic_fee('DAF', quantity, rate)
     end
 
     def add_dah
       return unless @claim.case_type.requires_trial_dates? && @claim.actual_trial_length > 40
       quantity = [@claim.actual_trial_length,50].min - 40
-      amount = 10 * @claim.actual_trial_length - 40
-      update_basic_fee('DAH', quantity, amount)
+      rate = 10 * @claim.actual_trial_length - 40
+      update_basic_fee('DAH', quantity, rate)
     end
 
     def add_daj
       return unless @claim.case_type.requires_trial_dates? && @claim.actual_trial_length > 50
       quantity = [@claim.actual_trial_length,60].min - 50
-      amount = 10 * @claim.actual_trial_length - 50
-      update_basic_fee('DAJ', quantity , amount)
+      rate = 10 * @claim.actual_trial_length - 50
+      update_basic_fee('DAJ', quantity , rate)
     end
 
     def add_pcm

--- a/lib/demo_data/fee_generator.rb
+++ b/lib/demo_data/fee_generator.rb
@@ -21,7 +21,7 @@ module DemoData
       while @codes_added.include?(fee_type.code)
         fee_type = @fee_types.sample
       end
-      Fee.create(claim: @claim, fee_type: fee_type, quantity: rand(1..10), amount: rand(100..900))
+      Fee.create(claim: @claim, fee_type: fee_type, quantity: rand(1..10), rate: rand(25..75))
       @codes_added << fee_type.code
     end
 

--- a/spec/api/v1/claims/fee_spec.rb
+++ b/spec/api/v1/claims/fee_spec.rb
@@ -20,7 +20,7 @@ describe API::V1::Advocates::Fee do
   let!(:misc_fee_type)      { create(:fee_type, :misc) }
   let!(:fixed_fee_type)      { create(:fee_type, :fixed) }
   let!(:claim)              { create(:claim, source: 'api').reload }
-  let!(:valid_params)       { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_type.id, quantity: 3, amount: 150.00 } }
+  let!(:valid_params)       { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_type.id, quantity: 3, rate: 50.00 } }
   let(:json_error_response) { [ {"error" => "Choose a type for the fee" } ].to_json }
 
   context 'sending non-permitted verbs' do
@@ -63,12 +63,12 @@ describe API::V1::Advocates::Fee do
         expect(fee.claim_id).to eq claim.id
         expect(fee.fee_type_id).to eq misc_fee_type.id
         expect(fee.quantity).to eq valid_params[:quantity]
-        expect(fee.amount).to eq valid_params[:amount]
+        expect(fee.rate).to eq valid_params[:rate]
       end
 
       context 'basic fees' do
 
-        let!(:valid_params) { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: basic_fee_type.id, quantity: 1, amount: 210.00 } }
+        let!(:valid_params) { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: basic_fee_type.id, quantity: 1, rate: 210.00 } }
 
         it 'should update, not create, the fee, return 200 and fee JSON output including UUID' do
           post_to_create_endpoint
@@ -83,13 +83,14 @@ describe API::V1::Advocates::Fee do
           expect{ post_to_create_endpoint }.to change { Fee.count }.by(0)
         end
 
-        it 'should update the basic fee with the quantity and amount' do
+        it 'should update the basic fee with the quantity, rate and amount' do
           post_to_create_endpoint
           json = JSON.parse(last_response.body)
           fee = Fee.find_by(uuid: json['id'])
           expect(fee.claim_id).to eq claim.id
           expect(fee.fee_type_id).to eq basic_fee_type.id
           expect(fee.quantity).to eq 1
+          expect(fee.rate).to eq 210.00
           expect(fee.amount).to eq 210.00
         end
       end
@@ -98,8 +99,8 @@ describe API::V1::Advocates::Fee do
 
     context "fee type specific errors" do
 
-      let!(:valid_params)       { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_type.id, quantity: 3, amount: 150.00 } }
-      before (:each) { valid_params.delete(:amount) }
+      let!(:valid_params)       { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_type.id, quantity: 3, rate: 50.00 } }
+      before (:each) { valid_params.delete(:rate) }
 
       it 'THE basic fee should raise basic fee (code BAF) errors' do
         valid_params[:fee_type_id] = basic_fee_type.id
@@ -107,8 +108,8 @@ describe API::V1::Advocates::Fee do
         post_to_create_endpoint
         expect(last_response.status).to eq 400
         expect_error_response("Enter a quantity of 1 for basic fee",0)
-        # NOTE: basic fee should allow 0 amount for claim basic fee at instantiontion/creation but not thereafter
-        expect_error_response("Enter a valid amount for the basic fee",1)
+        # NOTE: basic fee should allow 0 rate for claim basic fee at instantiation/creation but not thereafter
+        expect_error_response("Enter a valid rate for the basic fee",1)
       end
 
       # NOT exhaustive
@@ -116,21 +117,21 @@ describe API::V1::Advocates::Fee do
         valid_params[:fee_type_id] = basic_fee_type.id
         post_to_create_endpoint
         expect(last_response.status).to eq 400
-        expect_error_response("Enter a valid amount for the basic fee",0)
+        expect_error_response("Enter a valid rate for the basic fee",0)
       end
 
       it 'misc fees should raise misc fee errors from translations' do
         valid_params[:fee_type_id] = misc_fee_type.id
         post_to_create_endpoint
         expect(last_response.status).to eq 400
-        expect_error_response("Enter an amount for the miscellaneous fee",0)
+        expect_error_response("Enter a rate for the miscellaneous fee",0)
       end
 
       it 'fixed fees should raise misc fee errors from translations' do
         valid_params[:fee_type_id] = fixed_fee_type.id
         post_to_create_endpoint
         expect(last_response.status).to eq 400
-        expect_error_response("Enter an amount for the fixed fee",0)
+        expect_error_response("Enter a rate for the fixed fee",0)
       end
     end
 
@@ -201,7 +202,7 @@ describe API::V1::Advocates::Fee do
     end
 
     context 'basic fees' do
-      let!(:valid_params) { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: basic_fee_type.id, quantity: 1, amount: 210.00 } }
+      let!(:valid_params) { { api_key: chamber.api_key, claim_id: claim.uuid, fee_type_id: basic_fee_type.id, quantity: 1, rate: 210.00 } }
       include_examples "fee validate endpoint"
     end
 

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -603,18 +603,18 @@ def valid_claim_fee_params
      "additional_information" => "",
      "basic_fees_attributes"=>
       {
-        "0"=>{"quantity" => "10", "amount" => "1000", "fee_type_id" => basic_fee_type_1.id.to_s},
-        "1"=>{"quantity" => "0", "amount" => "0.00", "fee_type_id" => basic_fee_type_2.id.to_s},
-        "2"=>{"quantity" => "1", "amount" => "9000.45", "fee_type_id" => basic_fee_type_3.id.to_s},
-        "3"=>{"quantity" => "5", "amount" => "125", "fee_type_id" => basic_fee_type_4.id.to_s}
+        "0"=>{"quantity" => "10", "rate" => "100", "fee_type_id" => basic_fee_type_1.id.to_s},
+        "1"=>{"quantity" => "0", "rate" => "0.00", "fee_type_id" => basic_fee_type_2.id.to_s},
+        "2"=>{"quantity" => "1", "rate" => "9000.45", "fee_type_id" => basic_fee_type_3.id.to_s},
+        "3"=>{"quantity" => "5", "rate" => "25", "fee_type_id" => basic_fee_type_4.id.to_s}
         },
       "fixed_fees_attributes"=>
       {
-        "0"=>{"fee_type_id" => fixed_fee_type_1.id.to_s, "quantity" => "250", "amount" => "2500", "_destroy" => "false"}
+        "0"=>{"fee_type_id" => fixed_fee_type_1.id.to_s, "quantity" => "250", "rate" => "10", "_destroy" => "false"}
       },
       "misc_fees_attributes"=>
       {
-        "1"=>{"fee_type_id" => misc_fee_type_2.id.to_s, "quantity" => "2", "amount" => "250", "_destroy" => "false"},
+        "1"=>{"fee_type_id" => misc_fee_type_2.id.to_s, "quantity" => "2", "rate" => "125", "_destroy" => "false"},
       },
      "expenses_attributes"=>
      {

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     claim
     fee_type
     quantity 1
-    amount 25
+    rate 25
 
     trait :with_date_attended do
       after(:build) do |fee|
@@ -27,6 +27,7 @@ FactoryGirl.define do
 
     trait :random_values do
       quantity { rand(1..15) }
+      rate { rand(50..80) }
       amount   { rand(100..999).round(0) }
     end
 
@@ -44,7 +45,7 @@ FactoryGirl.define do
 
     trait :all_zero do
       quantity 0
-      amount 0
+      rate 0
     end
 
     trait :from_api do

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -533,10 +533,10 @@ RSpec.describe Claim, type: :model do
 
     before do
       subject.fees.destroy_all
-      create(:fee, fee_type: basic_fee, claim_id: subject.id, amount: 4.00)
-      create(:fee, fee_type: basic_fee, claim_id: subject.id, amount: 3.00)
-      create(:fee, fee_type: fixed_fee, claim_id: subject.id, amount: 0.50)
-      create(:fee, fee_type: misc_fee,  claim_id: subject.id, amount: 0.50)
+      create(:fee, fee_type: basic_fee, claim_id: subject.id, rate: 4.00)
+      create(:fee, fee_type: basic_fee, claim_id: subject.id, rate: 3.00)
+      create(:fee, fee_type: fixed_fee, claim_id: subject.id, rate: 0.50)
+      create(:fee, fee_type: misc_fee,  claim_id: subject.id, rate: 0.50)
       subject.reload
     end
 
@@ -558,7 +558,7 @@ RSpec.describe Claim, type: :model do
       end
 
       it 'updates the fees total' do
-        create(:fee, fee_type: basic_fee, claim_id: subject.id, amount: 2.00)
+        create(:fee, fee_type: basic_fee, claim_id: subject.id, rate: 2.00)
         subject.reload
         expect(subject.fees_total).to eq(10.0)
       end
@@ -611,9 +611,9 @@ RSpec.describe Claim, type: :model do
 
     before do
       subject.fees.destroy_all
-      create(:fee, fee_type: fee_type, claim_id: subject.id, amount: 3.00)
-      create(:fee, fee_type: fee_type, claim_id: subject.id, amount: 2.00)
-      create(:fee, fee_type: fee_type, claim_id: subject.id, amount: 1.00)
+      create(:fee, fee_type: fee_type, claim_id: subject.id, rate: 3.00)
+      create(:fee, fee_type: fee_type, claim_id: subject.id, rate: 2.00)
+      create(:fee, fee_type: fee_type, claim_id: subject.id, rate: 1.00)
 
       create(:expense, claim_id: subject.id, rate: 3.5, quantity: 1)
       create(:expense, claim_id: subject.id, rate: 1.0, quantity: 1)
@@ -630,7 +630,7 @@ RSpec.describe Claim, type: :model do
     describe '#update_total' do
       it 'updates the total' do
         create(:expense, claim_id: subject.id, rate: 3.0, quantity: 1)
-        create(:fee, fee_type: fee_type, claim_id: subject.id, amount: 0.5)
+        create(:fee, fee_type: fee_type, claim_id: subject.id, rate: 0.5)
         subject.reload
         expect(subject.total).to eq(156.00)
       end
@@ -884,7 +884,7 @@ RSpec.describe Claim, type: :model do
 
       [400, 10_000, 566, 1_000].each do |value|
         claim = create(:submitted_claim)
-        claim.fees << create(:fee, amount: value, claim: claim)
+        claim.fees << create(:fee, rate: value, claim: claim)
         claims << claim
       end
 
@@ -900,9 +900,9 @@ RSpec.describe Claim, type: :model do
 
     let(:claim_with_all_fee_types) do
       claim = FactoryGirl.create :draft_claim
-      FactoryGirl.create(:fee, :basic, :with_date_attended, claim: claim, amount: 9.99)
-      FactoryGirl.create(:fee, :fixed, :with_date_attended, claim: claim, amount: 9.99)
-      FactoryGirl.create(:fee, :misc, claim: claim, amount: 9.99)
+      FactoryGirl.create(:fee, :basic, :with_date_attended, claim: claim, rate: 9.99)
+      FactoryGirl.create(:fee, :fixed, :with_date_attended, claim: claim, rate: 9.99)
+      FactoryGirl.create(:fee, :misc, claim: claim, rate: 9.99)
       claim
     end
 
@@ -1196,9 +1196,9 @@ RSpec.describe Claim, type: :model do
              "_destroy"=>"false"}},
          "additional_information"=>"",
          "basic_fees_attributes"=>
-          {"0"=>{"quantity"=>"1", "amount"=>"150", "fee_type_id"=>fee_type.id}},
-         "misc_fees_attributes"=>{"0"=>{"fee_type_id"=> "", "quantity"=>"", "amount"=>"", "_destroy"=>"false"}},
-         "fixed_fees_attributes"=>{"0"=>{"fee_type_id"=>"", "quantity"=>"", "amount"=>"", "_destroy"=>"false"}},
+          {"0"=>{"quantity"=>"1", "rate"=>"150", "fee_type_id"=>fee_type.id}},
+         "misc_fees_attributes"=>{"0"=>{"fee_type_id"=> "", "quantity"=>"", "rate"=>"", "_destroy"=>"false"}},
+         "fixed_fees_attributes"=>{"0"=>{"fee_type_id"=>"", "quantity"=>"", "rate"=>"", "_destroy"=>"false"}},
          "expenses_attributes"=>{"0"=>{"expense_type_id"=>expense_type.id, "location"=>"London", "quantity"=>"1", "rate"=>"40", "_destroy"=>"false"}},
          "apply_vat"=>"0",
          "document_ids"=>[""],
@@ -1267,7 +1267,7 @@ RSpec.describe Claim, type: :model do
             "_destroy"=>"false"}},
         "additional_information"=>"",
         "basic_fees_attributes"=>
-          {"0"=>{"quantity"=>"1", "amount"=>"450", "fee_type_id"=>@bft1.id}},
+          {"0"=>{"quantity"=>"1", "rate"=>"450", "fee_type_id"=>@bft1.id}},
         "apply_vat"=>"0",
         "document_ids"=>[""],
         "evidence_checklist_ids"=>["1", ""]},

--- a/spec/models/claims/totals_spec.rb
+++ b/spec/models/claims/totals_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Claim, type: :model do
       end
 
       it 'updates the fees total' do
-        create(:fee, fee_type: fee_type, claim_id: subject.id, amount: 2.00)
+        create(:fee, fee_type: fee_type, claim_id: subject.id, rate: 2.00)
         subject.reload
         expect(subject.fees_total).to eq(27.0)
       end
 
       it 'updates total when claim fee destroyed' do
-        create(:fee, fee_type: fee_type, claim_id: subject.id, amount: 2.00)
+        create(:fee, fee_type: fee_type, claim_id: subject.id, rate: 2.00)
         subject.fees.first.destroy
         subject.reload
         expect(subject.fees_total).to eq(2.0)
@@ -74,7 +74,7 @@ RSpec.describe Claim, type: :model do
     describe '#update_total' do
       it 'updates the total' do
         create(:expense, claim_id: subject.id, quantity: 3, rate: 1)
-        create(:fee, fee_type: fee_type, claim_id: subject.id, amount: 4.00)
+        create(:fee, fee_type: fee_type, claim_id: subject.id, rate: 4.00)
         subject.reload
         expect(subject.total).to eq(178.5)
       end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -29,11 +29,19 @@ RSpec.describe Fee, type: :model do
     end
   end
 
- describe 'blank amount should be set to zero' do
-    it 'should replace blank amounts with zero before save' do
-      fee = FactoryGirl.build :fee, amount: nil
+  describe 'blank rate should be set to zero' do
+    it 'should replace blank rate with zero before save' do
+      fee = FactoryGirl.build :fee, rate: nil
       expect(fee).to be_valid
-      expect(fee.amount).to eq 0
+      expect(fee.rate).to eq 0
+    end
+  end
+
+ describe 'amount is calculated as quantity * rate before validation' do
+    it 'should replace blank amounts with zero before save' do
+      fee = FactoryGirl.build :fee, quantity: 12, rate: 3.01
+      expect(fee).to be_valid
+      expect(fee.amount).to eq 36.12
     end
   end
 
@@ -86,7 +94,7 @@ RSpec.describe Fee, type: :model do
   end
 
   describe '#category' do
-    it 'should return the abbreviateion of the fee type category' do
+    it 'should return the abbreviation of the fee type category' do
       cat = FactoryGirl.create :fee_category
       ft  = FactoryGirl.create :fee_type, fee_category: cat
       fee = FactoryGirl.create :fee, fee_type: ft

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fee, type: :model do
 
   it { should validate_presence_of(:claim).with_message('blank')}
 
-  describe 'blank quantity should be set to zero' do
+  describe 'blank quantity should be set to zero before validation' do
     it 'should replace blank quantities with zero before save' do
       fee = FactoryGirl.build :fee, quantity: nil
       expect(fee).to be_valid
@@ -29,7 +29,7 @@ RSpec.describe Fee, type: :model do
     end
   end
 
-  describe 'blank rate should be set to zero' do
+  describe 'blank rate should be set to zero before validation' do
     it 'should replace blank rate with zero before save' do
       fee = FactoryGirl.build :fee, rate: nil
       expect(fee).to be_valid
@@ -37,12 +37,36 @@ RSpec.describe Fee, type: :model do
     end
   end
 
- describe 'amount is calculated as quantity * rate before validation' do
-    it 'should replace blank amounts with zero before save' do
-      fee = FactoryGirl.build :fee, quantity: 12, rate: 3.01
+  describe 'blank amount with blank quantity and rate should be set to zero before validation' do
+    it 'should replace blank amount with zero before save' do
+      fee = FactoryGirl.build :fee, quantity: nil, rate: nil, amount: nil
       expect(fee).to be_valid
-      expect(fee.amount).to eq 36.12
+      expect(fee.amount).to eq 0
     end
+  end
+
+  describe '#calculate_amount' do
+
+    # this should be removed after gamma/private beta claims archived/deleted
+    context 'for fees entered before rate was reintroduced' do
+      it 'amount is NOT recalculated and rate presence is NOT validated' do
+        fee = FactoryGirl.build :fee, quantity: 10, rate: nil, amount: 255
+        fee.claim.force_validation = true
+        expect(fee).to be_valid
+        expect(fee.amount).to eq 255.00
+      end
+    end
+
+    # this will become default after gamma/private beta claims archived/deleted
+    context 'for fees entered after rate was reintroduced' do
+      it 'amount is calculated as quantity * rate before validation' do
+        fee = FactoryGirl.build :fee, quantity: 12, rate: 3.01
+        fee.claim.force_validation = true
+        expect(fee).to be_valid
+        expect(fee.amount).to eq 36.12
+      end
+    end
+
   end
 
   describe '.new_blank' do

--- a/spec/validators/fee_validator_spec.rb
+++ b/spec/validators/fee_validator_spec.rb
@@ -22,10 +22,12 @@ describe FeeValidator do
   end
 
   describe 'rate' do
+
     before(:each) do
       daf_fee.claim.actual_trial_length = 10
     end
-    context 'quantity greater than zero' do
+
+    context 'with quantity greater than zero' do
       it { should_be_valid_if_equal_to_value(daf_fee, :rate, 450.00) }
       it { should_error_if_equal_to_value(baf_fee, :rate, 0.00, 'baf_invalid') }
       it { should_error_if_equal_to_value(daf_fee, :rate, nil, 'daf_zero') }
@@ -33,14 +35,33 @@ describe FeeValidator do
       it { should_error_if_equal_to_value(daf_fee, :rate, -320, 'daf_zero') }
     end
 
-    context 'quantity = 0' do
+    context 'with quantity of 0' do
       before(:each) do
         daf_fee.quantity = 0
       end
       it { should_error_if_equal_to_value(daf_fee, :rate, 500.00, 'daf_invalid') }
     end
 
-    # TODO max_amount removed in later PR - remove?
+    # this should be removed after gamma/private beta claims archived/deleted
+    context 'for fees entered before rate was reintroduced' do
+      it 'should NOT require a rate of more than zero' do
+        fee.amount = 255
+        fee.rate = nil
+        expect(fee).to be_valid
+      end
+    end
+
+    # this will become default after gamma/private beta claims archived/deleted
+    context 'for fees entered after rate was reintroduced' do
+      it 'should require a rate of more than zero' do
+        fee.amount = nil
+        fee.rate = nil
+        expect(fee).to_not be_valid
+        expect(fee.rate).to eq 0
+      end
+    end
+    
+    # TODO: max_amount removed in later PR - remove?
     # context 'fee with max amount' do
     #   before(:each)       { fee.fee_type.max_amount = 9999 }
     #   it { should_be_valid_if_equal_to_value(fee, :amount, 9999) }

--- a/spec/validators/fee_validator_spec.rb
+++ b/spec/validators/fee_validator_spec.rb
@@ -21,34 +21,35 @@ describe FeeValidator do
     it { should_error_if_not_present(fee, :fee_type, 'blank') }
   end
 
-  describe 'amount' do
+  describe 'rate' do
     before(:each) do
       daf_fee.claim.actual_trial_length = 10
     end
     context 'quantity greater than zero' do
-      it { should_be_valid_if_equal_to_value(daf_fee, :amount, 450.00) }
-      it { should_error_if_equal_to_value(baf_fee, :amount, 0.00, 'baf_invalid') }
-      it { should_error_if_equal_to_value(daf_fee, :amount, nil, 'daf_zero') }
-      it { should_error_if_equal_to_value(daf_fee, :amount, 0.00, 'daf_zero') }
-      it { should_error_if_equal_to_value(daf_fee, :amount, -320, 'daf_zero') }
+      it { should_be_valid_if_equal_to_value(daf_fee, :rate, 450.00) }
+      it { should_error_if_equal_to_value(baf_fee, :rate, 0.00, 'baf_invalid') }
+      it { should_error_if_equal_to_value(daf_fee, :rate, nil, 'daf_zero') }
+      it { should_error_if_equal_to_value(daf_fee, :rate, 0.00, 'daf_zero') }
+      it { should_error_if_equal_to_value(daf_fee, :rate, -320, 'daf_zero') }
     end
 
     context 'quantity = 0' do
       before(:each) do
         daf_fee.quantity = 0
       end
-      it { should_error_if_equal_to_value(daf_fee, :amount, 500.00, 'daf_invalid') }
+      it { should_error_if_equal_to_value(daf_fee, :rate, 500.00, 'daf_invalid') }
     end
 
-    context 'fee with max amount' do
-      before(:each)       { fee.fee_type.max_amount = 9999 }
-      it { should_be_valid_if_equal_to_value(fee, :amount, 999) }
-    end
+    # TODO max_amount removed in later PR - remove?
+    # context 'fee with max amount' do
+    #   before(:each)       { fee.fee_type.max_amount = 9999 }
+    #   it { should_be_valid_if_equal_to_value(fee, :amount, 9999) }
+    # end
 
-    context 'fee with no max amount' do
-      before(:each)       { fee.fee_type.max_amount = nil }
-      it { should_be_valid_if_equal_to_value(fee, :amount, 100_000) }
-    end
+    # context 'fee with no max amount' do
+    #   before(:each)       { fee.fee_type.max_amount = nil }
+    #   it { should_be_valid_if_equal_to_value(fee, :amount, 100_000) }
+    # end
 
   end
 


### PR DESCRIPTION
This PR reintroduces simple fee calculation for all fee types.

It also applies conditional logic that prevents recalculation of individual fees amounts for claims that
already exist (for private-beta/gamma environment). This conditional logic permits rates of 0 if an amount already exists.
