### PR TITLE
fix broken demo data for retrials

### DIFF
--- a/lib/demo_data/basic_fee_generator.rb
+++ b/lib/demo_data/basic_fee_generator.rb
@@ -31,6 +31,7 @@ module DemoData
     end
 
     def add_daily_attendances
+      return if @claim.case_type.requires_retrial_dates?
       add_daf if @claim.actual_trial_length > 2
       add_dah if @claim.actual_trial_length > 40
       add_daj if @claim.actual_trial_length > 50


### PR DESCRIPTION
retrials validate daily attendance fees amounts against retrial actual length but demo data was 
not taking this into account. This is quick patch not a full solution.
