### PR TITLE
Add and modify allocation filters squashed

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -106,7 +106,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
     case params[:filter]
       when 'redetermination', 'awaiting_written_reasons'
         @claims = @claims.send(params[:filter].to_sym)
-      when 'fixed_fee', 'cracked', 'trial', 'guilty_plea'
+      when 'fixed_fee', 'cracked', 'trial', 'guilty_plea', 'graduated_fees' , 'risk_based_bills'
         @claims = @claims.where{state << %w( redetermination awaiting_written_reasons )}.send(params[:filter].to_sym)
     end
   end
@@ -150,25 +150,9 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
 
   def allocation_filters_for_scheme(scheme)
     if scheme == 'agfs'
-      [ 'all',
-        'fixed_fee',
-        'cracked',
-        'trial',
-        'guilty_plea',
-        'redetermination',
-        'awaiting_written_reasons'
-      ]
+      %w{ all fixed_fee cracked trial guilty_plea redetermination awaiting_written_reasons }
     elsif scheme == 'lgfs'
-      [ 'all',
-        'fixed_fee',
-        'graduated_fees',
-        'interim_fees',
-        'warrants',
-        'risk_based_bills',
-        'redetermination',
-        'awaiting_written_reasons',
-        'interim_disbursements'
-      ]
+      %w{ all fixed_fee graduated_fees interim_fees warrants risk_based_bills redetermination awaiting_written_reasons interim_disbursements }
     else
       []
     end

--- a/app/helpers/case_workers/admin/allocations_helper.rb
+++ b/app/helpers/case_workers/admin/allocations_helper.rb
@@ -1,14 +1,4 @@
 module CaseWorkers::Admin::AllocationsHelper
