### PR TITLE
update version when migrating vat_amount

### DIFF
--- a/db/migrate/20151207135840_add_vat_amount_to_determinations.rb
+++ b/db/migrate/20151207135840_add_vat_amount_to_determinations.rb
@@ -7,8 +7,16 @@ class AddVatAmountToDeterminations < ActiveRecord::Migration
       @claim = d.claim
 
       if @claim.apply_vat? && d.vat_amount == 0.0
+
         vat_amount = d.calculate_vat
         d.update_column(:vat_amount, vat_amount)
+
+        version = d.versions.last
+        if version.present?
+          object_changes = version.object_changes + "\nvat_amount:\n- 0.0\n- #{vat_amount}\n"
+          version.update_column(:object_changes, object_changes)
+        end
+
       end
     end
   end


### PR DESCRIPTION
@jsugarman and @aliuk2012 have a look at this too! :)
- I had to add this in so that papertrail version is also updated.  Its the papertrail version that's used to create claim history entries, rather than the determination itself.
- This has been tested locally only, because I didn't want to merge my own commit without you guys seeing it first.
- BUT, I did go through the process of rolling back the migration, creating new demo data, doing the migration without these changes, seeing the empty vat row, then migrating again with these changes... and it worked fine.
- when you deploy to staging, if you might need to ssh in, rollback the migration, and then migrate again in order to see the effects of this change on the existing data and model what will happen in gamma (but if you rollback, you will need to migrate again before the app will work since there's code in the deployed build that relies on determination#vat_amount)
