### PR TITLE
Hiding distance field for public transport expense types.

### DIFF
--- a/app/presenters/expense_type_presenter.rb
+++ b/app/presenters/expense_type_presenter.rb
@@ -30,7 +30,7 @@ class ExpenseTypePresenter < BasePresenter
   end
 
   def distance_field?
-    car_travel? || train?
+    car_travel?
   end
 
   def mileage_field?

--- a/spec/presenters/expense_type_presenter_spec.rb
+++ b/spec/presenters/expense_type_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Destination', distance: true, mileage: false, hours: false, reason_set: 'A' })
+          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, hours: false, reason_set: 'A' })
       end
     end
 


### PR DESCRIPTION
The distance field is not neccessary for public transport, so we hide it.