-  def allocation_filters
-    [ 'all',
-      'fixed_fee',
-      'cracked',
-      'trial',
-      'guilty_plea',
-      'redetermination',
-      'awaiting_written_reasons'
-    ]
-  end
 
   def allocation_scheme_filters
     [ 'agfs',

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -25,6 +25,7 @@ class CaseType < ActiveRecord::Base
   default_scope -> { order(name: :asc) }
 
   scope :fixed_fee,               -> { where(is_fixed_fee: true) }
+  scope :graduated_fees,          -> { where(fee_type_code: Fee::GraduatedFeeType.pluck(:code))}
   scope :requires_cracked_dates,  -> { where(requires_cracked_dates: true) }
   scope :requires_trial_dates,    -> { where(requires_trial_dates: true) }
   scope :requires_retrial_dates,  -> { where(requires_retrial_dates: true) }
@@ -47,4 +48,9 @@ class CaseType < ActiveRecord::Base
     return nil if fee_type_code.nil?
     Fee::FixedFeeType.by_code(fee_type_code)
   end
+
+  def is_graduated_fee?
+    graduated_fee_type.nil? ? false : true
+  end
+
 end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -117,11 +117,15 @@ module Claim
 
     scope :dashboard_displayable_states, -> { where(state: Claims::StateMachine.dashboard_displayable_states) }
 
-    # Trial type scopes
-    scope :cracked,     -> { where('case_type_id in (?)', CaseType.ids_by_types('Cracked Trial', 'Cracked before retrial')) }
-    scope :trial,       -> { where('case_type_id in (?)', CaseType.ids_by_types('Trial', 'Retrial')) }
-    scope :guilty_plea, -> { where('case_type_id in (?)', CaseType.ids_by_types('Guilty plea', 'Discontinuance')) }
-    scope :fixed_fee,   -> { where('case_type_id in (?)', CaseType.fixed_fee.map(&:id) ) }
+    # Allocation filtering scopes
+
+    # AGFS and LGFS
+    scope :fixed_fee,   -> { where(case_type_id: CaseType.fixed_fee.pluck(:id) ) }
+
+    # AGFS only
+    scope :cracked,     -> { where(case_type_id: CaseType.ids_by_types('Cracked Trial', 'Cracked before retrial')) }
+    scope :trial,       -> { where(case_type_id: CaseType.ids_by_types('Trial', 'Retrial')) }
+    scope :guilty_plea, -> { where(case_type_id: CaseType.ids_by_types('Guilty plea', 'Discontinuance')) }
 
     scope :total_greater_than_or_equal_to, -> (value) { where { total >= value } }
     scope :total_lower_than, -> (value) { where { total < value } }

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -74,6 +74,7 @@ module Claim
     include ::Claims::Calculations
     include ::Claims::UserMessages
     include ::Claims::Cloner
+    include ::Claims::AllocationFilters
 
     include NumberCommaParser
     numeric_attributes :fees_total, :expenses_total, :disbursements_total, :total, :vat_amount
@@ -116,16 +117,6 @@ module Claim
     scope :any_authorised,  -> { where(state: %w( part_authorised authorised )) }
 
     scope :dashboard_displayable_states, -> { where(state: Claims::StateMachine.dashboard_displayable_states) }
-
-    # Allocation filtering scopes
-
-    # AGFS and LGFS
-    scope :fixed_fee,   -> { where(case_type_id: CaseType.fixed_fee.pluck(:id) ) }
-
-    # AGFS only
-    scope :cracked,     -> { where(case_type_id: CaseType.ids_by_types('Cracked Trial', 'Cracked before retrial')) }
-    scope :trial,       -> { where(case_type_id: CaseType.ids_by_types('Trial', 'Retrial')) }
-    scope :guilty_plea, -> { where(case_type_id: CaseType.ids_by_types('Guilty plea', 'Discontinuance')) }
 
     scope :total_greater_than_or_equal_to, -> (value) { where { total >= value } }
     scope :total_lower_than, -> (value) { where { total < value } }

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -66,23 +66,6 @@ module Claim
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :graduated_fee, reject_if: :all_blank, allow_destroy: false
 
-    # LGFS allocation filtering scopes
-    scope :graduated_fees,        -> { where(case_type_id: CaseType.graduated_fees.pluck(:id) ) }
-
-    # TODO: An "interim fees" filter is for claims that are of type Claim::InterimClaim and have an interim fee that is of type Effective PCMH, Trial Start, Retrial New Solicitor or Retrial Start
-    # scope :interim_fees,          -> { where() }
-
-    # TODO: An "interim disbursments" filter is for claims that are of Type Claim::InterimClaim and have a fee type of disbursment only (This is to be done)
-    # TODO: no case type available yet
-    # scope :interim_disbursements, -> { where() }
-
-    # TODO: A "warrants" filter is for claims that are of Type Claim::InterimClaim and have a fee type of Warrant
-    # scope :warrants,              -> { where() }
-
-    # A "Risk based bill" is a claim that is considered low risk
-    # This filter is for claims that have a case type of Guilty plea and an offence that is of class E, F, H or I and a PPE fee of 50 or less
-    scope :risk_based_bills,      -> { where(case_type_id: CaseType.ids_by_types('Guilty plea')).where(offence_id: Offence.joins(:offence_class).where(offence_class: { class_letter: ['E','F','H','I'] })) }
-
     def eligible_case_types
       CaseType.lgfs
     end
@@ -106,7 +89,6 @@ module Claim
     def external_user_type
       :litigator
     end
-
 
     private
 

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -66,6 +66,23 @@ module Claim
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :graduated_fee, reject_if: :all_blank, allow_destroy: false
 
+    # LGFS allocation filtering scopes
+    scope :graduated_fees,        -> { where(case_type_id: CaseType.graduated_fees.pluck(:id) ) }
+
+    # TODO: An "interim fees" filter is for claims that are of type Claim::InterimClaim and have an interim fee that is of type Effective PCMH, Trial Start, Retrial New Solicitor or Retrial Start
+    # scope :interim_fees,          -> { where() }
+
+    # TODO: An "interim disbursments" filter is for claims that are of Type Claim::InterimClaim and have a fee type of disbursment only (This is to be done)
+    # TODO: no case type available yet
+    # scope :interim_disbursements, -> { where() }
+
+    # TODO: A "warrants" filter is for claims that are of Type Claim::InterimClaim and have a fee type of Warrant
+    # scope :warrants,              -> { where() }
+
+    # A "Risk based bill" is a claim that is considered low risk
+    # This filter is for claims that have a case type of Guilty plea and an offence that is of class E, F, H or I and a PPE fee of 50 or less
+    scope :risk_based_bills,      -> { where(case_type_id: CaseType.ids_by_types('Guilty plea')).where(offence_id: Offence.joins(:offence_class).where(offence_class: { class_letter: ['E','F','H','I'] })) }
+
     def eligible_case_types
       CaseType.lgfs
     end

--- a/app/models/claims/allocation_filters.rb
+++ b/app/models/claims/allocation_filters.rb
@@ -1,0 +1,80 @@
+#
+# mixin for scopes used to filter claims for allocating to case workers
+#
+# Note the state of the claim is not specified and is typical appended
+# by the calling method:
+#  e.g. @claims.where(state: :submitted).risk_based_bills
+#
+module Claims::AllocationFilters
+
+  def self.included(base)
+    base.extend(ClassMethods)
+    base.class_eval { add_scopes }
+  end
+
+  module ClassMethods
+
+    def add_scopes
+      agfs_lgfs_scopes
+      agfs_scopes
+      lgfs_scopes
+    end
+
+    def agfs_lgfs_scopes
+      scope :fixed_fee,   -> { where(case_type_id: CaseType.fixed_fee.pluck(:id) ) }
+    end
+
+    def agfs_scopes
+      scope :cracked,     -> { where(case_type_id: CaseType.ids_by_types('Cracked Trial', 'Cracked before retrial')) }
+      scope :trial,       -> { where(case_type_id: CaseType.ids_by_types('Trial', 'Retrial')) }
+      scope :guilty_plea, -> { where(case_type_id: CaseType.ids_by_types('Guilty plea', 'Discontinuance')) }
+    end
+
+    def lgfs_scopes
+      scope :graduated_fees,        -> { all_graduated_fees }
+      scope :risk_based_bills,      -> { all_risk_based_bills }
+      scope :interim_fees,          -> { all_interim_fees }
+      scope :warrants,              -> { all_interim_warrants }
+      scope :interim_disbursements, -> { all_interim_disbursements }
+    end
+
+    def all_graduated_fees
+      where(case_type_id: CaseType.graduated_fees.pluck(:id) )
+    end
+
+    def all_risk_based_bills
+      where(type: 'Claim::LitigatorClaim').
+      where(offence_id: Offence.joins(:offence_class).where(offence_class: { class_letter: ['E','F','H','I'] })).
+      joins(:fees).
+      where('"fees"."fee_type_id" = ?', Fee::GraduatedFeeType.where(description: 'Guilty plea').pluck(:id).first).
+      where('"fees"."quantity" between 1 and 50')
+    end
+
+    # An "interim fees" filter is for claims that are of type Claim::InterimClaim and have an interim fee that is of type Effective PCMH, Trial Start, Retrial New Solicitor or Retrial Start
+    def all_interim_fees
+      where(type: 'Claim::InterimClaim').
+      joins(:fees).
+      where('"fees"."fee_type_id" IN (?)', Fee::InterimFeeType.where(description: [ 'Effective PCMH', 'Trial Start', 'Retrial New Solicitor', 'Retrial Start']).pluck(:id))
+    end
+
+    # A "warrants" filter is for claims that are of Type Claim::InterimClaim and have a fee type of Warrant
+    def all_interim_warrants
+      all_interims_with_fee_type('Warrant')
+    end
+
+    # An "interim disbursements" filter is for claims that are of Type Claim::InterimClaim and have a fee type of disbursement only
+    def all_interim_disbursements
+      all_interims_with_fee_type('Disbursement only')
+    end
+
+    def all_interims_with_fee_type(fee_type_description)
+      where(type: 'Claim::InterimClaim').
+      joins(:fees).
+      where('"fees"."fee_type_id" = ?', Fee::InterimFeeType.where(description: fee_type_description).pluck(:id).first)
+    end
+
+
+  end
+
+
+end

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -14,14 +14,15 @@
   = hidden_field_tag :filter, params[:filter] if params[:filter]
 
   .grid-row
-    .column-quarter{ style: 'padding: 15px 0' }
-      = label_tag :quantity_to_allocate, t('.no_of_claims')
-      = number_field_tag :quantity_to_allocate, nil, { style: 'width:100%', min: 0, size: 5, class: 'form-control'}
-    .column-half{ style: 'padding: 15px 15px' }
-      = f.label :case_worker_id, t('dictionary.models.case_worker')
-      = f.grouped_collection_select :case_worker_id, Location.includes(case_workers: :user), :case_workers, :name, :id, :name, { include_blank: true }, { class: 'form-control autocomplete' }
-    .column-quarter{ style: 'padding: 30px 15px' }
-      = f.submit 'Allocate', class: 'button'
+    .form-row
+      .form-col
+        = label_tag :quantity_to_allocate, t('.no_of_claims')
+        = number_field_tag :quantity_to_allocate, nil, { style: 'width:100%', min: 0, size: 5, class: 'form-control'}
+      .form-col
+        = f.label :case_worker_id, t('dictionary.models.case_worker')
+        = f.grouped_collection_select :case_worker_id, Location.includes(case_workers: :user), :case_workers, :name, :id, :name, { include_blank: true }, { class: 'form-control autocomplete' }
+      .form-col{ style: 'padding: 26px 0 0' }
+        = f.submit 'Allocate', class: 'button'
   - if @claims.any?
 
     .container.table-container

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -4,24 +4,23 @@
 
 = form_tag case_workers_admin_allocations_path, method: :get do
   = hidden_field_tag :tab, params[:tab]
-  = render partial: 'scheme_filters'
-  = render partial: 'case_type_filters'
-  %noscript
-    = submit_tag 'Filter'
+  .grid-row
+    = render partial: 'scheme_filters'
+    = render partial: 'case_type_filters'
 
 = form_for [:case_workers, :admin, @allocation] do |f|
   = hidden_field_tag :tab, params[:tab]
   = hidden_field_tag :scheme, params[:scheme]
   = hidden_field_tag :filter, params[:filter] if params[:filter]
-  -# TODO: FIX BELOW
+
   .grid-row
-    .column-quarter
+    .column-quarter{ style: 'padding: 15px 0' }
       = label_tag :quantity_to_allocate, t('.no_of_claims')
       = number_field_tag :quantity_to_allocate, nil, { style: 'width:100%', min: 0, size: 5, class: 'form-control'}
-    .column-half
+    .column-half{ style: 'padding: 15px 15px' }
       = f.label :case_worker_id, t('dictionary.models.case_worker')
       = f.grouped_collection_select :case_worker_id, Location.includes(case_workers: :user), :case_workers, :name, :id, :name, { include_blank: true }, { class: 'form-control autocomplete' }
-    .column-quarter
+    .column-quarter{ style: 'padding: 30px 15px' }
       = f.submit 'Allocate', class: 'button'
   - if @claims.any?
 

--- a/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
@@ -1,7 +1,7 @@
 %fieldset.inline.allocation-filter-form
-  %legend
-    = t('.case_types')
-  -  allocation_filters.each do | filter_name |
-    = label_tag "filter_#{filter_name}", nil, class: 'block-label' do
-      = radio_button_tag :filter, filter_name, (params[:filter].blank? && filter_name == 'all') || params[:filter] == filter_name
-      = filter_name.humanize
+  .column-half
+    %legend
+      = t('.case_types')
+    = select_tag :filter, options_for_select(allocation_filters.collect{ |filter| [filter.humanize, filter] }, params[:filter]), class: 'select2'
+  .column-half{ style: 'padding: 15px 15px' }
+    = submit_tag 'Select', class: 'button'

--- a/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
@@ -2,6 +2,6 @@
   .column-half
     %legend
       = t('.case_types')
-    = select_tag :filter, options_for_select(allocation_filters.collect{ |filter| [filter.humanize, filter] }, params[:filter]), class: 'select2'
+    = select_tag :filter, options_for_select(allocation_filters_for_scheme(params[:scheme]).collect{ |filter| [filter.humanize, filter] }, params[:filter]), class: 'select2'
   .column-half{ style: 'padding: 15px 15px' }
     = submit_tag 'Select', class: 'button'

--- a/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
@@ -1,7 +1,7 @@
-%fieldset.inline.allocation-filter-form
-  .column-half
+%fieldset.inline.allocation-filter-form.form-row
+  .form-col
     %legend
       = t('.case_types')
-    = select_tag :filter, options_for_select(allocation_filters_for_scheme(params[:scheme] || 'agfs').collect{ |filter| [filter.humanize, filter] }, params[:filter]), class: 'select2'
-  .column-half{ style: 'padding: 15px 15px' }
+    = select_tag :filter, options_for_select(allocation_filters_for_scheme(params[:scheme] || 'agfs').collect{ |filter| [filter.humanize, filter] }, params[:filter]), class: 'form-control'
+  .form-col{ style: 'padding: 26px 0 0' }
     = submit_tag 'Select', class: 'button'

--- a/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
@@ -2,6 +2,6 @@
   .column-half
     %legend
       = t('.case_types')
-    = select_tag :filter, options_for_select(allocation_filters_for_scheme(params[:scheme]).collect{ |filter| [filter.humanize, filter] }, params[:filter]), class: 'select2'
+    = select_tag :filter, options_for_select(allocation_filters_for_scheme(params[:scheme] || 'agfs').collect{ |filter| [filter.humanize, filter] }, params[:filter]), class: 'select2'
   .column-half{ style: 'padding: 15px 15px' }
     = submit_tag 'Select', class: 'button'

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -37,7 +37,7 @@
       = f.grouped_collection_select :case_worker_id, Location.all, :case_workers, :name, :id, :name, { include_blank: true }, { class: 'form-control autocomplete' }
 
   .grid-row
-    .column-half
+    .column-quarter
       = f.submit 'Re-allocate', class: 'button'
 
   - if @claims.any?

--- a/app/views/case_workers/admin/allocations/_scheme_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_scheme_filters.html.haml
@@ -1,7 +1,10 @@
 %fieldset.inline.allocation-filter-form
-  %legend
-    = t('.scheme_types')
-  - allocation_scheme_filters.each do | filter_scheme |
-    = label_tag "scheme_#{filter_scheme}", nil, class: "block-label" do
-      = radio_button_tag :scheme, filter_scheme, params[:scheme].blank? ? filter_scheme == 'agfs' : params[:scheme] == filter_scheme
-      = filter_scheme.upcase
+  .column-half
+    %legend
+      = t('.scheme_types')
+    - allocation_scheme_filters.each do | filter_scheme |
+      = label_tag "scheme_#{filter_scheme}", nil, class: "block-label" do
+        = radio_button_tag :scheme, filter_scheme, params[:scheme].blank? ? filter_scheme == 'agfs' : params[:scheme] == filter_scheme
+        = filter_scheme.upcase
+    %noscript
+      = submit_tag 'Filter'

--- a/features/page_objects/allocation_page.rb
+++ b/features/page_objects/allocation_page.rb
@@ -6,7 +6,7 @@ class AllocationPage < SitePrism::Page
   element :notice, "#notice-summary-heading"
 
   element :allocate,
-    "form > div.grid-row:nth-of-type(1) > div:nth-of-type(3) > input"
+    "#new_allocation > div.grid-row > div > div:nth-of-type(3) > input"
 
   sections :allocations, "table.report > tbody > tr" do
     element :case_number, "td:nth-of-type(2) span"

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
 
   before(:all) do
+
+    # create one graduated fee type to match the "real" Trial case type seeded
+    create(:graduated_fee_type, code: 'GTRL') #use seeded case types "real" fee type codes
     load "#{Rails.root}/db/seeds/case_types.rb"
+
     @case_worker = create(:case_worker)
     @admin  = create(:case_worker, :admin)
   end
@@ -16,46 +20,47 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
 
   describe 'GET #new' do
 
-    before(:each) { get :new, tab: tab }
+    context 'basic rendering' do
+      before(:each) { get :new, tab: tab }
 
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
-    end
-
-    it 'assigns @case_workers' do
-      expect(assigns(:case_workers)).to eq(CaseWorker.all)
-    end
-
-    it 'assigns @allocation' do
-      expect(assigns(:allocation)).to be_new_record
-    end
-
-    it 'renders the template' do
-      expect(response).to render_template(:new)
-    end
-
-    context 'allocation tab' do
-      render_views
-      let(:tab) { 'unallocated' }
-      it 'renders the allocation partial' do
-        expect(response).to render_template(:partial => '_allocation')
-        expect(response).to render_template(:partial => '_scheme_filters')
-        expect(response).to render_template(:partial => '_case_type_filters')
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
       end
-    end
 
-    context 're-allocation tab' do
-      render_views
-      let(:tab) { 'allocated' }
-      it 'renders the re-allocation partial' do
-        expect(response).to render_template(:partial => '_re_allocation')
-        expect(response).to render_template(:partial => '_scheme_filters')
-        expect(response).to render_template(:partial => '_search_form')
+      it 'assigns @case_workers' do
+        expect(assigns(:case_workers)).to eq(CaseWorker.all)
+      end
+
+      it 'assigns @allocation' do
+        expect(assigns(:allocation)).to be_new_record
+      end
+
+      it 'renders the template' do
+        expect(response).to render_template(:new)
+      end
+
+      context 'allocation tab' do
+        render_views
+        let(:tab) { 'unallocated' }
+        it 'renders the allocation partial' do
+          expect(response).to render_template(:partial => '_allocation')
+          expect(response).to render_template(:partial => '_scheme_filters')
+          expect(response).to render_template(:partial => '_case_type_filters')
+        end
+      end
+
+      context 're-allocation tab' do
+        render_views
+        let(:tab) { 'allocated' }
+        it 'renders the re-allocation partial' do
+          expect(response).to render_template(:partial => '_re_allocation')
+          expect(response).to render_template(:partial => '_scheme_filters')
+          expect(response).to render_template(:partial => '_search_form')
+        end
       end
     end
 
     context 'allocation' do
-
       before(:all) do
         @submitted_agfs_claims = create_list(:submitted_claim, 1)
         @allocated_lgfs_claims = create_list(:litigator_claim, 1, :allocated)
@@ -83,12 +88,12 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
         end
       end
 
-      context 'Case type filter' do
+      context 'AGFS case type filter' do
         let(:params) { { tab: 'unallocated', scheme: 'agfs', filter: filter } }
 
         %w{ fixed_fee cracked trial guilty_plea redetermination awaiting_written_reasons }.each do |filter_type|
           context "filter by #{filter_type}" do
-            before { @claims = create_filterable_claim("#{filter_type}".to_sym, 1) }
+            before { @claims = create_filterable_claim(:advocate_claim, "#{filter_type}".to_sym, 1) }
             let(:filter) { "#{filter_type}" }
             it "should assign @claims to be only #{filter_type} type claims" do
               expect(assigns(:claims).map(&:id)).to eql @claims.map(&:id)
@@ -100,6 +105,29 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
           let(:filter) { 'all' }
           it "should assign @claims to be all unallocated agfs claims" do
             expect(assigns(:claims).map(&:id)).to eql @submitted_agfs_claims.map(&:id)
+          end
+        end
+      end
+
+      context 'LGFS case type filter' do
+        let(:params) { { tab: 'unallocated', scheme: 'lgfs', filter: filter } }
+
+        %w{ fixed_fee graduated_fees interim_fees warrants risk_based_bills redetermination awaiting_written_reasons interim_disbursements }.each do |filter_type|
+          # if filter_type == "risk_based_bills"
+          context "filter by #{filter_type}" do
+            before { @claims = create_filterable_claim(:litigator_claim, "#{filter_type}".to_sym, 1) }
+            let(:filter) { "#{filter_type}" }
+            it "should assign @claims to be only #{filter_type} type claims" do
+              expect(assigns(:claims).map(&:id)).to eql @claims.map(&:id)
+            end
+          end
+          # end
+        end
+
+        context "fitler by all" do
+          let(:filter) { 'all' }
+          it "should assign @claims to be all unallocated agfs claims" do
+            expect(assigns(:claims).map(&:id)).to eql @submitted_lgfs_claims.map(&:id)
           end
         end
       end
@@ -239,22 +267,42 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
 
   # local helpers
   # --------------
-  def create_filterable_claim(filter_type, number)
-   case filter_type
+  def create_filterable_claim(factory, filter_type, number)
+    for_advocate = factory == :advocate_claim
+    for_litigator = factory == :litigator_claim
+
+    case filter_type
+      # AGFS and LGFS (note: explicit return to avoid continuing)
       when :all
-        create_list(:submitted_claim, number)
+        return create_list(:submitted_claim, number) if for_advocate
+        return create_list(:litigator_claim, :submitted, number) if for_litigator
       when :fixed_fee
-        create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Contempt').id)
-      when :trial
-        create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Trial').id)
-      when :cracked
-        create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Cracked Trial').id)
-      when :guilty_plea
-        create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Guilty plea').id)
+        return create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Contempt').id) if for_advocate
+        return create_list(:litigator_claim, number, :submitted, case_type_id: CaseType.by_type('Contempt').id) if for_litigator
       when :redetermination
-        create_list(:redetermination_claim, number)
+        return create_list(:redetermination_claim, number) if for_advocate
+        return create_list(:litigator_claim, number, :redetermination) if for_litigator
       when :awaiting_written_reasons
-        create_list(:awaiting_written_reasons_claim, number)
+        return create_list(:awaiting_written_reasons_claim, number) if for_advocate
+        return create_list(:litigator_claim, number, :awaiting_written_reasons) if for_litigator
+
+      # AGFS only
+      when :trial
+        create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Trial').id) if for_advocate
+      when :cracked
+        create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Cracked Trial').id) if for_advocate
+      when :guilty_plea
+        create_list(:submitted_claim, number, case_type_id: CaseType.by_type('Guilty plea').id) if for_advocate
+
+      # LGFS only
+      when :graduated_fees
+        create_list(:litigator_claim, number, :submitted, case_type_id: CaseType.by_type('Trial').id) if for_litigator
+      when :risk_based_bills
+        if for_litigator
+          [create(:litigator_claim, :risk_based_bill, case_type_id: CaseType.by_type('Guilty plea').id )]
+        end
+      else
+        raise ArgumentError, "invalid filter type specified for \"#{__method__}\""
     end
   end
 

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -47,7 +47,7 @@ def claim_state_common_traits
     after(:create) { |c|  c.submit!; c.allocate!; set_amount_assessed(c); c.authorise! }
   end
 
-  trait :awaiting_written_reasons_claim do
+  trait :awaiting_written_reasons do
     after(:create) { |c|  c.submit!; c.allocate!; set_amount_assessed(c); c.authorise!; c.await_written_reasons! }
   end
 

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -47,8 +47,21 @@ def claim_state_common_traits
     after(:create) { |c|  c.submit!; c.allocate!; set_amount_assessed(c); c.authorise! }
   end
 
+  trait :awaiting_written_reasons_claim do
+    after(:create) { |c|  c.submit!; c.allocate!; set_amount_assessed(c); c.authorise!; c.await_written_reasons! }
+  end
+
   trait :part_authorised do
     after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.authorise_part! }
