### PR TITLE
Remove basic fee 1 validation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,11 +19,12 @@ module ApplicationHelper
     "current" if current_page?(path)
   end
 
-  def number_with_precision_or_blank(number, options = {})
+  def number_with_precision_or_default(number, options = {})
+    default = options.delete(:default) || ''
     if options.has_key?(:precision)
-      number == 0 ? '' : number_with_precision(number, options)
+      number == 0 ? default : number_with_precision(number, options)
     else
-      number == 0 ? '' : number.to_s
+      number == 0 ? default : number.to_s
     end
   end
 

--- a/app/interfaces/api/v1/advocates/claim.rb
+++ b/app/interfaces/api/v1/advocates/claim.rb
@@ -25,7 +25,6 @@ module API
               optional :court_id, type: Integer,                  desc: "REQUIRED: The unique identifier for this court"
               optional :case_type_id, type: Integer,              desc: "REQUIRED: The unique identifier of the case type"
               optional :case_number, type: String,                desc: "REQUIRED: The case number"
-              # optional :indictment_number, type: String,          desc: "REQUIRED: The indictment number" # TODO removed? to be confirmed and extended to rest of app
               optional :offence_id, type: Integer,                desc: "REQUIRED: The unique identifier for this offence"
               optional :first_day_of_trial, type: String,         desc: "REQUIRED: YYYY-MM-DD", standard_json_format: true
               optional :estimated_trial_length, type: Integer,    desc: "REQUIRED: The estimated trial length in days"

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -62,8 +62,8 @@ class Fee < ActiveRecord::Base
   end
 
   def self.new_blank(claim, fee_type)
-    quantity = (fee_type.code == 'BAF' ? 1 : 0)
-    Fee.new(claim: claim, fee_type: fee_type, quantity: quantity, amount: 0)
+    # quantity = (fee_type.code == 'BAF' ? 1 : 0)
+    Fee.new(claim: claim, fee_type: fee_type, quantity: 0, amount: 0)
   end
 
   def self.new_collection_from_form_params(claim, form_params)
@@ -110,18 +110,6 @@ class Fee < ActiveRecord::Base
     self.amount = nil;
     # explicitly destroy child relations
     self.dates_attended.destroy_all unless self.dates_attended.empty?
-  end
-
-  private
-
-  def basic_fee_quantity
-    if fee_type.present? && more_than_one_basic_fee? # fee_spec.rb:22/24/26 fail unless this fee_type.present? is used here
-      errors[:quantity] << '- only one basic fee can be claimed per case'
-    end
-  end
-
-  def more_than_one_basic_fee?
-    fee_type.description == 'Basic Fee' && quantity > 1
   end
 
 end

--- a/app/validators/fee_validator.rb
+++ b/app/validators/fee_validator.rb
@@ -23,7 +23,7 @@ class FeeValidator < BaseClaimValidator
 
     case @record.fee_type.try(:code)
       when 'BAF'
-        validate_basic_fee_quantity
+        validate_baf_quantity
       when 'DAF'
         validate_daily_attendance_3_40_quantity
       when 'DAH'
@@ -38,13 +38,8 @@ class FeeValidator < BaseClaimValidator
 
   end
 
-  def validate_basic_fee_quantity
-    if @record.claim.case_type.try(:is_fixed_fee?)
-      # TODO: remove? this should never be raised because a before validation hook will clear basic fees for fixed fee cases
-      validate_numericality(:quantity, 0, 0, 'You cannot claim a basic fee for this case type')
-    else
-      validate_numericality(:quantity, 1, 1, 'baf_qty1')
-    end
+  def validate_baf_quantity
+    validate_numericality(:quantity, 0, 1, 'baf_qty_numericality')
   end
 
   # cannot claim this fee if trial lasted less than 3 days
@@ -62,7 +57,7 @@ class FeeValidator < BaseClaimValidator
   end
 
   # cannot claim this fee if trial lasted less than 51 days
