### PR TITLE
Validate Creator and ExternalUser on a claim have appropriate roles

### DIFF
--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -70,4 +70,11 @@ class BaseValidator < ActiveModel::Validator
     1.0/0
   end
 
+  def validate_has_role(object, role, error_message_key, error_message)
+    return if object.nil?
+    unless object.is?(role)
+      @record.errors[error_message_key] << error_message
+    end
+  end
+
 end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -10,4 +10,13 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
     super
   end
 
+  def validate_creator
+    unless @record.creator.nil?
+      unless @record.creator.provider.is?(:agfs)
+        @record.errors[:creator] << "Creator must be from a Provider that has AGFS fee scheme"
+      end
+    end
+    super
+  end
+
 end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -2,21 +2,12 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
   
  # ALWAYS required/mandatory
   def validate_external_user
-    unless @record.external_user.nil?
-      unless @record.external_user.is?(:advocate)
-        @record.errors[:external_user] << 'External user must have advocate role'
-      end
-    end
+    validate_has_role(@record.external_user, :advocate, :external_user, 'must have advocate role')
     super
   end
 
   def validate_creator
-    unless @record.creator.nil?
-      unless @record.creator.provider.is?(:agfs)
-        @record.errors[:creator] << "Creator must be from a Provider that has AGFS fee scheme"
-      end
-    end
+    validate_has_role(@record.creator.try(:provider), :agfs, :creator, 'must be from a Provider that has AGFS fee scheme')
     super
   end
-
 end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -1,3 +1,13 @@
 class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
-  # TODO: implement AdvocateClaim specific validation
+  
+ # ALWAYS required/mandatory
+  def validate_external_user
+    unless @record.external_user.nil?
+      unless @record.external_user.is?(:advocate)
+        @record.errors[:external_user] << 'External user must have advocate role'
+      end
+    end
+    super
+  end
+
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -52,7 +52,7 @@ class Claim::BaseClaimValidator < BaseValidator
 
   # ALWAYS required/mandatory
   def validate_creator
-    validate_presence(:creator, "blank")
+    validate_presence(:creator, "blank") unless @record.errors.key?(:creator)
   end
 
   # must be present

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -43,7 +43,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # ALWAYS required/mandatory
   def validate_external_user
     validate_presence(:external_user, "blank")
-    if @record.errors[:external_user].empty?
+    unless @record.errors.key?(:external_user)
       unless @record.creator_id == @record.external_user_id || @record.creator.try(:provider) == @record.external_user.try(:provider)
         @record.errors[:external_user] << 'Creator and advocate must belong to the same provider'
       end

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -9,4 +9,14 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
     end
     super
   end
+
+
+  def validate_creator
+    unless @record.creator.nil?
+      unless @record.creator.provider.is?(:lgfs)
+        @record.errors[:creator] << "Creator must be from a Provider that has LGFS fee scheme"
+      end
+    end
+    super
+  end
 end

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -2,21 +2,13 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
   # TODO: implement LitigatorClaim specific validation
 
   def validate_external_user
-    unless @record.external_user.nil?
-      unless @record.external_user.is?(:litigator)
-        @record.errors[:external_user] << 'External user must have litigator role'
-      end
-    end
+    validate_has_role(@record.external_user, :litigator, :external_user, 'must have litigator role')
     super
   end
 
 
   def validate_creator
-    unless @record.creator.nil?
-      unless @record.creator.provider.is?(:lgfs)
-        @record.errors[:creator] << "Creator must be from a Provider that has LGFS fee scheme"
-      end
-    end
+    validate_has_role(@record.creator.provider, :lgfs, :creator, 'must be from a provider with the LGFS fee scheme')
     super
   end
 end

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -1,3 +1,12 @@
 class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
   # TODO: implement LitigatorClaim specific validation
+
+  def validate_external_user
+    unless @record.external_user.nil?
+      unless @record.external_user.is?(:litigator)
+        @record.errors[:external_user] << 'External user must have litigator role'
+      end
+    end
+    super
+  end
 end

--- a/features/step_definitions/shared/sign_in_steps.rb
+++ b/features/step_definitions/shared/sign_in_steps.rb
@@ -26,7 +26,7 @@ Given(/^I am a signed in advocate$/) do
 end
 
 Given(/^I am a signed in advocate admin$/) do
-  @advocate = create(:external_user, :admin)
+  @advocate = create(:external_user, :advocate_and_admin)
   visit new_user_session_path
   sign_in(@advocate.user, 'password')
 end

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -7,9 +7,13 @@ FactoryGirl.define do
     source { 'web' }
     apply_vat  false
 
+     after(:build) do |claim|
+      claim.creator = claim.external_user
+    end
+
     factory :unpersisted_litigator_claim do
       court         { FactoryGirl.build :court }