+  end
+
+  trait :redetermination do
+    after(:create) do |c|
+      Timecop.freeze(Time.now - 3.day) { c.submit! }
+      Timecop.freeze(Time.now - 2.day) { c.allocate! }
+      Timecop.freeze(Time.now - 1.day) { set_amount_assessed(c); c.authorise! }
+      c.redetermine!
+    end
   end
 
   trait :refused do

--- a/spec/factories/claim/interim_claims.rb
+++ b/spec/factories/claim/interim_claims.rb
@@ -4,4 +4,26 @@ FactoryGirl.define do
     litigator_base_setup
     claim_state_common_traits
   end
+
+  trait :interim_fee do
+    after(:build) do |claim|
+      claim.fees << build(:interim_fee, :pcmh, claim: claim)
+    end
+    after(:create) { |c| c.submit! }
+  end
+
+  trait :warrant_fee do
+    after(:build) do |claim|
+      claim.fees << build(:interim_fee, :warrant, claim: claim)
+    end
+    after(:create) { |c| c.submit! }
+  end
+
+  trait :disbursement_only_fee do
+    after(:build) do |claim|
+      claim.fees << build(:interim_fee, :disbursement, claim: claim)
+    end
+    after(:create) { |c| c.submit! }
+  end
+
 end

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -7,5 +7,16 @@ FactoryGirl.define do
     after(:build) do |claim|
       claim.fees << build(:misc_fee, claim: claim) # fees required for valid claims
     end
