### PR TITLE
Feedback loop journey for users when signing out

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def after_sign_out_path_for(resource)
+    new_feedback_url
+  end
+
   def after_sign_in_path_for(resource)
     method_name = "after_sign_in_path_for_#{current_user.persona.class.to_s.underscore.downcase}"
     send(method_name)

--- a/features/feedback_loop.feature
+++ b/features/feedback_loop.feature
@@ -1,15 +1,22 @@
+@stub_zendesk_request
+
 Feature: A user can provide feedback and report bugs
+  Background:
+    Given I am a signed in advocate
 
-@stub_zendesk_request
-Scenario: An advocate provides feedback on their experience of the service
-  Given I am a signed in advocate
-  When I click 'feedback'
-    And I fill in the 'feedback' form
-  Then I see confirmation that my 'feedback' was received
+  Scenario: An advocate provides feedback on their experience of the service
+    Given I click 'feedback'
+     When I fill in the 'feedback' form
+     Then I see confirmation that my 'feedback' was received
 
-@stub_zendesk_request
-Scenario: An advocate submits a bug report
-  Given I am a signed in advocate
-  When I click 'report a fault here.'
-    And I fill in the 'bug report' form
-  Then I see confirmation that my 'bug report' was received
+  Scenario: An advocate is redirected to the feedback page upon sign out
+    Given I sign out
+     Then I should be redirected to the feedback page
+     When I fill in the 'feedback' form
+     Then I see confirmation that my 'feedback' was received
+      And I should be on the sign in page
+
+  Scenario: An advocate submits a bug report
+    Given I click 'report a fault here.'
+     When I fill in the 'bug report' form
+     Then I see confirmation that my 'bug report' was received

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -23,3 +23,11 @@ Then(/^I see confirmation that my '(.*?)' was received$/) do |payload|
     expect(page).to have_content "Feedback submitted"
   end
 end
+
+Then(/^I should be redirected to the feedback page$/) do
+  expect(current_path).to eq(new_feedback_path)
+end
+
+Then(/^I should be on the sign in page$/) do
+  expect(current_path).to eq(new_user_session_path)
+end

--- a/features/step_definitions/shared/sign_in_steps.rb
+++ b/features/step_definitions/shared/sign_in_steps.rb
@@ -53,3 +53,7 @@ Then(/^I should see an Manage advocates link and it should work$/) do
   find('#primary-nav').click_link('Manage advocates')
   expect(find('h1.page-title')).to have_content('Manage advocates')
 end
+
+Given(/^I sign out$/) do
+  click_link 'Sign out' rescue nil
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -57,4 +57,57 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
   end
+
+  describe '#after_sign_out_path_for' do
+    let(:super_admin) { create(:super_admin) }
+    let(:advocate) { create(:external_user, :advocate) }
+    let(:advocate_admin) { create(:external_user, :admin) }
+    let(:case_worker) { create(:case_worker) }
+    let(:case_worker_admin) { create(:case_worker, :admin) }
+
+    before do
+      sign_in user
+      sign_out user
+    end
+
+    context 'given a super admin' do
+      let(:user) { super_admin.user }
+
+      it 'returns super admins root url' do
+        expect(subject.after_sign_out_path_for(user)).to eq(new_feedback_url)
+      end
+    end
+
+    context 'given an advocate' do
+      let(:user) { advocate.user }
+
+      it 'returns advocates root url ' do
+        expect(subject.after_sign_out_path_for(user)).to eq(new_feedback_url)
+      end
+    end
+
+    context 'given a case worker' do
+      let(:user) { case_worker.user }
+
+      it 'returns case workers root url ' do
+        expect(subject.after_sign_out_path_for(user)).to eq(new_feedback_url)
+      end
+    end
+
+    context 'given an admin advocate' do
+      let(:user) { advocate_admin.user }
+
+      it 'returns advocates admin root url ' do
+        expect(subject.after_sign_out_path_for(user)).to eq(new_feedback_url)
+      end
+    end
+
+    context 'given an admin case worker' do
+      let(:user) { case_worker_admin.user }
+
+      it 'returns case workers root url ' do
+        expect(subject.after_sign_out_path_for(user)).to eq(new_feedback_url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Feedback loop journey for users when signing out. Sign out redirects to new feedback form, submission of feedback redirects to sign in page. 

This PR closes #942 
