### PR TITLE
Ensuring invalid previous final claim fees are not left behind when changing to another fee type.

### DIFF
--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -103,10 +103,14 @@ module Claim
     end
 
     def destroy_all_invalid_fee_types
-      if case_type.present? && case_type.is_fixed_fee?
-        basic_fees.map(&:clear) unless basic_fees.empty?
+      return unless case_type.present?
+
+      if case_type.is_fixed_fee?
+        graduated_fee.try(:destroy)
+        self.graduated_fee = nil
       else
-        fixed_fee.try(:delete)
+        fixed_fee.try(:destroy)
+        self.fixed_fee = nil
       end
     end
   end


### PR DESCRIPTION
**PT#119977781**

Also a very small refactor to move the basic_fees relationship to the AdvocateClaim model where it belongs as no other claim types have basic_fees.

We could (in theory) do the same for **disbursements** and maybe **expenses**, and in fact I tried it but the cloner is very much attached to the BaseClaim so it is not as straightforward as thought:

`clone [:fees, :documents, :defendants, :expenses, :disbursements]`

Removing those relationships from the BaseClaim, despite making sense, will introduce some extra complexity to the already complex cloning mechanism so it is my opinion there is no harm in leave them.
