### PR TITLE
Optional supplier number and vat registration fields for advocates admin

### DIFF
--- a/app/views/advocates/admin/advocates/_form.html.haml
+++ b/app/views/advocates/admin/advocates/_form.html.haml
@@ -13,14 +13,16 @@
       = user_fields.label :email_confirmation, t(".email_confirmation"), class: "form-label"
       = user_fields.email_field :email_confirmation, class: "form-control"
 
-      = f.label :vat_registered, class: "form-label"
-      %div.form-group.inline
-        =f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
-          - b.label(class: 'block-label') { b.radio_button + (b.value.to_s == 'true' ? 'Yes' : 'No') }
+      - if current_user.persona.provider.chamber?
+        = f.label :vat_registered, class: "form-label"
+        %div.form-group.inline
+          =f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
+            - b.label(class: 'block-label') { b.radio_button + (b.value.to_s == 'true' ? 'Yes' : 'No') }
 
     %fieldset.user-form
-      = f.label :supplier_number, t(".supplier_number"), class: "form-label"
-      = f.text_field :supplier_number, class: "form-control"
+      - if current_user.persona.provider.chamber?
+        = f.label :supplier_number, t(".supplier_number"), class: "form-label"
+        = f.text_field :supplier_number, class: "form-control"
 
       = f.label :role, class: "form-label"
       %div.form-group.inline

--- a/app/views/advocates/admin/providers/edit.html.haml
+++ b/app/views/advocates/admin/providers/edit.html.haml
@@ -18,13 +18,14 @@
     = f.text_field :name
     = validation_error_message(@provider, :name)
 
-    = f.label t('.supplier_number'), class: "form-label"
-    = f.text_field :supplier_number
-    = validation_error_message(@provider, :supplier_number)
+    - if @provider.firm?
+      = f.label t('.supplier_number'), class: "form-label"
+      = f.text_field :supplier_number
+      = validation_error_message(@provider, :supplier_number)
 
-    %label
-      = f.check_box :vat_registered
-      = t('.vat_registered')
+      %label
+        = f.check_box :vat_registered
+        = t('.vat_registered')
 
     = f.label :api_key, t('.api_key'), class: "form-label"
     = @provider.api_key

--- a/app/views/advocates/admin/providers/show.html.haml
+++ b/app/views/advocates/admin/providers/show.html.haml
@@ -3,13 +3,14 @@
 %h2
   = @provider.name
 
-%p
-  = label_tag :supplier_number, "#{t('.supplier_number')}:", class: "form-label"
-  = @provider.supplier_number
+- if @provider.firm?
+  %p
+    = label_tag :supplier_number, "#{t('.supplier_number')}:", class: "form-label"
+    = @provider.supplier_number
 
-%p
-  = label_tag :vat_registered, "#{t('.vat_registered')}:", class: "form-label"
-  = @provider.vat_registered == true ? 'Yes' : 'No'
+  %p
+    = label_tag :vat_registered, "#{t('.vat_registered')}:", class: "form-label"
+    = @provider.vat_registered == true ? 'Yes' : 'No'
 
 %p
   = label_tag :api_key, "#{t('.api_key')}:", class: "form-label"

--- a/features/advocate_admin_edit_provider.feature
+++ b/features/advocate_admin_edit_provider.feature
@@ -9,10 +9,36 @@ Scenario: Generate a new API key for provider
      Then I should be redirected to the Manage provider page
       And I should see a new api key
 
-Scenario: Edit supplier number
+Scenario: Edit supplier number for firm
     Given I am a signed in advocate admin
+      And my provider is a "firm"
      When I visit the Edit provider page
       And I fill in supplier number with "C9999"
       And I click "Save"
      Then I should be redirected to the Manage provider page
       And I should see a supplier of "C9999"
+
+Scenario: Edit supplier number for chamber
+    Given I am a signed in advocate admin
+      And my provider is a "chamber"
+     When I visit the Edit provider page
+     Then I should not see the supplier number field
+      And I visit the Manage provider page
+     Then I should not see a supplier number
+
+Scenario: Edit VAT registration for firm
+    Given I am a signed in advocate admin
+      And my provider is a "firm"
+     When I visit the Edit provider page
+      And I check the VAT registration box
+      And I click "Save"
+     Then I should be redirected to the Manage provider page
+      And I should see VAT registration status of "Yes"
+
+Scenario: Edit VAT registration for chamber
+    Given I am a signed in advocate admin
+      And my provider is a "chamber"
+     When I visit the Edit provider page
+     Then I should not see the VAT registration checkbox
+      And I visit the Manage provider page
+     Then I should not see VAT registration information

