### PR TITLE
WIP: waiting for redis on live server before deploy: Background generation of Management Information report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,11 @@ features/examples/000
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+
+# Ignore Redis database dumps
+/.dump.rdb
+
+# Ignore any stats files that have been generated
+/tmp/stats/*
+/public/stats/*

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'uglifier',                '>= 1.3.0'
 gem 'yaml_db'
 gem 'zendesk_api'  ,       '1.12.1'
 gem 'premailer-rails', '~> 1.9'
+gem 'sidekiq', '~> 4.1'
 
 group :production, :devunicorn do
   gem 'rails_12factor', '0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.1)
+    connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     css_parser (1.3.7)
@@ -389,6 +390,7 @@ GEM
       ffi (>= 0.5.0)
     rdoc (4.2.2)
       json (~> 1.4)
+    redis (3.2.2)
     remotipart (1.2.1)
     request_store (1.3.0)
     responder (0.2.4)
@@ -446,6 +448,10 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    sidekiq (4.1.1)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
     simple_form (3.1.1)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -608,6 +614,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven!
   shoulda-matchers (~> 2.8.0)
+  sidekiq (~> 4.1)
   simple_form (~> 3.1.0)
   simplecov
   simplecov-csv

--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -16,7 +16,7 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
 
   def generate
     ManagemenInformationGenerationJob.perform_later
-    redirect_to case_workers_admin_management_information_url, alert: 'A background job has been scheduled to regenerate the Management Information report'
+    redirect_to case_workers_admin_management_information_url, alert: 'A background job has been scheduled to regenerate the Management Information report.  Please refresh this page in a few minutes.'
   end
 
   private

--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -1,23 +1,28 @@
 require 'csv'
 
 class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::ApplicationController
-  skip_load_and_authorize_resource only: [:index, :report]
-  before_action -> { authorize! :view, :management_information }, only: [:index, :report]
-  before_action :set_claims, only: :report
+  skip_load_and_authorize_resource only: [:index, :download, :generate]
+  before_action -> { authorize! :view, :management_information }, only: [:index, :download, :generate]
 
   def index
-
+    @filename = Stats::ManagementInformationGenerator.current_csv_filename
+    @time_generated = Stats::ManagementInformationGenerator.creation_time(@filename) unless @filename.nil?
   end
 
-  def report
-    respond_to do |format|
-      format.csv { send_data csv_report, filename: "all_claims_report.csv" }
-    end
+  def download
+    @filename = Stats::ManagementInformationGenerator.current_csv_filename
+    send_file @filename, type: 'text/csv; charset=iso-8859-1; header=present'
+  end
+
+  def generate
+    ManagemenInformationGenerationJob.perform_later
+    redirect_to case_workers_admin_management_information_url, alert: 'A background job has been scheduled to regenerate the Management Information report'
   end
 
   private
 
   def csv_report
+    @claims = Claim::BaseClaim.non_draft
     CSV.generate(headers: true) do |csv|
       csv << Settings.claim_csv_headers.map {|header| header.to_s.humanize}
       @claims.each do |claim|
@@ -28,10 +33,6 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
         end
       end
     end
-  end
-
-  def set_claims
-    @claims = Claim::BaseClaim.non_draft
   end
 
 end

--- a/app/jobs/managemen_information_generation_job.rb
+++ b/app/jobs/managemen_information_generation_job.rb
@@ -1,0 +1,7 @@
+class ManagemenInformationGenerationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(*args)
+    Stats::ManagementInformationGenerator.new.run
+  end
+end

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -4,7 +4,7 @@ module Stats
 
   class ManagementInformationGenerator
 
-    STATS_DIR = File.join(Rails.root, 'tmp', 'stats')
+    STATS_DIR = Rails.env.test? ? File.join(Rails.root, 'public', 'stats') : File.join(Rails.root, 'tmp', 'stats')
     PIDFILE_NAME = File.join(STATS_DIR, 'management_information.pid')
 
     def initialize

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -14,9 +14,14 @@ module Stats
 
     def run
       if drop_pidfile_ok?
-        generate_new_report
-        delete_old_reports
-        clean_up_pidfile
+        begin
+          generate_new_report
+          delete_old_reports
+        rescue => err
+          puts "ERROR: #{err.class} - #{err.message}"
+        ensure
+          clean_up_pidfile
+        end
       end
     end
 

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -1,0 +1,38 @@
+require 'csv'
+
+module Stats
+
+  class ManagementInformationGenerator
+
+    def initialize
+      @stats_dir = File.join(Rails.root, 'tmp', 'stats')
+      FileUtils.mkdir @stats_dir unless File.exist?(@stats_dir)
+      @filename = File.join(@stats_dir, "management_information_#{Time.now.strftime('%Y_%m_%d_%H_%M_%S')}.csv")
+    end
+
+    def run
+      generate_new_report
+      delete_old_reports
+    end
+
+  private
+    def delete_old_reports
+      files = Dir["#{@stats_dir}/**/*"] - [ @filename ]
+      FileUtils.rm files
+    end
+
+    def generate_new_report
+      CSV.open(@filename, "wb") do |csv|
+        csv << Settings.claim_csv_headers.map {|header| header.to_s.humanize}
+        Claim::BaseClaim.non_draft.find_each do |claim|
+          ClaimCsvPresenter.new(claim, 'view').present! do |claim_journeys|
+            claim_journeys.each do |claim_journey|
+              csv << claim_journey
+            end
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -4,20 +4,76 @@ module Stats
 
   class ManagementInformationGenerator
 
