### PR TITLE
Demo data generator for interim claims.

### DIFF
--- a/lib/demo_data/base_claim_generator.rb
+++ b/lib/demo_data/base_claim_generator.rb
@@ -16,7 +16,7 @@ module DemoData
       @states = options[:states] == :all ? Claims::StateMachine.dashboard_displayable_states : options[:states]
       @num_external_users = options[:num_external_users]
       @num_claims = options[:num_claims_per_state]
-      @external_user_persona = self.instance_of?(DemoData::LitigatorClaimGenerator) ? :litigator : :advocate
+      @external_user_persona = self.kind_of?(DemoData::LgfsSchemeClaimGenerator) ? :litigator : :advocate
     end
 
     def run
@@ -80,7 +80,7 @@ module DemoData
     end
 
     def add_defendants(claim)
-      rand(1..5).times { FactoryGirl.create(:defendant, claim: claim) }
+      rand(1..3).times { FactoryGirl.create(:defendant, claim: claim) }
       claim.save!
       claim.reload
     end

--- a/lib/demo_data/claim_state_advancer.rb
+++ b/lib/demo_data/claim_state_advancer.rb
@@ -39,11 +39,7 @@ module DemoData
     end
 
     def submit(claim)
-      if claim.instance_of? Claim::AdvocateClaim
-        add_message(claim, claim.external_user)
-      else
-        add_message(claim, claim.creator)
-      end
+      add_message(claim, claim.external_user)
       claim.update(last_submitted_at: rand(0..180).days.ago)
       claim.submit!
     end

--- a/lib/demo_data/interim_claim_generator.rb
+++ b/lib/demo_data/interim_claim_generator.rb
@@ -1,0 +1,25 @@
+require_relative 'lgfs_scheme_claim_generator'
+require_relative 'interim_fee_generator'
+
+module DemoData
+  class InterimClaimGenerator < LgfsSchemeClaimGenerator
+
+    def generate_claim(litigator)
+      super(Claim::InterimClaim, litigator)
+    end
+
+    private
+
+    def add_claim_detail(claim)
+      # do nothing for interim claims, not needed
+    end
+
+    def add_fees_expenses_and_disbursements(claim)
+      add_interim_fee(claim)
+    end
+
+    def add_interim_fee(claim)
+      DemoData::InterimFeeGenerator.new(claim).generate!
+    end
+  end
+end

--- a/lib/demo_data/interim_fee_generator.rb
+++ b/lib/demo_data/interim_fee_generator.rb
@@ -1,0 +1,60 @@
+module DemoData
+  class InterimFeeGenerator
+
+    def initialize(claim)
+      @claim     = claim
+      @fee_types = Fee::InterimFeeType.lgfs
+      @fee_types.reject! {|ft| ft.is_disbursement? }   # temporarily until we fix Assessment
+    end
+
+    def generate!
+      add_fee
+    end
+
+    private
+
+    def add_fee
+      fee_type = @fee_types.sample
+      fee = Fee::InterimFee.new(claim: @claim, fee_type: fee_type)
+
+      setup_fee(fee)
+
+      @claim.save
+      fee.save
+    end
+
+    def setup_fee(fee)
+      if fee.is_interim_warrant?
+        @claim.fees << FactoryGirl.build(:warrant_fee, amount: rand(100.0..2500.0))
+      end
+
+      if fee.is_disbursement? || fee.is_effective_pcmh?
+        @claim.disbursements << FactoryGirl.build_list(:disbursement, rand(1..3))
+      end
+
+      if fee.is_effective_pcmh?
+        @claim.effective_pcmh_date = rand(1..5).months.ago
+      end
+
+      if fee.is_trial_start?
+        @claim.first_day_of_trial = rand(1..5).months.ago
+        @claim.estimated_trial_length = rand(3..15)
+      end
+
+      if fee.is_retrial_start?
+        @claim.retrial_started_at = rand(1..5).months.ago
+        @claim.retrial_estimated_length = rand(3..15)
+      end
+
+      if fee.is_retrial_new_solicitor?
+        @claim.legal_aid_transfer_date = rand(1..5).months.ago
+        @claim.trial_concluded_at = rand(1..5).months.ago
+      end
+
+      unless fee.is_disbursement? || fee.is_interim_warrant?
+        fee.quantity = rand(10..50)
+        fee.amount   = rand(1000.0..5000.0)
+      end
+    end
+  end
+end

