### PR TITLE
Tidy up validations

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -47,7 +47,8 @@
 module Claim
   class AdvocateClaim < BaseClaim
 
-    include ::Claims::Cloner
+    validates_with ::Claim::AdvocateClaimValidator
+    validates_with ::Claim::AdvocateClaimSubModelValidator
 
   end
 end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -328,15 +328,7 @@ module Claim
       self.total + self.vat_amount
     end
 
-    private
-
-    # def creator_and_advocate_with_same_provider
-    #   return if errors[:external_user].include?('blank')
-
-    #   unless creator_id == external_user_id || creator.try(:provider) == external_user.try(:provider)
-    #     errors[:external_user] << 'Creator and advocate must belong to the same provider'
-    #   end
-    # end
+  private
 
     def find_and_associate_documents
       return if self.form_id.nil?

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -116,11 +116,11 @@ module Claim
     scope :total_lower_than, -> (value) { where { total < value } }
 
     # custom validators
-    validates_with ::ValidationInitializer
-    validates_with ::Claim::BaseClaimValidator
-    validates_with ::Claim::BaseClaimSubModelValidator
+    # validates_with ::ValidationInitializer
+    # validates_with ::Claim::BaseClaimValidator
+    # validates_with ::Claim::BaseClaimSubModelValidator
 
-    validate :creator_and_advocate_with_same_provider
+    # validate :creator_and_advocate_with_same_provider
 
     accepts_nested_attributes_for :basic_fees,        reject_if: :all_blank, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees,        reject_if: :all_blank, allow_destroy: true
@@ -141,10 +141,11 @@ module Claim
     after_initialize :instantiate_basic_fees
 
     before_validation do
+      errors.clear
+      destroy_all_invalid_fee_types
       documents.each { |d| d.external_user_id = self.external_user_id }
     end
 
-    before_validation :destroy_all_invalid_fee_types
 
     after_initialize :ensure_not_abstract_class, :default_values, :instantiate_assessment, :set_force_validation_to_false
 
@@ -336,13 +337,13 @@ module Claim
 
     private
 
-    def creator_and_advocate_with_same_provider
-      return if errors[:external_user].include?('blank')
+    # def creator_and_advocate_with_same_provider
+    #   return if errors[:external_user].include?('blank')
 
-      unless creator_id == external_user_id || creator.try(:provider) == external_user.try(:provider)
-        errors[:external_user] << 'Creator and advocate must belong to the same provider'
-      end
-    end
+    #   unless creator_id == external_user_id || creator.try(:provider) == external_user.try(:provider)
+    #     errors[:external_user] << 'Creator and advocate must belong to the same provider'
+    #   end
+    # end
 
     def find_and_associate_documents
       return if self.form_id.nil?

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -115,13 +115,6 @@ module Claim
     scope :total_greater_than_or_equal_to, -> (value) { where { total >= value } }
     scope :total_lower_than, -> (value) { where { total < value } }
 
-    # custom validators
-    # validates_with ::ValidationInitializer
-    # validates_with ::Claim::BaseClaimValidator
-    # validates_with ::Claim::BaseClaimSubModelValidator
-
-    # validate :creator_and_advocate_with_same_provider
-
     accepts_nested_attributes_for :basic_fees,        reject_if: :all_blank, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees,        reject_if: :all_blank, allow_destroy: true
     accepts_nested_attributes_for :misc_fees,         reject_if: :all_blank, allow_destroy: true

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -1,0 +1,8 @@
+module Claim
+  class LitigatorClaim < BaseClaim
+
+    validates_with ::Claim::LitigatorClaimValidator
+    validates_with ::Claim::LitigatorClaimSubModelValidator
+
+  end
+end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -43,6 +43,11 @@ class Claim::BaseClaimValidator < BaseValidator
   # ALWAYS required/mandatory
   def validate_external_user
     validate_presence(:external_user, "blank")
+    if @record.errors[:external_user].empty?
+      unless @record.creator_id == @record.external_user_id || @record.creator.try(:provider) == @record.external_user.try(:provider)
+        @record.errors[:external_user] << 'Creator and advocate must belong to the same provider'
+      end
+    end
   end
 
   # ALWAYS required/mandatory

--- a/app/validators/validation_initializer.rb
+++ b/app/validators/validation_initializer.rb
@@ -1,7 +1,0 @@
-class ValidationInitializer < ActiveModel::Validator
-
-  def validate(record)
-    record.errors.clear
-  end
-
-end


### PR DESCRIPTION
This PR removes validation from the BaseClaim class and moves it to the AdvocateClaim and
LitigatorClaim class, using specialised subclasses of BaseClaimValidator and BaseClaimSubModelValidator
