### PR TITLE
Refactor Claim ownership for AGFS/LGFS

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -76,7 +76,7 @@ module Claim
     belongs_to :creator, foreign_key: 'creator_id', class_name: 'ExternalUser'
     belongs_to :case_type
 
-    delegate   :provider_id, to: :external_user
+    delegate   :provider_id, :provider, to: :creator
 
     has_many :case_worker_claims,       foreign_key: :claim_id, dependent: :destroy
     has_many :case_workers,             through: :case_worker_claims

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -27,12 +27,18 @@ class BaseValidator < ActiveModel::Validator
     @record.__send__(attribute).nil?
   end
 
+  def attr_blank?(attribute)
+    @record.__send__(attribute).blank?
+  end
+
   def validate_presence(attribute, message)
     add_error(attribute, message) if @record.__send__(attribute).blank?
   end
 
   def validate_absence(attribute, message)
-    add_error(attribute, message) unless attr_nil?(attribute)
+    unless attr_nil?(attribute)
+      add_error(attribute, message) unless attr_blank?(attribute)
+    end
   end
 
   def validate_pattern(attribute, pattern, message)

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -1,10 +1,5 @@
 class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
 
-  def validate_external_user
-    super if defined?(super)
-    validate_has_role(@record.external_user, :advocate, :external_user, 'must have advocate role')
-  end
-
   def validate_creator
     super if defined?(super)
     validate_has_role(@record.creator.try(:provider), :agfs, :creator, 'must be from a provider with permission to submit AGFS claims')
@@ -19,4 +14,15 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
     validate_presence(:offence, "blank") unless fixed_fee_case?
   end
 
