### PR TITLE
Fix bug where submission of certification is attempted more than once

### DIFF
--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -1,5 +1,6 @@
 class ExternalUsers::CertificationsController < ExternalUsers::ApplicationController
-  before_action :set_claim, only: [:new, :create]
+  before_action :set_claim, only: [:new, :create, :update]
+  before_action :redirect_already_certified, only: [:new, :create]
 
   def new
     redirect_to external_users_claim_path(@claim), alert: 'Cannot certify a claim in submitted state' if @claim.submitted?
@@ -23,7 +24,15 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
     end
   end
 
+  def update
+    redirect_to external_users_claim_path(@claim), alert: 'Cannot certify a claim in submitted state'
+  end
+
   private
+
+  def redirect_already_certified
+    redirect_to external_users_claim_path(@claim), alert: 'Cannot certify a claim in submitted state' if @claim.submitted?
+  end
 
   def build_certification
     @certification = Certification.new(claim: @claim)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,7 +34,7 @@ class Ability
         can [:index, :create], Document
         can [:index, :new, :create], ExternalUser
         can [:show, :change_password, :update_password, :edit, :update, :destroy], ExternalUser, provider_id: persona.provider_id
-        can [:show, :create], Certification
+        can [:show, :create, :update], Certification
       else
         can [:create], ClaimIntention
         can [:index, :outstanding, :authorised, :archived, :new, :create], Claim::BaseClaim
@@ -48,7 +48,7 @@ class Ability
           end
         end
         can [:index, :create], Document
-        can [:show, :create], Certification
+        can [:show, :create, :update], Certification
         can [:show, :change_password, :update_password], ExternalUser, id: persona.id
       end
     elsif persona.is_a? CaseWorker

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,7 @@ Rails.application.routes.draw do
       get 'archived',         on: :collection
       patch 'clone_rejected', to: 'claims#clone_rejected', on: :member
 
-      resource :certification, only: [:new, :create]
+      resource :certification, only: [:new, :create, :update]
     end
 
     namespace :admin do

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
       end
     end
   end
+
+  describe 'PATCH #update' do
+    it 'should redirect to claim path with a flash message' do
+      claim = create(:claim)
+      patch :update, { claim_id: claim }
+      expect(response).to redirect_to(external_users_claim_path(claim))
+      expect(flash[:alert]).to eq 'Cannot certify a claim in submitted state'
+    end
+  end
 end
 
 


### PR DESCRIPTION
This handles the case where users may attempt to certify an already certified and submitted claim.
