### PR TITLE
Copy change redetermination marker

### DIFF
--- a/app/views/case_workers/claims/_claims.html.haml
+++ b/app/views/case_workers/claims/_claims.html.haml
@@ -37,7 +37,7 @@
             %td
               = claim.state.humanize
           %td
-            = claim.case_type.name
+            = claim.opened_for_redetermination? ? claim.case_type.name + "\n(redetermination)" : claim.case_type.name
           %td
             = claim.submitted_at(include_time: false) unless claim.draft?
           %td.messages

--- a/features/claim_redetermination.feature
+++ b/features/claim_redetermination.feature
@@ -28,6 +28,12 @@ Feature: Claim redetermination
       | Rejected                  | rejected                 |
       | Refused                   | refused                  |
 
+  Scenario: View redetermination claims
+    Given I am a signed in case worker
+      And a redetermined claim is assigned to me
+      And I visit my dashboard
+     Then I should see a claim marked as a redetermination
+
   Scenario: Handle written reasons for claim
     Given I am a signed in case worker
       And a written reasons claim is assigned to me

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -108,6 +108,13 @@ Then(/^I should see the claims sorted by oldest first$/) do
   end
 end
 
+Then(/^I should see a claim marked as a redetermination$/) do
+  within('.report') do
+    expect(find(:xpath, './tbody').find('tr')[:class]).to include('opened_for_redetermination')
+    expect(find(:xpath, './tbody')).to have_content("(redetermination)")
+  end
+end
+
 #TODO Reintroduce when sorting columns is implemented
 #When(/^I sort the claims by highest value first$/) do
 #  click_on 'Value - Highest first'


### PR DESCRIPTION
Tweek to existing functionality that highlights allocated claims that are opened for redetermination, in the case worker "Your claims" index page.

Added cuke to lock it down too.
