### PR TITLE
More transfer court validations and some refactor.

### DIFF
--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -59,8 +59,6 @@ module Claim
     validates_with ::Claim::InterimClaimValidator
     validates_with ::Claim::InterimClaimSubModelValidator
 
-    belongs_to :transfer_court, foreign_key: 'transfer_court_id', class_name: 'Court'
-
     has_one :interim_fee, foreign_key: :claim_id, class_name: 'Fee::InterimFee', dependent: :destroy, inverse_of: :claim
     has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
 

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -59,8 +59,6 @@ module Claim
     validates_with ::Claim::LitigatorClaimValidator
     validates_with ::Claim::LitigatorClaimSubModelValidator
 
-    belongs_to :transfer_court, foreign_key: 'transfer_court_id', class_name: 'Court'
-
     has_one :fixed_fee, foreign_key: :claim_id, class_name: 'Fee::FixedFee', dependent: :destroy, inverse_of: :claim
     has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
     has_one :graduated_fee, foreign_key: :claim_id, class_name: 'Fee::GraduatedFee', dependent: :destroy, inverse_of: :claim

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -62,13 +62,18 @@ class BaseValidator < ActiveModel::Validator
   end
 
   def validate_pattern(attribute, pattern, message)
-    return if attr_nil?(attribute)
+    return if attr_blank?(attribute)
     add_error(attribute, message) unless @record.__send__(attribute).match(pattern)
   end
 
   def validate_inclusion(attribute, inclusion_list, message)
     return if attr_nil?(attribute)
     add_error(attribute, message) unless inclusion_list.include?(@record.__send__(attribute))
+  end
+
+  def validate_exclusion(attribute, exclusion_list, message)
+    return if attr_nil?(attribute)
+    add_error(attribute, message) if exclusion_list.include?(@record.__send__(attribute))
   end
 
   def bounds(lower=nil,upper=nil)

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -53,6 +53,6 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
   end
 
   def validate_supplier_number
-    validate_pattern(:supplier_number, supplier_number_regex, 'invalid') if @record.supplier_number
+    validate_pattern(:supplier_number, supplier_number_regex, 'invalid')
   end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -65,7 +65,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # must have a format of capital letter followed by 8 digits
   def validate_case_number
     validate_presence(:case_number, "blank")