+  
+    # Risk based bills are litigator claims of case type guilty plea, with offences of class E,F,H,I and a PPE of 50 or less
+    # NOTE: case type is expected to be set using seeded case type of Guilty plea explicitly
+    trait :risk_based_bill do
+      offence { create(:offence, :miscellaneous, offence_class: create(:offence_class, :risk_based_bill_class)) }
+      # after(:build) do |claim|
+      #   claim.fees << build(:basic_fee, :ppe_fee, amount: 49, claim: claim)
+      # end
+      # submitted state needed for risk based bill allocation filter
+      after(:create) { |c| c.submit! }
+    end
   end
 end

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -7,15 +7,13 @@ FactoryGirl.define do
     after(:build) do |claim|
       claim.fees << build(:misc_fee, claim: claim) # fees required for valid claims
     end
-  
-    # Risk based bills are litigator claims of case type guilty plea, with offences of class E,F,H,I and a PPE of 50 or less
-    # NOTE: case type is expected to be set using seeded case type of Guilty plea explicitly
+
+    # Risk based bills are litigator claims of case type guilty plea, with offences of class E,F,H,I and a graduated fee PPE/quantity of 50 or less
     trait :risk_based_bill do
       offence { create(:offence, :miscellaneous, offence_class: create(:offence_class, :risk_based_bill_class)) }
