### PR TITLE
Show latest submission date

### DIFF
--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -17,7 +17,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
 
   def index
     @json_document_importer = JsonDocumentImporter.new
-    @claims = @context.claims.dashboard_displayable_states.order('last_submitted_at desc NULLS FIRST').
+    @claims = @context.claims.dashboard_displayable_states.order('last_submitted_at desc NULLS FIRST, created_at desc').
       page(params[:page]).
       per(10)
     search if params[:search].present?
@@ -34,7 +34,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   end
 
   def archived
-    @claims = @context.claims.archived_pending_delete.order(last_submitted_at: :desc)
+    @claims = @context.claims.archived_pending_delete.order(last_submitted_at: :desc, created_at: :desc)
     search(:archived_pending_delete) if params[:search].present?
     @claims = @claims.page(params[:page]).per(10)
   end

--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -17,7 +17,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
 
   def index
     @json_document_importer = JsonDocumentImporter.new
-    @claims = @context.claims.dashboard_displayable_states.order(created_at: :desc).
+    @claims = @context.claims.dashboard_displayable_states.order('last_submitted_at desc NULLS FIRST').
       page(params[:page]).
       per(10)
     search if params[:search].present?
@@ -34,7 +34,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
   end
 
   def archived
-    @claims = @context.claims.archived_pending_delete.order(created_at: :desc)
+    @claims = @context.claims.archived_pending_delete.order(last_submitted_at: :desc)
     search(:archived_pending_delete) if params[:search].present?
     @claims = @claims.page(params[:page]).per(10)
   end

--- a/app/controllers/advocates/claims_controller.rb
+++ b/app/controllers/advocates/claims_controller.rb
@@ -17,7 +17,7 @@ class Advocates::ClaimsController < Advocates::ApplicationController
 
   def index
     @json_document_importer = JsonDocumentImporter.new
-    @claims = @context.claims.dashboard_displayable_states.order('last_submitted_at desc NULLS FIRST, created_at desc').
+    @claims = @context.claims.dashboard_displayable_states.order('last_submitted_at asc NULLS FIRST, created_at asc').
       page(params[:page]).
       per(10)
     search if params[:search].present?

--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -41,7 +41,7 @@ class ClaimPresenter < BasePresenter
   def submitted_at(options={})
     options.assert_valid_keys(:include_time)
     format = options[:include_time] ? Settings.date_time_format : Settings.date_format
-    claim.original_submission_date.strftime(format) unless claim.original_submission_date.nil?
+    claim.last_submitted_at.strftime(format) unless claim.last_submitted_at.nil?
   end
 
   def authorised_at (options={})

--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -1,7 +1,6 @@
 class ClaimPresenter < BasePresenter
   presents :claim
 
-
   # returns a hash of state as a symbol, and state as a human readable name suitable for use in drop down
   #
   def valid_transitions(options = {include_submitted: true} )
@@ -38,16 +37,17 @@ class ClaimPresenter < BasePresenter
     end
   end
 
-  def submitted_at(options={})
+  def date_format(options={})
     options.assert_valid_keys(:include_time)
-    format = options[:include_time] ? Settings.date_time_format : Settings.date_format
-    claim.last_submitted_at.strftime(format) unless claim.last_submitted_at.nil?
+    options[:include_time] ? Settings.date_time_format : Settings.date_format
+  end
+
+  def submitted_at(options={})
+    claim.last_submitted_at.strftime(date_format(options)) unless claim.last_submitted_at.nil?
   end
 
   def authorised_at (options={})
-    options.assert_valid_keys(:include_time)
-    format = options[:include_time] ? Settings.date_time_format : Settings.date_format
-    claim.authorised_at.strftime(format) unless claim.authorised_at.nil?
+    claim.authorised_at.strftime(date_format(options)) unless claim.authorised_at.nil?
   end
 
   def retrial

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -59,19 +59,27 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
     end
   end
 
