### PR TITLE
Reintroduce the supplier number input field in superadmin provider creation.

### DIFF
--- a/app/assets/javascripts/modules/superadmin/Provider.js
+++ b/app/assets/javascripts/modules/superadmin/Provider.js
@@ -4,6 +4,7 @@ moj.Modules.SuperAdminProvider = {
   providerType : 'js-provider-type',
   $providerType : {},
   supplierNumber : 'js-supplier-number',
+  supplierNumbers : 'js-supplier-numbers',
   $supplierNumber : {},
   vatRegistered : 'js-vat-registered',
   $vatRegistered : {},
@@ -25,6 +26,7 @@ moj.Modules.SuperAdminProvider = {
     this.$form = $('#' + this.el);
     this.$providerType = $('#' + this.providerType);
     this.$supplierNumber = $('#' + this.supplierNumber);
+    this.$supplierNumbers = $('#' + this.supplierNumbers);
     this.$vatRegistered = $('#' + this.vatRegistered);
   },
 
@@ -32,9 +34,11 @@ moj.Modules.SuperAdminProvider = {
     //Show supplier number and vat registered if the provider is a firm
     if(providerTypeVal === 'firm'){
       this.$supplierNumber.show();
+      this.$supplierNumbers.show();
       this.$vatRegistered.show();
     }else if(providerTypeVal === 'chamber'){
       this.$supplierNumber.hide();
+      this.$supplierNumbers.hide();
       this.$vatRegistered.hide();
     }
   }

--- a/app/views/super_admins/providers/_form.html.haml
+++ b/app/views/super_admins/providers/_form.html.haml
@@ -29,6 +29,11 @@
         = validation_error_message(@provider, :name)
 
       #js-supplier-number
+        = f.label t('.supplier_number'), class: "form-label"
+        = f.text_field :supplier_number, class: "form-control"
+        = validation_error_message(@provider, :supplier_number)
+
+      #js-supplier-numbers
         = render 'shared/supplier_numbers', f: f
 
       #js-vat-registered

--- a/app/views/super_admins/providers/show.html.haml
+++ b/app/views/super_admins/providers/show.html.haml
@@ -12,7 +12,11 @@
   = t('.fee_schemes')
 = @provider.roles.map(&:upcase) * ', '
 
-- if @provider.firm?
+%h3
+  = t('.supplier_number')
+= @provider.supplier_number
+
+- if @provider.supplier_numbers.any?
   %h3
     = t('.supplier_numbers')
   = @provider.supplier_numbers.to_sentence


### PR DESCRIPTION
We need to maintain the ability to add a single supplier number to the provider for AGFS firms.
