### PR TITLE
Claim Assessment/Redetermination as a service

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -32,14 +32,13 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   end
 
   def update
-    @claim = Claim::BaseClaim.find(params[:id])
-    @messages = @claim.messages.most_recent_last
+    updater = Claims::CaseWorkerClaimUpdater.new(params[:id], claim_params).update!
+    @claim = updater.claim
     @doc_types = DocType.all
-
-    begin
-      @claim.update_model_and_transition_state(claim_params)
+    if updater.result == :ok
       redirect_to case_workers_claim_path(params.slice(:messages))
-    rescue StateMachines::InvalidTransition, ArgumentError
+    else
+      @claim.errors
       prepare_show_action
       render :show
     end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -231,37 +231,6 @@ module Claim
       self.state
     end
 
-    def validate_case_worker_state_transition(state)
-      if Claims::InputEventMapper.input_event(state) == nil
-        self.errors.add(:base, 'You must update the claim status to either authorised, part authorised, rejected or refused')
-        raise ArgumentError, 'Invalid state transition for case worker claim status update'
-      end
-    end
-
-    def transition_state(state, assessment_params = nil)
-      event = Claims::InputEventMapper.input_event(state)
-      validate_case_worker_state_transition(state)
-
-      unless assessment_params.nil?
-        # Now update assessment if nothing has gone wrong
-        asssessment_params_with_defaults = {'fees' => 0.0, 'expenses' => 0.0, 'disbursements' => 0.0}.merge(assessment_params)
-        self.assessment.update_values(
-          asssessment_params_with_defaults['fees'],
-          asssessment_params_with_defaults['expenses'],
-          asssessment_params_with_defaults['disbursements']
-        )
-      end
-
-      self.send(event) unless (state.blank? || state == self.state)
-    end
-
-    def update_model_and_transition_state(params)
-      state = params.delete('state_for_form')
-      assessment_params = params.delete('assessment_attributes')  # Don't update assessment yet
-      self.update(params) # must precede state transition to not violate validations
-      self.transition_state(state, assessment_params)
-    end
-
     def editable?
       draft?
     end

--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -28,7 +28,7 @@ class Determination < ActiveRecord::Base
 
 
   def calculate_total
-    self.total = [self.fees, self.expenses, self.disbursements].sum
+    self.total = [self.fees || 0.0, self.expenses || 0.0 , self.disbursements || 0.0].sum
   end
 
   def calculate_vat
@@ -43,6 +43,10 @@ class Determination < ActiveRecord::Base
 
   def blank?
     zero_or_nil?(self.fees) && zero_or_nil?(self.expenses) && zero_or_nil?(self.disbursements)
