### PR TITLE
validate existence of transfer fee on transfer claim

### DIFF
--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -13,6 +13,7 @@ module Claim
           :case_concluded_at
         ],
         [
+          :transfer_fee,
           :litigator_type,
           :elected_case,
           :transfer_stage_id,
@@ -25,6 +26,10 @@ module Claim
     end
 
     private
+
+    def validate_transfer_fee
+      add_error(:transfer_fee, 'blank') if @record.transfer_fee.nil?
+    end
 
     def validate_litigator_type
       unless @record.litigator_type.in? %w{ new original }

--- a/app/views/external_users/claims/transfer_fee/_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_fields.html.haml
@@ -1,4 +1,5 @@
 #transfer-fee.mod-fees
+  = f.anchored_without_label 'transfer_fee'
   %h2.bold-medium
     = t('.transfer_fee_section_header')
   %p.form-hint.xsmall
@@ -19,5 +20,6 @@
             %span.currency-indicator>< £
             = tf.number_field :amount, value: number_with_precision(tf.object.amount, precision: 2), class: 'form-control amount', size: 10, maxlength: 8
             = validation_error_message(@error_presenter, 'transfer_fee.amount')
+            = validation_error_message(@error_presenter, 'transfer_fee')
 
   = render partial: 'external_users/claims/transfer_fee/detail_fields', locals: { f: f }

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -942,6 +942,16 @@ warrant_fee:
 transfer_fee:
   _seq: 650
 
+  base:
+    uneditable_state:
+      long: You cannot edit a claim that is not in draft state
+      short: You cannot edit this claim
+      api: You cannot edit a claim that is not in draft state
+  blank:
+    long: Add a transfer fee
+    short: Enter an amount
+    api: Add a transfer fee
+
   amount:
     _seq: 5
     blank:

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -25,6 +25,7 @@ module Claim
         :case_concluded_at
       ],
       [
+        :transfer_fee,
         :litigator_type,
         :elected_case,
         :transfer_stage_id,
@@ -163,6 +164,21 @@ module Claim
         claim.case_conclusion_id = 40
         claim.valid?
         expect(claim.errors[:transfer_detail]).not_to include('invalid_combo')
+      end
+    end
+
+    context 'transfer fee' do
+      let(:claim) do
+        claim = Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id: 50)
+        claim.form_step = 2
+        claim.force_validation = true
+        claim
+      end
+
+      it 'should validate existence of a transfer fee on the claim' do
+        allow(claim).to receive_message_chain(:transfer_fee,:nil?).and_return(true)
+        expect(claim).not_to be_valid
+        expect(claim.errors[:transfer_fee]).to eq ['blank']
       end
     end
 


### PR DESCRIPTION
A user should not be able to submit a transfer claim without a transfer fee. This adds a validation to enforce this logic together with error message, translations, and error links.