-      # after(:build) do |claim|
-      #   claim.fees << build(:basic_fee, :ppe_fee, amount: 49, claim: claim)
-      # end
-      # submitted state needed for risk based bill allocation filter
+      after(:build) do |claim|
+        claim.fees << build(:graduated_fee, :guilty_plea_fee, quantity: 49, claim: claim)
+      end
       after(:create) { |c| c.submit! }
     end
   end

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -63,15 +63,15 @@ FactoryGirl.define do
     factory :graduated_fee_type, class: Fee::GraduatedFeeType do
       sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
       code 'GTRL'
-      calculated true
-      roles ['agfs']
+      calculated false
+      roles ['lgfs']
     end
 
     factory :interim_fee_type, class: Fee::InterimFeeType do
       sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
       code 'ITRS'
-      calculated true
-      roles ['agfs']
+      calculated false
+      roles ['lgfs']
 
       trait :disbursement do
         code 'IDISO'

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -66,6 +66,12 @@ FactoryGirl.define do
         amount nil
         disbursement_type nil
       end
+
+      trait :pcmh do
+        fee_type { build :interim_fee_type, :pcmh }
+        quantity 1
+      end
+
     end
 
     factory :basic_fee, class: Fee::BasicFee do
@@ -104,6 +110,18 @@ FactoryGirl.define do
         rate 0
         amount 25
         fee_type { build :basic_fee_type, description: 'Number of prosecution witnesses', code: 'NPW', calculated: false }
