### PR TITLE
add JS to modify transfer stage and date label text

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/TransferDetailFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/TransferDetailFieldsDisplay.js
@@ -5,23 +5,25 @@ moj.Modules.TransferDetailFieldsDisplay = {
   electedCaseRadio: '.js-elected-case',
   transferStageSelect: 'select.js-transfer-stage-id',
   caseConclusionSelect: '.js-case-conclusions-select',
+  transferStageLabel: '.js-transfer-stage-label',
+  transferDateLabel: '.js-transfer-date-label',
 
   init: function() {
     if ($(this.tdWrapper).length > 0) {
       this.$tdWrapper = $(this.tdWrapper);
-      this.addCaseConclusionShowHideEvent();
-      this.showHideCaseConclusionField();
+      this.addChangeEvent();
+      this.callCaseConclusionController();
     }
   },
 
-  addCaseConclusionShowHideEvent: function() {
+  addChangeEvent: function() {
     var self = this;
     var elements = [this.litigatorTypeRadio,
                     this.electedCaseRadio,
                     this.transferStageSelect
                     ].join(',');
     this.$tdWrapper.on('change', elements, function() {
-      self.showHideCaseConclusionField();
+      self.callCaseConclusionController();
     });
   },
 
@@ -33,6 +35,11 @@ moj.Modules.TransferDetailFieldsDisplay = {
       $('#claim_case_conclusion_id_autocomplete').val(''); // reset awesomplete displayed value
       $(this.caseConclusionSelect).hide();
     }
+  },
+
+  labelTextToggle: function(transfer_stage_label_text,transfer_date_label_text) {
+    this.$tdWrapper.find(this.transferStageLabel).text(transfer_stage_label_text);
+    this.$tdWrapper.find(this.transferDateLabel).text(transfer_date_label_text);
   },
 
   getParamVal: function(param_name, selector) {
@@ -51,7 +58,7 @@ moj.Modules.TransferDetailFieldsDisplay = {
     return params.substr(1);
   },
 
-  showHideCaseConclusionField: function() {
+  callCaseConclusionController: function() {
     var params = this.constructParams();
     $.getScript('/case_conclusions?' + params);
   }

--- a/app/controllers/case_conclusions_controller.rb
+++ b/app/controllers/case_conclusions_controller.rb
@@ -9,9 +9,12 @@ class CaseConclusionsController < ApplicationController
   skip_load_and_authorize_resource only: [:index]
 
   def index
+    @transfer_stage_label_text = transfer_stage_label_text
+    @transfer_date_label_text = transfer_date_label_text
     @transfer_detail = Claim::TransferDetail.new(litigator_type: params[:litigator_type],
                                                  elected_case: elected_case?,
                                                  transfer_stage_id: params[:transfer_stage_id])
+
   end
 
 private
@@ -21,4 +24,24 @@ private
     elected_case = ['true','false'].include?(params[:elected_case]) ? params[:elected_case] : 'true'
     elected_case
   end
+
+  def transfer_stage_label_text
+    replace_start_stop_label('external_users.claims.transfer_fee.detail_fields.transfer_stage_default_label_text',{ replace: 'stop/start',with: { start: 'start', stop: 'stop' } })
+  end
+
+  def transfer_date_label_text
+    replace_start_stop_label('external_users.claims.transfer_fee.detail_fields.transfer_date_default_label_text', { replace: 'stopped/started', with: { start: 'started', stop: 'stopped' } })
+  end
+
+  def replace_start_stop_label(translation, options={ replace: 'stop/start',with: { start: 'start', stop: 'stop' } })
+    label_text = I18n.t(translation)
+    case params[:litigator_type]
+    when 'new'
+      label_text.gsub!(options[:replace], options[:with][:start])
+    when 'original'
+      label_text.gsub!(options[:replace], options[:with][:stop])
+    end
+    label_text
+  end
+
 end

--- a/app/views/case_conclusions/index.js.erb
+++ b/app/views/case_conclusions/index.js.erb
@@ -1,1 +1,3 @@
+
+moj.Modules.TransferDetailFieldsDisplay.labelTextToggle('<%= @transfer_stage_label_text %>','<%= @transfer_date_label_text %>');
 moj.Modules.TransferDetailFieldsDisplay.caseConclusionToggle(<%= Claim::TransferBrain.case_conclusion_required?(@transfer_detail) %>);

--- a/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
@@ -22,14 +22,14 @@
     %fieldset
       .form-row
         .form-col
-          = f.anchored_label t('.transfer_stages'), 'transfer_stage_id'
+          = f.anchored_label t('.transfer_stage_default_label_text'), 'transfer_stage_id', { label_attributes: { class: 'js-transfer-stage-label' } }
           = f.collection_select :transfer_stage_id, claim.transfer_stages, :first, :last,{}, { class: 'form-control autocomplete js-transfer-stage-id'}
           = validation_error_message(@error_presenter, 'transfer_stage_id')
 
-  %fieldset
-    .form-row
-      .form-col
-        = f.gov_uk_date_field(:transfer_date, legend_text: t('.transfer_date'), legend_class: 'govuk-legend', id: "transfer_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, 'transfer_date'))
+    %fieldset
+      .form-row
+        .form-col
+          = f.gov_uk_date_field(:transfer_date, legend_text: t('.transfer_date_default_label_text'), legend_class: 'govuk-legend js-transfer-date-label', id: "transfer_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, 'transfer_date'))
 
   .js-case-conclusions-select
     %fieldset

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -588,8 +588,8 @@ en:
         detail_fields:
           litigator_type: Litigator type
           elected_case: Was the case elected?
-          transfer_stages: When did you start acting?
-          transfer_date: Date started acting
+          transfer_stage_default_label_text: When did you stop/start acting?
+          transfer_date_default_label_text: Date stopped/started acting
           case_conclusions: How did the case conclude?
       error_summary:
         prohibited_save: This claim has

--- a/spec/controllers/case_conclusions_controller_spec.rb
+++ b/spec/controllers/case_conclusions_controller_spec.rb
@@ -6,9 +6,33 @@ RSpec.describe CaseConclusionsController, type: :controller do
   let(:transfer_detail) { build :transfer_detail, litigator_type: 'new', elected_case: false, transfer_stage_id: 10 }
 
   describe 'GET index' do
-    it 'should assign dummy transfer details' do
+    it 'should assign @transfer_details' do
       xhr :get, :index, params
       expect(assigns(:transfer_detail)).to have_attributes(litigator_type: 'new', elected_case: false, transfer_stage_id: 30)
+    end
+
+    it 'should assign @transfer_stage_label_text' do
+      xhr :get, :index, params
+      expect(assigns(:transfer_stage_label_text)).to_not be_nil
+      expect(assigns(:transfer_stage_label_text)).to eql 'When did you start acting?'
+    end
+
+    it 'should modify transfer stage label text based on the litigator type' do
+      params[:litigator_type] = 'original'
+      xhr :get, :index, params
+      expect(assigns(:transfer_stage_label_text)).to eql 'When did you stop acting?'
+    end
+
+    it 'should assign @transfer_date_label' do
+      xhr :get, :index, params
+      expect(assigns(:transfer_date_label_text)).to_not be_nil
+      expect(assigns(:transfer_date_label_text)).to eql 'Date started acting'
+    end
+
+    it 'should modify transfer date label text based on the litigator type' do
+      params[:litigator_type] = 'original'
+      xhr :get, :index, params
+      expect(assigns(:transfer_date_label_text)).to eql 'Date stopped acting'
     end
 
     it 'should render the index template' do


### PR DESCRIPTION
The labels for these fields should say start(ed) if litigator type of 'new' and stop(ped) if 'original'