-  # can only claim a maximum of 10 (or trial length after first 40 days deducted)
+  # can only claim a maximum of trial length after first 50 days deducted
   def validate_daily_attendance_51_plus_quantity
     return if @record.quantity == 0
     add_error(:quantity, 'daj_qty_mismatch') if @actual_trial_length < 51 || @record.quantity > @actual_trial_length - 50
@@ -72,7 +67,7 @@ class FeeValidator < BaseClaimValidator
     if @record.claim.case_type.try(:allow_pcmh_fee_type?)
       add_error(:quantity, 'pcm_invalid') if @record.quantity > 3
     else
-      add_error(:quantity, 'pcm_invalid') unless (@record.quantity == 0 || @record.quantity.blank?)
+      add_error(:quantity, 'pcm_not_applicable') unless (@record.quantity == 0 || @record.quantity.blank?)
     end
   end
 
@@ -87,27 +82,15 @@ class FeeValidator < BaseClaimValidator
 
     fee_code = @record.fee_type.try(:code)
     case fee_code
-      when 'BAF'
-        validate_baf_rate
-      when "DAF", "DAH", "DAJ", "SAF", "PCM", "CAV", "NDR", "NOC", "NPW", "PPE"
-        validate_non_baf_basic_fee_rate(fee_code)
+      when "BAF", "DAF", "DAH", "DAJ", "SAF", "PCM", "CAV", "NDR", "NOC", "NPW", "PPE"
+        validate_basic_fee_rate(fee_code)
       else
-        validate_misc_and_fixed_fee_rate
+        validate_any_quantity_rate_combination
     end
   end
 
-  def validate_baf_rate
-    # we want to validate the Basic fee has a rate of more than 0 as quantity must be 1
-    # BUT
-    # - ignore for fixed fees (no baf required)
-    # - ignore if from the api (because basic fee instantiation sets
-    #   the BAF to 1 and rate to 0 via claim creation endpoint)
-    unless @record.claim.case_type.try(:is_fixed_fee?) || (@record.claim.try(:api_draft?) && @record.new_record?)
-      add_error(:rate, 'baf_invalid') if @record.rate <= 0
-    end
-  end
-
-  def validate_misc_and_fixed_fee_rate
+  # if one has a value and the other doesn't then we add error to the one that does NOT have a value
+  def validate_any_quantity_rate_combination
     if @record.quantity > 0 && @record.rate <= 0
       add_error(:rate, 'invalid')
     elsif @record.quantity <= 0 && @record.rate > 0
@@ -115,11 +98,13 @@ class FeeValidator < BaseClaimValidator
     end
   end
 
-  def validate_non_baf_basic_fee_rate(case_type)
-    if @record.quantity > 0
-      add_error(:rate, "#{case_type.downcase}_zero") if @record.rate <=0
-    else
-      add_error(:rate, "#{case_type.downcase}_invalid") if @record.rate != 0
+  # if one has a value and the other doesn't then we add error to the one that does NOT have a value
+  # NOTE: we have specific error messages for basic fees
+  def validate_basic_fee_rate(case_type)
+    if @record.quantity > 0 && @record.rate <=0
+      add_error(:rate, "#{case_type.downcase}_invalid")
+    elsif @record.quantity <= 0 && @record.rate > 0
+      add_error(:quantity, "#{case_type.downcase}_invalid")
     end
   end
 

--- a/app/validators/fee_validator.rb
+++ b/app/validators/fee_validator.rb
@@ -31,7 +31,7 @@ class FeeValidator < BaseClaimValidator
       when 'DAJ'
         validate_daily_attendance_51_plus_quantity
       when 'PCM'
-        validate_plea_and_case_management_hearing
+        validate_pcm_quantity
     end
 
     validate_any_quantity
