### PR TITLE
Add vat_registered? and supplier_number methods to the Claim

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -65,6 +65,20 @@ module Claim
     def eligible_fixed_fee_types
       Fee::FixedFeeType.agfs
     end
+
+
+    private
+
+    def provider_delegator
+      if provider.firm?
+        provider
+      elsif provider.chamber?
+        external_user
+      else
+        raise "Unknown provider type: #{provider.provider_type}"
+      end
+    end
+
   end
 end
 

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -333,6 +333,14 @@ module Claim
       self.total + self.vat_amount
     end
 
+    def vat_registered?
+      provider_delegator.vat_registered?
+    end
+
+    def supplier_number
+      provider_delegator.supplier_number
+    end
+
   private
 
     def find_and_associate_documents

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -66,5 +66,12 @@ module Claim
       Fee::FixedFeeType.lgfs
     end
 
+
+    private
+
+    def provider_delegator
+      provider
+    end
+
   end
 end

--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -42,8 +42,8 @@ module Claims::Calculations
   end
 
   def update_vat
-    return if self.external_user.nil?
-    update_column(:apply_vat, self.external_user.vat_registered?) if self.external_user.vat_registered?
+    update_column(:apply_vat, self.vat_registered?) if self.vat_registered?
+
     if self.apply_vat?
       update_column(:vat_amount, calculate_total_vat)
     else

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -57,22 +57,6 @@ class ExternalUser < ActiveRecord::Base
     end
   end
 
-  def supplier_number
-    if provider && provider.firm?
-      provider.supplier_number
-    else
-      read_attribute(:supplier_number)
-    end
-  end
-
-  def vat_registered?
-    if provider && provider.firm?
-      provider.vat_registered?
-    else
-      vat_registered
-    end
-  end
-
   def name_and_number
     "#{self.user.last_name}, #{self.user.first_name}: #{self.supplier_number}"
   end

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -25,10 +25,6 @@ class ClaimCsvPresenter < BasePresenter
     Settings.csv_claim_details.map { |detail| send(detail) }
   end
 
-  def supplier_number
-    external_user.supplier_number
-  end
-
   def claim_state
     unless state == 'archived_pending_delete'
       state

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -36,7 +36,7 @@
       .bold-xsmall
         = t('.adv_acc_no')
       .xsmall
-        = claim.owner.supplier_number
+        = claim.supplier_number
     .column-quarter
       &nbsp;
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1034,6 +1034,67 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
   end
 
+  describe 'provider type dependant methods' do
+    let(:claim) { FactoryGirl.build :unpersisted_claim }
+
+    describe 'for a chamber provider' do
+      before :each do
+        allow(claim.provider).to receive(:provider_type).and_return('chamber')
+      end
+
+      context '#vat_registered?' do
+        it 'returns the value from the external user' do
+          expect(claim.external_user).to receive(:vat_registered?)
+          claim.vat_registered?
+        end
+      end
+
+      context '#supplier_number' do
+        it 'returns the value from the external user' do
+          expect(claim.external_user).to receive(:supplier_number)
+          claim.supplier_number
+        end
+      end
+    end
+
+    describe 'for a firm provider' do
+      before :each do
+        allow(claim.provider).to receive(:provider_type).and_return('firm')
+      end
+
+      context '#vat_registered?' do
+        it 'returns the value from the provider' do
+          expect(claim.provider).to receive(:vat_registered?)
+          claim.vat_registered?
+        end
+      end
+
+      context '#supplier_number' do
+        it 'returns the value from the provider' do
+          expect(claim.provider).to receive(:supplier_number)
+          claim.supplier_number
+        end
+      end
+    end
+
+    describe 'for an unknown provider' do
+      before :each do
+        allow(claim.provider).to receive(:provider_type).and_return('zzzz')
+      end
+
+      context '#vat_registered?' do
+        it 'raises an exception' do
+          expect { claim.vat_registered? }.to raise_error
+        end
+      end
+
+      context '#supplier_number' do
+        it 'raises an exception' do
+          expect { claim.supplier_number }.to raise_error
+        end
+      end
+    end
+  end
 
   describe 'calculate_vat' do
 

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -117,5 +117,19 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
         expect(@claim.eligible_fixed_fee_types).to eq([@fft2])
       end
     end
+
+    describe '#vat_registered?' do
+      it 'returns the value from the provider' do
+        expect(@claim.provider).to receive(:vat_registered?)
+        @claim.vat_registered?
+      end
+    end
+
+    describe '#supplier_number' do
+      it 'returns the value from the provider' do
+        expect(@claim.provider).to receive(:supplier_number)
+        @claim.supplier_number
+      end
+    end
   end
 end

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -140,46 +140,6 @@ RSpec.describe ExternalUser, type: :model do
     end
   end
 
-  describe '#supplier_number' do
-    subject { create(:external_user, provider: provider, supplier_number: 'XY123') }
-
-    context 'when external_user in chamber' do
-      let(:provider) { create(:provider, :chamber, supplier_number: 'AB123') }
-
-      it "returns the external_user's supplier number" do
-        expect(subject.supplier_number).to eq('XY123')
-      end
-    end
-
-    context 'when external_user in firm' do
-      let(:provider) { create(:provider, :firm, supplier_number: 'AB123') }
-
-      it "returns the provider's supplier number" do
-        expect(subject.supplier_number).to eq('AB123')
-      end
-    end
-  end
-
-  describe '#vat_registered?' do
-    subject { create(:external_user, provider: provider, vat_registered: false) }
-
-    context 'when external_user in chamber' do
-      let(:provider) { create(:provider, :chamber, vat_registered: true) }
-
-      it "returns the external_user's VAT registration status" do
-        expect(subject.vat_registered?).to eq(false)
-      end
-    end
-
-    context 'when external_user in firm' do
-      let(:provider) { create(:provider, :firm, vat_registered: true) }
-
-      it "returns the provider's VAT registration status" do
-        expect(subject.vat_registered?).to eq(true)
-      end
-    end
-  end
-
   describe '#name' do
     subject { create(:external_user) }
 

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe ClaimCsvPresenter do
           end
         end
 
-        it 'account number' do
+        it 'supplier number' do
           subject.present! do |claim_journeys|
-            expect(claim_journeys.first).to include(claim.owner.supplier_number)
-            expect(claim_journeys.second).to include(claim.owner.supplier_number)
+            expect(claim_journeys.first).to include(claim.supplier_number)
+            expect(claim_journeys.second).to include(claim.supplier_number)
           end
         end
 
-        it 'organistion/provider_name' do
+        it 'organisation/provider_name' do
           subject.present! do |claim_journeys|
             expect(claim_journeys.first).to include(claim.owner.provider.name)
             expect(claim_journeys.second).to include(claim.owner.provider.name)


### PR DESCRIPTION
Remove the convenience methods from ExternalUser.

The way in which the vat registration status and the supplier number is determined differs between AdvocateClaim and LitigatorClaim.
We need methods on each of the claim submodels to determine the vat registration status and supplier number as follows:
- Advocate Claim
  when provider is chambers, use the value on the external user
  when provider is firm, use the value on the provider
- Litigator Claim
  always use the value on the provider
