### PR TITLE
Rake task to audit attached documents

### DIFF
--- a/lib/tasks/docaudit.rake
+++ b/lib/tasks/docaudit.rake
@@ -1,0 +1,32 @@
+desc 'rake task to audit the docs in the system after reports of docs going missing'
+task :docaudit => :environment do
+  DocAudit.new.run
+end
+
+
+class DocAudit
+  def initialize
+    @results = []
+    @results << %w{ doc_id claim_id path size created_at }
+  end
+
+  def run
+    docs = Document.all
+    docs.each { |doc| audit(doc) }
+  end
+
+
+  private
+  def audit(doc)
+    line = []
+    line << doc.id
+    line << doc.claim_id
+    line << doc.document.path
+    local_file = Paperclip.io_adapters.for(doc.document).path
+    line << File.stat(local_file).size
+    line << doc.created_at.to_s(:db)
+    @results << line
+    puts line.join(', ')
+    File.unlink(local_file)
+  end
+end


### PR DESCRIPTION
There have been several reports of "corrupted" documents.  It turns out that the
files don't actually exist in the S3 container.  All the ones investigated so far
were in a particular directory.

This rake task will examine all documents on the system, and report whether or not they are
present, and when they were created, to see if we can see some sort of correlation of
missing documents.
