### PR TITLE
Setting allocation type set on submit

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 module Claim

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 module Claim
@@ -374,6 +375,10 @@ module Claim
     end
 
     private
+
+    # called from state_machine before_transition on submit - override in subclass
+    #
+    def set_allocation_type; end
 
     def destroy_all_invalid_fee_types; end
 

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 module Claim

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 module Claim

--- a/app/models/claim/transfer_brain.rb
+++ b/app/models/claim/transfer_brain.rb
@@ -68,5 +68,9 @@ module Claim
       TransferBrainDataItemCollection.instance.to_json.chomp
     end
 
+    def self.allocation_type(detail)
+      TransferBrainDataItemCollection.instance.allocation_type(detail)
+    end
+
   end
 end

--- a/app/models/claim/transfer_brain_data_item.rb
+++ b/app/models/claim/transfer_brain_data_item.rb
@@ -14,7 +14,7 @@ module Claim
         @validity                 = arry.shift.to_bool
         @visibility               = get_visibility(arry.shift)
         @transfer_fee_full_name   = arry.shift
-        @allocation_case_type     = arry.shift
+        @allocation_type          = arry.shift
       rescue => err
         puts "#{err.class}: #{err.message}"
         ap copy_array
@@ -40,7 +40,7 @@ module Claim
                 :visibility => @visibility,
                 :validity => @validity,
                 :transfer_fee_full_name => @transfer_fee_full_name,
-                :allocation_case_type => @allocation_case_type
+                :allocation_type => @allocation_type
               }
             }
           }

--- a/app/models/claim/transfer_brain_data_item_collection.rb
+++ b/app/models/claim/transfer_brain_data_item_collection.rb
@@ -19,7 +19,6 @@ module Claim
     def initialize
       lines = load_file
       @collection = []
-      lines.shift
       lines.each { |line| @collection << TransferBrainDataItem.new(line) }
       @collection_hash = construct_collection_hash
     end
@@ -36,8 +35,12 @@ module Claim
     end
 
     def data_item_for(detail)
-      result =  @collection_hash[detail.litigator_type][detail.elected_case][detail.transfer_stage_id][detail.case_conclusion_id]
-      result = @collection_hash[detail.litigator_type][detail.elected_case][detail.transfer_stage_id]['*'] if result.nil?
+      begin
+        result = @collection_hash.fetch(detail.litigator_type).fetch(detail.elected_case).fetch(detail.transfer_stage_id)[detail.case_conclusion_id]
+        result = @collection_hash.fetch(detail.litigator_type).fetch(detail.elected_case).fetch(detail.transfer_stage_id).fetch('*') if result.nil?
+      rescue KeyError
+        result = nil
+      end
       result
     end
 
@@ -46,9 +49,9 @@ module Claim
       data_item_for(detail)[:transfer_fee_full_name]
     end
 
-    def allocation_case_type(detail)
+    def allocation_type(detail)
       raise ArgumentError.new('Invalid combination of transfer detail fields') unless detail_valid?(detail)
-      data_item_for(detail)[:allocation_case_type]
+      data_item_for(detail)[:allocation_type]
     end
 
     def detail_valid?(detail)

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 module Claim
@@ -56,11 +57,6 @@ module Claim
     has_one :transfer_detail, foreign_key: :claim_id
 
     validates_with TransferClaimValidator
-
-    after_initialize do
-      self.transfer_detail = TransferDetail.new if self.transfer_detail.nil?
-    end
-
 
     # The ActiveSupport delegate method doesn't work with new objects - i.e. You can't say Claim.new(xxx: value) where xxx is delegated
     # So we have to do this instead.  Probably good to put it in a gem eventually.
@@ -91,15 +87,16 @@ module Claim
       CaseType.lgfs
     end
 
-    # private
-    # def destroy_all_invalid_fee_types
-    #   # noop
-    # end
-
     private
+
+    # called from state_machine before_submit
+    def set_allocation_type
+      self.allocation_type = self.transfer_detail.allocation_type
+    end
 
     def provider_delegator
       provider
     end
+
   end
 end

--- a/app/models/claim/transfer_detail.rb
+++ b/app/models/claim/transfer_detail.rb
@@ -43,6 +43,10 @@ module Claim
       end
     end
 
