### PR TITLE
Fix a bug that related to rep order remove links

### DIFF
--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -17,4 +17,4 @@
     = f.text_field :maat_reference
     = validation_error_message(@error_presenter, "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_maat_reference")
 
-  = link_to_remove_association t('link.remove_rep_order'), f if @representation_order_count > 1
+  = link_to_remove_association t('link.remove_rep_order'), f


### PR DESCRIPTION
rep orders creation via cocoon for second defendants
were not receiving emove links. This was because of
the use of backend logic related to rep order counts
and them not being approrpriate for front-end conditional
logic if certain circumstances.

To implement this via javascript see:
http://stackoverflow.com/questions/12934925/cocoon-add-association-how-to-limit-number-of-associations
