### PR TITLE
add namespaced claim model validators

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -114,8 +114,8 @@ module Claim
 
     # custom validators
     validates_with ::ValidationInitializer
-    validates_with ::ClaimValidator
-    validates_with ::ClaimSubModelValidator
+    validates_with ::Claim::BaseClaimValidator
+    validates_with ::Claim::BaseClaimSubModelValidator
 
     validate :creator_and_advocate_with_same_provider
 

--- a/app/validators/claim/advocate_claim_sub_model_validator.rb
+++ b/app/validators/claim/advocate_claim_sub_model_validator.rb
@@ -1,0 +1,3 @@
+class Claim::AdvocateClaimSubModelValidator < Claim::BaseClaimSubModelValidator
+  # TODO: implement AdvocateClaimSubModel specific validation
+end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -1,0 +1,3 @@
+class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
+  # TODO: implement AdvocateClaim specific validation
+end

--- a/app/validators/claim/base_claim_sub_model_validator.rb
+++ b/app/validators/claim/base_claim_sub_model_validator.rb
@@ -1,4 +1,4 @@
-class ClaimSubModelValidator < BaseSubModelValidator
+class Claim::BaseClaimSubModelValidator < BaseSubModelValidator
 
   def has_many_association_names
     [

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -1,4 +1,4 @@
-class ClaimValidator < BaseValidator
+class Claim::BaseClaimValidator < BaseValidator
 
   def self.fields
     [

--- a/app/validators/claim/litigator_claim_sub_model_validator.rb
+++ b/app/validators/claim/litigator_claim_sub_model_validator.rb
@@ -1,0 +1,3 @@
+class Claim::LitigatorClaimSubModelValidator < Claim::BaseClaimSubModelValidator
+  # TODO: implement AdvocateClaimSubModel specific validation
+end

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -1,0 +1,3 @@
+class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
+  # TODO: implement LitigatorClaim specific validation
+end

--- a/spec/validators/base_claim_submodel_validator_spec.rb
+++ b/spec/validators/base_claim_submodel_validator_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Validations on Claim submodels' do
+describe Claim::BaseClaimSubModelValidator do
 
   let(:claim)               { FactoryGirl.create :claim }
   let(:defendant)           { claim.defendants.first }

--- a/spec/validators/base_claim_validator_spec.rb
+++ b/spec/validators/base_claim_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require File.dirname(__FILE__) + '/validation_helpers'
 
-describe ClaimValidator do
+describe Claim::BaseClaimValidator do
 
   include ValidationHelpers
 


### PR DESCRIPTION
create framework for splitting up validation logic for advocate and litigator claims. Currently relies on BasClaimValidator for existing advocate claims until such time as amoeba cloning considerations are handled.
