### PR TITLE
Fixing the issue where expenses will validate even when they are blank (problem was zeroes).

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -57,7 +57,7 @@ module Claim
     set_singular_route_key 'advocates_claim'
 
     has_many :fixed_fees, foreign_key: :claim_id, class_name: 'Fee::FixedFee', dependent: :destroy, inverse_of: :claim
-    accepts_nested_attributes_for :fixed_fees, reject_if: :all_blank, allow_destroy: true
+    accepts_nested_attributes_for :fixed_fees, reject_if: all_blank_or_zero, allow_destroy: true
 
     validates_with ::Claim::AdvocateClaimValidator
     validates_with ::Claim::AdvocateClaimSubModelValidator

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -124,10 +124,10 @@ module Claim
     scope :total_greater_than_or_equal_to, -> (value) { where { total >= value } }
     scope :total_lower_than, -> (value) { where { total < value } }
 
-    accepts_nested_attributes_for :basic_fees,        reject_if: :all_blank, allow_destroy: true
-    accepts_nested_attributes_for :misc_fees,         reject_if: :all_blank, allow_destroy: true
-    accepts_nested_attributes_for :expenses,          reject_if: :all_blank, allow_destroy: true
-    accepts_nested_attributes_for :disbursements,     reject_if: :all_blank, allow_destroy: true
+    accepts_nested_attributes_for :basic_fees,        reject_if: all_blank_or_zero, allow_destroy: true
+    accepts_nested_attributes_for :misc_fees,         reject_if: all_blank_or_zero, allow_destroy: true
+    accepts_nested_attributes_for :expenses,          reject_if: all_blank_or_zero, allow_destroy: true
+    accepts_nested_attributes_for :disbursements,     reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :defendants,        reject_if: :all_blank, allow_destroy: true
     accepts_nested_attributes_for :assessment
     accepts_nested_attributes_for :redeterminations,  reject_if: :all_blank

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -3,3 +3,11 @@ Dir[File.join(Rails.root, 'lib', 'extensions', '*.rb')].each { |file| require fi
 class Array
   include ArrayExtension
 end
+
+class String
+  include StringExtension
+end
+
+class ActiveRecord::Base
+  include NestedAttributesExtension
+end

--- a/lib/extensions/nested_attributes_extension.rb
+++ b/lib/extensions/nested_attributes_extension.rb
@@ -1,0 +1,13 @@
+module NestedAttributesExtension
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def all_blank_or_zero
+      ->(attributes) { attributes.all? { |key, value| key == '_destroy' || (value.blank? || value.zero?) } }
+    end
+  end
+
+end

--- a/lib/extensions/string_extension.rb
+++ b/lib/extensions/string_extension.rb
@@ -1,0 +1,7 @@
+module StringExtension
+
+  def zero?
+    present? && to_f == 0.0
+  end
+
+end

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -144,6 +144,31 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
             expect(response).to have_http_status(:redirect)
             expect(Claim::AdvocateClaim.first).to be_draft
           end
+
+          context 'blank expenses' do
+            let(:expense_params) do
+              {
+                  expense_type_id: '',
+                  location: '',
+                  distance: '',
+                  date_dd: '',
+                  date_mm: '',
+                  date_yyyy: '',
+                  reason_id: '',
+                  reason_text: '',
+                  amount: '0.00',
+                  vat_amount: '0.00',
+                  _destroy: false
+              }
+            end
+
+            it 'rejects the blank expense when all blank or zero, not failing validations, and creates the claim' do
+              expect {
+                post :create, commit_submit_claim: 'Submit to LAA', claim: claim_params
+              }.not_to change(Expense, :count)
+              expect(response).to have_http_status(:redirect)
+            end
+          end
         end
 
         context 'multi-step form submit to LAA' do

--- a/spec/lib/extensions/string_extension_spec.rb
+++ b/spec/lib/extensions/string_extension_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe String do
+
+  context '#zero?' do
+    context 'for blank values' do
+      it 'should be false' do
+        expect(''.zero?).to eq(false)
+      end
+    end
+
+    context 'for numeric non-zero values' do
+      %w(1 0.1 0.01 1.0).each do |value|
+        it "should be false for #{value}" do
+          expect(value.zero?).to eq(false)
+        end
+      end
+    end
+
+    context 'for numeric zero values' do
+      %w(0 0.0 0.00 000).each do |value|
+        it "should be true for #{value}" do
+          expect(value.zero?).to eq(true)
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Now we can choose:

`reject_if: :all_blank`
or
`reject_if: all_blank_or_zero`

blank or zero will ensure attributes like 0.00 are treated as blanks.
