### PR TITLE
Fix advocate supplier clone issue

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -63,6 +63,10 @@ module Claim
 
     delegate :requires_cracked_dates?, to: :case_type
 
+    before_validation do
+      set_supplier_number
+    end
+
     def eligible_case_types
       CaseType.agfs
     end
@@ -99,9 +103,9 @@ module Claim
       end
     end
 
-    def default_values
-      self.supplier_number ||= (provider_delegator.supplier_number rescue nil)
-      super
+    def set_supplier_number
+      supplier_no = (provider_delegator.supplier_number rescue nil)
+      self.supplier_number = supplier_no if self.supplier_number != supplier_no
     end
 
     def destroy_all_invalid_fee_types

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -21,6 +21,7 @@ module Claims::Cloner
       exclude_association :determinations
       exclude_association :assessment
       exclude_association :redeterminations
+      exclude_association :certification
 
       clone [:fees, :documents, :defendants, :expenses, :disbursements]
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1051,7 +1051,26 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       expect(claim.save).to eq(true)
       expect(claim.source).to eq('api')
     end
+  end
 
+  describe 'sets the supplier number before validation' do
+    let(:advocate)          { create(:external_user, :advocate) }
+    let(:another_advocate)  { create(:external_user, :advocate, provider: advocate.provider) }
+    let(:claim)             { build(:advocate_claim, external_user: advocate) }
+
+    it 'should not have a supplier number before creation' do
+      expect(claim.supplier_number).to be_nil
+    end
+
+    it 'should have a supplier number, derived from the external_user, after creation' do
+      expect{ claim.save! }.to change(claim, :supplier_number).to eql(advocate.supplier_number)
+    end
+
+    it 'should reset supplier number to match external_user' do
+      claim.save!
+      claim.external_user = another_advocate
+      expect{ claim.save! }.to change(claim, :supplier_number).to eql(another_advocate.supplier_number)
+    end
   end
 
   describe 'provider type dependant methods' do

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -131,10 +131,16 @@ RSpec.describe Claims::Cloner, type: :model do
         expect(@rejected_claim.assessment.nil?).to eq(false)
         expect(@cloned_claim.assessment.nil?).to eq(true)
       end
+
+      it 'does not clone certifications' do
+        expect(@rejected_claim.certification).to_not be_nil
+        expect(@cloned_claim.certification).to be_nil
+      end
     end
 
     def create_rejected_claim
       rejected_claim = create(:rejected_claim)
+      create(:certification, claim: rejected_claim)
       rejected_claim.fees.each do |fee|
         fee.dates_attended << create(:date_attended)
       end

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -55,8 +55,10 @@ describe Claim::AdvocateClaimValidator do
   end
 
   context 'supplier_number' do
-    it 'should error when the supplier number is not valid for advocates' do
-      claim.supplier_number = '9G606X'
+    # NOTE: In reality supplier number is derived from external_user which in turn is validated in any event
+    let(:advocate)  { build(:external_user, :advocate, supplier_number: '9G606X') }
+    it 'should error when the supplier number does not match pattern' do
+      claim.external_user = advocate
       should_error_with(claim, :supplier_number, 'invalid')
     end
   end


### PR DESCRIPTION
Fixes a bug which made it impossible to amend an advocate claims advocate/external_user once set on initialise of claim. relates to a zendesk ticket for this problem noticed during cloning of rejected claims but the problem was wider reaching
