### PR TITLE
Hiding misc-fees section for litigators claim as it is not quite ready.

### DIFF
--- a/app/views/external_users/litigators/claims/_form.html.haml
+++ b/app/views/external_users/litigators/claims/_form.html.haml
@@ -19,7 +19,7 @@
 
       = render partial: 'external_users/claims/graduated_fees/fields', locals: { f: f }
 
-      = render partial: 'external_users/claims/misc_fees/fields', locals: { f: f }
+      -#= render partial: 'external_users/claims/misc_fees/fields', locals: { f: f }
 
       = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }
 


### PR DESCRIPTION
Misc fees for litigators claims are not yet updated and was using the advocates partial/validations which will cause problems for litigators claims.

Hiding it for now until we finish the work, as claims can be succesfully submit without it (litigators claims with misc-fees are unsual as per Angela's information).
