### PR TITLE
Fix flickering tests where random creation of offence class causes in…

### DIFF
--- a/spec/factories/offence_classes.rb
+++ b/spec/factories/offence_classes.rb
@@ -11,11 +11,16 @@
 
 FactoryGirl.define do
   factory :offence_class do
-    sequence(:class_letter)     { |n| letter_hash[n % 11] }
+    sequence(:class_letter)   { generate_random_unused_class_letter }
     description { Faker::Lorem.sentence }
   end
 end
 
-def letter_hash
-  %w{ A B C D E F G H I J K}
+def generate_random_unused_class_letter 
+	existing_class_letters = OffenceClass.pluck(:class_letter)
+	possible_class_letters =  %w{ A B C D E F G H I J K } 
+	available_class_letters = possible_class_letters - existing_class_letters
+	raise "All class letters have been used" if available_class_letters.empty?
+	available_class_letters.sample
 end
+


### PR DESCRIPTION
…termittent failures if the offence class letter already exists
