### PR TITLE
add help/hint text to case worker redetermination form

### DIFF
--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -19,12 +19,8 @@ class ClaimPresenter < BasePresenter
     end
   end
 
-  def humanized_state
-    claim.state.humanize
-  end
-
   def case_type_name
-    claim.opened_for_redetermination? ? claim.case_type.name + "\n(redetermination)" : claim.case_type.name
+    claim.opened_for_redetermination? ? claim.case_type.name + ' (redetermination)' : claim.case_type.name
   end
 
   def defendant_names

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -2,10 +2,13 @@
   %fieldset#claim-status
     %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db)}}
       %thead
-        %tr
+        %tr{:style => "vertical-align: top;"}
           %th &nbsp;
           %th Claimed by advocate
-          %th Authorised by LAA
+          %th
+            Total authorised by LAA
+            - if claim.opened_for_redetermination?
+              .form-hint.xsmall include any amount already authorised
       %tbody
         -if @enable_assessment_input
           = f.fields_for :assessment do |af|

--- a/app/views/shared/_determinations_table.html.haml
+++ b/app/views/shared/_determinations_table.html.haml
@@ -1,12 +1,12 @@
 %fieldset#claim-status
-  = "Current status: #{claim.humanized_state}"
+  = "Current status: #{claim.state.humanize}"
 
   %table#determinations
     %thead
       %tr
         %th &nbsp;
         %th Claimed by advocate
-        %th Authorised by LAA
+        %th Total authorised by LAA
     %tbody
       - if claim.redeterminations.any?
         = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.redeterminations.last }


### PR DESCRIPTION
case workers were only entering any increase in amount
authorised from the previous amount authorised when they
should have entered the new total authorised amount.

Also:
- removed humanized state as redundant
- remove \n line break in presenter as redundant
