### PR TITLE
Carry over email address when signing out for feedback

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,8 +33,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def after_sign_out_path_for(resource)
-    new_feedback_url
+  def after_sign_out_path_for(resource, params={})
+    new_feedback_url(params)
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -18,7 +18,7 @@ class FeedbackController < ApplicationController
 
   def merged_feedback_params
     feedback_params.merge({
-      email: (current_user.email rescue 'anonymous'),
+      email: (current_user.email rescue (params[:email] || 'anonymous')),
       referrer: request.referer,
       user_agent: request.user_agent
     })

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,17 @@
 class SessionsController < Devise::SessionsController
   skip_load_and_authorize_resource only: [:new, :create, :destroy]
+  before_action :set_user_email, only: [:destroy]
+
+  private
+
+  def set_user_email
+    @current_user_email = current_user.email
+  end
+
+  def respond_to_on_destroy
+    respond_to do |format|
+      format.all { head :no_content }
+      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name, email: @current_user_email) }
+    end
+  end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,6 @@
 class Feedback
   include ActiveModel::Model
-  include ActiveModel::Validations  
+  include ActiveModel::Validations
 
   attr_accessor :email, :referrer, :user_agent, :comment, :rating
 
@@ -18,6 +18,7 @@ class Feedback
     return false unless valid?
 
     ZendeskSender.send!(self)
+
     true
   end
 

--- a/app/views/feedback/new.html.haml
+++ b/app/views/feedback/new.html.haml
@@ -3,7 +3,7 @@
 %p.medium.questions
   We will use your answers to the questions below to help us build a better service.
 
-= form_for @feedback, url: feedback_index_path, html: { novalidate: 'novalidate', class: 'normal'} do |f|
+= form_for @feedback, url: feedback_index_path(email: params[:email]), html: { novalidate: 'novalidate', class: 'normal'} do |f|
   - if @feedback.errors.any?
     .validation-summary
       %h3.heading-small= "This feedback has #{pluralize(@feedback.errors.count, 'error')}"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20160121161705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pgcrypto"
   enable_extension "uuid-ossp"
 
   create_table "case_types", force: :cascade do |t|


### PR DESCRIPTION
Email is persisted in params when signing out to send with Zendesk feedback.