+    def allocation_type
+      TransferBrain.allocation_type(self)
+    end
+
     def unpopulated?
       self.litigator_type.nil? && self.elected_case.nil? && self.transfer_stage_id.nil? && self.case_conclusion_id.nil?
     end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -1,5 +1,5 @@
 module Claims::StateMachine
-  ARCHIVE_VALIDITY = 180.days
+  ARCHIVE_VALIDITY  = 180.days
   STANDARD_VALIDITY = 21.days
 
   EXTERNAL_USER_DASHBOARD_DRAFT_STATES            = %w( draft )
@@ -68,6 +68,7 @@ module Claims::StateMachine
       after_transition on: :archive_pending_delete,   do: :set_valid_until!
       before_transition on: [:reject, :refuse], do: :set_amount_assessed_zero!
       after_transition on: :deallocate, do: :reset_state
+      before_transition on: :submit,                  do: :set_allocation_type
 
       event :redetermine do
         transition VALID_STATES_FOR_REDETERMINATION.map(&:to_sym) => :redetermination
@@ -158,6 +159,10 @@ module Claims::StateMachine
 
   def set_amount_assessed_zero!
     self.assessment.zeroize! if self.state == 'allocated'
+  end
+
+  def set_allocation_type
+    self.set_allocation_type
   end
 
   def remove_case_workers!

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -19,7 +19,7 @@
 #  mileage_rate_id :integer
 #  date            :date
 #  hours           :integer
-#  vat_amount      :decimal          default(0.0)
+#  vat_amount      :decimal(, )      default(0.0)
 #
 
 class Expense < ActiveRecord::Base

