### PR TITLE
deal with deallocation in MI; revert to submission state

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -23,8 +23,7 @@ class Allocation
     return false unless valid?
     claims.each do |claim|
       claim.case_workers.destroy_all
-      claim.case_workers << case_worker unless deallocating?
-      claim.update_column(:state, claim.last_state_transition.from) if deallocating?
+      deallocating? ? claim.deallocate! : claim.case_workers << case_worker
     end
     true
   end

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -4,7 +4,7 @@ class Claim::BaseClaimPresenter < BasePresenter
   # returns a hash of state as a symbol, and state as a human readable name suitable for use in drop down
   #
   def valid_transitions(options = {include_submitted: true} )
-    states = claim.state_transitions.map(&:to_name) - [:archived_pending_delete]
+    states = claim.state_transitions.map(&:to_name) - [:archived_pending_delete, :deallocated]
     if options[:include_submitted] == false
       states = states - [:submitted]
     end

--- a/app/presenters/claim_history_presenter.rb
+++ b/app/presenters/claim_history_presenter.rb
@@ -24,7 +24,7 @@ class ClaimHistoryPresenter < BasePresenter
   end
 
   def state_transitions
-    claim_state_transitions.reject{ |transition| transition.to == 'draft' }
+    claim_state_transitions.reject{ |transition| transition.to == 'draft' || transition.to == 'deallocated' }
   end
 
   def state_transition_dates

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -84,7 +84,7 @@ FactoryGirl.define do
     # - alphabetical list
     #
     factory :allocated_claim do
-      after(:create) { |c| publicise_errors(c) {c.submit!}; c.allocate!; }
+      after(:create) { |c| publicise_errors(c) {c.submit!}; c.case_workers << create(:case_worker); c.reload; }
     end
 
     factory :archived_pending_delete_claim do

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Claims::StateMachine, type: :model do
         :refused,
         :rejected,
         :redetermination,
-        :submitted
+        :submitted,
+        :deallocated
       ]
     end
 

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -88,6 +88,29 @@ RSpec.describe ClaimCsvPresenter do
         end
 
       end
+
+      context 'deallocation' do
+        let(:claim) { create(:allocated_claim) }
+
+        before {
+          case_worker = claim.case_workers.first
+          claim.case_workers.destroy_all; claim.deallocate!
+          claim.case_workers << case_worker; claim.allocate!
+          claim.case_workers.destroy_all; claim.deallocate!
+        }
+
+        it 'should not be reflected in the MI' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv[0]).not_to include('deallocated')
+          end
+        end
+
+        it 'and the claim should be refelcted as being in the state prior to allocation' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv[0]).to include('submitted')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- deallocated claims were showing up as being allocated in the MI download
- this is because deallocation events were not recorded in claim_state_transitions, and it is claim_state_transitions that are used to generate the MI.
- a transient state of deallocated is used to rectify this
- deallocation should not be shown in the MI though
- I have also elected not to include deallocation in the claim history on the assumption that case workers will not want advocates/litigators to see when a claim is returned to the allocation pool (a backwards steo in terms of claim processing)
