### PR TITLE
Update api

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -96,13 +96,13 @@ module API
           end
         end
 
-        desc "Return all Fee Types (optional category filter)."
+        desc "Return all AGFS Fee Types (optional category filter)."
         params { use :category_filter }
         get do
           if args[:category].blank? || args[:category].downcase == 'all'
-            ::Fee::BaseFeeType.all
+            ::Fee::BaseFeeType.all.agfs_only
           else
-            ::Fee::BaseFeeType.__send__(args[:category].downcase)
+            ::Fee::BaseFeeType.__send__(args[:category].downcase).agfs_only
           end
         end
       end

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -100,32 +100,18 @@ module API
         params { use :category_filter }
         get do
           if args[:category].blank? || args[:category].downcase == 'all'
-            ::Fee::BaseFeeType.all.agfs_only
+            ::Fee::BaseFeeType.agfs
           else
-            ::Fee::BaseFeeType.__send__(args[:category].downcase).agfs_only
+            ::Fee::BaseFeeType.__send__(args[:category].downcase).agfs
           end
         end
       end
 
       resource :expense_types do
-        helpers do
-          def reasons_to_array(reason_set)
-            reasons = if reason_set == "A"
-                        ExpenseType::REASON_SET_A
-                      else
-                        ExpenseType::REASON_SET_B
-                      end
-
-            reasons.map { |i, reason| reason.instance_values }
-          end
-        end
-
         desc "Return all Expense Types."
         params { use :api_key_params }
         get do
-          ::ExpenseType.all.map do |et|
-            et.attributes.merge!(reasons: reasons_to_array(et.reason_set))
-          end
+          ::ExpenseType.agfs.all_with_reasons
         end
       end
 

--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -2,16 +2,29 @@ module Roles
   extend ActiveSupport::Concern
 
   included do |klass|
+    klass.extend(ClassMethods)
     klass.serialize :roles, Array
     klass.before_validation :strip_empty_role
     klass.validate :roles_valid
 
     klass::ROLES.each do |role|
-      klass.scope role.pluralize.to_sym, -> { klass.select { |m| m.roles.include?(role) } }
+      klass.scope role.pluralize.to_sym, -> { matching_role_query(["#{role}"]) }
 
       define_method "#{role}?" do
         is?(role)
       end
+    end
+
+  end
+
+  module ClassMethods
+    # Chainable roles query
+    # e.g.
+    #   scope :lgfs_only, -> { matching_role_query(['lgfs']) }
+    #   scope :agfs_and_lgfs_only, -> { matching_role_query(['agfs','lgfs'],'AND') }
+    def matching_role_query(roles, condition = 'AND')
+      clause = roles.map { |role| "(roles ILIKE '%#{role}%')" }.join(" #{condition} ")
+      where clause
     end
   end
 

--- a/app/models/expense_type.rb
+++ b/app/models/expense_type.rb
@@ -14,7 +14,6 @@ class ExpenseType < ActiveRecord::Base
   ROLES = %w( agfs lgfs )
   include Roles
 
