### PR TITLE
add link expire instructions in welcome and reset emails

### DIFF
--- a/app/controllers/concerns/password_helpers.rb
+++ b/app/controllers/concerns/password_helpers.rb
@@ -20,7 +20,6 @@ module PasswordHelpers
   end
 
   def deliver_reset_password_instructions(user)
-    user.email_creator = current_user
     user.send_reset_password_instructions
   end
 

--- a/app/mailers/adp_mailer.rb
+++ b/app/mailers/adp_mailer.rb
@@ -1,7 +1,5 @@
 class AdpMailer < Devise::Mailer
 
-  MAILER_ADMIN_CONTACT = 'laa-product@digital.justice.gov.uk'
-
   # gives access to all helpers defined within `application_helper`.
   helper :application
 
@@ -12,23 +10,8 @@ class AdpMailer < Devise::Mailer
   default template_path: 'devise/mailer'
 
   def reset_password_instructions(record, token, opts={})
-    set_email_contact(record)
     opts.merge!(subject: t('devise.mailer.welcome_password_instructions.subject')) if record.sign_in_count == 0
     super
-  end
-
-private
-
-  # If user is being created by a superadmin we include a specific email contact in the mail
-  # otherwise we include the email of the creator of the user
-  def set_email_contact(record)
-    @email_contact  = if record.email_creator.persona.is_a?(SuperAdmin)
-                        MAILER_ADMIN_CONTACT
-                      else
-                        record.email_creator.email
-                      end
-  rescue
-    @email_contact = MAILER_ADMIN_CONTACT
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,6 @@ class User < ActiveRecord::Base
   validates :first_name, :last_name, presence: true
   validates :email, confirmation: true
   attr_accessor :email_confirmation
-  attr_accessor :email_creator # used to supply contact details in mailers
 
   validate :validate_no_plus_suffix
 

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -8,10 +8,7 @@
     Please follow the link below to reset your password.
   %p
     = link_to 'Reset your password', edit_password_url(@resource, reset_password_token: @token)
-  %p
-    = "This link will expire in #{distance_of_time_in_words(User.reset_password_within)}. If your link has expired please email"
-    = mail_to @email_contact
-    and request a new one.
+
   %p
     - if @resource.persona.admin?
       Please note: you have been given admin privileges, so you will also need to add to the system as a user each advocate for whom you wish to submit claims.  You can do this under "Manage users".
@@ -24,6 +21,10 @@
   %p
     If you didn't request this, please ignore this email. Your password won’t change until you access the link above and enter a new password.
 
+%p
+  = "This link will expire in #{distance_of_time_in_words(User.reset_password_within)}. If your link has expired please goto the"
+  = link_to 'Forgot your password?', new_user_password_url
+  page, provide your email address and click 'Send me password reset instructions'. You will then receive a new confirmation email.
 %p
   Yours sincerely,
 %p

--- a/features/new_user.feature
+++ b/features/new_user.feature
@@ -1,22 +1,32 @@
 Feature: User is added by advocate or caseworker admin
 
 Scenario: New advocate user for firm
-  Given I am a signed in advocate admin
+  Given Test mailer is reset
+    And I am a signed in advocate admin
     And my provider is a "firm"
     And I am on the new "external_user" page
    When I fill in the "external_user" details
-    And click save
+    And I click "Save"
    Then I see confirmation that a new "User" user has been created
     And a welcome email is sent to the new user
 
 Scenario: New advocate user for chamber
-  Given I am a signed in advocate admin
+  Given Test mailer is reset
+    And I am a signed in advocate admin
     And my provider is a "chamber"
     And I am on the new "external_user" page
    When I fill in the "external_user" details
-    And click save
+    And I click "Save"
    Then I see confirmation that a new "User" user has been created
     And a welcome email is sent to the new user
+
+Scenario: Advocate user forgets password
+  Given Test mailer is reset
+    And I am an advocate that has signed in before
+    And I am on the Forgot your password? page
+   When I fill in my email details
+    And I click "Send me password reset instructions"
+   Then a password reset email is sent to the user
 
 @javascript @webmock_allow_localhost_connect
 Scenario: New external user advocate for chamber
@@ -41,14 +51,15 @@ Scenario: New advocate with mismatching email_confirmation
     And my provider is a "chamber"
     And I am on the new "external_user" page
    When I fill in the "external_user" details but email and email_confirmation do not match
-    And click save
+    And I click "Save"
    Then I see an error message
 
 Scenario: New caseworker user
-  Given I am a signed in case worker admin
+  Given Test mailer is reset
+    And I am a signed in case worker admin
     And I am on the new "case_worker" page
    When I fill in the "case_worker" details
-    And click save
+    And I click "Save"
    Then I see confirmation that a new "Case worker" user has been created
     And a welcome email is sent to the new user
 
@@ -56,5 +67,5 @@ Scenario: New caseworker with mismatching email_confirmation
   Given I am a signed in case worker admin
     And I am on the new "case_worker" page
    When I fill in the "case_worker" details but email and email_confirmation do not match