+  end
+
+  def zero?
+    self.blank?
   end
 
   def present?

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -1,0 +1,93 @@
+module Claims
+  class CaseWorkerClaimUpdater
+
+    attr_reader :claim, :result, :messages
+
+    def initialize(claim_id, params)
+      @params = params
+      @claim = Claim::BaseClaim.find(claim_id)
+      @messages = @claim.messages.most_recent_last
+      @state = @params.delete('state_for_form')
+      extract_assessment_params
+      extract_redetermination_params
+      @result = :ok
+    end
+
+    def update!
+      validate_params
+      update_and_transition_state if @result == :ok
+      self
+    end
+
+    private
+
+    def extract_assessment_params
+      @assessment_params = @params.delete('assessment_attributes')
+      @assessment_params_present = nil_or_empty?(@assessment_params) ? false : true
+    end
+
+    def extract_redetermination_params
+      @redetermination_params = @params.delete('redeterminations_attributes')
+      @redetermination_params = @redetermination_params['0'] unless @redetermination_params.nil?
+      @redetermination_params_present = nil_or_empty?(@redetermination_params) ? false : true
+    end
+
+    def validate_params
+      if @assessment_params_present || @redetermination_params_present
+        validate_state_when_value_params_present
+      else
+        validate_state_when_no_value_params
+      end
+    end
+
+    def validate_state_when_value_params_present
+      if @state.blank?
+        @claim.errors[:determinations] << 'You must specify authorised or part authorised if you supply values'
+        @result = :error
+      elsif @state == 'refused'
+        @claim.errors[:determinations] << 'You cannot specify values when refusing a claim'
+        @result = :error
+      elsif @state == 'rejected'
+        @claim.errors[:determinations] << 'You cannot specify values when rejecting a claim'
+        @result = :error
+      end
+    end
+
+    def validate_state_when_no_value_params
+      if @state.in?(%w{ authorised part_authorised })
+        @claim.errors[:determinations] << 'You must specify values if authorising or part authorising a claim'
+        @result = :error
+      end
+    end
+
+    def nil_or_empty?(determination_params)
+      return true if determination_params.nil?
+      result = true
+      %w{ fees expenses disbursements }.each do |field|
+        next if determination_params[field].to_f == 0.0
+        result = false
+        break
+      end
+      result
+    end
+
+    def update_and_transition_state
+      @claim.update(@params)
+      event = Claims::InputEventMapper.input_event(@state)
+      update_assessment if @assessment_params_present
+      add_redetermination if @redetermination_params_present
+      @claim.send(event) unless (@state.blank? || @state == @claim.state)
+    end
+
+    def update_assessment
+      params_with_defaults = {'fees' => '0.00', 'expenses' => '0.00', 'disbursements' => '0.00'}.merge(@assessment_params)
+      @claim.assessment.update(params_with_defaults)
+    end
+
+    def add_redetermination
+      params_with_defaults = {'fees' => '0.00', 'expenses' => '0.00', 'disbursements' => '0.00'}.merge(@redetermination_params)
+      @claim.redeterminations << Redetermination.new(params_with_defaults)
+    end
+
+  end
+end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,12 +1,19 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [
-  :password,
-  :email,
-  :first_name,
-  :last_name,
-  :date_of_birth,
-  :supplier_number,
-  :body
-]
+if Rails.env.development?
+  Rails.application.config.filter_parameters += [
+    :password
+  ]
+else
+  Rails.application.config.filter_parameters += [
+    :password,
+    :email,
+    :first_name,
+    :last_name,
+    :date_of_birth,
+    :supplier_number,
+    :body
+  ]
+end
+

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -317,57 +317,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
   end
 
-  describe '.update_model_and_transition_state' do
-    it 'should update the model then transition state to prevent state transition validation errors' do
-      # given
-      claim = FactoryGirl.create :allocated_claim
-      claim.assessment = Assessment.new(claim: claim)
-      claim_params = {
-        "state_for_form"=>"part_authorised",
-        "assessment_attributes" => {
-          "id" => claim.assessment.id,
-          "fees" => "66.22",
-          "expenses" => "22.33"
-        },
-        "additional_information"=>""}
-
-      # when
-      claim.update_model_and_transition_state(claim_params)
-      #then
-      expect(claim.reload.state).to eq 'part_authorised'
-    end
-
-    it 'should not transition when "state_for_form" is the same as the claim\'s state' do
-      claim = FactoryGirl.create :authorised_claim
-      claim.assessment = Assessment.new(claim: claim)
-      claim_params = {
-        "state_for_form"=>"authorised",
-        'assessment_attributes' => {
-          "id" => claim.assessment.id,
-          "fees"=>"88.55",
-          'expenses' => '0.00'
-        },
-        "additional_information"=>""}
-      claim.update_model_and_transition_state(claim_params)
-      expect(claim.reload.state).to eq('authorised')
-    end
-
-    it 'should raise error and not transition when "state_for_form" is blank' do
-      claim = FactoryGirl.create :authorised_claim
-      claim.assessment = Assessment.new(claim: claim)
-      claim_params = {
-        "state_for_form"=>"",
-        'assessment_attributes' => {
-          "id" => claim.assessment.id,
-          "fees"=>"44.55",
-          'expenses' => '44.00'
-        },
-        "additional_information"=>""}
-      expect{ claim.update_model_and_transition_state(claim_params) }.to raise_error ArgumentError
-      expect(claim.reload.state).to eq('authorised')
-    end
-  end
-
   context 'basic fees' do
     before(:each) do
       @bft1 = FactoryGirl.create :basic_fee_type,  description: 'ZZZZ', id: 1