+    STATS_DIR = File.join(Rails.root, 'tmp', 'stats')
+    PIDFILE_NAME = File.join(STATS_DIR, 'management_information.pid')
+
     def initialize
-      @stats_dir = File.join(Rails.root, 'tmp', 'stats')
-      FileUtils.mkdir @stats_dir unless File.exist?(@stats_dir)
-      @filename = File.join(@stats_dir, "management_information_#{Time.now.strftime('%Y_%m_%d_%H_%M_%S')}.csv")
+      FileUtils.mkdir STATS_DIR unless Dir.exist?(STATS_DIR)
+      @filename = File.join(STATS_DIR, "management_information_#{Time.now.strftime('%Y_%m_%d_%H_%M_%S')}.csv")
     end
 
     def run
-      generate_new_report
-      delete_old_reports
+      if drop_pidfile_ok?
+        generate_new_report
+        delete_old_reports
+        clean_up_pidfile
+      end
+    end
+
+    def self.current_csv_filename
+      files = files = Dir["#{STATS_DIR}/**/*.csv"]
+      files.sort.first           # return the first file, because if there are two, then the second hasn't finished generating
+    end
+
+
+    def self.creation_time(filename)
+      unless filename =~ /management_information_(\d{4})_(\d{2})_(\d{2})_(\d{2})_(\d{2})_(\d{2})\.csv$/
+        raise ArgumentError.new("Invalid filename for management information file: #{filename}")
+      end
+      Time.new($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i)
     end
 
   private
+    def drop_pidfile_ok?
+      if pidfile_exists? 
+        return false if duplicate_job_running?
+        clean_up_pidfile
+      end
+      create_pidfile
+      true
+    end 
+
+    def pidfile_exists?
+      File.exist?(PIDFILE_NAME)
+    end
+
+    def duplicate_job_running?
+      pid = File.read(PIDFILE_NAME).chomp
+      active_process_with_pid?(pid)
+    end
+
+    def clean_up_pidfile
+      FileUtils.rm PIDFILE_NAME
+    end
+
+    def active_process_with_pid?(pid)
+      begin
+        Process.getpgid(pid.to_i)
+        true
+      rescue Errno::ESRCH
+        false
+      end
+    end
+
+    def create_pidfile
+      File.open(PIDFILE_NAME, 'w') do |fp|
+        fp.puts Process.pid
+      end
+    end
+
+
     def delete_old_reports
