### PR TITLE
Add email contact to welcome email

### DIFF
--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -24,9 +24,8 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
 
   def create
     @case_worker = CaseWorker.new(params_with_temporary_password)
-
     if @case_worker.save
-      @case_worker.user.send_reset_password_instructions
+      deliver_reset_password_instructions(@case_worker.user)
       redirect_to case_workers_admin_case_workers_url, notice: 'Case worker successfully created'
     else
       render :new

--- a/app/controllers/concerns/password_helpers.rb
+++ b/app/controllers/concerns/password_helpers.rb
@@ -19,6 +19,11 @@ module PasswordHelpers
     end
   end
 
+  def deliver_reset_password_instructions(user)
+    user.email_creator = current_user
+    user.send_reset_password_instructions
+  end
+
   private
 
   def user_for_controller_action

--- a/app/controllers/external_users/admin/external_users_controller.rb
+++ b/app/controllers/external_users/admin/external_users_controller.rb
@@ -23,10 +23,9 @@ class ExternalUsers::Admin::ExternalUsersController < ExternalUsers::Admin::Appl
 
   def create
     @external_user = ExternalUser.new(params_with_temporary_password.merge(provider_id: current_provider.id))
-
     if @external_user.save
       send_ga('event', 'external_user', 'created')
-      @external_user.user.send_reset_password_instructions
+      deliver_reset_password_instructions(@external_user.user)
       redirect_to external_users_admin_external_users_url, notice: 'User successfully created'
     else
       render :new

--- a/app/controllers/super_admins/external_users_controller.rb
+++ b/app/controllers/super_admins/external_users_controller.rb
@@ -20,7 +20,7 @@ class SuperAdmins::ExternalUsersController < ApplicationController
     @external_user = ExternalUser.new(params_with_temporary_password.merge(provider: @provider))
 
     if @external_user.save
-      @external_user.user.send_reset_password_instructions
+      deliver_reset_password_instructions(@external_user.user)
       redirect_to super_admins_provider_external_user_path(@provider, @external_user), notice: 'User successfully created'
     else
       render :new

--- a/app/mailers/adp_mailer.rb
+++ b/app/mailers/adp_mailer.rb
@@ -1,5 +1,7 @@
 class AdpMailer < Devise::Mailer
 
+  MAILER_ADMIM_CONTACT = 'laa-product@digital.justice.gov.uk'
+
   # gives access to all helpers defined within `application_helper`.
   helper :application
 
@@ -10,8 +12,21 @@ class AdpMailer < Devise::Mailer
   default template_path: 'devise/mailer'
 
   def reset_password_instructions(record, token, opts={})
+    set_email_contact(record)
     opts.merge!(subject: t('devise.mailer.welcome_password_instructions.subject')) if record.sign_in_count == 0
     super
+  end
+
+private
+
+  # If user is being created by a superadmin we include a specific email contact in the mail
+  # otherwise we include the email of the creator of the user
+  def set_email_contact(record)
+    @email_contact = if record.email_creator.is_a?(SuperAdmin)
+                      MAILER_ADMIM_CONTACT
+                    else
+                      record.email_creator.email rescue MAILER_ADMIM_CONTACT
+                    end
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,7 @@ class User < ActiveRecord::Base
   validates :first_name, :last_name, presence: true
   validates :email, confirmation: true
   attr_accessor :email_confirmation
+  attr_accessor :email_creator # used to supply contact details in mailers
 
   validate :validate_no_plus_suffix
 
@@ -65,4 +66,5 @@ class User < ActiveRecord::Base
       errors[:email] << '"+" not allowed in addresses'
     end
   end
+
 end

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -9,6 +9,10 @@
   %p
     = link_to 'Reset your password', edit_password_url(@resource, reset_password_token: @token)
   %p
+    = "This link will expire in #{distance_of_time_in_words(User.reset_password_within)}. If your link has expired please email"
+    = mail_to @email_contact
+    and request a new one.
+  %p
     Please note: if you have been given admin privileges, you will also need to add to the system as a user each advocate for whom you wish to submit claims.  You can do this under "Manage users".
 
 - else

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -13,7 +13,8 @@
     = mail_to @email_contact
     and request a new one.
   %p
