### PR TITLE
Add recently created new fees to the cloner and ensure we have a test to catch missing ones in the future.

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -372,6 +372,10 @@ module Claim
       }
     end
 
+    def self.fee_associations
+      reflect_on_all_associations.select{ |assoc| assoc.name =~ /^\S+_fees?$/ }.map(&:name)
+    end
+
     private
 
     # called from state_machine before_transition on submit - override in subclass

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -2,6 +2,10 @@ module Claims::Cloner
   extend ActiveSupport::Concern
   include Duplicable
 
+  EXCLUDED_FEE_ASSOCIATIONS = [
+    :basic_fees, :fixed_fees, :misc_fees, :fixed_fee, :warrant_fee, :graduated_fee, :interim_fee, :transfer_fee
+  ].freeze
+
   included do |klass|
     klass.duplicate_this do
       enable
@@ -15,13 +19,12 @@ module Claims::Cloner
       exclude_association :case_workers
       exclude_association :claim_state_transitions
       exclude_association :versions
-      exclude_association :basic_fees
-      exclude_association :fixed_fees
-      exclude_association :misc_fees
       exclude_association :determinations
       exclude_association :assessment
       exclude_association :redeterminations
       exclude_association :certification
+
+      EXCLUDED_FEE_ASSOCIATIONS.each { |assoc| exclude_association assoc }
 
       clone [:fees, :documents, :defendants, :expenses, :disbursements]
 


### PR DESCRIPTION
This will fix **PT#119743323** among others.

Some improvement to the `cloner_spec` so we can now catch possible missing fees that should be excluded in the cloner module.
