### PR TITLE
Demo data fix for case types

### DIFF
--- a/lib/demo_data/claim_generator.rb
+++ b/lib/demo_data/claim_generator.rb
@@ -42,7 +42,7 @@ module DemoData
         evidence_checklist_ids: [],
         source: "web",
         vat_amount: 0.0,
-        case_type: CaseType.all.sample)
+        case_type: CaseType.agfs.sample)
       claim.save!
       puts "Added claim #{claim.id} #{claim.case_type.name} for advocate #{advocate.name}"
       add_defendants(claim)


### PR DESCRIPTION
Ensure demo data AdvocateClaims only uses agfs case types.
