### PR TITLE
limit the carousel claim number to prevent cookie overflow

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -56,6 +56,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
     search_claims
     filter_claims
     order_claims
+    set_claim_carousel_info
   end
 
   def scheme

--- a/app/controllers/case_workers/application_controller.rb
+++ b/app/controllers/case_workers/application_controller.rb
@@ -1,8 +1,9 @@
 class CaseWorkers::ApplicationController < ApplicationController
   before_action :authenticate_case_worker!
 
-  def set_claim_carousel_info
-    session[:claim_ids] = @claims.all.map(&:id)
+  # NOTE: limit needed to prevent cookie overflow
+  def set_claim_carousel_info(limit=50)
+    session[:claim_ids] = @claims.limit(limit).map(&:id)
     session[:claim_count] = @claims.try(:size)
   end
 


### PR DESCRIPTION
reimplement carousel bug fix for allocation but with limit to prevent session cookies overflow
