### PR TITLE
ensure fee type factory never generates a "real" code

### DIFF
--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -162,4 +162,3 @@ class Fee::BaseFeeValidator < BaseValidator
   end
 
 end
-

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -67,7 +67,6 @@ FactoryGirl.define do
       end
 
       trait :without_misc_fee do
-        
         after(:build) do |claim|
           claim.misc_fees = []
         end
@@ -179,7 +178,7 @@ end
 
 # random capital letter followed by random 8 digits
 def random_case_number
-  ('A'..'Z').to_a.shuffle.first << rand(8**8).to_s.rjust(8,'0')
+  ('A'..'Z').to_a.sample << rand(8**8).to_s.rjust(8,'0')
 end
 
 def set_amount_assessed(claim)

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -15,7 +15,6 @@ FactoryGirl.define do
       claim.creator = claim.external_user
       populate_required_fields(claim)
     end
-    
 
     factory :unpersisted_litigator_claim do
       court         { build :court }

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -16,7 +16,7 @@
 FactoryGirl.define do
   factory :basic_fee_type, class: Fee::BasicFeeType do
     sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
-    sequence(:code) { ('A'..'Z').to_a.sample(3).join }
+    code { random_safe_code }
     calculated true
 
     trait :ppe do
@@ -26,7 +26,7 @@ FactoryGirl.define do
     end
 
     trait :npw do
-      description 'Numberof prosecution witnesses'
+      description 'Number of prosecution witnesses'
       code 'NPW'
       calculated false
     end
@@ -34,14 +34,18 @@ FactoryGirl.define do
 
   factory :misc_fee_type, class: Fee::MiscFeeType do
     sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
-    sequence(:code) { ('A'..'Z').to_a.sample(3).join }
+    code { random_safe_code }
     calculated true
   end
 
   factory :fixed_fee_type, class: Fee::FixedFeeType do
     sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
-    sequence(:code) { ('A'..'Z').to_a.sample(3).join }
-    calculated true  
+    code { random_safe_code }
+    calculated true
   end
 end
 
+def random_safe_code
+  # NOTE: use ZXX (zed plus 2 random chars) to ensure we never have a code that will cause inappropriate validations
+  'Z' << ('A'..'Z').to_a.sample(2).join
+end

--- a/spec/factories/offence_classes.rb
+++ b/spec/factories/offence_classes.rb
@@ -14,9 +14,7 @@ FactoryGirl.define do
     sequence(:class_letter)     { |n| letter_hash[n % 11] }
     description { Faker::Lorem.sentence }
   end
-  
 end
-
 
 def letter_hash
   %w{ A B C D E F G H I J K}


### PR DESCRIPTION
The random code generation in the fee type factory could create a code that
would have caused unexpected validations to fire and fail
