### PR TITLE
Proper handling of offence dropdowns.

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -59,8 +59,12 @@ moj.Modules.NewClaim = {
   },
 
   attachToOffenceClassSelect : function() {
-    $('#offence_class_description').change(function() {
+    $('#offence_class_description').on('change', function() {
       $('#claim_offence_id').val($(this).val());
+
+      if (!$(this).val()) {
+        $('.offence-class-select').hide();
+      }
     });
 
     $('#offence_class_description').change();

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -108,7 +108,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
       result = Claims::CreateDraft.call(@claim, validate: continue_claim?)
       tracking_args = %w(event claim draft created)
     end
-    
+
     send_ga(tracking_args) if result.success?
     render_or_redirect(result)
   end

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -73,13 +73,13 @@
           - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
         - else
           - selected_offence_category = @claim.offence.description rescue nil
-        = collection_select :offence_category, :description, @offence_descriptions, :description, :description, { include_blank: true, selected: selected_offence_category }, { class: 'form-control autocomplete' }
+        = collection_select :offence_category, :description, @offence_descriptions, :description, :description, { include_blank: true, prompt: true, selected: selected_offence_category }, { class: 'form-control autocomplete' }
         = validation_error_message(@error_presenter, :offence)
 
       .form-col
         .offence-class-select
           = render partial: 'external_users/claims/case_details/offence_select', locals: { offences: @offences }
-        = f.hidden_field :offence_id, value: f.object.offence ? f.object.offence.id : nil
+        = f.hidden_field :offence_id
 
 - unless @claim.agfs?
   .form-row

--- a/app/views/offences/index.js.erb
+++ b/app/views/offences/index.js.erb
@@ -1,8 +1,8 @@
 <% if params[:description].blank? %>
-  $('.offence-class-select').html('')
-  $('.offence-class-select').hide();
+  $('.offence-class-select').slideUp();
+  $('#claim_offence_id').val('');
 <% else %>
   $('.offence-class-select').html('<%=j render partial: "external_users/claims/case_details/offence_select", locals: { offences: @offences } %>');
-  moj.Modules.NewClaim.attachToOffenceClassSelect();
   $('.offence-class-select').slideDown();
+  moj.Modules.NewClaim.attachToOffenceClassSelect();
 <% end %>


### PR DESCRIPTION
**PT#120208623**

For AGFS claims no offence class or category is required to be selected (but the offence cat dropdown still shows on the claim form).

If these fields are not entered we are defaulting to the first entry on the list (which is abandonment of children).

This fix ensures when the dropdowns are left blank no offence id is assigned to the claim.
