### PR TITLE
add fee presenter specs and modify 'n/a' copy for rate

### DIFF
--- a/app/presenters/fee_presenter.rb
+++ b/app/presenters/fee_presenter.rb
@@ -7,7 +7,11 @@ class FeePresenter < BasePresenter
   end
 
   def rate
-    '%.2f' % fee.rate if fee.rate
+    if fee.calculated?
+      '%.2f' % fee.rate if fee.rate
+    else
+      h.content_tag :div, 'n/a', class: 'form-hint'
+    end
   end
 
   def amount

--- a/app/views/external_users/claims/_basic_fee_uncalculated_fields.html.haml
+++ b/app/views/external_users/claims/_basic_fee_uncalculated_fields.html.haml
@@ -5,7 +5,7 @@
   = f.number_field :quantity, value: number_with_precision_or_default(f.object.quantity) , class: 'quantity', min: 0, max: 99999, maxlength: 5
   = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
 %td
-  .form-hint='N/A'
+  = fee.rate
 %td
   %a{name: "basic_fee_#{@basic_fee_count}_amount"}
   %div.pound-wrapper


### PR DESCRIPTION
This PR adds fee presenter logic to output n/a for rate for "uncalculated" fees - PPE and NPW. Also add fee presenter specs.
