### PR TITLE
Fix pagination bug

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -8,7 +8,6 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   before_action :set_doctypes, only: [:show]
   before_action :set_context, only: [:index, :outstanding, :authorised, :archived ]
   before_action :set_financial_summary, only: [:index, :outstanding, :authorised]
-  before_action :set_search_options, only: [:index]
   before_action :load_advocates_in_chamber, only: [:new, :edit, :create, :update]
   before_action :generate_form_id, only: [:new, :edit]
   before_action :initialize_submodel_counts
@@ -313,14 +312,6 @@ class Advocates::ClaimsController < Advocates::ApplicationController
 
   def build_nested_resource(object, association)
     object.send(association).build if object.send(association).none?
-  end
-
-  def set_search_options
-    if current_user.persona.admin?
-      @search_options = ['All', 'Advocate', 'Defendant']
-    else
-      @search_options = ['All', 'Defendant']
-    end
   end
 
   def update_source_for_api

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -2,9 +2,11 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   include DocTypes
 
   respond_to :html
+  
+  # callback order is important (must set claims before resetting pagination)
   before_action :set_claims,          only: [:index, :archived]
-  before_action :set_search_options,  only: [:index, :archived]
   before_action :filter_claims,       only: [:index, :archived]
+  
   before_action :set_claim, only: [:show]
   before_action :set_doctypes, only: [:show, :update]
 
@@ -126,14 +128,6 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
 
   def set_claim
     @claim = Claim.find(params[:id])
-  end
-
-  def set_search_options
-    if current_user.persona.admin?
-      @search_options = ['All', 'MAAT Reference', 'Defendant', 'Case worker']
-    else
-      @search_options = ['All', 'MAAT Reference', 'Defendant']
-    end
   end
 
   def filter_claims

--- a/app/views/advocates/claims/_claims.html.haml
+++ b/app/views/advocates/claims/_claims.html.haml
@@ -2,6 +2,9 @@
   %p
     = t(".no_claims_found")
 - else
+  .claim-count
+    = "Number of claims: "
+    = @claims.total_count
   %table.claims_table
     %thead
       %th

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -14,14 +14,14 @@
         = link_to 'Manage chamber', advocates_admin_chamber_path(current_user.persona.chamber), class: cp(advocates_admin_chamber_path(current_user.persona.chamber))
     - elsif current_user.persona.is_a?(CaseWorker)
       - if current_user.persona.admin?
-        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id).merge(tab: 'current')), class: cp( case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current')))
-        = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action, :id).merge(tab: 'archived')), class: cp(archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived')))
+        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :page).merge(tab: 'current')), class: cp( case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current')))
+        = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action, :id, :page).merge(tab: 'archived')), class: cp(archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived')))
         = link_to "Allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search, :id).merge(tab: 'unallocated')), class: cp(case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search).merge(tab: 'unallocated')))
         = link_to "Re-allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search, :id).merge(tab: 'allocated')), class: cp(case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search).merge(tab: 'allocated')))
         = link_to 'Manage case workers', case_workers_admin_case_workers_path, class: cp(case_workers_admin_case_workers_path)
       - else
-        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id).merge(tab: 'current')), class: cp(case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current')))
-        = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action, :id).merge(tab: 'archived')), class: cp(archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived')))
+        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :page).merge(tab: 'current')), class: cp(case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current')))
+        = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action, :id, :page).merge(tab: 'archived')), class: cp(archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived')))
     - else
       = "Error"
   = render partial: 'layouts/user'

--- a/app/views/shared/_search_summary.html.haml
+++ b/app/views/shared/_search_summary.html.haml
@@ -1,4 +1,4 @@
 %section
   %h1
     %p
-      #{pluralize(@claims.count, 'claim')} matching "#{params[:search]}"
+      #{pluralize(@claims.count, 'claim')} of #{@claims.total_count} matching "#{params[:search]}"

--- a/features/step_definitions/advocate_claims_list_steps.rb
+++ b/features/step_definitions/advocate_claims_list_steps.rb
@@ -200,11 +200,11 @@ Then(/^I should see only claims that I have created$/) do
 end
 
 Then(/^I should only see the (\d+) claims for the advocate "(.*?)"$/) do |number, name|
-  expect(page).to have_content(/#{number} claims? matching "#{name}"/)
+  expect(page).to have_content(/#{number} claims? of #{number} matching "#{name}"/)
 end
 
 Then(/^I should only see the (\d+) claims involving defendant "(.*?)"$/) do |number, name|
-  expect(page).to have_content(/#{number} claims? matching "#{name}"/)
+  expect(page).to have_content(/#{number} claims? of #{number} matching "#{name}"/)
 end
 
 Then(/^I should NOT see column "(.*?)" under section id "(.*?)"$/) do |column_name, section_id|

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -136,7 +136,7 @@ When(/^I search claims by defendant name "(.*?)"$/) do |defendant_name|
 end
 
 Then(/^I should only see (\d+) claims$/) do |number|
-  expect(page).to have_content(/#{number} claims? matching/)
+  expect(page).to have_content(/#{number} claims? of #{number} matching/)
 end
 
 When(/^I search for a claim by MAAT reference$/) do


### PR DESCRIPTION
There was a bug whereby if on page 2 of case worker
archived claims when you hit Your claims it
tries to go to page 2 of Your claims (which may not exist).

This fix excludes the page param from the nav bar links.

Also, modified search summary to take account of pagination
information.