-      files = Dir["#{@stats_dir}/**/*"] - [ @filename ]
+      files = Dir["#{STATS_DIR}/**/*.csv"] - [ @filename ]
       FileUtils.rm files
     end
 

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -26,12 +26,6 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def supplier_number
-    if external_user.nil?
-       puts ">>>>>>>>>>> EXTERNAM USER NIL +++++++ #{__FILE__}::#{__LINE__} <<<<<<<<<"
-       ap claim
-       puts callback
-       raise "Bang"
-     end
     external_user.supplier_number
   end
 

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -26,6 +26,12 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def supplier_number
+    if external_user.nil?
+       puts ">>>>>>>>>>> EXTERNAM USER NIL +++++++ #{__FILE__}::#{__LINE__} <<<<<<<<<"
+       ap claim
+       puts callback
+       raise "Bang"
+     end
     external_user.supplier_number
   end
 

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -13,9 +13,9 @@
     this page in a few minutes to download the new report'.
   
 
-
-.form.fieldset.label
-= link_to 'Download', case_workers_admin_management_information_download_url(format: :csv), class: "button"
+- unless @filename.nil?
+  .form.fieldset.label
+  = link_to 'Download', case_workers_admin_management_information_download_url(format: :csv), class: "button"
 
 %p 
 

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -1,5 +1,24 @@
 = render partial: 'layouts/header', locals: {page_heading: t('.h1_managment_info')}
 
+- if @filename.nil?
+  %p
+    There is currently no management information report available.  Click the 'Regenerate' button below, and 
+    then refresh this page after a couple of minutes to download the report.
+- else
+  %p
+    The management information report was generated at #{@time_generated.strftime('%a %d %b %Y at %H:%M:%S')}.
+
+  %p
+    Click 'Download' to download this file now, or click 'Regenerate' to generate a more up to date report and refresh 
+    this page in a few minutes to download the new report'.
+  
+
+
 .form.fieldset.label
-  = label_tag t('.all_claims_report')
-= link_to 'Download', case_workers_admin_management_information_report_url(format: :csv), class: "button"
+= link_to 'Download', case_workers_admin_management_information_download_url(format: :csv), class: "button"
+
+%p 
+
+
+.form.fieldset.label
+= link_to 'Regenerate', case_workers_admin_management_information_generate_url, class: "button"

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,5 +51,7 @@ module AdvocateDefencePayments
     config.to_prepare do
       Devise::Mailer.layout "email" # email.haml or email.erb
     end
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,8 @@ Rails.application.routes.draw do
       end
 
       get 'management_information', to: 'management_information#index', as: :management_information
-      get 'management_information/report', to: 'management_information#report', as: :management_information_report
+      get 'management_information/download', to: 'management_information#download', as: :management_information_download
+      get 'management_information/generate', to: 'management_information#generate', as: :management_information_generate
     end
   end
 

--- a/features/management_information.feature
+++ b/features/management_information.feature
@@ -5,6 +5,7 @@ Feature: Management information
     Given I am a signed in case worker admin
 
   Scenario: Download management information as CSV
-    Given I am on the management information page
+   Given There is a CSV file in the stats directory
+     And I am on the management information page
     When I click "Download"
     Then I should have a CSV of the report

--- a/features/step_definitions/management_information_steps.rb
+++ b/features/step_definitions/management_information_steps.rb
@@ -3,5 +3,18 @@ Given(/^I am on the management information page$/) do
 end
 
 Then(/^I should have a CSV of the report$/) do
-  expect(page.driver.response.headers['Content-Disposition']).to include("filename=\"all_claims_report.csv\"")
+  # expect(page.driver.response.headers['Content-Disposition']).to include("filename=\"all_claims_report.csv\"")
+  expect(page.driver.response.headers['Content-Disposition']).to match /filename="management_information_.+\.csv/
 end
+
+
+Given(/^There is a CSV file in the stats directory$/) do
+  dirname = Stats::ManagementInformationGenerator::STATS_DIR
+  FileUtils.mkdir_p(dirname) unless Dir.exist?(dirname)
+  File.open(File.join(dirname, 'management_information_2016_03_02_12_11_10.csv'), 'w') do |fp|
+    fp.puts "dummy,csv,file"
+  end
+end
+
+
+

--- a/spec/models/stats/management_information_generator_spec.rb
+++ b/spec/models/stats/management_information_generator_spec.rb
@@ -8,6 +8,10 @@ module Stats
 
   describe ManagementInformationGenerator do
 
