### PR TITLE
fix Travis CI reporting success for broken features

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -48,7 +48,14 @@ AfterConfiguration do
 end
 
 at_exit do
+  #
+  # NOTE: ActiveRecord may be interfering with exit codes
+  #       so we need to explcitly return the test suite
+  #       run's exit code.
+  #
+  exit_status = $!.status if $!.is_a?(SystemExit)
   NON_TRUNCATED_TABLES.each do |table|
-    table.sub('fee_types', 'Fee::BaseFeeTypes').classify.safe_constantize.delete_all
+    table.sub('fee_types', 'Fee::BaseFeeType').classify.safe_constantize.delete_all
   end
+  exit exit_status if exit_status
 end


### PR DESCRIPTION
An at_exit hook's call to ActiveRecord
appears to have been altering exit codes
and returning success for cuke run regardless.

see https://github.com/cucumber/cucumber-ruby/issues/635
for details.
