### PR TITLE
Validate for presence of "+" in emails and do not allow

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,8 @@ class User < ActiveRecord::Base
   validates :email, confirmation: true
   attr_accessor :email_confirmation
 
+  validate :validate_no_plus_suffix
+
   delegate :claims, to: :persona
 
   scope :external_users, -> { where(persona_type: 'ExternalUser') }
@@ -56,4 +58,11 @@ class User < ActiveRecord::Base
     [last_name, first_name] * ' '
   end
 
+  private
+
+  def validate_no_plus_suffix
+    if self.email =~ /\+/
+      errors[:email] << '"+" not allowed in addresses'
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,8 +34,18 @@ RSpec.describe User, type: :model do
 
   it { should delegate_method(:claims).to(:persona) }
 
+  describe 'email "+" character validation' do
+    subject { build(:user) }
+
+    it 'is not valid with a "+" in the email address' do
+      subject.email = 'user+1@example.com'
+      subject.valid?
+      expect(subject.errors.full_messages).to include('Email "+" not allowed in addresses')
+    end
+  end
+
   describe '#name' do
-    subject { create(:user) }
+    subject { build(:user) }
 
     it 'returns the first and last names' do
       expect(subject.name).to eq("#{subject.first_name} #{subject.last_name}")


### PR DESCRIPTION
Prevents emails of the form user+1@example.com, user+2@example.com, user+3@example.com
