### PR TITLE
Making sure validations are incremental, a bit of spec refactoring.

### DIFF
--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -29,6 +29,10 @@ class BaseValidator < ActiveModel::Validator
     I18n.t "activerecord.errors.models.#{model}.attributes.#{attribute}.#{error}"
   end
 
+  def steps_range(record)
+    record.from_api? ? (0..9) : (0..record.current_step_index)
+  end
+
   def attr_nil?(attribute)
     @record.__send__(attribute).nil?
   end

--- a/app/validators/claim/base_claim_sub_model_validator.rb
+++ b/app/validators/claim/base_claim_sub_model_validator.rb
@@ -21,21 +21,13 @@ class Claim::BaseClaimSubModelValidator < BaseSubModelValidator
   private
 
   def validate_has_many_associations_step_fields(record)
-    if record.from_web?
-      has_many_association_names_for_steps[record.current_step_index] || []
-    else
-      has_many_association_names_for_steps.flatten
-    end.each do |association_name|
+    has_many_association_names_for_steps[steps_range(record)].flatten.each do |association_name|
       validate_collection_for(record, association_name)
     end
   end
 
   def validate_has_one_association_step_fields(record)
-    if record.from_web?
-      has_one_association_names_for_steps[record.current_step_index] || []
-    else
-      has_one_association_names_for_steps.flatten
-    end.each do |association_name|
+    has_one_association_names_for_steps[steps_range(record)].flatten.each do |association_name|
       validate_association_for(record, association_name)
     end
   end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -13,13 +13,7 @@ class Claim::BaseClaimValidator < BaseValidator
   private
 
   def validate_step_fields
-    fields = self.class.fields_for_steps
-
-    if @record.from_web?
-      fields[@record.current_step_index] || []
-    else
-      fields.flatten
-    end.each do |field|
+    self.class.fields_for_steps[steps_range(@record)].flatten.each do |field|
       validate_field(field)
     end
   end

--- a/spec/validators/claim/advocate_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_sub_model_validator_spec.rb
@@ -1,99 +1,19 @@
 require 'rails_helper'
 require_relative '../validation_helpers'
+require_relative 'shared_examples_for_step_validators'
 
 describe Claim::AdvocateClaimSubModelValidator do
 
   let(:claim) { FactoryGirl.create :claim }
 
