### PR TITLE
use update_column in vat_amount migration script

### DIFF
--- a/db/migrate/20151207135840_add_vat_amount_to_determinations.rb
+++ b/db/migrate/20151207135840_add_vat_amount_to_determinations.rb
@@ -8,7 +8,7 @@ class AddVatAmountToDeterminations < ActiveRecord::Migration
 
       if @claim.apply_vat? && d.vat_amount == 0.0
         vat_amount = d.calculate_vat
-        d.update_attribute(:vat_amount, vat_amount)
+        d.update_column(:vat_amount, vat_amount)
       end
     end
   end


### PR DESCRIPTION
- update_attribute was creating a new paper trail version which then caused problems with the claim history.  Now using update_column instead
