### PR TITLE
Disable uniqueness validation on supplier number

### DIFF
--- a/app/models/advocate.rb
+++ b/app/models/advocate.rb
@@ -29,7 +29,6 @@ class Advocate < ActiveRecord::Base
   validates :chamber, presence: true
   validates :supplier_number,
               presence: true,
-              uniqueness: { case_sensitive: false },
               format: { with: /\A[a-zA-Z0-9]{5}\z/, allow_nil: true }
 
   accepts_nested_attributes_for :user

--- a/app/models/chamber.rb
+++ b/app/models/chamber.rb
@@ -26,7 +26,7 @@ class Chamber < ActiveRecord::Base
   before_validation :set_api_key
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  validates :supplier_number, presence: true, uniqueness: { case_sensitive: false }
+  validates :supplier_number, presence: true
   validates :api_key, presence: true
 
   def regenerate_api_key!

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -1,5 +1,4 @@
 class ExpensePresenter < BasePresenter
-
   presents :expense
 
   def dates_attended_delimited_string
@@ -9,5 +8,4 @@ class ExpensePresenter < BasePresenter
  def amount
     h.number_to_currency(expense.amount)
  end
-
 end

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -71,7 +71,7 @@
                 %td
                   = expense.quantity
                 %td
-                  = expense.rate
+                  = '%.2f' % expense.rate if expense.rate
                 %td
                   = expense.amount
 

--- a/spec/models/chamber_spec.rb
+++ b/spec/models/chamber_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Chamber, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_uniqueness_of(:name) }
   it { should validate_presence_of(:supplier_number) }
-  it { should validate_uniqueness_of(:supplier_number) }
 
   context '.set_api_key' do
     let(:chamber) { FactoryGirl.create(:chamber) }


### PR DESCRIPTION
Disable uniqueness validation on supplier number for advocates and restore formatting for expense rate
