### PR TITLE
exclude byebug history from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@
 /*.REMOTE.*
 *.orig
 
+/.byebug_history
+
 public/system/documents
 public/paperclip
 public/uploads


### PR DESCRIPTION
noticed that i started getting a .byebug_history
appearing in my git status after running byebug.
Excluded because, in any event, this should be ignored.
