### PR TITLE
Applying vat

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -131,13 +131,11 @@ class Claim < ActiveRecord::Base
 
   after_initialize :instantiate_basic_fees
 
-  before_save :calculate_vat
-
   before_validation do
     documents.each { |d| d.advocate_id = self.advocate_id }
   end
 
-  before_validation :destroy_all_invalid_fee_types, :calculate_vat
+  before_validation :destroy_all_invalid_fee_types
 
   after_initialize :default_values, :instantiate_assessment, :set_force_validation_to_false
 
@@ -361,13 +359,4 @@ class Claim < ActiveRecord::Base
     self.build_assessment if self.assessment.nil?
   end
 
-  def calculate_vat
-    return if self.advocate.nil?
-    self.apply_vat = self.advocate.apply_vat
-    if self.apply_vat?
-      self.vat_amount = VatRate.vat_amount(self.total, self.vat_date)
-    else
-      self.vat_amount = 0.0
-    end
-  end
 end

--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -28,4 +28,27 @@ module Claims::Calculations
   def update_total
     update_column(:total, calculate_total)
   end
+
+  def calculate_expenses_vat
+    VatRate.vat_amount(calculate_expenses_total, self.vat_date)
+  end
+
+  def calculate_fees_vat
+    VatRate.vat_amount(calculate_fees_total, self.vat_date)
+  end
+
+  def calculate_total_vat
+    calculate_expenses_vat + calculate_fees_vat
+  end
+
+  def update_vat
+    return if self.advocate.nil?
+    self.apply_vat = self.advocate.apply_vat
+    if self.apply_vat?
+      update_column(:vat_amount, calculate_total_vat)
+    else
+      update_column(:vat_amount, 0.0)
+    end
+  end
+
 end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -59,7 +59,7 @@ module Claims::StateMachine
             :redetermination,
             :submitted
 
-      after_transition on: :submit,                   do: [:set_last_submission_date!, :set_original_submission_date!]
+      after_transition on: :submit,                   do: [:set_last_submission_date!, :set_original_submission_date!, :update_vat]
       after_transition on: :authorise,                do: :set_authorised_date!
       after_transition on: :authorise_part,           do: :set_authorised_date!
       after_transition on: :redetermine,              do: [:remove_case_workers!, :set_last_submission_date!]

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -38,11 +38,13 @@ class Expense < ActiveRecord::Base
   after_save do
     claim.update_expenses_total
     claim.update_total
+    #claim.update_vat
   end
 
   after_destroy do
     claim.update_expenses_total
     claim.update_total
+    claim.update_vat
   end
 
   def perform_validation?

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -38,7 +38,6 @@ class Expense < ActiveRecord::Base
   after_save do
     claim.update_expenses_total
     claim.update_total
-    #claim.update_vat
   end
 
   after_destroy do

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -36,11 +36,13 @@ class Fee < ActiveRecord::Base
   after_save do
     claim.update_fees_total
     claim.update_total
+    #claim.update_vat
   end
 
   after_destroy do
     claim.update_fees_total
     claim.update_total
+    claim.update_vat
   end
 
   def perform_validation?

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -36,7 +36,6 @@ class Fee < ActiveRecord::Base
   after_save do
     claim.update_fees_total
     claim.update_total
-    #claim.update_vat
   end
 
   after_destroy do

--- a/spec/models/claims/financial_summary_spec.rb
+++ b/spec/models/claims/financial_summary_spec.rb
@@ -76,12 +76,19 @@ RSpec.describe Claims::FinancialSummary, type: :model do
 
 
     context 'with no VAT applied' do
-      let(:summary)           { Claims::FinancialSummary.new(advocate_without_vat) }
-      before do
-        [submitted_claim, allocated_claim, part_authorised_claim, authorised_claim, old_part_authorised_claim].each do |claim|
-          claim.advocate = advocate_without_vat
-          claim.creator = advocate_without_vat
-          claim.save!
+      
+      let(:submitted_claim)           { create(:submitted_claim, advocate: advocate_without_vat) }
+      let(:allocated_claim)           { create(:allocated_claim, advocate: advocate_without_vat) }
+      let(:part_authorised_claim)     { create(:part_authorised_claim, advocate: advocate_without_vat)}
+      let(:authorised_claim)          { create(:authorised_claim, advocate: advocate_without_vat)}
+      let(:summary)                   { Claims::FinancialSummary.new(advocate_without_vat) }
+      let!(:old_part_authorised_claim) do
+        Timecop.freeze(Time.now - 2.week) do
+          claim = create(:part_authorised_claim)
+          Timecop.freeze(Time.now + 1.week) do
+            claim.determinations.first.update(fees: claim.fees_total/2, expenses: claim.expenses_total)
+            claim
+          end
         end
       end
 