-      external_user { FactoryGirl.build :external_user, provider: FactoryGirl.build(:provider) }
+      external_user { FactoryGirl.build :external_user, :litigator, provider: FactoryGirl.build(:provider, :lgfs) }
       offence       { FactoryGirl.build :offence, offence_class: FactoryGirl.build(:offence_class) }
       after(:build) do |claim|
         build(:certification, claim: claim)

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -1,0 +1,22 @@
+FactoryGirl.define do
+  factory :litigator_claim, class: Claim::LitigatorClaim do
+
+    court
+    case_number { random_case_number }
+    external_user { build :external_user, :litigator }
+    source { 'web' }
+    apply_vat  false
+
+    factory :unpersisted_litigator_claim do
+      court         { FactoryGirl.build :court }
+      external_user { FactoryGirl.build :external_user, provider: FactoryGirl.build(:provider) }
+      offence       { FactoryGirl.build :offence, offence_class: FactoryGirl.build(:offence_class) }
+      after(:build) do |claim|
+        build(:certification, claim: claim)
+        claim.defendants << build(:defendant, claim: claim)
+        claim.fees << build(:fee, :with_date_attended, claim: claim, fee_type: FactoryGirl.build(:fee_type))
+        claim.expenses << build(:expense, :with_date_attended, claim: claim, expense_type: FactoryGirl.build(:expense_type))
+      end
+    end
+  end
+end

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -1,0 +1,26 @@
+FactoryGirl.define do
+  factory :litigator_claim, class: Claim::LitigatorClaim do
+
+    court
+    case_number { random_case_number }
+    external_user { build :external_user, :litigator }
+    source { 'web' }
+    apply_vat  false
+
+     after(:build) do |claim|
+      claim.creator = claim.external_user
+    end
+
+    factory :unpersisted_litigator_claim do
+      court         { FactoryGirl.build :court }
+      external_user { FactoryGirl.build :external_user, :litigator, provider: FactoryGirl.build(:provider, :lgfs) }
+      offence       { FactoryGirl.build :offence, offence_class: FactoryGirl.build(:offence_class) }
+      after(:build) do |claim|
+        build(:certification, claim: claim)
+        claim.defendants << build(:defendant, claim: claim)
+        claim.fees << build(:fee, :with_date_attended, claim: claim, fee_type: FactoryGirl.build(:fee_type))
+        claim.expenses << build(:expense, :with_date_attended, claim: claim, expense_type: FactoryGirl.build(:expense_type))
+      end
+    end
+  end
+end

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
   end
 