+  # ALWAYS required/mandatory
+  def validate_external_user_id
+    validate_presence(:external_user, "blank")
+    validate_has_role(@record.external_user, :advocate, :external_user, 'must have advocate role') unless @record.external_user.nil?
+    unless @record.errors.key?(:external_user)
+      unless @record.creator_id == @record.external_user_id || @record.creator.try(:provider) == @record.external_user.try(:provider)
+        @record.errors[:external_user] << 'Creator and advocate must belong to the same provider'
+      end
+      
+    end
+  end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -25,7 +25,7 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def self.mandatory_fields
     [
-    :external_user,
+    :external_user_id,
     :creator,
     :amount_assessed,
     :evidence_checklist_ids
@@ -37,16 +37,6 @@ class Claim::BaseClaimValidator < BaseValidator
   def validate_total
     unless @record.source == 'api'
       validate_numericality(:total, 0.01, nil, "value claimed must be greater than £0.00")
-    end
-  end
-
-  # ALWAYS required/mandatory
-  def validate_external_user
-    validate_presence(:external_user, "blank")
-    unless @record.errors.key?(:external_user)
-      unless @record.creator_id == @record.external_user_id || @record.creator.try(:provider) == @record.external_user.try(:provider)
-        @record.errors[:external_user] << 'Creator and advocate must belong to the same provider'
-      end
     end
   end
 

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -20,4 +20,9 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
     validate_inclusion(:offence, Offence.miscellaneous.to_a, "invalid")
   end
 
+  # ALWAYS required/mandatory
+  def validate_external_user_id
+    validate_absence(:external_user_id, "present")
+  end
+
 end

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -5,6 +5,7 @@
       .message-left
         .message-container
           .message-body
+            ZZZZZZZZ MESSAGE BODY XXXXXXXX
             = message.body
           .grid-row.message-audit
             .column-half.sender
@@ -22,6 +23,7 @@
       .message-right
         .message-container
           .message-body
+            XXXXXXXX MESSAGE BODY XXXXXXXX
             = message.body
           .grid-row.message-audit
             .column-half.sender

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -2,33 +2,25 @@ FactoryGirl.define do
   factory :litigator_claim, class: Claim::LitigatorClaim do
 
     court
-    case_number { random_case_number }
-    external_user { build :external_user, :litigator }
-    source { 'web' }
-    apply_vat  false
-    offence    { create(:offence, :miscellaneous) } #only miscellaneous offeces valid for LGFS
-    case_type { create(:case_type) }
+    case_number         { random_case_number }
+    creator             { build :external_user, :litigator }
+    external_user       nil
+    source              { 'web' }
+    apply_vat           false
+    offence             { create(:offence, :miscellaneous) } #only miscellaneous offences valid for LGFS
+    case_type           { create(:case_type) }
 
     after(:build) do |claim|
-      # build(:certification, claim: claim) - needed??
       claim.fees << build(:misc_fee, claim: claim) # fees required for valid claims
-      claim.creator = claim.external_user
-      populate_required_fields(claim)
     end
     
 
     factory :unpersisted_litigator_claim do
       court         { build :court }
-      external_user { build :external_user, :litigator, provider: build(:provider, :lgfs) }
+      external_user nil
+      creator       { build :external_user, :litigator, provider: build(:provider, :lgfs) }
       offence       { build :offence, offence_class: build(:offence_class) }
-
-      after(:build) do |claim|
-        build(:certification, claim: claim)
-        claim.defendants << build(:defendant, claim: claim)
-        claim.fees << build(:misc_fee, :with_date_attended, claim: claim)
-        claim.expenses << build(:expense, :with_date_attended, claim: claim, expense_type: build(:expense_type))
-      end
-
     end
   end
 end
+

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -122,7 +122,7 @@ describe Ability do
 
     context 'can manage their own claims' do
       [:show, :show_message_controls, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
-        it { should be_able_to(action, Claim::AdvocateClaim.new(external_user: external_user)) }
+        it { should be_able_to(action, Claim::AdvocateClaim.new(external_user: external_user, creator: external_user)) }
       end
     end
 
@@ -130,7 +130,7 @@ describe Ability do
       let(:other_external_user) { create(:external_user, provider: provider) }
 
       [:show, :show_message_controls, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
-        it { should be_able_to(action, Claim::AdvocateClaim.new(external_user: other_external_user)) }
+        it { should be_able_to(action, Claim::AdvocateClaim.new(external_user: other_external_user, creator: other_external_user)) }
       end
     end
 
@@ -151,7 +151,7 @@ describe Ability do
       let(:other_external_user) { create(:external_user) }
 
       [:show, :show_message_controls, :edit, :update, :confirmation, :clone_rejected, :destroy].each do |action|
-        it { should_not be_able_to(action, Claim::AdvocateClaim.new(external_user: other_external_user)) }
+        it { should_not be_able_to(action, Claim::AdvocateClaim.new(external_user: other_external_user, creator: other_external_user)) }
       end
     end
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
   it { should belong_to(:external_user) }
   it { should belong_to(:creator).class_name('ExternalUser').with_foreign_key('creator_id') }
-  it { should delegate_method(:provider_id).to(:external_user) }
+  it { should delegate_method(:provider_id).to(:creator) }
 
   it { should belong_to(:court) }
   it { should belong_to(:offence) }
@@ -72,6 +72,12 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     let(:external_user) { create(:external_user, provider: provider) }
     let(:same_provider_external_user) { create(:external_user, provider: provider) }
     let(:other_provider_external_user) { create(:external_user, provider: other_provider) }
+
+    it 'should raise error message if no external user is specified' do
+      subject.external_user_id = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:external_user]).to eq( ['blank'] )
+    end
 
     it 'should be valid with the same external_user_id and creator_id' do
       subject.external_user_id = external_user.id

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -51,20 +51,6 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
 
   let(:claim)   { build :unpersisted_litigator_claim }
 
-
-  describe 'validate external user has litigator role' do
-    it 'validates external user with litigator role' do
-      expect(claim.external_user.is?(:litigator)).to be true
-      expect(claim).to be_valid
-    end
-
-    it 'rejects external user without litigator role' do
-      claim.external_user = build :external_user, :advocate, provider: claim.creator.provider
-      expect(claim).not_to be_valid
-      expect(claim.errors[:external_user]).to include('must have litigator role')
-    end
-  end
-
   describe 'validate creator provider is in LGFS fee scheme' do
     it 'rejects creators whose provider is only agfs' do
       claim.creator = build(:external_user, provider: build(:provider, :agfs))
@@ -80,6 +66,14 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
     it 'accepts creators whose provider is both agfs and lgfs' do
       claim.creator = build(:external_user, provider: build(:provider, :agfs_lgfs))
       expect(claim).to be_valid
+    end
+  end
+
+  describe 'external_user_id' do
+    it 'is not valid if present' do
+      claim.external_user_id = 134
+      expect(claim).not_to be_valid
+      expect(claim.errors[:external_user_id]).to eq(['present'])
     end
   end
 

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -12,12 +12,6 @@ describe Claim::LitigatorClaimValidator do
   let(:offence_class) { build(:offence_class, class_letter: 'X', description: 'Offences of dishonesty in Class F where the value in is in excess of £100,000') }
   let(:misc_offence)  { create(:offence, description: 'Miscellaneous/other', offence_class: offence_class) }
 
- context 'external_user' do
-    it 'should error when does not have litigator role' do
-      claim.external_user = advocate
-      should_error_with(claim, :external_user, "must have litigator role")
-    end
-  end
 
   context 'creator' do
     it 'should error when their provider does not have LGFS role' do


### PR DESCRIPTION
Advocate Claims are 'owned" by the external user who must have an advocate role.  Litigator Claims do not have an owner per se,
but do have creators who have a provider.

The provider method on base claim is now delegated to the creator, rather than the external user.

Litigator Claims validate that the external user id is empty.
