### PR TITLE
fix bug allowing case worker to assess a claim without changing the s…

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -39,7 +39,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
     begin
       @claim.update_model_and_transition_state(claim_params)
       redirect_to case_workers_claim_path(params.slice(:messages))
-    rescue StateMachines::InvalidTransition => err
+    rescue StateMachines::InvalidTransition, ArgumentError
       prepare_show_action
       render :show
     end


### PR DESCRIPTION
…tatus.

This is a patch for a problem whereby the caseworker can assess a claim and update it without specifying a status. This only raises an error to the user as a warning since the assessment is still updated - it will require a transaction to be rolled back to make it a more permanent fix.