--- a/db/migrate/20160425143749_add_allocation_type_to_claims.rb
+++ b/db/migrate/20160425143749_add_allocation_type_to_claims.rb
@@ -1,0 +1,5 @@
+class AddAllocationTypeToClaims < ActiveRecord::Migration
+  def change
+    add_column :claims, :allocation_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422103856) do
+ActiveRecord::Schema.define(version: 20160425143749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,6 +134,7 @@ ActiveRecord::Schema.define(version: 20160422103856) do
     t.string   "supplier_number"
     t.date     "effective_pcmh_date"
     t.date     "legal_aid_transfer_date"
+    t.string   "allocation_type"
   end
 
   add_index "claims", ["case_number"], name: "index_claims_on_case_number", using: :btree

--- a/spec/factories/claim/transfer_claims.rb
+++ b/spec/factories/claim/transfer_claims.rb
@@ -3,6 +3,13 @@ FactoryGirl.define do
     litigator_base_setup
     claim_state_common_traits
 
+    # transfer_detail attributes
+    litigator_type      'original'
+    elected_case        false
+    transfer_stage_id   10
+    transfer_date       2.months.ago
+    case_conclusion_id  10
+
     trait :trial do
       case_type  { build(:case_type, :trial) }
       first_day_of_trial 30.days.ago
@@ -11,12 +18,6 @@ FactoryGirl.define do
       actual_trial_length 3
     end
 
-
-    after(:build) do |rec|
-      if rec.transfer_detail.unpopulated?
-        rec.transfer_detail = build :transfer_detail, claim: rec
-      end
-    end
   end
 end
 

--- a/spec/factories/claim/transfer_details.rb
+++ b/spec/factories/claim/transfer_details.rb
@@ -1,13 +1,12 @@
 
 FactoryGirl.define do
   factory :transfer_detail, class: Claim::TransferDetail do
-    claim               { build :transfer_claim }
+
     litigator_type      'original'
     elected_case        false
     transfer_stage_id   10
     transfer_date       2.months.ago
     case_conclusion_id  10
-
   end
 end
 

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -19,7 +19,7 @@
 #  mileage_rate_id :integer
 #  date            :date
 #  hours           :integer
-#  vat_amount      :decimal          default(0.0)
+#  vat_amount      :decimal(, )      default(0.0)
 #
 
 FactoryGirl.define do

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -49,6 +49,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 require 'rails_helper'

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 require 'rails_helper'

--- a/spec/models/claim/interim_claim_spec.rb
+++ b/spec/models/claim/interim_claim_spec.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 require 'rails_helper'

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 require 'rails_helper'

--- a/spec/models/claim/transfer_claim_spec.rb
+++ b/spec/models/claim/transfer_claim_spec.rb
@@ -48,6 +48,7 @@
 #  supplier_number          :string
 #  effective_pcmh_date      :date
 #  legal_aid_transfer_date  :date
+#  allocation_type          :string
 #
 
 require "rails_helper"
@@ -60,11 +61,34 @@ describe Claim::TransferClaim, type: :model do
   describe '.new' do
     let(:today) { Date.today }
 
-    it 'creates an empty transfer detail class upon instantiation of a new object' do
+    it 'does not create a transfer detail if no params are passed to new' do
       claim = Claim::TransferClaim.new
+      expect(claim.transfer_detail).to be_nil
+    end
+
+    it 'builds a transfer detail if one of the transfer detail attributes is mentioned in a .new' do
+      claim = Claim::TransferClaim.new(elected_case: true)
+      expect(claim.transfer_detail).not_to be_nil
+      expect(claim.elected_case)
+    end
+
+    it 'builds a transfer detail on an existing claim when detail getter first used' do
+      claim = Claim::TransferClaim.new
+      expect(claim.transfer_detail).to be_nil
+      claim.litigator_type
       expect(claim.transfer_detail).not_to be_nil
       expect(claim.transfer_detail).to be_unpopulated
     end
+
+    it 'builds a transfer detail on an existing claim when detail setter first used' do
+      claim = Claim::TransferClaim.new
+      expect(claim.transfer_detail).to be_nil
+      claim.litigator_type = 'original'
+      expect(claim.transfer_detail).not_to be_nil
+      expect(claim.transfer_detail.litigator_type).to eq 'original'
+      expect(claim.litigator_type).to eq 'original'
+    end
+
 
     it 'populates transfer detail with transfer detail attributes' do
       claim = Claim::TransferClaim.new(case_number: 'A12345678', litigator_type: "new", elected_case: false, transfer_stage_id: 10, transfer_date: today, case_conclusion_id: 30)

--- a/spec/models/claim/transfer_detail_spec.rb
+++ b/spec/models/claim/transfer_detail_spec.rb
@@ -32,6 +32,9 @@ module Claim
     end
 
     describe  '#errors?' do
+
+      before(:each) { detail.claim = build(:transfer_claim) }
+
       it 'returns false if there are no errors relating to transfer_detail fields' do
         expect(detail.errors?).to be false
       end
@@ -44,6 +47,17 @@ module Claim
       it 'reteurns false if claim is nil' do
         detail.claim = nil
         expect(detail.errors?).to be false
+      end
+    end
+
+    describe '#allocation_type' do
+      it 'should return Grad' do
+        expect(detail.allocation_type).to eq 'Grad'
+      end
+
+      it 'should return Fixed' do
+        detail = build(:transfer_detail, litigator_type: 'new', elected_case: true, transfer_stage_id: 10, case_conclusion_id: nil)
+        expect(detail.allocation_type).to eq 'Fixed'
       end
     end
   end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -241,4 +241,13 @@ RSpec.describe Claims::StateMachine, type: :model do
       expect(ClaimStateTransition.last.to).to eq(expected[:to])
     end
   end
+
+  describe 'before submit state transition' do
+    it 'sets the allocation_type for trasfer_claims' do
+      claim = build :transfer_claim
+      expect(claim.allocation_type).to be nil
+      claim.submit!
+      expect(claim.allocation_type).to eq 'Grad'
+    end
+  end
 end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -19,7 +19,7 @@
 #  mileage_rate_id :integer
 #  date            :date
 #  hours           :integer
-#  vat_amount      :decimal          default(0.0)
+#  vat_amount      :decimal(, )      default(0.0)
 #
 
 require 'rails_helper'


### PR DESCRIPTION
The allocation type is set whenever a TransferClaim transitions to submitted state.
This is acheived by a after_transmission hook which calls set_allocation_type on the claim.
This method is implemented as an empty method on BaseClaim, but on TransferClaim it
calls TransferBrain to work out the allocation type according tothe fields on the TransferDetail and
save it to the claim record.
