### PR TITLE
Extracting each of the claim submission journeys to service objects.

### DIFF
--- a/app/controllers/external_users/advocates/claims_controller.rb
+++ b/app/controllers/external_users/advocates/claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Advocates::ClaimsController < ExternalUsers::ClaimsControll
 
 private
 
-  def update_claim_document_owners(claim)
-    claim.documents.each { |d| d.update_column(:external_user_id, claim.external_user_id) }
-  end
-
   def load_external_users_in_provider
     @advocates_in_provider = @provider.advocates if @external_user.admin?
   end

--- a/app/controllers/external_users/litigators/claims_controller.rb
+++ b/app/controllers/external_users/litigators/claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Litigators::ClaimsController < ExternalUsers::ClaimsControl
 
 private
 
-  def update_claim_document_owners(claim)
-    claim.documents.each { |d| d.update_column(:creator_id, claim.creator_id) }
-  end
-
   def load_external_users_in_provider
     @litigators_in_provider = @provider.litigators if @external_user.admin?
   end

--- a/app/controllers/external_users/litigators/interim_claims_controller.rb
+++ b/app/controllers/external_users/litigators/interim_claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Litigators::InterimClaimsController < ExternalUsers::Claims
 
 private
 
-  def update_claim_document_owners(claim)
-    claim.documents.each { |d| d.update_column(:creator_id, claim.creator_id) }
-  end
-
   def load_external_users_in_provider
     @litigators_in_provider = @provider.litigators if @external_user.admin?
   end

--- a/app/controllers/external_users/litigators/transfer_claims_controller.rb
+++ b/app/controllers/external_users/litigators/transfer_claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Litigators::TransferClaimsController < ExternalUsers::Claim
 
 private
 
-  def update_claim_document_owners(claim)
-    claim.documents.each { |d| d.update_column(:creator_id, claim.creator_id) }
-  end
-
   def load_external_users_in_provider
     @litigators_in_provider = @provider.litigators if @external_user.admin?
   end

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -92,6 +92,10 @@ module Claim
       true
     end
 
+    def update_claim_document_owners
+      documents.each { |d| d.update_column(:external_user_id, self.external_user_id) }
+    end
+
     private
 
     def provider_delegator

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -358,6 +358,10 @@ module Claim
       case_type.is_fixed_fee?
     end
 
+    def update_claim_document_owners
+      documents.each { |d| d.update_column(:creator_id, self.creator_id) }
+    end
+
     # This will ensure proper route paths are generated
     # when using helpers like: edit_polymorphic_path(claim)
     def self.set_singular_route_key(name)

--- a/app/services/claims/claim_actions_result.rb
+++ b/app/services/claims/claim_actions_result.rb
@@ -1,0 +1,16 @@
+module Claims
+  class ClaimActionsResult
+
+    attr_accessor :success, :error_code
+
+    def initialize(success: true, error_code: nil)
+      self.success = success
+      self.error_code = error_code
+    end
+
+    def success?
+      success
+    end
+
+  end
+end

--- a/app/services/claims/claim_actions_service.rb
+++ b/app/services/claims/claim_actions_service.rb
@@ -1,0 +1,70 @@
+module Claims
+  class ClaimActionsService
+
+    attr_accessor :claim, :params, :validate
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def ga_args
+      []
+    end
+
+    def draft?
+      false
+    end
+
+    def action
+    end
+
+    def result
+      @result ||= ClaimActionsResult.new
+    end
+
+
+    private
+
+    def validate?
+      self.validate
+    end
+
+    def save_claim!(validation)
+      claim.class.transaction do
+        claim.save
+        claim.force_validation = validation
+
+        if claim.valid?
+          claim.update_claim_document_owners
+        else
+          rollback!
+        end
+      end
+    end
+
+    def save_draft!(validation)
+      claim.class.transaction do
+        claim.force_validation = validation
+        rollback! unless claim.save
+      end
+    end
+
+    def rollback!
+      set_error_code(:rollback)
+      raise ActiveRecord::Rollback
+    end
+
+    def already_submitted?
+      claim.class.where(form_id: claim.form_id).where.not(last_submitted_at: nil).any?
+    end
+
+    def already_saved?
+      claim.class.where(form_id: claim.form_id).any?
+    end
+
+    def set_error_code(code)
+      @result = ClaimActionsResult.new(success: false, error_code: code)
+    end
+
+  end
+end