@@ -63,9 +63,9 @@ class FeeValidator < BaseClaimValidator
     add_error(:quantity, 'daj_qty_mismatch') if @actual_trial_length < 51 || @record.quantity > @actual_trial_length - 50
   end
 
-  def validate_plea_and_case_management_hearing
+  def validate_pcm_quantity
     if @record.claim.case_type.try(:allow_pcmh_fee_type?)
-      add_error(:quantity, 'pcm_invalid') if @record.quantity > 3
+      add_error(:quantity, 'pcm_numericality') if @record.quantity > 3
     else
       add_error(:quantity, 'pcm_not_applicable') unless (@record.quantity == 0 || @record.quantity.blank?)
     end

--- a/app/views/advocates/claims/_basic_fee_fields.html.haml
+++ b/app/views/advocates/claims/_basic_fee_fields.html.haml
@@ -7,7 +7,7 @@
           = raw t('.basic_fee_prompt_text')
     %td
       %a{name: "basic_fee_#{@basic_fee_count}_quantity"}
-      = f.number_field :quantity, value: number_with_precision_or_blank(f.object.quantity), class: 'quantity', min: 0, max: 99999, maxlength: 5
+      = f.number_field :quantity, value: number_with_precision_or_default(f.object.quantity) , class: 'quantity', min: 0, max: 99999, maxlength: 5
       = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
     %td
       %a{name: "basic_fee_#{@basic_fee_count}_rate"}
@@ -25,4 +25,4 @@
 
   = f.fields_for :dates_attended do |date_attended|
     - @basic_fee_date_attended_count += 1
-    = render 'date_attended_fields', { f: date_attended, submodel_count: @basic_fee_date_attended_count,  parent_model_prefix: "basic_fee_#{@basic_fee_count}" }
+    = render 'date_attended_fields', { f: date_attended, submodel_count: @basic_fee_date_attended_count, parent_model_prefix: "basic_fee_#{@basic_fee_count}" }

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -311,10 +311,10 @@ basic_fee:
 
   quantity:
     _seq: 10
-    baf_qty1:
-      long: Enter a quantity of 1 for basic fee
-      short: Enter 1
-      api: Enter a quantity of 1 for basic fee
+    baf_qty_numericality:
+      long: Enter a quantity of 0 to 1 for basic fee
+      short: Enter 0 to 1
+      api: Enter a quantity of 0 to 1 for basic fee
     daf_qty_mismatch:
       long: The number of daily attendance fees (3-40 days) does not fit the actual trial length
       short: Enter a number that fits the actual trial length
@@ -327,14 +327,60 @@ basic_fee:
       long: The number of daily attendance fees (51+ days) does not fit the actual trial length
       short: Enter a number that fits the actual trial length
       api: The number of daily attendance fees (51+ days) does not fit the actual trial length
-    pcm_invalid:
-      long: The quantity for plea and case management hearing must be less than or equal to 3
-      short: Enter a number less than or equal to 3
-      api: The quantity for plea and case management hearing must be less than or equal to 3
-    invalid:
+    pcm_not_applicable:
+      long: Plea and case management hearing fee not applicable to case type
+      short: Remove quantity as not applicable
+      api: Plea and case management hearing fee not applicable to case type
+
+    # standard quantity validations (when a rate exists but quantity not specified)
+    baf_invalid:
       long: Enter a valid quantity for the basic fee
       short: Enter a valid quantity
       api: Enter a valid quantity for the basic fee
