### PR TITLE
popluate daily attendance fees from actual trial length

### DIFF
--- a/app/assets/javascripts/modules/advocates/claims/FeePopulator.js
+++ b/app/assets/javascripts/modules/advocates/claims/FeePopulator.js
@@ -1,0 +1,39 @@
+// Description:
+//  The number/quantity of daily attendance fees are based
+//  on the number of days the advocate attended court.
+//  This JS populates the DAF quantities based on the
+//  user-specified trial length to a. avoid user error
+//  and b. simplify form completion.
+//
+moj.Modules.FeePopulator = {
+  $actualTrialLength: {},
+  $dafQuantity: {},
+  $dahQuantity: {},
+  $dajQuantity: {},
+
+  init : function() {
+    var self = this;
+
+    self.$actualTrialLength = $('#claim_actual_trial_length');
+    $dafQuantity = $('#claim_basic_fees_attributes_1_quantity');
+    $dahQuantity = $('#claim_basic_fees_attributes_2_quantity');
+    $dajQuantity = $('#claim_basic_fees_attributes_3_quantity');
+
+    self.$actualTrialLength.change(function(){
+      self.actualTrialLengthChanged();
+    });
+  },
+
+  actualTrialLengthChanged : function() {
+    var l = this.$actualTrialLength.val();
+    var daf = l-2  <= 0 ? 0 : Math.min(l,40)-2;
+    var dah = l-40 <= 0 ? 0 : Math.min(l,50)-40;
+    var daj = l-50 <= 0 ? 0 : l-50;
+
+    //form displays 0 as empty string
+    $dafQuantity.val(daf <= 0 ? '' : daf);
+    $dahQuantity.val(dah <= 0 ? '' : dah);
+    $dajQuantity.val(daj <= 0 ? '' : daj);
+  }
+
+};

