### PR TITLE
Perform page reload when redetermination or awaiting written reasons

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,6 +5,7 @@ class MessagesController < ApplicationController
     @message = Message.new(message_params.merge(sender_id: current_user.id))
 
     if @message.save
+      set_refresh_required
       @notification = { notice: 'Message successfully sent' }
     else
       @notification = { alert: 'Message not sent: ' + @message.errors.full_messages.join(', ') }
@@ -29,6 +30,10 @@ class MessagesController < ApplicationController
   end
 
   private
+
+  def set_refresh_required
+    @refresh = ['Apply for redetermination', 'Request written reasons'].include?(message_params[:claim_action])
+  end
 
   def message_params
     params.require(:message).permit(

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -1,17 +1,21 @@
 <% if @message.persisted? %>
-  var data = {
-    success : true,
-    statusMessage : '<%=j @notification[:notice].html_safe %>',
-    sentMessage : '<%=j render "shared/history_items_list", message: @message.claim %>'
-  }
-  moj.Modules.Messaging.processMsg(data);
+  <% if @refresh %>
+    window.location.href = window.location.href + '?messages=true#claim-accordion';
+  <% else %>
+    var data = {
+      success : true,
+      statusMessage : '<%=j @notification[:notice].html_safe %>',
+      sentMessage : '<%=j render "shared/history_items_list", message: @message.claim %>'
+    }
+    moj.Modules.Messaging.processMsg(data);
 
-  <% unless Claim::BaseClaim::VALID_STATES_FOR_REDETERMINATION.include?(@message.claim.state) %>
-    $('.js-hide-status').hide();
-  <% end %>
+    <% unless Claim::BaseClaim::VALID_STATES_FOR_REDETERMINATION.include?(@message.claim.state) %>
+      $('.js-hide-status').hide();
+    <% end %>
 
-  <% unless @message.claim.written_reasons_outstanding? %>
-    $('.written-reasons-checkbox').hide();
+    <% unless @message.claim.written_reasons_outstanding? %>
+      $('.written-reasons-checkbox').hide();
+    <% end %>
   <% end %>
 <% else %>
   var data = {

--- a/features/step_definitions/claim_messages_steps.rb
+++ b/features/step_definitions/claim_messages_steps.rb
@@ -19,6 +19,8 @@ When(/^I leave a message$/) do
 end
 
 Then(/^I should see my message at the bottom of the message list$/) do
+  sleep 1
+
   within '#panel1' do
     message_body = all('.message-body').last
     expect(message_body).to have_content(/Lorem/)

--- a/features/step_definitions/claim_messages_steps.rb
+++ b/features/step_definitions/claim_messages_steps.rb
@@ -20,7 +20,7 @@ end
 
 Then(/^I should see my message at the bottom of the message list$/) do
   within '#panel1' do
-    expect(find('.message-body')).to have_content(/Lorem/)
+    expect(all('.message-body').last || find('.message-body')).to have_content(/Lorem/)
   end
 end
 

--- a/features/step_definitions/claim_messages_steps.rb
+++ b/features/step_definitions/claim_messages_steps.rb
@@ -19,11 +19,8 @@ When(/^I leave a message$/) do
 end
 
 Then(/^I should see my message at the bottom of the message list$/) do
-  sleep 1
-
   within '#panel1' do
-    message_body = all('.message-body').last
-    expect(message_body).to have_content(/Lorem/)
+    expect(find('.message-body')).to have_content(/Lorem/)
   end
 end
 


### PR DESCRIPTION
…triggeredPerform page reload when redetermination or awaiting written reasons triggered via messages on external users claim detail view.