-  describe '#GET index order' do
-    context 'ordering' do
-      before(:each) do
-        create_list(:draft_claim, 1, advocate: advocate)
-        create_list(:draft_claim, 2, advocate: advocate, created_at: 1.day.ago)
-        create(:submitted_claim, advocate: advocate).update_column(:last_submitted_at, 1.day.ago)
-        create(:refused_claim, advocate: advocate).update_column(:last_submitted_at, 2.day.ago)
-      end
+  describe '#GET index - unstubbed' do
 
-      it 'orders claims so that most recently submitted is first with nulls/unsubmitted first' do
-        get :index
-        expect(assigns(:claims)).to eq(advocate.claims.dashboard_displayable_states.order('last_submitted_at desc NULLS FIRST, created_at desc').page(1).per(10))
-      end
+    before(:each) do
+      Timecop.freeze
+      create_list(:draft_claim, 1, advocate: advocate)
+      create_list(:draft_claim, 5, advocate: advocate, created_at: 5.days.ago)
+      create_list(:draft_claim, 2, advocate: advocate, created_at: 1.day.ago)
+      create(:submitted_claim, advocate: advocate).update_column(:last_submitted_at, 1.day.ago)
+      create(:refused_claim, advocate: advocate).update_column(:last_submitted_at, 2.days.ago)
+      get :index
+    end
+
+    after { Timecop.return }
+
+    it 'orders claims with draft first (most recently created first) then most recently submitted' do
+      expect(assigns(:claims).first.created_at).to eq(Time.now)
+      expect(assigns(:claims)).to eq(advocate.claims.dashboard_displayable_states.order('last_submitted_at desc NULLS FIRST, created_at desc').page(1).per(10))
+    end
+
+    it 'paginates to 10 per page' do
+      expect(assigns(:claims).count).to eq(10)
     end
   end
 
@@ -113,17 +121,25 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
     end
   end
 
-  describe '#GET archived order' do
-    context 'ordering' do
-      before(:each) do
-        create(:archived_pending_delete_claim, advocate: advocate).update_column(:last_submitted_at, 1.day.ago)
-        create(:archived_pending_delete_claim, advocate: advocate).update_column(:last_submitted_at, 2.day.ago)
-      end
+  describe '#GET archived - unstubbed' do
+    before(:each) do
+      Timecop.freeze
+      create_list(:archived_pending_delete_claim, 8, advocate: advocate).each { |c| c.update_column(:last_submitted_at, 8.days.ago) }
+      create(:archived_pending_delete_claim, advocate: advocate).update_column(:last_submitted_at, 3.days.ago)
+      create(:archived_pending_delete_claim, advocate: advocate).update_column(:last_submitted_at, 1.day.ago)
+      create(:archived_pending_delete_claim, advocate: advocate).update_column(:last_submitted_at, 2.days.ago)
+      get :archived
+    end
 
-      it 'most recently submitted claim first' do
-        get :archived
-        expect(assigns(:claims)).to eq(advocate.claims.archived_pending_delete.order('last_submitted_at desc NULLS FIRST, created_at desc').page(1).per(10))
-      end
+    after { Timecop.return }
+
+    it 'orders claims with most recently submitted first' do
+      expect(assigns(:claims).first.last_submitted_at).to eq(1.day.ago)
+      expect(assigns(:claims)).to eq(advocate.claims.archived_pending_delete.order(last_submitted_at: :desc, created_at: :desc).page(1).per(10))
+    end
+
+    it 'paginates to 10 per page' do
+      expect(assigns(:claims).count).to eq(10)
     end
   end
 

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
     before(:each) do
       Timecop.freeze
       create_list(:draft_claim, 1, advocate: advocate)
-      create_list(:draft_claim, 5, advocate: advocate, created_at: 5.days.ago)
-      create_list(:draft_claim, 2, advocate: advocate, created_at: 1.day.ago)
+      create_list(:draft_claim, 1, advocate: advocate, created_at: 5.days.ago)
+      create_list(:draft_claim, 6, advocate: advocate, created_at: 1.day.ago)
+      create_list(:draft_claim, 1, advocate: advocate, created_at: 2.days.ago)
       create(:submitted_claim, advocate: advocate).update_column(:last_submitted_at, 1.day.ago)
       create(:refused_claim, advocate: advocate).update_column(:last_submitted_at, 2.days.ago)
       get :index
