### PR TITLE
Miscellaneous fees for litigators with support for multiple case numbers.

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/MiscFeeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/MiscFeeFieldsDisplay.js
@@ -1,0 +1,42 @@
+moj.Modules.MiscFeeFieldsDisplay = {
+    el: '#misc-fees',
+    elGroup: '.misc-fee-group',
+    typeSelect: 'select.js-misc-fee-type',
+    caseNumbersInput: 'input.js-misc-fee-case-numbers',
+
+    init: function () {
+        var self = this;
+
+        this.addMiscFeeChangeEvent();
+
+        $(this.el).find(this.typeSelect).each(function () {
+            self.showHideMiscFeeFields(this);
+        });
+    },
+
+    addMiscFeeChangeEvent: function () {
+        var self = this;
+
+        $(this.el).on('change', self.typeSelect, function () {
+            self.showHideMiscFeeFields(this);
+        });
+    },
+
+    showHideMiscFeeFields: function (elem) {
+        var self = this;
+
+        var currentElement = $(elem).closest(self.elGroup);
+        var caseNumbersInput = currentElement.find(self.caseNumbersInput);
+
+        if (caseNumbersInput.exists()) {
+            var showCaseNumbers = currentElement.find('option:selected').data('case-numbers');
+
+            if (showCaseNumbers) {
+                caseNumbersInput.prop('disabled', false);
+            } else {
+                caseNumbersInput.val('');
+                caseNumbersInput.prop('disabled', true);
+            }
+        }
+    }
+};

--- a/app/controllers/external_users/application_controller.rb
+++ b/app/controllers/external_users/application_controller.rb
@@ -57,6 +57,7 @@ private
        :quantity,
        :rate,
        :amount,
+       :case_numbers,
        :_destroy,
        common_dates_attended_attributes
       ]

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 module Fee
@@ -31,6 +32,8 @@ module Fee
 
     self.table_name = 'fees'
     numeric_attributes :quantity, :amount
+
+    auto_strip_attributes :case_numbers, squish: true, nullify: true
 
     belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
     belongs_to :fee_type, class_name: Fee::BaseFeeType

--- a/app/models/fee/basic_fee.rb
+++ b/app/models/fee/basic_fee.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 class Fee::BasicFee < Fee::BaseFee

--- a/app/models/fee/fixed_fee.rb
+++ b/app/models/fee/fixed_fee.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 class Fee::FixedFee < Fee::BaseFee

--- a/app/models/fee/graduated_fee.rb
+++ b/app/models/fee/graduated_fee.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 class Fee::GraduatedFee < Fee::BaseFee

--- a/app/models/fee/misc_fee.rb
+++ b/app/models/fee/misc_fee.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 class Fee::MiscFee < Fee::BaseFee

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -22,4 +22,8 @@ class Fee::MiscFeeType < Fee::BaseFeeType
     'Miscellaneous Fees'
   end
 
+  def case_uplift?
+    code == 'XUPL'
+  end
+
 end

--- a/app/models/fee/warrant_fee.rb
+++ b/app/models/fee/warrant_fee.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 class Fee::WarrantFee < Fee::BaseFee

--- a/app/presenters/fee/misc_fee_type_presenter.rb
+++ b/app/presenters/fee/misc_fee_type_presenter.rb
@@ -1,0 +1,17 @@
+class Fee::MiscFeeTypePresenter < BasePresenter
+  presents :fee_type
+
+  def data_attributes
+    {
+      case_numbers: case_numbers_field?
+    }
+  end
+
+
+  private
+
+  def case_numbers_field?
+    case_uplift?
+  end
+
+end

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -1,5 +1,7 @@
 class BaseValidator < ActiveModel::Validator
 
+  CASE_NUMBER_PATTERN ||= /^[A-Z]{1}\d{8}$/
+
   # Override this method in the derived class
   def validate_step_fields; end
 

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -70,7 +70,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # must have a format of capital letter followed by 8 digits
   def validate_case_number
     validate_presence(:case_number, "blank")
-    validate_pattern(:case_number, /^[A-Z]{1}\d{8}$/, "invalid") unless @record.case_number.blank?
+    validate_pattern(:case_number, CASE_NUMBER_PATTERN, "invalid") unless @record.case_number.blank?
   end
 
   def validate_estimated_trial_length

--- a/app/validators/fee/fixed_fee_validator.rb
+++ b/app/validators/fee/fixed_fee_validator.rb
@@ -20,8 +20,11 @@ class Fee::FixedFeeValidator < Fee::BaseFeeValidator
   end
 
   def validate_amount