+    daf_invalid:
+      long: Enter a valid quantity for daily attendance fees (3-40 days)
+      short: Enter a valid quantity
+      api: Enter a valid quantity for daily attendance fees (3-40 days)
+    dah_invalid:
+      long: Enter a valid quantity for daily attendance fees (41-50 days)
+      short: Enter a valid quantity
+      api: Enter a valid quantity for daily attendance fees (41-50 days)
+    daj_invalid:
+      long: Enter a valid quantity for daily attendance fees (51+ days)
+      short: Enter a valid quantity
+      api: Enter a valid quantity for daily attendance fees (51+ days)
+    saf_invalid:
+      long: Enter a valid quantity for standard appearance fees
+      short: Enter a valid quantity
+      api: Enter a valid quantity for standard appearance fees
+    pcm_invalid:
+      long: Enter a valid quantity (0 to 3) for plea and case management hearing fees
+      short: Enter a valid quantity (0 to 3)
+      api: Enter a valid quantity (0 to 3) for plea and case management hearing fees
+    cav_invalid:
+      long: Enter a valid quantity for conference and views fees
+      short: Enter a valid quantity
+      api: Enter a valid quantity for conference and views fees
+    ndr_invalid:
+      long: Enter a valid quantity for number of defendants uplift fees
+      short: Enter a valid quantity
+      api: Enter a valid quantity for number of defendants uplift fees
+    noc_invalid:
+      long: Enter a valid quantity for number of cases uplift fees
+      short: Enter a valid quantity
+      api: Enter a valid quantity for number of cases uplift fees
+    npw_invalid:
+      long: Enter a valid quantity for number of prosecution witnesses fees
+      short: Enter a valid quantity
+      api: Enter a valid quantity for number of prosecution witnesses fees
+    ppe_invalid:
+      long: Enter a valid quantity for pages of prosecution evidence fees
+      short: Enter a valid quantity
+      api: Enter a valid quantity for pages of prosecution evidence fees
+    invalid:
+      long: Enter a valid quantity for the initial fee
+      short: Enter a valid quantity
+      api: Enter a valid quantity for the initial fee
 
   rate:
     _seq: 20
@@ -342,90 +388,50 @@ basic_fee:
       long: Enter a valid rate for the basic fee
       short: Enter a valid rate
       api: Enter a valid rate for the basic fee
-    daf_zero:
-      long: Enter a valid rate for daily attendance fees (3-40 days)
-      short: Enter a valid rate
-      api: Enter a valid rate for daily attendance fees (3-40 days)
     daf_invalid:
       long: Enter a valid rate for daily attendance fees (3-40 days)
       short: Enter a valid rate
       api: Enter a valid rate for daily attendance fees (3-40 days)
-    dah_zero:
-      long: Enter a valid rate for daily attendance fees (41-50 days)
-      short: Enter a valid rate
-      api: Enter a valid rate for daily attendance fees (41-50 days)
     dah_invalid:
       long: Enter a valid rate for daily attendance fees (41-50 days)
       short: Enter a valid rate
       api: Enter a valid rate for daily attendance fees (41-50 days)
-    daj_zero:
-      long: Enter a valid rate for daily attendance fees (51+ days)
-      short: Enter a valid rate
-      api: Enter a valid rate for daily attendance fees (51+ days)
     daj_invalid:
       long: Enter a valid rate for daily attendance fees (51+ days)
       short: Enter a valid rate
       api: Enter a valid rate for daily attendance fees (51+ days)
-    saf_zero:
-      long: Enter a valid rate for standard appearance fees
-      short: Enter a valid rate
-      api: Enter a valid rate for standard appearance fees
     saf_invalid:
       long: Enter a valid rate for standard appearance fees
       short: Enter a valid rate
       api: Enter a valid rate for standard appearance fees
-    pcm_zero:
-      long: Enter a valid rate for plea and case management hearing fees
-      short: Enter a valid rate
-      api: Enter a valid rate for plea and case management hearing fees
     pcm_invalid:
       long: Enter a valid rate for plea and case management hearing fees
       short: Enter a valid rate
       api: Enter a valid rate for plea and case management hearing fees
-    cav_zero:
-      long: Enter a valid rate for conference and views fees
-      short: Enter a valid rate
-      api: Enter a valid rate for conference and views fees
     cav_invalid:
       long: Enter a valid rate for conference and views fees
       short: Enter a valid rate
       api: Enter a valid rate for conference and views fees
