### PR TITLE
MI download: when state == archived_pending_delete show prev state

### DIFF
--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -10,6 +10,14 @@ class ClaimCsvPresenter < BasePresenter
     external_user.supplier_number
   end
 
+  def claim_state
+    unless state == 'archived_pending_delete'
+      state
+    else
+      claim_state_transitions.sort.last.from
+    end
+  end
+
   def organisation
     external_user.provider.name
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,6 +46,6 @@ csv_column_names:
   - :allocation_type
   - :case_type_name
   - :claim_total
-  - :state
+  - :claim_state
   - :last_allocated_at
   - :last_determined_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20160119133748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pgcrypto"
   enable_extension "uuid-ossp"
 
   create_table "case_types", force: :cascade do |t|

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ClaimCsvPresenter do
       expect(subject.present!).to include(claim.total.to_s)
     end
 
-    it 'current state' do
+    it 'caseworker-relent state' do
       expect(subject.present!).to include(claim.state)
     end
 


### PR DESCRIPTION
- caseworkers do not want to see archived_pending_delete in the MI download
- show state prior to this transition
- the presenter is being further refactored and I will also make tracking of state transitions, in this presenter, more consistent.
