### PR TITLE
Lgfs flat vat amount on determinations

### DIFF
--- a/app/assets/javascripts/modules/case_worker/claims/DeterminationCalculator.js
+++ b/app/assets/javascripts/modules/case_worker/claims/DeterminationCalculator.js
@@ -12,7 +12,9 @@ moj.Modules.DeterminationCalculator = {
     this.$determinationsTable = $(this.el);
     this.$totalExclVat = $('.js-total-exc-vat-determination', this.$determinationsTable);
     this.$totalVat = $('.js-vat-determination', this.$determinationsTable);
+    this.$totalLgfsVat = $('.js-lgfs-vat-determination', this.$determinationsTable);
     this.$totalInclVat = $('.js-total-determination', this.$determinationsTable);
+    this.scheme = this.$determinationsTable.data('scheme');
     this.ajaxVat = this.$determinationsTable.data('applyVat');
     this.vatUrl = this.$determinationsTable.data('vatUrl');
     this.vatDate = this.$determinationsTable.data('submittedDate');
@@ -43,19 +45,19 @@ moj.Modules.DeterminationCalculator = {
       });
   },
 
-    calculateAmount: function (fee, expenses, disbursements) {
-        var f = fee || 0,
-            e = expenses || 0,
-            d = disbursements || 0;
+  calculateAmount: function (fee, expenses, disbursements) {
+    var f = fee || 0,
+        e = expenses || 0,
+        d = disbursements || 0;
 
-        f = f < 0 ? 0 : f;
-        e = e < 0 ? 0 : e;
-        d = d < 0 ? 0 : d;
+    f = f < 0 ? 0 : f;
+    e = e < 0 ? 0 : e;
+    d = d < 0 ? 0 : d;
 
-        var t = (f + e + d).toFixed(2);
-        t = t < 0 ? 0 : t;
-        return t;
-    },
+    var t = (f + e + d).toFixed(2);
+    t = t < 0 ? 0 : t;
+    return t;
+  },
 
   addChangeEvent: function() {
     var self = this;
@@ -83,6 +85,7 @@ moj.Modules.DeterminationCalculator = {
     return $.ajax({
       url: this.vatUrl,
       data: {
+        scheme: this.scheme,
         date: this.vatDate,
         apply_vat: this.ajaxVat,
         net_amount: netAmount

--- a/app/assets/javascripts/modules/case_worker/claims/DeterminationCalculator.js
+++ b/app/assets/javascripts/modules/case_worker/claims/DeterminationCalculator.js
@@ -12,7 +12,7 @@ moj.Modules.DeterminationCalculator = {
     this.$determinationsTable = $(this.el);
     this.$totalExclVat = $('.js-total-exc-vat-determination', this.$determinationsTable);
     this.$totalVat = $('.js-vat-determination', this.$determinationsTable);
-    this.$totalLgfsVat = $('.js-lgfs-vat-determination', this.$determinationsTable);
+    this.$LgfsVat = $('.js-lgfs-vat-determination', this.$determinationsTable);
     this.$totalInclVat = $('.js-total-determination', this.$determinationsTable);
     this.scheme = this.$determinationsTable.data('scheme');
     this.ajaxVat = this.$determinationsTable.data('applyVat');
@@ -86,6 +86,7 @@ moj.Modules.DeterminationCalculator = {
       url: this.vatUrl,
       data: {
         scheme: this.scheme,
+        lgfs_vat_amount: this.$LgfsVat.val(),
         date: this.vatDate,
         apply_vat: this.ajaxVat,
         net_amount: netAmount

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -72,13 +72,15 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         :id,
         :fees,
         :expenses,
-        :disbursements
+        :disbursements,
+        :vat_amount
       ],
       :redeterminations_attributes => [
         :id,
         :fees,
         :expenses,
-        :disbursements
+        :disbursements,
+        :vat_amount
       ]
     )
   end

--- a/app/controllers/vat_rates_controller.rb
+++ b/app/controllers/vat_rates_controller.rb
@@ -33,6 +33,18 @@ class VatRatesController < ApplicationController
 
   private
 
+  def scheme
+    params['scheme']
+  end
+
+  def agfs?
+    scheme == 'agfs'
+  end
+
+  def lgfs?
+    scheme == 'lgfs'
+  end
+
   def apply_vat
     params['apply_vat'] == 'true' ? true : false
   end
@@ -54,7 +66,11 @@ class VatRatesController < ApplicationController
   end
 
   def vat_amount
-    apply_vat ? VatRate.vat_amount(net_amount, date) : 0
+    if agfs?
+      apply_vat ? VatRate.vat_amount(net_amount, date) : 0
+    else
+      0
+    end
   end
 
   def total_inc_vat

--- a/app/controllers/vat_rates_controller.rb
+++ b/app/controllers/vat_rates_controller.rb
@@ -20,15 +20,15 @@ class VatRatesController < ApplicationController
   respond_to :json
 
   def index
-      respond_with(
-        {
-          'net_amount'    => number_to_currency(net_amount),
-          'date'          => formatted_date,
-          'rate'          => rate,
-          'vat_amount'    => number_to_currency(vat_amount),
-          'total_inc_vat' => total
-        }
-      )
+    respond_with(
+      {
+        'net_amount'    => number_to_currency(net_amount),
+        'date'          => formatted_date,
+        'rate'          => rate,
+        'vat_amount'    => number_to_currency(vat_amount),
+        'total_inc_vat' => total
+      }
+    )
   end
 
   private
@@ -37,12 +37,8 @@ class VatRatesController < ApplicationController
     params['scheme']
   end
 
-  def agfs?
-    scheme == 'agfs'
-  end
-
-  def lgfs?
-    scheme == 'lgfs'
+  def lgfs_vat_amount
+    params['lgfs_vat_amount'].to_f.round(2)
   end
 
   def apply_vat
@@ -69,7 +65,7 @@ class VatRatesController < ApplicationController
     if agfs?
       apply_vat ? VatRate.vat_amount(net_amount, date) : 0
     else
-      0
+      lgfs_vat_amount
     end
   end
 
@@ -78,11 +74,21 @@ class VatRatesController < ApplicationController
   end
 
   def total
-    apply_vat ? number_to_currency(total_inc_vat) : number_to_currency(net_amount)
+    if agfs?
+      apply_vat ? number_to_currency(total_inc_vat) : number_to_currency(net_amount)
+    else
+      number_to_currency(total_inc_vat)
+    end
   end
 
   def number_to_currency(number)
     ActionController::Base.helpers.number_to_currency(number)
+  end
+
+private
+
+  def agfs?
+    scheme == 'agfs'
   end
 
 end

--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -32,7 +32,9 @@ class Determination < ActiveRecord::Base
   end
 
   def calculate_vat
-    self.vat_amount = VatRate.vat_amount(self.total, self.claim.vat_date).round(2) if self.claim.apply_vat?
+    if self.claim.is_a? Claim::AdvocateClaim
+      self.vat_amount = VatRate.vat_amount(self.total, self.claim.vat_date).round(2) if self.claim.apply_vat?
+    end
   end
 
   def total_including_vat

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -140,6 +140,15 @@ class Claim::BaseClaimPresenter < BasePresenter
     end
   end
 
+  def external_user_description
+    case claim
+      when Claim::AdvocateClaim
+        'advocate'
+      else
+        'litigator'
+    end
+  end
+
   def scheme
     case claim
       when Claim::AdvocateClaim

--- a/app/views/case_workers/claims/_determination_agfs_vat_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_agfs_vat_fields.html.haml
@@ -1,0 +1,16 @@
+%tr.determination-form-fields
+  %td
+    = "VAT (#{VatRate.pretty_rate(Date.parse(claim.vat_date))})"
+  %td
+    = claim.vat_amount
+  %td
+    %span.js-vat-determination
+      = number_to_currency(f.object.vat_amount)
+%tr.determination-form-fields
+  %td
+    = "Total (including #{VatRate.pretty_rate(Date.parse(claim.vat_date))} VAT)"
+  %td
+    = claim.total_inc_vat
+  %td
+    %span.js-total-determination
+      = number_to_currency(f.object.total_including_vat)

--- a/app/views/case_workers/claims/_determination_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_fields.html.haml
@@ -41,5 +41,5 @@
 
 - if claim.agfs?
   = render partial: 'determination_agfs_vat_fields', locals: { f: f, claim: claim }
--else
+- else
   = render partial: 'determination_lgfs_vat_fields', locals: { f: f, claim: claim }

--- a/app/views/case_workers/claims/_determination_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_fields.html.haml
@@ -39,20 +39,7 @@
     %span.js-total-exc-vat-determination
       = number_to_currency(f.object.total || 0)
 
-%tr.determination-form-fields
-  %td
-    = "VAT(#{VatRate.pretty_rate(Date.parse(claim.vat_date))})"
-  %td
-    = claim.vat_amount
-  %td
-    %span.js-vat-determination
-      = number_to_currency(f.object.vat_amount)
-
-%tr.determination-form-fields
-  %td
-    = "Total(including #{VatRate.pretty_rate(Date.parse(claim.vat_date))} VAT)"
-  %td
-    = claim.total_inc_vat
-  %td
-    %span.js-total-determination
-      = number_to_currency(f.object.total_including_vat)
+- if claim.agfs?
+  = render partial: 'determination_agfs_vat_fields', locals: { f: f, claim: claim }
+-else
+  = render partial: 'determination_lgfs_vat_fields', locals: { f: f, claim: claim }

--- a/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
@@ -1,0 +1,18 @@
+%tr.determination-form-fields
+  %td
+    = "VAT"
+  %td
+    = claim.vat_amount
+  %td
+    %span.js-lgfs-vat-determination
+      %div.pound-wrapper
+        = f.text_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control', size: 10, maxlength: 8
+      = validation_error_message(f.object, :vat_amount)
+%tr.determination-form-fields
+  %td
+    = "Total (including VAT)"
+  %td
+    = claim.total_inc_vat
+  %td
+    %span.js-total-determination
+      = number_to_currency(f.object.total_including_vat)

--- a/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
@@ -4,10 +4,9 @@
   %td
     = claim.vat_amount
   %td
-    %span.js-lgfs-vat-determination
-      %div.pound-wrapper
-        = f.text_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control', size: 10, maxlength: 8
-      = validation_error_message(f.object, :vat_amount)
+    %div.pound-wrapper
+      = f.text_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control js-lgfs-vat-determination', size: 10, maxlength: 8
+    = validation_error_message(f.object, :vat_amount)
 %tr.determination-form-fields
   %td
     = "Total (including VAT)"

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -2,11 +2,12 @@
   = hidden_field_tag :messages, 'true'
 
   #claim-status
-    %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db)}}
+    %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
       %thead
         %tr{:style => "vertical-align: top;"}
           %th &nbsp;
-          %th Claimed by advocate
+          %th
+            = "Claimed by #{ claim.external_user_description }"
           %th
             Total authorised by LAA
             - if claim.opened_for_redetermination?

--- a/spec/controllers/vat_rates_controller_spec.rb
+++ b/spec/controllers/vat_rates_controller_spec.rb
@@ -13,7 +13,6 @@ require 'rails_helper'
 
 RSpec.describe VatRatesController, type: :controller do
 
-
   before(:all) do
     @vr1 = FactoryGirl.create :vat_rate, effective_date: Date.new(2000, 1, 1),  rate_base_points: 1750
     @vr2 = FactoryGirl.create :vat_rate, effective_date: Date.new(2011, 4, 1),  rate_base_points: 2000
@@ -23,63 +22,79 @@ RSpec.describe VatRatesController, type: :controller do
     VatRate.destroy( [ @vr1.id, @vr2.id ] )
   end
 
-
   describe 'GET vat' do
+    context 'advocate claims' do
+      it 'if vat applies, it should return JSON struct with details' do
+        get :index, {:format => 'json',  'apply_vat' => 'true', 'net_amount' => '115.76', 'date' => '2015-07-15', 'scheme' => 'agfs' }
+        expect(response).to have_http_status(200)
+        expect(response.body).to eq(
+          {
+            'net_amount'    => '£115.76',
+            'date'          => '15/07/2015',
+            'rate'          => '20%',
+            'vat_amount'    => '£23.15',
+            'total_inc_vat' => '£138.91'
+          }.to_json
+        )
+      end
 
-    it 'if vat applies, it should return JSON struct with details' do
-      get :index, {:format => 'json',  'apply_vat' => 'true', 'net_amount' => '115.76', 'date' => '2015-07-15' }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(
-        {
-          'net_amount'    => '£115.76',
-          'date'          => '15/07/2015',
-          'rate'          => '20%',
-          'vat_amount'    => '£23.15',
-          'total_inc_vat' => '£138.91'
-        }.to_json
-      )
+      it 'if vat applies, it should round the net_amount to two decimal places' do
+        get :index, {:format => 'json', 'apply_vat' => 'true', 'net_amount' => '3115.768744', 'date' => '2006-07-15', 'scheme' => 'agfs' }
+        expect(response).to have_http_status(200)
+        expect(response.body).to eq(
+          {
+            'net_amount'    => '£3,115.77',
+            'date'          => '15/07/2006',
+            'rate'          => '17.5%',
+            'vat_amount'    => '£545.26',
+            'total_inc_vat' => '£3,661.03'
+          }.to_json
+        )
+      end
+
+      it 'if vat does not apply, it should return JSON struct with details and total_inc_vat = net_amount' do
+        get :index, {:format => 'json',  'apply_vat' => 'false', 'net_amount' => '115.76', 'date' => '2015-07-15', 'scheme' => 'agfs' }
+        expect(response).to have_http_status(200)
+        expect(response.body).to eq(
+          {
+            'net_amount'    => '£115.76',
+            'date'          => '',
+            'rate'          => '0%',
+            'vat_amount'    => '£0.00',
+            'total_inc_vat' => '£115.76'
+          }.to_json
+        )
+      end
+
+      it 'if vat does not apply, it should round the net_amount to two decimal places and total_inc_vat = net_amount' do
+        get :index, {:format => 'json', 'apply_vat' => 'false', 'net_amount' => '3115.768744', 'date' => '2006-07-15', 'scheme' => 'agfs' }
+        expect(response).to have_http_status(200)
+        expect(response.body).to eq(
+          {
+            'net_amount'    => '£3,115.77',
+            'date'          => '',
+            'rate'          => '0%',
+            'vat_amount'    => '£0.00',
+            'total_inc_vat' => '£3,115.77'
+          }.to_json
+        )
+      end
     end
 
-    it 'if vat applies, it should round the net_amount to two decimal places' do
-      get :index, {:format => 'json', 'apply_vat' => 'true', 'net_amount' => '3115.768744', 'date' => '2006-07-15' }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(
-        {
-          'net_amount'    => '£3,115.77',
-          'date'          => '15/07/2006',
-          'rate'          => '17.5%',
-          'vat_amount'    => '£545.26',
-          'total_inc_vat' => '£3,661.03'
-        }.to_json
-      )
-    end
-
-    it 'if vat does not apply, it should return JSON struct with details and total_inc_vat = net_amount' do
-      get :index, {:format => 'json',  'apply_vat' => 'false', 'net_amount' => '115.76', 'date' => '2015-07-15' }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(
-        {
-          'net_amount'    => '£115.76',
-          'date'          => '',
-          'rate'          => '0%',
-          'vat_amount'    => '£0.00',
-          'total_inc_vat' => '£115.76'
-        }.to_json
-      )
-    end
-
-    it 'if vat does not apply, it should round the net_amount to two decimal places and total_inc_vat = net_amount' do
-      get :index, {:format => 'json', 'apply_vat' => 'false', 'net_amount' => '3115.768744', 'date' => '2006-07-15' }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(
-        {
-          'net_amount'    => '£3,115.77',
-          'date'          => '',
-          'rate'          => '0%',
-          'vat_amount'    => '£0.00',
-          'total_inc_vat' => '£3,115.77'
-        }.to_json
-      )
+    context 'litigator claims' do
+      it 'should add a flat vat amount provided by user and round to two decimal places ' do
+        get :index, {:format => 'json', 'net_amount' => '3115.768744', 'date' => '2006-07-15', 'scheme' => 'lgfs', 'lgfs_vat_amount' => '22.229'}
+        expect(response).to have_http_status(200)
+        expect(response.body).to eq(
+          {
+            'net_amount'    => '£3,115.77',
+            'date'          => '',
+            'rate'          => '0%',
+            'vat_amount'    => '£22.23',
+            'total_inc_vat' => '£3,138.00'
+          }.to_json
+        )
+      end
     end
   end
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -76,11 +76,23 @@ describe Assessment do
   end
 
   context '#calculate_vat' do
-    it 'automatically calculates the vat amount based on the total assessed and the claim vat_date' do
-      claim = FactoryGirl.create :claim, apply_vat: true
-      ass = claim.assessment
-      ass.update_values(100.0, 250.0, 150.0)
-      expect(ass.vat_amount).to eq((ass.total * 0.175).round(2))
+    context 'advocate claims' do
+      it 'should automatically calculate the vat amount based on the total assessed and the claim vat_date' do
+        claim = FactoryGirl.create :advocate_claim, apply_vat: true
+        ass = claim.assessment
+        ass.update_values(100.0, 250.0)
+        expect(ass.vat_amount).to eq((ass.total * 0.175).round(2))
+      end
+    end
+
+    context 'litigator claims' do
+      it 'should not automatically calculate the VAT amount, instead using manually input vat_amount' do
+        claim = FactoryGirl.create :litigator_claim, apply_vat: true
+        ass = claim.assessment
+        ass.vat_amount = 0.33
+        ass.update_values(100.0, 250.0)
+        expect(ass.vat_amount).to eql((0.33))
+      end
     end
   end
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -54,7 +54,7 @@ describe Assessment do
     end
 
     context 'disbursements' do
-      it 'should not accept negative values'  do
+      it 'should not accept negative values' do
         expect {
           claim.assessment.update!(disbursements: -33.55)
         }.to raise_error ActiveRecord::RecordInvalid, 'Validation failed: Assessed disbursements must be greater than or equal to zero'
@@ -80,7 +80,7 @@ describe Assessment do
       it 'should automatically calculate the vat amount based on the total assessed and the claim vat_date' do
         claim = FactoryGirl.create :advocate_claim, apply_vat: true
         ass = claim.assessment
-        ass.update_values(100.0, 250.0)
+        ass.update_values(100.0, 250.0, 0)
         expect(ass.vat_amount).to eq((ass.total * 0.175).round(2))
       end
     end
@@ -90,7 +90,7 @@ describe Assessment do
         claim = FactoryGirl.create :litigator_claim, apply_vat: true
         ass = claim.assessment
         ass.vat_amount = 0.33
-        ass.update_values(100.0, 250.0)
+        ass.update_values(100.0, 250.0, 150.0)
         expect(ass.vat_amount).to eql((0.33))
       end
     end


### PR DESCRIPTION
all LGFS assessments and redeterminations should never automatically apply VAT (regardless of any apply_vat attribute). Instead, all assessments and redeterminations on LGFS claims must have an assessed VAT amount completed by the case worker as a flat amount.

This flat amount is simply added to the net total to reach a total including VAT.
