### PR TITLE
"Discontinuance" case type should not require trial dates

### DIFF
--- a/db/seeds/case_types.rb
+++ b/db/seeds/case_types.rb
@@ -43,7 +43,7 @@ CaseType.find_or_create_by!(name: 'Cracked before retrial',
 CaseType.find_or_create_by!(name: 'Discontinuance',
                             is_fixed_fee:             false,
                             requires_cracked_dates:   false,
-                            requires_trial_dates:     true,
+                            requires_trial_dates:     false,
                             allow_pcmh_fee_type:      true,
                             requires_maat_reference:  true)
 CaseType.find_or_create_by!(name: 'Elected cases not proceeded',

--- a/features/trial_details_visibility_by_case_type.feature
+++ b/features/trial_details_visibility_by_case_type.feature
@@ -24,7 +24,7 @@ Feature: Trial detail visibility by case type
     | Cracked before retrial      | should not |
     | Elected cases not proceeded | should not |
     | Guilty plea                 | should not |
-    | Discontinuance              | should     |
+    | Discontinuance              | should not |
     | Retrial                     | should     |
     | Trial                       | should     |
 
@@ -45,6 +45,6 @@ Feature: Trial detail visibility by case type
       | Cracked before retrial      | should not |
       | Elected cases not proceeded | should not |
       | Guilty plea                 | should not |
-      | Discontinuance              | should     |
+      | Discontinuance              | should not |
       | Retrial                     | should     |
       | Trial                       | should     |


### PR DESCRIPTION
"Discontinuance" case type should not require trial dates. Hides trial date fields on claim form and turns off trial date validations.
