### PR TITLE
remove caseworker visual redetermination marker

### DIFF
--- a/app/assets/stylesheets/claims-table.scss
+++ b/app/assets/stylesheets/claims-table.scss
@@ -11,11 +11,6 @@
           border-left: 10px solid #DF3034;
         }
       }
-      &.opened_for_redetermination {
-        td:first-child {
-          border-left: 10px solid #0b0c0c;
-        }
-      }
     }
 
     th,td {

--- a/app/views/case_workers/claims/_claims.html.haml
+++ b/app/views/case_workers/claims/_claims.html.haml
@@ -24,7 +24,7 @@
   %tbody
     - @claims.each do |claim_object|
       - present(claim_object) do |claim|
-        %tr{class: "#{claim.opened_for_redetermination? ? 'opened_for_redetermination': nil}" }
+        %tr
           %td
             = link_to claim.case_number , case_workers_claim_path(claim),{:class => 'js-test-case-number-link'}
           %td

--- a/features/step_definitions/caseworker_claims_list_steps.rb
+++ b/features/step_definitions/caseworker_claims_list_steps.rb
@@ -108,13 +108,6 @@ Then(/^I should see the claims sorted by oldest first$/) do
   end
 end
 
-Then(/^I should see a claim marked as a redetermination$/) do
-  within('.report') do
-    expect(find(:xpath, './tbody').find('tr')[:class]).to include('opened_for_redetermination')
-    expect(find(:xpath, './tbody')).to have_content("(redetermination)")
-  end
-end
-
 #TODO Reintroduce when sorting columns is implemented
 #When(/^I sort the claims by highest value first$/) do
 #  click_on 'Value - Highest first'

--- a/features/step_definitions/claim_redetermination_steps.rb
+++ b/features/step_definitions/claim_redetermination_steps.rb
@@ -83,7 +83,6 @@ When(/^I enter redetermination amounts$/) do
   click_button 'Update'
 end
 
-
 Then(/^There should be no form to enter redetermination amounts$/) do
   expect(page).not_to have_selector('#claim_redeterminations_attributes_0_fees')
 end
@@ -94,5 +93,11 @@ Then(/^The redetermination I just entered should be visible$/) do
   end
   within('#determination-expenses') do
     expect(page).to have_content('£805.75')
+  end
+end
+
+Then(/^I should see a claim marked as a redetermination$/) do
+  within('.report') do
+    expect(find(:xpath, './tbody')).to have_content("(redetermination)")
   end
 end


### PR DESCRIPTION
removed the css class marking as user (case worker manager) requested
change to purely use copy to mark a claim as "opened for redetermination"
in the caseworkers "Your claims" list.