-    super if run_base_fee_validators? || fee_code.nil?
-    add_error(:amount, "#{fee_code.downcase}_invalid") if @record.amount < 0.01
+    if run_base_fee_validators? || fee_code.nil?
+      super
+    else
+      add_error(:amount, "#{fee_code.downcase}_invalid") if @record.amount < 0.01
+    end
   end
 
   def validate_sub_type

--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -1,3 +1,56 @@
 class Fee::MiscFeeValidator < Fee::BaseFeeValidator
 
+  def self.fields
+    [
+      :quantity,
+      :rate,
+      :amount,
+      :case_numbers
+    ]
+  end
+
+  private
+
+  def validate_quantity
+    super if run_base_fee_validators?
+  end
+
+  def validate_rate
+    super if run_base_fee_validators?
+  end
+
+  def validate_amount
+    if run_base_fee_validators? || fee_code.nil?
+      super
+    else
+      add_error(:amount, "#{fee_code.downcase}_invalid") if @record.amount < 0.01
+    end
+  end
+
+  def validate_case_numbers
+    return if fee_code.nil?
+
+    if case_uplift_fee?
+      validate_presence(:case_numbers, 'blank')
+      validate_each_case_number(:case_numbers, 'invalid')
+    else
+      validate_absence(:case_numbers, 'present')
+    end
+  end
+
+  def validate_each_case_number(attribute, message)
+    return if @record.__send__(attribute).blank?
+
+    @record.__send__(attribute).split(',').each do |case_number|
+      case_number.strip.match(CASE_NUMBER_PATTERN) || (add_error(attribute, message) && return)
+    end
+  end
+
+  def run_base_fee_validators?
+    !@record.claim.lgfs?
+  end
+
+  def case_uplift_fee?
+    @record.fee_type.case_uplift?
+  end
 end

--- a/app/views/external_users/claims/misc_fees/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/_fields.html.haml
@@ -1,6 +1,8 @@
 #misc-fees
   %h2.bold-medium
     = t('.misc_fees')
+  .form-hint.xsmall
+    = t('.prompt_text_html')
   %table
     %thead
       %tr

--- a/app/views/external_users/claims/misc_fees/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/_misc_fee_fields.html.haml
@@ -3,7 +3,7 @@
 
     %td
       %a{name: "misc_fee_#{@misc_fee_count}_fee_type"}
-      = f.collection_select :fee_type_id, @claim.eligible_misc_fee_types, :id, :description, {prompt: true}, {class: 'select2', style: 'width:350px'}
+      = f.collection_select :fee_type_id, @claim.eligible_misc_fee_types, :id, :description, {prompt: true}, {class: 'select2 js-misc-fee-type', style: 'width:350px'}
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
     %td
       %a{name: "misc_fee_#{@misc_fee_count}_quantity"}

--- a/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
@@ -1,0 +1,23 @@
+#misc-fees
+  %h2.bold-medium
+    = t('.misc_fees')
+  .form-hint.xsmall
+    = t('.prompt_text_html')
+  %table
+    %thead
+      %tr
+        %th
+          = t('.fee_type')
+        %th
+          = t('.case_numbers')
+          .form-hint.xsmall.zero-vert-margin
+            = "eg A12345678,A12345588"
+        %th
+          = t('.amount')
+        %td
+        %td
+    = f.fields_for :misc_fees do |misc_fee_fields|
+      - @misc_fee_count += 1
+      = render 'external_users/claims/misc_fees/litigators/misc_fee_fields', f: misc_fee_fields
+
+  = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'table'}

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -1,0 +1,22 @@
+%tbody.misc-fee-group
+  %tr.nested-fields
+
+    %td
+      %a{name: "misc_fee_#{@misc_fee_count}_fee_type"}
+      - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
+      = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, {include_blank: 'Please select'}, {class: 'select2 js-misc-fee-type', style: 'width:350px'}
+      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
+
+    %td
+      %a{name: "misc_fee_#{@misc_fee_count}_case_numbers"}
+      = f.text_field :case_numbers, {class: 'form-control js-misc-fee-case-numbers', style: 'width:150px'}
+      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_case_numbers")
+
+    %td
+      %div.pound-wrapper
+        %a{name: "misc_fee_#{@misc_fee_count}_amount"}
+        = f.text_field :amount, value: number_with_precision(f.object.amount, precision: 2), class: 'form-control rate', size: 10, maxlength: 8
+      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_amount")
+
+    %td.remove-misc-fee
+      = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group' }

--- a/app/views/external_users/litigators/claims/_form.html.haml
+++ b/app/views/external_users/litigators/claims/_form.html.haml
@@ -19,7 +19,7 @@
 
       = render partial: 'external_users/claims/graduated_fees/fields', locals: { f: f }
 
