### PR TITLE
Fix missing misc fee error translations

### DIFF
--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -23,7 +23,7 @@ class Fee::MiscFeeValidator < Fee::BaseFeeValidator
     if run_base_fee_validators? || fee_code.nil?
       super
     else
-      add_error(:amount, "#{fee_code.downcase}_invalid") if @record.amount < 0.01
+      validate_float_numericality(:amount, 0.01, 'invalid')
     end
   end
 

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -444,29 +444,36 @@ legal_aid_transfer_date:
 #                                                                               #
 #################################################################################
 
+transfer_detail:
+  _seq: 220
+  invalid_combo:
+    long: Check combination of transfer details
+    short: Check transfer details combination
+    api: Check combination of transfer details
+
 litigator_type:
-  _seq: 215
+  _seq: 230
   invalid:
     long: Choose the litigator type
     short: Choose a type
     api: Choose the litigator type
 
 elected_case:
-  _seq: 216
+  _seq: 240
   invalid:
     long: Choose the elected case status
     short: Choose an answer
     api: Choose the elected case status
 
 transfer_stage_id:
-  _seq: 217
+  _seq: 250
   invalid:
     long: Check the stage at which the case was transfered
     short: Check selected option
     api: Check the stage at which the case was transfered
 
 transfer_date:
-  _seq: 218
+  _seq: 260
   blank:
     long: Enter the transfer date
     short: *enter_date
@@ -481,7 +488,7 @@ transfer_date:
     api: 'Check the transfer date'
 
 case_conclusion_id:
-  _seq: 219
+  _seq: 270
   blank:
     long: Enter a case conclusion
     short: Choose an option
@@ -814,7 +821,7 @@ misc_fee:
   amount:
     _seq: 50
     invalid:
-      long: 'Enter an amount for the #{misc_fee}'
+      long: 'Enter a valid amount for the #{misc_fee}'
       short: Enter a valid amount
       api: Enter a valid amount for the miscellaneous fee
 
@@ -947,7 +954,7 @@ warrant_fee:
 #################################################################################
 
 transfer_fee:
-  _seq: 650
+  _seq: 200
 
   base:
     uneditable_state:
@@ -955,27 +962,21 @@ transfer_fee:
       short: You cannot edit this claim
       api: You cannot edit a claim that is not in draft state
   blank:
+    _seq: 5
     long: Add a transfer fee
     short: Enter an amount
     api: Add a transfer fee
 
   amount:
-    _seq: 5
+    _seq: 10
     blank:
-      long: Enter an amount for the tranfer
+      long: Enter an amount for the transfer
       short: Enter an amount
       api: Enter an amount for the transfer
     numericality:
       long: Enter a valid amount for the transfer fee
       short: Enter a valid amount
       api: Enter a valid amount for the transfer fee
-
-transfer_detail:
-  _seq: 670
-  invalid_combo:
-    long: Check combination of transfer details
-    short: Check transfer details combination
-    api: Check combination of transfer details
 
 #################################################################################
 #                                                                               #

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -811,6 +811,13 @@ misc_fee:
       short: Enter valid case numbers
       api: Enter valid case numbers for the miscellaneous fee
 
+  amount:
+    _seq: 50
+    invalid:
+      long: 'Enter an amount for the #{misc_fee}'
+      short: Enter a valid amount
+      api: Enter a valid amount for the miscellaneous fee
+
 #################################################################################
 #                                                                               #
 #   FIXED FEE                                                                   #

--- a/spec/javascripts/modules-sidebar_spec.js
+++ b/spec/javascripts/modules-sidebar_spec.js
@@ -209,7 +209,7 @@ describe("Modules.SideBar.js", function() {
         expect(jQuery.fn.on).toHaveBeenCalled();
       });
 
-      xit('should call the correct callback for events', function() {
+      it('should call the correct callback for events', function() {
         spyOn(moj.Modules.SideBar, 'recalculate');
         spyOn(moj.Modules.SideBar, 'loadBlocks');
 

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -131,5 +131,5 @@ boot_files:
 #
 # random: true
 #
-random: true
+random: false
 

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -47,11 +47,11 @@ describe Fee::MiscFeeValidator do
 
     describe '#validate_amount' do
       it 'should error if amount is equal to zero' do
-        should_error_if_equal_to_value(fee, :amount,  0.00, "#{fee_code.downcase}_invalid")
+        should_error_if_equal_to_value(fee, :amount,  0.00, 'invalid')
       end
 
       it 'should error if amount is less than zero' do
-        should_error_if_equal_to_value(fee, :amount,  -10.00, "#{fee_code.downcase}_invalid")
+        should_error_if_equal_to_value(fee, :amount,  -10.00, 'invalid')
       end
     end
 


### PR DESCRIPTION
This results from different error messages based on the
fee code of the miscellaneous fee. 

These fee code specific error messages are only currently supplied for basic 
fees so amount validation raises inappropriate messages for agfs and lgfs BUT
does not matter for agfs since amount is calculated. They validation for lgfs 
claims has been amended to use a generic invalid message.
