### PR TITLE
fixes a validation that relies on trial lengths

### DIFF
--- a/app/validators/base_claim_validator.rb
+++ b/app/validators/base_claim_validator.rb
@@ -43,7 +43,6 @@ class BaseClaimValidator < ActiveModel::Validator
 
   def validate_numericality(attribute, lower_bound=nil, upper_bound=nil, message)
     return if attr_nil?(attribute)
-    infinity = 1.0/0
     lower_bound = lower_bound.blank? ? -infinity : lower_bound
     upper_bound = upper_bound.blank? ? infinity : upper_bound
     add_error(attribute, message) unless (lower_bound..upper_bound).include?(@record.__send__(attribute).to_i)
@@ -65,6 +64,10 @@ class BaseClaimValidator < ActiveModel::Validator
   def validate_not_before(date, attribute, message)
     return if attr_nil?(attribute)|| date.nil?
     add_error(attribute, message) if @record.__send__(attribute) < date.to_date
+  end
+
+  def infinity
+    1.0/0
   end
 
 end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -376,17 +376,17 @@ basic_fee:
       short: Enter 0 to 1
       api: Enter a quantity of 0 to 1 for basic fee
     daf_qty_mismatch:
-      long: The number of daily attendance fees (3-40 days) does not fit the actual trial length
-      short: Enter a number that fits the actual trial length
-      api: The number of daily attendance fees (3-40 days) does not fit the actual trial length
+      long: The number of daily attendance fees (3-40 days) does not fit the actual (re)trial length
+      short: Enter a number that fits the actual (re)trial length
+      api: The number of daily attendance fees (3-40 days) does not fit the actual (re)trial length
     dah_qty_mismatch:
-      long: The number of daily attendance fees (41-50 days) does not fit the actual trial length
-      short: Enter a number that fits the actual trial length
-      api: The number of daily attendance fees (41-50 days) does not fit the actual trial length
+      long: The number of daily attendance fees (41-50 days) does not fit the actual (re)trial length
+      short: Enter a number that fits the actual (re)trial length
+      api: The number of daily attendance fees (41-50 days) does not fit the actual (re)trial length
     daj_qty_mismatch:
-      long: The number of daily attendance fees (51+ days) does not fit the actual trial length
-      short: Enter a number that fits the actual trial length
-      api: The number of daily attendance fees (51+ days) does not fit the actual trial length
+      long: The number of daily attendance fees (51+ days) does not fit the actual (re)trial length
+      short: Enter a number that fits the actual (re)trial length
+      api: The number of daily attendance fees (51+ days) does not fit the actual (re)trial length
     pcm_not_applicable:
       long: Plea and case management hearing fee not applicable to case type
       short: Remove quantity as not applicable

--- a/spec/validators/fee_validator_spec.rb
+++ b/spec/validators/fee_validator_spec.rb
@@ -163,6 +163,15 @@ describe FeeValidator do
           should_be_valid_if_equal_to_value(daf_fee, :quantity, 10)
         end
       end
+
+      it 'should validate based on retrial length for retrials' do
+          daf_fee.claim.case_type = FactoryGirl.create(:case_type, :retrial)
+          daf_fee.claim.actual_trial_length = 2
+          daf_fee.claim.retrial_actual_length = 20
+          should_be_valid_if_equal_to_value(daf_fee, :quantity, 18)
+          should_error_if_equal_to_value(daf_fee, :quantity, 19, 'daf_qty_mismatch')
+      end
+
     end
 
     context 'daily_attendance_41_50 (DAH)' do
@@ -188,6 +197,14 @@ describe FeeValidator do
           should_be_valid_if_equal_to_value(dah_fee, :quantity, 10)
         end
       end
+
+      it 'should validate based on retrial length for retrials' do
+          dah_fee.claim.case_type = FactoryGirl.create(:case_type, :retrial)
+          dah_fee.claim.actual_trial_length = 2
+          dah_fee.claim.retrial_actual_length = 45
+          should_be_valid_if_equal_to_value(dah_fee, :quantity, 5)
+          should_error_if_equal_to_value(dah_fee, :quantity, 6, 'dah_qty_mismatch')
+      end
     end
 
     context 'daily attendance 51 plus (DAJ)' do
@@ -209,6 +226,14 @@ describe FeeValidator do
           should_be_valid_if_equal_to_value(daj_fee, :quantity, 1)
           should_be_valid_if_equal_to_value(daj_fee, :quantity, 10)
         end
+      end
+
+      it 'should validate based on retrial length for retrials' do
+          daj_fee.claim.case_type = FactoryGirl.create(:case_type, :retrial)
+          daj_fee.claim.actual_trial_length = 2
+          daj_fee.claim.retrial_actual_length = 70
+          should_be_valid_if_equal_to_value(daj_fee, :quantity, 20)
+          should_error_if_equal_to_value(daj_fee, :quantity, 21, 'daj_qty_mismatch')
       end
     end
 


### PR DESCRIPTION
Daily attendance fee quantity validations set an upper bound
of the actual trial length. The trial length should now 
be the retrial length for retrials.
