### PR TITLE
Reverse a change made to authorised claims method

### DIFF
--- a/app/models/claims/financial_summary.rb
+++ b/app/models/claims/financial_summary.rb
@@ -8,10 +8,13 @@ class Claims::FinancialSummary
   end
 
   def authorised_claims
-    @context.claims.any_authorised
-      .joins(:determinations)
-      .where('determinations.created_at = (SELECT MAX(d.created_at) FROM "determinations" d WHERE d."claim_id" = "claims"."id")') #latest determination
+    @context.claims.any_authorised.joins(:determinations)
       .where('determinations.updated_at >= ?', Time.now.beginning_of_week)
+      .group('claims.id')
+    # @context.claims.any_authorised
+    #   .joins(:determinations)
+    #   .where('determinations.created_at = (SELECT MAX(d.created_at) FROM "determinations" d WHERE d."claim_id" = "claims"."id")') #latest determination
+    #   .where('determinations.updated_at >= ?', Time.now.beginning_of_week)
   end
 
   def total_outstanding_claim_value


### PR DESCRIPTION
This change came in as part of sortable claims list
but breaks spec/models/claims/financial_summary_spec.rb:69
if full test suite run (only and sometimes??).
