### PR TITLE
Fix certification 'Return to claim' button

### DIFF
--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -85,4 +85,4 @@
         &nbsp;
     .button-holder
       = f.submit "Certify and submit claim", class: "button"
-      = button_to 'Return to claim', edit_external_users_claim_path(@claim), class: 'button-secondary'
+      = link_to 'Return to claim', edit_external_users_claim_path(@claim), class: 'button-secondary'


### PR DESCRIPTION
Return to claim button changed to link_to instead of button_to. button_to submits claim rather than returning to claim form for editing.
