### PR TITLE
Clean up headers to partial

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,4 +98,12 @@ module ApplicationHelper
     (current_user.persona.is_a?(ExternalUser) && !@claim.redeterminable?) || message.claim_action.present?
   end
 
+  def your_claims_header
+    if current_user.persona.admin?
+      t('external_users.all_claims')
+    else
+      t('external_users.your_claims')
+    end
+  end
+
 end

--- a/app/views/bug_report/new.html.haml
+++ b/app/views/bug_report/new.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  Help us improve this service
+= render partial: 'layouts/header', locals: {page_heading: 'Help us improve this service'}
 
 %p.medium.questions
   Please tell us about your experience of using this service today.

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  Allocation
+= render partial: 'layouts/header', locals: {page_heading: 'Allocation'}
 
 = form_tag case_workers_admin_allocations_path, method: :get do
 

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  Re-allocation
+= render partial: 'layouts/header', locals: {page_heading: 'Re-allocation'}
 
 .grid-row
   .column-half

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -1,12 +1,11 @@
+= render partial: 'layouts/header', locals: {page_heading: 'Change password'}
+
 - if @case_worker.user.errors.any?
   .validation-summary
     %h3.heading-small= "#{t('.prohibited_save')} #{pluralize(@case_worker.user.errors.count, 'error')}"
     %ul
       - @case_worker.user.errors.full_messages.each do |msg|
         %li= msg
-
-%h1.page-title
-  Change password
 
 = form_for [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path do |f|
   = f.fields_for :user do |user_fields|

--- a/app/views/case_workers/admin/case_workers/edit.html.haml
+++ b/app/views/case_workers/admin/case_workers/edit.html.haml
@@ -1,10 +1,10 @@
+= render partial: 'layouts/header', locals: {page_heading: 'Edit case worker details'}
+
 - if @case_worker.errors.any?
   .validation-summary
     %h3.heading-small= "This case worker has #{pluralize(@case_worker.errors.count, 'error')}"
     %ul
       - @case_worker.errors.full_messages.each do |msg|
         %li= msg
-        
-%h1.page-title Edit case worker details
 
 = render 'form'

--- a/app/views/case_workers/admin/case_workers/index.html.haml
+++ b/app/views/case_workers/admin/case_workers/index.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  Manage case workers
+= render partial: 'layouts/header', locals: {page_heading: 'Manage case workers'}
 
 .grid-row
   .column-half

--- a/app/views/case_workers/admin/case_workers/new.html.haml
+++ b/app/views/case_workers/admin/case_workers/new.html.haml
@@ -5,6 +5,6 @@
       - @case_worker.errors.full_messages.each do |msg|
         %li= msg
 
-%h1.page-title New case worker details
+= render partial: 'layouts/header', locals: {page_heading: 'New case worker details'}
 
 = render 'form'

--- a/app/views/case_workers/admin/case_workers/show.html.haml
+++ b/app/views/case_workers/admin/case_workers/show.html.haml
@@ -1,5 +1,5 @@
-%h1.page-title
-  = 'Your account'
+= render partial: 'layouts/header', locals: {page_heading: 'Your account'}
+
 
 .grid-row.basic-info-row
   .column-quarter

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -1,5 +1,4 @@
-%h1
-  = t('.h1_managment_info')
+= render partial: 'layouts/header', locals: {page_heading: t('.h1_managment_info')}
 
 .form.fieldset.label
   = label_tag t('.all_claims_report')

--- a/app/views/case_workers/claims/archived.html.haml
+++ b/app/views/case_workers/claims/archived.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  = t('.archived_claims')
+= render partial: 'layouts/header', locals: {page_heading: t('.archived_claims')}
 
 = render partial: 'claims_list'
 = paginate @claims

--- a/app/views/case_workers/claims/index.html.haml
+++ b/app/views/case_workers/claims/index.html.haml
@@ -1,6 +1,4 @@
-%header.main-header{role: 'banner'}
-  %h1
-    = t('.your_claims')
+= render partial: 'layouts/header', locals: {page_heading: t('.your_claims')}
 
 = render partial: 'claims_list'
 = paginate @claims

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend confirmation instructions</h2>
+= render partial: 'layouts/header', locals: {page_heading: 'Resend confirmation instructions'}
 
 <%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.error_notification %>

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  Change your password
+= render partial: 'layouts/header', locals: {page_heading: 'Change your password'}
 
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
   = f.error_notification

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  Forgot your password?
+= render partial: 'layouts/header', locals: {page_heading: 'Forgot your password?'}
 
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
   - if resource.errors.any?

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  = "Sign in"
+= render partial: 'layouts/header', locals: {page_heading: "Sign in"}
 
 = simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }) do |f|
   .form-group