-      -#= render partial: 'external_users/claims/misc_fees/fields', locals: { f: f }
+      = render partial: 'external_users/claims/misc_fees/litigators/fields', locals: { f: f }
 
       = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -535,9 +535,20 @@ en:
           misc_fees: 'Miscellaneous fees'
           quantity: 'Quantity'
           rate: 'Rate'
+          prompt_text_html: Complete <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/503308/af1-special-prep-form.pdf" target="_blank" rel="external" title="Special Prep Form">special prep form</a> and attach
         misc_fee_fields:
           add_date_attended: 'Add date(s)'
           remove: *remove
+        litigators:
+          fields:
+            misc_fees: "Miscellaneous fees"
+            prompt_text_html: Complete <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/503308/af1-special-prep-form.pdf" target="_blank" rel="external" title="Special Prep Form">special prep form</a> and attach
+            fee_type: "Fee type"
+            case_numbers: "Case number(s)"
+            amount: "Total"
+            add_misc_fee: "Add another miscellaneous fee"
+          misc_fee_fields:
+            remove: *remove
       financial_summary:
         total_outstanding: 'Total outstanding:'
         total_authorised: 'Total authorised:'

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -576,6 +576,21 @@ misc_fee:
       short: Enter a valid quantity
       api: Enter a valid quantity for the miscellaneous fee
 
+  case_numbers:
+    _seq: 40
+    blank:
+      long: 'Enter at least one case number for the #{misc_fee}'
+      short: Enter at least one case number
+      api: Enter at least one case number for the miscellaneous fee
+    present:
+      long: 'Case numbers for the #{misc_fee} are not allowed'
+      short: Case numbers are not allowed
+      api: Case numbers for the miscellaneous are not allowed
+    invalid:
+      long: 'Enter valid case numbers for the #{misc_fee}'
+      short: Enter valid case numbers
+      api: Enter valid case numbers for the miscellaneous fee
+
 #################################################################################
 #                                                                               #
 #   FIXED FEE                                                                   #

