### PR TITLE
Fix flickering cukes 

### DIFF
--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -39,6 +39,8 @@ class ClaimFormPage < SitePrism::Page
 
   element :add_another_defendant, "div.defendants > div:nth-of-type(2) > a.add_fields"
 
+  element :continue_button, 'div.button-holder > input.btn-green.left'
+
   section :initial_fees, "div#basic-fees" do
     # In CSS 'foo + bar' means instances of bar which immediately follow foo and
     # have the same parent.

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -34,6 +34,7 @@ end
 
 When(/I click the claim '(.*?)'$/) do |case_number|
   @external_user_home_page.claim_for(case_number).case_number.click
+  sleep 0.5   # wait for page to load and populate select lists
 end
 
 When(/I edit this claim/) do

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -10,6 +10,7 @@ end
 
 Then(/^I should be on the litigator new interim claim page$/) do
   expect(@interim_claim_form_page).to be_displayed
+  @interim_claim_form_page.wait_until_continue_button_visible
 end
 
 When(/^I select the supplier number '(.*)'$/) do |number|


### PR DESCRIPTION
Cukes were occasionally failing on Travis due to all the category offences not being loaded before capybara tries to select one.  This PR attempts to fix that by waiting until the page has fully loaded (by waiting until the continue button is visible) before trying to select.
