### PR TITLE
Getting rid of custom URL methods and using polymorphic route helpers instead.

### DIFF
--- a/app/controllers/external_users/application_controller.rb
+++ b/app/controllers/external_users/application_controller.rb
@@ -1,33 +1,6 @@
 class ExternalUsers::ApplicationController < ApplicationController
   before_action :authenticate_external_user!
 
-  helper_method :url_for_external_users_claim
-  helper_method :url_for_edit_external_users_claim
-
-  def url_for_external_users_claim(claim)
-    if claim.agfs?
-      claim.persisted? ? advocates_claim_path(claim) : advocates_claims_path
-    elsif claim.lgfs?
-      claim.persisted? ? litigators_claim_path(claim) : litigators_claims_path
-    elsif claim.interim?
-      claim.persisted? ? litigators_interim_claim_path(claim) : litigators_interim_claims_path
-    elsif claim.transfer?
-      claim.persisted? ? litigators_transfer_claim_path(claim) : litigators_transfer_claims_path
-    end
-  end
-
-  def url_for_edit_external_users_claim(claim)
-    if claim.agfs?
-      edit_advocates_claim_path(claim)
-    elsif claim.lgfs?
-      edit_litigators_claim_path(claim)
-    elsif claim.interim?
-      edit_litigators_interim_claim_path(claim)
-    elsif claim.transfer?
-      edit_litigators_transfer_claim_path(claim)
-    end
-  end
-
 private
 
   def authenticate_external_user!

--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -9,7 +9,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
     if @claim.valid?
       build_certification
     else
-      redirect_to url_for_edit_external_users_claim(@claim), alert: 'Claim is not in a state to be submitted'
+      redirect_to edit_polymorphic_path(@claim), alert: 'Claim is not in a state to be submitted'
     end
   end
 

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -61,7 +61,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
     begin
       draft = @claim.clone_rejected_to_new_draft
       send_ga('event', 'claim', 'draft', 'clone-rejected')
-      redirect_to url_for_edit_external_users_claim(draft), notice: 'Draft created'
+      redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
     rescue
       redirect_to external_users_claims_url, alert: 'Can only clone rejected claims'
     end

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -54,6 +54,7 @@
 
 module Claim
   class AdvocateClaim < BaseClaim
+    set_singular_route_key 'advocates_claim'
 
     has_many :fixed_fees, foreign_key: :claim_id, class_name: 'Fee::FixedFee', dependent: :destroy, inverse_of: :claim
     accepts_nested_attributes_for :fixed_fees, reject_if: :all_blank, allow_destroy: true

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -389,6 +389,15 @@ module Claim
       case_type.is_fixed_fee?
     end
 
+    # This will ensure proper route paths are generated
+    # when using helpers like: edit_polymorphic_path(claim)
+    def self.set_singular_route_key(name)
+      model_name.class_eval %Q{
+        def singular_route_key; '#{name}'; end
+        def route_key; '#{name.pluralize}'; end
+      }
+    end
+
     private
 
     # called from state_machine before_transition on submit - override in subclass

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -54,6 +54,7 @@
 
 module Claim
   class InterimClaim < BaseClaim
+    set_singular_route_key 'litigators_interim_claim'
 
     validates_with ::Claim::InterimClaimValidator
     validates_with ::Claim::InterimClaimSubModelValidator

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -54,6 +54,7 @@
 
 module Claim
   class LitigatorClaim < BaseClaim
+    set_singular_route_key 'litigators_claim'
 
     validates_with ::Claim::LitigatorClaimValidator
     validates_with ::Claim::LitigatorClaimSubModelValidator

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -54,6 +54,7 @@
 
 module Claim
   class TransferClaim < BaseClaim
+    set_singular_route_key 'litigators_transfer_claim'
 
     has_one :transfer_detail, foreign_key: :claim_id
 

--- a/app/views/external_users/advocates/claims/_form.html.haml
+++ b/app/views/external_users/advocates/claims/_form.html.haml
@@ -1,5 +1,5 @@
 #claim-form