+    before(:all) do
+      FileUtils.mkdir ManagementInformationGenerator::STATS_DIR unless Dir.exist?(ManagementInformationGenerator::STATS_DIR)
+    end
+
     let(:generator)  { ManagementInformationGenerator.new }
     after(:each) do
       remove_pidfile

--- a/spec/models/stats/management_information_generator_spec.rb
+++ b/spec/models/stats/management_information_generator_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+require 'support/database_housekeeping'
+
+
+include DatabaseHousekeeping
+
+module Stats
+
+  describe ManagementInformationGenerator do
+
+    let(:generator)  { ManagementInformationGenerator.new }
+    after(:each) do
+      remove_pidfile
+    end
+
+
+    context 'prevent duplication of running jobs' do
+      it 'runs ok if no pidfile present' do
+        remove_pidfile
+        expect(generator).to receive(:generate_new_report)
+        expect(generator).to receive(:delete_old_reports)
+        expect(generator).to receive(:clean_up_pidfile)
+        
+        generator.run
+      end
+
+      it 'runs ok if pidfile present but no process with that pid' do
+        remove_pidfile
+        create_pidfile_with_pid(988773)
+        expect(generator).to receive(:generate_new_report)
+        expect(generator).to receive(:delete_old_reports)
+        expect(generator).to receive(:clean_up_pidfile).exactly(2)
+        
+        generator.run
+      end
+
+      it 'does not run if pidfile present and process with that pid' do
+        remove_pidfile
+        create_pidfile_with_pid(Process.pid)
+        expect(generator).not_to receive(:generate_new_report)
+        expect(generator).not_to receive(:delete_old_reports)
+        expect(generator).not_to receive(:clean_up_pidfile)
+
+        generator.run
+      end
+    end
+
+    def remove_pidfile
+      pidfile_name
+      FileUtils.rm(pidfile_name) if File.exist?(pidfile_name)
+    end
+
+    def pidfile_name
+      File.join(Rails.root, 'tmp', 'stats', 'management_information.pid')
+    end
+
+    def create_pidfile_with_pid(pid)
+      File.open(pidfile_name, 'w') do |fp|
+        fp.puts pid.to_s
+      end
+    end
+
+
+
+    describe '.current_csv_filename' do
+      before(:each) do
+        clear_files
+      end
+
+      after(:each) do
+        clear_files
+      end
+
+
+      it 'returns the name of the ony csv file in the tmp/stats directory' do
+        create_files('abc_9.csv', 'abc_1.txt')
+        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'tmp', 'stats', 'abc_9.csv'))
+      end
+      
+      it 'returns the name of the first csv file in the tmp/stats directory' do
+        create_files('abc_9.csv', 'abc_6.csv', 'abc_1.txt')
+        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'tmp', 'stats', 'abc_6.csv'))
+      end
+
+      def create_files(*filenames)
+        filenames.each do |filename|
+          FileUtils.touch File.join(Rails.root, 'tmp', 'stats', filename)
+        end
+      end
+
+      def clear_files
+        files = Dir["#{Rails.root}/tmp/stats/*.csv"]
+        FileUtils.rm files
+      end
+    end
+
+    describe '.creation_time' do
+      it 'returns the time parsed from the filename' do
+        filename = '/tmp/stats/management_information_2016_03_01_23_55_59.csv'
+        expected_time = Time.new(2016, 3, 1, 23, 55, 59)
+        expect(ManagementInformationGenerator.creation_time(filename)).to eq expected_time
+      end
+
+      it 'raises if invalid filename' do
+        filename = '/tmp/stats/abd_1.txt'
+        expect{ 
+          ManagementInformationGenerator.creation_time(filename)
+          }.to raise_error ArgumentError, 'Invalid filename for management information file: /tmp/stats/abd_1.txt'
+      end
+    end
+   
+    context 'data generation' do
+      before(:all) do
+        create :allocated_claim
+        create :authorised_claim
+        create :part_authorised_claim
+        create :draft_claim
+        execution_time = Time.new(2016, 3, 10, 11, 44, 55) 
+        Timecop.freeze(execution_time) do
+          ManagementInformationGenerator.new.run
+        end   
+      end
+
+      after(:all) do
+        clean_database
+        FileUtils.rm expected_filename
+      end
+
+      it 'creates a file in the tmp/stats directory' do
+        expect(File.exist?(expected_filename)).to be true
+      end
+
+      it 'creates a file with a header line and one line for each submitted claim' do
+        lines = File.readlines(expected_filename)
+        expect(lines.size).to eq 4
+      end
+
+      def expected_filename
+        "#{Rails.root}/tmp/stats/management_information_2016_03_10_11_44_55.csv"
+      end
+    end
+  end
+end

