### PR TITLE
Write Management Information Reports to database

### DIFF
--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -5,34 +5,18 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
   before_action -> { authorize! :view, :management_information }, only: [:index, :download, :generate]
 
   def index
-    @filename = Stats::ManagementInformationGenerator.current_csv_filename
-    @time_generated = Stats::ManagementInformationGenerator.creation_time(@filename) unless @filename.nil?
+    mi_report = Stats::StatsReport.most_recent_management_information
+    @time_generated = mi_report.started_at unless mi_report.nil?
   end
 
   def download
-    @filename = Stats::ManagementInformationGenerator.current_csv_filename
-    send_file @filename, type: 'text/csv; charset=iso-8859-1; header=present'
+    mi_report = Stats::StatsReport.most_recent_management_information
+    send_data mi_report.report, filename: mi_report.download_filename
   end
 
   def generate
     ManagemenInformationGenerationJob.perform_later
     redirect_to case_workers_admin_management_information_url, alert: 'A background job has been scheduled to regenerate the Management Information report.  Please refresh this page in a few minutes.'
-  end
-
-  private
-
-  def csv_report
-    @claims = Claim::BaseClaim.non_draft
-    CSV.generate(headers: true) do |csv|
-      csv << Settings.claim_csv_headers.map {|header| header.to_s.humanize}
-      @claims.each do |claim|
-        ClaimCsvPresenter.new(claim, 'view').present! do |claim_journeys|
-          claim_journeys.each do |claim_journey|
-            csv << claim_journey
-          end
-        end
-      end
-    end
   end
 
 end

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -4,86 +4,22 @@ module Stats
 
   class ManagementInformationGenerator
 
-    STATS_DIR = Rails.env.test? ? File.join(Rails.root, 'public', 'stats') : File.join(Rails.root, 'tmp', 'stats')
-    PIDFILE_NAME = File.join(STATS_DIR, 'management_information.pid')
-
-    def initialize
-      FileUtils.mkdir STATS_DIR unless Dir.exist?(STATS_DIR)
-      @filename = File.join(STATS_DIR, "management_information_#{Time.now.strftime('%Y_%m_%d_%H_%M_%S')}.csv")
-    end
-
     def run
-      if drop_pidfile_ok?
+      unless StatsReport.generation_in_progress?('management_information')
         begin
-          generate_new_report
-          delete_old_reports
+          report_record = Stats::StatsReport.record_start('management_information')
+          report_contents = generate_new_report
+          report_record.write_report(report_contents)
         rescue => err
-          puts "ERROR: #{err.class} - #{err.message}"
-        ensure
-          clean_up_pidfile
+          report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
+          report_record.write_error(report_contents)
         end
       end
     end
 
-    def self.current_csv_filename
-      files = files = Dir["#{STATS_DIR}/**/*.csv"]
-      files.sort.first           # return the first file, because if there are two, then the second hasn't finished generating
-    end
-
-
-    def self.creation_time(filename)
-      unless filename =~ /management_information_(\d{4})_(\d{2})_(\d{2})_(\d{2})_(\d{2})_(\d{2})\.csv$/
-        raise ArgumentError.new("Invalid filename for management information file: #{filename}")
-      end
-      Time.new($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i)
-    end
-
   private
-    def drop_pidfile_ok?
-      if pidfile_exists? 
-        return false if duplicate_job_running?
-        clean_up_pidfile
-      end
-      create_pidfile
-      true
-    end 
-
-    def pidfile_exists?
-      File.exist?(PIDFILE_NAME)
-    end
-
-    def duplicate_job_running?
-      pid = File.read(PIDFILE_NAME).chomp
-      active_process_with_pid?(pid)
-    end
-
-    def clean_up_pidfile
-      FileUtils.rm PIDFILE_NAME
-    end
-
-    def active_process_with_pid?(pid)
-      begin
-        Process.getpgid(pid.to_i)
-        true
-      rescue Errno::ESRCH
-        false
-      end
-    end
-
-    def create_pidfile
-      File.open(PIDFILE_NAME, 'w') do |fp|
-        fp.puts Process.pid
-      end
-    end
-
-
-    def delete_old_reports
-      files = Dir["#{STATS_DIR}/**/*.csv"] - [ @filename ]
-      FileUtils.rm files
-    end
-
     def generate_new_report
-      CSV.open(@filename, "wb") do |csv|
+      csv_string = CSV.generate do |csv|
         csv << Settings.claim_csv_headers.map {|header| header.to_s.humanize}
         Claim::BaseClaim.non_draft.find_each do |claim|
           ClaimCsvPresenter.new(claim, 'view').present! do |claim_journeys|
