### PR TITLE
Refactor primary nav bar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,3 @@
-require 'CGI'
-
 module ApplicationHelper
 
   #

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+require 'CGI'
+
 module ApplicationHelper
 
   #
@@ -14,9 +16,14 @@ module ApplicationHelper
     presenter
   end
 
-  #Returns a "current" css class if the path = current_page
+  # TODO: this will not work on those routes that are also rooted to for the namespace or which have js that interferes
   def cp(path)
-    "current" if current_page?(path)
+    tab = extract_uri_param(path, 'tab')
+    if tab.present?
+      "current" if request.path == strip_params(path) && extract_uri_param(request.fullpath,'tab') == tab
+    else
+      "current" if request.path == strip_params(path)
+    end
   end
 
   def number_with_precision_or_default(number, options = {})
@@ -56,5 +63,16 @@ module ApplicationHelper
     css_class = column == sort_column ? "current #{sort_direction}" : nil
     direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
     link_to title, params.except(:page).merge({ sort: column, direction: direction }), { class: css_class }
+  end
+
+  def extract_uri_param(path,param)
+    uri = URI.parse(path)
+    CGI.parse(uri.query)[param][0]
+  rescue
+    nil
+  end
+
+  def strip_params(path)
+    path.split('?')[0]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   def cp(path)
     tab = extract_uri_param(path, 'tab')
     if tab.present?
-      "current" if request.path == strip_params(path) && extract_uri_param(request.fullpath,'tab') == tab
+      "current" if request.path == strip_params(path) && request.GET[:tab] == tab
     else
       "current" if request.path == strip_params(path)
     end
@@ -64,13 +64,11 @@ module ApplicationHelper
   end
 
   def extract_uri_param(path,param)
-    uri = URI.parse(path)
-    CGI.parse(uri.query)[param][0]
-  rescue
-    nil
+    CGI.parse(URI.parse(path).query)[param][0] rescue nil
   end
 
   def strip_params(path)
-    path.split('?')[0]
+    URI.parse(path).path rescue nil
   end
+
 end

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -14,15 +14,15 @@
         = link_to "Manage provider", external_users_admin_provider_path(current_user.persona.provider), class: cp(external_users_admin_provider_path(current_user.persona.provider))
     - elsif current_user.persona.is_a?(CaseWorker)
       - if current_user.persona.admin?
-        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :search, :sort, :direction).merge(tab: :current)), class: cp(case_workers_claims_path)
-        = link_to 'Archive', archived_case_workers_claims_path(params.except(:controller, :action, :id, :search, :sort, :direction).merge(tab: :archived)), class: cp(archived_case_workers_claims_path)
-        = link_to "Allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :id, :search, :sort, :direction).merge(tab: :unallocated)), class: cp(case_workers_admin_allocations_path(params.merge(tab: :unallocated)))
-        = link_to "Re-allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :id, :search, :sort, :direction).merge(tab: :allocated)), class: cp(case_workers_admin_allocations_path(params.merge(tab: :allocated)))
+        = link_to 'Your claims', case_workers_claims_path({ tab: :current }), class: cp(case_workers_claims_path)
+        = link_to 'Archive', archived_case_workers_claims_path({ tab: :archived }), class: cp(archived_case_workers_claims_path)
+        = link_to "Allocation", case_workers_admin_allocations_path({ tab: :unallocated }), class: cp(case_workers_admin_allocations_path({ tab: :unallocated }))
+        = link_to "Re-allocation", case_workers_admin_allocations_path({ tab: :allocated }), class: cp(case_workers_admin_allocations_path({ tab: :allocated }))
         = link_to 'Manage case workers', case_workers_admin_case_workers_path, class: cp(case_workers_admin_case_workers_path)
         = link_to 'Management information', case_workers_admin_management_information_path, class: cp(case_workers_admin_management_information_path)
       - else
-        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :sort, :direction).merge(tab: :current)), class: cp(case_workers_claims_path)
-        = link_to 'Archive', archived_case_workers_claims_path(params.except(:controller, :action, :id, :sort, :direction).merge(tab: :archived)), class: cp(archived_case_workers_claims_path)
+        = link_to 'Your claims', case_workers_claims_path({ tab: :current }), class: cp(case_workers_claims_path)
+        = link_to 'Archive', archived_case_workers_claims_path({ tab: :archived }), class: cp(archived_case_workers_claims_path)
     - else
       = "Error"
   = render partial: 'layouts/user'

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -14,15 +14,15 @@
         = link_to "Manage provider", external_users_admin_provider_path(current_user.persona.provider), class: cp(external_users_admin_provider_path(current_user.persona.provider))
     - elsif current_user.persona.is_a?(CaseWorker)
       - if current_user.persona.admin?
-        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :search, :sort, :direction).merge(tab: 'current')), class: cp( case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current')))
-        = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action, :id, :search, :sort, :direction).merge(tab: 'archived')), class: cp(archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived')))
-        = link_to "Allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :id, :search, :sort, :direction).merge(tab: 'unallocated')), class: cp(case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search).merge(tab: 'unallocated')))
-        = link_to "Re-allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :id, :search, :sort, :direction).merge(tab: 'allocated')), class: cp(case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :search).merge(tab: 'allocated')))
+        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :search, :sort, :direction).merge(tab: :current)), class: cp(case_workers_claims_path)
+        = link_to 'Archive', archived_case_workers_claims_path(params.except(:controller, :action, :id, :search, :sort, :direction).merge(tab: :archived)), class: cp(archived_case_workers_claims_path)
+        = link_to "Allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :id, :search, :sort, :direction).merge(tab: :unallocated)), class: cp(case_workers_admin_allocations_path(params.merge(tab: :unallocated)))
+        = link_to "Re-allocation", case_workers_admin_allocations_path(params.except(:controller, :action, :filter, :id, :search, :sort, :direction).merge(tab: :allocated)), class: cp(case_workers_admin_allocations_path(params.merge(tab: :allocated)))
         = link_to 'Manage case workers', case_workers_admin_case_workers_path, class: cp(case_workers_admin_case_workers_path)
         = link_to 'Management information', case_workers_admin_management_information_path, class: cp(case_workers_admin_management_information_path)
       - else
-        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :sort, :direction).merge(tab: 'current')), class: cp(case_workers_claims_path(params.except(:controller, :action).merge(tab: 'current')))
-        = link_to 'Archive',     archived_case_workers_claims_path(params.except(:controller, :action, :id, :sort, :direction).merge(tab: 'archived')), class: cp(archived_case_workers_claims_path(params.except(:controller, :action).merge(tab: 'archived')))
+        = link_to 'Your claims', case_workers_claims_path(params.except(:controller, :action, :id, :sort, :direction).merge(tab: :current)), class: cp(case_workers_claims_path)
+        = link_to 'Archive', archived_case_workers_claims_path(params.except(:controller, :action, :id, :sort, :direction).merge(tab: :archived)), class: cp(archived_case_workers_claims_path)
     - else
       = "Error"
   = render partial: 'layouts/user'


### PR DESCRIPTION
the cp helper method for highlighting the current page was not catching the current url when on the
same page but with other params in the uri for searching and sorting.

The primary nav bar partial URL helpers do not need any params other than tab passed to them in any event and the helpers should use symbolized params not strings (Deprecated).
