### PR TITLE
amend claim type (STI) data migration

### DIFF
--- a/db/migrate/20160215174515_modify_claim_type.rb
+++ b/db/migrate/20160215174515_modify_claim_type.rb
@@ -1,0 +1,7 @@
+class ModifyClaimType < ActiveRecord::Migration
+  def change
+    # change previous data migration as STI sub-models cannot be cloned
+    # by Amoeba gem. Awaiting fix.
+    ActiveRecord::Base.connection.execute "UPDATE claims SET type = 'Claim::BaseClaim'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160208131812) do
+ActiveRecord::Schema.define(version: 20160215174515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
claims must currently default to BaseClaim instances
since amoeba gem cannot handle STI sub-classes and
so the cloning tool does not function on submodels/assocation
cloning as expected.
