### PR TITLE
Display document and message attachment file sizes

### DIFF
--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -22,10 +22,18 @@ class MessagePresenter < BasePresenter
 
   def download_file_link
     h.concat(
-      h.content_tag :a, "#{message.attachment.original_filename} (#{h.number_to_human_size(message.attachment_file_size)})",
+      h.content_tag :a, "#{attachment_file_name} (#{attachment_file_size})",
       href: "/messages/#{message.id}/download_attachment",
-      title: 'Download '+ message.attachment.original_filename
+      title: 'Download '+ attachment_file_name
     )
+  end
+
+  def attachment_file_name
+    message.attachment.original_filename
+  end
+
+  def attachment_file_size
+    h.number_to_human_size(message.attachment_file_size)
   end
 
   def sender_name

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -22,7 +22,7 @@ class MessagePresenter < BasePresenter
 
   def download_file_link
     h.concat(
-      h.content_tag :a, "#{message.attachment.original_filename}",
+      h.content_tag :a, "#{message.attachment.original_filename} (#{h.number_to_human_size(message.attachment_file_size)})",
       href: "/messages/#{message.id}/download_attachment",
       title: 'Download '+ message.attachment.original_filename
     )

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -16,6 +16,8 @@
         %tr
           %th{scope:'col'}
             = t('.name_of_file')
+          %th{scope:'col'}
+            = t('.file_size')
           %th.numerical{scope:'col'}
             = t('.date_added')
           %th{scope:'col'}
@@ -26,6 +28,8 @@
           %tr
             %td
               = document.document_file_name
+            %td
+              = number_to_human_size(document.document_file_size)
             %td.numerical
               = document.created_at
             %td

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -566,6 +566,7 @@ en:
       existing_evidence: Existing evidence
       no_documents_uploaded: No documents have been uploaded.
       name_of_file: Name of file
+      file_size: File size
       date_added: Date added
       actions: Actions
     summary:


### PR DESCRIPTION
Displays the document file sizes and message attachment file sizes
![screen shot 2016-03-04 at 14 06 18](https://cloud.githubusercontent.com/assets/4628936/13529325/8bae2b0e-e213-11e5-8acb-ade86634ff9a.png)
![screen shot 2016-03-04 at 14 06 08](https://cloud.githubusercontent.com/assets/4628936/13529330/901f35b6-e213-11e5-98cd-0eb12568f210.png)
