### PR TITLE
Update logstash source to reflect the true environment 

### DIFF
--- a/app/controllers/case_conclusions_controller.rb
+++ b/app/controllers/case_conclusions_controller.rb
@@ -9,9 +9,9 @@ class CaseConclusionsController < ApplicationController
   skip_load_and_authorize_resource only: [:index]
 
   def index
-    @transfer_detail = Claim::TransferDetail.new( litigator_type: params[:litigator_type],
-                                                   elected_case: elected_case?,
-                                                   transfer_stage_id: params[:transfer_stage_id])
+    @transfer_detail = Claim::TransferDetail.new(litigator_type: params[:litigator_type],
+                                                 elected_case: elected_case?,
+                                                 transfer_stage_id: params[:transfer_stage_id])
   end
 
 private

--- a/app/models/claim/transfer_brain.rb
+++ b/app/models/claim/transfer_brain.rb
@@ -78,9 +78,9 @@ module Claim
     # are required to specify case conclusions.
     # i.e. 'new', false, [10,20,30,50,60]
     def self.case_conclusion_required?(detail)
-      return detail.litigator_type == 'new' &&
-             detail.elected_case == false && # treat nil as failure i.e. non-false
-             [10,20,30,50,60].include?(detail.transfer_stage_id)
+      detail.litigator_type == 'new' &&
+        detail.elected_case == false && # treat nil as failure i.e. non-false
+        [10,20,30,50,60].include?(detail.transfer_stage_id)
     end
 
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,7 +101,7 @@ Rails.application.configure do
   config.logstasher.enabled = true
 
   # This line is optional, it allows you to set a custom value for the @source field of the log event
-  config.logstasher.source = 'Advocate Defence Payments App production'
+  config.logstasher.source = "Advocate Defence Payments App #{ENV['ENV']}"
 
   # This line is optional if you do not want to suppress app logs in your <environment>.log
   config.logstasher.suppress_app_log = true


### PR DESCRIPTION
Currently, logs from all environments (production, staging, dev, demo, sandbox) were being written to logstash with a source of 'Advocate Defence Payments production', making them impossible to distinguish on kibana.

This PR substitutes production for the name of the environemnt (production, staging, etc). derivied from the ENV environment variable
