### PR TITLE
modify summary page to hide irrelevant fee details

### DIFF
--- a/app/models/claim/transfer_detail.rb
+++ b/app/models/claim/transfer_detail.rb
@@ -14,7 +14,7 @@
 module Claim
   class TransferDetail < ActiveRecord::Base
 
-    belongs_to :claim, class_name: Claim::TransferClaim, foreign_key: :claim_id
+    belongs_to :claim, class_name: Claim::TransferClaim, foreign_key: :claim_id, inverse_of: :transfer_detail
 
     acts_as_gov_uk_date :transfer_date
 

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -19,16 +19,18 @@
           = t('shared.summary.fee_type')
         %td
           = fee.fee_type.description
-      %tr
-        %th{ scope: 'row'}
-          = t('shared.summary.quantity')
-        %td
-          = fee.quantity
-      %tr
-        %th{ scope: 'row'}
-          = t('shared.summary.rate')
-        %td
-          = fee.rate
+
+      - if fee.claim.agfs?
+        %tr
+          %th{ scope: 'row'}
+            = t('shared.summary.quantity')
+          %td
+            = fee.quantity
+        %tr
+          %th{ scope: 'row'}
+            = t('shared.summary.rate')
+          %td
+            = fee.rate
       %tr
         %th{ scope: 'row'}
           = t('shared.summary.amount')

--- a/spec/presenters/transfer_claim_presenter_spec.rb
+++ b/spec/presenters/transfer_claim_presenter_spec.rb
@@ -51,9 +51,6 @@ RSpec.describe Claim::TransferClaimPresenter do
   end
 
   context '#transfer_detail_summary' do
-    #
-    # TEMPLATE: '{if elected_case=true, 'elected case -'} {transfer_stage_id description} {(litigator_type abbrev ie. new|org)} - (case_conclusion_id description if exists)'
-    #
     context 'for transfer details NOT requiring a conclusion' do
       let(:claim) { create :transfer_claim, litigator_type: 'new', elected_case: true, transfer_stage_id: 10, case_conclusion_id: nil }
       it 'should return a string of expected values' do


### PR DESCRIPTION
No LGFS fees (misc, fixed, grad, interim, transfer, warrant) require quantity and rate and therefore
do not need to be displayed on summary page.