--- a/app/services/claims/create_claim.rb
+++ b/app/services/claims/create_claim.rb
@@ -1,0 +1,27 @@
+module Claims
+  class CreateClaim < ClaimActionsService
+
+    def initialize(claim)
+      self.claim = claim
+      self.validate = true
+    end
+
+    def call
+      if already_submitted?
+        set_error_code(:already_submitted) and return
+      end
+
+      save_claim!(validate?)
+
+      self
+    end
+
+    def action
+      :new
+    end
+
+    def ga_args
+      %w(event claim submit started)
+    end
+  end
+end

--- a/app/services/claims/create_draft.rb
+++ b/app/services/claims/create_draft.rb
@@ -1,0 +1,31 @@
+module Claims
+  class CreateDraft < ClaimActionsService
+
+    def initialize(claim, validate:)
+      self.claim = claim
+      self.validate = validate
+    end
+
+    def call
+      if already_saved?
+        set_error_code(:already_saved) and return
+      end
+
+      save_draft!(validate?)
+
+      self
+    end
+
+    def draft?
+      true
+    end
+
+    def action
+      :new
+    end
+
+    def ga_args
+      %w(event claim draft created)
+    end
+  end
+end

--- a/app/services/claims/update_claim.rb
+++ b/app/services/claims/update_claim.rb
@@ -1,0 +1,31 @@
+module Claims
+  class UpdateClaim < ClaimActionsService
+
+    def initialize(claim, params:)
+      self.claim = claim
+      self.params = params
+      self.validate = true
+    end
+
+    def call
+      if already_submitted?
+        set_error_code(:already_submitted) and return
+      end
+
+      claim.assign_attributes(params)
+      claim.source = 'api_web_edited' if claim.from_api?
+
+      save_claim!(validate?)
+
+      self
+    end
+
+    def action
+      :edit
+    end
+
+    def ga_args
+      %w(event claim update started)
+    end
+  end
+end

--- a/app/services/claims/update_draft.rb
+++ b/app/services/claims/update_draft.rb
@@ -1,0 +1,31 @@
+module Claims
+  class UpdateDraft < ClaimActionsService
+
+    def initialize(claim, params:, validate:)
+      self.claim = claim
+      self.params = params
+      self.validate = validate
+    end
+
+    def call
+      claim.assign_attributes(params)
+      claim.source = 'api_web_edited' if claim.from_api?
+
+      save_draft!(validate?)
+
+      self
+    end
+
+    def draft?
+      true
+    end
+
+    def action
+      :edit
+    end
+
+    def ga_args
+      %w(event claim draft updated)
+    end
+  end
+end

