### PR TITLE
Translator and presenter support for weird associations.

### DIFF
--- a/app/presenters/error_message_translator.rb
+++ b/app/presenters/error_message_translator.rb
@@ -35,6 +35,14 @@ class ErrorMessageTranslator
     @long_message.nil? || @short_message.nil? || @api_message.nil?
   end
 
+  # Support for keys in the format: fixed_fee.date_attended_1_date
+  # Will convert it to: fixed_fee_0_date_attended_0_date
+  #
+  def self.association_key(key)
+    return key unless key.index('.').present?
+    key.sub('.', '_0_').sub('_1_', '_0_')
+  end
+
   private
 
   # needed for GovUkDateField error handling (at least)
@@ -74,7 +82,7 @@ class ErrorMessageTranslator
   end
 
   def last_parent_attribute(translations, key)
-    attribute = key
+    attribute = self.class.association_key(key)
     while attribute =~ @regex do
       parent_model = $1
       submodel_id  = $3
@@ -127,8 +135,7 @@ class ErrorMessageTranslator
   end
 
   def to_ordinal_in_words(n)
-    ordinals = %w{ first second third fourth fifth sixth seventh eighth ninth tenth }
-    ordinals[n-1]
+    %W(#{} first second third fourth fifth sixth seventh eighth ninth tenth)[n]
   end
 
 end

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -42,7 +42,7 @@ class ErrorPresenter
   end
 
   def last_parent_attribute(translations, key)
-    attribute = key
+    attribute = ErrorMessageTranslator.association_key(key)
     while attribute =~ SUBMODEL_REGEX do
       parent_model = $1
       attribute = $4
@@ -73,7 +73,7 @@ class ErrorPresenter
   #
   def generate_sequence(key)
     translations_subset, parent_sequence = translations_sub_set_and_parent_sequence(key)
-    translations_subset['_seq'].present? ? translations_subset['_seq'] + parent_sequence : parent_sequnece || 99999 rescue 99999
+    translations_subset['_seq'].present? ? translations_subset['_seq'] + parent_sequence : parent_sequence || 99999 rescue 99999
  end
 
   def generate_link(fieldname)

--- a/app/views/external_users/claims/_date_generic_fields.html.haml
+++ b/app/views/external_users/claims/_date_generic_fields.html.haml
@@ -1,2 +1,2 @@
-= f.gov_uk_date_field(:date, legend_text: t('.date'), legend_class: 'govuk-legend', id: 'something',
-error_messages: gov_uk_date_field_error_messages(@error_presenter, :something))
+= f.gov_uk_date_field(:date, legend_text: t('.date'), legend_class: 'govuk-legend', id: field_id,
+error_messages: gov_uk_date_field_error_messages(@error_presenter, field_id))

--- a/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
@@ -24,7 +24,7 @@
           .column-two-thirds
             - ff.object.dates_attended << DateAttended.new unless ff.object.dates_attended.any?
             = ff.fields_for :dates_attended do |date_attended|
-              = render 'date_generic_fields', f: date_attended, submodel_count: date_attended.index+1
+              = render 'date_generic_fields', f: date_attended, field_id: 'fixed_fee.date_attended_1_date'
 
           .column-one-third.condensed.js-expense-amount.fee-total
             %label.form-label Total

--- a/app/views/external_users/claims/graduated_fees/_fields.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_fields.html.haml
@@ -30,7 +30,7 @@
           .column-one-third
             - gf.object.dates_attended << DateAttended.new unless gf.object.dates_attended.any?
             = gf.fields_for :dates_attended do |date_attended|
-              = render 'date_generic_fields', f: date_attended, submodel_count: date_attended.index+1
+              = render 'date_generic_fields', f: date_attended, field_id: 'graduated_fee.date_attended_1_date'
 
           .column-one-third.js-expense-reason
             %label.form-label

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -11,3 +11,7 @@ end
 class ActiveRecord::Base
   include NestedAttributesExtension
 end
+
+class ActionController::Parameters
+  include ParametersExtension
+end

--- a/lib/extensions/parameters_extension.rb
+++ b/lib/extensions/parameters_extension.rb
@@ -1,0 +1,7 @@
+module ParametersExtension
+
+  def zero?
+    all? { |key, value| key == '_destroy' || (value.blank? || value.zero?) }
+  end
+
+end

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -131,5 +131,5 @@ boot_files:
 #
 # random: true
 #
-random: true
+random: false
 


### PR DESCRIPTION
Graduated Fee and Fixed Fee (singular, has_one association) and possibly others now also need a has_many association (attended_dates) but the way this is done (using attended_dates but only needing one date, not many) doesn't play nice with our in-house `error translator` and `presenter`.

Also, the error messages were wrong like this:

> Enter the first date attended (from) for the first fixed fee

When we only have one fixed fee and only one attended date (so no need for 'first, second...'). This now works (mostly) fine. There is still a weird 'from' string that doesn't really apply in this case:

> Enter the date attended (from) for the fixed fee