-    validate_pattern(:case_number, CASE_NUMBER_PATTERN, "invalid") unless @record.case_number.blank?
+    validate_pattern(:case_number, CASE_NUMBER_PATTERN, "invalid")
   end
 
   def validate_estimated_trial_length

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -3,14 +3,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
 
   def self.fields_for_steps
     [
-      [
-        :case_type,
-        :court,
-        :case_number,
-        :advocate_category,
-        :offence,
-        :case_concluded_at
-      ],
+      [].unshift(first_step_common_validations),
       [
         :first_day_of_trial,
         :estimated_trial_length,

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -3,15 +3,7 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
 
   def self.fields_for_steps
     [
-      [
-        :case_type,
-        :court,
-        :case_number,
-        :transfer_case_number,
-        :advocate_category,
-        :offence,
-        :case_concluded_at
-      ],
+      [].unshift(first_step_common_validations),
       [
         :actual_trial_length,
         :total

--- a/app/validators/claim/litigator_common_validations.rb
+++ b/app/validators/claim/litigator_common_validations.rb
@@ -1,6 +1,23 @@
 module Claim
   module LitigatorCommonValidations
 
+    def self.included(base)
+      base.class_eval do
+        def self.first_step_common_validations
+          [
+            :case_type,
+            :court,
+            :case_number,
+            :transfer_court,
+            :transfer_case_number,
+            :advocate_category,
+            :offence,
+            :case_concluded_at
+          ]
+        end
+      end
+    end
+
     private
 
     def validate_creator
@@ -12,8 +29,18 @@ module Claim
       validate_absence(:advocate_category, "invalid")
     end
 
+    def validate_transfer_court
+      return unless @record.transfer_case_number.present?
+
+      validate_presence(:transfer_court, 'blank')
+      validate_exclusion(:transfer_court, [@record.court], 'same')
+    end
+
     def validate_transfer_case_number
-      validate_pattern(:transfer_case_number, BaseValidator::CASE_NUMBER_PATTERN, "invalid") unless @record.transfer_case_number.blank?
+      return unless @record.transfer_court.present?
+
+      validate_presence(:transfer_case_number, 'blank')
+      validate_pattern(:transfer_case_number, BaseValidator::CASE_NUMBER_PATTERN, 'invalid')
     end
 
     def validate_offence

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -1,74 +1,64 @@
-module Claim
-  class TransferClaimValidator < BaseClaimValidator
-    include Claim::LitigatorCommonValidations
+class Claim::TransferClaimValidator < Claim::BaseClaimValidator
+  include Claim::LitigatorCommonValidations
 
-    def self.fields_for_steps
+  def self.fields_for_steps
+    [
+      [].unshift(first_step_common_validations),
       [
-        [
-          :case_type,
-          :court,
-          :case_number,
-          :advocate_category,
-          :offence,
-          :case_concluded_at
-        ],
-        [
-          :transfer_fee,
-          :litigator_type,
-          :elected_case,
-          :transfer_stage_id,
-          :transfer_date,
-          :case_conclusion_id,
-          :transfer_detail_combo,
-          :total
-        ]
+        :transfer_fee,
+        :litigator_type,
+        :elected_case,
+        :transfer_stage_id,
+        :transfer_date,
+        :case_conclusion_id,
+        :transfer_detail_combo,
+        :total
       ]
+    ]
+  end
+
+  private
+
+  def validate_transfer_fee
+    add_error(:transfer_fee, 'blank') if @record.transfer_fee.nil?
+  end
+
+  def validate_litigator_type
+    unless @record.litigator_type.in? %w{ new original }
+      add_error(:litigator_type, 'invalid')
     end
+  end
 
-    private
-
-    def validate_transfer_fee
-      add_error(:transfer_fee, 'blank') if @record.transfer_fee.nil?
+  def validate_elected_case
+    unless @record.elected_case.in?([true, false])
+      add_error(:elected_case, 'invalid')
     end
+  end
 
-    def validate_litigator_type
-      unless @record.litigator_type.in? %w{ new original }
-        add_error(:litigator_type, 'invalid')
-      end
+  def validate_transfer_stage_id
+    unless @record.transfer_stage_id.in? Claim::TransferBrain.transfer_stage_ids
+      add_error(:transfer_stage_id, 'invalid')
     end
+  end
 
-    def validate_elected_case
-      unless @record.elected_case.in?([ true, false ])
-        add_error(:elected_case, 'invalid')
-      end
+  def validate_transfer_date
+    validate_presence(:transfer_date, 'blank')
+    validate_not_after(Date.today, :transfer_date, 'check_not_in_future')
+    validate_not_before(Settings.earliest_permitted_date, :transfer_date, 'check_not_too_far_in_past')
+  end
+
+  def validate_case_conclusion_id
+    if Claim::TransferBrain.case_conclusion_required?(@record.transfer_detail)
+      validate_presence(:case_conclusion_id, 'blank')
+      validate_inclusion(:case_conclusion_id, Claim::TransferBrain.case_conclusion_ids, 'invalid')
+    else
+      validate_absence(:case_conclusion_id, 'present')
     end
+  end
 
-    def validate_transfer_stage_id
-      unless @record.transfer_stage_id.in? TransferBrain.transfer_stage_ids
-        add_error(:transfer_stage_id, 'invalid')
-      end
+  def validate_transfer_detail_combo
+    unless Claim::TransferBrain.details_combo_valid?(@record.transfer_detail)
+      add_error(:transfer_detail, 'invalid_combo')
     end
-
-    def validate_transfer_date
-      validate_presence(:transfer_date, 'blank')
-      validate_not_after(Date.today, :transfer_date, 'check_not_in_future')
-      validate_not_before(Settings.earliest_permitted_date, :transfer_date, 'check_not_too_far_in_past')
-    end
-
-    def validate_case_conclusion_id
-      if TransferBrain.case_conclusion_required?(@record.transfer_detail)
-        validate_presence(:case_conclusion_id,'blank')
-        validate_inclusion(:case_conclusion_id,TransferBrain.case_conclusion_ids,'invalid')
-      else
-        validate_absence(:case_conclusion_id,'present')
-      end
-    end
-
-    def validate_transfer_detail_combo
-      unless TransferBrain.details_combo_valid?(@record.transfer_detail)
-        add_error(:transfer_detail, 'invalid_combo')
-      end
-    end
-
   end
 end

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -45,14 +45,14 @@
     - unless @claim.agfs?
       .form-row
         .form-col
-          = f.anchored_label t('.transfer_court')
+          = f.anchored_label t('.transfer_court'), :transfer_court
           .form-hint.xsmall.zero-vert-margin
             = "eg Cardiff"
           = f.collection_select :transfer_court_id, Court.alphabetical, :id, :name, { include_blank: true }, { class: 'autocomplete' }
           = validation_error_message(@error_presenter, :transfer_court)
 
         .form-col.form-col-two-thirds
-          = f.anchored_label t('.transfer_case_number')
+          = f.anchored_label t('.transfer_case_number'), :transfer_case_number
           .form-hint.xsmall.zero-vert-margin
             = "eg A12345678"
           = f.text_field :transfer_case_number, {class: 'form-control'}

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -46,7 +46,7 @@
     - if claim.transfer_case_number.present?
       %tr
         %th{scope: 'row'}
-          = t("#{locale_path}.transfer_case_number")
+          = t("common.transfer_case_number")
         %td
           = claim.transfer_case_number
 

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -92,12 +92,12 @@ court:
 case_number:
   _seq: 50
   blank:
-    long: Enter a case number
-    short: Enter a case number eg A12345678
-    api: Enter a case number
+    long: Enter a case number eg A12345678
+    short: Enter a case number
+    api: Enter a case number eg A12345678
   invalid:
     long: The case number must be in the format A12345678
-    short: Enter a case number eg A12345678
+    short: Invalid case number
     api: The case number must be in the format A12345678
 
 transfer_court:
@@ -106,16 +106,20 @@ transfer_court:
     long: Choose a transfer court
     short: Choose a transfer court
     api: Choose a transfer court
+  same:
+    long: Transfer court cannot be the same as the original court
+    short: Choose a different transfer court
+    api: Transfer court cannot be the same as the original court
 
 transfer_case_number:
   _seq: 60
   blank:
-    long: Enter a transfer case number
-    short: Enter a transfer case number eg A12345678
-    api: Enter a transfer case number
+    long: Enter a transfer case number eg A12345678
+    short: Enter a transfer case number
+    api: Enter a transfer case number eg A12345678
   invalid:
     long: The transfer case number must be in the format A12345678
-    short: Enter a transfer case number eg A12345678
+    short: Invalid transfer case number
     api: The transfer case number must be in the format A12345678
 
 first_day_of_trial:

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -19,6 +19,8 @@ describe Claim::InterimClaimValidator do
       :case_type,
       :court,
       :case_number,
+      :transfer_court,
+      :transfer_case_number,
       :advocate_category,
       :offence,
       :case_concluded_at

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -19,6 +19,7 @@ describe Claim::LitigatorClaimValidator do
           :case_type,
           :court,
           :case_number,
+          :transfer_court,
           :transfer_case_number,
           :advocate_category,
           :offence,

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -156,4 +156,30 @@ shared_examples "common litigator validations" do
       expect(claim).to be_valid
     end
   end
+
+  context 'transfer_court' do
+    before(:each) { claim.transfer_case_number = 'A12345678' }
+
+    it 'should error if blank when a transfer case number is filled' do
+      should_error_with(claim, :transfer_court, 'blank')
+    end
+
+    it 'should error when the transfer court is the same as the original court' do
+      claim.transfer_court = claim.court
+      should_error_with(claim, :transfer_court, 'same')
+    end
+  end
+
+  context 'transfer_case_number' do
+    before(:each) { claim.transfer_court = FactoryGirl.build(:court) }
+
+    it 'should error if blank when a transfer court is selected' do
+      should_error_with(claim, :transfer_case_number, 'blank')
+    end
+
+    it 'should error if wrong format when a transfer court is selected' do
+      claim.transfer_case_number = 'ABC'
+      should_error_with(claim, :transfer_case_number, 'invalid')
+    end
+  end
 end

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -20,6 +20,8 @@ module Claim
         :case_type,
         :case_number,
         :court,
+        :transfer_court,
+        :transfer_case_number,
         :advocate_category,
         :offence,
         :case_concluded_at


### PR DESCRIPTION
**PT#119819197**

Ensuring the transfer court cannot be the same as the original court, and also enforcing filling both fields (transfer court and transfer case number) when any of them are filled. If both are blank then is fine (as it is optional).

Some validation refactor so LGFS claims all share the same first page validations but can include some extra validations if needed.
