### PR TITLE
Update Devise mailer sender address

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'advocate-defence-payment@digital.justice.gov.uk'
+  config.mailer_sender = 'crowncourtdefence@digital.justice.gov.uk'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'AdpMailer'


### PR DESCRIPTION
Update Devise mailer sender address crowncourtdefence@digital.justice.gov.uk