+      end
+    end
+
+    factory :graduated_fee, class: Fee::GraduatedFee do
+      claim
+      fee_type { build :graduated_fee_type }
+      quantity 1
+      amount 25
+      rate 0
+
+      trait :guilty_plea_fee do
+        fee_type { build(:graduated_fee_type, description: 'Guilty plea', code: 'GGLTY') }
       end
     end
 

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -21,7 +21,7 @@
 
 FactoryGirl.define do
   factory :fixed_fee, class: Fee::FixedFee do
-    claim 
+    claim
     fee_type { build :fixed_fee_type }
     quantity 1
     rate 25
@@ -30,7 +30,7 @@ FactoryGirl.define do
       claim
       fee_type { build :misc_fee_type }
       quantity 1
-      rate 25 
+      rate 25
     end
 
     factory :warrant_fee, class: Fee::WarrantFee do
@@ -38,7 +38,7 @@ FactoryGirl.define do
       fee_type { build :warrant_fee_type }
       warrant_issued_date    1.month.ago
 
-      trait :warrant_exectued do
+      trait :warrant_executed do
         warrant_exectuted_date { warrant_issued_date + 5.days }
       end
 
@@ -72,7 +72,7 @@ FactoryGirl.define do
       claim
       fee_type { build :basic_fee_type }
       quantity 1
