### PR TITLE
Fix bug with Draft claims expenses

### DIFF
--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -5,7 +5,16 @@ class ExpensePresenter < BasePresenter
     expense.dates_attended.order(date: :asc).map(&:to_s).join(', ')
   end
 
- def amount
+  def amount
     h.number_to_currency(expense.amount)
- end
+  end
+
+  def name
+    if expense.expense_type.blank?
+      "Not selected"
+    else
+      expense.expense_type.name
+    end
+  end
+
 end

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -63,7 +63,7 @@
           - present_collection(claim.expenses).each do |expense|
             %tr
               %td
-                = expense.expense_type.name
+                = expense.name
                 - if expense.dates_attended.any?
                   %br
                   Dates attended:

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ExpensePresenter do
+
+  let(:claim)     { create(:claim) }
+  let(:expense_type)  { create(:expense_type) }
+  let(:expense)       { create(:expense, quantity: 4, claim: claim, expense_type: expense_type) }
+  let(:presenter) {ExpensePresenter.new(expense, view) }
+
+  describe '#dates_attended_delimited_string' do
+
+    before {
+      claim.expenses .each do |fee|
+        expense.dates_attended << create(:date_attended, attended_item: fee, date: Date.parse('21/05/2015'), date_to: Date.parse('23/05/2015'))
+        expense.dates_attended << create(:date_attended, attended_item: fee, date: Date.parse('25/05/2015'), date_to: nil)
+      end
+    }
+
+    it 'outputs string of dates or date ranges separated by comma' do
+      claim.expenses.each do |fee|
+        expense = ExpensePresenter.new(fee, view)
+        expect(expense.dates_attended_delimited_string).to eql('21/05/2015 - 23/05/2015, 25/05/2015')
+      end
+    end
+  end
+
+  describe '#amount' do
+    it 'formats as currency' do
+      expense.amount = 32456.3
+      expect(presenter.amount).to eq '£32,456.30'
+    end
+  end
+
+  describe '#name' do
+    it 'outputs "Not selected" if there is no expense type' do
+      expense.expense_type_id = nil
+      expect(presenter.name).to eql('Not selected')
+    end
+
+    it 'outputs the type name is there is an expense type' do
+      expense.expense_type_id = expense_type.id
+      expect(presenter.name).to eql(expense.expense_type.name)
+    end
+  end
+
+
+
+
+
+end

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -43,8 +43,4 @@ RSpec.describe ExpensePresenter do
     end
   end
 
-
-
-
-
 end


### PR DESCRIPTION
Fixes Zendesk ticket 13398.

To replicate bug:
Create a draft claim that has some data entered but leave the expense type blank.
Edit the claim and it should throw an error.