-  = form_for [:external_users, @claim], as: :claim, url: url_for_external_users_claim(@claim), builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_for @claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -100,4 +100,4 @@
         &nbsp;
     .button-holder
       = f.submit "Certify and submit claim", class: "button"
-      = link_to 'Return to claim', url_for_edit_external_users_claim(@claim), class: 'button-secondary'
+      = link_to 'Return to claim', edit_polymorphic_path(@claim), class: 'button-secondary'

--- a/app/views/external_users/claims/_summary_claims_sidebar.html.haml
+++ b/app/views/external_users/claims/_summary_claims_sidebar.html.haml
@@ -35,4 +35,4 @@
 
   - if display_buttons == true
     = link_to 'Continue', new_external_users_claim_certification_path(claim), {class: 'button', role: 'button'}
-    = link_to 'Edit this claim', url_for_edit_external_users_claim(claim), {class: 'button button-secondary', role: 'button'}
+    = link_to 'Edit this claim', edit_polymorphic_path(claim), {class: 'button button-secondary', role: 'button'}

--- a/app/views/external_users/claims/supporting_evidence_checklist/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_summary.html.haml
@@ -2,7 +2,7 @@
   %p.form-hint
     If you don't provide enough evidence, your claim may be rejected.
 - if current_user == claim.external_user.user && claim.editable?
-  = link_to 'Edit', "#{url_for_edit_external_users_claim(@claim)}#evidence-checklist"
+  = link_to 'Edit', "#{edit_polymorphic_path(@claim)}#evidence-checklist"
 - if claim.evidence_checklist_ids.empty?
   %p
     No documentary evidence specified as having been provided.

--- a/app/views/external_users/litigators/claims/_form.html.haml
+++ b/app/views/external_users/litigators/claims/_form.html.haml
@@ -1,5 +1,5 @@
 #claim-form
-  = form_for [:external_users, @claim], as: :claim, url: url_for_external_users_claim(@claim), builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_for @claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step

--- a/app/views/external_users/litigators/interim_claims/_form.html.haml
+++ b/app/views/external_users/litigators/interim_claims/_form.html.haml
@@ -1,5 +1,5 @@
 #claim-form
-  = form_for [:external_users, @claim], as: :claim, url: url_for_external_users_claim(@claim), builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_for @claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step

--- a/app/views/external_users/litigators/transfer_claims/_form.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_form.html.haml
@@ -1,5 +1,5 @@
 #claim-form
-  = form_for [:external_users, @claim], as: :claim, url: url_for_external_users_claim(@claim), builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_for @claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -22,7 +22,7 @@
       .claim-detail-actions
         = "Actions:"
         %div
-          = link_to 'Edit this claim', url_for_edit_external_users_claim(claim), class: 'button'
+          = link_to 'Edit this claim', edit_polymorphic_path(claim), class: 'button'
           = link_to 'Delete draft', external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button-secondary'
     - if claim.archivable?
       .claim-detail-actions

--- a/app/views/shared/_evidence_checklist.html.haml
+++ b/app/views/shared/_evidence_checklist.html.haml
@@ -5,7 +5,7 @@
     %p.form-hint
       If you don't provide enough evidence, your claim may be rejected.
   - if current_user == @claim.external_user.user && @claim.editable?
-    = link_to 'Edit', "#{url_for_edit_external_users_claim(@claim)}#evidence-checklist"
+    = link_to 'Edit', "#{edit_polymorphic_path(@claim)}#evidence-checklist"
   - if @claim.evidence_checklist_ids.empty?
     %p
       No documentary evidence specified as having been provided.

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
       it 'should redirect to edit page with flash message' do
         claim = create(:claim, case_type_id: nil)
         get :new, { claim_id: claim }
-        expect(response).to redirect_to(controller.send(:url_for_edit_external_users_claim,claim))
+        expect(response).to redirect_to(controller.send(:edit_polymorphic_path,claim))
         expect(flash[:alert]).to eq 'Claim is not in a state to be submitted'
       end
     end