@@ -132,13 +139,18 @@ RSpec.describe Claims::FinancialSummary, type: :model do
     end
 
     context 'with VAT' do
-      let(:summary)   { Claims::FinancialSummary.new(advocate_with_vat) }
-
-      before do
-        [submitted_claim, allocated_claim, part_authorised_claim, authorised_claim].each do |claim|
-          claim.advocate = advocate_with_vat
-          claim.creator = advocate_with_vat
-          claim.save!
+      let(:submitted_claim)           { create(:submitted_claim, advocate: advocate_with_vat) }
+      let(:allocated_claim)           { create(:allocated_claim, advocate: advocate_with_vat) }
+      let(:part_authorised_claim)     { create(:part_authorised_claim, advocate: advocate_with_vat)}
+      let(:authorised_claim)          { create(:authorised_claim, advocate: advocate_with_vat)}
+      let(:summary)                   { Claims::FinancialSummary.new(advocate_with_vat) }
+      let!(:old_part_authorised_claim) do
+        Timecop.freeze(Time.now - 2.week) do
+          claim = create(:part_authorised_claim)
+          Timecop.freeze(Time.now + 1.week) do
+            claim.determinations.first.update(fees: claim.fees_total/2, expenses: claim.expenses_total)
+            claim
+          end
         end
       end
 
@@ -156,12 +168,19 @@ RSpec.describe Claims::FinancialSummary, type: :model do
     end
 
     context 'claim without VAT applied' do
-      let(:summary)   { Claims::FinancialSummary.new(advocate_without_vat) }
-      before do
-        [submitted_claim, allocated_claim, part_authorised_claim, authorised_claim].each do |claim|
-          claim.advocate = advocate_without_vat
-          claim.creator = advocate_without_vat
-          claim.save!
+
+      let(:submitted_claim)           { create(:submitted_claim, advocate: advocate_without_vat) }
+      let(:allocated_claim)           { create(:allocated_claim, advocate: advocate_without_vat) }
+      let(:part_authorised_claim)     { create(:part_authorised_claim, advocate: advocate_without_vat)}
+      let(:authorised_claim)          { create(:authorised_claim, advocate: advocate_without_vat)}
+      let(:summary)                   { Claims::FinancialSummary.new(advocate_without_vat) }
+      let!(:old_part_authorised_claim) do
+        Timecop.freeze(Time.now - 2.week) do
+          claim = create(:part_authorised_claim)
+          Timecop.freeze(Time.now + 1.week) do
+            claim.determinations.first.update(fees: claim.fees_total/2, expenses: claim.expenses_total)
+            claim
+          end
         end
       end
 

--- a/spec/presenters/claim_presenter_spec.rb
+++ b/spec/presenters/claim_presenter_spec.rb
@@ -195,7 +195,10 @@ RSpec.describe ClaimPresenter do
   describe '#amount_assessed' do
     context 'when assessment present' do
       before do
+        claim.submit!
+        claim.allocate!
         create(:assessment, claim: claim, fees: 100, expenses: 20.43)
+        claim.authorise!
       end
 
       it 'display a currency formatted amount assessed' do

--- a/spec/validators/claim_submodel_validation_spec.rb
+++ b/spec/validators/claim_submodel_validation_spec.rb
@@ -61,7 +61,6 @@ describe 'Validations on Claim submodels' do
     context 'bubbling up errors from defendant to claim' do
       before do
         claim.force_validation = false
-        claim.defendants << FactoryGirl.build(:defendant)
       end
       it 'should transfer errors up to claim' do
         claim.defendants.first.update(date_of_birth: nil)
@@ -69,8 +68,8 @@ describe 'Validations on Claim submodels' do
         claim.force_validation = true
         claim.reload.valid?
 
-        expect(claim.errors[:defendant_2_date_of_birth]).to eq(['blank'])
-        expect(claim.errors[:defendant_2_first_name]).to eq(['blank'])
+        expect(claim.errors[:defendant_1_date_of_birth]).to eq(['blank'])
+        expect(claim.errors[:defendant_1_first_name]).to eq(['blank'])
       end
     end
 
@@ -78,28 +77,17 @@ describe 'Validations on Claim submodels' do
     context 'bubbling up errors two levels to the claim' do
 
       let(:expected_results) do