-      rate 25 
+      rate 25
 
       trait :baf_fee do
         fee_type { build :basic_fee_type, code: 'BAF', description: 'Basic Fee' }
@@ -105,7 +105,6 @@ FactoryGirl.define do
         amount 25
         fee_type { build :basic_fee_type, description: 'Number of prosecution witnesses', code: 'NPW', calculated: false }
       end
-      
     end
 
     trait :with_date_attended do
@@ -120,8 +119,6 @@ FactoryGirl.define do
       amount   { rand(100..999).round(0) }
     end
 
-
-
     trait :all_zero do
       quantity 0
       rate 0
@@ -130,7 +127,6 @@ FactoryGirl.define do
     trait :from_api do
       claim         { FactoryGirl.create :claim, source: 'api' }
     end
-
 
   end
 

--- a/spec/factories/offence_classes.rb
+++ b/spec/factories/offence_classes.rb
@@ -14,11 +14,16 @@ FactoryGirl.define do
     sequence(:class_letter)   { generate_random_unused_class_letter }
     description { Faker::Lorem.sentence }
   end
+
+  trait :risk_based_bill_class do
+    sequence(:class_letter)   { generate_random_unused_class_letter(%w{ E F H I }) }
+  end
+
 end
 
-def generate_random_unused_class_letter
+def generate_random_unused_class_letter(letters=%w{ A B C D E F G H I J K })
 	existing_class_letters = OffenceClass.pluck(:class_letter)
