### PR TITLE
Fix cracked at third bug

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -82,7 +82,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # must be final third if case type is cracked before retrial (cannot be first or second third)
   def validate_trial_cracked_at_third
     validate_presence(:trial_cracked_at_third, "blank") if cracked_case?
-    validate_pattern(:trial_cracked_at_third, /^final_third$/, "Case cracked in can only be Final Third for trials that cracked before retrial") if (@record.case_type.name == 'Cracked before retrial' rescue false)
+    validate_pattern(:trial_cracked_at_third, /^Final third$/, 'invalid' ) if (@record.case_type.name == 'Cracked before retrial' rescue false)
   end
 
   def validate_amount_assessed

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -79,10 +79,14 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   # must be present if case type is cracked trial or cracked before retial
+  # must be one of the list of values
   # must be final third if case type is cracked before retrial (cannot be first or second third)
   def validate_trial_cracked_at_third
-    validate_presence(:trial_cracked_at_third, "blank") if cracked_case?
-    validate_pattern(:trial_cracked_at_third, /^Final third$/, 'invalid' ) if (@record.case_type.name == 'Cracked before retrial' rescue false)
+    if cracked_case?
+      validate_presence(:trial_cracked_at_third, "blank")
+      validate_inclusion(:trial_cracked_at_third, Settings.trial_cracked_at_third, 'invalid')
+      validate_pattern(:trial_cracked_at_third, /^final_third$/, 'invalid_case_type_third_combination' ) if (@record.case_type.name == 'Cracked before retrial' rescue false)
+    end
   end
 
   def validate_amount_assessed

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -20,6 +20,6 @@
 
     = f.anchored_label t('.trial_cracked_at_third'), 'trial_cracked_at_third'
     %div.form-group.inline
-      = f.collection_radio_buttons(:trial_cracked_at_third, Settings.trial_cracked_at_third,:humanize, :humanize,) do |b|
-        - b.label(class: "block-label") { b.radio_button + b.value }
+      = f.collection_radio_buttons(:trial_cracked_at_third, Settings.trial_cracked_at_third, :to_s, :humanize) do |b|
+        - b.label(class: "block-label") { b.radio_button + b.text }
     = validation_error_message(@error_presenter, :trial_cracked_at_third)

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -235,6 +235,10 @@ trial_cracked_at_third:
     long: Choose an option for "Case cracked in"
     short: Choose an option
     api:  Choose an option for "Case cracked in"
+  invalid:
+    long: "\"Case cracked in\" can only be Final Third for trials that cracked before retrial"
+    short: Choose Final third
+    api:  "\"Case cracked in\" can only be Final Third for trials that cracked before retrial"
 
 offence:
   _seq: 180

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -236,8 +236,12 @@ trial_cracked_at_third:
     short: Choose an option
     api:  Choose an option for "Case cracked in"
   invalid:
+    long: "Choose a valid option for \"Case cracked in\""
+    short: Choose a valid option
+    api:  "Choose a valid option for \"Case cracked in\""
+  invalid_case_type_third_combination:
     long: "\"Case cracked in\" can only be Final Third for trials that cracked before retrial"
-    short: Choose Final third
+    short: "Choose \"Final third\""
     api:  "\"Case cracked in\" can only be Final Third for trials that cracked before retrial"
 
 offence:

--- a/db/migrate/20160301122625_modify_trial_cracked_at_third_data.rb
+++ b/db/migrate/20160301122625_modify_trial_cracked_at_third_data.rb
@@ -1,0 +1,15 @@
+class ModifyTrialCrackedAtThirdData < ActiveRecord::Migration
+  def up
+    Claim::BaseClaim.where.not(trial_cracked_at_third: nil).each do |claim|
+      clean_trial_cracked_at_third = claim.trial_cracked_at_third.downcase.strip.gsub(/\s/,'_')
+      puts "WARNING: #{clean_trial_cracked_at_third} for claim (id: #{claim.id}) does not match expected value after cleaning" unless Settings.trial_cracked_at_third.include?(clean_trial_cracked_at_third)
+      claim.update_column(:trial_cracked_at_third, clean_trial_cracked_at_third)
+    end
+  end
+
+  def down
+    Claim::BaseClaim.where.not(trial_cracked_at_third: nil).each do |claim|
+      claim.update_column(:trial_cracked_at_third, claim.trial_cracked_at_third.humanize)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160227185548) do
+ActiveRecord::Schema.define(version: 20160301122625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/features/cracked_trial.feature
+++ b/features/cracked_trial.feature
@@ -1,9 +1,10 @@
 Feature: Cracked trial
   Background:
     As an advocate i want to see cracked trial detail fields for
-    cracked trial case types only
+    cracked trial case types only. Submission should validate these.
 
     Given a case type of "Cracked trial" exists
+      And a case type of "Cracked before retrial" exists
       And a case type of "Contempt" exists
 
   @javascript @webmock_allow_localhost_connect
@@ -15,3 +16,18 @@ Feature: Cracked trial
      Then I should see Cracked trial fields
       And I select2 a Case Type of "Contempt"
      Then I should NOT see Cracked trial fields
+
+  @javascript @webmock_allow_localhost_connect
+  Scenario: Cracked before retrial requires final third
+    Given I am a signed in advocate
+      And There are case types in place
+      And certification types are seeded
+      And I am on the new claim page
+      And I select2 a Case Type of "Cracked before retrial"
+      And I fill in cracked trial dates
+      And I choose radio button "First third"
+      And I submit to LAA
+     Then I should see summary error ""Case cracked in" can only be Final Third for trials that cracked before retrial"
+     When I choose radio button "Final third"
+      And I submit to LAA
+     Then I should not see summary error ""Case cracked in" can only be Final Third for trials that cracked before retrial"

--- a/features/step_definitions/cracked_trial_steps.rb
+++ b/features/step_definitions/cracked_trial_steps.rb
@@ -14,3 +14,15 @@ Then(/^I should( not)? see Cracked Trial fields$/i) do |negation|
     expect(page).method(does).call have_content(label_text)
   end
 end
+
+Then(/^I fill in cracked trial dates$/) do
+  fill_in "claim_trial_fixed_notice_at_dd", with: '22'
+  fill_in "claim_trial_fixed_notice_at_mm", with: '05'
+  fill_in "claim_trial_fixed_notice_at_yyyy", with: '2015'
+  fill_in "claim_trial_fixed_at_dd", with: '23'
+  fill_in "claim_trial_fixed_at_mm", with: '05'
+  fill_in "claim_trial_fixed_at_yyyy", with: '2015'
+  fill_in "claim_trial_cracked_at_dd", with: '24'
+  fill_in "claim_trial_cracked_at_mm", with: '05'
+  fill_in "claim_trial_cracked_at_yyyy", with: '2015'
+end

--- a/features/step_definitions/shared/general_form_steps.rb
+++ b/features/step_definitions/shared/general_form_steps.rb
@@ -1,0 +1,13 @@
+Then(/^I choose radio button "(.*?)"$/) do |id_or_label|
+  choose id_or_label
+end
+
+Then(/^I should (not )?see summary error "(.*?)"$/) do |negate, error_message|
+  within '.validation-summary' do
+    if negate
+      expect(page).to_not have_content("#{error_message}")
+    else
+      expect(page).to have_content("#{error_message}")
+    end
+  end
+end


### PR DESCRIPTION
Correct cracked at third validation and data:
- [x] correct validation (inline with existing data)
- [X] apply inclusion validation to prevent bug recurring
- [X] migration to clean existing humanized data

The validation was preventing any submission of cracked before
retrial cases (none existed on gamma til recently??). This probably 
goes back to 10/2015, at least. Possibly caused by the front end
changing the values (as well as presented text) to be humanized.

This fix adds a cracked at third inclusion validation and specs to
prevent recurrence and cleans existing data to match.