@@ -73,9 +74,9 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
 
     after { Timecop.return }
 
-    it 'orders claims with draft first (most recently created first) then most recently submitted' do
-      expect(assigns(:claims).first.created_at).to eq(Time.now)
-      expect(assigns(:claims)).to eq(advocate.claims.dashboard_displayable_states.order('last_submitted_at desc NULLS FIRST, created_at desc').page(1).per(10))
+    it 'orders claims with draft first (oldest created first) then oldest submitted' do
+      expect(assigns(:claims).first.created_at).to eq(5.days.ago)
+      expect(assigns(:claims)).to eq(advocate.claims.dashboard_displayable_states.order('last_submitted_at asc NULLS FIRST, created_at asc').page(1).per(10))
     end
 
     it 'paginates to 10 per page' do

--- a/spec/controllers/advocates/claims_controller_spec.rb
+++ b/spec/controllers/advocates/claims_controller_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
   describe '#GET index - unstubbed' do
 
     before(:each) do
-      Timecop.freeze
       create_list(:draft_claim, 1, advocate: advocate)
       create_list(:draft_claim, 1, advocate: advocate, created_at: 5.days.ago)
       create_list(:draft_claim, 6, advocate: advocate, created_at: 1.day.ago)
@@ -72,10 +71,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
       get :index
     end
 
-    after { Timecop.return }
-
     it 'orders claims with draft first (oldest created first) then oldest submitted' do
-      expect(assigns(:claims).first.created_at).to eq(5.days.ago)
       expect(assigns(:claims)).to eq(advocate.claims.dashboard_displayable_states.order('last_submitted_at asc NULLS FIRST, created_at asc').page(1).per(10))
     end
 
@@ -124,7 +120,6 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
 
   describe '#GET archived - unstubbed' do
     before(:each) do
-      Timecop.freeze
       create_list(:archived_pending_delete_claim, 8, advocate: advocate).each { |c| c.update_column(:last_submitted_at, 8.days.ago) }
       create(:archived_pending_delete_claim, advocate: advocate).update_column(:last_submitted_at, 3.days.ago)
       create(:archived_pending_delete_claim, advocate: advocate).update_column(:last_submitted_at, 1.day.ago)
@@ -132,10 +127,7 @@ RSpec.describe Advocates::ClaimsController, type: :controller, focus: true do
       get :archived
     end
 
-    after { Timecop.return }
-
     it 'orders claims with most recently submitted first' do
-      expect(assigns(:claims).first.last_submitted_at).to eq(1.day.ago)
       expect(assigns(:claims)).to eq(advocate.claims.archived_pending_delete.order(last_submitted_at: :desc, created_at: :desc).page(1).per(10))
     end
 

--- a/spec/custom_matchers.rb
+++ b/spec/custom_matchers.rb
@@ -5,14 +5,14 @@ RSpec::Matchers.define :contain_claims do |*expected|
     result = expected.size == actual.size
     expected.each do |e|
       unless actual.include?(e)
-        result = false 
+        result = false
         break
       end
     end
   end
   failure_message do |actual|
     "expected that records:\n\t #{actual.inspect} \n\nwould be equal to records\n\t #{expected.inspect}"
-  end  
+  end
 
 end
 

--- a/spec/presenters/claim_presenter_spec.rb
+++ b/spec/presenters/claim_presenter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ClaimPresenter do
   end
 
   it '#submitted_at' do
-    claim.original_submission_date = Time.current
+    claim.last_submitted_at = Time.current
     expect(subject.submitted_at).to eql(Time.current.strftime('%d/%m/%Y'))
     expect(subject.submitted_at(include_time: true)).to eql(Time.current.strftime('%d/%m/%Y %H:%M'))
   end


### PR DESCRIPTION
This PR syncs the displayed "submitted date" in claims list to the ordered "submitted date". It also uses the last_submitted_date, rather than the original_submission_date for display purposes. 

As Applies to both case worker and advocate sides.
