### PR TITLE
add redetermination marker copy to allocation and re-allocation pages

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -75,7 +75,7 @@
                   = claim.defendant_names
               %td
                 = b.label do
-                  = claim.case_type.name
+                  = claim.case_type_name
               %td
                 = b.label do
                   = claim.submitted_at

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -62,7 +62,7 @@
                 = claim.defendant_names
             %td
               = b.label do
-                = claim.case_type.name
+                = claim.case_type_name
             %td
               = b.label do
                 = claim.submitted_at

--- a/features/caseworker_admin_claims_list.feature
+++ b/features/caseworker_admin_claims_list.feature
@@ -24,7 +24,6 @@ Feature: Caseworker claims list
     When I visit my dashboard
      And I click "Allocation"
     Then I should see the unallocated claims
-     # And I should see the claims sorted by oldest first
 
   Scenario: View re-allocation tool
    Given I am a signed in case worker admin
@@ -32,7 +31,6 @@ Feature: Caseworker claims list
     When I visit my dashboard
      And I click "Re-allocation"
     Then I should see the allocated claims
-     # And I should see the claims sorted by oldest first
 
   Scenario: View case workers
       Given I am a signed in case worker admin

--- a/features/claim_redetermination.feature
+++ b/features/claim_redetermination.feature
@@ -29,9 +29,14 @@ Feature: Claim redetermination
       | Refused                   | refused                  |
 
   Scenario: View redetermination claims in dashboard
-    Given I am a signed in case worker
+    Given I am a signed in case worker admin
+      And there are 1 "redetermination" claims
+     When I visit the allocation page
+     Then I should see a claim marked as a redetermination
       And a redetermined claim is assigned to me
       And I visit my dashboard
+     Then I should see a claim marked as a redetermination
+      And I visit the re-allocation page
      Then I should see a claim marked as a redetermination
 
   Scenario: Handle written reasons for claim

--- a/features/step_definitions/claim_allocation_steps.rb
+++ b/features/step_definitions/claim_allocation_steps.rb
@@ -6,6 +6,10 @@ When(/^I visit the allocation page$/) do
   visit case_workers_admin_allocations_path
 end
 
+Then(/^I visit the re\-allocation page$/) do
+  visit case_workers_admin_allocations_path(tab: 'allocated')
+end
+
 When(/^I select claims$/) do
   check(@claims.first.case_number)
   check(@claims.second.case_number)


### PR DESCRIPTION
Display (redetermination) next to case type in case worker allocation and re-allocation pages.

Requested by users.
