### PR TITLE
Offence class copy change. PT#118922117.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,7 +453,7 @@ en:
           retrial_started_at: 'First day of retrial'
         offence_id_select:
           offence_class: "Offence class"
-          offence_class_hint: "eg Theft"
+          offence_class_hint: "eg Burglary"
           select_offence_class: "Please select"
       defendants:
         defendant_fields:


### PR DESCRIPTION
As per Angela ticket:

> Multiple zendesk tickets have indicated that the user is not sure what to enter to find the offence class. The example given above the field is the likely source of the confusion as the example "theft" is an offence type not an offence class.

The example has been changed to **Burglary** to avoid confusion.
