### PR TITLE
written reasons received is more helpful than state in history

### DIFF
--- a/app/presenters/claim_state_transition_presenter.rb
+++ b/app/presenters/claim_state_transition_presenter.rb
@@ -3,8 +3,8 @@ class ClaimStateTransitionPresenter < BasePresenter
   presents :claim_state_transition
 
   def transition_message
-    new_state = claim_state_transition.to
-    return "#{transition_messages[new_state][current_user_persona]}"
+    state = new_state
+    return "#{transition_messages[state][current_user_persona]}"
   end
 
   def timestamp
@@ -17,6 +17,7 @@ private
     {
       'redetermination'               => {"CaseWorker" => "Redetermination requested",     "ExternalUser" => "You requested redetermination"},
       'awaiting_written_reasons'      => {"CaseWorker" => "Written reasons requested",     "ExternalUser" => "You requested written reasons"},
+      'written_reasons_provided'      => {"CaseWorker" => "Written reasons provided",      "ExternalUser" => "You received written reasons"},
       'submitted'                     => {"CaseWorker" => "Claim submitted",               "ExternalUser" => "Your claim has been submitted"},
       'allocated'                     => {"CaseWorker" => "Claim allocated",               "ExternalUser" => "Your claim has been allocated"},
       'authorised'                    => {"CaseWorker" => "Claim authorised",              "ExternalUser" => "Your claim has been authorised"},
@@ -29,6 +30,26 @@ private
 
   def current_user_persona
     @view.current_user.persona.class.to_s
+  end
+
+  def new_state
+    previous_transition.from == 'awaiting_written_reasons' ? 'written_reasons_provided' : claim_state_transition.to
+  end
+
+  def all_transitions
+    claim_state_transition.claim.claim_state_transitions
+  end
+
+  def current_index
+    all_transitions.index(claim_state_transition)
+  end
+
+  def previous_index
+    current_index - 1
+  end
+
+  def previous_transition
+    all_transitions[previous_index]
   end
 
 end


### PR DESCRIPTION
- at the moment, after written reasons are provided, state prior to 'awaiting written reasons is displayed'
- makes more sense to display a message along the lines of 'written reasons received'