-	possible_class_letters =  %w{ A B C D E F G H I J K } 
+	possible_class_letters = letters
 	available_class_letters = possible_class_letters - existing_class_letters
 	raise "All class letters have been used" if available_class_letters.empty?
 	available_class_letters.sample

--- a/spec/helpers/allocations_helper_spec.rb
+++ b/spec/helpers/allocations_helper_spec.rb
@@ -14,5 +14,4 @@ describe CaseWorkers::Admin::AllocationsHelper do
       expect(owner_column_header).to eql 'Litigator'
     end
   end
-
 end

--- a/spec/models/case_type_spec.rb
+++ b/spec/models/case_type_spec.rb
@@ -30,7 +30,9 @@ describe CaseType do
     let!(:grad_fee_type)     { create :graduated_fee_type, code: 'GRAD' }
     let(:grad_case_type)    { build :case_type, fee_type_code: 'GRAD' }
     let(:grad_case_type_x)  { build :case_type, fee_type_code: 'XXXX' }
-    let(:fixed_case_type)   { build :case_type, fee_type_code: nil }
+    let(:nil_case_type)      { build :case_type, fee_type_code: nil }
+    let!(:fixed_fee_type)     { create :fixed_fee_type, code: 'FIXED' }
+    let(:fixed_case_type)    { build :case_type, fee_type_code: 'FIXED' }
 
     it 'returns nil if no fee_type_code' do
       expect(fixed_case_type.graduated_fee_type).to be_nil
@@ -40,9 +42,28 @@ describe CaseType do
       expect(grad_case_type.graduated_fee_type).to eq grad_fee_type
     end
 
-    it 'returns nil if the code doesnt exist' do
+    it 'returns nil if the code does not exist' do
       expect(grad_case_type_x.graduated_fee_type).to be_nil
     end
+
+    describe 'is_graduated_fee?' do
+      it 'returns false if no fee_type_code' do
+        expect(nil_case_type.is_graduated_fee?).to eql false
+      end
+
+      it 'returns false if invalid fee_type_code' do
+        expect(grad_case_type_x.is_graduated_fee?).to eql false
+      end
+
+      it 'returns true if is a grad fee case type' do
+        expect(grad_case_type.is_graduated_fee?).to eql true
+      end
+
+      it 'returns false if it is not a grad fee case type' do
+        expect(fixed_case_type.is_graduated_fee?).to eql false
+      end
+    end
+
   end
 
   describe 'fixed_fee_type' do


### PR DESCRIPTION
Case workers need different LGFS allocation filters to enable them to prioritise workload: this PR implements the fundamentals of the filters but will need iteration. It also applies latest designs for the filters.
- modify allocation filters to dropdown
- apply conditional filter lists
- apply controller and model scopes for LGFS filters
- modify factories for creation of filterable claims
