### PR TITLE
prevent the mass allocation of claims if any already allocated

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -26,20 +26,18 @@ class Allocation
     return false unless valid?
 
     # could be allocating, deallocating or reallocating
-    @claims.each do |claim|
-      if allocating?
-        if claim.case_workers.exists?
-          errors.add(:base,"Claim #{claim.case_number} has already been allocated to #{claim.case_workers.first.name}")
-        else
+    if allocating?
+      allocate_all_claims_or_none! @claims
+    else
+      @claims.each do |claim|
+        if deallocating?
+          deallocate_claim! claim
+        else #reallocating
           allocate_claim! claim
         end
-      elsif deallocating?
-        deallocate_claim! claim
-      else #reallocating
-        allocate_claim! claim
       end
-
     end
+
     true
   end
 
@@ -52,6 +50,24 @@ class Allocation
   end
 
   private
+
+  def allocate_all_claims_or_none!(claims)
+    ActiveRecord::Base.transaction do
+        claims.each do |claim|
+        if claim.case_workers.exists?
+            errors.add(:base,"Claim #{claim.case_number} has already been allocated to #{claim.case_workers.first.name}")
+          else
+            allocate_claim! claim
+          end
+        end
+
+        if errors.any?
+          errors.add(:base,"All allocations prevented")
+          @successful_claims = []
+          raise ActiveRecord::Rollback
+        end
+    end
+  end
 
   def deallocating?
     @deallocate

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -51,7 +51,7 @@ class Allocation
 
   private
 
-  def allocate_all_claims_or_none!(claims)
+def allocate_all_claims_or_none!(claims)
     ActiveRecord::Base.transaction do
         claims.each do |claim|
         if claim.case_workers.exists?
@@ -62,7 +62,7 @@ class Allocation
         end
 
         if errors.any?
-          errors.add(:base,"All allocations prevented")
+          errors[:base].unshift("NO claims allocated because: ")
           @successful_claims = []
           raise ActiveRecord::Rollback
         end

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -114,27 +114,27 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
         post :create, allocation: allocation_params, commit: 'Allocate'
       end
 
-      it 'allocates only unallocated claims to case worker' do
-        expect(@case_worker.claims.map(&:id)).to match_array(@claims[0].id)
-      end
+      # TODO: reimplement once method of validation settled
+      # it 'allocates only unallocated claims to case worker' do
+      #   expect(@case_worker.claims.map(&:id)).to match_array(@claims[0].id)
+      # end
 
-      it 'renders new allocation template' do
-        expect(response).to render_template :new
-      end
+      # TODO: reimplement once method of validation settled
+      # it 'tells the user how many claims were successfully allocated' do
+      #   expect(flash[:notice]).to match /\d claim[s]{0,1} allocated to.*/
+      # end
 
-      it 'tells the user how many claims were successfully allocated' do
-        expect(flash[:notice]).to match /\d claim[s]{0,1} allocated to.*/
-      end
+      # TODO: reimplement once method of validation settled
+      # it 'stores errors for display' do
+        # expect(assigns(:allocation).errors.full_messages.size).to eql 1
+        # expect(assigns(:allocation).errors.full_messages.first).to match /Claim.*already.*allocated/
+      # end
 
-      it 'stores errors for display' do
-        expect(assigns(:allocation).errors.full_messages.size).to eql 1
-        expect(assigns(:allocation).errors.full_messages.first).to match /Claim.*already.*allocated/
-      end
-
-      it 'does not allocate already allocated claims to the case worker' do
-        expect(assigns(:allocation).claims.count).to eql 2
-        expect(@case_worker.claims.count).to eql 1
-      end
+      # TODO: reimplement once method of validation settled
+      # it 'does not allocate already allocated claims to the case worker' do
+      #   expect(assigns(:allocation).claims.count).to eql 2
+      #   expect(@case_worker.claims.count).to eql 1
+      # end
 
       it 'renders the new template' do
         expect(response).to render_template(:new)

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -59,41 +59,41 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    context 'already allocated claims' do
-      let(:case_worker) { create(:case_worker) }
-      let(:claims) do
-        claims = create_list(:submitted_claim, 2)
-        claims << create(:allocated_claim)
-      end
+    # TODO: reimplment once method of validation settled
+    # context 'already allocated claims' do
+    #   let(:case_worker) { create(:case_worker) }
+    #   let(:claims) do
+    #     claims = create_list(:submitted_claim, 2)
+    #     claims << create(:allocated_claim)
+    #   end
 
-      subject { Allocation.new(claim_ids: claims.map(&:id), case_worker_id: case_worker.id) }
+    #   subject { Allocation.new(claim_ids: claims.map(&:id), case_worker_id: case_worker.id) }
 
-      context 'when allocating' do
-        before { allow(subject).to receive(:allocating?).and_return(true) }
+    #   context 'when allocating' do
+    #     before { allow(subject).to receive(:allocating?).and_return(true) }
 
-        it 'will NOT be re-allocated' do
-          subject.save
-          expect(claims.count).to eq 3
-          expect(case_worker.claims.count).to eq 2
-        end
+    #     it 'will NOT be re-allocated' do
+    #       subject.save
+    #       expect(claims.count).to eq 3
+    #       expect(case_worker.claims.count).to eq 2
+    #     end
 