--- a/spec/routing/claims_controller_spec.rb
+++ b/spec/routing/claims_controller_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+require 'action_dispatch/routing/polymorphic_routes'
+
+include ActionDispatch::Routing::PolymorphicRoutes
+
+describe ExternalUsers::Advocates::ClaimsController, :type => :routing do
+  let(:claim) { instance_double(Claim::AdvocateClaim, id: 123) }
+
+  it { should route(:get,  '/advocates/claims/new').to(action: :new) }
+  it { should route(:post, '/advocates/claims').to(action: :create) }
+  it { should route(:put,  '/advocates/claims/123').to(action: :update, id: 123) }
+  it { should route(:get,  '/advocates/claims/123/edit').to(action: :edit, id: 123) }
+
+  describe 'Route helpers' do
+    context 'unpersisted (POST)' do
+      let(:claim) { FactoryGirl.build(:advocate_claim) }
+      it { expect(polymorphic_path(claim)).to eq('/advocates/claims') }
+    end
+
+    context 'persisted (put or edit)' do
+      let(:claim) { FactoryGirl.create(:advocate_claim) }
+      it { expect(polymorphic_path(claim)).to eq(%Q{/advocates/claims/#{claim.id}}) }
+      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/advocates/claims/#{claim.id}/edit}) }
+    end
+  end
+end
+
+describe ExternalUsers::Litigators::ClaimsController, :type => :routing do
+  let(:claim) { instance_double(Claim::LitigatorClaim, id: 123) }
+
+  it { should route(:get,  '/litigators/claims/new').to(action: :new) }
+  it { should route(:post, '/litigators/claims').to(action: :create) }
+  it { should route(:put,  '/litigators/claims/123').to(action: :update, id: 123) }
+  it { should route(:get,  '/litigators/claims/123/edit').to(action: :edit, id: 123) }
+
+  describe 'Route helpers' do
+    context 'unpersisted (POST)' do
+      let(:claim) { FactoryGirl.build(:litigator_claim) }
+      it { expect(polymorphic_path(claim)).to eq('/litigators/claims') }
+    end
+
+    context 'persisted (put or edit)' do
+      let(:claim) { FactoryGirl.create(:litigator_claim) }
+      it { expect(polymorphic_path(claim)).to eq(%Q{/litigators/claims/#{claim.id}}) }
+      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/litigators/claims/#{claim.id}/edit}) }
+    end
+  end
+end
+
+describe ExternalUsers::Litigators::InterimClaimsController, :type => :routing do
+  let(:claim) { instance_double(Claim::InterimClaim, id: 123) }
+
+  it { should route(:get,  '/litigators/interim_claims/new').to(action: :new) }
+  it { should route(:post, '/litigators/interim_claims').to(action: :create) }
+  it { should route(:put,  '/litigators/interim_claims/123').to(action: :update, id: 123) }
+  it { should route(:get,  '/litigators/interim_claims/123/edit').to(action: :edit, id: 123) }
+
+  describe 'Route helpers' do
+    context 'unpersisted (POST)' do
+      let(:claim) { FactoryGirl.build(:interim_claim) }
+      it { expect(polymorphic_path(claim)).to eq('/litigators/interim_claims') }
+    end
+
+    context 'persisted (put or edit)' do
+      let(:claim) { FactoryGirl.create(:interim_claim) }
+      it { expect(polymorphic_path(claim)).to eq(%Q{/litigators/interim_claims/#{claim.id}}) }
+      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/litigators/interim_claims/#{claim.id}/edit}) }
+    end
+  end
+end
+
+describe ExternalUsers::Litigators::TransferClaimsController, :type => :routing do
+  let(:claim) { instance_double(Claim::TransferClaim, id: 123) }
+
+  it { should route(:get,  '/litigators/transfer_claims/new').to(action: :new) }
+  it { should route(:post, '/litigators/transfer_claims').to(action: :create) }
+  it { should route(:put,  '/litigators/transfer_claims/123').to(action: :update, id: 123) }
+  it { should route(:get,  '/litigators/transfer_claims/123/edit').to(action: :edit, id: 123) }
+
+  describe 'Route helpers' do
+    context 'unpersisted (POST)' do
+      let(:claim) { FactoryGirl.build(:transfer_claim) }
+      it { expect(polymorphic_path(claim)).to eq('/litigators/transfer_claims') }
+    end
+
+    context 'persisted (put or edit)' do
+      let(:claim) { FactoryGirl.create(:transfer_claim) }
+      it { expect(polymorphic_path(claim)).to eq(%Q{/litigators/transfer_claims/#{claim.id}}) }
+      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/litigators/transfer_claims/#{claim.id}/edit}) }
+    end
+  end
+end

--- a/spec/routing/claims_controller_spec.rb
+++ b/spec/routing/claims_controller_spec.rb
@@ -3,8 +3,7 @@ require 'action_dispatch/routing/polymorphic_routes'
 
 include ActionDispatch::Routing::PolymorphicRoutes
 
-describe ExternalUsers::Advocates::ClaimsController, :type => :routing do
-  let(:claim) { instance_double(Claim::AdvocateClaim, id: 123) }
+describe ExternalUsers::Advocates::ClaimsController, type: :routing do
 
   it { should route(:get,  '/advocates/claims/new').to(action: :new) }
   it { should route(:post, '/advocates/claims').to(action: :create) }
@@ -12,21 +11,20 @@ describe ExternalUsers::Advocates::ClaimsController, :type => :routing do
   it { should route(:get,  '/advocates/claims/123/edit').to(action: :edit, id: 123) }
 
   describe 'Route helpers' do
-    context 'unpersisted (POST)' do
+    context 'unpersisted (post)' do
       let(:claim) { FactoryGirl.build(:advocate_claim) }
       it { expect(polymorphic_path(claim)).to eq('/advocates/claims') }
     end
 
     context 'persisted (put or edit)' do
       let(:claim) { FactoryGirl.create(:advocate_claim) }
-      it { expect(polymorphic_path(claim)).to eq(%Q{/advocates/claims/#{claim.id}}) }
-      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/advocates/claims/#{claim.id}/edit}) }
+      it { expect(polymorphic_path(claim)).to eq("/advocates/claims/#{claim.id}") }
+      it { expect(edit_polymorphic_path(claim)).to eq("/advocates/claims/#{claim.id}/edit") }
     end
   end
 end
 
-describe ExternalUsers::Litigators::ClaimsController, :type => :routing do
-  let(:claim) { instance_double(Claim::LitigatorClaim, id: 123) }
+describe ExternalUsers::Litigators::ClaimsController, type: :routing do
 
   it { should route(:get,  '/litigators/claims/new').to(action: :new) }
   it { should route(:post, '/litigators/claims').to(action: :create) }
@@ -34,21 +32,20 @@ describe ExternalUsers::Litigators::ClaimsController, :type => :routing do
   it { should route(:get,  '/litigators/claims/123/edit').to(action: :edit, id: 123) }
 
   describe 'Route helpers' do
-    context 'unpersisted (POST)' do
+    context 'unpersisted (post)' do
       let(:claim) { FactoryGirl.build(:litigator_claim) }
       it { expect(polymorphic_path(claim)).to eq('/litigators/claims') }
     end
 
     context 'persisted (put or edit)' do
       let(:claim) { FactoryGirl.create(:litigator_claim) }
-      it { expect(polymorphic_path(claim)).to eq(%Q{/litigators/claims/#{claim.id}}) }
-      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/litigators/claims/#{claim.id}/edit}) }
+      it { expect(polymorphic_path(claim)).to eq("/litigators/claims/#{claim.id}") }
+      it { expect(edit_polymorphic_path(claim)).to eq("/litigators/claims/#{claim.id}/edit") }
     end
   end
 end
 
-describe ExternalUsers::Litigators::InterimClaimsController, :type => :routing do
-  let(:claim) { instance_double(Claim::InterimClaim, id: 123) }
+describe ExternalUsers::Litigators::InterimClaimsController, type: :routing do
 
   it { should route(:get,  '/litigators/interim_claims/new').to(action: :new) }
   it { should route(:post, '/litigators/interim_claims').to(action: :create) }
@@ -56,21 +53,20 @@ describe ExternalUsers::Litigators::InterimClaimsController, :type => :routing d
   it { should route(:get,  '/litigators/interim_claims/123/edit').to(action: :edit, id: 123) }
 
   describe 'Route helpers' do
-    context 'unpersisted (POST)' do
+    context 'unpersisted (post)' do
       let(:claim) { FactoryGirl.build(:interim_claim) }
       it { expect(polymorphic_path(claim)).to eq('/litigators/interim_claims') }
     end
 
     context 'persisted (put or edit)' do
       let(:claim) { FactoryGirl.create(:interim_claim) }
-      it { expect(polymorphic_path(claim)).to eq(%Q{/litigators/interim_claims/#{claim.id}}) }
-      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/litigators/interim_claims/#{claim.id}/edit}) }
+      it { expect(polymorphic_path(claim)).to eq("/litigators/interim_claims/#{claim.id}") }
+      it { expect(edit_polymorphic_path(claim)).to eq("/litigators/interim_claims/#{claim.id}/edit") }
     end
   end
 end
 
-describe ExternalUsers::Litigators::TransferClaimsController, :type => :routing do
-  let(:claim) { instance_double(Claim::TransferClaim, id: 123) }
+describe ExternalUsers::Litigators::TransferClaimsController, type: :routing do
 
   it { should route(:get,  '/litigators/transfer_claims/new').to(action: :new) }
   it { should route(:post, '/litigators/transfer_claims').to(action: :create) }
@@ -78,15 +74,15 @@ describe ExternalUsers::Litigators::TransferClaimsController, :type => :routing 
   it { should route(:get,  '/litigators/transfer_claims/123/edit').to(action: :edit, id: 123) }
 
   describe 'Route helpers' do
-    context 'unpersisted (POST)' do
+    context 'unpersisted (post)' do
       let(:claim) { FactoryGirl.build(:transfer_claim) }
       it { expect(polymorphic_path(claim)).to eq('/litigators/transfer_claims') }
     end
 
     context 'persisted (put or edit)' do
       let(:claim) { FactoryGirl.create(:transfer_claim) }
-      it { expect(polymorphic_path(claim)).to eq(%Q{/litigators/transfer_claims/#{claim.id}}) }
-      it { expect(edit_polymorphic_path(claim)).to eq(%Q{/litigators/transfer_claims/#{claim.id}/edit}) }
+      it { expect(polymorphic_path(claim)).to eq("/litigators/transfer_claims/#{claim.id}") }
+      it { expect(edit_polymorphic_path(claim)).to eq("/litigators/transfer_claims/#{claim.id}/edit") }
     end
   end
 end

--- a/spec/support/view_spec_helpers.rb
+++ b/spec/support/view_spec_helpers.rb
@@ -15,10 +15,6 @@ module ViewSpecHelper
       raise 'Stub current_user if you want to test the behavior.'
     end
 
-    def url_for_edit_external_users_claim(claim)
-      raise 'Stub url_for_edit_external_users_claims in the spec to provide the behaviour you need'
-    end
-
   end
 
   def initialize_view_helpers(view)

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -16,7 +16,6 @@ describe 'external_users/claims/show.html.haml', type: :view do
     initialize_view_helpers(view)
     sign_in :user, @external_user.user
     allow(view).to receive(:current_user_persona_is?).and_return(false)
-    allow(view).to receive(:url_for_edit_external_users_claim).and_return('http://my_edit_external_users_path')
     render
   end
 


### PR DESCRIPTION
This refactor allows us to get rid of our custom URL helper methods and let Rails deal with the routes, with the only drawback of having to specify in the claims classes the singular route form of the class:

``` ruby
class InterimClaim < BaseClaim
  set_singular_route_key 'litigators_interim_claim'
end
```
