### PR TITLE
old claims in gamma have non state-change versions; handle nils

### DIFF
--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -23,13 +23,21 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def last_allocated_at
-    last_allocation = versions.select { |version| version.changeset['state'][1] == 'allocated' }.last
+    last_allocation = versions.select { |version| transition_to_allocated?(version) }.last
     last_allocation ? last_allocation.created_at.to_s : 'n/a'
   end
 
+  def transition_to_allocated?(version)
+    version.changeset['state'].present? && version.changeset['state'][1] == 'allocated'
+  end
+
   def last_determined_at
-    last_determination = versions.select { |version| determined_states.include?(version.changeset['state'][1]) }.last
+    last_determination = versions.select { |version| transition_to_determined_state?(version) }.last
     last_determination ? last_determination.created_at.to_s : 'n/a'
+  end
+
+  def transition_to_determined_state?(version)
+    version.changeset['state'].present? && determined_states.include?(version.changeset['state'][1])
   end
 
   def determined_states


### PR DESCRIPTION
- old claims have update events tracked in versions
- when the claim_csv_presenter looks for allocation dates and determination dates the old 'update' event versions return nil
- this doesn't happen in other envs because the data is newer and the new codebase does not version control update events
- I will refactor some of these methods when melissas suggestions are implemented; we need a separate line for each passage of each claim through the system.  Currently each claim is only represented by one line, describing their most recent passage.
