### PR TITLE
fix bug making draft claims require fee type id

### DIFF
--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -2,20 +2,25 @@ class Fee::BaseFeeValidator < BaseValidator
 
   def self.fields
     [
+      :fee_type,
       :quantity,
       :rate,
-      :amount
+      :amount,
     ]
   end
 
   def self.mandatory_fields
-    [:claim, :fee_type]
+    [:claim, :type]
   end
 
   private
 
   def validate_claim
     validate_presence(:claim, 'blank')
+  end
+
+  def validate_type
+    validate_presence(:type, 'blank')
   end
 
   def validate_fee_type

--- a/spec/validators/base_fee_validator_spec.rb
+++ b/spec/validators/base_fee_validator_spec.rb
@@ -15,8 +15,15 @@ describe Fee::BaseFeeValidator do
   let(:ppe_fee)    { FactoryGirl.build :basic_fee, :ppe_fee, claim: claim }
   let(:npw_fee)    { FactoryGirl.build :basic_fee, :npw_fee, claim: claim }
 
-  describe '#validate_claim' do
-    it { should_error_if_not_present(fee, :claim, 'blank') }
+  context 'mandatory required fields' do
+    let(:claim)      { FactoryGirl.build :claim, force_validation: false }
+    describe '#validate_claim' do
+      it { should_error_if_not_present(fee, :claim, 'blank') }
+    end
+
+    describe '#validate_type' do
+      it { should_error_if_not_present(fee, :type, 'blank') }
+    end
   end
 
   describe '#validate_fee_type' do


### PR DESCRIPTION
This meant you could not save a draft if you had a misc
or fixed fee that did not have a description.