--- a/spec/services/claims/create_claim_spec.rb
+++ b/spec/services/claims/create_claim_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe Claims::CreateClaim do
+
+  after(:all) do
+    clean_database
+  end
+
+  context 'claim creation' do
+    let(:claim) { FactoryGirl.build :advocate_claim }
+    subject { described_class.new(claim) }
+
+    it 'defines the action' do
+      expect(subject.action).to eq(:new)
+    end
+
+    it 'defines the google analytics tokens' do
+      expect(subject.ga_args).to eq %w(event claim submit started)
+    end
+
+    it 'is not a draft' do
+      expect(subject.draft?).to be_falsey
+    end
+
+    context 'successful creations' do
+      it 'forces validation' do
+        allow(subject.claim).to receive(:force_validation=).with(true)
+        subject.call
+      end
+
+      it 'is successful' do
+        expect(subject.claim.persisted?).to be_falsey
+        expect(subject.claim).to receive(:update_claim_document_owners)
+
+        subject.call
+
+        expect(subject.result.success?).to be_truthy
+        expect(subject.result.error_code).to be_nil
+        expect(subject.claim.persisted?).to be_truthy
+      end
+    end
+
+    context 'unsuccessful creations' do
+      it 'is unsuccessful' do
+        claim.case_number = nil
+
+        expect(subject.claim.persisted?).to be_falsey
+        expect(subject.claim).not_to receive(:update_claim_document_owners)
+
+        subject.call
+
+        expect(subject.result.success?).to be_falsey
+        expect(subject.result.error_code).to eq(:rollback)
+        expect(subject.claim.persisted?).to be_falsey
+      end
+
+      it 'is unsuccessful for an already submitted claim' do
+        allow(subject).to receive(:already_submitted?).and_return(true)
+
+        expect(subject.claim.persisted?).to be_falsey
+        expect(subject.claim).not_to receive(:update_claim_document_owners)
+
+        subject.call
+
+        expect(subject.result.success?).to be_falsey
+        expect(subject.result.error_code).to eq(:already_submitted)
+        expect(subject.claim.persisted?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/claims/create_draft_spec.rb
+++ b/spec/services/claims/create_draft_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+describe Claims::CreateDraft do
+
+  after(:all) do
+    clean_database
+  end
+
+  context 'draft claim creation' do
+    let(:claim) { FactoryGirl.build :advocate_claim }
+    let(:validate) { true }
+
+    subject { described_class.new(claim, validate: validate) }
+
+    it 'defines the action' do
+      expect(subject.action).to eq(:new)
+    end
+
+    it 'defines the google analytics tokens' do
+      expect(subject.ga_args).to eq %w(event claim draft created)
+    end
+
+    it 'is a draft' do
+      expect(subject.draft?).to be_truthy
+    end
+
+    context 'successful draft creations' do
+      context 'validation enabled' do
+        let(:validate) { true }
+
+        it 'forces validation if indicated' do
+          allow(subject.claim).to receive(:force_validation=).with(true)
+          subject.call
+        end
+      end
+
+      context 'validation not enabled' do
+        let(:validate) { false }
+
+        it 'forces validation if indicated' do
+          allow(subject.claim).to receive(:force_validation=).with(false)
+          subject.call
+        end
+      end
+
+      it 'is successful' do
+        expect(subject.claim.persisted?).to be_falsey
+
+        subject.call
+
+        expect(subject.result.success?).to be_truthy
+        expect(subject.result.error_code).to be_nil
+        expect(subject.claim.persisted?).to be_truthy
+      end
+    end
+
+    context 'unsuccessful draft creations' do
+      it 'is unsuccessful' do
+        claim.case_number = nil
+
+        expect(subject.claim.persisted?).to be_falsey
+
+        subject.call
+
+        expect(subject.result.success?).to be_falsey
+        expect(subject.result.error_code).to eq(:rollback)
+        expect(subject.claim.persisted?).to be_falsey
+      end
+
+      it 'is unsuccessful for an already submitted claim' do
+        expect(subject.claim.persisted?).to be_falsey
+        allow(subject).to receive(:already_saved?).and_return(true)
+
+        subject.call
+
+        expect(subject.result.success?).to be_falsey
+        expect(subject.result.error_code).to eq(:already_saved)
+        expect(subject.claim.persisted?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/claims/update_claim_spec.rb
+++ b/spec/services/claims/update_claim_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe Claims::UpdateClaim do
+
+  after(:all) do
+    clean_database
+  end
+
+  context 'claim updating' do
+    let(:claim) { FactoryGirl.create :advocate_claim, case_number: 'A12345678' }
+    let(:claim_params) { { case_number: 'A55555555' } }
+
+    subject { described_class.new(claim, params: claim_params) }
+
+    it 'defines the action' do
+      expect(subject.action).to eq(:edit)
+    end
+
+    it 'defines the google analytics tokens' do
+      expect(subject.ga_args).to eq %w(event claim update started)
+    end
+
+    it 'is not a draft' do
+      expect(subject.draft?).to be_falsey
+    end
+
+    context 'successful updates' do
+      it 'forces validation' do
+        allow(subject.claim).to receive(:force_validation=).with(true)
+        subject.call
+      end
+
+      it 'updates the source when editing an API submitted claim' do
+        allow(subject.claim).to receive(:from_api?).and_return(true)
+        subject.call
+        expect(subject.claim.source).to eq('api_web_edited')
+      end
+
+      it 'is successful' do
+        expect(subject.claim.case_number).to eq('A12345678')
+        expect(subject.claim).to receive(:update_claim_document_owners)
+
+        subject.call
+
+        expect(subject.result.success?).to be_truthy
+        expect(subject.result.error_code).to be_nil
+        expect(subject.claim.case_number).to eq('A55555555')
+      end
+    end
+
+    context 'unsuccessful updates' do
+      let(:claim_params) { { case_number: '123' } }
+
+      it 'is unsuccessful' do
+        expect(subject.claim).not_to receive(:update_claim_document_owners)
+
+        subject.call
+
+        expect(subject.result.success?).to be_falsey
+        expect(subject.result.error_code).to eq(:rollback)
+      end
+
+      it 'is unsuccessful for an already submitted claim' do
+        allow(subject).to receive(:already_submitted?).and_return(true)
+        expect(subject.claim).not_to receive(:update_claim_document_owners)
+
+        subject.call
+
+        expect(subject.result.success?).to be_falsey
+        expect(subject.result.error_code).to eq(:already_submitted)
+      end
+    end
+  end
+end

--- a/spec/services/claims/update_draft_spec.rb
+++ b/spec/services/claims/update_draft_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe Claims::UpdateDraft do
+
+  after(:all) do
+    clean_database
+  end
+
+  context 'draft claim updates' do
+    let(:claim) { FactoryGirl.create :advocate_claim, case_number: 'A12345678' }
+    let(:claim_params) { { case_number: 'A55555555' } }
+    let(:validate) { true }
+
+    subject { described_class.new(claim, params: claim_params, validate: validate) }
+
+    it 'defines the action' do
+      expect(subject.action).to eq(:edit)
+    end
+
+    it 'defines the google analytics tokens' do
+      expect(subject.ga_args).to eq %w(event claim draft updated)
+    end
+
+    it 'is a draft' do
+      expect(subject.draft?).to be_truthy
+    end
+
+    context 'successful draft updates' do
+      context 'validation enabled' do
+        let(:validate) { true }
+
+        it 'forces validation if indicated' do
+          allow(subject.claim).to receive(:force_validation=).with(true)
+          subject.call
+        end
+      end
+
+      context 'validation not enabled' do
+        let(:validate) { false }
+
+        it 'forces validation if indicated' do
+          allow(subject.claim).to receive(:force_validation=).with(false)
+          subject.call
+        end
+      end
+
+      it 'updates the source when editing an API submitted claim' do
+        allow(subject.claim).to receive(:from_api?).and_return(true)
+        subject.call
+        expect(subject.claim.source).to eq('api_web_edited')
+      end
+
+      it 'is successful' do
+        expect(subject.claim.case_number).to eq('A12345678')
+
+        subject.call
+
+        expect(subject.result.success?).to be_truthy
+        expect(subject.result.error_code).to be_nil
+        expect(subject.claim.case_number).to eq('A55555555')
+      end
+    end
+
+    context 'unsuccessful draft updates' do
+      let(:claim_params) { { case_number: '123' } }
+
+      it 'is unsuccessful' do
+        subject.call
+
+        expect(subject.result.success?).to be_falsey
+        expect(subject.result.error_code).to eq(:rollback)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This refactor creates 4 individual small service objects with a common interface to handle the 4 different claim submission journeys that we currently have:
- Claim creation
- Claim update
- Draft creation
- Draft update

An error object can be queried to know if the action was success or not, and if not to retrieve an error_code used for later error handling.

There is space for improvement.