--- a/lib/demo_data/lgfs_scheme_claim_generator.rb
+++ b/lib/demo_data/lgfs_scheme_claim_generator.rb
@@ -1,0 +1,76 @@
+require_relative 'base_claim_generator'
+require_relative 'disbursement_generator'
+
+module DemoData
+  # For claims: litigator, interim, transfer...
+  class LgfsSchemeClaimGenerator < BaseClaimGenerator
+
+    def generate_claim(klass, litigator)
+      claim = klass.new(
+          creator: litigator,
+          external_user: litigator,
+          advocate_category: nil,
+          court: Court.all.sample,
+          case_number: ('A'..'Z').to_a.sample + rand(10000000..99999999).to_s,
+          offence: Offence.miscellaneous.sample,
+          apply_vat: (rand(1..4) % 4 == 0 ? false : true),
+          state: "draft",
+          cms_number: "CMS-2015-195-1",
+          evidence_checklist_ids: [],
+          source: "web",
+          vat_amount: 0.0,
+          additional_information: generate_additional_info,
+          supplier_number: litigator.provider.supplier_numbers.sample.supplier_number
+      )
+
+      claim.case_type = claim.eligible_case_types.sample
+      claim.case_concluded_at = generate_case_concluded_at(claim)
+      claim.save!
+
+      puts "Added #{klass.to_s.demodulize} #{claim.id} #{claim.case_type.name} for litigator #{litigator.name}"
+      add_defendants(claim)
+      add_documents(claim)
+      add_claim_detail(claim)
+      claim.save
+
+      add_fees_expenses_and_disbursements(claim)
+      claim.reload  # load all the fees, expenses and disbursements that have been created
+      claim.save    # save in order to update fee, expense and disbursement totals
+      claim
+    end
+
+    private
+
+    def add_certification(claim)
+      FactoryGirl.create(:certification, claim: claim, certified_by: claim.creator.name, certification_type: CertificationType.all.sample)
+      claim.save!
+    end
+
+    def add_disbursements(claim)
+      DisbursementGenerator.new(claim).generate!
+    end
+
+    def latest_of(*dates)
+      latest = Date.new(1970, 1, 1)
+      dates.each do |date|
+        latest = date unless (date.nil? || date < latest)
+      end
+      latest + 1
+    end
+
+    def generate_case_concluded_at(claim)
+      latest_of(
+          claim.trial_concluded_at,
+          claim.retrial_concluded_at,
+          claim.trial_fixed_notice_at,
+          claim.trial_fixed_at,
+          claim.trial_cracked_at,
+          claim.trial_cracked_at_third,
+          random_concluded_date)
+    end
+
+    def random_concluded_date
+      rand(1..10).days.ago
+    end
+  end
+end

--- a/lib/demo_data/litigator_claim_generator.rb
+++ b/lib/demo_data/litigator_claim_generator.rb
@@ -1,79 +1,23 @@
-require_relative 'base_claim_generator'
-require_relative 'disbursement_generator'
+require_relative 'lgfs_scheme_claim_generator'
 
 module DemoData
-  class LitigatorClaimGenerator < BaseClaimGenerator
+  class LitigatorClaimGenerator < LgfsSchemeClaimGenerator
 
     def generate_claim(litigator)
-      claim = Claim::LitigatorClaim.new(
-        creator: litigator,
-        external_user: litigator,
-        advocate_category: nil,
-        court: Court.all.sample,
-        case_type: CaseType.lgfs.sample,
-        case_number: ('A'..'Z').to_a.sample +  rand(10000000..99999999).to_s,
-        offence: Offence.miscellaneous.sample,
-        apply_vat: (rand(1..4) % 4 == 0 ? false : true),
-        state: "draft",
-        cms_number: "CMS-2015-195-1",
-        evidence_checklist_ids: [],
-        source: "web",
-        vat_amount: 0.0,
-        additional_information: generate_additional_info,
-        supplier_number: litigator.provider.supplier_numbers.sample.supplier_number
-      )
-      claim.case_concluded_at = generate_case_concluded_at(claim)
-      claim.save!
-      puts "Added claim #{claim.id} #{claim.case_type.name} for litigator #{litigator.name}"
-      add_defendants(claim)
-      add_documents(claim)
-      add_claim_detail(claim)
-      claim.save
-      add_fees(claim)
-      add_expenses(claim)
-      add_disbursements(claim)
-      claim.reload              # load all the fees, expenses and disbursements that have been created
-      claim.save                # save in order to update fee, expense and disbursement totals
-      claim
+      super(Claim::LitigatorClaim, litigator)
     end
 
-  private
+    private
 
-    def add_certification(claim)
-      FactoryGirl.create(:certification, claim: claim, certified_by: claim.creator.name, certification_type: CertificationType.all.sample)
-      claim.save!
+    def add_claim_detail(claim)
+      super
     end
 
-    def add_disbursements(claim)
-      DisbursementGenerator.new(claim).generate!
-    end
-
-    def add_fees(claim)
+    def add_fees_expenses_and_disbursements(claim)
       add_fixed_fees(claim) if claim.case_type.is_fixed_fee?
       add_misc_fees(claim)
-    end
-
-    def latest_of(*dates)
-      latest = Date.new(1970, 1, 1)
-      dates.each do |date|
-        latest = date unless (date.nil? || date < latest)
-      end
-      latest + 1
-    end
-
-    def generate_case_concluded_at(claim)
-      latest_of(
-        claim.trial_concluded_at, 
-        claim.retrial_concluded_at, 
-        claim.trial_fixed_notice_at,
-        claim.trial_fixed_at,
-        claim.trial_cracked_at,
-        claim.trial_cracked_at_third,
-        random_concluded_date)
-    end
-
-    def random_concluded_date
-      rand(1..10).days.ago
+      add_expenses(claim)
+      add_disbursements(claim)
     end
   end
 end

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -16,8 +16,10 @@ namespace :claims do
     load File.join(Rails.root, 'lib', 'demo_data', 'demo_seeds.rb')
     require File.join(Rails.root, 'lib', 'demo_data', 'advocate_claim_generator')
     require File.join(Rails.root, 'lib', 'demo_data', 'litigator_claim_generator')
+    require File.join(Rails.root, 'lib', 'demo_data', 'interim_claim_generator')
     DemoData::AdvocateClaimGenerator.new(num_external_users: 2).run
     DemoData::LitigatorClaimGenerator.new(num_external_users: 2).run
+    DemoData::InterimClaimGenerator.new(num_external_users: 2).run
   end
 
   desc  'ADP Task: Delete sample providers'


### PR DESCRIPTION
Disabled temporarily the creation of `disbursements interim fees` as we need to update the Assessment model to store the disbursements total as we are doing for fees and expenses.

Other than that, the generator is fully functional.