--- a/spec/models/stats/management_information_generator_spec.rb
+++ b/spec/models/stats/management_information_generator_spec.rb
@@ -55,7 +55,7 @@ module Stats
     end
 
     def pidfile_name
-      File.join(Rails.root, 'tmp', 'stats', 'management_information.pid')
+      File.join(Rails.root, 'public', 'stats', 'management_information.pid')
     end
 
     def create_pidfile_with_pid(pid)
@@ -76,40 +76,40 @@ module Stats
       end
 
 
-      it 'returns the name of the ony csv file in the tmp/stats directory' do
+      it 'returns the name of the ony csv file in the public/stats directory' do
         create_files('abc_9.csv', 'abc_1.txt')
-        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'tmp', 'stats', 'abc_9.csv'))
+        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'public', 'stats', 'abc_9.csv'))
       end
       
-      it 'returns the name of the first csv file in the tmp/stats directory' do
+      it 'returns the name of the first csv file in the public/stats directory' do
         create_files('abc_9.csv', 'abc_6.csv', 'abc_1.txt')
-        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'tmp', 'stats', 'abc_6.csv'))
+        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'public', 'stats', 'abc_6.csv'))
       end
 
       def create_files(*filenames)
         filenames.each do |filename|
-          FileUtils.touch File.join(Rails.root, 'tmp', 'stats', filename)
+          FileUtils.touch File.join(Rails.root, 'public', 'stats', filename)
         end
       end
 
       def clear_files
-        files = Dir["#{Rails.root}/tmp/stats/*.csv"]
+        files = Dir["#{Rails.root}/public/stats/*.csv"]
         FileUtils.rm files
       end
     end
 
     describe '.creation_time' do
       it 'returns the time parsed from the filename' do
-        filename = '/tmp/stats/management_information_2016_03_01_23_55_59.csv'
+        filename = '/public/stats/management_information_2016_03_01_23_55_59.csv'
         expected_time = Time.new(2016, 3, 1, 23, 55, 59)
         expect(ManagementInformationGenerator.creation_time(filename)).to eq expected_time
       end
 
       it 'raises if invalid filename' do
-        filename = '/tmp/stats/abd_1.txt'
+        filename = '/public/stats/abd_1.txt'
         expect{ 
           ManagementInformationGenerator.creation_time(filename)
-          }.to raise_error ArgumentError, 'Invalid filename for management information file: /tmp/stats/abd_1.txt'
+          }.to raise_error ArgumentError, 'Invalid filename for management information file: /public/stats/abd_1.txt'
       end
     end
    
@@ -130,7 +130,7 @@ module Stats
         FileUtils.rm expected_filename
       end
 
-      it 'creates a file in the tmp/stats directory' do
+      it 'creates a file in the public/stats directory' do
         expect(File.exist?(expected_filename)).to be true
       end
 
@@ -140,7 +140,7 @@ module Stats
       end
 
       def expected_filename
-        "#{Rails.root}/tmp/stats/management_information_2016_03_10_11_44_55.csv"
+        "#{Rails.root}/public/stats/management_information_2016_03_10_11_44_55.csv"
       end
     end
   end


### PR DESCRIPTION
The management information report was timing out as it is now taking a longer time with the increased number of claims to process.

This PR makes the generation of the job a background task.  The Management Information page shows the date and time the file was last generated and allows you to download the file, or generate a new on (in which case you have to return to the page in a few minutes after the background process has run).

A separate PR will introduce the scheduled generation of this report.
