### PR TITLE
Force validation of FeeType and display error messages from json_docu…

### DIFF
--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -66,9 +66,10 @@ class JsonDocumentImporter
         create_expenses_or_fees_and_dates_attended(@expenses, EXPENSE_CREATION)
         @imported_claims << Claim.find_by(uuid: @claim_id)
       rescue ArgumentError => e
-        claim_hash['claim']['case_number'] = "Claim #{index+1} (no readable case number)" if claim_hash['claim']['case_number'].blank?
+        case_number =  claim_hash['claim']['case_number'].blank? ? "Claim #{index+1} (no readable case number)" : claim_hash['claim']['case_number']
+        claim_hash['claim']['case_number'] = case_number
         @failed_imports << claim_hash
-        @errors["claim_#{index + 1}".to_sym] = JSON.parse(e.message)
+        @errors[case_number] = JSON.parse(e.message).map{ |error_hash| error_hash['error'] }
         claim = Claim.find_by(uuid: @claim_id) # if an exception is raised the claim is destroyed along with all its dependent objects
         claim.destroy if claim.present?
       rescue JSON::Schema::ValidationError => e

--- a/app/validators/fee_validator.rb
+++ b/app/validators/fee_validator.rb
@@ -2,7 +2,6 @@ class FeeValidator < BaseClaimValidator
 
   def self.fields
     [
-      :fee_type,
       :quantity,
       :rate,
       :amount
@@ -10,7 +9,7 @@ class FeeValidator < BaseClaimValidator
   end
 
   def self.mandatory_fields
-    [:claim]
+    [:claim, :fee_type]
   end
 
   private

--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -6,6 +6,11 @@ var $importerResults = $('.importer-results');
 	$importerResults.html(
       '<div class="results-body import-success">' +
         '<h4>Successfully imported <%= pluralize(@json_document_importer.imported_claims.count, "new claim") %> in draft state</h4>' +
+        '<ul>' +
+        <% @json_document_importer.imported_claims.each do |claim| %>
+          '<li><%= claim.case_number %></li>' +
+        <% end %>
+        '</ul>' +
       '</div>'
   );
 	<% @json_document_importer.imported_claims.each do |imported_claim| %>
@@ -43,8 +48,12 @@ var $importerResults = $('.importer-results');
       '<div class="results-body import-failed">' +
         '<h4>There were errors in the following <%= pluralize(@json_document_importer.failed_imports.count, "claim") %> and these were not imported</h4>' +
         '<ul>' +
-        <% @json_document_importer.failed_imports.each do |fail| %>
-          '<li><%= fail["claim"]["case_number"] %></li>' +
+        <% @json_document_importer.errors.each do |case_number, error_messages| %>
+          '<li><%= "#{case_number}:" %><ul>' +
+          <% error_messages.each do |msg| %>
+            '<li><%= msg %></li>' +
+          <% end %>
+          '</ul>' + 
         <% end %>
         '</ul>' +
       '</div>'

--- a/spec/examples/invalid_fee_type_id.json
+++ b/spec/examples/invalid_fee_type_id.json
@@ -2,16 +2,16 @@
   {
     "claim": {
       "creator_email": "advocateadmin@example.com",
-      "advocate_email": "advocate@example.com",
-      "case_number": "A12345678",
-      "case_type_id": 1,
+      "advocate_email": "",
+      "case_number": "A00000021",
+      "case_type_id": 0,
       "first_day_of_trial": "2015-06-01",
       "estimated_trial_length": 3,
-      "actual_trial_length": 3,
+      "actual_trial_length": -2,
       "trial_concluded_at": "2015-06-03",
       "advocate_category": "QC",
-      "offence_id": 1,
-      "court_id": 1,
+      "offence_id": 0,
+      "court_id": 0,
       "cms_number": "12345678",
       "additional_information": "string",
       "apply_vat": true,
@@ -34,8 +34,8 @@
       ],
       "fees": [
         {
-          "fee_type_id": 2,
-          "quantity": 1,
+          "fee_type_id": 1,
+          "quantity": -1,
           "rate": 1.1,
           "dates_attended": [
             {
@@ -67,7 +67,7 @@
     "claim": {
       "creator_email": "advocateadmin@example.com",
       "advocate_email": "advocate@example.com",
-      "case_number": "A987654321",
+      "case_number": "A00000022",
       "case_type_id": 1,
       "first_day_of_trial": "2015-06-01",
       "estimated_trial_length": 3,
@@ -98,7 +98,7 @@
       ],
       "fees": [
         {
-          "fee_type_id": 2,
+          "fee_type_id": 0,
           "quantity": 1,
           "rate": 1.1,
           "dates_attended": [

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Fee, type: :model do
     end
   end
 
+  describe 'non-existent fee_type_id' do
+    it 'does not validate' do
+      fee = FactoryGirl.build :fee, quantity: 1, rate: 5, amount: 5, fee_type_id: 0
+      expect(fee).not_to be_valid
+      expect(fee.errors.full_messages).to eq(["Fee type blank"])
+    end
+  end
+
   describe '#calculate_amount' do
 
     # this should be removed after gamma/private beta claims archived/deleted

--- a/spec/models/json_document_importer_spec.rb
+++ b/spec/models/json_document_importer_spec.rb
@@ -78,7 +78,7 @@ describe JsonDocumentImporter do
         expect(subject.errors.blank?).to be true
         subject.import!
         expect(subject.errors.blank?).to be false
-        expect(subject.errors).to eq({:claim_1=>[{"error"=>"Advocate email is invalid"}]})
+        expect(subject.errors).to eq({"Claim 1 (no readable case number)"=>["Advocate email is invalid"]})
       end
     end
 
@@ -129,13 +129,28 @@ describe JsonDocumentImporter do
         it 'one Claim model error from each of two claims' do
           allow(JsonDocumentImporter::CLAIM_CREATION).to receive(:post).and_return(failed_claim_response)
           subject.import!
-          expect(subject.errors).to eq({:claim_1=>[{"error"=>"Advocate email is invalid"}], :claim_2=>[{"error"=>"Advocate email is invalid"}]})
+          expect(subject.errors).to eq({'A12345678'=>["Advocate email is invalid"], 'A987654321' => ["Advocate email is invalid"]})
         end
 
         it 'multiple Claim model errors from each of two claims' do
           allow(JsonDocumentImporter::CLAIM_CREATION).to receive(:post).and_return(failed_claim_response_2)
           subject.import!
-          expect(subject.errors).to eq({:claim_1=>[{"error"=>"Case type cannot be blank, you must select a case type"}, {"error"=>"Court cannot be blank, you must select a court"}, {"error"=>"Case number cannot be blank, you must enter a case number"}, {"error"=>"Advocate category cannot be blank, you must select an appropriate advocate category"}, {"error"=>"Offence Category cannot be blank, you must select an offence category"}], :claim_2=>[{"error"=>"Case type cannot be blank, you must select a case type"}, {"error"=>"Court cannot be blank, you must select a court"}, {"error"=>"Case number cannot be blank, you must enter a case number"}, {"error"=>"Advocate category cannot be blank, you must select an appropriate advocate category"}, {"error"=>"Offence Category cannot be blank, you must select an offence category"}]})
+          expect(subject.errors).to eq({
+            'A12345678'=>[
+              "Case type cannot be blank, you must select a case type", 
+              "Court cannot be blank, you must select a court", 
+              "Case number cannot be blank, you must enter a case number", 
+              "Advocate category cannot be blank, you must select an appropriate advocate category", 
+              "Offence Category cannot be blank, you must select an offence category"
+            ], 
+            'A987654321'=>[
+              "Case type cannot be blank, you must select a case type",
+              "Court cannot be blank, you must select a court",
+              "Case number cannot be blank, you must enter a case number",
+              "Advocate category cannot be blank, you must select an appropriate advocate category",
+              "Offence Category cannot be blank, you must select an offence category"
+            ]
+          })
         end
 
         it "but stops when the first validation fail is met" do
@@ -144,7 +159,7 @@ describe JsonDocumentImporter do
           expect(JsonDocumentImporter::CLAIM_CREATION).to receive(:post).exactly(2).times # claim creation end point is hit and returns an error
           expect(JsonDocumentImporter::DEFENDANT_CREATION).not_to receive(:post) # defendant creation is, therefore, not hit
           subject.import!
-          expect(subject.errors).to eq({:claim_1=>[{"error"=>"Advocate email is invalid"}], :claim_2=>[{"error"=>"Advocate email is invalid"}]}) # claim model errors are received and stored but no error is returned from defendant model
+          expect(subject.errors).to eq({'A12345678' => ["Advocate email is invalid"], 'A987654321'=>["Advocate email is invalid"]}) # claim model errors are received and stored but no error is returned from defendant model
         end
       end
     end


### PR DESCRIPTION
…ment_importer

The Fee class was only validating presence of FeeType when claim.force_validation was set to true.  It now always validates this field.

The GUI was not displaying error messages generated by invalid input to the JsonDocumentImporter.  Now it does.