-        it 'will populate allocation errors without failing' do
-          subject.save
-          expect(subject.errors.count).to eq 1
-          expect(case_worker.claims.count).to eq 2
-        end
-      end
+    #     it 'will populate allocation errors without failing' do
+    #       subject.save
+    #       expect(subject.errors.count).to eq 1
+    #       expect(case_worker.claims.count).to eq 2
+    #     end
+    #   end
 
-      context 'when re-allocating' do
-        before { allow(subject).to receive(:allocating?).and_return(nil) }
+    #   context 'when re-allocating' do
+    #     before { allow(subject).to receive(:allocating?).and_return(nil) }
 
-        it 'claims will be re-allocated' do
-          subject.save
-          expect(case_worker.claims.count).to eq 3
-        end
-      end
-
-    end
+    #     it 'claims will be re-allocated' do
+    #       subject.save
+    #       expect(case_worker.claims.count).to eq 3
+    #     end
+    #   end
+    # end
 
     context 'deallocating' do
       let(:claims) { create_list(:submitted_claim, 3) }

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -59,44 +59,45 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    # TODO: reimplment once method of validation settled
-    # context 'already allocated claims' do
-    #   let(:case_worker) { create(:case_worker) }
-    #   let(:claims) do
-    #     claims = create_list(:submitted_claim, 2)
-    #     claims << create(:allocated_claim)
-    #   end
+    context 'when already allocated claims included' do
+      let(:case_worker) { create(:case_worker) }
+      let(:claims) do
+        claims = create_list(:submitted_claim, 1)
+        claims << create(:allocated_claim)
+      end
 
-    #   subject { Allocation.new(claim_ids: claims.map(&:id), case_worker_id: case_worker.id) }
+      subject { Allocation.new(claim_ids: claims.map(&:id), case_worker_id: case_worker.id) }
 
-    #   context 'when allocating' do
-    #     before { allow(subject).to receive(:allocating?).and_return(true) }
+      context 'when allocating' do
+        before { allow(subject).to receive(:allocating?).and_return(true) }
 
-    #     it 'will NOT be re-allocated' do
-    #       subject.save
-    #       expect(claims.count).to eq 3
-    #       expect(case_worker.claims.count).to eq 2
-    #     end
+        it 'NO claims will be allocated' do
+          subject.save
+          expect(claims.count).to eq 2
+          expect(case_worker.claims.count).to eq 0
+        end
 
-    #     it 'will populate allocation errors without failing' do
-    #       subject.save
-    #       expect(subject.errors.count).to eq 1
-    #       expect(case_worker.claims.count).to eq 2
-    #     end
-    #   end
+        it 'will populate allocation errors including header without failing' do
+          subject.save
+          expect(subject.errors.count).to eq 2 # claim error plus heading error warning
+          expect(subject.errors.full_messages.first).to match /NO claims allocated/
+          expect(subject.errors.full_messages.second).to match /Claim .* has already been allocated/
+          expect(case_worker.claims.count).to eq 0
+        end
+      end
 
-    #   context 'when re-allocating' do
-    #     before { allow(subject).to receive(:allocating?).and_return(nil) }
+      context 'when re-allocating' do
+        before { allow(subject).to receive(:allocating?).and_return(nil) }
 
-    #     it 'claims will be re-allocated' do
-    #       subject.save
-    #       expect(case_worker.claims.count).to eq 3
-    #     end
-    #   end
-    # end
+        it 'claims will be re-allocated' do
+          subject.save
+          expect(case_worker.claims.count).to eq 2
+        end
+      end
+    end
 
     context 'deallocating' do
-      let(:claims) { create_list(:submitted_claim, 3) }
+      let(:claims) { create_list(:submitted_claim, 2) }
       let(:case_worker) { create(:case_worker) }
 
       context 'when valid' do
@@ -121,7 +122,7 @@ RSpec.describe Allocation, type: :model do
           before { subject.save }
 
           context 'for submitted claims' do
-            let(:claims) { create_list(:submitted_claim, 3) }
+            let(:claims) { create_list(:submitted_claim, 2) }
 
             it 'sets the claims to the state to "submitted"' do
               expect(claims.map(&:reload).map(&:state).uniq).to eq(['submitted'])
@@ -129,7 +130,7 @@ RSpec.describe Allocation, type: :model do
           end
 
           context 'for redetermination claims' do
-            let(:claims) { create_list(:redetermination_claim, 3) }
+            let(:claims) { create_list(:redetermination_claim, 2) }
 
             it 'sets the claims state to "redetermination"' do
               expect(claims.map(&:reload).map(&:state).uniq).to eq(['redetermination'])
@@ -149,12 +150,12 @@ RSpec.describe Allocation, type: :model do
 
         it 'does not create case worker claim join records' do
           subject.save
-          expect(CaseWorkerClaim.count).to eq(3)
+          expect(CaseWorkerClaim.count).to eq(2)
         end
 
         it 'does not delete case worker claim join records' do
           subject.save
-          expect(CaseWorkerClaim.count).to eq(3)
+          expect(CaseWorkerClaim.count).to eq(2)
         end
 
         it 'leaves the claims as "allocated"' do


### PR DESCRIPTION
still needs spec changes to match the new functionality but this appears to work when manually tested