@@ -93,6 +29,7 @@ module Stats
           end
         end
       end
+      csv_string
     end
 
   end

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: stats_reports
+#
+#  id           :integer          not null, primary key
+#  report_name  :string
+#  report       :string
+#  status       :string
+#  started_at   :datetime
+#  completed_at :datetime
+#
+
+module Stats
+
+  class StatsReport < ActiveRecord::Base
+
+    validates :status, inclusion: { in: %w{ started completed error } }
+
+    default_scope { order('started_at DESC') }
+
+    scope :completed, -> { where(status: 'completed') }
+
+    scope :not_errored, -> { where('status != ?', 'error') }
+
+    scope :management_information, -> { not_errored.where(report_name: 'management_information') }
+
+    def self.most_recent_management_information
+      self.management_information.completed.first
+    end
+
+    def self.generation_in_progress?(report_name)
+      self.where('report_name = ? and status = ?', report_name, 'started').any?
+    end
+
+    def self.record_start(report_name)
+      self.create!(report_name: report_name, status: 'started', started_at: Time.now)
+    end
+
+
+    def write_report(report_contents)
+      update(report: report_contents, status: 'completed', completed_at: Time.now)
+    end
+
+    def write_error(report_contents)
+      update(report: report_contents, status: 'error', completed_at: nil)
+    end
+
+    def download_filename
+      "#{self.report_name}_#{self.started_at.strftime('%Y_%m_%d_%H_%M_%S')}.csv"
+    end
+
+  end
+end

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'layouts/header', locals: {page_heading: t('.h1_managment_info')}
 
-- if @filename.nil?
+- if @time_generated.nil?
   %p
     There is currently no management information report available.  Click the 'Regenerate' button below, and 
     then refresh this page after a couple of minutes to download the report.
@@ -13,7 +13,7 @@
     this page in a few minutes to download the new report'.
   
 
-- unless @filename.nil?
+- unless @time_generated.nil?
   .form.fieldset.label
   = link_to 'Download', case_workers_admin_management_information_download_url(format: :csv), class: "button"
 

