### PR TITLE
fix broken case worker archive search on gamma

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -3,9 +3,11 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
 
   respond_to :html
   
-  # callback order is important (must set claims before resetting pagination)
-  before_action :set_claims,          only: [:index, :archived]
-  before_action :filter_claims,       only: [:index, :archived]
+  # callback order is important (must set claims before filtering and sorting)
+  before_action :set_claims,              only: [:index, :archived]
+  before_action :filter_current_claims,   only: [:index]
+  before_action :filter_archived_claims,  only: [:archived]
+  before_action :sort_claims,             only: [:index, :archived]
   
   before_action :set_claim, only: [:show]
   before_action :set_doctypes, only: [:show, :update]
@@ -130,8 +132,15 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
     @claim = Claim.find(params[:id])
   end
 
-  def filter_claims
-    search if params[:search].present?
+  def filter_current_claims
+    search(Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES) if params[:search].present?
+  end
+
+  def filter_archived_claims
+    search(Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES) if params[:search].present?
+  end
+
+  def sort_claims
     @claims = @claims.order("#{sort_column} #{sort_direction}")
     set_claim_ids_and_count
   end

--- a/app/models/claims/search.rb
+++ b/app/models/claims/search.rb
@@ -28,6 +28,7 @@ module Claims::Search
     states.each do |state|
       raise "Invalid state, #{state}, specified" unless Claim.state_machine.states.map(&:name).include?(state.to_sym)
     end
+
     relation.where(sql, term: "%#{term.downcase}%").where(state: states).uniq
   end
 end


### PR DESCRIPTION
On gamma most case worker archive claims are in the "archived pending delete” state.  This plus the fact that search does not specify a list of states to filter by means the default dashboard_displayable_states is used to filter claims. This default does NOT include archived_pending_delete, hence archive search excludes claims in that state and returns 0 found for most searches (you can search and find claims in any other state on the dashboard).