--- a/app/assets/javascripts/modules/advocates/claims/FeePopulator.js
+++ b/app/assets/javascripts/modules/advocates/claims/FeePopulator.js
@@ -15,25 +15,26 @@ moj.Modules.FeePopulator = {
     var self = this;
 
     self.$actualTrialLength = $('#claim_actual_trial_length');
-    $dafQuantity = $('#claim_basic_fees_attributes_1_quantity');
-    $dahQuantity = $('#claim_basic_fees_attributes_2_quantity');
-    $dajQuantity = $('#claim_basic_fees_attributes_3_quantity');
+    self.$dafQuantity = $('#claim_basic_fees_attributes_1_quantity');
+    self.$dahQuantity = $('#claim_basic_fees_attributes_2_quantity');
+    self.$dajQuantity = $('#claim_basic_fees_attributes_3_quantity');
 
-    self.$actualTrialLength.change(function(){
+    self.$actualTrialLength.change(function() {
       self.actualTrialLengthChanged();
     });
   },
 
   actualTrialLengthChanged : function() {
-    var l = this.$actualTrialLength.val();
-    var daf = l-2  <= 0 ? 0 : Math.min(l,40)-2;
-    var dah = l-40 <= 0 ? 0 : Math.min(l,50)-40;
-    var daj = l-50 <= 0 ? 0 : l-50;
+    var self = this;
+    var l    = self.$actualTrialLength.val();
+    var daf  = l-2  <= 0 ? 0 : Math.min(l,40)-2;
+    var dah  = l-40 <= 0 ? 0 : Math.min(l,50)-40;
+    var daj  = l-50 <= 0 ? 0 : l-50;
 
     //form displays 0 as empty string
-    $dafQuantity.val(daf <= 0 ? '' : daf);
-    $dahQuantity.val(dah <= 0 ? '' : dah);
-    $dajQuantity.val(daj <= 0 ? '' : daj);
+    self.$dafQuantity.val(daf <= 0 ? '' : daf);
+    self.$dahQuantity.val(dah <= 0 ? '' : dah);
+    self.$dajQuantity.val(daj <= 0 ? '' : daj);
   }
 
 };

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -181,3 +181,24 @@ Feature: Advocate new claim
       And I submit to LAA
      Then There should not be any Initial Fees saved
       And There should be a Miscellaneous Fee Saved
+
+  @javascript @webmock_allow_localhost_connect
+  Scenario Outline: Daily attendance fees derived from actual trial length
+  Given I am a signed in advocate
+    And There are case types in place
+    And I am on the new claim page with Daily Attendance Fees in place
+   When I fill in the trial details
+    And I fill in actual trial length with <actual_trial_length>
+   Then The daily attendance fields should have quantities <daf_quantity>, <dah_quantity>, <daj_quantity>
+
+  Examples:
+    | actual_trial_length         | daf_quantity | dah_quantity | daj_quantity |
+    | 1                           | 0            | 0            | 0            |
+    | 2                           | 0            | 0            | 0            |
+    | 3                           | 1            | 0            | 0            |
+    | 40                          | 38           | 0            | 0            |
+    | 41                          | 38           | 1            | 0            |
+    | 50                          | 38           | 10           | 0            |
+    | 51                          | 38           | 10           | 1            |
+    | 60                          | 38           | 10           | 10           |
+    | 70                          | 38           | 10           | 20           |

--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -187,7 +187,7 @@ Feature: Advocate new claim
   Given I am a signed in advocate
     And There are case types in place
     And I am on the new claim page with Daily Attendance Fees in place
-   When I fill in the trial details
+    And I select2 a Case Type of "Trial"
     And I fill in actual trial length with <actual_trial_length>
    Then The daily attendance fields should have quantities <daf_quantity>, <dah_quantity>, <daj_quantity>
 

--- a/features/cracked_trial.feature
+++ b/features/cracked_trial.feature
@@ -11,7 +11,7 @@ Feature: Cracked trial
     Given I am a signed in advocate
       And I am on the new claim page
      Then I should NOT see Cracked trial fields
-      And I select2 "Cracked trial" from "claim_case_type_id"
+      And I select2 a Case Type of "Cracked trial"
      Then I should see Cracked trial fields
-      And I select2 "Contempt" from "claim_case_type_id"
+      And I select2 a Case Type of "Contempt"
      Then I should NOT see Cracked trial fields

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -411,6 +411,32 @@ Given(/^a non\-fixed\-fee claim exists with basic and miscellaneous fees$/) do
   create(:fee, :misc,  claim: claim, quantity: 2, amount: 5.0)
 end
 
+Given(/^I am on the new claim page with Daily Attendance Fees in place$/) do
+  create(:fee_type, :basic, description: 'Basic Fee', code: 'BAF')
+  create(:fee_type, :basic, description: 'Daily attendance fee (3 to 40)', code: 'DAF')
+  create(:fee_type, :basic, description: 'Daily attendance fee (41 to 50)', code: 'DAH')
+  create(:fee_type, :basic, description: 'Daily attendance fee (51+)', code: 'DAJ')
+  visit new_advocates_claim_path
+end
+
+When(/^I fill in the trial details$/) do
+  select2('Trial', from: 'claim_case_type_id')
+  fill_in 'claim_actual_trial_length', with: 1
+end
+
+When(/^I fill in actual trial length with (\d+)$/) do |actual_trial_length|
+  fill_in 'claim_actual_trial_length', with: actual_trial_length.to_i
+end
+
+Then(/^The daily attendance fields should have quantities (\d+), (\d+), (\d+)$/) do |daf_quantity, dah_quantity, daj_quantity|
+  daf_quantity  = '' if daf_quantity.nil? || daf_quantity.to_i == 0
+  dah_quantity  = '' if dah_quantity.nil? || dah_quantity.to_i == 0
+  daj_quantity  = '' if daj_quantity.nil? || daj_quantity.to_i == 0
+  expect(page).to have_field("claim_basic_fees_attributes_1_quantity", with: "#{daf_quantity}")
+  expect(page).to have_field("claim_basic_fees_attributes_2_quantity", with: "#{dah_quantity}")
+  expect(page).to have_field("claim_basic_fees_attributes_3_quantity", with: "#{daj_quantity}")
+end
+
 # local helpers
 # -----------------
 def fee_type_to_id(fee_type)

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -356,10 +356,6 @@ Then(/^There should not be any Initial Fees saved$/) do
   expect(Claim.last.calculate_fees_total(:basic).to_f).to eql(0.0)
 end
 
-# Then(/^There should not be any Miscellaneous Fees Saved$/) do
-#   expect(Claim.last.misc_fees.size).to eql(0)
-# end
-
 Then(/^There should be a Miscellaneous Fee Saved$/) do
   expect(Claim.last.misc_fees.size).to eql(1)
 end
@@ -413,15 +409,10 @@ end
 
 Given(/^I am on the new claim page with Daily Attendance Fees in place$/) do
   create(:fee_type, :basic, description: 'Basic Fee', code: 'BAF')
-  create(:fee_type, :basic, description: 'Daily attendance fee (3 to 40)', code: 'DAF')
+  create(:fee_type, :basic, description: 'Daily attendance fee (3 to 40)',  code: 'DAF')
   create(:fee_type, :basic, description: 'Daily attendance fee (41 to 50)', code: 'DAH')
-  create(:fee_type, :basic, description: 'Daily attendance fee (51+)', code: 'DAJ')
+  create(:fee_type, :basic, description: 'Daily attendance fee (51+)',      code: 'DAJ')
   visit new_advocates_claim_path
-end
-
-When(/^I fill in the trial details$/) do
-  select2('Trial', from: 'claim_case_type_id')
-  fill_in 'claim_actual_trial_length', with: 1
 end
 
 When(/^I fill in actual trial length with (\d+)$/) do |actual_trial_length|
@@ -429,9 +420,9 @@ When(/^I fill in actual trial length with (\d+)$/) do |actual_trial_length|
 end
 
 Then(/^The daily attendance fields should have quantities (\d+), (\d+), (\d+)$/) do |daf_quantity, dah_quantity, daj_quantity|
-  daf_quantity  = '' if daf_quantity.nil? || daf_quantity.to_i == 0
-  dah_quantity  = '' if dah_quantity.nil? || dah_quantity.to_i == 0
-  daj_quantity  = '' if daj_quantity.nil? || daj_quantity.to_i == 0
+  daf_quantity = '' if daf_quantity.nil? || daf_quantity.to_i == 0
+  dah_quantity = '' if dah_quantity.nil? || dah_quantity.to_i == 0
+  daj_quantity = '' if daj_quantity.nil? || daj_quantity.to_i == 0
   expect(page).to have_field("claim_basic_fees_attributes_1_quantity", with: "#{daf_quantity}")
   expect(page).to have_field("claim_basic_fees_attributes_2_quantity", with: "#{dah_quantity}")
   expect(page).to have_field("claim_basic_fees_attributes_3_quantity", with: "#{daj_quantity}")


### PR DESCRIPTION
The number/quantity of daily attendance fees is calculable from the actual trial length. This JS populates the DAF quantities based on the user-specified trial length to:
a. avoid user error
b. simplify form completion.
