### PR TITLE
Better default mechanism for pagination.

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -1,6 +1,5 @@
 class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::ApplicationController
   include PaginationHelpers
-  PaginationHelpers::DEFAULT_PAGE_SIZE = 50
 
   before_action :set_case_workers, only: [:new, :create]
   before_action :set_claims, only: [:new, :create]
@@ -181,4 +180,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
     end
   end
 
+  def default_page_size
+    50
+  end
 end

--- a/app/controllers/concerns/pagination_helpers.rb
+++ b/app/controllers/concerns/pagination_helpers.rb
@@ -1,13 +1,16 @@
 module PaginationHelpers
   extend ActiveSupport::Concern
 
-  DEFAULT_PAGE_SIZE ||= 10
-
   private
+
+  # Override this method in your class to change the default
+  def default_page_size
+    10
+  end
 
   def page_size
     limit = params[:limit].to_i
-    limit > 0 ? limit : DEFAULT_PAGE_SIZE
+    limit > 0 ? limit : default_page_size
   end
 
   def current_page


### PR DESCRIPTION
Using template pattern so we get rid of that pesky warning:
`already initialized constant PaginationHelpers::DEFAULT_PAGE_SIZE`
