### PR TITLE
Ensure email images display

### DIFF
--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -8,10 +8,10 @@
     %tr
       / absolute URLs required for assets
       %td#govuk-logo
-        %img{ src: image_url('govuk_logotype_email.png'), alt: 'GOV.UK' }
+        = image_tag image_url('govuk_logotype_email.png'), alt: 'GOV.UK'
     %tr
       %td#moj-logo
-        %img{ src: image_url('moj_logotype_email.png'), alt: 'Ministry of Justice' }
+        = image_tag image_url('moj_logotype_email.png'), alt: 'Ministry of Justice'
     %tr
       %td
         .title

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -4,14 +4,14 @@
   = stylesheet_link_tag "email", media: "all"
 
 %body
-
   %table#mail-header
     %tr
+      / absolute URLs required for assets
       %td#govuk-logo
-        = image_tag 'govuk_logotype_email.png'
+        %img{ src: image_url('govuk_logotype_email.png'), alt: 'GOV.UK' }
     %tr
       %td#moj-logo
-        = image_tag 'moj_logotype_email.png'
+        %img{ src: image_url('moj_logotype_email.png'), alt: 'Ministry of Justice' }
     %tr
       %td
         .title

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
+  config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -60,5 +61,19 @@ Rails.application.configure do
   # And index of all can, be viewed at:
   # using webrick defaults at http://localhost:3000/rails/mailers
   config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
+
+  config.action_mailer.perform_deliveries = false
+  config.action_mailer.delivery_method = :file
+
+  # set local dev vars, uncomment and change delivery_emthod to :smtp
+  # config.action_mailer.smtp_settings = {
+  #   address:              ENV['SMTP_SERVER'],
+  #   port:                 ENV['SMTP_PORT'],
+  #   domain:               ENV['SMTP_DOMAIN'],
+  #   user_name:            ENV['SMTP_USER'],
+  #   password:             ENV['SMTP_PASSWORD'],
+  #   authentication:       :login,
+  #   enable_starttls_auto: true
+  # }
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: 'localhost' }
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/devunicorn.rb
+++ b/config/environments/devunicorn.rb
@@ -51,4 +51,27 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
+  config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
+
+  # enable the ability to preview devise emails
+  # And index of all can, be viewed at:
+  # using webrick defaults at http://localhost:3000/rails/mailers
+  config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
+
+  config.action_mailer.perform_deliveries = false
+  config.action_mailer.delivery_method = :file
+
+  # set local dev vars, uncomment and change delivery_emthod to :smtp
+  # config.action_mailer.smtp_settings = {
+  #   address:              ENV['SMTP_SERVER'],
+  #   port:                 ENV['SMTP_PORT'],
+  #   domain:               ENV['SMTP_DOMAIN'],
+  #   user_name:            ENV['SMTP_USER'],
+  #   password:             ENV['SMTP_PASSWORD'],
+  #   authentication:       :login,
+  #   enable_starttls_auto: true
+  # }
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,6 +79,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.default_url_options = { host: ENV['GRAPE_SWAGGER_ROOT_URL'] }
+  config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: 'localhost' }
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
+  config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Raise exceptions instead of rendering exception templates.


### PR DESCRIPTION
need absolute URLs for images in emails. This uses the apps asset host to serve the email images and provides an fallback alt text.

NOTE: this should be manually tested on dev/staging to ensure images in email appear as expected before deploying to production.
