### PR TITLE
Speed up tests:

### DIFF
--- a/app/presenters/claim_presenter.rb
+++ b/app/presenters/claim_presenter.rb
@@ -108,11 +108,11 @@ class ClaimPresenter < BasePresenter
   end
 
   def case_worker_names
-    claim.case_workers.map(&:name).join(', ')
+    claim.case_workers.map(&:name).sort.join(', ')
   end
 
   def case_worker_email_addresses
-    claim.case_workers.map(&:email).join(', ')
+    claim.case_workers.map(&:email).sort.join(', ')
   end
 
   def caseworker_claim_id

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -1,33 +1,35 @@
 require 'rails_helper'
+require 'support/database_housekeeping'
 
 RSpec.describe CaseWorkers::ClaimsController, type: :controller do
-  let!(:case_worker) { create(:case_worker) }
-  # let!(:claims)      { create_list(:allocated_claim, 5) }
+  include DatabaseHousekeeping
 
-  let!(:claims) do
-    claims = []
+  before(:all) do
+    @case_worker = create(:case_worker)
+    @claims = []
     10.times do |n|
       Timecop.freeze(n.days.ago) do
         claim = create(:allocated_claim, case_number: "A" + "#{(n+1).to_s.rjust(8,"0")}")
-        claims << claim
+        @claims << claim
       end
     end
 
     # make the oldest/5th one be resubmitted for redetermination so we can test ordering by last_submitted_at
     # i.e. A00000005 to A00000001 is oldest to most recently CREATED, but A00000005 was LAST_SUBMITTED most recently
-    oldest = claims.last
+    oldest = @claims.last
     oldest.assessment.update(fees: random_amount, expenses: random_amount)
     oldest.authorise!; oldest.redetermine!
-    claims
+
+    @claims.each { |claim| claim.case_workers << @case_worker }
+    @other_claim = create :submitted_claim
   end
 
-  let!(:other_claim) { create(:submitted_claim) }
+  after(:all) do
+    clean_database
+  end
 
   before do
-    claims.each do |claim|
-      claim.case_workers << case_worker
-    end
-    sign_in case_worker.user
+    sign_in @case_worker.user
   end
 
   describe "GET #index" do
@@ -44,42 +46,44 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
 
     context 'current claims' do
       it 'shows claims allocated to current user' do
-        expect(assigns(:claims)).to match_array(case_worker.claims.caseworker_dashboard_under_assessment.limit(10))
+        expect(assigns(:claims)).to match_array(@case_worker.claims.caseworker_dashboard_under_assessment.limit(10))
       end
 
       it 'defaults ordering of claims to oldest first based on last submitted date' do
-        expect(assigns(:claims)).to eq(case_worker.claims.caseworker_dashboard_under_assessment.order(last_submitted_at: :asc).page(1).per(10))
+        expect(assigns(:claims)).to eq(@case_worker.claims.caseworker_dashboard_under_assessment.order(last_submitted_at: :asc).page(1).per(10))
       end
 
       it 'paginates to 10 per page' do
-        case_worker.claims << create(:allocated_claim)
-        expect(case_worker.claims.caseworker_dashboard_under_assessment.count).to eql(11)
+        additional_claim = create(:allocated_claim)
+        @case_worker.claims << additional_claim
+        expect(@case_worker.claims.caseworker_dashboard_under_assessment.count).to eql(11)
         expect(assigns(:claims).count).to eq(10)
+        additional_claim.destroy
       end
     end
 
     context 'search by maat' do
-      let(:search) { case_worker.claims.first.defendants.first.representation_orders.first.maat_reference }
+      let(:search) { @case_worker.claims.first.defendants.first.representation_orders.first.maat_reference }
 
       it 'finds the claims with MAAT reference "12345"' do
-        expect(assigns(:claims)).to eq([case_worker.claims.first])
+        expect(assigns(:claims)).to eq([@case_worker.claims.first])
       end
     end
 
     context 'search by defendant' do
-      let(:search) { case_worker.claims.first.defendants.first.name }
+      let(:search) { @case_worker.claims.first.defendants.first.name }
 
       it 'finds the claims with specified defendant' do
-        expect(assigns(:claims)).to eq([case_worker.claims.first])
+        expect(assigns(:claims)).to eq([@case_worker.claims.first])
       end
     end
 
     it 'only includes claims associated with the case worker' do
-      expect(assigns(:claims)).to match_array(claims)
+      expect(assigns(:claims)).to match_array(@claims)
     end
 
     it 'does not include claim not assigned to case worker' do
-      expect(assigns(:claims)).to_not include(other_claim)
+      expect(assigns(:claims)).to_not include(@other_claim)
     end
 
     it 'renders the template' do
@@ -107,24 +111,25 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
     end
 
     it 'automatically marks unread messages on claim for current user as "read"' do
-      subject.case_workers << case_worker
+      subject.case_workers << @case_worker
 
-      message_1 = create(:message, claim_id: subject.id, sender_id: case_worker.user.id)
-      message_2 = create(:message, claim_id: subject.id, sender_id: case_worker.user.id)
-      message_3 = create(:message, claim_id: subject.id, sender_id: case_worker.user.id)
+      message_1 = create(:message, claim_id: subject.id, sender_id: @case_worker.user.id)
+      message_2 = create(:message, claim_id: subject.id, sender_id: @case_worker.user.id)
+      message_3 = create(:message, claim_id: subject.id, sender_id: @case_worker.user.id)
 
