### PR TITLE
change help text in initial fee header section

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,7 +388,7 @@ en:
         additional_information: 'Additional information'
         basic_fees: 'Initial fees'
         fee_prompt_text: |
-          You must enter a quantity and calculate the amount.  Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a>
+          You must enter a quantity and rate.  Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a>
           for help.
         fee_type: 'Type of fee'
         quantity: 'Quantity'


### PR DESCRIPTION
noticed that the header text made no sense in the context
of the changes made to fees recently - requiring rate NOT amount.

PM has confirmed this change.
