### PR TITLE
Change provider and advocate management copy

### DIFF
--- a/app/controllers/external_users/admin/providers_controller.rb
+++ b/app/controllers/external_users/admin/providers_controller.rb
@@ -15,7 +15,7 @@ class ExternalUsers::Admin::ProvidersController < ExternalUsers::Admin::Applicat
   def update
     if @provider.update(provider_params)
       send_ga('event', 'provider', 'updated')
-      redirect_to external_users_admin_provider_path, notice: "#{@provider.provider_type.humanize} successfully updated"
+      redirect_to external_users_admin_provider_path, notice: "Provider successfully updated"
     else
       render :edit
     end

--- a/app/views/external_users/admin/providers/edit.html.haml
+++ b/app/views/external_users/admin/providers/edit.html.haml
@@ -9,7 +9,7 @@
       = t('.form_error_hint')
 
 %h1.page-title
-  = "Edit #{@provider.provider_type} details"
+  = "Edit provider details"
 
 = form_for [:external_users, :admin, @provider], html: { novalidate: true } do |f|
 
@@ -28,7 +28,7 @@
       %div.form-group.inline
         =f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
           - b.label(class: 'block-label') { b.radio_button + (b.value.to_s == 'true' ? 'Yes' : 'No') }
-  
+
     = f.label :api_key, t('.api_key'), class: "form-label"
     = @provider.api_key
 

--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -1,9 +1,9 @@
-%h1.page-title Manage #{@provider.provider_type}
+%h1.page-title Manage provider
 
 .grid-row.basic-info-row
   .column-quarter
     .bold-xsmall
-      = "#{@provider.provider_type.titlecase} name"
+      Provider name
     .xsmall
       = @provider.name
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -171,8 +171,8 @@
             <% end %>
             <%= link_to t('link.add_claim'), '/external_users/claims/new', title: "Start a new claim" %>
             <% if current_user.persona.admin? %>
-              <%= link_to 'Manage advocates', '/external_users/admin/external_users' %>
-              <%= link_to "Manage #{current_user.persona.provider.provider_type}", "/external_users/admin/providers/#{current_user.persona.provider.id}" %>
+              <%= link_to 'Manage users', '/external_users/admin/external_users' %>
+              <%= link_to "Manage provider", "/external_users/admin/providers/#{current_user.persona.provider.id}" %>
             <% end %>
           <% elsif current_user.persona.is_a?(CaseWorker) %>
             <% if current_user.persona.admin? %>

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -10,8 +10,8 @@
         = link_to "API Documentation", api_landing_page_path, class: cp(api_landing_page_path)
       = link_to t('link.add_claim'), new_external_users_claim_path, title: "Start a new claim", class: cp(new_external_users_claim_path)
       - if current_user.persona.admin?