-    ndr_zero:
-      long: Enter a valid rate for number of defendants uplift fees
-      short: Enter a valid rate
-      api: Enter a valid rate for number of defendants uplift fees
     ndr_invalid:
       long: Enter a valid rate for number of defendants uplift fees
       short: Enter a valid rate
       api: Enter a valid rate for number of defendants uplift fees
-    noc_zero:
-      long: Enter a valid rate for number of cases uplift fees
-      short: Enter a valid rate
-      api: Enter a valid rate for number of cases uplift fees
     noc_invalid:
       long: Enter a valid rate for number of cases uplift fees
       short: Enter a valid rate
       api: Enter a valid rate for number of cases uplift fees
-    npw_zero:
-      long: Enter a valid rate for number of prosecution witnesses fees
-      short: Enter a valid rate
-      api: Enter a valid rate for number of prosecution witnesses fees
     npw_invalid:
       long: Enter a valid rate for number of prosecution witnesses fees
       short: Enter a valid rate
       api: Enter a valid rate for number of prosecution witnesses fees
-    ppe_zero:
-      long: Enter a valid rate for pages of prosecution evidence fees
-      short: Enter a valid rate
-      api: Enter a valid rate for pages of prosecution evidence fees
     ppe_invalid:
       long: Enter a valid rate for pages of prosecution evidence fees
       short: Enter a valid rate
       api: Enter a valid rate for pages of prosecution evidence fees
     invalid:
-      long: Enter a valid rate for the basic fee
+      long: Enter a valid rate for the initial fee
       short: Enter a valid rate
-      api: Enter a valid rate for the basic fee
+      api: Enter a valid rate for the initial fee
 
 #################################################################################
 #                                                                               #
@@ -446,8 +452,8 @@ misc_fee:
   rate:
     _seq: 20
     invalid:
-      long: 'Enter a rate for the #{misc_fee}'
-      short: Enter a rate
+      long: 'Enter a valid rate for the #{misc_fee}'
+      short: Enter a valid rate
       api: Enter a rate for the miscellaneous fee
 
   quantity:
@@ -476,8 +482,8 @@ fixed_fee:
   rate:
     _seq: 20
     invalid:
-      long: 'Enter a rate for the #{fixed_fee}'
-      short: Enter a rate
+      long: 'Enter a valid rate for the #{fixed_fee}'
+      short: Enter a valid rate
       api: Enter a rate for the fixed fee
 
   quantity:

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -331,6 +331,10 @@ basic_fee:
       long: Plea and case management hearing fee not applicable to case type
       short: Remove quantity as not applicable
       api: Plea and case management hearing fee not applicable to case type
+    pcm_numericality:
+      long: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+      short: Enter a valid quantity (1 to 3)
+      api: Enter a valid quantity (1 to 3) for plea and case management hearing fees
 
     # standard quantity validations (when a rate exists but quantity not specified)
     baf_invalid:
@@ -354,9 +358,9 @@ basic_fee:
       short: Enter a valid quantity
       api: Enter a valid quantity for standard appearance fees
     pcm_invalid:
-      long: Enter a valid quantity (0 to 3) for plea and case management hearing fees
-      short: Enter a valid quantity (0 to 3)
-      api: Enter a valid quantity (0 to 3) for plea and case management hearing fees
+      long: Enter a valid quantity for plea and case management hearing fees
+      short: Enter a valid quantity
+      api: Enter a valid quantity for plea and case management hearing fees
     cav_invalid:
       long: Enter a valid quantity for conference and views fees
       short: Enter a valid quantity

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -2,11 +2,6 @@
 
 Feature: Advocate new claim
 
