### PR TITLE
Fix flickers in specs

### DIFF
--- a/spec/models/case_type_spec.rb
+++ b/spec/models/case_type_spec.rb
@@ -19,6 +19,7 @@
 require 'rails_helper'
 
 describe CaseType do
+  include DatabaseHousekeeping
   it_behaves_like 'roles', CaseType, CaseType::ROLES
 
   context 'parents and children' do
@@ -30,7 +31,7 @@ describe CaseType do
     end
 
     after(:all) do
-      CaseType.delete_all
+      clean_database
     end
 
     describe '.parents' do

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -14,6 +14,7 @@
 require 'rails_helper'
 
 RSpec.describe Disbursement, type: :model do
+  include DatabaseHousekeeping
 
   it { should belong_to(:disbursement_type) }
   it { should belong_to(:claim) }
@@ -40,7 +41,7 @@ RSpec.describe Disbursement, type: :model do
     end
 
     after :all do
-      Claim::BaseClaim.destroy(@claim.id)
+      clean_database
     end
 
     it 'calculates the disbursements total amount' do


### PR DESCRIPTION
Two 'before :all' blocks in specs weren't cleaning up after themselves.
