### PR TITLE
ensure transfer claim cannot have 0 total

### DIFF
--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -18,7 +18,8 @@ module Claim
           :transfer_stage_id,
           :transfer_date,
           :case_conclusion_id,
-          :transfer_detail_combo
+          :transfer_detail_combo,
+          :total
         ]
       ]
     end

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -30,7 +30,8 @@ module Claim
         :transfer_stage_id,
         :transfer_date,
         :case_conclusion_id,
-        :transfer_detail_combo
+        :transfer_detail_combo,
+        :total
       ]
   ]
 


### PR DESCRIPTION
this had been missed form validators. Transfer claims can only be valid if they are actually claiming remuneration of some variety.
