### PR TITLE
Allow caseworker to make a redetermination from written reason

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -49,8 +49,6 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
 
   def prepare_show_action
     @claim.assessment = Assessment.new if @claim.assessment.nil?
-    @enable_assessment_input = @claim.assessment.blank? && @claim.state == 'allocated'
-
     @doc_types = DocType.all
     @messages = @claim.messages.most_recent_last
     @message = @claim.messages.build

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -51,7 +51,6 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def show
     @messages = @claim.messages.most_recent_last
     @message = @claim.messages.build
-    @enable_assessment_input = false
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,9 @@
 module ApplicationHelper
 
+  def current_user_is_caseworker?
+      current_user.persona.is_a?(CaseWorker) 
+  end
+
   #
   # Can be called in views in order to instantiate a presenter for a partilcular model
   # following the <Model>Presenter naming convention or, optionally, a named presenter

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -314,6 +314,23 @@ module Claim
       last_state_transition.created_at
     end
 
+    def enable_assessment_input?
+      assessment.blank? && state == 'allocated'
+    end
+
+    def enable_redetermination_input?
+      state == 'allocated' && (opened_for_redetermination? || opened_for_written_reasons?)
+    end
+
+    def enable_determination_input?
+      enable_assessment_input? || enable_redetermination_input? 
+    end
+
+    def opened_for_written_reasons?
+      last_state_transition.from == 'awaiting_written_reasons'
+    end
+
+
     def opened_for_redetermination?
       return true if self.redetermination?
 

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -12,7 +12,7 @@ class Claim::BaseClaimPresenter < BasePresenter
   end
 
   def valid_transitions_for_detail_form
-    if claim.state == "allocated" && !written_reasons_outstanding?
+    if claim.state == "allocated"
       valid_transitions(include_submitted: false)
     else
       nil

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -12,10 +12,10 @@
             - if claim.opened_for_redetermination?
               .form-hint.xsmall include any amount already authorised
       %tbody
-        -if @enable_assessment_input
+        -if current_user_is_caseworker? && @claim.enable_assessment_input?
           = f.fields_for :assessment do |af|
             = render partial: 'determination_fields', locals: { f: af, claim: claim}
-        -elsif current_user.persona.is_a?(CaseWorker) && claim.requested_redetermination? == true
+        -elsif current_user_is_caseworker? && @claim.enable_determination_input?
           = f.fields_for :redeterminations, claim.redeterminations.build do |rf|
             = render partial: 'determination_fields', locals: { f: rf, claim: claim}
         - elsif claim.redeterminations.any?
@@ -23,7 +23,7 @@
         - else
           = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.assessment }
 
-  - if current_user.persona.is_a?(CaseWorker)
+  - if current_user_is_caseworker?
     .js-test-cw-claim-action
       %fieldset.form-group.inline
         %legend.bold-normal.form-label

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -25,7 +25,7 @@
             = message.body
           .grid-row.message-audit
             .column-half.sender
-              - if current_user.persona.is_a?(CaseWorker)
+              - if current_user_is_caseworker?
                 = message.sender_name
               (#{message.sender_persona})
             .column-half.sent

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -8,14 +8,14 @@
         = f.collection_radio_buttons(:claim_action, Settings.claim_actions, :to_s, :to_s) do |b|
           - b.label(class: "block-label") { b.radio_button + b.value.humanize }
 
-  - if advocate_messaging_permitted?(message) || current_user_persona_is?(CaseWorker)
+  - if advocate_messaging_permitted?(message) || current_user_is_caseworker?
     .grid-row.js-test-send-buttons
       .upload-column
         = f.file_field :attachment, class: 'button-secondary', label: false
       .message-column
         = f.input :body, as: :string, placeholder: t('.message_placeholder'), label: false
 
-        - if current_user_persona_is?(CaseWorker) && @claim.written_reasons_outstanding?
+        - if current_user_is_caseworker? && @claim.written_reasons_outstanding?
           .written-reasons-checkbox
             = f.input :written_reasons_submitted, as: :boolean
       .submit-column


### PR DESCRIPTION
When an advocate requests written reasons for a part authorised, refused or rejected
claim, the caseworker currently is not able to assess the claim and authorise.  This PR rectifies
that.