-        = link_to 'Manage advocates', external_users_admin_external_users_path, class: cp(external_users_admin_external_users_path)
-        = link_to "Manage #{current_user.persona.provider.provider_type}", external_users_admin_provider_path(current_user.persona.provider), class: cp(external_users_admin_provider_path(current_user.persona.provider))
+        = link_to 'Manage users', external_users_admin_external_users_path, class: cp(external_users_admin_external_users_path)
+        = link_to "Manage provider", external_users_admin_provider_path(current_user.persona.provider), class: cp(external_users_admin_provider_path(current_user.persona.provider))
     - elsif current_user.persona.is_a?(CaseWorker)
       - if current_user.persona.admin?
         = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :sort, :direction).merge(tab: 'current')), class: cp( case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current')))

--- a/app/views/pages/api_landing.html.haml
+++ b/app/views/pages/api_landing.html.haml
@@ -104,7 +104,7 @@
     To access our software vendor API development environment (our API sandbox), you must #{link_to "complete a short registration form", new_registration_path('user')} and agree to our API users’ terms and conditions. You will then get advocate administrator credentials so you can access the web application.
 
   %p
-    You can retrieve the API key assigned to your chamber/firm from the "Manage chamber"/"Manage firm" page.  You can use the key, along with your admin account's email address and another advocate account, to submit claims through the interactive API documentation in the sandbox environment. You can create new advocates from the "Manage advocates" page.
+    You can retrieve the API key assigned to your chamber/firm from the "Manage provider" page.  You can use the key, along with your admin account's email address and another advocate account, to submit claims through the interactive API documentation in the sandbox environment. You can create new advocates from the "Manage users" page.
 
   %p
     = link_to "Sign up", new_registration_path('user'), class: 'button'

--- a/app/views/super_admins/external_users/change_password.html.haml
+++ b/app/views/super_admins/external_users/change_password.html.haml
@@ -1,5 +1,5 @@
 %h1.page-title
-  Manage advocates
+  Manage users
 %h2
   = "Change password for #{@external_user.name}"
 

--- a/app/views/super_admins/external_users/edit.html.haml
+++ b/app/views/super_admins/external_users/edit.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage advocates
-%h2 Edit advocate details
+%h1.page-title Manage users
+%h2 Edit user details
 
 = render 'form'

--- a/app/views/super_admins/external_users/index.html.haml
+++ b/app/views/super_admins/external_users/index.html.haml
@@ -1,9 +1,9 @@
-%h1.page-title Manage advocates
+%h1.page-title Manage users
 %h2.heading-medium.left
-  = "Advocates in #{@provider.name}"
+  = "Users in #{@provider.name}"
 
 .grid-row.clear-float
-  = link_to "Add advocate to #{@provider.provider_type}", new_super_admins_provider_external_user_path(@provider), class: 'button right'
+  = link_to "Add user to provider", new_super_admins_provider_external_user_path(@provider), class: 'button right'
 
 %table.external_users_table
   %thead

--- a/app/views/super_admins/external_users/new.html.haml
+++ b/app/views/super_admins/external_users/new.html.haml
@@ -1,5 +1,5 @@
-%h1.page-title Manage advocates
+%h1.page-title Manage users
 %h2
-  = "New advocate details for #{@provider.name}"
+  = "New user details for #{@provider.name}"
 
 = render 'form'

--- a/app/views/super_admins/external_users/show.html.haml
+++ b/app/views/super_admins/external_users/show.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage advocates
+%h1.page-title Manage users
 
 %h2
   = @external_user.email

--- a/app/views/super_admins/providers/_providers.html.haml
+++ b/app/views/super_admins/providers/_providers.html.haml
@@ -13,7 +13,7 @@
       %th
         = t('.vat_registered')
       %th
-        Advocates
+        Users
     %tbody
       - providers.each do |provider|
         %tr{id: dom_id(provider) }
@@ -26,4 +26,4 @@
           %td
             = provider.vat_registered == true ? 'Yes' : 'No'
           %td
-            = link_to "Manage advocates in #{provider.provider_type}", super_admins_provider_external_users_path(provider)
+            = link_to "Manage users in provider", super_admins_provider_external_users_path(provider)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,7 +173,7 @@ en:
           add_super_admin: 'Add Super administrator'
           edit: *edit
         edit:
-          edit_super_admin: 'Edit advocate'
+          edit_super_admin: 'Edit user'
         form:
           error: 'error'
           prohibited_save: 'This Super administrator has'
@@ -223,7 +223,7 @@ en:
         email: 'Email'
       form:
         error: 'error'
-        prohibited_save: 'This advocate has'
+        prohibited_save: 'This user has'
         email: *email
         email_confirmation: *email_confirmation
         password: *password
@@ -233,10 +233,10 @@ en:
         supplier_number: *supplier_number
         apply_vat: "VAT registered"
         roles: *roles
-        submit: 'Create advocate'
+        submit: 'Create user'
       change_password:
         error: 'error'
-        prohibited_save: 'This advocate password change has'
+        prohibited_save: 'This user password change has'
         current_password: Current password
         password: *password
         password_confirmation: *password_confirmation
@@ -247,27 +247,27 @@ en:
     admin:
       external_users:
         index:
-          title: 'Manage advocates'
+          title: 'Manage users'
           actions: Manage details
-          advocates: 'Advocates'
-          add_advocate: 'Add Advocate'
+          advocates: 'Users'
+          add_advocate: 'Add User'
           edit: *edit
           email: 'Email'
           delete: *delete
           confirm_delete: 'Are you sure?'
           first_name: 'Name'
           last_name: 'Surname'
-          new_user: 'New advocate'
-          search: 'Search for advocate'
+          new_user: 'New user'
+          search: 'Search for user'
           supplier_number: 'Supplier number'
         new:
           error: 'error'
-          new_advocate: 'New advocate'
-          prohibited_save: 'This advocate has'
+          new_advocate: 'New user'
+          prohibited_save: 'This user has'
         edit:
-          edit_advocate: 'Edit advocate'
+          edit_advocate: 'Edit user'
           error: 'error'
-          prohibited_save: 'This advocate has'
+          prohibited_save: 'This user has'
         form:
           email: *email
           email_confirmation: *email_confirmation
@@ -277,10 +277,10 @@ en:
           last_name: *last_name
           supplier_number: 'Supplier number'
           roles: *roles
-          submit: 'Create advocate'
+          submit: 'Create user'
         change_password:
           error: 'error'
-          prohibited_save: 'This advocate password change has'
+          prohibited_save: 'This user password change has'
           current_password: Current password
           password: *password
           password_confirmation: *password_confirmation

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 20160126103102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pgcrypto"
   enable_extension "uuid-ossp"
 
   create_table "case_types", force: :cascade do |t|

--- a/features/step_definitions/shared/sign_in_steps.rb
+++ b/features/step_definitions/shared/sign_in_steps.rb
@@ -50,8 +50,8 @@ Given(/^I am a signed in super admin$/) do
 end
 
 Then(/^I should see an Manage advocates link and it should work$/) do
-  find('#primary-nav').click_link('Manage advocates')
-  expect(find('h1.page-title')).to have_content('Manage advocates')
+  find('#primary-nav').click_link('Manage users')
+  expect(find('h1.page-title')).to have_content('Manage users')
 end
 
 Given(/^I sign out$/) do

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -92,13 +92,13 @@ Then(/^I should see the advocates Start a claim link and it should work$/) do
 end
 
 Then(/^I should see the admin advocates Manage advocates link and it should work$/) do
-  find('#primary-nav').click_link('Manage advocates')
-  expect(find('h1.page-title')).to have_content('Manage advocates')
+  find('#primary-nav').click_link('Manage users')
+  expect(find('h1.page-title')).to have_content('Manage users')
 end
 
 Then(/^I should see the admin advocates Manage provider link and it should work$/) do
-  find('#primary-nav').click_link('Manage chamber')
-  expect(find('h1.page-title')).to have_content("Manage chamber")
+  find('#primary-nav').click_link('Manage provider')
+  expect(find('h1.page-title')).to have_content("Manage provider")
 end
 
 Then(/^I should see the caseworkers correct working primary navigation$/) do


### PR DESCRIPTION
"Manage chamber", "Manage firm" changed to "Manage provider", "Manage advocates" to "Manage users" and other copy changed accordingly.
