### PR TITLE
use the transfer detail attributes delegated to claim and fix bug

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -216,6 +216,11 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
       date_attributes_for(:legal_aid_transfer_date),
       :trial_cracked_at_third,
       :additional_information,
+      :litigator_type,
+      :elected_case,
+      :transfer_stage_id,
+      date_attributes_for(:transfer_date),
+      :case_conclusion_id,
       evidence_checklist_ids: [],
       defendants_attributes: [
        :id,
@@ -269,19 +274,12 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
           :amount,
           :quantity
       ],
-      transfer_detail_attributes: [
-        :litigator_type,
-        :elected_case,
-        :transfer_stage_id,
-        date_attributes_for(:transfer_date),
-        :case_conclusion_id
-        ],
       transfer_fee_attributes: [
         :id,
         :claim_id,
         :fee_type_id,
         :amount
-        ],
+      ],
       warrant_fee_attributes: [
           :id,
           :claim_id,

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -68,7 +68,7 @@ module Claim
     # The ActiveSupport delegate method doesn't work with new objects - i.e. You can't say Claim.new(xxx: value) where xxx is delegated
     # So we have to do this instead.  Probably good to put it in a gem eventually.
     #
-    DELEGATED_ATTRS = [ :litigator_type, :elected_case, :transfer_stage_id, :transfer_date, :case_conclusion_id ]
+    DELEGATED_ATTRS = [ :litigator_type, :elected_case, :transfer_stage_id, :transfer_date, :transfer_date_dd, :transfer_date_mm, :transfer_date_yyyy, :case_conclusion_id ]
 
     DELEGATED_ATTRS.each do |getter_method|
       define_method getter_method do

--- a/app/views/external_users/claims/transfer_detail/_fields.html.haml
+++ b/app/views/external_users/claims/transfer_detail/_fields.html.haml
@@ -1,41 +1,38 @@
+- present(f.object.transfer_detail) do |transfer_detail|
 
-= f.fields_for :transfer_detail do |td|
-  - present(td.object) do |transfer_detail|
+  = f.anchored_without_label 'transfer_detail'
 
-    = td.anchored_without_label 'transfer_detail'
+  %fieldset
+    .form-row
+      %fieldset.inline
+        = f.anchored_label t('.litigator_type'), 'litigator_type'
+        = f.collection_radio_buttons(:litigator_type, ['original','new'], :to_s, :humanize) do |b|
+          - b.label(class: "block-label") { b.radio_button + b.text }
+      = validation_error_message(@error_presenter, :litigator_type)
 
-    %fieldset
-      .form-row
-        %fieldset.inline
-          = td.anchored_label t('.litigator_type'), 'litigator_type'
-          = td.collection_radio_buttons(:litigator_type, ['original','new'], :to_s, :humanize) do |b|
-            - b.label(class: "block-label") { b.radio_button + b.text }
-        = validation_error_message(@error_presenter, :litigator_type)
+  %fieldset
+    .form-row
+      %fieldset.inline
+        = f.anchored_label t('.elected_case'), 'elected_case'
+        = f.collection_radio_buttons(:elected_case, [['Yes','true'],['No','false']], :last, :first ) do |b|
+          - b.label(class: "block-label") { b.radio_button + b.text }
+      = validation_error_message(@error_presenter, :elected_case)
 
-    %fieldset
-      .form-row
-        %fieldset.inline
-          = td.anchored_label t('.elected_case'), 'elected_case'
-          = td.collection_radio_buttons(:elected_case, [['Yes','true'],['No','false']], :last, :first ) do |b|
-            - b.label(class: "block-label") { b.radio_button + b.text }
-        = validation_error_message(@error_presenter, :elected_case)
+  %fieldset
+    .form-row
+      .form-col
+        = f.anchored_label t('.transfer_stages'), 'transfer_stage_id'
+        = f.collection_select :transfer_stage_id, transfer_detail.transfer_stages, :first, :last,{}, { class: 'form-control autocomplete'}
+        = validation_error_message(@error_presenter, 'transfer_stage_id')
 
-    %fieldset
-      .form-row
-        .form-col
-          = td.anchored_label t('.transfer_stages'), 'transfer_stage_id'
-          = td.collection_select :transfer_stage_id, transfer_detail.transfer_stages, :first, :last,{}, { class: 'form-control autocomplete'}
-          = validation_error_message(@error_presenter, 'transfer_stage_id')
+  %fieldset
+    .form-row
+      .form-col
+        = f.gov_uk_date_field(:transfer_date, legend_text: t('.transfer_date'), legend_class: 'govuk-legend', id: "transfer_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, 'transfer_date'))
 
-    %fieldset
-      .form-row
-        .form-col
-          = td.gov_uk_date_field(:transfer_date, legend_text: t('.transfer_date'), legend_class: 'govuk-legend', id: "transfer_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, 'transfer_date'))
-          = validation_error_message(@error_presenter, :transfer_date)
-
-    %fieldset
-      .form-row
-        .form-col
-          = td.anchored_label t('.case_conclusions'), 'case_conclusion_id'
-          = td.collection_select :case_conclusion_id, transfer_detail.case_conclusions, :first, :last,{}, { class: 'form-control autocomplete'}
-          = validation_error_message(@error_presenter, 'case_conclusion_id')
+  %fieldset
+    .form-row
+      .form-col
+        = f.anchored_label t('.case_conclusions'), 'case_conclusion_id'
+        = f.collection_select :case_conclusion_id, transfer_detail.case_conclusions, :first, :last,{}, { class: 'form-control autocomplete'}
+        = validation_error_message(@error_presenter, 'case_conclusion_id')

--- a/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
@@ -114,15 +114,13 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
           let(:case_number) { 'A88888888' }
           let(:transfer_detail_params) {
             {
-                transfer_detail_attributes: {
-                  litigator_type: 'original',
-                  elected_case: false,
-                  transfer_stage_id: 10,
-                  transfer_date_dd:   5.days.ago.day.to_s,
-                  transfer_date_mm:   5.days.ago.month.to_s,
-                  transfer_date_yyyy: 5.days.ago.year.to_s,
-                  case_conclusion_id: 10
-                }
+              litigator_type: 'original',
+              elected_case: false,
+              transfer_stage_id: 10,
+              transfer_date_dd:   5.days.ago.day.to_s,
+              transfer_date_mm:   5.days.ago.month.to_s,
+              transfer_date_yyyy: 5.days.ago.year.to_s,
+              case_conclusion_id: 10
             }
           }
           let(:transfer_fee_params) {

--- a/spec/models/claim/transfer_claim_spec.rb
+++ b/spec/models/claim/transfer_claim_spec.rb
@@ -63,6 +63,13 @@ describe Claim::TransferClaim, type: :model do
   it { should_not delegate_method(:requires_trial_dates?).to(:case_type) }
   it { should_not delegate_method(:requires_retrial_dates?).to(:case_type) }
 
+  context 'should delegate transfer detail attributes to transfer detail object' do
+    [ :litigator_type, :elected_case, :transfer_stage_id, :transfer_date, :transfer_date_dd, :transfer_date_mm, :transfer_date_yyyy, :case_conclusion_id ].
+    each do |attribute|
+      it { should delegate_method(attribute).to(:transfer_detail) }
+    end
+  end
+
   context 'transfer fee' do
     it 'creates a transfer fee when created in a factory' do
       claim = create :transfer_claim


### PR DESCRIPTION
controller and views were previously using the transfer
detail object's attributes directly. This modifies the controller
and views to use the transfer detail attributes delegated to the transfer
claim object. This also fixes a bug whereby transfer date errors 
were not being displayed by the gov_uk_date_field