-  Scenario: New claim instantiates Basic Fee Type (BAF) to quantity of 1
-   Given I am a signed in advocate
-     And I am on the new claim page
-    Then I should see a Basic Fee quantity of exactly one
-
   Scenario: Fill in claim form and submit to LAA
     Given I am a signed in advocate
       And There are case types in place

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -374,10 +374,6 @@ Then(/^I should( not)? be able to view "(.*?)"$/i) do |have, content|
   expect(page).method(to_or_not_to).call have_content(content)
 end
 
-Then(/^I should see a Basic Fee quantity of exactly one$/) do
-  expect(page).to have_field('claim_basic_fees_attributes_0_quantity', with: 1)
-end
-
 Given(/^I fill in an Initial Fee$/) do
   within '#basic-fees' do
     fill_in 'claim_basic_fees_attributes_0_quantity', with: 2

--- a/features/unhappy_paths.feature
+++ b/features/unhappy_paths.feature
@@ -39,12 +39,15 @@ Scenario Outline: Attempt to submit claim to LAA without specifying required tex
       And I should see a summary error message <error_message>
 
     Examples:
-    | field_id                                   | error_message                                      |
-    | "claim_case_number"                        | "Enter a case number"                              |
-    | "claim_defendants_attributes_0_first_name" | "Enter a first name for the first defendant"       |
-    | "claim_basic_fees_attributes_0_quantity"   | "Enter a quantity of 1 for basic fee"              |
+    | field_id                                   | error_message                                 |
+    | "claim_case_number"                        | "Enter a case number"                         |
+    | "claim_defendants_attributes_0_first_name" | "Enter a first name for the first defendant"  |
+    | "claim_basic_fees_attributes_0_quantity"   | "Enter a valid quantity for the basic fee"    |
+    | "claim_basic_fees_attributes_0_rate"       | "Enter a valid rate for the basic fee"        |
     | "claim_misc_fees_attributes_0_quantity"    | "Enter a valid quantity for the first miscellaneous fee" |
-    | "claim_expenses_attributes_0_quantity"     | "Enter a quantity for the first expense"           |
+    | "claim_misc_fees_attributes_0_rate"        | "Enter a valid rate for the first miscellaneous fee" |
+    | "claim_expenses_attributes_0_quantity"     | "Enter a quantity for the first expense"      |
+    | "claim_expenses_attributes_0_rate"         | "Enter a rate for the first expense"          |
 
     # TODO: unhappy paths for representation order details
 

--- a/spec/api/v1/claims/fee_spec.rb
+++ b/spec/api/v1/claims/fee_spec.rb
@@ -107,7 +107,7 @@ describe API::V1::Advocates::Fee do
         basic_fee_type.update(code: 'BAF') # need to use real basic fee codes to trigger code specific validation and errors
         post_to_create_endpoint
         expect(last_response.status).to eq 400
-        expect_error_response("Enter a quantity of 1 for basic fee",0)
+        expect_error_response("Enter a quantity of 0 to 1 for basic fee",0)
         # NOTE: basic fee should allow 0 rate for claim basic fee at instantiation/creation but not thereafter
         expect_error_response("Enter a valid rate for the basic fee",1)
       end
@@ -117,7 +117,7 @@ describe API::V1::Advocates::Fee do
         valid_params[:fee_type_id] = basic_fee_type.id
         post_to_create_endpoint
         expect(last_response.status).to eq 400
-        expect_error_response("Enter a valid rate for the basic fee",0)
+        expect_error_response("Enter a valid rate for the initial fee",0)
       end
 
       it 'misc fees should raise misc fee errors from translations' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -16,34 +16,44 @@ describe ApplicationHelper do
 
   end
 
-  context '#number_with_precision_or_blank' do
+  context '#number_with_precision_or_default' do
 
     it 'should return empty string if given integer zero and no precision' do
-      expect(number_with_precision_or_blank(0)).to eq ''
+      expect(number_with_precision_or_default(0)).to eq ''
     end
 
     it 'should return empty string if given integer zero and precision' do