--- a/db/migrate/20160314122816_create_stats_reports.rb
+++ b/db/migrate/20160314122816_create_stats_reports.rb
@@ -1,0 +1,12 @@
+class CreateStatsReports < ActiveRecord::Migration
+  def change
+    create_table :stats_reports do |t|
+      t.string :report_name
+      t.string :report
+      t.string :status
+      t.datetime :started_at
+      t.datetime :completed_at
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160310170946) do
+ActiveRecord::Schema.define(version: 20160314122816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -362,6 +362,14 @@ ActiveRecord::Schema.define(version: 20160310170946) do
     t.string   "maat_reference"
     t.date     "representation_order_date"
     t.uuid     "uuid",                      default: "uuid_generate_v4()"
+  end
+
+  create_table "stats_reports", force: :cascade do |t|
+    t.string   "report_name"
+    t.string   "report"
+    t.string   "status"
+    t.datetime "started_at"
+    t.datetime "completed_at"
   end
 
   create_table "super_admins", force: :cascade do |t|

--- a/features/management_information.feature
+++ b/features/management_information.feature
@@ -5,7 +5,7 @@ Feature: Management information
     Given I am a signed in case worker admin
 
   Scenario: Download management information as CSV
-   Given There is a CSV file in the stats directory
+   Given There is a Management Information report in the database
      And I am on the management information page
     When I click "Download"
     Then I should have a CSV of the report

--- a/features/step_definitions/management_information_steps.rb
+++ b/features/step_definitions/management_information_steps.rb
@@ -8,12 +8,8 @@ Then(/^I should have a CSV of the report$/) do
 end
 
 
-Given(/^There is a CSV file in the stats directory$/) do
-  dirname = Stats::ManagementInformationGenerator::STATS_DIR
-  FileUtils.mkdir_p(dirname) unless Dir.exist?(dirname)
-  File.open(File.join(dirname, 'management_information_2016_03_02_12_11_10.csv'), 'w') do |fp|
-    fp.puts "dummy,csv,file"
-  end
+Given(/^There is a Management Information report in the database$/) do
+  FactoryGirl.create :stats_report
 end
 
 

--- a/spec/factories/stats/stats_reports.rb
+++ b/spec/factories/stats/stats_reports.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: stats_reports
+#
+#  id           :integer          not null, primary key
+#  report_name  :string
+#  report       :string
+#  status       :string
+#  started_at   :datetime
+#  completed_at :datetime
+#
+
+FactoryGirl.define do
+  factory :stats_report, class: Stats::StatsReport do
+    report_name 'management_information'
+    report 'report contents'
+    status 'completed'
+    started_at { 2.minutes.ago }
+    completed_at { 2.seconds.ago }
+    
+    trait :incomplete do
+      status 'started'
+      completed_at nil
+    end
+
+    trait :error do
+      status 'error'
+    end
+
+    trait :other_report do
+      report_name 'other_report'
+    end
+  end
+end

--- a/spec/models/stats/management_information_generator_spec.rb
+++ b/spec/models/stats/management_information_generator_spec.rb
@@ -8,111 +8,9 @@ module Stats
 
   describe ManagementInformationGenerator do
 
-    before(:all) do
-      FileUtils.mkdir ManagementInformationGenerator::STATS_DIR unless Dir.exist?(ManagementInformationGenerator::STATS_DIR)
-    end
-
     let(:generator)  { ManagementInformationGenerator.new }
-    after(:each) do
-      remove_pidfile
-    end
 
-
-    context 'prevent duplication of running jobs' do
-      it 'runs ok if no pidfile present' do
-        remove_pidfile
-        expect(generator).to receive(:generate_new_report)
-        expect(generator).to receive(:delete_old_reports)
-        expect(generator).to receive(:clean_up_pidfile)
-        
-        generator.run
-      end
-
-      it 'runs ok if pidfile present but no process with that pid' do
-        remove_pidfile
-        create_pidfile_with_pid(988773)
-        expect(generator).to receive(:generate_new_report)
-        expect(generator).to receive(:delete_old_reports)
-        expect(generator).to receive(:clean_up_pidfile).exactly(2)
-        
-        generator.run
-      end
-
-      it 'does not run if pidfile present and process with that pid' do
-        remove_pidfile
-        create_pidfile_with_pid(Process.pid)
-        expect(generator).not_to receive(:generate_new_report)
-        expect(generator).not_to receive(:delete_old_reports)
-        expect(generator).not_to receive(:clean_up_pidfile)
-
-        generator.run
-      end
-    end
-
-    def remove_pidfile
-      pidfile_name
-      FileUtils.rm(pidfile_name) if File.exist?(pidfile_name)
-    end
-
-    def pidfile_name
-      File.join(Rails.root, 'public', 'stats', 'management_information.pid')
-    end
-
-    def create_pidfile_with_pid(pid)
-      File.open(pidfile_name, 'w') do |fp|
-        fp.puts pid.to_s
-      end
-    end
-
-
-
-    describe '.current_csv_filename' do
-      before(:each) do
-        clear_files
-      end
-
-      after(:each) do
-        clear_files
-      end
-
-
-      it 'returns the name of the ony csv file in the public/stats directory' do
-        create_files('abc_9.csv', 'abc_1.txt')
-        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'public', 'stats', 'abc_9.csv'))
-      end
-      
-      it 'returns the name of the first csv file in the public/stats directory' do
-        create_files('abc_9.csv', 'abc_6.csv', 'abc_1.txt')
-        expect(ManagementInformationGenerator.current_csv_filename).to eq(File.join(Rails.root, 'public', 'stats', 'abc_6.csv'))
-      end
-
-      def create_files(*filenames)
-        filenames.each do |filename|
-          FileUtils.touch File.join(Rails.root, 'public', 'stats', filename)
-        end
-      end
-
-      def clear_files
-        files = Dir["#{Rails.root}/public/stats/*.csv"]
-        FileUtils.rm files
-      end
-    end
-
-    describe '.creation_time' do
-      it 'returns the time parsed from the filename' do
-        filename = '/public/stats/management_information_2016_03_01_23_55_59.csv'
-        expected_time = Time.new(2016, 3, 1, 23, 55, 59)
-        expect(ManagementInformationGenerator.creation_time(filename)).to eq expected_time
-      end
-
-      it 'raises if invalid filename' do
-        filename = '/public/stats/abd_1.txt'
-        expect{ 
-          ManagementInformationGenerator.creation_time(filename)
-          }.to raise_error ArgumentError, 'Invalid filename for management information file: /public/stats/abd_1.txt'
-      end
-    end
-   
+    
     context 'data generation' do
       before(:all) do
         create :allocated_claim
@@ -120,28 +18,33 @@ module Stats
         create :part_authorised_claim
         create :draft_claim
         execution_time = Time.new(2016, 3, 10, 11, 44, 55) 
