### PR TITLE
Fixing incorrect misc fees, fixed fees, disbursements and expenses.

### DIFF
--- a/lib/demo_data/disbursement_generator.rb
+++ b/lib/demo_data/disbursement_generator.rb
@@ -2,19 +2,20 @@ module DemoData
 
   class DisbursementGenerator
 
-    def initialize(claim)
+    def initialize(claim = nil)
       @claim = claim
     end
 
-    def generate!
-      DisbursementType.order('RANDOM()').first(rand(0..2)).each { |type| add_disbursement(type) }
+    def generate!(range = 0..2)
+      DisbursementType.order('RANDOM()').first(rand(range)).map { |type| add_disbursement(type) }
     end
 
     private
 
     def add_disbursement(type)
-      vat_amount = @claim.vat_registered? ? rand(0.0..15.0).round(2) : 0.0
-      Disbursement.create(claim: @claim, disbursement_type: type, net_amount: rand(1.0..99.99).round(2), vat_amount: vat_amount)
+      Disbursement.create(claim: @claim, disbursement_type: type,
+                          net_amount: rand(100.0..999.99).round(2),
+                          vat_amount: rand(0.0..99.99).round(2))
     end
 
   end

--- a/lib/demo_data/expense_v2_generator.rb
+++ b/lib/demo_data/expense_v2_generator.rb
@@ -9,7 +9,7 @@ module DemoData
     end
 
     def generate!
-      rand(0..5).times { add_expense }
+      rand(0..3).times { add_expense }
     end
 
     private
@@ -53,7 +53,7 @@ module DemoData
     end
 
     def generate_distance(ex)
-      ex.car_travel? || ex.train? ? rand(1..500) : nil
+      ex.car_travel? ? rand(1..500) : nil
     end
 
     def generate_mileage_rate_id(ex)

--- a/lib/demo_data/fee_generator.rb
+++ b/lib/demo_data/fee_generator.rb
@@ -4,9 +4,9 @@ module DemoData
 
     # Call as FeeGenerator.new(claim, :fixed) or FeeGenerator.new(claim, :misc)
     #
-    def initialize(claim, fee_type_class)
+    def initialize(claim, fee_type_class, fee_types = nil)
       @claim          = claim
-      @fee_types      = fee_type_class.agfs
+      @fee_types      = fee_types || fee_type_class.agfs
       @codes_added    = []
       @fee_type_class = fee_type_class
       @fee_class      = derive_fee_class_from_fee_type_class

--- a/lib/demo_data/fixed_fee_generator.rb
+++ b/lib/demo_data/fixed_fee_generator.rb
@@ -1,0 +1,19 @@
+module DemoData
+  class FixedFeeGenerator
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def generate!
+      fee_type = @claim.case_type.fixed_fee_type
+      fee = Fee::FixedFee.new(claim: @claim, fee_type: fee_type, amount: rand(100.0..2500.0).round(2))
+
+      if fee_type.children.any?
+        fee.sub_type_id = fee_type.children.sample.id
+      end
+
+      fee.save
+    end
+  end
+end

--- a/lib/demo_data/interim_fee_generator.rb
+++ b/lib/demo_data/interim_fee_generator.rb
@@ -1,3 +1,5 @@
+require_relative 'disbursement_generator'
+
 module DemoData
   class InterimFeeGenerator
 
@@ -24,11 +26,11 @@ module DemoData
 
     def setup_fee(fee)
       if fee.is_interim_warrant?
-        @claim.fees << FactoryGirl.build(:warrant_fee, amount: rand(100.0..2500.0))
+        @claim.fees << warrant_fee
       end
 
       if fee.is_disbursement? || fee.is_effective_pcmh?
-        @claim.disbursements << FactoryGirl.build_list(:disbursement, rand(1..3))
+        @claim.disbursements << disbursements(1..3)
       end
 
       if fee.is_effective_pcmh?
@@ -52,8 +54,19 @@ module DemoData
 
       unless fee.is_disbursement? || fee.is_interim_warrant?
         fee.quantity = rand(10..50)
-        fee.amount   = rand(1000.0..5000.0)
+        fee.amount   = rand(1000.0..5000.0).round(2)
       end
+    end
+
+    def warrant_fee
+      Fee::WarrantFee.new(fee_type: Fee::WarrantFeeType.instance,
+                          amount: rand(100.0..2500.0).round(2),
+                          warrant_issued_date: rand(3..5).months.ago,
+                          warrant_executed_date: rand(1..2).months.ago)
+    end
+
+    def disbursements(range)
+      DisbursementGenerator.new.generate!(range)
     end
   end
 end

--- a/lib/demo_data/litigator_claim_generator.rb
+++ b/lib/demo_data/litigator_claim_generator.rb
@@ -1,4 +1,6 @@
 require_relative 'lgfs_scheme_claim_generator'
+require_relative 'fixed_fee_generator'
+require_relative 'fee_generator'
 
 module DemoData
   class LitigatorClaimGenerator < LgfsSchemeClaimGenerator
@@ -11,6 +13,21 @@ module DemoData
 
     def add_claim_detail(claim)
       super
+    end
+
+    def add_fixed_fees(claim)
+      FixedFeeGenerator.new(claim).generate!
+    end
+
+    def add_misc_fees(claim)
+      FeeGenerator.new(claim, Fee::MiscFeeType, misc_fee_types).generate!
+    end
+
+    # Case uplift requires filling case numbers
+    # To simplify this generator we avoid this fee type
+    #
+    def misc_fee_types
+      Fee::MiscFeeType.lgfs.reject!{ |ft| ft.case_uplift? }
     end
 
     def add_fees_expenses_and_disbursements(claim)


### PR DESCRIPTION
The litigator claim demo data generator was generating some incorrect data for _misc fees_, _fixed fees_ and _expenses_, and also for interim claims it was using the `Disbursements factory` thus generating fake data.

Changes and fixes to solve all this.
