### PR TITLE
change interim claim warrant fee to interim warrant

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -278,8 +278,10 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
           :id,
           :claim_id,
           :fee_type_id,
+          :quantity,
           :amount,
-          :quantity
+          date_attributes_for(:warrant_issued_date),
+          date_attributes_for(:warrant_executed_date)
       ],
       transfer_fee_attributes: [
         :id,

--- a/app/models/fee/interim_fee.rb
+++ b/app/models/fee/interim_fee.rb
@@ -23,6 +23,8 @@ class Fee::InterimFee < Fee::BaseFee
 
   belongs_to :fee_type, class_name: Fee::InterimFeeType
 
+  acts_as_gov_uk_date :warrant_issued_date, :warrant_executed_date
+
   validates_with Fee::InterimFeeValidator
 
   def is_interim?

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -14,8 +14,16 @@ class BasePresenter < SimpleDelegator
 
   private_class_method :presents
 
-  private
+  def format_date(date)
+    date.strftime(Settings.date_format) rescue nil
+  end
 
+  def date_format(options={})
+    options.assert_valid_keys(:include_time)
+    options[:include_time] ? Settings.date_time_format : Settings.date_format
+  end
+
+  private
 
   def h
     @view

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -44,11 +44,6 @@ class Claim::BaseClaimPresenter < BasePresenter
     end
   end
 
-  def date_format(options={})
-    options.assert_valid_keys(:include_time)
-    options[:include_time] ? Settings.date_time_format : Settings.date_format
-  end
-
   def submitted_at(options={})
     claim.last_submitted_at.strftime(date_format(options)) unless claim.last_submitted_at.nil?
   end
@@ -67,6 +62,10 @@ class Claim::BaseClaimPresenter < BasePresenter
 
   def trial_concluded
     claim.trial_concluded_at.blank? ? 'not specified' : claim.trial_concluded_at.strftime(Settings.date_format)
+  end
+
+  def case_concluded_at
+    format_date(claim.case_concluded_at)
   end
 
   def vat_date(format = nil)

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -5,10 +5,6 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
     h.number_to_currency(claim.disbursements_total)
   end
 
-  def case_concluded_at
-    claim.case_concluded_at.strftime('%d/%m/%Y') rescue ''
-  end
-
   def pretty_type
     'LGFS Final'
   end

--- a/app/presenters/claim/transfer_claim_presenter.rb
+++ b/app/presenters/claim/transfer_claim_presenter.rb
@@ -29,7 +29,7 @@ class Claim::TransferClaimPresenter < Claim::BaseClaimPresenter
   end
 
   def transfer_date
-    claim.transfer_date.strftime(Settings.date_format) rescue ''
+    format_date(claim.transfer_date)
   end
 
   def case_conclusion_description

--- a/app/presenters/fee/interim_fee_presenter.rb
+++ b/app/presenters/fee/interim_fee_presenter.rb
@@ -41,11 +41,15 @@ class Fee::InterimFeePresenter < Fee::BaseFeePresenter
     _claim.retrial_estimated_length
   end
 
-  private
-
-  def format_date(date)
-    date.strftime(Settings.date_format) rescue '[date error]'
+  def warrant_issued_date
+    format_date(fee.warrant_issued_date)
   end
+
+  def warrant_executed_date
+    format_date(fee.warrant_executed_date)
+  end
+
+  private
 
   def _claim
     fee.claim

--- a/app/presenters/fee/interim_fee_type_presenter.rb
+++ b/app/presenters/fee/interim_fee_type_presenter.rb
@@ -8,18 +8,21 @@ class Fee::InterimFeeTypePresenter < BasePresenter
         legal_aid_transfer:   fee_type.is_retrial_new_solicitor?,
         trial_concluded:      fee_type.is_retrial_new_solicitor?,
         retrial_dates:        fee_type.is_retrial_start?,
-        ppe:                  unless_disbursement_or_warrant?,
-        fee_total:            unless_disbursement_or_warrant?,
+        ppe:                  is_not_disbursement_or_warrant?,
+        fee_total:            is_not_disbursement?,
         warrant:              fee_type.is_interim_warrant?,
         disbursements:        is_not_warrant?
     }
   end
 
-
   private
 
-  def unless_disbursement_or_warrant?
-    !(fee_type.is_disbursement? || fee_type.is_interim_warrant?)
+  def is_not_disbursement_or_warrant?
+    is_not_disbursement? && is_not_warrant?
+  end
+
+  def is_not_disbursement?
+    !fee_type.is_disbursement?
   end
 
   def is_not_warrant?

