### PR TITLE
Removing litigator category copy from claim detail.

### DIFF
--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -30,10 +30,11 @@
         .xsmall
           = claim.external_user.name
       .column-quarter
-        .bold-xsmall
-          = t("common.external_user.category.#{@claim.external_user_type}")
-        .xsmall
-          = claim.advocate_category
+        - if @claim.agfs?
+          .bold-xsmall
+            = t("common.external_user.category.#{@claim.external_user_type}")
+          .xsmall
+            = claim.advocate_category
       .column-quarter
         .bold-xsmall
           = t("common.external_user.account_number.#{@claim.external_user_type}")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,7 +411,6 @@ en:
         fields:
           advocate: *advocate
           advocate_category: 'Advocate category'
-          itigator_category: 'Litigator category'
           case_advocate_offence: 'Case, instructed advocate & offence'
           case_number: 'Case number'
           case_type: 'Case type'

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -6,9 +6,6 @@ describe 'external_users/claims/show.html.haml', type: :view do
 
   before(:all) do
     @advocate = create(:external_user, :advocate_and_admin)
-    @claim = create :claim, evidence_checklist_ids: [1, 9]
-    @messages = @claim.messages.most_recent_last
-    @message = @claim.messages.build
   end
 
   after(:all) do
@@ -18,17 +15,51 @@ describe 'external_users/claims/show.html.haml', type: :view do
   before(:each) do
     initialize_view_helpers(view)
     sign_in :user, @advocate.user
-    # allow(view).to receive(:current_user_persona_is?).and_return(false)
-    assign(:claim, @claim)
     allow(view).to receive(:url_for_edit_external_users_claim).and_return('http://my_edit_external_users_path')
+    render
   end
 
-  context 'document checklist' do
-    it 'displays the documents that have been uploaded' do
-      render
-      expect(response.body).to have_selector('li', text: 'Representation order')
-      expect(response.body).to have_selector('li', text: 'Justification for out of time claim')
+  context 'for AGFS claims' do
+    before(:all) do
+      @claim = create :claim, evidence_checklist_ids: [1, 9]
+      @messages = @claim.messages.most_recent_last
+      @message  = @claim.messages.build
+    end
+
+    describe 'document checklist' do
+      it 'displays the documents that have been uploaded' do
+        expect(rendered).to have_selector('li', text: 'Representation order')
+        expect(rendered).to have_selector('li', text: 'Justification for out of time claim')
+      end
+    end
+
+    describe 'basic claim information' do
+      it 'displays the advocate category section' do
+        expect(rendered).to have_selector('div', text: 'Advocate category')
+      end
+
+      it 'displays the advocate account number section' do
+        expect(rendered).to have_selector('div', text: 'Advocate account number')
+      end
     end
   end
 
+  context 'for LGFS claims' do
+    before(:all) do
+      @claim = create :litigator_claim
+      @messages = @claim.messages.most_recent_last
+      @message  = @claim.messages.build
+    end
+
+    describe 'basic claim information' do
+      it 'doesn\'t display the litigator category section' do
+        expect(rendered).not_to have_selector('div', text: 'Advocate category')
+        expect(rendered).not_to have_selector('div', text: 'Litigator category')
+      end
+
+      it 'displays the litigator account number section' do
+        expect(rendered).to have_selector('div', text: 'Litigator account number')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**PT#118459501**

On litigator claims, users were seeing a blank 'Litigator category' field.  Litigator category does not exist therefore this need to be removed for these claims.