@@ -813,41 +762,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
           expect(claim.validation_required?).to eq true
         end
       end
-    end
-
-  end
-
-  describe '#transition_state' do
-    it 'should call authorise! if authorised' do
-      expect(subject).to receive(:authorise!)
-      subject.transition_state('authorised')
-    end
-    it 'should call authorise_part! if part_authorised' do
-      expect(subject).to receive(:authorise_part!)
-      subject.transition_state('part_authorised')
-    end
-    it 'should call reject! if rejected' do
-      expect(subject).to receive(:reject!)
-      subject.transition_state('rejected')
-    end
-    it 'should call refuse! if refused' do
-      expect(subject).to receive(:refuse!)
-      subject.transition_state('refused')
-    end
-    it 'should call redetermine! if redetermination' do
-      expect(subject).to receive(:redetermine!)
-      subject.transition_state('redetermination')
-    end
-    it 'should raise an exception if anything else' do
-      expect{
-        subject.transition_state('allocated')
-      }.to raise_error ArgumentError, 'Invalid state transition for case worker claim status update'
-    end
-    it 'should append an error to the claim object if anything else' do
-      expect{ subject.transition_state('allocated') rescue nil }.to change{ subject.errors.count }.by(1)
-    end
-    it 'should not transition the claim object if anything else' do
-      expect{ subject.transition_state('allocated') rescue nil }.not_to change subject, :state
     end
   end
 

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -141,10 +141,6 @@ RSpec.describe Claims::StateMachine, type: :model do
             }
           end
 
