### PR TITLE
Change offence category search

### DIFF
--- a/app/assets/javascripts/modules/advocates/claims/Select2.js
+++ b/app/assets/javascripts/modules/advocates/claims/Select2.js
@@ -1,10 +1,13 @@
 moj.Modules.Select2 = {
   init : function() {
     $('.select2').select2({
-      matcher: this.startOfMatcher
+      matcher: this.anyOfMatcher
     });
   },
   startOfMatcher : function(term, text) {
     return text.toUpperCase().indexOf(term.toUpperCase()) === 0;
+  },
+  anyOfMatcher : function(term, text) {
+    return text.toUpperCase().indexOf(term.toUpperCase()) >= 0;
   }
 };

--- a/app/views/advocates/claims/_form.html.haml
+++ b/app/views/advocates/claims/_form.html.haml
@@ -44,6 +44,8 @@
       .grid-row#offence
         .column-half
           = f.anchored_label t('.offence_category')
+          %span.form-hint
+            = "If the offence category is not listed, choose \"Miscellaneous/other\""
           - if @claim.new_record?
             - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
           - else


### PR DESCRIPTION
This PR remedies 2 issues:
- users who were failing to use the Miscellaneous/other offence category - now have help text
- the search of offences now search anywhere in text (not form start)
