### PR TITLE
Handle duplication of claim when using back button to return to form

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -336,6 +336,10 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def create_and_submit
+    if Claim::AdvocateClaim.where(form_id: @claim.form_id).any?
+      redirect_to external_users_claims_path, alert: 'Claim already submitted' and return
+    end
+
     Claim::AdvocateClaim.transaction do
       @claim.save
       @claim.force_validation = true

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -5,9 +5,11 @@ module Claims::Cloner
   included do |klass|
     klass.duplicate_this do
       enable
+
       nullify :last_submitted_at
       nullify :original_submission_date
       nullify :uuid
+
       exclude_association :messages
       exclude_association :case_worker_claims
       exclude_association :case_workers
@@ -19,7 +21,16 @@ module Claims::Cloner
       exclude_association :determinations
       exclude_association :assessment
       exclude_association :redeterminations
+
       clone [:fees, :documents, :defendants, :expenses]
+
+      set form_id: SecureRandom.uuid
+
+      customize(lambda { |original_claim, new_claim|
+        new_claim.documents.each do |d|
+          d.form_id = new_claim.form_id
+        end
+      })
     end
 
     Fee::BaseFee.class_eval do |klass|

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -2,6 +2,7 @@
 FactoryGirl.define do
   factory :claim, class: Claim::AdvocateClaim do
 
+    form_id SecureRandom.uuid
     court
     case_number { random_case_number }
     external_user
@@ -67,7 +68,7 @@ FactoryGirl.define do
       end
 
       trait :without_misc_fee do
-        
+
         after(:build) do |claim|
           claim.misc_fees = []
         end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Claims::Cloner, type: :model do
     end
 
     context 'rejected_claims' do
-      before(:all) do 
+      before(:all) do
         @rejected_claim = create_rejected_claim
         @cloned_claim = @rejected_claim.clone_rejected_to_new_draft
       end
@@ -107,6 +107,16 @@ RSpec.describe Claims::Cloner, type: :model do
       it 'clones the documents' do
         expect(@cloned_claim.documents.count).to eq(1)
         expect(@cloned_claim.documents.count).to eq(@rejected_claim.documents.count)
+
+      end
+
+      it 'generates a new form_id for the cloned claim' do
+        expect(@cloned_claim.form_id).to_not be_blank
+        expect(@cloned_claim.form_id).to_not eq(@rejected_claim.form_id)
+      end
+
+      it 'copies the new form_id to the cloned documents' do
+        expect(@cloned_claim.documents.map(&:reload).map(&:form_id).uniq).to eq([@cloned_claim.form_id])
       end
 
       it 'does not clone determinations - assessments or redeterminations' do


### PR DESCRIPTION
Users can duplicate a claim by using the back button to return to the claim form and submitting again. This solves the issue by using the claim's unique form_id to see if it already exists. The rejected claim cloner now sets a new form_id for cloned claims.
