### PR TITLE
Derive supplier number and VAT registration from provider model

### DIFF
--- a/app/models/advocate.rb
+++ b/app/models/advocate.rb
@@ -41,7 +41,7 @@ class Advocate < ActiveRecord::Base
   delegate :name, to: :user
 
   def supplier_number
-    if provider.firm?
+    if provider && provider.firm?
       provider.supplier_number
     else
       read_attribute(:supplier_number)
@@ -49,7 +49,7 @@ class Advocate < ActiveRecord::Base
   end
 
   def apply_vat?
-    if provider.firm?
+    if provider && provider.firm?
       provider.vat_registered?
     else
       read_attribute(:apply_vat)

--- a/app/models/advocate.rb
+++ b/app/models/advocate.rb
@@ -40,7 +40,21 @@ class Advocate < ActiveRecord::Base
   delegate :last_name, to: :user
   delegate :name, to: :user
 
+  def supplier_number
+    if provider.firm?
+      provider.supplier_number
+    else
+      read_attribute(:supplier_number)
+    end
+  end
 
+  def apply_vat?
+    if provider.firm?
+      provider.vat_registered?
+    else
+      read_attribute(:apply_vat)
+    end
+  end
 
   def advocates_in_provider
     raise "Cannot call #advocates_in_provider on advocates who are not admins" unless self.is?('admin')

--- a/spec/models/advocate_spec.rb
+++ b/spec/models/advocate_spec.rb
@@ -94,6 +94,45 @@ RSpec.describe Advocate, type: :model do
     end
   end
 
+  describe '#supplier_number' do
+    subject { create(:advocate, provider: provider, supplier_number: 'XY123') }
+
+    context 'when advocate in chamber' do
+      let(:provider) { create(:provider, :chamber, supplier_number: 'AB123') }
+
+      it "returns the advocate's supplier number" do
+        expect(subject.supplier_number).to eq('XY123')
+      end
+    end
+
+    context 'when advocate in firm' do
+      let(:provider) { create(:provider, :firm, supplier_number: 'AB123') }
+
+      it "returns the provider's supplier number" do
+        expect(subject.supplier_number).to eq('AB123')
+      end
+    end
+  end
+
+  describe '#apply_vat?' do
+    subject { create(:advocate, provider: provider, apply_vat: false) }
+
+    context 'when advocate in chamber' do
+      let(:provider) { create(:provider, :chamber, vat_registered: true) }
+
+      it "returns the advocate's VAT registration status" do
+        expect(subject.apply_vat?).to eq(false)
+      end
+    end
+
+    context 'when advocate in firm' do
+      let(:provider) { create(:provider, :firm, vat_registered: true) }
+
+      it "returns the provider's VAT registration status" do
+        expect(subject.apply_vat?).to eq(true)
+      end
+    end
+  end
 
   describe '#name' do
     subject { create(:advocate) }


### PR DESCRIPTION
Advocate#supplier_number and Advocate#apply_vat? methods to derive value from Provider model if provider is a firm, otherwise returns attributes from Advocate model.
