### PR TITLE
Remove disabled property on checkboxes for persisted provider roles

### DIFF
--- a/app/views/super_admins/providers/_form.html.haml
+++ b/app/views/super_admins/providers/_form.html.haml
@@ -21,7 +21,7 @@
         = f.label :roles, t('.fee_schemes'), class: "form-label"
         %div.form-group.inline
           =f.collection_check_boxes(:roles, Provider::ROLES, :to_s, :to_s) do |b|
-            - b.label(class: 'block-label') { b.check_box(disabled: @provider.persisted?) + b.value.upcase }
+            - b.label(class: 'block-label') { b.check_box + b.value.upcase }
 
       #js-provider-name
         = f.label t('.provider_name'), class: "form-label"


### PR DESCRIPTION
Make provider role checkboxes editable.