--- a/features/new_user.feature
+++ b/features/new_user.feature
@@ -1,31 +1,42 @@
 Feature: User is added by advocate or caseworker admin
 
-Scenario: New advocate user
+Scenario: New advocate user for firm
   Given I am a signed in advocate admin
+    And my provider is a "firm"
     And I am on the new "advocate" page
-  When I fill in the "advocate" details
+   When I fill in the "advocate" details
     And click save
-  Then I see confirmation that a new "Advocate" user has been created
+   Then I see confirmation that a new "Advocate" user has been created
+    And an email is sent to the new user
+
+Scenario: New advocate user for chamber
+  Given I am a signed in advocate admin
+    And my provider is a "chamber"
+    And I am on the new "advocate" page
+   When I fill in the "advocate" details
+    And click save
+   Then I see confirmation that a new "Advocate" user has been created
     And an email is sent to the new user
 
 Scenario: New advocate with mismatching email_confirmation
   Given I am a signed in advocate admin
+    And my provider is a "chamber"
     And I am on the new "advocate" page
-  When I fill in the "advocate" details but email and email_confirmation do not match
+   When I fill in the "advocate" details but email and email_confirmation do not match
     And click save
-  Then I see an error message
+   Then I see an error message
 
 Scenario: New caseworker user
   Given I am a signed in case worker admin
     And I am on the new "case_worker" page
-  When I fill in the "case_worker" details
+   When I fill in the "case_worker" details
     And click save
-  Then I see confirmation that a new "Case worker" user has been created
+   Then I see confirmation that a new "Case worker" user has been created
     And an email is sent to the new user
 
 Scenario: New caseworker with mismatching email_confirmation
   Given I am a signed in case worker admin
     And I am on the new "case_worker" page
-  When I fill in the "case_worker" details but email and email_confirmation do not match
+   When I fill in the "case_worker" details but email and email_confirmation do not match
     And click save
-  Then I see an error message
+   Then I see an error message

--- a/features/step_definitions/advocate_admin_edit_provider_steps.rb
+++ b/features/step_definitions/advocate_admin_edit_provider_steps.rb
@@ -11,6 +11,10 @@ Then(/^I should see a supplier of "(.*?)"$/) do |supplier_number|
   expect(page).to have_content(supplier_number)
 end
 
+Then(/^I should not see a supplier number$/) do
+  expect(page).to_not have_content(/Supplier number/i)
+end
+
 When(/^I visit the Manage provider page$/) do
   visit advocates_admin_provider_path(@advocate.provider)
   @api_key = find('#api-key').text
@@ -24,4 +28,38 @@ Then(/^I should see a new api key$/) do
   expect(page).to have_selector('#api-key')
   new_api_key = find('#api-key').text
   expect(new_api_key).to_not eql @api_key
+end
+
+Given(/^my provider is a "(.*?)"$/) do |provider_type|
+  @advocate.provider.update_column(:provider_type, provider_type)
+  @advocate.provider.update_column(:vat_registered, false)
+end
+
+Then(/^I should (not )?see the supplier number field$/) do |negate|
+  if negate.present?
+    expect(page).to_not have_selector('#provider_supplier_number')
+  else
+    expect(page).to have_selector('#provider_supplier_number')
+  end
+end
+
+When(/^I check the VAT registration box$/) do
+  fill_in 'provider_supplier_number', with: 'XX111'
+  check 'provider_vat_registered'
+end
+
+Then(/^I should (not )?see VAT registration status of "(.*?)"$/) do |negate, value|
+  if negate.present?
+    expect(page).to_not have_content(/VAT registered/i)
+  else
+    expect(page).to have_content(/VAT registered: Yes/i)
+  end
+end
+
+Then(/^I should not see the VAT registration checkbox$/) do
+  expect(page).to_not have_selector('#provider_vat_registered')
+end
+
+Then(/^I should not see VAT registration information$/) do
+  expect(page).to_not have_content(/VAT registered/i)
 end

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -10,8 +10,10 @@ When(/^I fill in the "(.*?)" details$/) do |persona|
   fill_in "#{persona}_user_attributes_email_confirmation", with: 'harold.hughes@example.com'
   case persona
   when 'advocate'
-    choose(('advocate[vat_registered]').first)
-    fill_in 'advocate_supplier_number', with: '31425'
+    if @advocate.provider.chamber?
+      choose(('advocate[vat_registered]').first)
+      fill_in 'advocate_supplier_number', with: '31425'
+    end
     choose(("#{persona}[role]").first)
   when 'case_worker'
     check('case_worker[days_worked_0]')


### PR DESCRIPTION
Optional supplier number and vat registration fields for advocates admin depending on provider type, chamber or firm.
