### PR TITLE
Rename user_roles shared examples to roles and include in provider spec

### DIFF
--- a/spec/models/case_worker_spec.rb
+++ b/spec/models/case_worker_spec.rb
@@ -13,7 +13,7 @@
 require 'rails_helper'
 
 RSpec.describe CaseWorker, type: :model do
-  it_behaves_like 'user_roles', CaseWorker, CaseWorker::ROLES
+  it_behaves_like 'roles', CaseWorker, CaseWorker::ROLES
 
   it { should belong_to(:location) }
   it { should have_one(:user) }

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -15,7 +15,7 @@
 require 'rails_helper'
 
 RSpec.describe ExternalUser, type: :model do
-  it_behaves_like 'user_roles', ExternalUser, ExternalUser::ROLES
+  it_behaves_like 'roles', ExternalUser, ExternalUser::ROLES
 
   it { should belong_to(:provider) }
   it { should have_many(:claims) }
@@ -335,7 +335,7 @@ RSpec.describe ExternalUser, type: :model do
         end
       end
       context 'handles only LGFS claims' do
-        it 'returns admin and litigator' do 
+        it 'returns admin and litigator' do
           expect(litigator.available_roles).to eq ['admin', 'litigator']
         end
       end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -16,8 +16,10 @@
 require 'rails_helper'
 
 RSpec.describe Provider, type: :model do
-  let!(:firm) { create(:provider, :firm) }
-  let!(:chamber) { create(:provider, :chamber) }
+  it_behaves_like 'roles', Provider, Provider::ROLES
+
+  let(:firm) { create(:provider, :firm) }
+  let(:chamber) { create(:provider, :chamber) }
 
   it { should have_many(:external_users) }
   it { should have_many(:claims) }

--- a/spec/support/roles.rb
+++ b/spec/support/roles.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-shared_examples_for 'user_roles' do |klass, roles|
+shared_examples_for 'roles' do |klass, roles|
   describe 'validation' do
     let(:assigned_roles) { [] }
     subject { build(klass.to_s.underscore.to_sym, roles: assigned_roles) }


### PR DESCRIPTION
Rename 'user_roles' shared examples to 'roles' and include in Provider spec. Fix duplicate inclusion of shared examples warning.