-
   REASON_SET_A = {
     1 => ExpenseReason.new(1, 'Court hearing', false),
     2 => ExpenseReason.new(2, 'Pre-trial conference expert witnesses', false),
@@ -71,4 +70,19 @@ class ExpenseType < ActiveRecord::Base
   def self.for_claim_type(claim)
     claim.lgfs? ? self.lgfs : self.agfs
   end
+
+  # Used by API lookup/dropdown data endpoints
+  def self.all_with_reasons
+    ExpenseType.all.map do |et|
+      et.attributes.merge!(reasons: reasons_to_array(et.reason_set))
+    end
+  end
+
+private
+
+  def self.reasons_to_array(reason_set)
+    reasons = reason_set == "A" ? ExpenseType::REASON_SET_A : ExpenseType::REASON_SET_B
+    reasons.map { |i, reason| reason.instance_values }
+  end
+
 end

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -41,7 +41,7 @@ module Fee
 
     has_many :dates_attended, as: :attended_item, dependent: :destroy, inverse_of: :attended_item
 
-    default_scope { includes(:fee_type) }
+    default_scope   { includes(:fee_type) }
 
     validates_with FeeSubModelValidator
 

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -40,15 +40,6 @@ module Fee
 
     after_initialize :ensure_not_abstract_class
 
-    scope :agfs_only, -> { matching_role_query(['agfs']) }
-    scope :lgfs_only, -> { matching_role_query(['lgfs']) }
-    scope :agfs_and_lgfs_only, -> { matching_role_query(['agfs','lgfs'],'AND') }
-
-    def self.matching_role_query(roles, condition = 'AND')
-      clause = roles.map { |role| "(roles ILIKE '%#{role}%')" }.join(" #{condition} ")
-      where clause
-    end
-
     def ensure_not_abstract_class
       raise FeeBaseFeeTypeAbstractClassError if self.class == BaseFeeType
     end

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -40,6 +40,15 @@ module Fee
 
     after_initialize :ensure_not_abstract_class
 
+    scope :agfs_only, -> { matching_role_query(['agfs']) }
+    scope :lgfs_only, -> { matching_role_query(['lgfs']) }
+    scope :agfs_and_lgfs_only, -> { matching_role_query(['agfs','lgfs'],'AND') }
+
+    def self.matching_role_query(roles, condition = 'AND')
+      clause = roles.map { |role| "(roles ILIKE '%#{role}%')" }.join(" #{condition} ")
+      where clause
+    end
+
     def ensure_not_abstract_class
       raise FeeBaseFeeTypeAbstractClassError if self.class == BaseFeeType
     end

--- a/app/views/external_users/advocates/claims/_form.html.haml
+++ b/app/views/external_users/advocates/claims/_form.html.haml
@@ -17,14 +17,9 @@
 
       = render partial: 'external_users/claims/fees_shared_header'
 
-      // one or the other based on claim type
-      // graduated fees / basic
       = render partial: 'external_users/claims/basic_fees/fields', locals: { f: f }
 
-      // fixed fees
       = render partial: 'external_users/claims/fixed_fees/fields', locals: { f: f }
-
-      
 
       = render partial: 'external_users/claims/misc_fees/fields', locals: { f: f }
 

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -1,10 +1,4 @@
 CLASS,ROLES,FEE TYPE,CODE,MAX_AMOUNT,CALCULATED,PARENT
-GRADUATED,lgfs,Trial,GTRL,9999,false
-GRADUATED,lgfs,Retrial,GRTR,9999,false
-GRADUATED,lgfs,Guilty plea,GGLTY,9999,false
-GRADUATED,lgfs,Discontinuance,GDIS,9999,false
-GRADUATED,lgfs,Cracked trial,GCRAK,9999,false
-GRADUATED,lgfs,Cracked before retrial,GCBR,9999,false
 BASIC,agfs,Basic fee,BAF,9999,true,
 BASIC,agfs,Daily attendance fee (3 to 40),DAF,999,true,
 BASIC,agfs,Daily attendance fee (41 to 50),DAH,9999,true,
@@ -90,6 +84,12 @@ MISC,lgfs,Evidence provision fee,XEVI,,
 MISC,lgfs,Costs judge application,XCJA,,
 MISC,lgfs,Costs judge preparation,XCJP,,
 MISC,lgfs,Case uplift,XUPL
+GRADUATED,lgfs,Trial,GTRL,9999,false
+GRADUATED,lgfs,Retrial,GRTR,9999,false
+GRADUATED,lgfs,Guilty plea,GGLTY,9999,false
+GRADUATED,lgfs,Discontinuance,GDIS,9999,false
+GRADUATED,lgfs,Cracked trial,GCRAK,9999,false
+GRADUATED,lgfs,Cracked before retrial,GCBR,9999,false
 WARRANT,lgfs,Warrant Fee,XWAR
 INTERIM,lgfs,Effective PCMH,IPCMH
 INTERIM,lgfs,Trial start,ITST

--- a/lib/demo_data/demo_seeds/external_users.rb
+++ b/lib/demo_data/demo_seeds/external_users.rb
@@ -16,7 +16,7 @@ require Rails.root.join('db','seed_helper')
 provider = SeedHelper.find_or_create_provider!(
   name: 'Test chamber',
   supplier_number: nil,
-  api_key_env_var: ENV['TEST_CHAMBER_API_KEY'],
+  api_key: ENV['TEST_CHAMBER_API_KEY'],
   provider_type: 'chamber',
   vat_registered: true,
   roles: ['agfs']
@@ -55,7 +55,7 @@ end
 provider = SeedHelper.find_or_create_provider!(
   name: 'Test firm A',
   supplier_number: '1A222Z',
-  api_key: ENV['TEST_CHAMBER_API_KEY'],
+  # api_key: ENV['TEST_CHAMBER_API_KEY'],
   provider_type: 'firm',
   vat_registered: true,
   roles: ['lgfs']
@@ -98,7 +98,7 @@ end
 provider = SeedHelper.find_or_create_provider!(
   name: 'Test firm B',
   supplier_number: '22BBB',
-  api_key_env_var: ENV['TEST_CHAMBER_API_KEY'],
+  # api_key: ENV['TEST_CHAMBER_API_KEY'],
   provider_type: 'firm',
   vat_registered: false,
   roles: ['agfs','lgfs']
@@ -155,7 +155,7 @@ end
 # provider = SeedHelper.find_or_create_provider!(
 #   name: 'Test firm C',
 #   supplier_number: 'C1234567',
-#   api_key_env_var: ENV['TEST_CHAMBER_API_KEY'],
+#   api_key: ENV['TEST_CHAMBER_API_KEY'],
 #   provider_type: 'firm',
 #   vat_registered: false,
 #   roles: ['agfs']
@@ -194,7 +194,7 @@ end
 # -------------------------------------------------------
 # provider = SeedHelper.find_or_create_provider!(
 #   name: 'Test chamber',
-#   api_key_env_var: ENV['TEST_CHAMBER_API_KEY'],
+#   api_key: ENV['TEST_CHAMBER_API_KEY'],
 #   provider_type: 'chamber',
 #   vat_registered: true,
 #   roles: ['agfs', 'lgfs']

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -99,11 +99,11 @@ describe API::V1::DropdownData do
   end
 
   context 'GET api/fee_types/[:category]' do
-
     before {
       create(:basic_fee_type, id: 1)
       create(:misc_fee_type, id: 2)
       create(:fixed_fee_type, id: 3)
+      create(:graduated_fee_type, id: 4) # LGFS fee, not applicable to AGFS
     }
 
     def get_filtered_fee_types(category=nil)
@@ -111,15 +111,14 @@ describe API::V1::DropdownData do
       get FEE_TYPE_ENDPOINT, params , format: :json
     end
 
-    it 'should filter by category' do
-      categories = ['all', 'basic', 'misc', 'fixed']
+    it 'should filter by category and scheme applicability' do
+      categories = [ 'basic', 'misc', 'fixed']
       categories.each do |category|
         response = get_filtered_fee_types(category)
         expect(response.status).to eq 200
-        expect(response.body).to eq Fee::BaseFeeType.send(category).to_json
+        expect(response.body).to eq Fee::BaseFeeType.send(category).agfs_only.to_json
       end
     end
-
   end
 
   context "expense v1" do

--- a/spec/api/v1/external_users/claim_spec.rb
+++ b/spec/api/v1/external_users/claim_spec.rb
@@ -191,11 +191,16 @@ describe API::V1::ExternalUsers::Claim do
         end
       end
 
-      context "invalid advocate email input" do
+      context "invalid email input" do
         it "should return 400 and a JSON error array when advocate email is invalid" do
           valid_params[:advocate_email] = "non_existent_advocate@bigblackhole.com"
           post_to_create_endpoint
           expect_error_response("Advocate email is invalid")
+        end
+         it "should return 400 and a JSON error array when creator email is invalid" do
+          valid_params[:creator_email] = "non_existent_creator@bigblackhole.com"
+          post_to_create_endpoint
+          expect_error_response("Creator email is invalid")
         end
       end
 

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -16,7 +16,7 @@
 
 FactoryGirl.define do
   factory :basic_fee_type, class: Fee::BasicFeeType do
-    sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
+    sequence(:description) { |n| "AGFS, Basic fee type, basic fee -#{n}" }
     code { random_safe_code }
     calculated true
     roles ['agfs']
@@ -60,14 +60,14 @@ FactoryGirl.define do
     end
 
     factory :fixed_fee_type, class: Fee::FixedFeeType do
-      sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
+      sequence(:description) { |n| "AGFS, Fixed fee type, Contempt - #{n}" }
       code { random_safe_code }
       calculated true
       roles ['agfs']
     end
 
     factory :graduated_fee_type, class: Fee::GraduatedFeeType do
-      sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
+      sequence(:description) { |n| "LGFS, Fixed fee, Elected case not proceeded - #{n}" }
       code 'GTRL'
       calculated false
       roles ['lgfs']


### PR DESCRIPTION
Ensures only AGFS fee types and expenses returned from API lookup data endpoints, reintroducing skipped specs. Plus some refactoring.
