### PR TITLE
Implement scheduled jobs to run nightly housekeeping tasks.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# dockerignore doesn't implement recursivity yet
+.idea/*/*/*/
+.idea/*/*/
+.idea/*/
+.idea/
+
+/log/*.log
+/log/*.output
+
+/tmp/stats/*.csv
+/tmp/*.log
+
+/coverage/*

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # Ignore all logfiles and tempfiles.
 /log/*.log
+/log/*.output
 /tmp
 
 # ignore simplecov output

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'remotipart',             '~> 1.2'
 gem 'responder',              '~> 0.2.4'
 gem 'rest-client',            '~> 1.8' # needed for scheduled smoke testing plus others
 gem 'sass-rails',             '~> 5.0.0'
+gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.git'
 gem 'susy',	                  '~> 2.2.12'
 gem 'select2-rails',          '~> 3.5.9.3'
 gem 'sentry-raven',           git: 'https://github.com/getsentry/raven-ruby.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,17 @@ GIT
     sentry-raven (0.15.6)
       faraday (>= 0.7.6)
 
+GIT
+  remote: https://github.com/jalkoby/scheduler_daemon.git
+  revision: 3ed40449777383cf38b7c814075c992974add3df
+  specs:
+    scheduler_daemon (1.1.5)
+      activesupport
+      chronic (>= 0.2.0)
+      daemons (>= 1.0.10)
+      eventmachine (>= 0.12.8)
+      rufus-scheduler (~> 2.0.24)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -84,6 +95,7 @@ GEM
       timers (~> 4.0.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     chunky_png (1.3.5)
     climate_control (0.0.3)
       activesupport (>= 3.0)
@@ -131,6 +143,7 @@ GEM
       nokogiri (~> 1.5)
       railties (>= 3, < 5)
     cucumber-wire (0.0.1)
+    daemons (1.2.3)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     descendants_tracker (0.0.4)
@@ -425,6 +438,8 @@ GEM
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
     rubyzip (1.2.0)
+    rufus-scheduler (2.0.24)
+      tzinfo (>= 0.3.22)
     safe_yaml (1.0.4)
     sass (3.4.21)
     sass-rails (5.0.4)
@@ -609,6 +624,7 @@ DEPENDENCIES
   rspec-mocks (~> 3.2.1)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0.0)
+  scheduler_daemon!
   sdoc (~> 0.4.0)
   select2-rails (~> 3.5.9.3)
   selenium-webdriver

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
 
   #Rack livereload for frontend development
-  config.middleware.use Rack::LiveReload
+  config.middleware.use Rack::LiveReload rescue (puts 'Rack::LiveReload not available')
 
   config.action_mailer.perform_deliveries = false
   config.action_mailer.delivery_method = :file

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -80,5 +80,8 @@ esac
 echo "starting redis server"
 service redis-server start
 
+echo "starting scheduler daemon"
+bundle exec scheduler_daemon start
+
 echo "launching unicorn"
-exec bundle exec unicorn -p 80 -c config/unicorn.rb
+bundle exec unicorn -p 80 -c config/unicorn.rb

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,23 @@
+namespace :scheduler do
+
+  desc 'Starts the scheduler daemon in console mode'
+  task :run do
+    sh 'bundle exec scheduler_daemon run'
+  end
+
+  desc 'Starts the scheduler daemon'
+  task :start do
+    sh 'bundle exec scheduler_daemon start'
+  end
+
+  desc 'Stops the scheduler daemon'
+  task :stop do
+    sh 'bundle exec scheduler_daemon stop'
+  end
+
+  desc 'Restarts the scheduler daemon'
+  task :restart do
+    sh 'bundle exec scheduler_daemon restart'
+  end
+
+end

--- a/scheduled_tasks/document_cleaner_task.rb
+++ b/scheduled_tasks/document_cleaner_task.rb
@@ -1,0 +1,15 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class DocumentCleanerTask < Scheduler::SchedulerTask
+
+  every '1d', first_at: Chronic.parse('next 4 am')
+
+  def run
+    log('Document Cleaner started')
+
+    DocumentCleaner.new.clean!
+
+    log('Document Cleaner finished')
+  end
+end

--- a/scheduled_tasks/management_information_generation_task.rb
+++ b/scheduled_tasks/management_information_generation_task.rb
@@ -1,0 +1,17 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class ManagementInformationGenerationTask < Scheduler::SchedulerTask
+
+  # change the frequency once we are sure it is working
+  # every '1d', first_at: Chronic.parse('next 3 am')
+  every '15m'
+
+  def run
+    log('Management Information Generation started')
+
+    Stats::ManagementInformationGenerator.new.run
+
+    log('Management Information Generation finished')
+  end
+end


### PR DESCRIPTION
There are at the moment two nightly housekeeping tasks that need to be scheduled to run everynight, at 3am or so, and they are:
- Management Information Generation
- Document Cleaner

This pull request is to prepare to be able to run this kind of scheduled jobs.