-      expect(subject.unread_messages_for(case_worker.user).count).to eq(3)
+      expect(subject.unread_messages_for(@case_worker.user).count).to eq(3)
 
       get :show, id: subject
 
-      expect(subject.unread_messages_for(case_worker.user).count).to eq(0)
+
+      expect(subject.unread_messages_for(@case_worker.user).count).to eq(0)
     end
   end
 
 
   describe 'PATCH #update' do
     it 'should update the model' do
-      claim = claims.first
+      claim = @claims.first
       patch :update, id: claim, claim: { additional_information: 'foo bar' }, commit: 'Update'
       expect(assigns(:claim).additional_information).to eq 'foo bar'
     end

--- a/spec/models/timed_state_transitions/batch_transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/batch_transitioner_spec.rb
@@ -5,47 +5,19 @@ module TimedTransitions
 
   describe BatchTransitioner do 
 
-    before(:each) do
-      Timecop.freeze 61.days.ago do
-        @old_draft     = FactoryGirl.create :claim
-        @old_auth      = FactoryGirl.create :authorised_claim
-        @old_part_auth = FactoryGirl.create :part_authorised_claim
-        @old_refused   = FactoryGirl.create :refused_claim
-        @old_rejected  = FactoryGirl.create :rejected_claim
-        @old_archived  = FactoryGirl.create :archived_pending_delete_claim
-      end
+    it 'should instantiate a Transitioner and run it for each claim' do
+      bt = BatchTransitioner.new
 
-      Timecop.freeze 59.days.ago do
-        @new_draft     = FactoryGirl.create :claim
-        @new_auth      = FactoryGirl.create :authorised_claim
-        @new_part_auth = FactoryGirl.create :part_authorised_claim
-        @new_refused   = FactoryGirl.create :refused_claim
-        @new_rejected  = FactoryGirl.create :rejected_claim
-        @new_archived  = FactoryGirl.create :archived_pending_delete_claim
-      end
-    end
-   
-    it 'should transition those that need to be transitioned and not others' do
-      BatchTransitioner.new.run
-      
-      expect(@new_draft.state).to eq 'draft'
-      expect(@new_auth.state).to eq 'authorised'
-      expect(@new_part_auth.state).to eq 'part_authorised'
-      expect(@new_refused.state).to eq 'refused'
-      expect(@new_rejected.state).to eq 'rejected'
-      expect(@new_archived.state).to eq 'archived_pending_delete'
+      claims = %w{mock_claim_1 mock_claim_2}
+      expect(Transitioner).to receive(:candidate_claims).and_return(claims)
+      transitioner_1 = double Transitioner
+      transitioner_2 = double Transitioner
+      expect(Transitioner).to receive(:new).with('mock_claim_1').and_return(transitioner_1)
+      expect(Transitioner).to receive(:new).with('mock_claim_2').and_return(transitioner_2)
+      expect(transitioner_1).to receive(:run)
+      expect(transitioner_2).to receive(:run)
 
-      expect(@old_draft.reload.state).to eq 'draft'
-      expect(@old_auth.reload.state).to eq 'archived_pending_delete'
-      expect(@old_part_auth.reload.state).to eq 'archived_pending_delete'
-      expect(@old_refused.reload.state).to eq 'archived_pending_delete'
-      expect(@old_rejected.reload.state).to eq 'archived_pending_delete'
-      
-      expect {
-        @old_archived.reload
-      }.to raise_error ActiveRecord::RecordNotFound
-
-
+      bt.run
     end
 
   end

--- a/spec/presenters/claim_presenter_spec.rb
+++ b/spec/presenters/claim_presenter_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe ClaimPresenter do
     cw2.user.email = 'bob@bigblackhole.com'
     claim.case_workers << cw1
     claim.case_workers << cw2
-    expect(subject.case_worker_email_addresses).to eql('john@bigblackhole.com, bob@bigblackhole.com')
+    expect(subject.case_worker_email_addresses).to eql('bob@bigblackhole.com, john@bigblackhole.com')
   end
 
   it '#caseworker_claim_id' do

--- a/spec/support/database_housekeeping.rb
+++ b/spec/support/database_housekeeping.rb
@@ -1,0 +1,47 @@
+module DatabaseHousekeeping
+	def clean_database
+		models = [
+      CaseType,
+      Expense,
+      ClaimStateTransition,
+      Claim,
+      DateAttended,
+      Defendant,
+      Determination,
+      Document,
+      ExpenseType,
+      FeeType,
+      Fee,
+      Location,
+      OffenceClass,
+      Offence,
+      FeeCategory,
+      RepresentationOrder,
+      SuperAdmin,
+      UserMessageStatus,
+      User,
+      CaseWorkerClaim,
+      Message,
+      Court,
+      CaseWorker,
+      CertificationType,
+      Certification,
+      ClaimIntention,
+      ExternalUser,
+      Provider,
+    ]
+
+    models.each do |model|
+      model.delete_all
+    end
+  end
+
+  def report_record_counts
+    tables = ActiveRecord::Base.connection.tables
+    tables.each do |t|
+      next if t == 'schema_migrations'
+      next if t == 'versions'
+      puts "#{t.classify} #{t.classify.constantize.count}"
+    end
+  end
+end


### PR DESCRIPTION
- spec/controllers/case_worker/claims_controller_spec: set up 10 claim records once at the beginning of the test, and tear down at the end instead of for each example
- spec/models/batch_transitioner_spec: remove useless tests and replace with one using mocks and expectations
