### PR TITLE
wip flickering cuke

### DIFF
--- a/features/advocate_new_claim.feature
+++ b/features/advocate_new_claim.feature
@@ -81,7 +81,8 @@ Feature: Advocate new claim
      Then I should not see any dates attended fields for "misc" fees
       # And the dates attended are not saved for <fee_type>
 
- @javascript @webmock_allow_localhost_connect
+  # TODO: this cuke flickers about one in 5 times
+ @wip @javascript @webmock_allow_localhost_connect
   Scenario: Add fixed fee with dates attended then remove fee
     Given I am a signed in advocate
       And a claim exists with state "draft"


### PR DESCRIPTION
This integration test has been flickering for a long time
and has been wip'd to prevent it necessitating travis reruns.

Its test is somewhat redundant since the same test is applied
to miscellaneus fees - which functionally map closely to fixed
fees.
