### PR TITLE
Retain visibility of messages section when processing claim

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -47,7 +47,8 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
     end
     @enable_status_change = true
     @message = @claim.messages.build
-    redirect_to case_workers_claim_path(errors: @claim.errors.full_messages)
+    redirect_to case_workers_claim_path(params.slice(:messages).merge(errors: @claim.errors.full_messages))
+    # redirect_to case_workers_claim_path(errors: @claim.errors.full_messages)
   end
 
   private

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -1,4 +1,6 @@
 = form_for(claim, url: case_workers_claim_path(claim), as: :claim) do |f|
+  = hidden_field_tag :messages, 'true'
+
   #claim-status
     %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db)}}
       %thead

--- a/features/claim_history.feature
+++ b/features/claim_history.feature
@@ -21,5 +21,5 @@ Feature: Claim history
      When I visit the claim's case worker detail page
       And I expand the accordion
       And I mark the claim authorised
-      And I expand the accordion
-     Then I should see the state change to authorised reflected in the history
+     Then the messages section should be expanded
+      And I should see the state change to authorised reflected in the history

--- a/features/step_definitions/claim_history_steps.rb
+++ b/features/step_definitions/claim_history_steps.rb
@@ -42,3 +42,7 @@ end
 When(/^I visit the claim's detail page$/) do
   visit external_users_claim_path(@claim)
 end
+
+Then(/^the messages section should be expanded$/) do
+  expect(find(:css, '#panel1')).to be_visible
+end


### PR DESCRIPTION
Upon page reload from claim processing by a case worker (authorising, rejecting etc) the messages section remains open after reload.
