### PR TITLE
Remove Unused expense types from seed data

### DIFF
--- a/db/seeds/expense_types.rb
+++ b/db/seeds/expense_types.rb
@@ -5,8 +5,6 @@ require Rails.root.join('db','seed_helper')
   'Conference and view - hotel stay',
   'Conference and view - train',
   'Conference and view - travel time',
-  'Costs judge application fee',
-  'Costs judge Preparation award',
   'Travel and hotel - car',
   'Travel and hotel - conference and view',
   'Travel and hotel - hotel stay',


### PR DESCRIPTION
The two Cost Judge expense types in the seed data are not used in real life, and cannot be migrated
as part of the expense type refactor.  This PR removes them from the seed data so that demo data claims
using them is not created.
