### PR TITLE
Updating the VAT total on claim save.

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -150,7 +150,7 @@ module Claim
                      :instantiate_assessment,
                      :set_force_validation_to_false
 
-    after_save :find_and_associate_documents
+    after_save :find_and_associate_documents, :update_vat
 
     def ensure_not_abstract_class
       raise BaseClaimAbstractClassError if self.class == BaseClaim

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -60,7 +60,7 @@ module Claims::StateMachine
             :submitted,
             :deallocated
 
-      after_transition on: :submit,                   do: [:set_last_submission_date!, :set_original_submission_date!, :update_vat]
+      after_transition on: :submit,                   do: [:set_last_submission_date!, :set_original_submission_date!]
       after_transition on: :authorise,                do: :set_authorised_date!
       after_transition on: :authorise_part,           do: :set_authorised_date!
       after_transition on: :redetermine,              do: [:remove_case_workers!, :set_last_submission_date!]

--- a/lib/demo_data/litigator_claim_generator.rb
+++ b/lib/demo_data/litigator_claim_generator.rb
@@ -7,7 +7,7 @@ module DemoData
     def generate_claim(litigator)
       claim = Claim::LitigatorClaim.new(
         creator: litigator,
-        external_user: nil,
+        external_user: litigator,
         advocate_category: nil,
         court: Court.all.sample,
         case_type: CaseType.lgfs.sample,

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1313,7 +1313,8 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   end
 
   describe '#amount_assessed' do
-    let!(:claim)  { create(:claim, state: 'draft') }
+    let(:external_user) { build(:external_user, vat_registered: false) }
+    let!(:claim) { create(:claim, state: 'draft', external_user: external_user) }
 
     context 'when VAT applied' do
       # VAT rate 17.5%

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -126,7 +126,12 @@ RSpec.describe Claims::StateMachine, type: :model do
     describe 'make archive_pending_delete valid for 180 days' do
       subject { create(:authorised_claim) }
 
-      it { expect(subject).to receive(:update_column).with(:valid_until, Time.now + 180.days); subject.archive_pending_delete! }
+      it {
+        frozen_time = Time.now
+        Timecop.freeze(frozen_time) { subject.archive_pending_delete! }
+
+        expect(subject.valid_until).to eq(frozen_time + 180.days)
+      }
     end
 
     describe 'make last_submitted_at attribute equal now' do
@@ -173,9 +178,12 @@ RSpec.describe Claims::StateMachine, type: :model do
       before { subject.submit!; subject.allocate! }
 
       it {
-        expect(subject).to receive(:update_column).with(:authorised_at,Time.now)
         subject.assessment.update(fees: 100.00, expenses: 23.45)
-        subject.authorise!
+
+        frozen_time = Time.now + 1.month
+        Timecop.freeze(frozen_time) { subject.authorise! }
+
+        expect(subject.authorised_at).to eq(frozen_time)
       }
     end
 
@@ -183,9 +191,12 @@ RSpec.describe Claims::StateMachine, type: :model do
       before { subject.submit!; subject.allocate! }
 
       it {
-        expect(subject).to receive(:update_column).with(:authorised_at,Time.now)
         subject.assessment.update(fees: 100.00, expenses: 23.45)
-        subject.authorise_part!
+
+        frozen_time = Time.now + 1.month
+        Timecop.freeze(frozen_time) { subject.authorise_part! }
+
+        expect(subject.authorised_at).to eq(frozen_time)
       }
     end
   end # describe 'set triggers'

--- a/spec/models/fee/basic_fee_type_spec.rb
+++ b/spec/models/fee/basic_fee_type_spec.rb
@@ -50,7 +50,8 @@ module Fee
 
     describe 'automatic calculation of amount' do
       context 'for fee types not requiring calculation' do
-        fee = FactoryGirl.build :basic_fee, :ppe_fee, quantity: 999, rate: 2.0, amount: 999
+        let(:fee) { FactoryGirl.build :basic_fee, :ppe_fee, quantity: 999, rate: 2.0, amount: 999 }
+
         it 'should not calculate the amount' do
           expect(fee).to be_valid
           expect(fee.amount).to eq 999


### PR DESCRIPTION
Now that we have an intermediate summary page, the VAT total was not properly being updated and shown in this page as it was only being updated on submit state change (which doesn't happen until after certification).

Fixed by moving the call to update the VAT from the state transition to a claim `after_save` callback.