+  describe 'validate external user is advocate role' do
+    let(:claim)   { build :unpersisted_claim }
+
+    it 'validates external user with advocate role' do
+      expect(claim.external_user.is?(:advocate)).to be true
+      expect(claim).to be_valid
+    end
+
+    it 'rejects external user without advocate role' do
+      claim.external_user = build :external_user, :litigator, provider: claim.creator.provider
+      expect(claim).not_to be_valid
+      expect(claim.errors[:external_user]).to include('External user must have advocate role')
+    end
+  end
+
   context 'State Machine meta states magic methods' do
     let(:claim)       { FactoryGirl.build :claim }
     let(:all_states)  { [  'allocated', 'archived_pending_delete',

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     it 'rejects external user without advocate role' do
       claim.external_user = build :external_user, :litigator, provider: claim.creator.provider
       expect(claim).not_to be_valid
-      expect(claim.errors[:external_user]).to include('External user must have advocate role')
+      expect(claim.errors[:external_user]).to include('must have advocate role')
     end
   end
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       subject.external_user_id = external_user.id
       subject.creator_id = external_user.id
       subject.save
-      expect(subject.reload.errors.messages[:external_user]).to be_empty
+      expect(subject.reload.errors.messages[:external_user]).to be_nil
     end
 
     it 'should be valid with different external_user_id and creator_id but same provider' do
       subject.external_user_id = external_user.id
       subject.creator_id = same_provider_external_user.id
       subject.save
-      expect(subject.reload.errors.messages[:external_user]).to be_empty
+      expect(subject.reload.errors.messages[:external_user]).to be_nil
     end
 
     it 'should not be valid when the external_user and creator are with the same provider' do

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       subject.external_user_id = external_user.id
       subject.creator_id = external_user.id
       subject.save
-      expect(subject.reload.errors.messages[:external_user]).to be_empty
+      expect(subject.reload.errors.messages[:external_user]).to be_nil
     end
 
     it 'should be valid with different external_user_id and creator_id but same provider' do
       subject.external_user_id = external_user.id
       subject.creator_id = same_provider_external_user.id
       subject.save
-      expect(subject.reload.errors.messages[:external_user]).to be_empty
+      expect(subject.reload.errors.messages[:external_user]).to be_nil
     end
 
     it 'should not be valid when the external_user and creator are with the same provider' do
@@ -87,6 +87,21 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       subject.creator_id = other_provider_external_user.id
       subject.save
       expect(subject.reload.errors.messages[:external_user]).to eq(['Creator and advocate must belong to the same provider'])
+    end
+  end
+
+  describe 'validate external user is advocate role' do
+    let(:claim)   { build :unpersisted_claim }
+
+    it 'validates external user with advocate role' do
+      expect(claim.external_user.is?(:advocate)).to be true
+      expect(claim).to be_valid
+    end
+
+    it 'rejects external user without advocate role' do
+      claim.external_user = build :external_user, :litigator, provider: claim.creator.provider
+      expect(claim).not_to be_valid
+      expect(claim.errors[:external_user]).to include('External user must have advocate role')
     end
   end
 

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
     it 'rejects external user without litigator role' do
       claim.external_user = build :external_user, :advocate, provider: claim.creator.provider
       expect(claim).not_to be_valid
-      expect(claim.errors[:external_user]).to include('External user must have litigator role')
+      expect(claim.errors[:external_user]).to include('must have litigator role')
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
     it 'rejects creators whose provider is only agfs' do
       claim.creator = build(:external_user, provider: build(:provider, :agfs))
       expect(claim).not_to be_valid
-      expect(claim.errors[:creator]).to eq(["Creator must be from a Provider that has LGFS fee scheme"])
+      expect(claim.errors[:creator]).to eq(["must be from a provider with the LGFS fee scheme"])
     end
 
     it 'accepts creators whose provider is only lgfs' do

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
   describe 'validate external user has litigator role' do
     let(:claim)   { build :unpersisted_litigator_claim }
 
-    it 'validates external user with advocate role' do
-      expect(claim.external_user.is?(:advocate)).to be true
+    it 'validates external user with litigator role' do
+      expect(claim.external_user.is?(:litigator)).to be true
       expect(claim).to be_valid
     end
 
-    it 'rejects external user without advocate role' do
-      claim.external_user = build :external_user, :litigator, provider: claim.creator.provider
+    it 'rejects external user without litigator role' do
+      claim.external_user = build :external_user, :advocate, provider: claim.creator.provider
       expect(claim).not_to be_valid
-      expect(claim.errors[:external_user]).to include('External user must have advocate role')
+      expect(claim.errors[:external_user]).to include('External user must have litigator role')
     end
   end
 

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require 'custom_matchers'
+
+RSpec.describe Claim::LitigatorClaim, type: :model do
+
+  describe 'validate external user has litigator role' do
+    let(:claim)   { build :unpersisted_litigator_claim }
+
+    it 'validates external user with advocate role' do
+      expect(claim.external_user.is?(:advocate)).to be true
+      expect(claim).to be_valid
+    end
+
+    it 'rejects external user without advocate role' do
+      claim.external_user = build :external_user, :litigator, provider: claim.creator.provider
+      expect(claim).not_to be_valid
+      expect(claim.errors[:external_user]).to include('External user must have advocate role')
+    end
+  end
+
+end

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -3,9 +3,10 @@ require 'custom_matchers'
 
 RSpec.describe Claim::LitigatorClaim, type: :model do
 
-  describe 'validate external user has litigator role' do
-    let(:claim)   { build :unpersisted_litigator_claim }
+  let(:claim)   { build :unpersisted_litigator_claim }
 
+
+  describe 'validate external user has litigator role' do
     it 'validates external user with litigator role' do
       expect(claim.external_user.is?(:litigator)).to be true
       expect(claim).to be_valid
@@ -15,6 +16,24 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
       claim.external_user = build :external_user, :advocate, provider: claim.creator.provider
       expect(claim).not_to be_valid
       expect(claim.errors[:external_user]).to include('External user must have litigator role')
+    end
+  end
+
+  describe 'validate creator provider is in LGFS fee scheme' do
+    it 'rejects creators whose provider is only agfs' do
+      claim.creator = build(:external_user, provider: build(:provider, :agfs))
+      expect(claim).not_to be_valid
+      expect(claim.errors[:creator]).to eq(["Creator must be from a Provider that has LGFS fee scheme"])
+    end
+
+    it 'accepts creators whose provider is only lgfs' do
+      claim.creator = build(:external_user, provider: build(:provider, :lgfs))
+      expect(claim).to be_valid
+    end
+    
+    it 'accepts creators whose provider is both agfs and lgfs' do
+      claim.creator = build(:external_user, provider: build(:provider, :agfs_lgfs))
+      expect(claim).to be_valid
     end
   end
 

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require 'custom_matchers'
+
+RSpec.describe Claim::LitigatorClaim, type: :model do
+
+  describe 'validate external user has litigator role' do
+    let(:claim)   { build :unpersisted_litigator_claim }
+
+    it 'validates external user with litigator role' do
+      expect(claim.external_user.is?(:litigator)).to be true
+      expect(claim).to be_valid
+    end
+
+    it 'rejects external user without litigator role' do
+      claim.external_user = build :external_user, :advocate, provider: claim.creator.provider
+      expect(claim).not_to be_valid
+      expect(claim.errors[:external_user]).to include('External user must have litigator role')
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds validation to the AdvocateClaim and LitigatorClaim to ensure that the external_user has the appropriate role(advocate or litigator) and the creator is from a provider with the appropriate fee scheme (agfs or lgfs).
