### PR TITLE
Transition to state prior to allocation when deallocating

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -25,7 +25,7 @@ class Allocation
     claims.each do |claim|
       claim.case_workers.destroy_all
       claim.case_workers << case_worker unless deallocating?
-      claim.update_column(:state, 'submitted') if deallocating?
+      claim.update_column(:state, claim.last_state_transition.from) if deallocating?
     end
 
     true

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Allocation, type: :model do
 
   describe '#save' do
     context 'allocating and re-allocating' do
-      let(:claims) { create_list(:submitted_claim, 5) }
+      let(:claims) { create_list(:submitted_claim, 3) }
       let(:case_worker) { create(:case_worker) }
 
       context 'when valid' do
@@ -59,7 +59,7 @@ RSpec.describe Allocation, type: :model do
     end
 
     context 'deallocating' do
-      let(:claims) { create_list(:submitted_claim, 5) }
+      let(:claims) { create_list(:submitted_claim, 3) }
       let(:case_worker) { create(:case_worker) }
 
       context 'when valid' do
@@ -76,13 +76,28 @@ RSpec.describe Allocation, type: :model do
           expect(case_worker.reload.claims).to be_empty
         end
 
-        it 'sets the claims to "submitted"' do
-          subject.save
-          expect(claims.map(&:reload).map(&:state).uniq).to eq(['submitted'])
-        end
-
         it 'returns true' do
           expect(subject.save).to eq(true)
+        end
+
+        describe 'state change' do
+          before { subject.save }
+
+          context 'for submitted claims' do
+            let(:claims) { create_list(:submitted_claim, 3) }
+
+            it 'sets the claims to the state to "submitted"' do
+              expect(claims.map(&:reload).map(&:state).uniq).to eq(['submitted'])
+            end
+          end
+
+          context 'for redetermination claims' do
+            let(:claims) { create_list(:redetermination_claim, 3) }
+
+            it 'sets the claims state to "redetermination"' do
+              expect(claims.map(&:reload).map(&:state).uniq).to eq(['redetermination'])
+            end
+          end
         end
       end
 
@@ -97,12 +112,12 @@ RSpec.describe Allocation, type: :model do
 
         it 'does not create case worker claim join records' do
           subject.save
-          expect(CaseWorkerClaim.count).to eq(5)
+          expect(CaseWorkerClaim.count).to eq(3)
         end
 
         it 'does not delete case worker claim join records' do
           subject.save
-          expect(CaseWorkerClaim.count).to eq(5)
+          expect(CaseWorkerClaim.count).to eq(3)
         end
 
         it 'leaves the claims as "allocated"' do


### PR DESCRIPTION
When deallocating a claim transition back to the state prior to the claim's allocation, i.e. submitted, redetermination.