-    Please note: if you have been given admin privileges, you will also need to add to the system as a user each advocate for whom you wish to submit claims.  You can do this under "Manage users".
+    - if @resource.persona.admin?
+      Please note: you have been given admin privileges, so you will also need to add to the system as a user each advocate for whom you wish to submit claims.  You can do this under "Manage users".
 
 - else
   %p

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -50,7 +50,7 @@ Then(/^I see confirmation that a new "(.*?)" user has been created$/) do |person
 end
 
 Then(/^a welcome email is sent to the new user$/) do
-  email_contact = User.last.email
+  email_contact = User.first.email
   expect(ActionMailer::Base.deliveries.length).to eq 1
   expect(ActionMailer::Base.deliveries.last.to).to eq ["harold.hughes@example.com"]
   expect(ActionMailer::Base.deliveries.last.to_s).to include("Dear Harold Hughes,","You have been registered", email_contact) #multipart email so need to stringify it

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -50,9 +50,10 @@ Then(/^I see confirmation that a new "(.*?)" user has been created$/) do |person
 end
 
 Then(/^a welcome email is sent to the new user$/) do
+  email_contact = User.last.email
   expect(ActionMailer::Base.deliveries.length).to eq 1
   expect(ActionMailer::Base.deliveries.last.to).to eq ["harold.hughes@example.com"]
-  expect(ActionMailer::Base.deliveries.last.to_s).to include("Dear Harold Hughes,","You have been registered") #multipart email so need to stringify it
+  expect(ActionMailer::Base.deliveries.last.to_s).to include("Dear Harold Hughes,","You have been registered", email_contact) #multipart email so need to stringify it
   expect(ActionMailer::Base.deliveries.last.subject).to eq "Welcome to Claim for crown court defence"
 end
 

--- a/spec/mailers/previews/adp_mailer_preview.rb
+++ b/spec/mailers/previews/adp_mailer_preview.rb
@@ -5,12 +5,34 @@ class AdpMailerPreview < ActionMailer::Preview
   #   Devise::Mailer.confirmation_instructions(User.first, "faketoken")
   # end
 
-  def welcome_password_instructions
+  def welcome_password_instructions_for_advocate_created_by_admin
     creator = FactoryGirl.create(:external_user, :advocate, :advocate_and_admin)
     advocate = FactoryGirl.create(:external_user, :advocate)
     advocate.user.email_creator = creator
     AdpMailer.reset_password_instructions(advocate.user, "faketoken")
   end
+
+  def welcome_password_instructions_for_advocate_created_by_superadmin
+    creator = FactoryGirl.create(:super_admin)
+    advocate = FactoryGirl.create(:external_user, :advocate)
+    advocate.user.email_creator = creator
+    AdpMailer.reset_password_instructions(advocate.user, "faketoken")
+  end
+
+  def welcome_password_instructions_for_advocate_admin
+    creator = FactoryGirl.create(:external_user, :advocate, :advocate_and_admin)
+    advocate = FactoryGirl.create(:external_user, :advocate, :advocate_and_admin)
+    advocate.user.email_creator = creator
+    AdpMailer.reset_password_instructions(advocate.user, "faketoken")
+  end
+
+  def welcome_password_instructions_for_caseworker_admin
+    creator = FactoryGirl.create(:case_worker, roles: ['admin','case_worker'])
+    caseworker = FactoryGirl.create(:case_worker, roles: ['admin','case_worker'])
+    caseworker.user.email_creator = creator
+    AdpMailer.reset_password_instructions(caseworker.user, "faketoken")
+  end
+
 
   def reset_password_instructions
     advocate = FactoryGirl.create(:external_user, :advocate)

--- a/spec/mailers/previews/adp_mailer_preview.rb
+++ b/spec/mailers/previews/adp_mailer_preview.rb
@@ -6,7 +6,9 @@ class AdpMailerPreview < ActionMailer::Preview
   # end
 
   def welcome_password_instructions
+    creator = FactoryGirl.create(:external_user, :advocate, :advocate_and_admin)
     advocate = FactoryGirl.create(:external_user, :advocate)
+    advocate.user.email_creator = creator
     AdpMailer.reset_password_instructions(advocate.user, "faketoken")
   end
 


### PR DESCRIPTION
add a contact email to the welcome email so that if reset token expires user have the creator of their account to contact. The contact is the creator of their account or, for super admins a generic mailbox.

also, 
- add conditional admin user note 
- update previewers and add new ones to reflect conditional logic