--- a/db/migrate/20160414121855_add_case_numbers_to_fees.rb
+++ b/db/migrate/20160414121855_add_case_numbers_to_fees.rb
@@ -1,0 +1,5 @@
+class AddCaseNumbersToFees < ActiveRecord::Migration
+  def change
+    add_column :fees, :case_numbers, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160413144330) do
+ActiveRecord::Schema.define(version: 20160414121855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -308,6 +308,7 @@ ActiveRecord::Schema.define(version: 20160413144330) do
     t.date     "warrant_issued_date"
     t.date     "warrant_executed_date"
     t.integer  "sub_type_id"
+    t.string   "case_numbers"
   end
 
   add_index "fees", ["claim_id"], name: "index_fees_on_claim_id", using: :btree

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
           before { sign_in litigator.user }
           it 'should assign context to claims for the provider' do
             get :index
-            expected_claims = Claim::BaseClaim.where(external_user_id: litigator.id)
-            expect(assigns(:claims_context)).to eq(expected_claims)
+            expected_claims = Claim::BaseClaim.where(external_user_id: litigator.id).pluck(:id)
+            expect(assigns(:claims_context).map(&:id).sort).to eq(expected_claims.sort)
           end
 
           it 'should assign claims to dashboard displayable state claims for all members of the provder' do

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 FactoryGirl.define do

--- a/spec/models/fee/base_fee_spec.rb
+++ b/spec/models/fee/base_fee_spec.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 require 'rails_helper'

--- a/spec/models/fee/basic_fee_spec.rb
+++ b/spec/models/fee/basic_fee_spec.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 require 'rails_helper'

--- a/spec/models/fee/fixed_fee_spec.rb
+++ b/spec/models/fee/fixed_fee_spec.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 require 'rails_helper'

--- a/spec/models/fee/graduated_fee_spec.rb
+++ b/spec/models/fee/graduated_fee_spec.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 require 'rails_helper'

--- a/spec/models/fee/misc_fee_spec.rb
+++ b/spec/models/fee/misc_fee_spec.rb
@@ -15,6 +15,7 @@
 #  warrant_issued_date   :date
 #  warrant_executed_date :date
 #  sub_type_id           :integer
+#  case_numbers          :string
 #
 
 require 'rails_helper'

--- a/spec/models/fee/misc_fee_type_spec.rb
+++ b/spec/models/fee/misc_fee_type_spec.rb
@@ -39,5 +39,16 @@ module Fee
       end
     end
 
+    describe '#case_uplift?' do
+      it 'should return true when fee_type is Case Uplift' do
+        fee_type.code = 'XUPL'
+        expect(fee_type.case_uplift?).to be_truthy
+      end
+
+      it 'should return false when fee_type is not Case Uplift' do
+        fee_type.code = 'XXX'
+        expect(fee_type.case_uplift?).to be_falsey
+      end
+    end
   end
 end

--- a/spec/presenters/misc_fee_type_presenter_spec.rb
+++ b/spec/presenters/misc_fee_type_presenter_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Fee::MiscFeeTypePresenter do
+
+  let(:fee_type)  { build :misc_fee_type }
+  let(:presenter) { described_class.new(fee_type, view) }
+
+  describe '#data_attributes' do
+    context 'case_numbers' do
+      it 'returns false when it is not Case uplift' do
+        expect(presenter.data_attributes[:case_numbers]).to be_falsey
+      end
+
+      it 'returns true when is Case uplift' do
+        fee_type.code = 'XUPL'
+        expect(presenter.data_attributes[:case_numbers]).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/validators/misc_fee_validator_spec.rb
+++ b/spec/validators/misc_fee_validator_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+require File.dirname(__FILE__) + '/validation_helpers'
+
+describe Fee::MiscFeeValidator do
+
+  include ValidationHelpers
+
+  let(:fee) { FactoryGirl.build :misc_fee, claim: claim }
+  let(:fee_code) { fee.fee_type.code }
+
+  # AGFS claims are validated as part of the base_fee_validator_spec
+  #
+  context 'LGFS claim' do
+    let(:claim) { FactoryGirl.build :litigator_claim, force_validation: true }
+
+    before(:each) do
+      fee.clear   # reset some attributes set by the factory
+      fee.amount = 1.00
+    end
+
+    describe '#validate_claim' do
+      it { should_error_if_not_present(fee, :claim, 'blank') }
+    end
+
+    describe '#validate_fee_type' do
+      it { should_error_if_not_present(fee, :fee_type, 'blank') }
+    end
+
+    context 'override validation of fields from the superclass validator' do
+      let(:superclass) { described_class.superclass }
+
+      it 'quantity' do
+        expect_any_instance_of(superclass).not_to receive(:validate_quantity)
+        fee.valid?
+      end
+
+      it 'rate' do
+        expect_any_instance_of(superclass).not_to receive(:validate_rate)
+        fee.valid?
+      end
+
+      it 'amount' do
+        expect_any_instance_of(superclass).not_to receive(:validate_amount)
+        fee.valid?
+      end
+    end
+
+    describe '#validate_amount' do
+      it 'should error if amount is equal to zero' do
+        should_error_if_equal_to_value(fee, :amount,  0.00, "#{fee_code.downcase}_invalid")
+      end
+
+      it 'should error if amount is less than zero' do
+        should_error_if_equal_to_value(fee, :amount,  -10.00, "#{fee_code.downcase}_invalid")
+      end
+    end
+
+    describe '#validate_case_numbers' do
+      context 'for a non Case Uplift fee type' do
+        before(:each) do
+          allow(fee.fee_type).to receive(:case_uplift?).and_return(false)
+        end
+
+        it 'should error if case_numbers is present' do
+          should_error_if_equal_to_value(fee, :case_numbers, '123', 'present')
+        end
+      end
+
+      context 'for a Case Uplift fee type' do
+        before(:each) do
+          allow(fee.fee_type).to receive(:case_uplift?).and_return(true)
+        end
+
+        it 'should error if case_numbers is blank' do
+          should_error_if_equal_to_value(fee, :case_numbers, '', 'blank')
+        end
+
+        it 'should error if case_numbers is invalid' do
+          should_error_if_equal_to_value(fee, :case_numbers, '123', 'invalid')
+        end
+
+        it 'should be valid for a proper case number' do
+          fee.case_numbers = 'A12345678'
+          should_not_error(fee, :case_numbers)
+        end
+
+        it 'should be valid for several proper case number' do
+          fee.case_numbers = 'A12345678,A12345588'
+          should_not_error(fee, :case_numbers)
+        end
+
+        it 'should be valid for several proper case number even with spaces between them' do
+          fee.case_numbers = 'A12345678 , A12345588'
+          should_not_error(fee, :case_numbers)
+        end
+
+        it 'should error if any case number is invalid' do
+          fee.case_numbers = 'A12345678,Z123,A12345588'
+          should_error_with(fee, :case_numbers, 'invalid')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Miscellaneous fees for litigators use a different partial and have different validations in place.

Also some javascript will enable or disable the case numbers input field when applicable (Case uplift).
