### PR TITLE
include transfers in graduated_fees and fixed_fee allocation filters

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -91,7 +91,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def filter_by_claim_type
-    @claims = (scheme == 'lgfs' ? Claim::BaseClaim.where(type: [Claim::LitigatorClaim,Claim::InterimClaim] ) : Claim::BaseClaim.where(type: Claim::AdvocateClaim) )
+    @claims = (scheme == 'lgfs' ? Claim::BaseClaim.where(type: [Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim] ) : Claim::BaseClaim.where(type: Claim::AdvocateClaim) )
     load_claim_associations
   end
 

--- a/app/models/claims/allocation_filters.rb
+++ b/app/models/claims/allocation_filters.rb
@@ -21,7 +21,7 @@ module Claims::AllocationFilters
     end
 
     def agfs_lgfs_scopes
-      scope :fixed_fee,   -> { where(case_type_id: CaseType.fixed_fee.pluck(:id) ) }
+      scope :fixed_fee,   -> { all_fixed_fee }
     end
 
     def agfs_scopes
@@ -38,8 +38,12 @@ module Claims::AllocationFilters
       scope :interim_disbursements, -> { all_interim_disbursements }
     end
 
+    def all_fixed_fee
+      where('"claims"."case_type_id" IN (?) OR "claims"."allocation_type" = ?', CaseType.fixed_fee.pluck(:id), 'Fixed')
+    end
+
     def all_graduated_fees
-      where(case_type_id: CaseType.graduated_fees.pluck(:id) )
+      where('"claims"."case_type_id" IN (?) OR "claims"."allocation_type" = ?', CaseType.graduated_fees.pluck(:id), 'Grad')
     end
 
     def all_risk_based_bills

--- a/spec/factories/case_types.rb
+++ b/spec/factories/case_types.rb
@@ -30,6 +30,12 @@ FactoryGirl.define do
       is_fixed_fee    true
     end
 
+    trait :graduated_fee do
+      name 'Graduated fee'
+      is_fixed_fee false
+      fee_type_code { build(:graduated_fee_type).code }
+    end
+
     trait :requires_cracked_dates do
       requires_cracked_dates true
     end

--- a/spec/factories/claim/transfer_claims.rb
+++ b/spec/factories/claim/transfer_claims.rb
@@ -1,3 +1,5 @@
+# require 'awesome_print'
+
 FactoryGirl.define do
   factory :transfer_claim, class: Claim::TransferClaim do
     litigator_base_setup
@@ -8,7 +10,7 @@ FactoryGirl.define do
     elected_case        false
     transfer_stage_id   10
     transfer_date       2.months.ago
-    case_conclusion_id  10
+    case_conclusion_id  nil
 
     trait :trial do
       case_type  { build(:case_type, :trial) }
@@ -17,5 +19,28 @@ FactoryGirl.define do
       estimated_trial_length 3
       actual_trial_length 3
     end
+
+    # TODO: rather than short circuiting the "transfer brain" this trait should apply expected attribute logic
+    trait :graduated_fee_allocation_type do
+      litigator_type      'new'
+      elected_case        false
+      transfer_stage_id   50
+      case_conclusion_id  40
+      after(:create) do |claim|
+        claim.submit! # submission will set the allocation_type
+      end
+    end
+
+    # TODO: rather than short circuiting the "transfer brain" this trait should apply expected attribute logic
+    trait :fixed_fee_allocation_type do
+      litigator_type      'new'
+      elected_case        true
+      transfer_stage_id   10
+      case_conclusion_id  nil
+      after(:create) do |claim|
+        claim.submit! # submission will set the allocation_type
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This extends the existing allocation filters for graduated fee and fixed fee type claim types to include transfer claims with attributes denoting they should be considered a graduated or fixed fee.
