### PR TITLE
ensure provider seeds are idempotent and do not search on role

### DIFF
--- a/db/seeds/seed_helper.rb
+++ b/db/seeds/seed_helper.rb
@@ -1,4 +1,5 @@
 module SeedHelper
+
   def self.find_or_create_caseworker!(attrs)
     if User.find_by(first_name: attrs[:first_name], last_name: attrs[:last_name], email: attrs[:email].downcase).blank?
       # puts "+creating case worker #{attrs[:first_name]}, #{attrs[:last_name]}, #{attrs[:email]}"
@@ -15,4 +16,21 @@ module SeedHelper
       case_worker.save!
     end
   end
+
+  # NOTE: since provider roles are serialized we cannot used standard find_or_create_by activerrecord helper
+  def self.find_or_create_provider!(attrs)
+    provider = Provider.find_by(name: attrs[:name])
+    if provider.blank?
+      provider = Provider.create!(
+        name: attrs[:name],
+        supplier_number: attrs[:supplier_number],
+        api_key: attrs[:api_key],
+        provider_type: attrs[:provider_type],
+        vat_registered: attrs[:vat_registered],
+        roles: attrs[:roles]
+      )
+    end
+    provider
+  end
+
 end

--- a/lib/demo_data/demo_seeds/external_users.rb
+++ b/lib/demo_data/demo_seeds/external_users.rb
@@ -1,6 +1,15 @@
-# Create a external users for AGFS firm
+require Rails.root.join('db','seeds','seed_helper')
 
-provider = Provider.find_or_create_by!(name: 'Test firm A', supplier_number: 'A1234567', api_key: ENV['TEST_CHAMBER_API_KEY'], provider_type: 'firm', vat_registered: true, roles: ['agfs'])
+# Create a external users for AGFS firm
+# -------------------------------------------------------
+provider = SeedHelper.find_or_create_provider!(
+  name: 'Test firm A',
+  supplier_number: 'A1234567',
+  api_key_env_var: ENV['TEST_CHAMBER_API_KEY'],
+  provider_type: 'firm',
+  vat_registered: true,
+  roles: ['agfs']
+)
 
 if User.find_by(email: 'advocate@example.com').blank?
   user = User.create!(
@@ -31,8 +40,15 @@ if User.find_by(email: 'advocateadmin@example.com').blank?
 end
 
 # Create a external users for LGFS firm
-
-provider = Provider.find_or_create_by!(name: 'Test firm B', supplier_number: 'C1234567', api_key: ENV['TEST_CHAMBER_API_KEY'], provider_type: 'firm', vat_registered: true, roles: ['lgfs'])
+# -------------------------------------------------------
+SeedHelper.find_or_create_provider!(
+  name: 'Test firm B',
+  supplier_number: 'B1234567',
+  api_key: ENV['TEST_CHAMBER_API_KEY'],
+  provider_type: 'firm',
+  vat_registered: true,
+  roles: ['lgfs']
+)
 
 if User.find_by(email: 'litigator@example.com').blank?
   user = User.create!(
@@ -62,9 +78,16 @@ if User.find_by(email: 'litigatoradmin@example.com').blank?
   external_user.save!
 end
 
-#Create external users belonging to AGFS firm
-
-provider = Provider.find_or_create_by!(name: 'Test firm C', supplier_number: 'B1234567', api_key: ENV['TEST_CHAMBER_API_KEY'], provider_type: 'firm', vat_registered: false, roles: ['agfs'])
+# Create external users belonging to AGFS firm
+# -------------------------------------------------------
+provider = SeedHelper.find_or_create_provider!(
+  name: 'Test firm C',
+  supplier_number: 'C1234567',
+  api_key_env_var: ENV['TEST_CHAMBER_API_KEY'],
+  provider_type: 'firm',
+  vat_registered: false,
+  roles: ['agfs']
+)
 
 if User.find_by(email: 'advocatefirm@example.com').blank?
   user = User.create!(
@@ -94,10 +117,14 @@ if User.find_by(email: 'advocatefirmadmin@example.com').blank?
   external_user.save!
 end
 
-
 # Create an external_user who belongs to a AGFS and LGFS chamber
-
-provider = Provider.find_or_create_by!(name: 'Test chamber', api_key: ENV['TEST_CHAMBER_API_KEY'], provider_type: 'chamber', roles: ['agfs', 'lgfs'])
+# -------------------------------------------------------
+provider = SeedHelper.find_or_create_provider!(
+  name: 'Test chamber',
+  api_key_env_var: ENV['TEST_CHAMBER_API_KEY'],
+  provider_type: 'chamber',
+  roles: ['agfs', 'lgfs']
+)
 
 if User.find_by(email: 'advocatechamber@example.com').blank?
   user = User.create!(

--- a/lib/demo_data/demo_seeds/providers.rb
+++ b/lib/demo_data/demo_seeds/providers.rb
@@ -1,2 +1,13 @@
-Provider.find_or_create_by!(provider_type: 'chamber', name: 'Doughty Street Chambers', roles: ['agfs'])
-Provider.find_or_create_by!(provider_type: 'chamber', name: 'Matrix Chambers', roles: ['lgfs'] )
+require Rails.root.join('db','seeds','seed_helper')
+
+SeedHelper.find_or_create_provider!(
+  name: 'Doughty Street Chambers',
+  provider_type: 'chamber',
+  roles: ['agfs']
+)
+
+SeedHelper.find_or_create_provider!(
+  name: 'Matrix Chambers',
+  provider_type: 'chamber',
+  roles: ['lgfs']
+)


### PR DESCRIPTION
the serialized role attribute cannot be used with find_or_create_by
activerrecord method. Applied a provider specific find_or_create
method that handles this.
