### PR TITLE
Better error feedback related to the locking of the account.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -651,7 +651,6 @@ Style/TrailingWhitespace:
     - 'app/models/concerns/duplicable.rb'
     - 'app/models/timed_transitions/batch_transitioner.rb'
     - 'app/models/timed_transitions/transitioner.rb'
-    - 'app/models/user.rb'
 
 # Offense count: 6
 # Cop supports --auto-correct.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ActiveRecord::Base
   delegate :claims_created, to: :persona
   delegate :roles, to: :persona
   delegate :provider, to: :persona
-  
+
   scope :external_users, -> { where(persona_type: 'ExternalUser') }
 
   def name
@@ -61,6 +61,13 @@ class User < ActiveRecord::Base
 
   def sortable_name
     [last_name, first_name] * ' '
+  end
+
+  # So we are able to return useful error messages to the user related to the locking of the account,
+  # without having to disable Devise paranoid mode globally (security issues).
+  #
+  def unauthenticated_message
+    override_paranoid_setting(false) { super }
   end
 
   private

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -15,3 +15,7 @@ end
 class ActionController::Parameters
   include ParametersExtension
 end
+
+module Devise::Models::Lockable
+  include DeviseExtension
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -10,7 +10,7 @@ en:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys} or password."
-      locked: "Your account is locked."
+      locked: "Your account is locked. Check your email for instructions on how to unlock your account."
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."

--- a/lib/extensions/devise_extension.rb
+++ b/lib/extensions/devise_extension.rb
@@ -1,0 +1,11 @@
+module DeviseExtension
+
+  def override_paranoid_setting(value)
+    previous_value = Devise.paranoid
+    Devise.paranoid = value
+    result = yield
+    Devise.paranoid = previous_value
+    result
+  end
+
+end

--- a/spec/lib/extensions/devise_extension_spec.rb
+++ b/spec/lib/extensions/devise_extension_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe DeviseExtension do
+  let(:example_class) { Class.new { extend DeviseExtension } }
+
+  context '#override_paranoid_setting (original value being true)' do
+    before { Devise.paranoid = true }
+
+    it 'should override the setting and call the passed block' do
+      expect(Devise.paranoid).to be_truthy
+
+      expect(
+        example_class.override_paranoid_setting(false) { Devise.paranoid }
+      ).to be_falsey
+
+      expect(Devise.paranoid).to be_truthy
+    end
+  end
+
+  context '#override_paranoid_setting (original value being false)' do
+    before { Devise.paranoid = false }
+
+    it 'should override the setting and call the passed block' do
+      expect(Devise.paranoid).to be_falsey
+
+      expect(
+          example_class.override_paranoid_setting(true) { Devise.paranoid }
+      ).to be_truthy
+
+      expect(Devise.paranoid).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Devise has a mode called 'Paranoid' that prevents leaking account/user information in error messages.

So for example, if an account is locked, and the user (any user) try to login, the error message will not be 'your account is locked' but instead a generic 'email/password invalid'.

This was causing issues with some users, not knowing their account was locked or about to get locked.

The paranoid mode **should remain activated globally** but we are making an exception for lock-related feedback errors, so the user will get more accurate messages.
