### PR TITLE
Fix cloning bug

### DIFF
--- a/app/assets/javascripts/modules/advocates/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/advocates/claims/NewClaim.js
@@ -12,7 +12,7 @@ moj.Modules.NewClaim = {
       this.$offenceCategorySelect.change();
     }
     else {
-      $('#offence_class_description').select2('val', $('#claim_offence_id').val(  ));
+      $('#offence_class_description').select2('val', $('#claim_offence_id').val());
     }
 
     this.attachToOffenceClassSelect();

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -48,7 +48,7 @@
             - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
           - else
             - selected_offence_category = @claim.offence.description rescue nil
-          = collection_select :offence_category, :description, @offence_descriptions, :description, :description, { prompt:  t('.select_category'), selected: selected_offence_category }, {  class: 'select2' }
+          = collection_select :offence_category, :description, @offence_descriptions, :description, :description, { prompt: t('.select_category'), selected: selected_offence_category }, { class: 'select2' }
           = validation_error_message(@error_presenter, :offence)
         .column-half
           .offence-class-select

--- a/app/views/advocates/claims/_offence_select.html.haml
+++ b/app/views/advocates/claims/_offence_select.html.haml
@@ -1,3 +1,3 @@
 = label_tag t('.offence_class')
 
-= collection_select :offence_class, :description, offences, :id, :offence_class, options = { prompt: t('.select_offence_class'), selected: offences.count == 1 ? offences.first : nil }, html_options = { class: 'select2', disabled: offences.count == 1 }
+= collection_select :offence_class, :description, offences, :id, :offence_class, options = { prompt: t('.select_offence_class'), selected: @claim.try(:offence) ? @claim.offence.id : (offences.count == 1 ? offences.first : nil) }, html_options = { class: 'select2', disabled: offences.count == 1 }

--- a/app/views/advocates/claims/_offence_select.html.haml
+++ b/app/views/advocates/claims/_offence_select.html.haml
@@ -1,3 +1,3 @@
 = label_tag t('.offence_class')
-
-= collection_select :offence_class, :description, offences, :id, :offence_class, options = { prompt: t('.select_offence_class'), selected: @claim.try(:offence) ? @claim.offence.id : (offences.count == 1 ? offences.first : nil) }, html_options = { class: 'select2', disabled: offences.count == 1 }
+- selected_offence = @claim.try(:offence) ? @claim.offence.id : (offences.count == 1 ? offences.first : nil)
+= collection_select :offence_class, :description, offences, :id, :offence_class, options = { prompt: t('.select_offence_class'), selected: selected_offence }, html_options = { class: 'select2', disabled: offences.count == 1 }


### PR DESCRIPTION
the claim edit action/view was not correctly populating
offence class from offence category. This effected
draft claims including cloned claims.
