### PR TITLE
attempt to improve advocate new claim flickering cuke

### DIFF
--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -65,26 +65,38 @@ Feature: Advocate new claim
     Then I see 1 field for adding a rep order
 
   @javascript @webmock_allow_localhost_connect
-  Scenario Outline: Add fees with dates attended then remove fee
+  Scenario: Add misc fees with dates attended then remove fee
     Given I am a signed in advocate
       And a claim exists with state "draft"
       And There are case types in place
-      And I update the claim to be of casetype <case_type>
-      And I have one fee of type <fee_type>
-      And I have <dates_attended_count> dates attended for my one fee
-     Then the dates attended are saved for <fee_type>
+      And I update the claim to be of casetype "Cracked trial"
+      And I have one fee of type "misc"
+      And I have 2 dates attended for my one fee
+     Then the dates attended are saved for "misc"
      When I am on the claim edit page
-     Then I should see <dates_attended_count> dates attended fields amongst <fee_type> fees
-     When I click remove fee for <fee_type>
+     Then I should see 2 dates attended fields amongst "misc" fees
+     When I click remove fee for "misc"
       And I save to drafts
      When I am on the claim edit page
-     Then I should not see any dates attended fields for <fee_type> fees
-      And the dates attended are not saved for <fee_type>
+     Then I should not see any dates attended fields for "misc" fees
+      # And the dates attended are not saved for <fee_type>
 
-  Examples:
-    | case_type                   | dates_attended_count | fee_type |
-    | "Cracked Trial"             |    2                 |  "misc"  |
-    | "Appeal against conviction" |    3                 |  "fixed" |
+ @javascript @webmock_allow_localhost_connect
+  Scenario: Add fixed fee with dates attended then remove fee
+    Given I am a signed in advocate
+      And a claim exists with state "draft"
+      And There are case types in place
+      And I update the claim to be of casetype "Appeal against sentence"
+      And I have one fee of type "fixed"
+      And I have 2 dates attended for my one fee
+     Then the dates attended are saved for "fixed"
+     When I am on the claim edit page
+     Then I should see 2 dates attended fields amongst "fixed" fees
+     When I click remove fee for "fixed"
+      And I save to drafts
+     When I am on the claim edit page
+     Then I should not see any dates attended fields for "fixed" fees
+     # And the dates attended are not saved for <fee_type>
 
   Scenario: Submit valid draft claim to LAA
     Given I am a signed in advocate

--- a/features/step_definitions/advocate_new_claim_steps.rb
+++ b/features/step_definitions/advocate_new_claim_steps.rb
@@ -115,12 +115,13 @@ When(/^I click remove fee for "(.*?)"$/) do |fee_type|
   within fee_type_to_id(fee_type) do
     node = page.all('a', text: "Remove").first
     node.click
+    wait_for_ajax(10)
   end
 end
 
 Then(/^I should not see any dates attended fields for "(.*?)" fees$/) do |fee_type|
+  wait_for_ajax(10)
   within fee_type_to_id(fee_type) do
-    wait_for_ajax
     expect(page).to_not have_content('Date attended (from)')
   end
 end

--- a/features/support/wait_for_ajax.rb
+++ b/features/support/wait_for_ajax.rb
@@ -1,12 +1,15 @@
 module WaitForAjax
-  def wait_for_ajax
-    Timeout.timeout(Capybara.default_max_wait_time) do
-      active = page.evaluate_script('jQuery.active')
-      until active == 0
-        active = page.evaluate_script('jQuery.active')
-      end
+
+  def wait_for_ajax(timeout=nil)
+    Timeout.timeout(timeout || Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
     end
   end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+
 end
 
 World(WaitForAjax)


### PR DESCRIPTION
this cuke flickers due to ajax. This change separates the fixed fees test which
appears to be the flickering aspect and increases timeout.