--- a/app/presenters/fee/warrant_fee_presenter.rb
+++ b/app/presenters/fee/warrant_fee_presenter.rb
@@ -5,16 +5,12 @@ class Fee::WarrantFeePresenter < Fee::BaseFeePresenter
     not_applicable
   end
 
-  def amount
-    not_applicable
-  end
-
   def warrant_issued_date
-    fee.warrant_issued_date.strftime(Settings.date_format) rescue ''
+    format_date(fee.warrant_issued_date)
   end
 
   def warrant_executed_date
-    fee.warrant_executed_date.strftime(Settings.date_format) rescue ''
+    format_date(fee.warrant_executed_date)
   end
 
   def warrant_executed?

--- a/app/validators/claim/interim_claim_sub_model_validator.rb
+++ b/app/validators/claim/interim_claim_sub_model_validator.rb
@@ -5,7 +5,6 @@ class Claim::InterimClaimSubModelValidator < Claim::BaseClaimSubModelValidator
       [ ],
       [
         :interim_fee,
-        :warrant_fee,
         :assessment,
         :certification
       ]

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -5,6 +5,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
     [
       [].unshift(first_step_common_validations),
       [
+        :interim_fee,
         :first_day_of_trial,
         :estimated_trial_length,
         :trial_concluded_at,
@@ -18,6 +19,10 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
   end
 
   private
+
+  def validate_interim_fee
+    add_error(:interim_fee, 'blank') if @record.interim_fee.nil?
+  end
 
   def validate_first_day_of_trial
     if @record.interim_fee.try(:is_trial_start?)

--- a/app/validators/fee/interim_fee_validator.rb
+++ b/app/validators/fee/interim_fee_validator.rb
@@ -6,27 +6,24 @@ class Fee::InterimFeeValidator < Fee::BaseFeeValidator
       :rate,
       :amount,
       :disbursements,
-      :warrant
     ]
-  end
-
-  def self.mandatory_fields
-   [ :claim, :fee_type ]
   end
 
   def validate_quantity
     if @record.is_disbursement? || @record.is_interim_warrant?
       validate_absence_or_zero(:quantity, 'present')
     else
-      validate_any_quantity
+      validate_presence(:quantity,'blank')
+      validate_numericality(:quantity,1,nil,'numericality')
     end
   end
 
   def validate_amount
-    if @record.is_disbursement? || @record.is_interim_warrant?
+    if @record.is_disbursement?
       validate_absence_or_zero(:amount, 'present')
     else
-      add_error(:amount, 'invalid') if @record.amount < 0.01
+      validate_presence(:amount,'blank')
+      validate_float_numericality(:amount,0.01,nil,'numericality')
     end
   end
 
@@ -42,11 +39,17 @@ class Fee::InterimFeeValidator < Fee::BaseFeeValidator
     end
   end
 
-  def validate_warrant
-    if @record.is_interim_warrant?
-      add_error(:warrant, 'blank') if @record.claim.warrant_fee.nil?
-    else
-      add_error(:warrant, 'present') if @record.claim.warrant_fee.present?
-    end
+  def validate_warrant_issued_date
+    return if !@record.is_interim_warrant?
+    validate_presence(:warrant_issued_date, 'blank')
+    validate_not_before(Settings.earliest_permitted_date, :warrant_issued_date, 'check_not_too_far_in_past')
+    validate_not_after(Date.today, :warrant_issued_date, 'check_not_in_future')
   end
+
+  def validate_warrant_executed_date
+    return if !@record.is_interim_warrant?
+    validate_not_before(@record.warrant_issued_date, :warrant_executed_date, 'warrant_executed_before_issued')
+    validate_not_after(Date.today, :warrant_executed_date, 'check_not_in_future')
+  end
+
 end

--- a/app/validators/fee/warrant_fee_validator.rb
+++ b/app/validators/fee/warrant_fee_validator.rb
@@ -8,23 +8,19 @@ class Fee::WarrantFeeValidator < Fee::BaseFeeValidator
 
   def validate_warrant_issued_date
     validate_presence(:warrant_issued_date, 'blank')
-    validate_not_after(Date.today, :warrant_issued_date, 'invalid') unless @record.warrant_issued_date.nil?
+    validate_not_before(Settings.earliest_permitted_date, :warrant_issued_date, 'check_not_too_far_in_past')
+    validate_not_after(Date.today, :warrant_issued_date, 'check_not_in_future') unless @record.warrant_issued_date.nil?
   end
 
   def validate_warrant_executed_date
     validate_not_before(@record.warrant_issued_date, :warrant_executed_date, 'warrant_executed_before_issued')
-    validate_not_after(Date.today, :warrant_executed_date, 'invalid')
+    validate_not_before(Settings.earliest_permitted_date, :warrant_executed_date, 'check_not_too_far_in_past')
+    validate_not_after(Date.today, :warrant_executed_date, 'check_not_in_future') unless @record.warrant_executed_date.nil?
   end
 
   def validate_amount
-    if validate_amount?
-      validate_numericality(:amount, 0.01, nil, 'numericality')
-    else
-      validate_absence_or_zero(:amount, 'present')
-    end
+    validate_presence(:amount, 'blank')
+    validate_float_numericality(:amount, 0.01, nil, 'numericality')
   end
 
-  def validate_amount?
-    @record.claim.interim? && @record.claim.interim_fee.try(:is_interim_warrant?)
-  end
 end

--- a/app/views/external_users/claims/interim_fee/_fields.html.haml
+++ b/app/views/external_users/claims/interim_fee/_fields.html.haml
@@ -1,4 +1,5 @@
 #interim-fee.mod-fees
+  = f.anchored_without_label 'interim_fee'
   %h2.bold-medium
     = t('.interim_fees')
   %p.form-hint.xsmall
@@ -55,7 +56,6 @@
               = f.number_field :estimated_trial_length, step: 1, min: 1, class: 'form-control'
               = validation_error_message(@error_presenter, :estimated_trial_length)
 
-
           .column-first-child.column-three-quarters.js-interim-legalAidTransfer.visually-hidden
             .column-half
               = f.anchored_without_label 'legal_aid_transfer_date'
@@ -65,7 +65,16 @@
               = f.anchored_without_label 'trial_concluded_at'
               = f.gov_uk_date_field(:trial_concluded_at, legend_text: t('.trial_concluded_at'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_concluded_at))
 
-          .column-quarter.fee-rate.js-interim-feeTotal.visually-hidden
+          .column-first-child.column-three-quarters.js-interim-warrant.visually-hidden
+            .column-half
+              = inf.anchored_attribute 'warrant_issued_date'
+              = inf.gov_uk_date_field :warrant_issued_date, legend_text: t('.warrant_issued'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_fee.warrant_issued_date')
+
+            .column-half
+              = inf.anchored_attribute 'warrant_executed_date'
+              = inf.gov_uk_date_field :warrant_executed_date, legend_text: t('.warrant_executed'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_fee.warrant_executed_date')
+
+          .column-quarter.fee-amount.js-interim-feeTotal.visually-hidden
             = inf.label :amount, t('.total'), {class: 'form-label form-date-spacing'}
             = inf.anchored_attribute 'amount'
             %span.currency-indicator>< &pound;
@@ -75,5 +84,3 @@
     .js-interim-disbursements.visually-hidden
       = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }
 
-    .js-interim-warrant.visually-hidden
-      = render partial: 'external_users/claims/warrant_fee/fields', locals: { f: f }

--- a/app/views/external_users/claims/interim_fee/_summary.html.haml
+++ b/app/views/external_users/claims/interim_fee/_summary.html.haml
@@ -1,9 +1,9 @@
-- if claim.interim_fee.nil? || claim.interim_fee.is_interim_warrant?
+- if claim.interim_fee.nil? || claim.interim_fee.is_disbursement?
   %p
     There is no interim fee for this claim
 - else
   - fee = present(claim.interim_fee)
-    - unless fee.is_disbursement? || fee.is_interim_warrant?
+    - unless fee.is_disbursement?
     %table
       %caption
         %span.table-caption.visuallyhidden
@@ -18,11 +18,26 @@
           %td
             = fee.fee_type.description
 
-        %tr
-          %th{scope: 'row'}
-            = t('shared.summary.ppe_total')
-          %td
-            = fee.quantity
+        - unless fee.is_interim_warrant?
+          %tr
+            %th{scope: 'row'}
+              = t('shared.summary.ppe_total')
+            %td
+              = fee.quantity
+
+        - if fee.is_interim_warrant?
+          %tr
+            %th{scope: 'row'}
+              = t('shared.summary.warrant_fee.date_issued')
+            %td
+              = fee.warrant_issued_date
+
+          - if fee.warrant_executed_date.present?
+            %tr
+              %th{scope: 'row'}
+                = t('shared.summary.warrant_fee.date_executed')
+              %td
+                = fee.warrant_executed_date
 
         - if fee.is_effective_pcmh?
           %tr

--- a/app/views/external_users/claims/warrant_fee/_fields.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_fields.html.haml
@@ -1,5 +1,5 @@
 #warrant_fee.mod-fees
-  = f.anchored_without_label 'interim_fee.warrant'
+  = f.anchored_without_label 'warrant_fee'
   %h2.bold-medium
     = t('.warrant_fee')
 
@@ -15,12 +15,11 @@
           = wf.gov_uk_date_field :warrant_executed_date, legend_text: t('.date_executed'), legend_class: 'govuk-legend',
             id: 'warrant_fee.warrant_executed_date', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_executed_date')
 
-      - if @claim.interim?
-        .grid-row
-          .column-one-half
-            %label.form-label
-              = t('.total')
-            %a{name: "amount"}
-            %span.currency-indicator>< &pound;
-            = wf.text_field :amount, value: number_with_precision(wf.object.amount, precision: 2), class: 'amount form-control', size: 10, maxlength: 8
-            = validation_error_message(@error_presenter, 'warrant_fee.amount')
+      .grid-row
+        .column-one-half
+          %label.form-label
+            = t('.total')
+          %a{name: "amount"}
+          %span.currency-indicator>< &pound;
+          = wf.number_field :amount, value: number_with_precision(wf.object.amount, precision: 2), class: 'amount form-control', size: 10, maxlength: 8
+          = validation_error_message(@error_presenter, 'interim_fee.amount')

--- a/app/views/external_users/claims/warrant_fee/_summary.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_summary.html.haml
@@ -30,10 +30,3 @@
             = t('shared.summary.warrant_fee.date_executed')
           %td
             = warrant_fee.warrant_executed_date
-
-      - if claim.interim?
-        %tr
-          %th{scope: 'row'}
-            = t('shared.summary.warrant_fee.total')
-          %td
-            = warrant_fee.amount

--- a/app/views/shared/_claim_interim_details.html.haml
+++ b/app/views/shared/_claim_interim_details.html.haml
@@ -7,18 +7,18 @@
     .xsmall
       = fee.fee_type.description
 
-  - if fee.is_interim_warrant? && (warrant_fee = present(claim.warrant_fee))
+  - if fee.is_interim_warrant?
     .column-quarter
       .bold-xsmall
         = t('shared.summary.warrant_fee.date_issued')
       .xsmall
-        = warrant_fee.warrant_issued_date
+        = fee.warrant_issued_date
     .column-quarter
-      - if warrant_fee.warrant_executed?
+      - if fee.warrant_executed_date.present?
         .bold-xsmall
           = t('shared.summary.warrant_fee.date_executed')
         .xsmall
-          = warrant_fee.warrant_executed_date
+          = fee.warrant_executed_date
   - else
     .column-quarter
       - unless fee.is_disbursement?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -695,8 +695,8 @@ en:
       warrant_fee:
         fields:
           warrant_fee: "Warrant fee"
-          date_issued: "Warrant date issued"
-          date_executed: "Warrant date executed (if applicable)"
+          date_issued: "Warrant issued"
+          date_executed: "Warrant executed (if applicable)"
           total: "Total"
       supplier_number:
         fields:
@@ -717,6 +717,8 @@ en:
           retrial_started_at: "Re-trial start"
           retrial_estimated_length: "Estimated length"
           number_days_hint: "Number of days"
+          warrant_issued: "Warrant issued"
+          warrant_executed: "Warrant executed (if applicable)"
       transfer_fees:
         fields:
           transfer_fees_prompt_text_html: Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a> for help
@@ -802,8 +804,8 @@ en:
         vat_amount: "VAT amount"
         total: "Total"
       warrant_fee:
-        date_issued: "Warrant fee date issued"
-        date_executed: "Warrant fee date executed"
+        date_issued: "Warrant issued"
+        date_executed: "Warrant executed"
         total: "Total"
       total: "Total"
       ppe_total: "PPE total at the time"

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -12,6 +12,7 @@ dictionary:
     enter_date: &enter_date 'Enter a date'
     enter_valid_date: &enter_valid_date 'Enter a valid date'
     date_not_allowed: &date_not_allowed 'Date not allowed'
+    enter_quantity: &enter_quantity 'Enter a quantity'
     enter_amount: &enter_amount 'Enter an amount'
     enter_valid_amount: &enter_valid_amount 'Enter a valid amount'
     check_amount: &check_amount 'Check amount'
@@ -933,6 +934,14 @@ warrant_fee:
       long: Enter a valid warrant issued date
       short: *enter_valid_date
       api: Enter a valid warrant issued date
+    check_not_in_future:
+      long: Check the warrant issued date
+      short: *in_future
+      api: Check the warrant issued date
+    check_not_too_far_in_past:
+      long: Check the warrant issued date
+      short: *too_far_in_past
+      api: Check the warrant issued date
 
   warrant_executed_date:
     _seq: 30
@@ -948,6 +957,14 @@ warrant_fee:
       long: Enter a valid warrant executed date
       short: *enter_valid_date
       api: Enter a valid warrant executed date
+    check_not_in_future:
+      long: Check the warrant executed date
+      short: *in_future
+      api: Check the warrant executed date
+    check_not_too_far_in_past:
+      long: Check the warrant executed date
+      short: *too_far_in_past
+      api: Check the warrant executed date
     warrant_executed_before_issued:
       long: The warrant executed date is before the issued date
       short: *enter_valid_date
@@ -1247,6 +1264,11 @@ graduated_fee:
 
 interim_fee:
   _seq: 1100
+  blank:
+    _seq: 5
+    long: Add an interim fee
+    short: *enter_amount
+    api: Add an interim fee
 
   base:
     uneditable_state:
@@ -1263,7 +1285,11 @@ interim_fee:
 
   quantity:
     _seq: 20
-    invalid:
+    blank:
+      long: Enter a quantity for the interim fee
+      short: *enter_quantity
+      api: Enter a quantity for the interim fee
+    numericality:
       long: Enter a valid quantity for the interim fee
       short: *enter_valid_quantity
       api: Enter a valid quantity for the interim fee
@@ -1274,7 +1300,7 @@ interim_fee:
 
   amount:
     _seq: 30
-    invalid:
+    numericality:
       long: Enter a valid amount for the interim fee
       short: *enter_valid_amount
       api: Enter a valid amount for the interim fee
@@ -1283,8 +1309,54 @@ interim_fee:
       short: Do not enter an amount
       api: Do not enter an amount for the interim fee
 
-  disbursements:
+  warrant_issued_date:
     _seq: 40
+    blank:
+      long: Enter a warrant issued date
+      short: *enter_date
+      api: Enter a warrant issued date
+    invalid:
+      long: Enter a valid warrant issued date
+      short: *enter_valid_date
+      api: Enter a valid warrant issued date
+    invalid_date:
+      long: Enter a valid warrant issued date
+      short: *enter_valid_date
+      api: Enter a valid warrant issued date
+    check_not_in_future:
+      long: Check the warrant issued date
+      short: *in_future
+      api: Check the warrant issued date
+    check_not_too_far_in_past:
+      long: Check the warrant issued date
+      short: *too_far_in_past
+      api: Check the warrant issued date
+
+  warrant_executed_date:
+    _seq: 50
+    blank:
+      long: Enter a warrant executed date
+      short: *enter_date
+      api: Enter a warrant executed date
+    invalid:
+      long: Enter a valid warrant executed date
+      short: *enter_valid_date
+      api: Enter a valid warrant executed date
+    invalid_date:
+      long: Enter a valid warrant executed date
+      short: *enter_valid_date
+      api: Enter a valid warrant executed date
+    check_not_in_future:
+      long: Check the warrant issued date
+      short: *in_future
+      api: Check the warrant issued date
+    warrant_executed_before_issued:
+      long: The warrant executed date is before the issued date
+      short: *enter_valid_date
+      api: The warrant executed date is before the issued date
+
+  disbursements:
+    _seq: 70
     blank:
       long: You must add at least one disbursement
       short: Add at least one disbursement
@@ -1295,7 +1367,7 @@ interim_fee:
       api: Adding disbursements to this claim is not allowed
 
   warrant:
-    _seq: 50
+    _seq: 80
     blank:
       long: You must add a warrant fee
       short: Add a warrant fee

--- a/lib/demo_data/claim_state_advancer.rb
+++ b/lib/demo_data/claim_state_advancer.rb
@@ -15,8 +15,6 @@ module DemoData
       'awaiting_written_reasons'  => [ :submit, :allocate, :authorise, :await_written_reasons ]
     }
 
-
-
     def initialize(claim)
       @claim                = claim
       @case_worker          = User.where("email like '%example.com' and  persona_type = 'CaseWorker'").map(&:persona).sample
@@ -30,7 +28,6 @@ module DemoData
       end
       puts "   Claim advanced to #{desired_state}."
     end
-
 
     private
 

--- a/lib/demo_data/interim_fee_generator.rb
+++ b/lib/demo_data/interim_fee_generator.rb
@@ -26,7 +26,8 @@ module DemoData
 
     def setup_fee(fee)
       if fee.is_interim_warrant?
-        @claim.fees << warrant_fee
+        fee.warrant_issued_date = rand(1..5).months.ago
+        fee.warrant_executed_date = fee.warrant_issued_date + rand(1..7)
       end
 
       if fee.is_disbursement? || fee.is_effective_pcmh?
@@ -52,17 +53,10 @@ module DemoData
         @claim.trial_concluded_at = rand(1..5).months.ago
       end
 
-      unless fee.is_disbursement? || fee.is_interim_warrant?
-        fee.quantity = rand(10..50)
+      unless fee.is_disbursement?
+        fee.quantity = rand(10..50) unless fee.is_interim_warrant?
         fee.amount   = rand(1000.0..5000.0).round(2)
       end
-    end
-
-    def warrant_fee
-      Fee::WarrantFee.new(fee_type: Fee::WarrantFeeType.instance,
-                          amount: rand(100.0..2500.0).round(2),
-                          warrant_issued_date: rand(3..5).months.ago,
-                          warrant_executed_date: rand(1..2).months.ago)
     end
 
     def disbursements(range)

--- a/lib/demo_data/transfer_claim_generator.rb
+++ b/lib/demo_data/transfer_claim_generator.rb
@@ -1,5 +1,5 @@
 require_relative 'lgfs_scheme_claim_generator'
-require_relative 'interim_fee_generator'
+require_relative 'transfer_fee_generator'
 require_relative 'transfer_detail_generator'
 
 module DemoData
@@ -16,11 +16,12 @@ module DemoData
     end
 
     def add_fees_expenses_and_disbursements(claim)
-      add_interim_fee(claim)
+      add_transfer_fee(claim)
+      add_disbursements(claim)
     end
 
-    def add_interim_fee(claim)
-      DemoData::InterimFeeGenerator.new(claim).generate!
+    def add_transfer_fee(claim)
+      DemoData::TransferFeeGenerator.new(claim).generate!
     end
   end
 end

--- a/lib/demo_data/transfer_fee_generator.rb
+++ b/lib/demo_data/transfer_fee_generator.rb
@@ -1,0 +1,26 @@
+require_relative 'disbursement_generator'
+
+module DemoData
+  class TransferFeeGenerator
+
+    def initialize(claim)
+      @claim     = claim
+      @fee_types = Fee::TransferFeeType.all
+    end
+
+    def generate!
+      add_fee
+    end
+
+    private
+
+    def add_fee
+      fee_type = @fee_types.sample
+      fee = Fee::TransferFee.new(claim: @claim, fee_type: fee_type)
+      fee.amount   = rand(250.0..5000.0).round(2)
+
+      @claim.save
+      fee.save
+    end
+  end
+end

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -329,11 +329,11 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
       when :risk_based_bills
         [create(:litigator_claim, :risk_based_bill, case_type_id: CaseType.by_type('Guilty plea').id )] if for_litigator
       when :interim_fees
-        [create(:interim_claim, :interim_fee)] if for_litigator
+        [create(:interim_claim, :interim_effective_pcmh_fee, :submitted)] if for_litigator
       when :warrants
-        [create(:interim_claim, :warrant_fee)] if for_litigator
+        [create(:interim_claim, :interim_warrant_fee, :submitted)] if for_litigator
       when :interim_disbursements
-        [create(:interim_claim, :disbursement_only_fee)] if for_litigator
+        [create(:interim_claim, :disbursement_only_fee, :submitted)] if for_litigator
       else
         raise ArgumentError, "invalid filter type specified for \"#{__method__}\""
     end

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
         end
       end
 
-      context 'basic and non-basic fees' do
+      context 'conditional fee logic' do
         let!(:misc_fee_type_1)          { FactoryGirl.create :misc_fee_type, description: 'Miscellaneous Fee Type 1' }
         let!(:misc_fee_type_2)          { FactoryGirl.create :misc_fee_type, description: 'Miscellaneous Fee Type 2' }
         let!(:fixed_fee_type_1)         { FactoryGirl.create :fixed_fee_type, description: 'Fixed Fee Type 1' }

--- a/spec/factories/claim/interim_claims.rb
+++ b/spec/factories/claim/interim_claims.rb
@@ -5,19 +5,17 @@ FactoryGirl.define do
     claim_state_common_traits
   end
 
-  trait :interim_fee do
+  trait :interim_effective_pcmh_fee do
     after(:build) do |claim|
       claim.fees << build(:interim_fee, :effective_pcmh, claim: claim)
+      claim.effective_pcmh_date = 2.days.ago
     end
-    after(:create) { |c| c.submit! }
   end
 
-  trait :warrant_fee do
+  trait :interim_warrant_fee do
     after(:build) do |claim|
-      claim.fees << build(:warrant_fee, amount: 10.0)
       claim.fees << build(:interim_fee, :warrant, claim: claim)
     end
-    after(:create) { |c| c.submit! }
   end
 
   trait :disbursement_only_fee do
@@ -25,6 +23,9 @@ FactoryGirl.define do
       claim.disbursements << build_list(:disbursement, 1)
       claim.fees << build(:interim_fee, :disbursement, claim: claim)
     end
+  end
+
+  trait :submitted do
     after(:create) { |c| c.submit! }
   end
 

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -120,6 +120,7 @@ FactoryGirl.define do
     factory :warrant_fee_type, class: Fee::WarrantFeeType do
       description  'Warrant Fee'
       code 'XWAR'
+      calculated false
       roles [ 'lgfs' ]
     end
 

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -52,6 +52,7 @@ FactoryGirl.define do
     claim
     fee_type { build :warrant_fee_type }
     warrant_issued_date    1.month.ago
+    amount 25.01
 
     trait :warrant_executed do
       warrant_exectuted_date { warrant_issued_date + 5.days }
@@ -65,7 +66,7 @@ FactoryGirl.define do
   factory :interim_fee, class: Fee::InterimFee do
     claim { build :interim_claim }
     fee_type { build :interim_fee_type }
-    quantity  nil
+    quantity  2
     amount  245.56
     uuid SecureRandom.uuid
     rate nil
@@ -74,12 +75,14 @@ FactoryGirl.define do
       claim { build :interim_claim, disbursements: build_list(:disbursement, 1) }
       fee_type { build :interim_fee_type, :disbursement }
       amount nil
+      quantity nil
     end
 
     trait :warrant do
-      claim { build :interim_claim, warrant_fee: build(:warrant_fee, amount: 10.0) }
       fee_type { build :interim_fee_type, :warrant }
-      amount nil
+      quantity nil
+      amount 25.02
+      warrant_issued_date 5.days.ago
     end
 
     trait :effective_pcmh do

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Claims::Cloner, type: :model do
     end
 
     def create_rejected_claim
-      claim = create(:interim_claim, :interim_fee)
+      claim = create(:interim_claim, :interim_effective_pcmh_fee, :submitted)
 
       create(:certification, claim: claim)
 

--- a/spec/presenters/interim_fee_presenter_spec.rb
+++ b/spec/presenters/interim_fee_presenter_spec.rb
@@ -36,4 +36,17 @@ describe Fee::InterimFeePresenter do
     end
   end
 
+  context '#amount' do
+    it 'should return fee amount for interim warrants' do
+      allow(interim_fee).to receive(:is_interim_warrant?).and_return true
+      expect(interim_fee).to receive(:amount).and_return 13.00
+      expect(presenter.amount).to eq '£13.00'
+    end
+    it 'should return fee amount for any any other interim fee' do
+      allow(interim_fee).to receive(:is_interim_warrant?).and_return false
+      expect(interim_fee).to receive(:amount).and_return 13.01
+      expect(presenter.amount).to eq '£13.01'
+    end
+  end
+
 end

--- a/spec/presenters/interim_fee_type_presenter_spec.rb
+++ b/spec/presenters/interim_fee_type_presenter_spec.rb
@@ -44,7 +44,7 @@ describe Fee::InterimFeeTypePresenter do
     context 'warrant'do
       let(:fee_type)  { build :interim_fee_type, :warrant }
       it 'produces expected data attributes' do
-        expect(presenter.data_attributes).to eq expected_data(false, false, false, false, false, false, false, true, false)
+        expect(presenter.data_attributes).to eq expected_data(false, false, false, false, false, false, true, true, false)
       end
     end
   end

--- a/spec/presenters/warrant_fee_presenter_spec.rb
+++ b/spec/presenters/warrant_fee_presenter_spec.rb
@@ -2,19 +2,20 @@ require 'rails_helper'
 
 describe Fee::WarrantFeePresenter do
 
-  let(:war_fee) { instance_double(Fee::WarrantFee, claim: double) }
-  let(:presenter) { Fee::WarrantFeePresenter.new(war_fee, view) }
+  let(:warrant_fee) { instance_double(Fee::WarrantFee, claim: double) }
+  let(:presenter) { Fee::WarrantFeePresenter.new(warrant_fee, view) }
 
+  # DO NOT confuse Warrant Fees (XWAR) with Interim fees of warrant description/code (IWARR)
   context '#amount' do
-    it 'should call not_applicable ' do
-      expect(presenter).to receive(:not_applicable)
-      presenter.amount
+    it 'should return fee amount as currency' do
+      expect(warrant_fee).to receive(:amount).and_return 13.02
+      expect(presenter.amount).to eq '£13.02'
     end
   end
 
   context '#rate' do
     it 'should call not_applicable' do
-      expect(war_fee).to receive(:calculated?).and_return false
+      expect(warrant_fee).to receive(:calculated?).and_return false
       expect(presenter).to receive(:not_applicable)
       presenter.rate
     end

--- a/spec/validators/claim/interim_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_sub_model_validator_spec.rb
@@ -9,7 +9,7 @@ describe Claim::InterimClaimSubModelValidator do
   include_examples 'common partial association validations', {
       has_one: [
           [],
-          [:interim_fee, :warrant_fee, :assessment, :certification]
+          [:interim_fee, :assessment, :certification]
       ],
       has_many: [
           [:defendants],

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -26,6 +26,7 @@ describe Claim::InterimClaimValidator do
       :case_concluded_at
     ],
     [
+      :interim_fee,
       :first_day_of_trial,
       :estimated_trial_length,
       :trial_concluded_at,

--- a/spec/validators/fee/warrant_fee_validator_spec.rb
+++ b/spec/validators/fee/warrant_fee_validator_spec.rb
@@ -5,16 +5,41 @@ module Fee
 
     let(:fee)       { build :warrant_fee }
 
+    before(:each) do
+      allow(fee).to receive(:perform_validation?).and_return(true)
+    end
+
+    describe '#amount' do
+      it 'should be invalid if absent' do
+        allow(fee).to receive(:amount).and_return nil # NOTE: need to mock nil amount as callback will set to 0
+        expect(fee).to_not be_valid
+        expect(fee.errors[:amount]).to include 'blank'
+      end
+
+      it 'should be invalid if less than 0.01 ' do
+        fee.amount = 0.00999
+        expect(fee).to_not be_valid
+        expect(fee.errors[:amount]).to include 'numericality'
+      end
+
+    end
+
     describe '#validate_warrant_issued_date' do
       it 'should be valid if present and in the past' do
         fee.warrant_issued_date = Date.today
         expect(fee).to be_valid
       end
 
+      it 'should be invalid if present and too far in the past' do
+        fee.warrant_issued_date = 6.years.ago
+        expect(fee).to_not be_valid
+        expect(fee.errors[:warrant_issued_date]).to include 'check_not_too_far_in_past'
+      end
+
       it 'should be invalid if present and in the future' do
         fee.warrant_issued_date = 3.days.from_now
         expect(fee).not_to be_valid
-        expect(fee.errors[:warrant_issued_date]).to eq(  [ 'invalid' ] )
+        expect(fee.errors[:warrant_issued_date]).to include 'check_not_in_future'
       end
 
       it 'should be invalid if not present' do
@@ -32,10 +57,16 @@ module Fee
         expect(fee.errors[:warrant_executed_date]).to eq( [ 'warrant_executed_before_issued'] )
       end
 
+      it 'should be invalid if present and too far in the past' do
+        fee.warrant_executed_date = 6.years.ago
+        expect(fee).to_not be_valid
+        expect(fee.errors[:warrant_executed_date]).to include 'check_not_too_far_in_past'
+      end
+
       it 'should raise error if in future' do
         fee.warrant_executed_date = 3.days.from_now
         expect(fee).not_to be_valid
-        expect(fee.errors[:warrant_executed_date]).to eq( [ 'invalid'] )
+        expect(fee.errors[:warrant_executed_date]).to include 'check_not_in_future'
       end
 
       it 'should not raise error if absent' do
@@ -43,7 +74,7 @@ module Fee
         expect(fee).to be_valid
       end
 
-      it 'should not riase error if present and in the past' do
+      it 'should not raise error if present and in the past' do
         fee.warrant_executed_date = 1.day.ago
         expect(fee).to be_valid
       end

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -65,7 +65,7 @@ describe 'external_users/claims/show.html.haml', type: :view do
 
   context 'Interim claims' do
     before(:all) do
-      @claim = create(:interim_claim, :interim_fee)
+      @claim = create(:interim_claim, :interim_effective_pcmh_fee)
       @messages = @claim.messages.most_recent_last
       @message  = @claim.messages.build
     end


### PR DESCRIPTION
Interim claims were using "final warrants" (Fee::WarrantFee of type Fee::WarrantFeeType with code XWAR) objects for their warrant fees. This has been changed to use Interim fees of description warrant (Fee:InterimFee of type Fee::InterimFeeType with code of IWARR).

This necessitated changing validations (and error messages) as well as presenters which were also refactored. summary and claim details views were also changed in line with the changes.

In addition "final warrants" (Fee::WarrantFee) have been amended to require an amount, with commensurate changes to validators and presenters and specs

factories and spec modified in line with changes too.