-        Timecop.freeze(execution_time) do
-          ManagementInformationGenerator.new.run
-        end   
       end
 
       after(:all) do
         clean_database
-        FileUtils.rm expected_filename
       end
 
-      it 'creates a file in the public/stats directory' do
-        expect(File.exist?(expected_filename)).to be true
+      it 'creates a new management information record with a header and 3 lines in the report' do
+        Timecop.freeze(Time.new(2016, 3, 10, 11, 44, 55)) do
+          generator.run
+          expect(StatsReport.count).to eq 1
+          report = StatsReport.first
+          expect(report.started_at).to eq Time.new(2016, 3, 10, 11, 44, 55) 
+          expect(report.status).to eq 'completed'
+          expect(report.report.split("\n").size).to eq 4
+        end
       end
 
-      it 'creates a file with a header line and one line for each submitted claim' do
-        lines = File.readlines(expected_filename)
-        expect(lines.size).to eq 4
+      it 'creates an errored report if exception occurs' do
+        expect(Settings).to receive(:claim_csv_headers).and_raise ArgumentError.new('XXXXXXXX')
+        generator.run
+
+        expect(StatsReport.count).to eq 1
+        report = StatsReport.first
+        expect(report.status).to eq 'error'
+        expect(report.report).to match /^ArgumentError - XXXXXX/
       end
 
-      def expected_filename
-        "#{Rails.root}/public/stats/management_information_2016_03_10_11_44_55.csv"
-      end
     end
   end
 end

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -1,0 +1,106 @@
+# == Schema Information
+#
+# Table name: stats_reports
+#
+#  id           :integer          not null, primary key
+#  report_name  :string
+#  report       :string
+#  status       :string
+#  started_at   :datetime
+#  completed_at :datetime
+#
+
+require 'rails_helper'
+
+module Stats
+
+  describe StatsReport do
+
+    before(:all) do
+      @mi_old = create :stats_report, started_at: 10.days.ago
+      @mi_complete = create :stats_report
+      @mi_incomplete = create :stats_report, :incomplete
+      @other_report = create :stats_report, :other_report
+      @error_report = create :stats_report, :error
+    end
+
+    after(:all) do
+      StatsReport.delete_all
+    end
+
+    it 'returns all management information reports' do
+      results = StatsReport.management_information
+      expect(results.size).to eq 3
+      expect(results).to include(@mi_complete)
+      expect(results).to include(@mi_incomplete)
+      expect(results).to include(@mi_old  )
+    end
+ 
+    it 'returns the latest completed management information report' do
+      expect(StatsReport.most_recent_management_information).to eq @mi_complete
+    end
+
+    describe '.report_generation_in_progress?' do
+      it 'returns true for management information' do
+        expect(StatsReport.generation_in_progress?('management_information')).to be true
+      end
+
+      it 'returns false for other reports' do
+        expect(StatsReport.generation_in_progress?('other_report')).to be false
+      end
+    end
+
+    describe '#download_filename' do
+      it 'generates a filename incorportating the report name and started at time' do\
+        report = build :stats_report, report_name: 'my_new_report', started_at: Time.new(2016, 2, 3, 4, 55, 12)
+        expect(report.download_filename).to eq 'my_new_report_2016_02_03_04_55_12.csv'
+      end
+    end
+
+    describe '.record_start' do
+      it 'creates and incomplete record' do
+        frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
+        Timecop.freeze(frozen_time) do
+          record = StatsReport.record_start('my_new_report')
+          expect(record.report_name).to eq 'my_new_report'
+          expect(record.started_at).to eq frozen_time
+          expect(record.completed_at).to be_nil
+          expect(record.report).to be_nil
+        end
+      end
+    end
+
+    describe '#write_report' do
+      it 'updates with report contents and completed_at time' do
+        frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
+        record = nil
+        Timecop.freeze(frozen_time) do
+          record = StatsReport.record_start('my_new_report')
+        end
+
+        Timecop.freeze(frozen_time + 2.minutes) do
+          record.write_report('The contents of my new report')
+        end
+
+        report = StatsReport.completed.where(report_name: 'my_new_report').first
+        expect(report.report).to eq 'The contents of my new report'    
+        expect(report.started_at).to eq frozen_time
+        expect(report.completed_at).to eq frozen_time + 2.minutes
+      end
+    end
+  end
+end
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
The original method of writing management information reports as a local CSV file on the web server does not work
in a clustered server environment because requests can't be guaranteed to go to one particular server.

This pull requests changes the Management Information report generation and retrieval to use the database instead.
