### PR TITLE
Fix flickering MI report presenter spec

### DIFF
--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe ClaimCsvPresenter do
       end
 
       context 'and unique values for' do
+        before { Timecop.freeze(Time.now) }
+        after  { Timecop.return }
 
         it 'submission type' do
           subject.present! do |claim_journeys|
@@ -64,7 +66,7 @@ RSpec.describe ClaimCsvPresenter do
           end
         end
 
-        it 'date allocated' do      
+        it 'date allocated' do
           subject.present! do |claim_journeys|
             expect(claim_journeys.first).to include((Time.now - 2.day).to_s)
             expect(claim_journeys.second).to include('n/a', 'n/a')


### PR DESCRIPTION
there  is a time related spec which may
occasionally flicker (see pic).
<img width="969" alt="screen shot 2016-01-30 at 10 03 42" src="https://cloud.githubusercontent.com/assets/7016425/12695047/42a57d8a-c739-11e5-89e8-a8cf18c6b510.png">