-          {
+          { 
             defendant_1_representation_order_1_maat_reference:            "invalid",
+            defendant_1_representation_order_1_representation_order_date: "invalid",
             defendant_1_date_of_birth:                                    "blank",
-            defendant_1_first_name:                                       "blank",
-            defendant_1_last_name:                                        "blank",
-            defendant_1_representation_order_1_representation_order_date: "blank",
-            defendant_1_representation_order_1_granting_body:             "blank",
-            defendant_2_representation_order_1_representation_order_date: "invalid",
-            defendant_2_representation_order_3_representation_order_date: "blank",
-            defendant_2_representation_order_3_granting_body:             "blank"
           }
         end
 
       before(:each) do
-        claim.defendants << Defendant.new
-        claim.save!
-        claim.defendants.first.representation_orders << RepresentationOrder.new
-        claim.defendants.second.representation_orders << RepresentationOrder.new
-        claim.save!
+        claim.defendants.first.update(date_of_birth: nil)
         claim.defendants.first.representation_orders.first.update(maat_reference: 'XYZ')
-        claim.defendants.first.representation_orders.last.update(granting_body: nil)
-        claim.defendants.second.representation_orders.first.update(representation_order_date: 20.years.ago)
+        claim.defendants.first.representation_orders.first.update(representation_order_date: 20.years.ago)
         claim.save!
         claim.force_validation = true
 

--- a/spec/validators/claim_submodel_validation_spec.rb
+++ b/spec/validators/claim_submodel_validation_spec.rb
@@ -59,52 +59,59 @@ describe 'Validations on Claim submodels' do
     end
 
     context 'bubbling up errors from defendant to claim' do
-      before(:each) do
+      before do
         claim.force_validation = false
         claim.defendants << FactoryGirl.build(:defendant)
       end
       it 'should transfer errors up to claim' do
         claim.defendants.first.update(date_of_birth: nil)
-        claim.defendants.last.update(first_name: nil)
+        claim.defendants.first.update(first_name: nil)
         claim.force_validation = true
         claim.reload.valid?
 
-        expect(claim.errors[:defendant_1_date_of_birth]).to eq(['blank'])
+        expect(claim.errors[:defendant_2_date_of_birth]).to eq(['blank'])
         expect(claim.errors[:defendant_2_first_name]).to eq(['blank'])
       end
     end
 
 
     context 'bubbling up errors two levels to the claim' do
-      it 'should bubble up the error from reporder to defendant and then to the claim' do
 
+      let(:expected_results) do
+          {
+            defendant_1_representation_order_1_maat_reference:            "invalid",
+            defendant_1_date_of_birth:                                    "blank",
+            defendant_1_first_name:                                       "blank",
+            defendant_1_last_name:                                        "blank",
+            defendant_1_representation_order_1_representation_order_date: "blank",
+            defendant_1_representation_order_1_granting_body:             "blank",
+            defendant_2_representation_order_1_representation_order_date: "invalid",
+            defendant_2_representation_order_3_representation_order_date: "blank",
+            defendant_2_representation_order_3_granting_body:             "blank"
+          }
+        end
+
+      before(:each) do
         claim.defendants << Defendant.new
         claim.save!
-        claim.defendants.last.representation_orders << RepresentationOrder.new
+        claim.defendants.first.representation_orders << RepresentationOrder.new
+        claim.defendants.second.representation_orders << RepresentationOrder.new
         claim.save!
         claim.defendants.first.representation_orders.first.update(maat_reference: 'XYZ')
         claim.defendants.first.representation_orders.last.update(granting_body: nil)
-        claim.defendants.last.representation_orders.first.update(representation_order_date: 20.years.ago)
+        claim.defendants.second.representation_orders.first.update(representation_order_date: 20.years.ago)
         claim.save!
         claim.force_validation = true
 
         claim.valid?
-
-        expected_results = {
-          defendant_1_representation_order_1_maat_reference:            "invalid",
-          defendant_1_representation_order_2_granting_body:             "blank",
-          defendant_2_date_of_birth:                                    "blank",
-          defendant_2_first_name:                                       "blank",
-          defendant_2_last_name:                                        "blank",
-          defendant_2_representation_order_1_representation_order_date: "invalid",
-          defendant_2_representation_order_1_granting_body:             "blank"
-        }
-
-        expected_results.each do |key, message|
-          expect(claim.errors[key]).to eq( [message] )
-        end
-        
       end
+
+      it 'should bubble up the error from reporder to defendant and then to the claim' do
+        expected_results.each do |key, message|
+          expect(claim.errors[key]).to eq( [message] ), "EXPECTED: #{key} to have error [\"#{message}\"] but found #{claim.errors[key]}"
+        end  
+      end
+
     end
 
   end


### PR DESCRIPTION
- Vat is supposed to be applied at claim submission
- This has been implemented using the transition callback in statemachine
- Other callbacks to this effect are no longer required
- Vat is now applied using a method in the calculations module

*\* You'll see that I ended up changing some tests which were unrelated to the work here but flickered a lot and needed simplifying.
