### PR TITLE
replace name - remove "work" from "Claim for crown court defence work"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Advocate Defence Payments
-###a.k.a Claim for crown court defence work
+###a.k.a Claim for crown court defence
 
 [![Build Status](https://travis-ci.org/ministryofjustice/advocate-defence-payments.svg)](https://travis-ci.org/ministryofjustice/advocate-defence-payments)
 [![Code Climate](https://codeclimate.com/github/ministryofjustice/crime-billing-online/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/crime-billing-online)

--- a/app/models/json_schema.rb
+++ b/app/models/json_schema.rb
@@ -3,7 +3,7 @@ class JsonSchema
   class << self
 
     def generate(json_template)
-      schema = JSON::SchemaGenerator.generate 'Claim for crown court defence work - claim import', json_template
+      schema = JSON::SchemaGenerator.generate 'Claim for crown court defence - claim import', json_template
       parsed_schema = JSON.parse(schema)
       edit_required_items(parsed_schema) # schema is used to validate data type and json structure only
       parsed_schema

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,7 +1,7 @@
 <% if @resource.sign_in_count == 0 %>
 	<p>Hello <%= @resource.email %>!</p>
 
-	<p>You have been registered as a new user for "Claim for crown court defence work".  Please click on the link below and reset your password.</p>
+	<p>You have been registered as a new user for "Claim for crown court defence".  Please click on the link below and reset your password.</p>
 	<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 	<p>If you didn't request this, please ignore this email.</p>
 

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -15,6 +15,6 @@
     = f.input_field :email, autofocus: true, autocomplete: 'off', class: "form-control"
 
   %div.form-group
-    = f.button :submit, "Send me reset password instructions", class: "button text-small"
+    = f.button :submit, "Send me password reset instructions", class: "button text-small"
 
 = render "devise/shared/links"

--- a/app/views/devise/registrations/_terms_and_conditions.html.haml
+++ b/app/views/devise/registrations/_terms_and_conditions.html.haml
@@ -1,8 +1,8 @@
 %h2
-  "CLAIM FOR CROWN COURT DEFENCE WORK" TEST ENVIRONMENT – TERMS OF USE
+  "CLAIM FOR CROWN COURT DEFENCE" TEST ENVIRONMENT – TERMS OF USE
 
 %p
-  You are required to read and sign the following terms and conditions before you will be granted access to the "Claim for crown court defence work" Test Environment. Sections 1-4 are specific to software vendor testing, sections 5-10 are general terms & conditions that all external users of LAA environments are required to observe.
+  You are required to read and sign the following terms and conditions before you will be granted access to the "Claim for crown court defence" Test Environment. Sections 1-4 are specific to software vendor testing, sections 5-10 are general terms & conditions that all external users of LAA environments are required to observe.
 
 %h3
   1.	INTRODUCTION
@@ -10,7 +10,7 @@
 %p
   1.1
   %br
-  The below terms apply to you when you use the "Claim for crown court defence work" Test Environment available at #{link_to 'https://api-sandbox-adp.dsd.io/', 'https://api-sandbox-adp.dsd.io/'}
+  The below terms apply to you when you use the "Claim for crown court defence" Test Environment available at #{link_to 'https://api-sandbox-adp.dsd.io/', 'https://api-sandbox-adp.dsd.io/'}
   %br
   This website is hosted by Amazon Web Services through a contract with the Ministry of Justice Digital Team.
 
@@ -20,25 +20,25 @@
   These Terms govern your use of this website, therefore you are required to read and agree to these Terms prior to use.
 
 %h3
-  2.  ACCESSING THE "CLAIM FOR CROWN COURT DEFENCE WORK" TEST ENVIRONMENT
+  2.  ACCESSING THE "CLAIM FOR CROWN COURT DEFENCE" TEST ENVIRONMENT
 
 %p
   2.1
   %br
-  Access to The "Claim for crown court defence work" Test Environment is provided to your organisation only under condition of agreement to these terms. You are therefore prohibited from sharing the url address of this website outside of your organisation.
+  Access to The "Claim for crown court defence" Test Environment is provided to your organisation only under condition of agreement to these terms. You are therefore prohibited from sharing the url address of this website outside of your organisation.
 
 %p
   2.2
   %br
-  Where you are provided with a username, password or any other piece of information as part of our security procedures, you must treat such information as confidential and you must not disclose it to any third party. We have the right to disable or change any username or password at any time if in our opinion you have failed to comply with any of the provisions of these Terms or we feel it is necessary to safeguard security of the "Claim for crown court defence work" Test Environment.
+  Where you are provided with a username, password or any other piece of information as part of our security procedures, you must treat such information as confidential and you must not disclose it to any third party. We have the right to disable or change any username or password at any time if in our opinion you have failed to comply with any of the provisions of these Terms or we feel it is necessary to safeguard security of the "Claim for crown court defence" Test Environment.
 
 %h3
-  3.	USE OF THE "CLAIM FOR CROWN COURT DEFENCE WORK" TEST ENVIRONMENT
+  3.	USE OF THE "CLAIM FOR CROWN COURT DEFENCE" TEST ENVIRONMENT
 
 %p
   3.1
   %br
-  You have been granted access to the "Claim for crown court defence work" Test Environment for the specific purpose of testing integration between your software and the "Claim for crown court defence work" API.
+  You have been granted access to the "Claim for crown court defence" Test Environment for the specific purpose of testing integration between your software and the "Claim for crown court defence" API.
 
 %p
   3.2
@@ -46,7 +46,7 @@
   As such, you are authorised to perform the following actions only:
   %br
   %br
-  i)	Log in to the "Claim for crown court defence work" Test Environment
+  i)	Log in to the "Claim for crown court defence" Test Environment
   %br
   ii)	Access the API documentation
   %br
@@ -62,12 +62,12 @@
   You may not use this website to carry out any other activities, submitting applications, manual creation of bills, or submission of bills using the ‘Start a new claim functionality’
 
 %h3
-  4.  AVAILABILITY OF "CLAIM FOR CROWN COURT DEFENCE WORK" TEST ENVIRONMENT
+  4.  AVAILABILITY OF "CLAIM FOR CROWN COURT DEFENCE" TEST ENVIRONMENT
 
 %p
   4.1
   %br
-  We will use our reasonable endeavours to ensure access to the "Claim for crown court defence work" Test Environment during the timescales agreed for testing, but we will not be liable to you if for any reason the "Claim for crown court defence work" Test Environment is unavailable at any time or for any period.
+  We will use our reasonable endeavours to ensure access to the "Claim for crown court defence" Test Environment during the timescales agreed for testing, but we will not be liable to you if for any reason the "Claim for crown court defence" Test Environment is unavailable at any time or for any period.
 
 
 %h3
@@ -76,12 +76,12 @@
 %p
   5.1
   %br
-  We are the owner or the licensee of all intellectual property rights in the "Claim for crown court defence work" Test Environment, and in the material published on it. Those works are protected by copyright laws and treaties around the world. All such rights are reserved.
+  We are the owner or the licensee of all intellectual property rights in the "Claim for crown court defence" Test Environment, and in the material published on it. Those works are protected by copyright laws and treaties around the world. All such rights are reserved.
 
 %p
   5.2
   %br
-  You may print extracts from the contents of the "Claim for crown court defence work" Test Environment only in so far as it is necessary for you to do so to use the service provided by the "Claim for crown court defence work" Test Environment, provided that you do not alter, amend or delete any intellectual property rights, notices or marks. Reproduction of all or part of the "Claim for crown court defence work" Test Environment or contents of the "Claim for crown court defence work" Test Environment in any form is prohibited for any other purpose. None of the contents of the "Claim for crown court defence work" Test Environment may be copied or otherwise incorporated into or stored in any other electronic system, publication or other work in any form (whether hard copy, electronic or other) other than as set out in this section 5.
+  You may print extracts from the contents of the "Claim for crown court defence" Test Environment only in so far as it is necessary for you to do so to use the service provided by the "Claim for crown court defence" Test Environment, provided that you do not alter, amend or delete any intellectual property rights, notices or marks. Reproduction of all or part of the "Claim for crown court defence" Test Environment or contents of the "Claim for crown court defence" Test Environment in any form is prohibited for any other purpose. None of the contents of the "Claim for crown court defence" Test Environment may be copied or otherwise incorporated into or stored in any other electronic system, publication or other work in any form (whether hard copy, electronic or other) other than as set out in this section 5.
 
 %p
   5.3
@@ -91,7 +91,7 @@
 %p
   5.4
   %br
-  If you print off, copy or download any part of the "Claim for crown court defence work" Test Environment in breach of these Terms, you must, at our request, return or destroy any copies of any materials from the "Claim for crown court defence work" Test Environment that you have made and we shall have the right to take action in accordance with section 7.
+  If you print off, copy or download any part of the "Claim for crown court defence" Test Environment in breach of these Terms, you must, at our request, return or destroy any copies of any materials from the "Claim for crown court defence" Test Environment that you have made and we shall have the right to take action in accordance with section 7.
 
 %h3
   6.	PROHIBITED USES
@@ -99,7 +99,7 @@
 %p
   6.1
   %br
-  You may not use the "Claim for crown court defence work" Test Environment:
+  You may not use the "Claim for crown court defence" Test Environment:
   %br
   6.1.1
   %br
@@ -120,20 +120,20 @@
   %br
   6.2.1
   %br
-  not to reproduce, duplicate copy or re-sell any part of the "Claim for crown court defence work" Test Environment in contravention of the provisions of these Terms;
+  not to reproduce, duplicate copy or re-sell any part of the "Claim for crown court defence" Test Environment in contravention of the provisions of these Terms;
   %br
   6.2.2
   %br
   not to access without authority, interfere with, damage or disrupt:
   %br
   (a)
-  any part of the "Claim for crown court defence work" Test Environment;
+  any part of the "Claim for crown court defence" Test Environment;
   %br
   (b)
-  any equipment or network on which the "Claim for crown court defence work" Test Environment is stored;
+  any equipment or network on which the "Claim for crown court defence" Test Environment is stored;
   %br
   (c)
-  any software and/or database used in the provision of the "Claim for crown court defence work" Test Environment;
+  any software and/or database used in the provision of the "Claim for crown court defence" Test Environment;
   %br
   (d)
   any equipment or network or software owned or used by any third party; or
@@ -145,12 +145,12 @@
 %p
   6.2.3
   %br
-  not to attack the "Claim for crown court defence work" Test Environment via a denial-of-service attack or a distributed denial-of-service attack.
+  not to attack the "Claim for crown court defence" Test Environment via a denial-of-service attack or a distributed denial-of-service attack.
   %br
 
   6.3
   %br
-  By breaching this section 6, you may commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities and we will co-operate with those authorities by disclosing your identity. In the event of such a breach, your right to use the "Claim for crown court defence work" Test Environment will cease immediately.
+  By breaching this section 6, you may commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities and we will co-operate with those authorities by disclosing your identity. In the event of such a breach, your right to use the "Claim for crown court defence" Test Environment will cease immediately.
 
 %h3
   7.	SUSPENSION AND TERMINATION
@@ -158,7 +158,7 @@
 %p
   7.1
   %br
-  We may revoke your access to the "Claim for crown court defence work" Test Environment and terminate these Terms with immediate effect if you breach these Terms.
+  We may revoke your access to the "Claim for crown court defence" Test Environment and terminate these Terms with immediate effect if you breach these Terms.
 
 %p
   7.2
@@ -172,7 +172,7 @@
   %br
   7.3.1
   %br
-  immediate, temporary or permanent withdrawal of your right to use the "Claim for crown court defence work" Test Environment;
+  immediate, temporary or permanent withdrawal of your right to use the "Claim for crown court defence" Test Environment;
   %br
   7.3.2
   %br
@@ -200,12 +200,12 @@
 %p
   8.1
   %br
-  We will not be liable for any loss or damage caused by a distributed denial-of-service attack, viruses or other technologically harmful material that may infect your computer equipment, computer programs, data or other proprietary material due to your use of the "Claim for crown court defence work" Test Environment or to your downloading of any content on it, or on any website linked to it.
+  We will not be liable for any loss or damage caused by a distributed denial-of-service attack, viruses or other technologically harmful material that may infect your computer equipment, computer programs, data or other proprietary material due to your use of the "Claim for crown court defence" Test Environment or to your downloading of any content on it, or on any website linked to it.
 
 %p
   8.2
   %br
-  Data held in the "Claim for crown court defence work" test environment will be deleted every two days.  We will not be held liable for the loss of any dummy data or impacts on development activities as a result of this deletion.
+  Data held in the "Claim for crown court defence" test environment will be deleted every two days.  We will not be held liable for the loss of any dummy data or impacts on development activities as a result of this deletion.
 
 %h3
   9. INFORMATION ABOUT YOU AND YOUR VISITS TO OUR SITE
@@ -213,7 +213,7 @@
 %p
   9.1
   %br
-  We collect and process your personal data (such as your contact details and, to the extent it constitutes personal data, your IP address) in accordance with these Terms. By using the "Claim for crown court defence work" Test Environment, you consent to such processing in accordance with the Terms.
+  We collect and process your personal data (such as your contact details and, to the extent it constitutes personal data, your IP address) in accordance with these Terms. By using the "Claim for crown court defence" Test Environment, you consent to such processing in accordance with the Terms.
 
 %h3
   10. JURISDICTION AND APPLICABLE LAW

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -136,7 +136,7 @@
           </div>
         </div>
         <div class="header-app-name">
-          <%= content_for?(:header_app_name) ? yield(:header_app_name) : 'Claim for crown court defence work' %>
+          <%= content_for?(:header_app_name) ? yield(:header_app_name) : 'Claim for crown court defence' %>
         </div>
         <div id="log-in-out">
           <%= yield :log_in_out %>

--- a/app/views/pages/api_landing.html.haml
+++ b/app/views/pages/api_landing.html.haml
@@ -1,17 +1,17 @@
 %section.api-documentation
   %h1.page-title
-    Claim for crown court defence work API
+    Claim for crown court defence API
 
   %h3
     Overview
 
   %p
-    An Application Program Interface (API) enables one computer system to talk to another. The "Claim for crown court defence work" system has an API that allows external applications to create claims.
+    An Application Program Interface (API) enables one computer system to talk to another. The "Claim for crown court defence" system has an API that allows external applications to create claims.
 
   %p
-    The API’s typical users are commercial case management systems.  This page is mainly for software vendors of these systems, to help them provide the functionality to submit claims to the "Claim for crown court defence work" system automatically.
+    The API’s typical users are commercial case management systems.  This page is mainly for software vendors of these systems, to help them provide the functionality to submit claims to the "Claim for crown court defence" system automatically.
   %p
-    The API only submits draft claims. The end user then logs on to the "Claim for crown court defence work" system to review the claim, upload documentary evidence, and submit the claim to the Legal Aid Agency.
+    The API only submits draft claims. The end user then logs on to the "Claim for crown court defence" system to review the claim, upload documentary evidence, and submit the claim to the Legal Aid Agency.
 
   %h3
     Documentation
@@ -115,7 +115,7 @@
     Example Desktop Application
 
   %p
-    We’ve provided a basic example of a desktop application written in .NET (C#) that uses the "Claim for crown court defence work" API to help you write your own CMS extension. You can #{link_to 'download the source code from github', 'https://github.com/ministryofjustice/adp_api_client', rel: 'external'}.
+    We’ve provided a basic example of a desktop application written in .NET (C#) that uses the "Claim for crown court defence" API to help you write your own CMS extension. You can #{link_to 'download the source code from github', 'https://github.com/ministryofjustice/adp_api_client', rel: 'external'}.
   %p
     We’ll try to keep this application up to date with any changes to the API so it can submit basic claims
 

--- a/app/views/pages/tandcs.haml
+++ b/app/views/pages/tandcs.haml
@@ -1,6 +1,6 @@
 %section.tandcs
   %h2
-    THE "CLAIM FOR CROWN COURT DEFENCE WORK" APPLICATION TERMS OF USE
+    THE "CLAIM FOR CROWN COURT DEFENCE" APPLICATION TERMS OF USE
 
   %h3
     1. INTRODUCTION
@@ -11,12 +11,12 @@
     The below terms (the
     = succeed ')' do
       %b &ldquo;Terms&rdquo;
-    apply to you when you use the "Claim for crown court defence work" Application available at
+    apply to you when you use the "Claim for crown court defence" Application available at
     <a href="http://staging-adp.dsd.io">http://staging-adp.dsd.io</a>
     the
     = succeed ')' do
-      %b &ldquo;Claim for crown court defence work Application&rdquo;
-    and as applicable to Authorising Organisations. The "Claim for crown court defence work" Application is a single point of log in for payments under the Advocates’ Graduated Fee Scheme
+      %b &ldquo;Claim for crown court defence Application&rdquo;
+    and as applicable to Authorising Organisations. The "Claim for crown court defence" Application is a single point of log in for payments under the Advocates’ Graduated Fee Scheme
     = surround '(', ').' do
       %b &ldquo;AGFS&rdquo;
     These Terms will also apply to the Litigators’ Graduate Fee Scheme
@@ -34,7 +34,7 @@
   %p
     1.3
     %br
-    These Terms govern your use of the "Claim for crown court defence work" Application, therefore please read these Terms carefully and do not use the "Claim for crown court defence work" Application if you do not agree with them.
+    These Terms govern your use of the "Claim for crown court defence" Application, therefore please read these Terms carefully and do not use the "Claim for crown court defence" Application if you do not agree with them.
 
   %h3 2. DEFINITIONS
 
@@ -61,7 +61,7 @@
   %p
     %b
       &ldquo;Authorising Organisation&rdquo;
-    means an organisation or person making Claims under the Standard Terms or any other organisation or person who has written authority from us to use the "Claim for crown court defence work" Application in accordance with the Terms;
+    means an organisation or person making Claims under the Standard Terms or any other organisation or person who has written authority from us to use the "Claim for crown court defence" Application in accordance with the Terms;
 
   %p
     %b
@@ -98,7 +98,7 @@
       &ldquo;LAA Data&rdquo;
     means:
   %p
-    (a) the Data on the "Claim for crown court defence work" Application (including drawings, diagrams, images or sounds (together with any database made up of any of these which is embodied in any electronic, magnetic optical or tangible media)) which:
+    (a) the Data on the "Claim for crown court defence" Application (including drawings, diagrams, images or sounds (together with any database made up of any of these which is embodied in any electronic, magnetic optical or tangible media)) which:
     %br
     i.  are supplied to you by us or on our behalf;
     %br
@@ -130,7 +130,7 @@
   %p
     %b
       &ldquo;Shared Data&rdquo;
-    means Data (including Personal Data) on the "Claim for crown court defence work" Application for which you are the Data Controller, either alone or in common with us;
+    means Data (including Personal Data) on the "Claim for crown court defence" Application for which you are the Data Controller, either alone or in common with us;
 
   %p
     %b
@@ -150,7 +150,7 @@
     means the Lord Chancellor acting through the LAA; and
     %b
       &ldquo;you&rdquo;, &ldquo;your&rdquo;
-    refers to (unless expressly indicated otherwise) you as an Authorised Representative, whom the Authorising Organisation has authorised to use the "Claim for crown court defence work" Application , an Advocate or a Litigator (as relevant).
+    refers to (unless expressly indicated otherwise) you as an Authorised Representative, whom the Authorising Organisation has authorised to use the "Claim for crown court defence" Application , an Advocate or a Litigator (as relevant).
 
 
   %h3
@@ -161,78 +161,78 @@
   %p
     3.1
     %br
-    In order to use the "Claim for crown court defence work" Application, you must be either (i) an Authorised Representative (ii) Authorised Signatory (iii) an Advocate or (iiii) a Litigator.
+    In order to use the "Claim for crown court defence" Application, you must be either (i) an Authorised Representative (ii) Authorised Signatory (iii) an Advocate or (iiii) a Litigator.
 
   %p
     3.2
     %br
-    The Authorising Organisation shall ensure that any Authorised Representative to whom it provides or facilitates access to the "Claim for crown court defence work" Application complies with these Terms and the applicable provisions in the Standard Terms.
+    The Authorising Organisation shall ensure that any Authorised Representative to whom it provides or facilitates access to the "Claim for crown court defence" Application complies with these Terms and the applicable provisions in the Standard Terms.
 
   %p
     3.3
     %br
-    To the extent you are an Authorised Representative, Advocate or a Litigator, you shall comply with these Terms when using the "Claim for crown court defence work" Application.
+    To the extent you are an Authorised Representative, Advocate or a Litigator, you shall comply with these Terms when using the "Claim for crown court defence" Application.
 
 
   %h3
     4.
     %br
-    LICENCE TO USE THE "CLAIM FOR CROWN COURT DEFENCE WORK" APPLICATION
+    LICENCE TO USE THE "CLAIM FOR CROWN COURT DEFENCE" APPLICATION
 
   %p
     4.1
     %br
-    To the extent you are an Authorised Representative and subject to section 13, we grant you a non-exclusive, non-transferable and revocable licence to use the Claim for crown court defence work" Application in accordance with the purposes set out in the Standard Terms.
+    To the extent you are an Authorised Representative and subject to section 13, we grant you a non-exclusive, non-transferable and revocable licence to use the Claim for crown court defence" Application in accordance with the purposes set out in the Standard Terms.
 
   %p
     4.2
     %br
-    To the extent you are an Advocate and subject to section 13, we grant you a non-exclusive, non-transferable and revocable licence to use the "Claim for crown court defence work" Application for the purpose of assisting us to fulfil our statutory obligations under Part 1 of the Legal Aid, Sentencing and Punishment of Offenders Act 2012 relating to the Legal Aid scheme.
+    To the extent you are an Advocate and subject to section 13, we grant you a non-exclusive, non-transferable and revocable licence to use the "Claim for crown court defence" Application for the purpose of assisting us to fulfil our statutory obligations under Part 1 of the Legal Aid, Sentencing and Punishment of Offenders Act 2012 relating to the Legal Aid scheme.
 
   %p
     4.3
     %br
-    To the extent you are a Litigator and subject to section 13, we grant you a non-exclusive, non-transferable and revocable licence to use the "Claim for crown court defence work" Application in accordance with the purposes set out in the Standard Terms.
+    To the extent you are a Litigator and subject to section 13, we grant you a non-exclusive, non-transferable and revocable licence to use the "Claim for crown court defence" Application in accordance with the purposes set out in the Standard Terms.
 
   %h3
     5.
     %br
-    INFORMATION ON "CLAIM FOR CROWN COURT DEFENCE WORK" APPLICATION
+    INFORMATION ON "CLAIM FOR CROWN COURT DEFENCE" APPLICATION
 
   %p
-    You acknowledge that any information and other materials posted on the "Claim for crown court defence work" Application are not intended to amount to advice on which reliance should be placed.
+    You acknowledge that any information and other materials posted on the "Claim for crown court defence" Application are not intended to amount to advice on which reliance should be placed.
 
   %h3
     6.
     %br
-    AVAILABILITY OF "CLAIM FOR CROWN COURT DEFENCE WORK" APPLICATION
+    AVAILABILITY OF "CLAIM FOR CROWN COURT DEFENCE" APPLICATION
 
   %p
     6.1
     %br
-    We will use our reasonable endeavours to ensure access to the "Claim for crown court defence work" Application but we will not be liable to you if for any reason the "Claim for crown court defence work" Application is unavailable at any time or for any period.
+    We will use our reasonable endeavours to ensure access to the "Claim for crown court defence" Application but we will not be liable to you if for any reason the "Claim for crown court defence" Application is unavailable at any time or for any period.
 
   %p
     6.2
     %br
-    We reserve the right to withdraw or amend the "Claim for crown court defence work" Application or the services we provide through the "Claim for crown court defence work" Application without notice. From time to time, we may:
+    We reserve the right to withdraw or amend the "Claim for crown court defence" Application or the services we provide through the "Claim for crown court defence" Application without notice. From time to time, we may:
 
   %p
     6.2.1
     %br
-    restrict access to some or all of the "Claim for crown court defence work" Application; and
+    restrict access to some or all of the "Claim for crown court defence" Application; and
 
   %p
     6.2.2
     %br
-    make changes to the "Claim for crown court defence work" Application and any material on it.
+    make changes to the "Claim for crown court defence" Application and any material on it.
 
 
 
   %h3
     7.
     %br
-    INFORMATION SUBMITTED THROUGH THE "CLAIM FOR CROWN COURT DEFENCE WORK" APPLICATION
+    INFORMATION SUBMITTED THROUGH THE "CLAIM FOR CROWN COURT DEFENCE" APPLICATION
 
   %p
     7.1
@@ -242,13 +242,13 @@
   %p
     7.1.1
     %br
-    Your Authorised Representatives, Advocates and Litigators submit Claims, information and requests through the "Claim for crown court defence work" Application in accordance with the Standard Terms;
+    Your Authorised Representatives, Advocates and Litigators submit Claims, information and requests through the "Claim for crown court defence" Application in accordance with the Standard Terms;
 
 
   %p
     7.1.2
     %br
-    Your Authorised Representatives, Advocates and Litigators do not make the same submission in paper form and electronically through the "Claim for crown court defence work" Application unless authorised to do so by us; and
+    Your Authorised Representatives, Advocates and Litigators do not make the same submission in paper form and electronically through the "Claim for crown court defence" Application unless authorised to do so by us; and
 
   %p
     7.1.3
@@ -268,12 +268,12 @@
   %p
     7.3.1
     %br
-    submit Claims, information and requests through the "Claim for crown court defence work" Application in accordance with these Terms;
+    submit Claims, information and requests through the "Claim for crown court defence" Application in accordance with these Terms;
 
   %p
     7.3.2
     %br
-    not make the same submission in paper form and electronically through the "Claim for crown court defence work" Application unless authorised to do so by us; and
+    not make the same submission in paper form and electronically through the "Claim for crown court defence" Application unless authorised to do so by us; and
 
   %p
     7.3.3
@@ -288,7 +288,7 @@
   %p
     7.6
     %br
-    We will use the information you provide via the "Claim for crown court defence work" Application to administer your Claims and submissions in accordance with the Legal Aid Legislation, and the Standard Terms where appropriate.
+    We will use the information you provide via the "Claim for crown court defence" Application to administer your Claims and submissions in accordance with the Legal Aid Legislation, and the Standard Terms where appropriate.
 
   %h3
     8.
@@ -308,7 +308,7 @@
   %p
     8.1.2
     %br
-    all obligations imposed on you by the Data Protection Legislation whilst Processing Data on the "Claim for crown court defence work" Application; and
+    all obligations imposed on you by the Data Protection Legislation whilst Processing Data on the "Claim for crown court defence" Application; and
 
   %p
     8.1.3
@@ -323,7 +323,7 @@
   %p
     8.3
     %br
-    Without prejudice to the general obligations at section 8.1 above, in relation to the Data on the "Claim for crown court defence work" Application, you shall:
+    Without prejudice to the general obligations at section 8.1 above, in relation to the Data on the "Claim for crown court defence" Application, you shall:
 
   %p
     8.3.1
@@ -388,7 +388,7 @@
   %p
     8.6
     %br
-    The provisions of this section 8 shall apply for as long as you continue to have a valid licence to use the "Claim for crown court defence work" Application under section 4, and shall continue to apply for a period of six years following termination (howsoever caused) of your licence.
+    The provisions of this section 8 shall apply for as long as you continue to have a valid licence to use the "Claim for crown court defence" Application under section 4, and shall continue to apply for a period of six years following termination (howsoever caused) of your licence.
 
   %h3
     9
@@ -398,7 +398,7 @@
   %p
     9.1
     %br
-    A description of each type of user of the "Claim for crown court defence work" Application is set out along with their respective permissions and access rights in Sections 9.1 to 9.7 below.
+    A description of each type of user of the "Claim for crown court defence" Application is set out along with their respective permissions and access rights in Sections 9.1 to 9.7 below.
 
   %p
     9.2
@@ -419,7 +419,7 @@
   %p
     9.4
     %br
-    Where we provide you with Advocate Administrator User or Advocate User rights to access the "Claim for crown court defence work" Application, as an Authorising Organisation, in relation to the Authorised Representatives, as an Advocate, or as a Litigator in relation to any persons or organisations to whom you arrange access to the "Claim for crown court defence work" Application , you shall ensure that they:
+    Where we provide you with Advocate Administrator User or Advocate User rights to access the "Claim for crown court defence" Application, as an Authorising Organisation, in relation to the Authorised Representatives, as an Advocate, or as a Litigator in relation to any persons or organisations to whom you arrange access to the "Claim for crown court defence" Application , you shall ensure that they:
 
   %p
     9.4.1
@@ -436,17 +436,17 @@
   %p
     9.4.3
     %br
-    are prevented from accessing the "Claim for crown court defence work" Application once they cease to be authorised by the Authorising Organisation, Advocate or Litigator to access the "Claim for crown court defence work" Application.
+    are prevented from accessing the "Claim for crown court defence" Application once they cease to be authorised by the Authorising Organisation, Advocate or Litigator to access the "Claim for crown court defence" Application.
 
   %p
     9.5
     %br
-    If you are provided with a username, password or any other piece of information as part of our security procedures, you must treat such information as confidential and you must not disclose it to any third party. We have the right to disable or change any username or password, whether chosen by you or allocated by us, at any time if in our opinion you have failed to comply with any of the provisions of these Terms or we feel it is necessary to safeguard security of the "Claim for crown court defence work" Application.
+    If you are provided with a username, password or any other piece of information as part of our security procedures, you must treat such information as confidential and you must not disclose it to any third party. We have the right to disable or change any username or password, whether chosen by you or allocated by us, at any time if in our opinion you have failed to comply with any of the provisions of these Terms or we feel it is necessary to safeguard security of the "Claim for crown court defence" Application.
 
   %p
     9.6
     %br
-    You are responsible for making all arrangements necessary for you to have access to the "Claim for crown court defence work" Application
+    You are responsible for making all arrangements necessary for you to have access to the "Claim for crown court defence" Application
 
   %p
     9.7
@@ -461,12 +461,12 @@
   %p
     10.1
     %br
-    We are the owner or the licensee of all intellectual property rights in the "Claim for crown court defence work" Application, and in the material published on it. Those works are protected by copyright laws and treaties around the world. All such rights are reserved.
+    We are the owner or the licensee of all intellectual property rights in the "Claim for crown court defence" Application, and in the material published on it. Those works are protected by copyright laws and treaties around the world. All such rights are reserved.
 
   %p
     10.2
     %br
-    You may print extracts from the contents of the "Claim for crown court defence work" Application only in so far as it is necessary for you to do so to use the service provided by the "Claim for crown court defence work" Application, [provided that you do not alter, amend or delete any intellectual property rights, notices or marks]. Reproduction of all or part of the "Claim for crown court defence work" Application or contents of the "Claim for crown court defence work" Application in any form is prohibited for any other purpose. None of the contents of the "Claim for crown court defence work" Application may be copied or otherwise incorporated into or stored in any other electronic system, publication or other work in any form (whether hard copy, electronic or other) other than as set out in this section 10.
+    You may print extracts from the contents of the "Claim for crown court defence" Application only in so far as it is necessary for you to do so to use the service provided by the "Claim for crown court defence" Application, [provided that you do not alter, amend or delete any intellectual property rights, notices or marks]. Reproduction of all or part of the "Claim for crown court defence" Application or contents of the "Claim for crown court defence" Application in any form is prohibited for any other purpose. None of the contents of the "Claim for crown court defence" Application may be copied or otherwise incorporated into or stored in any other electronic system, publication or other work in any form (whether hard copy, electronic or other) other than as set out in this section 10.
 
   %p
     10.3
@@ -476,7 +476,7 @@
   %p
     10.4
     %br
-    If you print off, copy or download any part of the "Claim for crown court defence work" Application in breach of these Terms, you must, at our option, return or destroy any copies of any materials from the "Claim for crown court defence work" Application that you have made and we shall have the right to take action in accordance with section 13.
+    If you print off, copy or download any part of the "Claim for crown court defence" Application in breach of these Terms, you must, at our option, return or destroy any copies of any materials from the "Claim for crown court defence" Application that you have made and we shall have the right to take action in accordance with section 13.
 
   %h3
     11.
@@ -486,7 +486,7 @@
   %p
     11.1
     %br
-    You may not use the "Claim for crown court defence work" Application:
+    You may not use the "Claim for crown court defence" Application:
 
   %p
     11.1.1
@@ -512,35 +512,35 @@
   %p
     11.2.1
     %br
-    not to reproduce, duplicate copy or re-sell any part of the "Claim for crown court defence work" Application in contravention of the provisions of these Terms;
+    not to reproduce, duplicate copy or re-sell any part of the "Claim for crown court defence" Application in contravention of the provisions of these Terms;
 
   %p
     11.2.2
     %br
     not to access without authority, interfere with, damage or disrupt:
-  (a) any part of the "Claim for crown court defence work" Application;
-  (b) any equipment or network on which the "Claim for crown court defence work" Application is stored;
-  (c) any software and/or database used in the provision of the "Claim for crown court defence work" Application;
+  (a) any part of the "Claim for crown court defence" Application;
+  (b) any equipment or network on which the "Claim for crown court defence" Application is stored;
+  (c) any software and/or database used in the provision of the "Claim for crown court defence" Application;
   (d) any equipment or network or software owned or used by any third party; or
   (e) other users' accounts or information; and
 
   %p
     11.2.3
     %br
-    not to attack the "Claim for crown court defence work" Application via a denial-of-service attack or a distributed denial-of-service attack.
+    not to attack the "Claim for crown court defence" Application via a denial-of-service attack or a distributed denial-of-service attack.
 
   %p
     11.3
     %br
-    By breaching this section 11, you may commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities and we will co-operate with those authorities by disclosing your identity. In the event of such a breach, your right to use the "Claim for crown court defence work" Application will cease immediately.
+    By breaching this section 11, you may commit a criminal offence under the Computer Misuse Act 1990. We will report any such breach to the relevant law enforcement authorities and we will co-operate with those authorities by disclosing your identity. In the event of such a breach, your right to use the "Claim for crown court defence" Application will cease immediately.
 
 
   %h3
     12.
     %br
-    LINKS FROM THE "CLAIM FOR CROWN COURT DEFENCE WORK" APPLICATION
+    LINKS FROM THE "CLAIM FOR CROWN COURT DEFENCE" APPLICATION
 
-  Where the "Claim for crown court defence work" Application contains links to other websites and resources provided by third parties, these links are provided for your information only. We have no control over the contents of those websites or resources, and accept no responsibility for them or for any loss or damage that may arise from your use of them.
+  Where the "Claim for crown court defence" Application contains links to other websites and resources provided by third parties, these links are provided for your information only. We have no control over the contents of those websites or resources, and accept no responsibility for them or for any loss or damage that may arise from your use of them.
 
 
   %h3
@@ -566,12 +566,12 @@
   %p
     13.3.1
     %br
-    immediate, temporary or permanent withdrawal of your right to use the "Claim for crown court defence work" Application;
+    immediate, temporary or permanent withdrawal of your right to use the "Claim for crown court defence" Application;
 
   %p
     13.3.2
     %br
-    immediate, temporary or permanent removal of any material uploaded by you to the "Claim for crown court defence work" Application;
+    immediate, temporary or permanent removal of any material uploaded by you to the "Claim for crown court defence" Application;
 
   %p
     13.3.3
@@ -611,12 +611,12 @@
   %p
     14.2
     %br
-    To the extent permitted by law, the "Claim for crown court defence work" Application is provided without any guarantee, conditions or warranties as to its availability, accuracy or fitness for purpose.
+    To the extent permitted by law, the "Claim for crown court defence" Application is provided without any guarantee, conditions or warranties as to its availability, accuracy or fitness for purpose.
 
   %p
     14.3
     %br
-    To the extent permitted by law, we expressly exclude all and any liability to you in respect of all or any claims arising out of or in connection with these Terms and your use of the "Claim for crown court defence work" Application (including without limitation as a result of, negligence or any other tort (including without limitation negligence), under statute or otherwise).
+    To the extent permitted by law, we expressly exclude all and any liability to you in respect of all or any claims arising out of or in connection with these Terms and your use of the "Claim for crown court defence" Application (including without limitation as a result of, negligence or any other tort (including without limitation negligence), under statute or otherwise).
 
   %p
     14.4
@@ -626,7 +626,7 @@
   %p
     14.5
     %br
-    We will not be liable for any loss or damage caused by a distributed denial-of-service attack, viruses or other technologically harmful material that may infect your computer equipment, computer programs, data or other proprietary material due to your use of the "Claim for crown court defence work" Application or to your downloading of any content on it, or on any website linked to it.
+    We will not be liable for any loss or damage caused by a distributed denial-of-service attack, viruses or other technologically harmful material that may infect your computer equipment, computer programs, data or other proprietary material due to your use of the "Claim for crown court defence" Application or to your downloading of any content on it, or on any website linked to it.
 
   %h3
     15.
@@ -634,7 +634,7 @@
     CHANGES TO THESE TERMS
 
   %p
-  We may amend these Terms from time to time and we will notify you of this on our website. Such changes are effective from the date they are notified. Your continued use of the "Claim for crown court defence work" Application after such date shows your acceptance of such changes.
+  We may amend these Terms from time to time and we will notify you of this on our website. Such changes are effective from the date they are notified. Your continued use of the "Claim for crown court defence" Application after such date shows your acceptance of such changes.
 
   %h3
     16.
@@ -646,14 +646,14 @@
     %br
     %b
       Your information:
-    We collect and process your personal data (such as your contact details and, to the extent it constitutes personal data, your IP address) in accordance with these Terms. By using the "Claim for crown court defence work" Application you consent to such processing in accordance with the Terms.
+    We collect and process your personal data (such as your contact details and, to the extent it constitutes personal data, your IP address) in accordance with these Terms. By using the "Claim for crown court defence" Application you consent to such processing in accordance with the Terms.
 
   %p
     16.2
     %br
     %b
       Cookies:
-    We may use information obtained about you from cookies (files which are sent to us by your computer or other access device) which we can access when you visit the "Claim for crown court defence work" Application in future. The cookies store small pieces of information about our users, such as names and email addresses. There are different kinds of cookies with different functions:
+    We may use information obtained about you from cookies (files which are sent to us by your computer or other access device) which we can access when you visit the "Claim for crown court defence" Application in future. The cookies store small pieces of information about our users, such as names and email addresses. There are different kinds of cookies with different functions:
 
   %p
     16.2.1
@@ -674,17 +674,17 @@
     %br
     %b
       Google Analytics:
-    The "Claim for crown court defence work" Application uses Google Analytics, a web analytics service provided by Google, Inc.
+    The "Claim for crown court defence" Application uses Google Analytics, a web analytics service provided by Google, Inc.
     = surround '("', '").' do
       %b Google
-    Google Analytics uses cookies to help analyse how the "Claim for crown court defence work" Application is being used. The information generated by the cookie about your use of the "Claim for crown court defence work" Application (including your IP address) will be transmitted to and stored by Google on servers in the U.S. Google will use this information for the purpose of evaluating your use of the "Claim for crown court defence work" Application, compiling reports on "Claim for crown court defence work" Application activity and internet usage. Google may also transfer this information to third parties where required to do so by law, or where such third parties process the information on Google’s behalf. Google will not associate your IP address with any other data held by Google. By using the "Claim for crown court defence work" Application you consent to the processing of your personal data about you by Google in the manner and for the purposes set out above.
+    Google Analytics uses cookies to help analyse how the "Claim for crown court defence" Application is being used. The information generated by the cookie about your use of the "Claim for crown court defence" Application (including your IP address) will be transmitted to and stored by Google on servers in the U.S. Google will use this information for the purpose of evaluating your use of the "Claim for crown court defence" Application, compiling reports on "Claim for crown court defence" Application activity and internet usage. Google may also transfer this information to third parties where required to do so by law, or where such third parties process the information on Google’s behalf. Google will not associate your IP address with any other data held by Google. By using the "Claim for crown court defence" Application you consent to the processing of your personal data about you by Google in the manner and for the purposes set out above.
 
   %p
     16.4
     %br
     %b
       Deleting cookies:
-    If you want to delete any cookies that are already on your computer, please refer to the instructions for your file management software to locate the file or directory that stores cookies. If you want to stop cookies being stored on your computer in future, please refer to your browser manufacturer’s instructions by clicking "Help" in your browser menu. Further information on deleting or controlling cookies is available at <a href="www.AboutCookies.org">www.AboutCookies.org</a>. Please note that by deleting our cookies or disabling future cookies you may not be able to access certain areas or features of the "Claim for crown court defence work" Application.
+    If you want to delete any cookies that are already on your computer, please refer to the instructions for your file management software to locate the file or directory that stores cookies. If you want to stop cookies being stored on your computer in future, please refer to your browser manufacturer’s instructions by clicking "Help" in your browser menu. Further information on deleting or controlling cookies is available at <a href="www.AboutCookies.org">www.AboutCookies.org</a>. Please note that by deleting our cookies or disabling future cookies you may not be able to access certain areas or features of the "Claim for crown court defence" Application.
 
   17.
   JURISDICTION AND APPLICABLE LAW
@@ -702,5 +702,5 @@
   If you wish to contact us you can write to us at: The Legal Aid Agency, 102 Petty France, London, SW1H 9AJ.
 
   %b
-    Thank you for visiting our "Claim for crown court defence work" Application.
+    Thank you for visiting our "Claim for crown court defence" Application.
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,9 +26,9 @@ module AdvocateDefencePayments
     end
 
     # Application Title (Populates <title>)
-    config.app_title = 'Claim for crown court defence work'
+    config.app_title = 'Claim for crown court defence'
     # Proposition Title (Populates proposition header)
-    config.proposition_title = 'Claim for crown court defence work'
+    config.proposition_title = 'Claim for crown court defence'
     # Current Phase (Sets the current phase and the colour of phase tags)
     # Presumed values: alpha, beta, live
     config.phase = 'ALPHA'

--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -1,3 +1,3 @@
 GrapeSwaggerRails.options.url      = "/api/v1/advocates/swagger_doc"
 GrapeSwaggerRails.options.app_url  = ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000'
-GrapeSwaggerRails.options.app_name = 'Claim for crown court defence work API'
+GrapeSwaggerRails.options.app_name = 'Claim for crown court defence API'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,11 +18,11 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Claim for crown court defence work - Confirmation instructions"
+        subject: "Claim for crown court defence - Confirmation instructions"
       reset_password_instructions:
-        subject: "Claim for crown court defence work - Change your password"
+        subject: "Claim for crown court defence - Change your password"
       unlock_instructions:
-        subject: "Claim for crown court defence work - Unlock your account"
+        subject: "Claim for crown court defence - Unlock your account"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/features/examples/minjust.html
+++ b/features/examples/minjust.html
@@ -78,7 +78,7 @@
             </div>
           </div>
           <div class="header-app-name">
-            Claim for crown court defence work
+            Claim for crown court defence
           </div>
           <div id="log-in-out">
             

--- a/features/step_definitions/api_documentation_steps.rb
+++ b/features/step_definitions/api_documentation_steps.rb
@@ -20,7 +20,7 @@ When(/^I click on the API Sign up and Documentation link$/) do
 end
 
 Then(/^I should be directed to the API landing page$/) do
-  expect(find('.page-title')).to have_content('Claim for crown court defence work API')
+  expect(find('.page-title')).to have_content('Claim for crown court defence API')
 end
 
 When(/^I visit the Interactive API Documentation page$/) do

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -52,7 +52,7 @@ end
 Then(/^an email is sent to the new user$/) do
   expect(ActionMailer::Base.deliveries.length).to eq 1
   expect(ActionMailer::Base.deliveries.first.to).to eq ["harold.hughes@example.com"]
-  expect(ActionMailer::Base.deliveries.first.subject).to eq "Claim for crown court defence work - Change your password"
+  expect(ActionMailer::Base.deliveries.first.subject).to eq "Claim for crown court defence - Change your password"
 end
 
 Then(/^I see an error message$/) do

--- a/ux/user-journey-advocates.gv
+++ b/ux/user-journey-advocates.gv
@@ -6,7 +6,7 @@ digraph ADP_Advocate_Journey {
 	nodesep		= 2.4
 	ranksep 	= .9
 
-	label 		= "Claim for crown court defence work - Advocate User Journey Map"
+	label 		= "Claim for crown court defence - Advocate User Journey Map"
 	fontsize	= 16
 	size 		= "11x8"
 

--- a/ux/user-journey-caseworkers.gv
+++ b/ux/user-journey-caseworkers.gv
@@ -6,7 +6,7 @@ digraph CLA_User_Journey {
 	nodesep		= .5
 	ranksep 	= .3
 
-	label 		= "Claim for crown court defence work - Claim Allocation User Journey Map"
+	label 		= "Claim for crown court defence - Claim Allocation User Journey Map"
 	fontsize	= 16
 	size 		= "11x8"
 
@@ -21,7 +21,7 @@ digraph CLA_User_Journey {
 	}
 
 	subgraph cluster_adp_digital_service {
-		label="Claim for crown court defence work - Digital Service"
+		label="Claim for crown court defence - Digital Service"
 
 		sign_in [ label="Sign in\n\n/" ]
 


### PR DESCRIPTION
This is a tweak of previous rename that was deployed to staging for review. It shortens the new name to "Claim for crown court defence"