-          it "raises ArgumentError" do
-            expect{claim.update_model_and_transition_state(params)}.to raise_error(ArgumentError)
-          end
-
           it "does not update the assessment" do
             claim.update_model_and_transition_state(params) rescue nil
             expect(claim.reload.assessment.fees).to eq(0)

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+
+
+module Claims
+  describe CaseWorkerClaimUpdater do
+
+    context 'assessments' do
+
+      let(:claim) { create :allocated_claim }
+
+      context 'successful transitions' do
+        it 'advances the claim to part authorised' do
+          params = {'state_for_form' => 'part_authorised', 'assessment_attributes' => {'fees' => '45', 'expenses' => '0.00'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'part_authorised'
+          expect(updater.claim.assessment.fees).to eq 45.0
+          expect(updater.claim.assessment.expenses).to eq 0.0
+          expect(updater.claim.assessment.disbursements).to eq 0.0
+        end
+
+        it 'advances the claim to authorised' do
+          params = {'state_for_form' => 'authorised', 'assessment_attributes' => {'fees' => '128.33', 'expenses' => '42.88'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'authorised'
+          expect(updater.claim.assessment.fees.to_f).to eq 128.33
+          expect(updater.claim.assessment.expenses).to eq 42.88
+          expect(updater.claim.assessment.disbursements).to eq 0.0
+        end
+
+        it 'advances the claim to rejected when no values are supplied' do
+          params = {'state_for_form' => 'rejected', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'rejected'
+          expect(updater.claim.assessment).to be_zero
+        end
+
+        it 'advances the claim to refused when no values are supplied' do
+          params = {'state_for_form' => 'refused', 'assessment_attributes' => {'expenses' => ''}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'refused'
+          expect(updater.claim.assessment).to be_zero
+        end
+      end
+
+      context 'errors' do
+        it 'errors if part auth selected and no values' do
+          params = {'assessment_attributes'=>{'fees'=>'0.00', 'expenses'=>'0.00', 'id'=>'3'}, 'state_for_form'=>'part_authorised'}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.assessment).to be_zero
+          expect(updater.claim.errors[:determinations]).to eq(['You must specify values if authorising or part authorising a claim'])
+        end
+
+        it 'errors if assessment data is present in the params but no state specified' do
+          params = {'state_for_form' => '', 'assessment_attributes' => {'fees' => '128.33', 'expenses' => '42.88'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['You must specify authorised or part authorised if you supply values'])
+        end
+
+        it 'errors if values are supplied with refused' do
+          params = {'state_for_form' => 'refused', 'assessment_attributes' => {'fees' => '93.65','expenses' => '42.88'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['You cannot specify values when refusing a claim'])
+          expect(updater.claim.state).to eq 'allocated'
+          expect(updater.claim.assessment.fees.to_f).to eq 0.0
+          expect(updater.claim.assessment.expenses).to eq 0.0
+          expect(updater.claim.assessment.disbursements).to eq 0.0
+        end
+
+        it 'errors if values are supplied with rejected' do
+          params = {'state_for_form' => 'rejected', 'assessment_attributes' => {'fees' => '93.65','expenses' => '42.88'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['You cannot specify values when rejecting a claim'])
+          expect(updater.claim.state).to eq 'allocated'
+          expect(updater.claim.assessment.fees.to_f).to eq 0.0
+          expect(updater.claim.assessment.expenses).to eq 0.0
+          expect(updater.claim.assessment.disbursements).to eq 0.0
+        end
+      end
+    end
+
+    context 'redeterminations' do
+
+      let(:claim)  {
+        klaim = create :allocated_claim
+        klaim.assessment.update(fees: 200.15, expenses: 77.66)
+        klaim
+      }
+
+      context 'successful transitions' do
+        it 'advances the claim to part authorised' do
+          params = {'state_for_form' => 'part_authorised', 'redeterminations_attributes' => {'0' => {'fees' => '45', 'expenses' => '0.00'}}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'part_authorised'
+          expect(updater.claim.redeterminations.first.fees).to eq 45.0
+          expect(updater.claim.redeterminations.first.expenses).to eq 0.0
+          expect(updater.claim.redeterminations.first.disbursements).to eq 0.0
+        end
+
+        it 'advances the claim to authorised' do
+          params = {'state_for_form' => 'authorised', 'redeterminations_attributes' => {'0' => {'fees' => '', 'expenses' => '230.00'}}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'authorised'
+          expect(updater.claim.redeterminations.first.fees.to_f).to eq 0.0
+          expect(updater.claim.redeterminations.first.expenses).to eq 230.0
+          expect(updater.claim.redeterminations.first.disbursements).to eq 0.0
+        end
+
+        it 'advances the claim to rejected when no values are supplied' do
+          params = {'state_for_form' => 'rejected', 'redeterminations_attributes' => {'0' => {'fees' => '', 'expenses' => '0'}}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'rejected'
+          expect(updater.claim.redeterminations).to be_empty
+        end
+
+        it 'advances the claim to refused when no values are supplied' do
+          params = {'state_for_form' => 'refused'}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :ok
+          expect(updater.claim.state).to eq 'refused'
+          expect(updater.claim.redeterminations).to be_empty
+        end
+      end
+
+
+      context 'errors' do
+        it 'errors if assessment data is present in the params but no state specified' do
+          params = {'state_for_form' => '', 'redeterminations_attributes' => {'0' => {'fees' => '128.33', 'expenses' => '42.40'}}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['You must specify authorised or part authorised if you supply values'])
+        end
+
+        it 'errors if values are supplied with refused' do
+          params = {'state_for_form' => 'refused', 'redeterminations_attributes' => {'0' => {'fees' => '128.33', 'expenses' => '42.40'}}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['You cannot specify values when refusing a claim'])
+          expect(updater.claim.state).to eq 'allocated'
+          expect(updater.claim.redeterminations).to be_empty
+        end
+
+        it 'errors if values are supplied with rejected' do
+          params = {'state_for_form' => 'rejected', 'redeterminations_attributes' => {'0' => {'fees' => '128.33', 'expenses' => '42.40'}}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['You cannot specify values when rejecting a claim'])
+          expect(updater.claim.state).to eq 'allocated'
+          expect(updater.claim.redeterminations).to be_empty
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This PR moves all the logic for assessing / redetermining a claim into a service object
asd remoes that logic from the Claim model and the controller
