### PR TITLE
Fix MAAT reference validation

### DIFF
--- a/app/models/representation_order.rb
+++ b/app/models/representation_order.rb
@@ -13,10 +13,17 @@
 
 class RepresentationOrder < ActiveRecord::Base
   include Duplicable
-  
+
   auto_strip_attributes :maat_reference, squish: true, nullify: true
 
   before_save :upcase_maat_ref
+
+  before_validation do
+    case_type = defendant.claim.case_type rescue nil
+    if case_type && !case_type.requires_maat_reference?
+      self.maat_reference = nil
+    end
+  end
 
   acts_as_gov_uk_date :representation_order_date
 

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -30,8 +30,9 @@ class RepresentationOrderValidator < BaseValidator
   # must be exactly 7 - 10 numeric digits
   def validate_maat_reference
     case_type = @record.defendant.claim.case_type rescue nil
-    validate_presence(:maat_reference, "invalid") if case_type && case_type.requires_maat_reference?
-    validate_pattern(:maat_reference, /^[0-9]{7,10}$/, 'invalid')
+    if case_type && case_type.requires_maat_reference?
+      validate_presence(:maat_reference, "invalid")
+      validate_pattern(:maat_reference, /^[0-9]{7,10}$/, 'invalid')
+    end
   end
-
 end

--- a/spec/api/v1/claims/representation_order_spec.rb
+++ b/spec/api/v1/claims/representation_order_spec.rb
@@ -54,12 +54,30 @@ describe API::V1::ExternalUsers::RepresentationOrder do
         expect{ post_to_create_endpoint }.to change { RepresentationOrder.count }.by(1)
       end
 
-      it 'creates a new representation_order record with all provided attributes' do
-        post_to_create_endpoint
-        new_representation_order = RepresentationOrder.last
-        expect(new_representation_order.defendant_id).to eq defendant.id
-        expect(new_representation_order.representation_order_date).to eq valid_params[:representation_order_date].to_date
-        expect(new_representation_order.maat_reference).to eq valid_params[:maat_reference]
+      context 'MAAT reference' do
+        context 'when case type requires MAAT reference' do
+          before { claim.case_type.update_column(:requires_maat_reference, true) }
+
+          it 'creates a new representation_order record with all provided attributes' do
+            post_to_create_endpoint
+            new_representation_order = RepresentationOrder.last
+            expect(new_representation_order.defendant_id).to eq defendant.id
+            expect(new_representation_order.representation_order_date).to eq valid_params[:representation_order_date].to_date
+            expect(new_representation_order.maat_reference).to eq valid_params[:maat_reference]
+          end
+        end
+
+        context 'when case type does not require MAAT reference' do
+          before { claim.case_type.update_column(:requires_maat_reference, false) }
+
+          it 'creates a new representation_order record with all provided attributes' do
+            post_to_create_endpoint
+            new_representation_order = RepresentationOrder.last
+            expect(new_representation_order.defendant_id).to eq defendant.id
+            expect(new_representation_order.representation_order_date).to eq valid_params[:representation_order_date].to_date
+            expect(new_representation_order.maat_reference).to eq nil
+          end
+        end
       end
     end
 

--- a/spec/factories/case_types.rb
+++ b/spec/factories/case_types.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
     is_fixed_fee                false
     requires_cracked_dates      false
     requires_trial_dates        false
-    requires_maat_reference     false
+    requires_maat_reference     true
 
     trait :fixed_fee do
       is_fixed_fee    true


### PR DESCRIPTION
Do not validate presence or format of MAAT reference numbers when case type does not require MAAT reference, e.g. Breach of crown court order. Additionally nullify maat_reference field when MAAT reference not required.  