-      expect(number_with_precision_or_blank(0, precision: 2)).to eq ''
+      expect(number_with_precision_or_default(0, precision: 2)).to eq ''
     end
 
     it 'should return empty string if given BigDecimal zero' do
-      expect(number_with_precision_or_blank(BigDecimal.new(0,5))).to eq ''
+      expect(number_with_precision_or_default(BigDecimal.new(0,5))).to eq ''
     end
 
     it 'should return empty string if given Float zero' do
-      expect(number_with_precision_or_blank(0.0, precision: 2)).to eq ''
+      expect(number_with_precision_or_default(0.0, precision: 2)).to eq ''
     end
 
     it 'should return 3.33 if given 3.3333 with precsion 2' do
-      expect(number_with_precision_or_blank(3.333, precision: 2)).to eq '3.33'
+      expect(number_with_precision_or_default(3.333, precision: 2)).to eq '3.33'
     end
 
     it 'should return 24.5 if given 24.5 with no precision' do
-      expect(number_with_precision_or_blank(24.5)).to eq '24.5'
+      expect(number_with_precision_or_default(24.5)).to eq '24.5'
     end
 
     it 'should return 4 if given 3.645 with precsion 0' do
-      expect(number_with_precision_or_blank(3.645, precision: 0)).to eq '4'
+      expect(number_with_precision_or_default(3.645, precision: 0)).to eq '4'
+    end
+
+    context 'with default specified' do
+      it 'should return default value if given Float zero with precision 2' do
+        expect(number_with_precision_or_default(0.0, precision: 2, default: '1')).to eq '1'
+      end
+
+      it 'should NOT return default value if given a non-zero value' do
+        expect(number_with_precision_or_default(2, default: '1')).to eq '2'
+      end
     end
 
   end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -82,14 +82,15 @@ RSpec.describe Fee, type: :model do
       expect(fee).to be_new_record
     end
 
+    # TODO: BAF fee type used to be instatiated to 1 but has been removed - POCA ticket - can remove eventually
     context 'for the BAF basic fee' do
-      it 'should be called as part of claim instatiation and assign 1 as quantity for BAF fee types' do
+      it 'should be called as part of claim instatiation and assign 0 as quantity for BAF fee types' do
         baf_fee_type = FactoryGirl.create :fee_type, :basic, code: 'BAF'
         claim = FactoryGirl.build :claim
         fee = claim.basic_fees.first
         expect(fee.fee_type.code).to eql 'BAF'
         expect(fee.amount).to eq 0.00
-        expect(fee.quantity).to eq 1
+        expect(fee.quantity).to eq 0
         expect(fee).to be_new_record
       end
     end

--- a/spec/validators/fee_validator_spec.rb
+++ b/spec/validators/fee_validator_spec.rb
@@ -198,7 +198,8 @@ describe FeeValidator do
         before(:each) do
           claim.case_type = FactoryGirl.build :case_type, :allow_pcmh_fee_type
         end
-        it { should_error_if_equal_to_value(pcm_fee, :quantity, 4, 'pcm_invalid') }
+        it { should_error_if_equal_to_value(pcm_fee, :quantity, 0, 'pcm_invalid') }
+        it { should_error_if_equal_to_value(pcm_fee, :quantity, 4, 'pcm_numericality') }
         it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 3) }
         it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 1) }
       end
@@ -210,6 +211,7 @@ describe FeeValidator do
         it { should_error_if_equal_to_value(pcm_fee, :quantity, 1, 'pcm_not_applicable') }
         it { should_error_if_equal_to_value(pcm_fee, :quantity, -1, 'pcm_not_applicable') }
       end
+
     end
 
     context 'any other fee' do


### PR DESCRIPTION
Due to approx 1% of Proceeds of crime act (POCA) cases submitting claims without Basic Fee BAF this PR removes the validation that enforces and defaults BAF fees to quantity of 1.

also:
- removed some unneeded error messages and separated some into two
- modified number_with_precision_or_blank helper to accept/use a default arg
