### PR TITLE
standardise use of claim action options

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -32,7 +32,7 @@ class MessagesController < ApplicationController
   private
 
   def set_refresh_required
-    @refresh = ['Apply for redetermination', 'Request written reasons'].include?(message_params[:claim_action])
+    @refresh = Settings.claim_actions.include?(message_params[:claim_action])
   end
 
   def message_params


### PR DESCRIPTION
- options for claim_actions moved to settings in previous commit
- now making all references point to the same place