--- a/app/views/errors/internal_server_error.html.haml
+++ b/app/views/errors/internal_server_error.html.haml
@@ -1,2 +1,1 @@
-%h1
-  500 - internal server error
+= render partial: 'layouts/header', locals: {page_heading: '500 - internal server error'}

--- a/app/views/errors/not_found.html.haml
+++ b/app/views/errors/not_found.html.haml
@@ -1,2 +1,1 @@
-%h1
-  404 - not found
+= render partial: 'layouts/header', locals: {page_heading: '404 - not found'}

--- a/app/views/external_users/admin/external_users/change_password.html.haml
+++ b/app/views/external_users/admin/external_users/change_password.html.haml
@@ -4,7 +4,7 @@
     %ul
       - @external_user.user.errors.full_messages.each do |msg|
         %li= msg
-%h1.page-title
+= render partial: 'layouts/header', locals: {page_heading: 'Change password'}
   Change password
 
 = form_for [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path do |f|

--- a/app/views/external_users/admin/external_users/edit.html.haml
+++ b/app/views/external_users/admin/external_users/edit.html.haml
@@ -4,8 +4,7 @@
     %ul
       - @external_user.errors.full_messages.each do |msg|
         %li= msg
-        
-%h1.page-title
-  = t('.edit_advocate')
+
+= render partial: 'layouts/header', locals: {page_heading: t('.edit_advocate')}
 
 = render 'form'

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  = t('.title')
+= render partial: 'layouts/header', locals: {page_heading: t('.title')}
 
 .grid-row
   .column-half

--- a/app/views/external_users/admin/external_users/new.html.haml
+++ b/app/views/external_users/admin/external_users/new.html.haml
@@ -5,7 +5,6 @@
       - @external_user.errors.full_messages.each do |msg|
         %li= msg
 
-%h1.page-title
-  = t('.new_advocate')
+= render partial: 'layouts/header', locals: {page_heading: t('.new_advocate')}
 
 = render 'form'

--- a/app/views/external_users/admin/external_users/show.html.haml
+++ b/app/views/external_users/admin/external_users/show.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  = "Your account"
+= render partial: 'layouts/header', locals: {page_heading: 'Your account'}
 
 .grid-row.basic-info-row
   .column-quarter

--- a/app/views/external_users/admin/providers/edit.html.haml
+++ b/app/views/external_users/admin/providers/edit.html.haml
@@ -8,8 +8,7 @@
     %span.form-hint
       = t('.form_error_hint')
 
-%h1.page-title
-  = "Edit provider details"
+= render partial: 'layouts/header', locals: {page_heading: 'Edit provider details'}
 
 = form_for [:external_users, :admin, @provider], html: { novalidate: true } do |f|
 

--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage provider
+= render partial: 'layouts/header', locals: {page_heading: 'Manage provider'}
 
 .grid-row.basic-info-row
   .column-quarter

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -5,12 +5,10 @@
       - @certification.errors.full_messages.each do |msg|
         %li= msg
 
+= render partial: 'layouts/header', locals: {page_heading: 'Certification'}
 
 = form_for @certification, builder: AdpFormBuilder, url: external_users_claim_certification_path(@claim) do |f|
   %section.certification.normal
-    %h1.page-title
-      Certification
-
     .grid-row
       .column-two-thirds
         %p

--- a/app/views/external_users/claims/authorised.html.haml
+++ b/app/views/external_users/claims/authorised.html.haml
@@ -1,6 +1,6 @@
-%header.main-header
-  %h1
-    = t('.authorised_claims')
+= render partial: 'layouts/header', locals: {page_heading: t('.authorised_claims')}
+
+.container.sub-header
   .hgroup
     %h2
       = "#{@claims.size} of #{@claims.total_count}"

--- a/app/views/external_users/claims/edit.html.haml
+++ b/app/views/external_users/claims/edit.html.haml
@@ -1,4 +1,3 @@
-%h1.page-title
-  = t('.edit')
+= render partial: 'layouts/header', locals: {page_heading: t('.edit')}
 
 = render 'form'

--- a/app/views/external_users/claims/index.html.haml
+++ b/app/views/external_users/claims/index.html.haml
@@ -1,9 +1,5 @@
-%header.main-header{role: 'banner'}
-  %h1
-    - if current_user.persona.admin?
-      = t('.all_claims')
-    - else
-      = t('.your_claims')
+= render partial: 'layouts/header', locals: {page_heading: your_claims_header}
+
 .container.sub-header
   .financial-summary
     = render partial: 'financial_summary', locals: { financial_summary: @financial_summary }

--- a/app/views/external_users/claims/new.html.haml
+++ b/app/views/external_users/claims/new.html.haml
@@ -1,5 +1,3 @@
-%header.main-header{role: 'banner'}
-  %h1
-    =t('.heading')
+= render partial: 'layouts/header', locals: {page_heading: t('.heading')}
 
 = render 'form'

--- a/app/views/external_users/claims/outstanding.html.haml
+++ b/app/views/external_users/claims/outstanding.html.haml
@@ -1,6 +1,6 @@
-%header.main-header
-  %h1
-    = t('.heading')
+= render partial: 'layouts/header', locals: {page_heading: t('.heading')}
+
+.container.sub-header
   .hgroup
     %h2
       = "#{@claims.size} of #{@claims.total_count}"

--- a/app/views/feedback/new.html.haml
+++ b/app/views/feedback/new.html.haml
@@ -1,5 +1,5 @@
-%h1.page-title
-  Help us improve this service
+= render partial: 'layouts/header', locals: {page_heading: 'Help us improve this service'}
+
 %p.medium.questions
   We will use your answers to the questions below to help us build a better service.
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -225,7 +225,11 @@
 
     <div id="content">
       <main class="main-content">
-        <h1 class="page-title">Interactive API Documentation</h2>
+        <header class="main-header" role="banner">
+          <h1>
+            Interactive API Documentation
+          </h1>
+        </header>
         <div id="message-bar" class="swagger-ui-wrap">
           &nbsp;
         </div>

--- a/app/views/json_template/index.html.haml
+++ b/app/views/json_template/index.html.haml
@@ -1,4 +1,4 @@
-%h1 Our current JSON schema
+= render partial: 'layouts/header', locals: {page_heading: 'Our current JSON schema'}
 %h3 Given below is the JSON schema that can be used to validate your JSON documents.
 %p
   != ap @schema

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,0 +1,3 @@
+%header.main-header{role: 'banner'}
+  %h1
+    = page_heading

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -8,7 +8,7 @@
           = link_to 'Add a provider', new_super_admins_provider_path, class: cp(new_super_admins_provider_path)
       - elsif current_user.persona.is_a?(ExternalUser)
         %li
-          = link_to "#{current_user.persona.admin? ? 'All' : 'Your'} claims", external_users_root_path, class: cp(external_users_root_path)
+          = link_to your_claims_header, external_users_root_path, class: cp(external_users_root_path)
         %li
           = link_to "Archive", archived_external_users_claims_path, title: "View archived claims", class: cp(archived_external_users_claims_path)
         - if Rails.host.api_sandbox?

--- a/app/views/pages/api_landing.html.haml
+++ b/app/views/pages/api_landing.html.haml
@@ -1,8 +1,8 @@
-%section.api-documentation
-  %h1.page-title
-    Claim for crown court defence API
+= render partial: 'layouts/header', locals: {page_heading: 'Claim for crown court defence API'}
 
-  %h3
+%section.api-documentation
+
+  %h2
     Overview
 
   %p
@@ -13,7 +13,7 @@
   %p
     The API only submits draft claims. The end user then logs on to the "Claim for crown court defence" system to review the claim, upload documentary evidence, and submit the claim to the Legal Aid Agency.
 
-  %h3
+  %h2
     Release notes
 
   %p
@@ -21,13 +21,13 @@
     = link_to "publish release notes", api_release_notes_path
     \.
 
-  %h3
+  %h2
     Documentation
 
   %p
     The API exposes a number of HTTP endpoints which accept JSON formatted input to create a claim. We’ve provided #{link_to 'detailed interactive documentation', grape_swagger_rails_path}, allowing developers to try out the API from a browser.
 
-  %h3
+  %h2
     A note on authentication
   %p
     To authenticate a request to any endpoint you will need to provide an API key.  To get an API key, you’ll need to #{link_to "sign up", new_registration_path('user')}. The claim endpoint also requires the following:
@@ -85,13 +85,13 @@
           %li
             fee or expense id required for dates attended
 
-  %h3
+  %h2
     JSON file importer
 
   %p
     The web application provides a claim importer facility that can be used to create one or more claims (per upload). The file must follow the #{link_to "JSON schema definition", json_schema_path}.
 
-  %h3
+  %h2
     API versioning
 
   %p
@@ -105,7 +105,7 @@
   %p
     We will always signal non-backwards-compatible versions by changing the first digit of the version number, eg moving from 1.5.8 to 2.0.0.  When this happens, we will run the two versions at the same time and always give 6 months’ notice before we stop supporting an old deprecated version.
 
-  %h3
+  %h2
     Sign up as a software vendor
 
   %p
@@ -117,7 +117,7 @@
   %p
     = link_to "Sign up", new_registration_path('user'), class: 'button'
 
-  %h3
+  %h2
     Example Desktop Application
 
   %p
@@ -125,7 +125,7 @@
   %p
     We’ll try to keep this application up to date with any changes to the API so it can submit basic claims
 
-  %h3
+  %h2
     API Sandbox - Testing Environment
   %p
     The Interactive API button below will take you to our interactive API testing page where you can create claims and their sub-components, retrieve lookup data needed to create components, and view responses from the various API endpoints.

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -1,22 +1,21 @@
-%section.api-documentation
-  %h1.page-title
-    API release notes
+= render partial: 'layouts/header', locals: {page_heading: 'API release notes'}
 
-  %h3
+%section.api-documentation
+  %h2
     July 2015
 
   %ul.list-bullet
     %li
       created
 
-  %h3
+  %h2
     October 2015
 
   %ul.list-bullet
     %li
       first significant release
 
-  %h3
+  %h2
     February 2016
 
   %ul.list-bullet

--- a/app/views/pages/tandcs.haml
+++ b/app/views/pages/tandcs.haml
@@ -1,8 +1,6 @@
+= render partial: 'layouts/header', locals: {page_heading: 'THE “CLAIM FOR CROWN COURT DEFENCE” APPLICATION TERMS OF USE'}
 
 %section.tandcs
-  %p
-    %h2.section-title
-      THE “CLAIM FOR CROWN COURT DEFENCE” APPLICATION TERMS OF USE
   %p
     %h3.section-title
       1. INTRODUCTION
@@ -84,7 +82,7 @@
   %p
     %b data
     means as defined in the Data Protection Act 1998.
-  
+
   %p
     %b
       data controller 
@@ -654,7 +652,7 @@
     cookies being stored on your computer in future, please refer to your
     browser manufacturer’s instructions by clicking "Help"
     in your browser menu. You can find out more about deleting or
-    controlling cookies at 
+    controlling cookies at
     = link_to 'www.AboutCookies.org', 'http://www.AboutCookies.org', rel: 'external'
     \.
     Please note: if you delete our cookies or disable future cookies you

--- a/app/views/super_admins/admin/super_admins/change_password.html.haml
+++ b/app/views/super_admins/admin/super_admins/change_password.html.haml
@@ -1,7 +1,4 @@
-%h1.page-title
-  Manage super administrators
-%h2
-  Change password
+= render partial: 'layouts/header', locals: {page_heading: 'Change password'}
 
 = form_for [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path do |f|
   - if @super_admin.user.errors.any?
@@ -21,4 +18,3 @@
       = user_fields.password_field :password_confirmation, class: "form-control"
 
   = f.submit t(".submit"), class: "button"
-

--- a/app/views/super_admins/admin/super_admins/edit.html.haml
+++ b/app/views/super_admins/admin/super_admins/edit.html.haml
@@ -1,4 +1,3 @@
-%h1.page-title Manage super administrators
-%h2 Edit super administrator details
+= render partial: 'layouts/header', locals: {page_heading: 'Edit super administrator details'}
 
 = render 'form'

--- a/app/views/super_admins/admin/super_admins/show.html.haml
+++ b/app/views/super_admins/admin/super_admins/show.html.haml
@@ -1,7 +1,5 @@
-%h1.page-title Manage super administrators
+= render partial: 'layouts/header', locals: {page_heading: 'Your account'}
 
-%h2
-  = @super_admin.email
 
 %p
   Name:

--- a/app/views/super_admins/external_users/change_password.html.haml
+++ b/app/views/super_admins/external_users/change_password.html.haml
@@ -1,5 +1,4 @@
-%h1.page-title
-  Manage users
+= render partial: 'layouts/header', locals: {page_heading: 'Manage users'}
 %h2
   = "Change password for #{@external_user.name}"
 
@@ -19,4 +18,3 @@
       = user_fields.password_field :password_confirmation, class: "form-control"
 
   = f.submit t(".submit"), class: "button"
-

--- a/app/views/super_admins/external_users/edit.html.haml
+++ b/app/views/super_admins/external_users/edit.html.haml
@@ -1,4 +1,5 @@
-%h1.page-title Manage users
+= render partial: 'layouts/header', locals: {page_heading:  'Manage users'}
+
 %h2 Edit user details
 
 = render 'form'

--- a/app/views/super_admins/external_users/index.html.haml
+++ b/app/views/super_admins/external_users/index.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage users
+= render partial: 'layouts/header', locals: {page_heading: 'Manage Users'}
 %h2.heading-medium.left
   = "Users in #{@provider.name}"
 

--- a/app/views/super_admins/external_users/new.html.haml
+++ b/app/views/super_admins/external_users/new.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage users
+= render partial: 'layouts/header', locals: {page_heading: 'Manage users'}
 %h2
   = "New user details for #{@provider.name}"
 

--- a/app/views/super_admins/external_users/show.html.haml
+++ b/app/views/super_admins/external_users/show.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage users
+= render partial: 'layouts/header', locals: {page_heading: 'Manage users'}
 
 %h2
   = @external_user.email

--- a/app/views/super_admins/providers/edit.html.haml
+++ b/app/views/super_admins/providers/edit.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage providers
+= render partial: 'layouts/header', locals: {page_heading: 'Manage providers'}
 
 %h2 Edit provider details
 

--- a/app/views/super_admins/providers/index.html.haml
+++ b/app/views/super_admins/providers/index.html.haml
@@ -1,7 +1,7 @@
 .grid-row
   .column-two-thirds
-    %h1.page-title
-      Manage providers
+    = render partial: 'layouts/header', locals: {page_heading: 'Manage providers'}
+    
     %h2 #{pluralize(@providers.count, 'provider')}
   .column-third
     = link_to t('.add_a_provider'), new_super_admins_provider_path, class: 'button button-get-started'

--- a/app/views/super_admins/providers/new.html.haml
+++ b/app/views/super_admins/providers/new.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage providers
+= render partial: 'layouts/header', locals: {page_heading: 'Manage providers'}
 
 %h2 New provider details
 

--- a/app/views/super_admins/providers/show.html.haml
+++ b/app/views/super_admins/providers/show.html.haml
@@ -1,4 +1,4 @@
-%h1.page-title Manage providers
+= render partial: 'layouts/header', locals: {page_heading: 'Manage providers'}
 
 %h2
   = @provider.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -321,6 +321,8 @@ en:
           api_key: *api_key
           vat_registered: *vat_registered
           form_error_hint: 'Check below for more detail'
+    all_claims: All claims
+    your_claims: Your claims
     certifications:
       new:
         certified_by: 'Name of person certifying'
@@ -492,8 +494,6 @@ en:
         total_authorised: 'Total authorised:'
         view_details: 'View details'
       index:
-        all_claims: All claims
-        your_claims: Your claims
         claims: Claims
         completed: Completed
         draft: Draft

--- a/features/step_definitions/api_documentation_steps.rb
+++ b/features/step_definitions/api_documentation_steps.rb
@@ -20,7 +20,7 @@ When(/^I click on the API Sign up and Documentation link$/) do
 end
 
 Then(/^I should be directed to the API landing page$/) do
-  expect(find('.page-title')).to have_content('Claim for crown court defence API')
+  expect(find('.main-header')).to have_content('Claim for crown court defence API')
 end
 
 When(/^I visit the Interactive API Documentation page$/) do
@@ -42,11 +42,11 @@ When(/^I click the link to the Interactive API Documentation$/) do
 end
 
 Then(/^I should be directed to the Interactive API Documentation$/) do
-  expect(find('.page-title')).to have_content('Interactive API Documentation')
+  expect(find('.main-header')).to have_content('Interactive API Documentation')
 end
 
 When(/^It should be styled to ADP GDS standards$/) do
-  expect(find('.page-title')).to have_content('Interactive API Documentation')
+  expect(find('.main-header')).to have_content('Interactive API Documentation')
   expect(find('strong.phase-tag')).to have_content(Rails.configuration.send(:phase))
   node = find('#logo').find('img')['src']
   expect(node).to have_content('moj_logo_horizontal_36x246_for_swagger.png')

--- a/features/step_definitions/shared/sign_in_steps.rb
+++ b/features/step_definitions/shared/sign_in_steps.rb
@@ -51,7 +51,7 @@ end
 
 Then(/^I should see an Manage advocates link and it should work$/) do
   find('#primary-nav').click_link('Manage users')
-  expect(find('h1.page-title')).to have_content('Manage users')
+  expect(find('header.main-header')).to have_content('Manage users')
 end
 
 Given(/^I sign out$/) do


### PR DESCRIPTION
Standardise the markup used for page headers. Header partial called on each page that needs it and a new application help was created to determine if an external user should see the text (All claims or Your claims)
