### PR TITLE
highlight claims opened for redetermination

### DIFF
--- a/app/assets/stylesheets/claims-table.scss
+++ b/app/assets/stylesheets/claims-table.scss
@@ -11,6 +11,11 @@
           border-left: 10px solid #DF3034;
         }
       }
+      &.opened_for_redetermination {
+        td:first-child {
+          border-left: 10px solid #0b0c0c;
+        }
+      }
     }
 
     th,td {

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -153,7 +153,7 @@ class Claim < ActiveRecord::Base
 
   def redetermination_since_allocation?
     if last_state_transition.from == 'redetermination'
-      last_state_transition_later_than_redeterination?(last_state_transition)
+      last_state_transition_later_than_redetermination?(last_state_transition)
     else
       false
     end
@@ -288,7 +288,6 @@ class Claim < ActiveRecord::Base
     last_state_transition.created_at
   end
 
-
   def opened_for_redetermination?
     return true if self.redetermination?
 
@@ -330,7 +329,7 @@ class Claim < ActiveRecord::Base
     end
   end
 
-  def last_state_transition_later_than_redeterination?(last_state_transition)
+  def last_state_transition_later_than_redetermination?(last_state_transition)
     last_redetermination.nil? ? true : last_redetermination.created_at < last_state_transition.created_at
   end
 

--- a/app/views/case_workers/claims/_claims.html.haml
+++ b/app/views/case_workers/claims/_claims.html.haml
@@ -23,8 +23,8 @@
         = t(".messages")
   %tbody
     - @claims.each do |claim_object|
-      - present(claim_object) do | claim |
-        %tr
+      - present(claim_object) do |claim|
+        %tr{class: "#{claim.opened_for_redetermination? ? 'opened_for_redetermination': nil}" }
           %td
             = link_to claim.case_number , case_workers_claim_path(claim),{:class => 'js-test-case-number-link'}
           %td


### PR DESCRIPTION
case workers want to plan there work based on the whether a claim has been opened for redetermination
and its case type. This PR highlights redeterminations with black left border.
