### PR TITLE
Ensure seeds idempotent

### DIFF
--- a/db/seeds/fee_categories.rb
+++ b/db/seeds/fee_categories.rb
@@ -1,4 +1,3 @@
-FeeCategory.delete_all
 FeeCategory.find_or_create_by(abbreviation: 'BASIC', name: 'Basic Fee & Enhancements (amount excluding VAT)')
 FeeCategory.find_or_create_by(abbreviation: 'FIXED', name: 'Fixed Fees (amount excluding VAT)')
 FeeCategory.find_or_create_by(abbreviation: 'MISC', name: 'Miscellaneous Fees (amount excluding VAT)')

--- a/db/seeds/fee_types.rb
+++ b/db/seeds/fee_types.rb
@@ -5,8 +5,6 @@ FeeCategory.all.each do |rec|
   fee_categories[rec.abbreviation] = rec
 end
 
-FeeType.delete_all
-
 file_path = Rails.root.join('lib', 'assets', 'data', 'fee_types.csv')
 data = CSV.read(file_path)
 data.shift


### PR DESCRIPTION
ensure fee types and categories are truly idempotent: I noticed this problem when running demo_data twice or more (to create enough records for pagination testing).

A delete_all in the FeeType and FeeCategory seeds
meant that FeeTypes and Categories were being recreated
regardless. While fine normally it means that  if a db:clear
does not precede it the IDs of the records would have incremented
on the second seed and thereafter (1 to 72 on first run, 73 to 154 on second run etc). 

This would break existing claims because they have fees of a type with an id that no
longer exists. It therefore becomes impossible to run claims:demo_data
more than once without breaking existing claims fees (at least).

**_Perhaps we should be hardcoding seed IDs in the long run in any event**_