-  before(:each) do
-    claim.force_validation = true
-  end
-
-  context 'partial validation' do
-    let(:step1_has_one) { [] }
-    let(:step2_has_one) { [ :assessment, :certification ] }
-
-    let(:step1_has_many) { [ :defendants ] }
-    let(:step2_has_many) { [ :basic_fees, :misc_fees, :fixed_fees, :expenses, :messages, :redeterminations, :documents ] }
-
-    context 'from web' do
-      before do
-        claim.source = 'web'
-      end
-
-      context 'step 1' do
-        before do
-          claim.form_step = 1
-        end
-
-        it 'should validate has_one associations for this step' do
-          step1_has_one.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-          end
-
-          step2_has_one.each do |association|
-            expect_any_instance_of(described_class).not_to receive(:validate_association_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-
-        it 'should validate has_many associations for this step' do
-          step1_has_many.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-          end
-
-          step2_has_many.each do |association|
-            expect_any_instance_of(described_class).not_to receive(:validate_collection_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-      end
-
-      context 'step 2' do
-        before do
-          claim.form_step = 2
-        end
-
-        it 'should validate has_one associations for this step' do
-          step2_has_one.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-
-        it 'should validate has_many associations for this step' do
-          step2_has_many.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-      end
-    end
-
-    context 'from API' do
-      before do
-        claim.source = 'api'
-      end
-
-      it 'should validate all the has_one associations for all the steps' do
-        (step1_has_one + step2_has_one).each do |association|
-          expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-        end
-
-        claim.valid?
-      end
-
-      it 'should validate all the has_many associations for all the steps' do
-        (step1_has_many + step2_has_many).each do |association|
-          expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-        end
-
-        claim.valid?
-      end
-    end
-  end
+  include_examples 'common partial association validations', {
+      has_one: [
+          [],
+          [:assessment, :certification]
+      ],
+      has_many: [
+          [:defendants],
+          [:basic_fees, :misc_fees, :fixed_fees, :expenses, :messages, :redeterminations, :documents]
+      ]
+  }
 end

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 require_relative '../validation_helpers'
 require_relative 'shared_examples_for_advocate_litigator'
+require_relative 'shared_examples_for_step_validators'
 
 describe Claim::AdvocateClaimValidator do
 
@@ -95,8 +96,7 @@ describe Claim::AdvocateClaimValidator do
     end
   end
 
-  context 'partial validation' do
-    let(:step1_attributes) {
+  include_examples 'common partial validations', [
       [
           :case_type,
           :court,
@@ -116,68 +116,9 @@ describe Claim::AdvocateClaimValidator do
           :retrial_started_at,
           :retrial_concluded_at,
           :case_concluded_at
-      ]
-    }
-    let(:step2_attributes) {
+      ],
       [
           :total
       ]
-    }
-
-    context 'from web' do
-      before do
-        claim.source = 'web'
-      end
-
-      context 'step 1' do
-        before do
-          claim.form_step = 1
-        end
-
-        it 'should validate only attributes for this step' do
-          step1_attributes.each do |attrib|
-            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-          end
-
-          step2_attributes.each do |attrib|
-            expect_any_instance_of(described_class).not_to receive(:validate_field).with(attrib)
-          end
-
-          claim.valid?
-        end
-      end
-
-      context 'step 2' do
-        before do
-          claim.form_step = 2
-        end
-
-        it 'should validate only attributes for this step' do
-          step2_attributes.each do |attrib|
-            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-          end
-
-          step1_attributes.each do |attrib|
-            expect_any_instance_of(described_class).not_to receive(:validate_field).with(attrib)
-          end
-
-          claim.valid?
-        end
-      end
-    end
-
-    context 'from API' do
-      before do
-        claim.source = 'api'
-      end
-
-      it 'should validate all the attributes for all the steps' do
-        (step1_attributes + step2_attributes).each do |attrib|
-          expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-        end
-
-        claim.valid?
-      end
-    end
-  end
+  ]
 end

--- a/spec/validators/claim/interim_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_sub_model_validator_spec.rb
@@ -1,99 +1,19 @@
 require 'rails_helper'
 require_relative '../validation_helpers'
+require_relative 'shared_examples_for_step_validators'
 
 describe Claim::InterimClaimSubModelValidator do
 
   let(:claim) { FactoryGirl.create :interim_claim }
 
-  before(:each) do
-    claim.force_validation = true
-  end
-
-  context 'partial validation' do
-    let(:step1_has_one) { [] }
-    let(:step2_has_one) { [ :interim_fee, :warrant_fee, :assessment, :certification ] }
-
-    let(:step1_has_many) { [ :defendants ] }
-    let(:step2_has_many) { [ :disbursements, :messages, :redeterminations, :documents ] }
-
-    context 'from web' do
-      before do
-        claim.source = 'web'
-      end
-
-      context 'step 1' do
-        before do
-          claim.form_step = 1
-        end
-
-        it 'should validate has_one associations for this step' do
-          step1_has_one.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-          end
-
-          step2_has_one.each do |association|
-            expect_any_instance_of(described_class).not_to receive(:validate_association_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-
-        it 'should validate has_many associations for this step' do
-          step1_has_many.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-          end
-
-          step2_has_many.each do |association|
-            expect_any_instance_of(described_class).not_to receive(:validate_collection_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-      end
-
-      context 'step 2' do
-        before do
-          claim.form_step = 2
-        end
-
-        it 'should validate has_one associations for this step' do
-          step2_has_one.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-
-        it 'should validate has_many associations for this step' do
-          step2_has_many.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-      end
-    end
-
-    context 'from API' do
-      before do
-        claim.source = 'api'
-      end
-
-      it 'should validate all the has_one associations for all the steps' do
-        (step1_has_one + step2_has_one).each do |association|
-          expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-        end
-
-        claim.valid?
-      end
-
-      it 'should validate all the has_many associations for all the steps' do
-        (step1_has_many + step2_has_many).each do |association|
-          expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-        end
-
-        claim.valid?
-      end
-    end
-  end
+  include_examples 'common partial association validations', {
+      has_one: [
+          [],
+          [:interim_fee, :warrant_fee, :assessment, :certification]
+      ],
+      has_many: [
+          [:defendants],
+          [:disbursements, :messages, :redeterminations, :documents]
+      ]
+  }
 end

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 require_relative '../validation_helpers'
 require_relative 'shared_examples_for_advocate_litigator'
+require_relative 'shared_examples_for_step_validators'
 
 describe Claim::InterimClaimValidator do
 
@@ -13,8 +14,7 @@ describe Claim::InterimClaimValidator do
   include_examples "common advocate litigator validations", :litigator
   include_examples "common litigator validations"
 
-  context 'partial validation' do
-    let(:step1_attributes) {
+  include_examples 'common partial validations', [
       [
           :case_type,
           :court,
@@ -22,9 +22,7 @@ describe Claim::InterimClaimValidator do
           :advocate_category,
           :offence,
           :case_concluded_at
-      ]
-    }
-    let(:step2_attributes) {
+      ],
       [
           :first_day_of_trial,
           :estimated_trial_length,
@@ -35,62 +33,5 @@ describe Claim::InterimClaimValidator do
           :legal_aid_transfer_date,
           :total
       ]
-    }
-
-    context 'from web' do
-      before do
-        claim.source = 'web'
-      end
-
-      context 'step 1' do
-        before do
-          claim.form_step = 1
-        end
-
-        it 'should validate only attributes for this step' do
-          step1_attributes.each do |attrib|
-            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-          end
-
-          step2_attributes.each do |attrib|
-            expect_any_instance_of(described_class).not_to receive(:validate_field).with(attrib)
-          end
-
-          claim.valid?
-        end
-      end
-
-      context 'step 2' do
-        before do
-          claim.form_step = 2
-        end
-
-        it 'should validate only attributes for this step' do
-          step2_attributes.each do |attrib|
-            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-          end
-
-          step1_attributes.each do |attrib|
-            expect_any_instance_of(described_class).not_to receive(:validate_field).with(attrib)
-          end
-
-          claim.valid?
-        end
-      end
-    end
-
-    context 'from API' do
-      before do
-        claim.source = 'api'
-      end
-
-      it 'should validate all the attributes for all the steps' do
-        (step1_attributes + step2_attributes).each do |attrib|
-          expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-        end
-
-        claim.valid?
-      end
-    end
-  end
+  ]
 end

--- a/spec/validators/claim/litigator_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_sub_model_validator_spec.rb
@@ -1,99 +1,19 @@
 require 'rails_helper'
 require_relative '../validation_helpers'
+require_relative 'shared_examples_for_step_validators'
 
 describe Claim::LitigatorClaimSubModelValidator do
 
   let(:claim) { FactoryGirl.create :litigator_claim }
 
-  before(:each) do
-    claim.force_validation = true
-  end
-
-  context 'partial validation' do
-    let(:step1_has_one) { [] }
-    let(:step2_has_one) { [ :graduated_fee, :fixed_fee, :warrant_fee, :assessment, :certification ] }
-
-    let(:step1_has_many) { [ :defendants ] }
-    let(:step2_has_many) { [ :misc_fees, :disbursements, :expenses, :messages, :redeterminations, :documents ] }
-
-    context 'from web' do
-      before do
-        claim.source = 'web'
-      end
-
-      context 'step 1' do
-        before do
-          claim.form_step = 1
-        end
-
-        it 'should validate has_one associations for this step' do
-          step1_has_one.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-          end
-
-          step2_has_one.each do |association|
-            expect_any_instance_of(described_class).not_to receive(:validate_association_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-
-        it 'should validate has_many associations for this step' do
-          step1_has_many.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-          end
-
-          step2_has_many.each do |association|
-            expect_any_instance_of(described_class).not_to receive(:validate_collection_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-      end
-
-      context 'step 2' do
-        before do
-          claim.form_step = 2
-        end
-
-        it 'should validate has_one associations for this step' do
-          step2_has_one.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-
-        it 'should validate has_many associations for this step' do
-          step2_has_many.each do |association|
-            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-          end
-
-          claim.valid?
-        end
-      end
-    end
-
-    context 'from API' do
-      before do
-        claim.source = 'api'
-      end
-
-      it 'should validate all the has_one associations for all the steps' do
-        (step1_has_one + step2_has_one).each do |association|
-          expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
-        end
-
-        claim.valid?
-      end
-
-      it 'should validate all the has_many associations for all the steps' do
-        (step1_has_many + step2_has_many).each do |association|
-          expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
-        end
-
-        claim.valid?
-      end
-    end
-  end
+  include_examples 'common partial association validations', {
+      has_one: [
+          [],
+          [:graduated_fee, :fixed_fee, :warrant_fee, :assessment, :certification]
+      ],
+      has_many: [
+          [:defendants],
+          [:misc_fees, :disbursements, :expenses, :messages, :redeterminations, :documents]
+      ]
+  }
 end

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 require_relative '../validation_helpers'
 require_relative 'shared_examples_for_advocate_litigator'
+require_relative 'shared_examples_for_step_validators'
 
 describe Claim::LitigatorClaimValidator do
 
@@ -13,8 +14,7 @@ describe Claim::LitigatorClaimValidator do
   include_examples "common advocate litigator validations", :litigator
   include_examples "common litigator validations"
 
-  context 'partial validation' do
-    let(:step1_attributes) {
+  include_examples 'common partial validations', [
       [
           :case_type,
           :court,
@@ -22,9 +22,7 @@ describe Claim::LitigatorClaimValidator do
           :advocate_category,
           :offence,
           :case_concluded_at
-      ]
-    }
-    let(:step2_attributes) {
+      ],
       [
           :estimated_trial_length,
           :actual_trial_length,
@@ -40,62 +38,5 @@ describe Claim::LitigatorClaimValidator do
           :retrial_concluded_at,
           :total
       ]
-    }
-
-    context 'from web' do
-      before do
-        claim.source = 'web'
-      end
-
-      context 'step 1' do
-        before do
-          claim.form_step = 1
-        end
-
-        it 'should validate only attributes for this step' do
-          step1_attributes.each do |attrib|
-            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-          end
-
-          step2_attributes.each do |attrib|
-            expect_any_instance_of(described_class).not_to receive(:validate_field).with(attrib)
-          end
-
-          claim.valid?
-        end
-      end
-
-      context 'step 2' do
-        before do
-          claim.form_step = 2
-        end
-
-        it 'should validate only attributes for this step' do
-          step2_attributes.each do |attrib|
-            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-          end
-
-          step1_attributes.each do |attrib|
-            expect_any_instance_of(described_class).not_to receive(:validate_field).with(attrib)
-          end
-
-          claim.valid?
-        end
-      end
-    end
-
-    context 'from API' do
-      before do
-        claim.source = 'api'
-      end
-
-      it 'should validate all the attributes for all the steps' do
-        (step1_attributes + step2_attributes).each do |attrib|
-          expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
-        end
-
-        claim.valid?
-      end
-    end
-  end
+  ]
 end

--- a/spec/validators/claim/shared_examples_for_step_validators.rb
+++ b/spec/validators/claim/shared_examples_for_step_validators.rb
@@ -1,0 +1,154 @@
+shared_examples 'common partial validations' do |steps|
+
+  context 'partial validation' do
+    let(:step1_attributes) { steps[0] }
+    let(:step2_attributes) { steps[1] }
+
+    context 'from web' do
+      before do
+        claim.source = 'web'
+      end
+
+      context 'step 1' do
+        before do
+          claim.form_step = 1
+        end
+
+        it 'should validate only attributes for this step' do
+          step1_attributes.each do |attrib|
+            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
+          end
+
+          step2_attributes.each do |attrib|
+            expect_any_instance_of(described_class).not_to receive(:validate_field).with(attrib)
+          end
+
+          claim.valid?
+        end
+      end
+
+      context 'step 2' do
+        before do
+          claim.form_step = 2
+        end
+
+        it 'should validate attributes for this step and previous steps' do
+          (step1_attributes + step2_attributes).each do |attrib|
+            expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
+          end
+
+          claim.valid?
+        end
+      end
+    end
+
+    context 'from API' do
+      before do
+        claim.source = 'api'
+      end
+
+      it 'should validate all the attributes for all the steps' do
+        (step1_attributes + step2_attributes).each do |attrib|
+          expect_any_instance_of(described_class).to receive(:validate_field).with(attrib)
+        end
+
+        claim.valid?
+      end
+    end
+  end
+end
+
+shared_examples 'common partial association validations' do |steps|
+
+  context 'partial validation' do
+    let(:step1_has_one) { steps[:has_one][0] }
+    let(:step2_has_one) { steps[:has_one][1] }
+
+    let(:step1_has_many) { steps[:has_many][0] }
+    let(:step2_has_many) { steps[:has_many][1] }
+
+    before(:each) do
+      claim.force_validation = true
+    end
+
+    context 'from web' do
+      before do
+        claim.source = 'web'
+      end
+
+      context 'step 1' do
+        before do
+          claim.form_step = 1
+        end
+
+        it 'should validate has_one associations for this step' do
+          step1_has_one.each do |association|
+            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
+          end
+
+          step2_has_one.each do |association|
+            expect_any_instance_of(described_class).not_to receive(:validate_association_for).with(claim, association)
+          end
+
+          claim.valid?
+        end
+
+        it 'should validate has_many associations for this step' do
+          step1_has_many.each do |association|
+            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
+          end
+
+          step2_has_many.each do |association|
+            expect_any_instance_of(described_class).not_to receive(:validate_collection_for).with(claim, association)
+          end
+
+          claim.valid?
+        end
+      end
+
+      context 'step 2' do
+        before do
+          claim.form_step = 2
+        end
+
+        it 'should validate has_one associations for this step and previous steps' do
+          (step1_has_one + step2_has_one).each do |association|
+            expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
+          end
+
+          claim.valid?
+        end
+
+        it 'should validate has_many associations for this step and previous steps' do
+          (step1_has_many + step2_has_many).each do |association|
+            expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
+          end
+
+          claim.valid?
+        end
+      end
+    end
+
+    context 'from API' do
+      before do
+        claim.source = 'api'
+      end
+
+      it 'should validate all the has_one associations for all the steps' do
+        (step1_has_one + step2_has_one).each do |association|
+          expect_any_instance_of(described_class).to receive(:validate_association_for).with(claim, association)
+        end
+
+        claim.valid?
+      end
+
+      it 'should validate all the has_many associations for all the steps' do
+        (step1_has_many + step2_has_many).each do |association|
+          expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
+        end
+
+        claim.valid?
+      end
+    end
+  end
+end


### PR DESCRIPTION
**PT#118274931**

Validations (from web, not API) are now run in an incremental mode where for page 1, only step 1 validations are run, but for page 2, validations for step 1 and step 2 are run, and so on (we only have 2 steps currently but might have more in the future).

Also a bit of spec refactoring to avoid so much repetition now we have several kind of claims.