-    And click save
+    And I click "Save"
    Then I see an error message

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -1,3 +1,9 @@
+Given(/^Test mailer is reset$/) do
+  ActionMailer::Base.delivery_method = :test
+  ActionMailer::Base.perform_deliveries = true
+  ActionMailer::Base.deliveries = []
+end
+
 Given(/^I am on the new "(.*?)" page$/) do |persona|
   personas = persona.pluralize
   visit "/#{personas}/admin/#{personas}/new"
@@ -39,22 +45,15 @@ When(/^I fill in the "(.*?)" details but email and email_confirmation do not mat
   end
 end
 
-When(/^click save$/) do
-  ActionMailer::Base.delivery_method = :test
-  ActionMailer::Base.perform_deliveries = true
-  click_on 'Save'
-end
-
 Then(/^I see confirmation that a new "(.*?)" user has been created$/) do |persona|
   expect(page).to have_content "#{persona} successfully created"
 end
 
 Then(/^a welcome email is sent to the new user$/) do
-  email_contact = User.first.email
   expect(ActionMailer::Base.deliveries.length).to eq 1
   expect(ActionMailer::Base.deliveries.last.to).to eq ["harold.hughes@example.com"]
-  expect(ActionMailer::Base.deliveries.last.to_s).to include("Dear Harold Hughes,","You have been registered", email_contact) #multipart email so need to stringify it
   expect(ActionMailer::Base.deliveries.last.subject).to eq "Welcome to Claim for crown court defence"
+  expect(ActionMailer::Base.deliveries.last.to_s).to include("Dear Harold Hughes,","You have been registered", "Reset your password", "This link will expire in") #multipart email so need to stringify it
 end
 
 Then(/^I see an error message$/) do
@@ -73,4 +72,28 @@ end
 
 When(/^I check "(.*?)"$/) do |role|
   check role
+end
+
+Given(/^I am an advocate that has signed in before/) do
+  @advocate = create(:external_user, :advocate)
+  @advocate.user.first_name = 'Ned'
+  @advocate.user.last_name = 'Passreset'
+  @advocate.user.email = 'ned.passreset@example.com'
+  @advocate.user.sign_in_count = 21
+  @advocate.save
+end
+
+Given(/^I am on the Forgot your password\? page$/) do
+  visit new_user_password_path
+end
+
+When(/^I fill in my email details$/) do
+  fill_in 'user_email', with: @advocate.email
+end
+
+Then(/^a password reset email is sent to the user$/) do
+  expect(ActionMailer::Base.deliveries.length).to eq 1
+  expect(ActionMailer::Base.deliveries.last.to).to eq ["ned.passreset@example.com"]
+  expect(ActionMailer::Base.deliveries.last.subject).to eq "Claim for crown court defence - change your password"
+  expect(ActionMailer::Base.deliveries.last.to_s).to include("Dear Ned Passreset,","Someone has requested a link to change your password", "Change your password", "This link will expire in") #multipart email so need to stringify it
 end

--- a/spec/mailers/previews/adp_mailer_preview.rb
+++ b/spec/mailers/previews/adp_mailer_preview.rb
@@ -5,34 +5,15 @@ class AdpMailerPreview < ActionMailer::Preview
   #   Devise::Mailer.confirmation_instructions(User.first, "faketoken")
   # end
 
-  def welcome_password_instructions_for_advocate_created_by_admin
-    creator = FactoryGirl.create(:external_user, :advocate, :advocate_and_admin)
+  def welcome_password_instructions
     advocate = FactoryGirl.create(:external_user, :advocate)
-    advocate.user.email_creator = creator.user
-    AdpMailer.reset_password_instructions(advocate.user, "faketoken")
-  end
-
-  def welcome_password_instructions_for_advocate_created_by_superadmin
-    creator = FactoryGirl.create(:super_admin)
-    advocate = FactoryGirl.create(:external_user, :advocate)
-    advocate.user.email_creator = creator.user
     AdpMailer.reset_password_instructions(advocate.user, "faketoken")
   end
 
   def welcome_password_instructions_for_advocate_admin
-    creator = FactoryGirl.create(:external_user, :advocate, :advocate_and_admin)
     advocate = FactoryGirl.create(:external_user, :advocate, :advocate_and_admin)
-    advocate.user.email_creator = creator.user
     AdpMailer.reset_password_instructions(advocate.user, "faketoken")
   end
-
-  def welcome_password_instructions_for_caseworker_admin
-    creator = FactoryGirl.create(:case_worker, roles: ['admin','case_worker'])
-    caseworker = FactoryGirl.create(:case_worker, roles: ['admin','case_worker'])
-    caseworker.user.email_creator = creator.user
-    AdpMailer.reset_password_instructions(caseworker.user, "faketoken")
-  end
-
 
   def reset_password_instructions
     advocate = FactoryGirl.create(:external_user, :advocate)


### PR DESCRIPTION
amended copy to instruct user to use the Forgot your password?
facility in app in the even that their token has expired.
