### PR TITLE
Fee quantity as decimal for certain fee types

### DIFF
--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -8,7 +8,7 @@ module Roles
     klass.validate :roles_valid
 
     klass::ROLES.each do |role|
-      klass.scope role.pluralize.to_sym, -> { matching_role_query(["#{role}"]) }
+      klass.scope role.pluralize.to_sym, -> { matching_role_query([role.to_s]) }
 
       define_method "#{role}?" do
         is?(role)

--- a/app/models/expense_type.rb
+++ b/app/models/expense_type.rb
@@ -78,11 +78,11 @@ class ExpenseType < ActiveRecord::Base
     end
   end
 
-private
-
   def self.reasons_to_array(reason_set)
     reasons = reason_set == "A" ? ExpenseType::REASON_SET_A : ExpenseType::REASON_SET_B
-    reasons.map { |i, reason| reason.instance_values }
+    reasons.map { |_i, reason| reason.instance_values }
   end
+
+  private_class_method :reasons_to_array
 
 end

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime
@@ -69,6 +69,11 @@ module Fee
       claim.update_fees_total
       claim.update_total
       claim.update_vat
+    end
+
+    def quantity_is_decimal?
+      return false if fee_type.nil?
+      fee_type.quantity_is_decimal?
     end
 
     # default type logic

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -41,7 +41,7 @@ module Fee
 
     has_many :dates_attended, as: :attended_item, dependent: :destroy, inverse_of: :attended_item
 
-    default_scope   { includes(:fee_type) }
+    default_scope { includes(:fee_type) }
 
     validates_with FeeSubModelValidator
 

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 module Fee

--- a/app/models/fee/basic_fee.rb
+++ b/app/models/fee/basic_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/app/models/fee/basic_fee_type.rb
+++ b/app/models/fee/basic_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 class Fee::BasicFeeType < Fee::BaseFeeType

--- a/app/models/fee/fixed_fee.rb
+++ b/app/models/fee/fixed_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/app/models/fee/fixed_fee_type.rb
+++ b/app/models/fee/fixed_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 class Fee::FixedFeeType < Fee::BaseFeeType

--- a/app/models/fee/graduated_fee.rb
+++ b/app/models/fee/graduated_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/app/models/fee/graduated_fee_type.rb
+++ b/app/models/fee/graduated_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 class Fee::GraduatedFeeType < Fee::BaseFeeType

--- a/app/models/fee/interim_fee.rb
+++ b/app/models/fee/interim_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/app/models/fee/interim_fee_type.rb
+++ b/app/models/fee/interim_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 class Fee::InterimFeeType < Fee::BaseFeeType

--- a/app/models/fee/misc_fee.rb
+++ b/app/models/fee/misc_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 class Fee::MiscFeeType < Fee::BaseFeeType

--- a/app/models/fee/transfer_fee.rb
+++ b/app/models/fee/transfer_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/app/models/fee/transfer_fee_type.rb
+++ b/app/models/fee/transfer_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 class Fee::TransferFeeType < Fee::BaseFeeType

--- a/app/models/fee/warrant_fee.rb
+++ b/app/models/fee/warrant_fee.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/app/models/fee/warrant_fee_type.rb
+++ b/app/models/fee/warrant_fee_type.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 class Fee::WarrantFeeType < Fee::BaseFeeType

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@
 #  last_name              :string
 #  failed_attempts        :integer          default(0), not null
 #  locked_at              :datetime
+#  unlock_token           :string
 #
 
 class User < ActiveRecord::Base

--- a/app/presenters/fee/base_fee_presenter.rb
+++ b/app/presenters/fee/base_fee_presenter.rb
@@ -29,6 +29,17 @@ class Fee::BaseFeePresenter < BasePresenter
     uncalculated_fee_type_code? ? t(t_scope, '_section_hint') : ''
   end
 
+  def quantity
+    # if the error is that the user has typed a decimal when it should be an integer,
+    # we want to preserve the decimal value and display on the error page
+    #
+    if fee.quantity_is_decimal? || fee.errors[:quantity].include?('integer')
+      h.number_with_precision(fee.quantity, precision: 2)
+    else
+      h.number_with_precision(fee.quantity, precision: 0)
+    end
+  end
+
 private
 
   def t(scope, suffix=nil)

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -88,7 +88,15 @@ private
   end
 
   def validate_any_quantity
+    validate_integer_decimal
     add_error(:quantity, 'invalid') if @record.quantity < 0 || @record.quantity > 99999
+  end
+
+  def validate_integer_decimal
+    return if @record.fee_type.nil? || @record.quantity.nil?
+    unless @record.quantity_is_decimal?
+      add_error(:quantity, 'integer') unless @record.quantity.frac == 0.0
+    end
   end
 
   def validate_rate
@@ -130,7 +138,7 @@ private
   # NOTE: we have specific error messages for basic fees
   def validate_basic_fee_rate(code)
     if @record.quantity > 0 && @record.rate <= 0
-      add_error(:rate, "#{code.downcase}_invalid")
+      add_error(:rate, "invalid")
     elsif @record.quantity <= 0 && @record.rate > 0
       add_error(:quantity, "#{code.downcase}_invalid")
     end

--- a/app/views/external_users/claims/basic_fees/_basic_fee_calculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_calculated_fields.html.haml
@@ -4,10 +4,10 @@
       = t('.fee_type')
 
     = f.object.description
-    - if f.object.fee_type.code == 'BAF'
+    - if fee.fee_type.code == 'BAF'
       .form-hint
         = raw t('.basic_fee_prompt_text')
-    - if f.object.fee_type.code == 'SAF'
+    - if fee.fee_type.code == 'SAF'
       .form-hint
         = raw t('.saf_prompt_text')
 
@@ -15,7 +15,7 @@
     %label.form-label
       = t('.quantity')
       %a{name: "basic_fee_#{@basic_fee_count}_quantity"}
-      = f.number_field :quantity, value: number_with_precision_or_default(f.object.quantity) , class: 'form-control quantity', min: 0, max: 99999
+      = f.number_field :quantity, value: number_with_precision_or_default(fee.quantity) , class: 'form-control quantity', min: 0, max: 99999
       = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
 
   .column-one-quarter.fee-rate
@@ -23,11 +23,11 @@
       = t('.rate')
     %a{name: "basic_fee_#{@basic_fee_count}_rate"}
     %span.currency-indicator>< &pound;
-    = f.number_field :rate, value: number_with_precision(f.object.rate, precision: 2), class: 'form-control rate', size: 10, min: 0, max: 99999
+    = f.number_field :rate, value: number_with_precision(fee.rate, precision: 2), class: 'form-control rate', size: 10, min: 0, max: 99999
     = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_rate")
 
 .grid-row
   .column-one-third.fee-total
     %label.form-label Total
-    %span.total{data: {'total': f.object.amount ||= 0}}
-      = number_to_currency(f.object.amount ||= 0)
+    %span.total{data: {'total': fee.amount ||= 0}}
+      = number_to_currency(fee.amount ||= 0)

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields.html.haml
@@ -2,7 +2,7 @@
   = f.hidden_field :fee_type_id, value: f.object.fee_type_id
 
   - if f.object.calculated?
-    = render 'external_users/claims/basic_fees/basic_fee_calculated_fields', f: f
+    = render partial: 'external_users/claims/basic_fees/basic_fee_calculated_fields', locals: { f: f, fee: present(f.object) }
   - else
     = render partial: 'external_users/claims/basic_fees/basic_fee_uncalculated_fields', locals: { f: f, fee: present(f.object) }
 

--- a/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
@@ -8,7 +8,7 @@
     %label.form-label
       = t('.quantity')
       %a{name: "basic_fee_#{@basic_fee_count}_quantity"}
-      = f.number_field :quantity, value: number_with_precision_or_default(f.object.quantity) , class: 'form-control quantity', min: 0, max: 99999
+      = f.number_field :quantity, value: number_with_precision_or_default(fee.quantity) , class: 'form-control quantity', min: 0, max: 99999
       = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
 
   .column-one-quarter.fee-rate
@@ -16,5 +16,5 @@
       = t('.total')
       %a{name: "basic_fee_#{@basic_fee_count}_amount"}
     %span.currency-indicator>< &pound;
-    = f.number_field :amount, value: number_with_precision(f.object.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
+    = f.number_field :amount, value: number_with_precision(fee.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
     = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_amount")

--- a/app/views/external_users/claims/fixed_fees/_fixed_fee_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/_fixed_fee_fields.html.haml
@@ -1,3 +1,4 @@
+-fee = present(f.object)
 .form-group.fixed-fee-group.nested-fields.js-block{data:{type:"fees", autovat: @claim.apply_vat? ? "true" : "false", "block-type": "FeeBlockCalculator"}}
   .grid-row
     .column-one-half.fee-type
@@ -11,7 +12,7 @@
       %label.form-label
         = t('.quantity')
       %a{name: "fixed_fee_#{@fixed_fee_count}_quantity"}
-        = f.number_field :quantity, min: 0, max: 99999, maxlength: 5, class: 'form-control quantity'
+        = f.number_field :quantity, value: fee.quantity, min: 0, max: 99999, maxlength: 5, class: 'form-control quantity'
         = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_quantity")
 
     .column-one-quarter.fee-rate
@@ -19,14 +20,14 @@
         = t('.rate')
       %a{name: "fixed_fee_#{@fixed_fee_count}_rate"}
       %span.currency-indicator>< &pound;
-      = f.number_field :rate, min: 0, max: 99999, value: number_with_precision(f.object.rate, precision: 2), class: 'form-control rate', size: 10
+      = f.number_field :rate, min: 0, max: 99999, value: number_with_precision(fee.rate, precision: 2), class: 'form-control rate', size: 10
       = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_rate")
 
   .grid-row
     .column-one-third.fee-total
       %label.form-label Total
-      %span.total{data: {'total': f.object.amount ||= 0}}
-        = number_to_currency(f.object.amount ||= 0)
+      %span.total{data: {'total': fee.amount ||= 0}}
+        = number_to_currency(fee.amount ||= 0)
 
   .grid-row.fee-dates-row
 

--- a/app/views/external_users/claims/graduated_fees/_fields.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_fields.html.haml
@@ -6,30 +6,30 @@
     .form-hint.xsmall
       = raw t('.graduated_prompt_text')
 
-    = f.fields_for :graduated_fee do |gf|
-
+    = f.fields_for :graduated_fee do |grad_fee_form|
+      - grad_fee = present(grad_fee_form.object)
       .expense-group.nested-fields.js-block{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false"}}
         .grid-row
 
           .column-one-third
             %label.form-label
               = t('.fee_type')
-            = gf.anchored_attribute 'fee_type'
+            = grad_fee_form.anchored_attribute 'fee_type'
             = @claim.case_type.graduated_fee_type.description
-            = gf.hidden_field :fee_type_id, value: @claim.case_type.graduated_fee_type.id
+            = grad_fee_form.hidden_field :fee_type_id, value: @claim.case_type.graduated_fee_type.id
             = validation_error_message(@error_presenter, :fee_type)
 
           .column-one-third.condensed.js-expense-location
             %label.form-label
               = t('.ppe_total')
-            = gf.anchored_attribute 'quantity'
-            = gf.number_field :quantity, class: 'quantity', min: 0, max: 99999, maxlength: 5
+            = grad_fee_form.anchored_attribute 'quantity'
+            = grad_fee_form.number_field :quantity, value: grad_fee.quantity, class: 'quantity', min: 0, max: 99999, maxlength: 5
             = validation_error_message(@error_presenter, 'graduated_fee.quantity')
 
         .grid-row
           .column-one-third
-            = gf.anchored_attribute 'date'
-            = gf.gov_uk_date_field(:date, legend_text: t('.date'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'graduated_fee.date'))
+            = grad_fee_form.anchored_attribute 'date'
+            = grad_fee_form.gov_uk_date_field(:date, legend_text: t('.date'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'graduated_fee.date'))
 
           .column-one-third.js-expense-reason
             %label.form-label
@@ -40,8 +40,8 @@
           .column-one-third.condensed.js-expense-amount.fee-total
             %label.form-label Total
 
-            = gf.anchored_attribute 'amount'
+            = grad_fee_form.anchored_attribute 'amount'
             %span.currency-indicator>< &pound;
-            = gf.number_field :amount, value: number_with_precision(gf.object.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
+            = grad_fee_form.number_field :amount, value: number_with_precision(grad_fee_form.object.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
             = validation_error_message(@error_presenter, :amount)
-            = gf.anchored_attribute 'amount'
+            = grad_fee_form.anchored_attribute 'amount'

--- a/app/views/external_users/claims/interim_fee/_fields.html.haml
+++ b/app/views/external_users/claims/interim_fee/_fields.html.haml
@@ -6,6 +6,7 @@
     = t('.interim_fees_prompt_text_html')
 
   = f.fields_for :interim_fee do |inf|
+    - fee = present(inf.object)
     .interim-fee-group.nested-fields.mod-fees.js-block{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false"}}
       %fieldset
         .form-row
@@ -22,7 +23,7 @@
             .form-hint.xsmall
               = t('.ppe_total_hint')
             = inf.anchored_attribute 'quantity'
-            = inf.number_field :quantity, class: 'form-control quantity', min: 0, max: 99999, maxlength: 5
+            = inf.number_field :quantity, value: fee.quantity, class: 'form-control quantity', min: 0, max: 99999, maxlength: 5
             = validation_error_message(@error_presenter, 'interim_fee.quantity')
 
         .form-row

--- a/app/views/external_users/claims/misc_fees/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/_fields.html.haml
@@ -5,6 +5,6 @@
   .misc-fee-group-wrapper
     = f.fields_for :misc_fees do |misc_fee_fields|
       - @misc_fee_count += 1
-      = render 'external_users/claims/misc_fees/misc_fee_fields', f: misc_fee_fields
+      = render partial: 'external_users/claims/misc_fees/misc_fee_fields', locals: {f: misc_fee_fields }
 
   = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/misc_fee_fields', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'div'}

--- a/app/views/external_users/claims/misc_fees/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/_misc_fee_fields.html.haml
@@ -1,3 +1,4 @@
+- fee = present(f.object)
 .form-group.misc-fee-group.nested-fields.js-block{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false", "block-type": "FeeBlockCalculator"}}
   .grid-row
     .column-one-half.fee-type
@@ -11,7 +12,7 @@
       %label.form-label
         = t('.quantity')
       %a{name: "misc_fee_#{@misc_fee_count}_quantity"}
-        = f.number_field :quantity, min: 0, max: 99999, maxlength: 5, class: 'form-control quantity'
+        = f.number_field :quantity, value: fee.quantity, min: 0, max: 99999, maxlength: 5, class: 'form-control quantity'
         = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_quantity")
 
     .column-one-quarter.fee-rate

--- a/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
@@ -7,6 +7,6 @@
   .misc-fee-group-wrapper
     = f.fields_for :misc_fees do |misc_fee_fields|
       - @misc_fee_count += 1
-      = render 'external_users/claims/misc_fees/litigators/misc_fee_fields', f: misc_fee_fields
+      = render partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', locals: { f: misc_fee_fields }
 
   = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', data: {'association-insertion-method' => 'append', 'association-insertion-traversal' => 'prev', 'association-insertion-node' => 'div'}

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -1,3 +1,4 @@
+- fee = present(f.object)
 .form-group.misc-fee-group.js-block.nested-fields{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false"}}
   .grid-row
     .column-three-quarters
@@ -27,7 +28,7 @@
         = t('.amount')
       %a{name: "misc_fee_#{@misc_fee_count}_amount"}
       %span.currency-indicator>< &pound;
-      = f.number_field :amount, value: number_with_precision(f.object.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
+      = f.number_field :amount, value: number_with_precision(fee.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_amount")
 
   = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group' }

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -768,7 +768,7 @@ basic_fee:
     invalid:
       long: Enter a valid rate for the initial fee
       short: *enter_valid_rate
-      api: Enter a valid rate for the initial fee
+      api: Enter a valid rate for the basic fee
 
   amount:
     _seq: 30
@@ -816,6 +816,11 @@ misc_fee:
       long: 'Enter a valid quantity for the #{misc_fee}'
       short: *enter_valid_quantity
       api: Enter a valid quantity for the miscellaneous fee
+
+    integer:
+      long: You must specify a whole number for this type of fee
+      short: Whole number
+      api: You must specify a whole number for this type of fee
 
   case_numbers:
     _seq: 40
@@ -874,6 +879,11 @@ fixed_fee:
       long: 'Enter a valid quantity for the #{fixed_fee}'
       short: *enter_valid_quantity
       api: Enter a valid quantity for the fixed fee
+    integer:
+      long: You must specify a whole number for this type of fee
+      short: Whole number
+      api: You must specify a whole number for this type of fee
+
 
   sub_type:
     _seq: 40

--- a/db/migrate/20160527101526_change_fee_quantity_to_decimal.rb
+++ b/db/migrate/20160527101526_change_fee_quantity_to_decimal.rb
@@ -1,0 +1,9 @@
+class ChangeFeeQuantityToDecimal < ActiveRecord::Migration
+  def up
+    change_column :fees, :quantity,  :decimal
+  end
+
+  def down
+    change_column :fees, :quantity,  :integer
+  end
+end

--- a/db/migrate/20160527102644_add_quantity_is_decimal_to_fee_type.rb
+++ b/db/migrate/20160527102644_add_quantity_is_decimal_to_fee_type.rb
@@ -1,5 +1,11 @@
 class AddQuantityIsDecimalToFeeType < ActiveRecord::Migration
-  def change
+  def up
     add_column :fee_types, :quantity_is_decimal, :boolean, default: false
+    Fee::BaseFeeType.reset_column_information
+    Rake::Task['data:migrate:set_quantity_is_decimal'].invoke
+  end
+
+  def down
+    remove_column :fee_types, :quantity_is_decimal
   end
 end

--- a/db/migrate/20160527102644_add_quantity_is_decimal_to_fee_type.rb
+++ b/db/migrate/20160527102644_add_quantity_is_decimal_to_fee_type.rb
@@ -1,0 +1,5 @@
+class AddQuantityIsDecimalToFeeType < ActiveRecord::Migration
+  def change
+    add_column :fee_types, :quantity_is_decimal, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160526143740) do
+ActiveRecord::Schema.define(version: 20160527102644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -298,10 +298,11 @@ ActiveRecord::Schema.define(version: 20160526143740) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.decimal  "max_amount"
-    t.boolean  "calculated",  default: true
+    t.boolean  "calculated",          default: true
     t.string   "type"
     t.string   "roles"
     t.integer  "parent_id"
+    t.boolean  "quantity_is_decimal", default: false
   end
 
   add_index "fee_types", ["code"], name: "index_fee_types_on_code", using: :btree
@@ -310,7 +311,7 @@ ActiveRecord::Schema.define(version: 20160526143740) do
   create_table "fees", force: :cascade do |t|
     t.integer  "claim_id"
     t.integer  "fee_type_id"
-    t.integer  "quantity"
+    t.decimal  "quantity"
     t.decimal  "amount"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/db/seeds/fee_types.rb
+++ b/db/seeds/fee_types.rb
@@ -14,7 +14,7 @@ data.shift
 
 data.each do |row|
   begin
-    fee_type, roles, description, code, max_amount, calculated, parent = row
+    fee_type, roles, description, code, max_amount, calculated, parent, quantity_is_decimal = row
     klass = "Fee::#{fee_type.capitalize}FeeType".constantize
     roles = roles.split(';')
     calculated = 'false' if calculated.nil?
@@ -24,12 +24,27 @@ data.each do |row|
     parent_id = parent.nil? ? nil : klass.find_by(description: parent.strip).try(:id)
     record = klass.find_by(description: description)
     if record
-      record.update!(roles: roles, description: description, code: code, max_amount: max_amount, calculated: calculated, type: klass.to_s, parent_id: parent_id)
+      record.update!(roles: roles,
+                     description: description,
+                     code: code,
+                     max_amount: max_amount,
+                     calculated: calculated,
+                     type: klass.to_s,
+                     parent_id: parent_id,
+                     quantity_is_decimal: quantity_is_decimal)
     else
-      klass.create!(roles: roles, description: description, code: code, max_amount: max_amount, calculated: calculated, type: klass.to_s, parent_id: parent_id)
+      klass.create!(roles: roles,
+                    description: description,
+                    code: code,
+                    max_amount: max_amount,
+                    calculated: calculated,
+                    type: klass.to_s,
+                    parent_id: parent_id,
+                    quantity_is_decimal: quantity_is_decimal)
     end
   rescue => err
     puts "***************** #{err.class}  #{err.message} *********** #{__FILE__}::#{__LINE__} ***********\n"
+    puts err.backtrace
     puts row
   end
 end

--- a/lib/api_test_client.rb
+++ b/lib/api_test_client.rb
@@ -268,7 +268,6 @@ private
       "claim_id": claim_uuid,
       "fee_type_id": fee_type_id,
       "quantity": 1,
-      "rate": 2.1,
     }
   end
 

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -1,100 +1,100 @@
-CLASS,ROLES,FEE TYPE,CODE,MAX_AMOUNT,CALCULATED,PARENT
-BASIC,agfs,Basic fee,BAF,9999,true,
-BASIC,agfs,Daily attendance fee (3 to 40),DAF,999,true,
-BASIC,agfs,Daily attendance fee (41 to 50),DAH,9999,true,
-BASIC,agfs,Daily attendance fee (51+),DAJ,999,true,
-BASIC,agfs,Standard appearance fee,SAF,999,true,
-BASIC,agfs,Plea and case management hearing,PCM,999,true,
-BASIC,agfs,Conferences and views,CAV,nil,true,
-BASIC,agfs,Number of defendants uplift,NDR,nil,true,
-BASIC,agfs,Number of cases uplift,NOC,nil,true,
-BASIC,agfs,Number of prosecution witnesses,NPW,nil,false,
-BASIC,agfs,Pages of prosecution evidence,PPE,nil,false,
-FIXED,agfs;lgfs,Appeals to the crown court against conviction,ACV,nil,true,
-FIXED,agfs,Appeals to the crown court against conviction uplift,ACU,nil,true,
-FIXED,agfs;lgfs,Appeals to the crown court against sentence,ASE,nil,true,
-FIXED,agfs,Appeals to the crown court against sentence uplift,ASU,nil,true,
-FIXED,agfs;lgfs,Breach of a crown court order,CBR,nil,true,
-FIXED,agfs,Breach of a crown court order uplift,CBU,nil,true,
-FIXED,agfs,Contempt,ZCON,nil,true,
-FIXED,agfs,Contempt hearings - unapportioned fee,CON,nil,true,
-FIXED,agfs,Contempt hearings - apportioned fee,COA,nil,true,
-FIXED,agfs;lgfs,Committal for sentence hearings,CSE,nil,true,
-FIXED,agfs,Committal for sentence hearings uplift,CSU,nil,true,
-FIXED,agfs;lgfs,Cracked case discontinued,CCD,nil,true,
-FIXED,agfs,Cracked case discontinued uplift,CDU,nil,true,
-FIXED,agfs;lgfs,Elected case not proceeded,ENP,nil,true,
-FIXED,agfs,Elected case not proceeded uplift,ENU,nil,true,
-FIXED,agfs;lgfs,Number of cases uplift,NOC,nil,true,
-FIXED,agfs;lgfs,Number of defendants uplift,NDR,nil,true,
-FIXED,agfs,Standard appearance fee,SAF,nil,true,
-FIXED,lgfs,Hearing subsequent to sentence,XH2S,,
-FIXED,lgfs,Vary/discharge an ASBO s1c Crime and Disorder Act 1998,XASB,,,Hearing subsequent to sentence
-FIXED,lgfs,Alteration of Crown Court sentence s155 Powers of Criminal Courts (Sentencing Act 2000),XALT,,,Hearing subsequent to sentence
-FIXED,lgfs,Assistance by defendant: review of sentence s74 Serious Organised Crime and Police Act 2005,XASS,,,Hearing subsequent to sentence
-MISC,agfs,Abuse of process hearings (half day),APH,nil,true,
-MISC,agfs,Abuse of process hearings (whole day),APW,nil,true,
-MISC,agfs,Abuse of process hearings (half day uplift),AHU,nil,true,
-MISC,agfs,Abuse of process hearings (whole day uplift),AWU,nil,true,
-MISC,agfs,Adjourned appeals,SAF,nil,true,
-MISC,agfs,Application to dismiss a charge (half day),PAH,nil,true,
-MISC,agfs,Application to dismiss a charge (whole day),PAW,nil,true,
-MISC,agfs,Application to dismiss a charge (half day uplift),PHU,nil,true,
-MISC,agfs,Application to dismiss a charge (whole day uplift),PWU,nil,true,
-MISC,agfs,Confiscation hearings (half day),DTH,nil,true,
-MISC,agfs,Confiscation hearings (whole day),DTW,nil,true,
-MISC,agfs,Confiscation hearings (half day uplift),DHU,nil,true,
-MISC,agfs,Confiscation hearings (whole day uplift),DWU,nil,true,
-MISC,agfs,Deferred sentence hearings,DSE,nil,true,
-MISC,agfs,Deferred sentence hearings uplift,DSU,nil,true,
-MISC,agfs,Hearings relating to admissibility of evidence (half day),AEH,nil,true,
-MISC,agfs,Hearings relating to admissibility of evidence (whole day),AEW,nil,true,
-MISC,agfs,Hearings relating to admissibility of evidence (half day uplift),EHU,nil,true,
-MISC,agfs,Hearings relating to admissibility of evidence (whole day uplift),EWU,nil,true,
-MISC,agfs,Hearings relating to disclosure (half day),HDH,nil,true,
-MISC,agfs,Hearings relating to disclosure (whole day),HDW,nil,true,
-MISC,agfs,Hearings relating to disclosure (half day uplift),HHU,nil,true,
-MISC,agfs,Hearings relating to disclosure (whole day uplift),HWU,nil,true,
-MISC,agfs,Noting brief fee,NBR,nil,true,
-MISC,agfs,Paper plea & case management,PPC,nil,true,
-MISC,agfs,Paper plea & case management uplift,PCU,nil,true,
-MISC,agfs,Proceeds of crime hearings (half day),PCH,nil,true,
-MISC,agfs,Proceeds of crime hearings (whole day),PCW,nil,true,
-MISC,agfs,Proceeds of crime hearings (half day uplift),CHU,nil,true,
-MISC,agfs,Proceeds of crime hearings (whole day uplift),CHW,nil,true,
-MISC,agfs,Public interest immunity hearings (half day),PAH,nil,true,
-MISC,agfs,Public interest immunity hearings (whole day),PAW,nil,true,
-MISC,agfs,Public interest immunity hearings (half day uplift),PHU,nil,true,
-MISC,agfs,Public interest immunity hearings (whole day uplift),PWU,nil,true,
-MISC,agfs,Research of very unusual or novel factual issue,RNF,nil,true,
-MISC,agfs,Research of very unusual or novel point of law,RNL,nil,true,
-MISC,agfs,Standard appearance fee uplift,SAU,nil,true,
-MISC,agfs,Sentence hearings,SHR,nil,true,
-MISC,agfs,Sentence hearings uplift,SHU,nil,true,
-MISC,agfs;lgfs,Special preparation fee,SPF,nil,true,
-MISC,agfs,Trial not proceed,TNP,nil,true,
-MISC,agfs,Trial not proceed uplift,TNU,nil,true,
-MISC,agfs,Unsuccessful application to vacate a guilty plea (half day),PAH,nil,true,
-MISC,agfs,Unsuccessful application to vacate a guilty plea (whole day),PAW,nil,true,
-MISC,agfs,Unsuccessful application to vacate a guilty plea (half day uplift),PHU,nil,true,
-MISC,agfs,Unsuccessful application to vacate a guilty plea (whole day uplift),PWU,nil,true,
-MISC,agfs,Written / oral advice,WOA,nil,true,
-MISC,agfs,Wasted preparation fee,WPF,nil,true,
-MISC,lgfs,Evidence provision fee,XEVI,,
-MISC,lgfs,Costs judge application,XCJA,,
-MISC,lgfs,Costs judge preparation,XCJP,,
-MISC,lgfs,Case uplift,XUPL
-GRADUATED,lgfs,Trial,GTRL,9999,false
-GRADUATED,lgfs,Retrial,GRTR,9999,false
-GRADUATED,lgfs,Guilty plea,GGLTY,9999,false
-GRADUATED,lgfs,Discontinuance,GDIS,9999,false
-GRADUATED,lgfs,Cracked trial,GCRAK,9999,false
-GRADUATED,lgfs,Cracked before retrial,GCBR,9999,false
-WARRANT,lgfs,Warrant Fee,XWAR
-INTERIM,lgfs,Effective PCMH,IPCMH
-INTERIM,lgfs,Trial start,ITST
-INTERIM,lgfs,Retrial New solicitor,IRNS
-INTERIM,lgfs,Retrial start,IRST
-INTERIM,lgfs,Disbursement only,IDISO
-INTERIM,lgfs,Warrant,IWARR
-TRANSFER,lgfs,Transfer,TRANS
+CLASS,ROLES,FEE TYPE,CODE,MAX_AMOUNT,CALCULATED,PARENT,QUANITY_IS_DECIMAL
+BASIC,agfs,Basic fee,BAF,9999,true,,false
+BASIC,agfs,Daily attendance fee (3 to 40),DAF,999,true,,false
+BASIC,agfs,Daily attendance fee (41 to 50),DAH,9999,true,,false
+BASIC,agfs,Daily attendance fee (51+),DAJ,999,true,,false
+BASIC,agfs,Standard appearance fee,SAF,999,true,,false
+BASIC,agfs,Plea and case management hearing,PCM,999,true,,false
+BASIC,agfs,Conferences and views,CAV,nil,true,,true
+BASIC,agfs,Number of defendants uplift,NDR,nil,true,,false
+BASIC,agfs,Number of cases uplift,NOC,nil,true,,false
+BASIC,agfs,Number of prosecution witnesses,NPW,nil,false,,false
+BASIC,agfs,Pages of prosecution evidence,PPE,nil,false,,false
+FIXED,agfs;lgfs,Appeals to the crown court against conviction,ACV,nil,true,,false
+FIXED,agfs,Appeals to the crown court against conviction uplift,ACU,nil,true,,false
+FIXED,agfs;lgfs,Appeals to the crown court against sentence,ASE,nil,true,,false
+FIXED,agfs,Appeals to the crown court against sentence uplift,ASU,nil,true,,false
+FIXED,agfs;lgfs,Breach of a crown court order,CBR,nil,true,,false
+FIXED,agfs,Breach of a crown court order uplift,CBU,nil,true,,false
+FIXED,agfs,Contempt,ZCON,nil,true,,false
+FIXED,agfs,Contempt hearings - unapportioned fee,CON,nil,true,,false
+FIXED,agfs,Contempt hearings - apportioned fee,COA,nil,true,,false
+FIXED,agfs;lgfs,Committal for sentence hearings,CSE,nil,true,,false
+FIXED,agfs,Committal for sentence hearings uplift,CSU,nil,true,,false
+FIXED,agfs;lgfs,Cracked case discontinued,CCD,nil,true,,false
+FIXED,agfs,Cracked case discontinued uplift,CDU,nil,true,,false
+FIXED,agfs;lgfs,Elected case not proceeded,ENP,nil,true,,false
+FIXED,agfs,Elected case not proceeded uplift,ENU,nil,true,,false
+FIXED,agfs;lgfs,Number of cases uplift,NOC,nil,true,,false
+FIXED,agfs;lgfs,Number of defendants uplift,NDR,nil,true,,false
+FIXED,agfs,Standard appearance fee,SAF,nil,true,,false
+FIXED,lgfs,Hearing subsequent to sentence,XH2S,,,,false
+FIXED,lgfs,Vary/discharge an ASBO s1c Crime and Disorder Act 1998,XASB,,,Hearing subsequent to sentence,false
+FIXED,lgfs,Alteration of Crown Court sentence s155 Powers of Criminal Courts (Sentencing Act 2000),XALT,,,Hearing subsequent to sentence,false
+FIXED,lgfs,Assistance by defendant: review of sentence s74 Serious Organised Crime and Police Act 2005,XASS,,,Hearing subsequent to sentence,false
+MISC,agfs,Abuse of process hearings (half day),APH,nil,true,,false
+MISC,agfs,Abuse of process hearings (whole day),APW,nil,true,,false
+MISC,agfs,Abuse of process hearings (half day uplift),AHU,nil,true,,false
+MISC,agfs,Abuse of process hearings (whole day uplift),AWU,nil,true,,false
+MISC,agfs,Adjourned appeals,SAF,nil,true,,false
+MISC,agfs,Application to dismiss a charge (half day),PAH,nil,true,,false
+MISC,agfs,Application to dismiss a charge (whole day),PAW,nil,true,,false
+MISC,agfs,Application to dismiss a charge (half day uplift),PHU,nil,true,,false
+MISC,agfs,Application to dismiss a charge (whole day uplift),PWU,nil,true,,false
+MISC,agfs,Confiscation hearings (half day),DTH,nil,true,,false
+MISC,agfs,Confiscation hearings (whole day),DTW,nil,true,,false
+MISC,agfs,Confiscation hearings (half day uplift),DHU,nil,true,,false
+MISC,agfs,Confiscation hearings (whole day uplift),DWU,nil,true,,false
+MISC,agfs,Deferred sentence hearings,DSE,nil,true,,false
+MISC,agfs,Deferred sentence hearings uplift,DSU,nil,true,,false
+MISC,agfs,Hearings relating to admissibility of evidence (half day),AEH,nil,true,,false
+MISC,agfs,Hearings relating to admissibility of evidence (whole day),AEW,nil,true,,false
+MISC,agfs,Hearings relating to admissibility of evidence (half day uplift),EHU,nil,true,,false
+MISC,agfs,Hearings relating to admissibility of evidence (whole day uplift),EWU,nil,true,,false
+MISC,agfs,Hearings relating to disclosure (half day),HDH,nil,true,,false
+MISC,agfs,Hearings relating to disclosure (whole day),HDW,nil,true,,false
+MISC,agfs,Hearings relating to disclosure (half day uplift),HHU,nil,true,,false
+MISC,agfs,Hearings relating to disclosure (whole day uplift),HWU,nil,true,,false
+MISC,agfs,Noting brief fee,NBR,nil,true,,false
+MISC,agfs,Paper plea & case management,PPC,nil,true,,false
+MISC,agfs,Paper plea & case management uplift,PCU,nil,true,,false
+MISC,agfs,Proceeds of crime hearings (half day),PCH,nil,true,,false
+MISC,agfs,Proceeds of crime hearings (whole day),PCW,nil,true,,false
+MISC,agfs,Proceeds of crime hearings (half day uplift),CHU,nil,true,,false
+MISC,agfs,Proceeds of crime hearings (whole day uplift),CHW,nil,true,,false
+MISC,agfs,Public interest immunity hearings (half day),PAH,nil,true,,false
+MISC,agfs,Public interest immunity hearings (whole day),PAW,nil,true,,false
+MISC,agfs,Public interest immunity hearings (half day uplift),PHU,nil,true,,false
+MISC,agfs,Public interest immunity hearings (whole day uplift),PWU,nil,true,,false
+MISC,agfs,Research of very unusual or novel factual issue,RNF,nil,true,,true
+MISC,agfs,Research of very unusual or novel point of law,RNL,nil,true,,false
+MISC,agfs,Standard appearance fee uplift,SAU,nil,true,,false
+MISC,agfs,Sentence hearings,SHR,nil,true,,false
+MISC,agfs,Sentence hearings uplift,SHU,nil,true,,false
+MISC,agfs;lgfs,Special preparation fee,SPF,nil,true,,true
+MISC,agfs,Trial not proceed,TNP,nil,true,,false
+MISC,agfs,Trial not proceed uplift,TNU,nil,true,,false
+MISC,agfs,Unsuccessful application to vacate a guilty plea (half day),PAH,nil,true,,false
+MISC,agfs,Unsuccessful application to vacate a guilty plea (whole day),PAW,nil,true,,false
+MISC,agfs,Unsuccessful application to vacate a guilty plea (half day uplift),PHU,nil,true,,false
+MISC,agfs,Unsuccessful application to vacate a guilty plea (whole day uplift),PWU,nil,true,,false
+MISC,agfs,Written / oral advice,WOA,nil,true,,true
+MISC,agfs,Wasted preparation fee,WPF,nil,true,,true
+MISC,lgfs,Evidence provision fee,XEVI,,,,false
+MISC,lgfs,Costs judge application,XCJA,,,,false
+MISC,lgfs,Costs judge preparation,XCJP,,,,false
+MISC,lgfs,Case uplift,XUPL,,,,false
+GRADUATED,lgfs,Trial,GTRL,9999,false,,false
+GRADUATED,lgfs,Retrial,GRTR,9999,false,,false
+GRADUATED,lgfs,Guilty plea,GGLTY,9999,false,,false
+GRADUATED,lgfs,Discontinuance,GDIS,9999,false,,false
+GRADUATED,lgfs,Cracked trial,GCRAK,9999,false,,false
+GRADUATED,lgfs,Cracked before retrial,GCBR,9999,false,,false
+WARRANT,lgfs,Warrant Fee,XWAR,,,,false
+INTERIM,lgfs,Effective PCMH,IPCMH,,,,false
+INTERIM,lgfs,Trial start,ITST,,,,false
+INTERIM,lgfs,Retrial New solicitor,IRNS,,,,false
+INTERIM,lgfs,Retrial start,IRST,,,,false
+INTERIM,lgfs,Disbursement only,IDISO,,,,false
+INTERIM,lgfs,Warrant,IWARR,,,,false
+TRANSFER,lgfs,Transfer,TRANS,,,,false

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -67,9 +67,18 @@
       end
     end
 
+    desc 'Set fee types quantities to decimal for SPF, WPF, RNF, CAV, WOA'
+    task :set_quantity_is_decimal => :environment do
+      %w{ SPF WPF RNF CAV WOA }.each do |code|
+        recs = Fee::BaseFeeType.where(code: code)
+        recs.each { |rec| rec.update(quantity_is_decimal: true) }
+      end
+    end
+
     desc 'Run all outstanding data migrations'
     task :all => :environment do
       {
+        'set_quantity_is_decimal' => 'Set fee types quantities to decimal for SPF, WPF, RNF, CAV, WOA'
       }.each do |task, comment|
         puts comment
         Rake::Task["data:migrate:#{task}"].invoke

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -72,6 +72,7 @@
       %w{ SPF WPF RNF CAV WOA }.each do |code|
         recs = Fee::BaseFeeType.where(code: code)
         recs.each { |rec| rec.update(quantity_is_decimal: true) }
+        puts "Quantity is decimal set to TRUE for fee types #{code}"
       end
     end
 

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -137,7 +137,7 @@ describe API::V1::ExternalUsers::Fee do
         valid_params[:fee_type_id] = basic_fee_type.id
         post_to_create_endpoint
         expect(last_response.status).to eq 400
-        expect_error_response("Enter a valid rate for the initial fee",0)
+        expect_error_response("Enter a valid rate for the basic fee",0)
       end
 
       it 'misc fees should raise misc fee errors from translations' do

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 FactoryGirl.define do
@@ -20,6 +21,8 @@ FactoryGirl.define do
     code { random_safe_code }
     calculated true
     roles ['agfs']
+    quantity_is_decimal false
+
 
     trait :ppe do
       description 'Pages of prosecution evidence'
@@ -56,6 +59,12 @@ FactoryGirl.define do
         sequence(:description) { |n| "LGFS, Misc fee type, Special preparation fee - #{n}" }
         calculated false
         roles ['lgfs']
+      end
+
+      trait :spf do
+        description 'Special preparation fee'
+        code 'SPF'
+        quantity_is_decimal true
       end
     end
 

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime
@@ -47,6 +47,11 @@ FactoryGirl.define do
       rate 0
       amount 25
     end
+
+    trait :spf_fee do
+      fee_type { build :misc_fee_type, :spf }
+    end
+
   end
 
   factory :warrant_fee, class: Fee::WarrantFee do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,6 +21,7 @@
 #  last_name              :string
 #  failed_attempts        :integer          default(0), not null
 #  locked_at              :datetime
+#  unlock_token           :string
 #
 
 FactoryGirl.define do

--- a/spec/models/fee/base_fee_spec.rb
+++ b/spec/models/fee/base_fee_spec.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime
@@ -32,6 +32,8 @@ end
 
     it { should belong_to(:claim) }
     it { should have_many(:dates_attended) }
+
+    before(:each) { allow(subject).to receive(:quantity_is_decimal?).and_return(false) }
 
     describe 'blank quantity should be set to zero before validation' do
       it 'should replace blank quantities with zero before save' do
@@ -113,6 +115,7 @@ end
         end
       end
     end
+
 
   end
 

--- a/spec/models/fee/base_fee_type_spec.rb
+++ b/spec/models/fee/base_fee_type_spec.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 require 'rails_helper'
@@ -51,6 +52,17 @@ module Fee
       it 'returns false' do
         expect(build(:fixed_fee_type).requires_dates_attended?).to be false
         expect(build(:misc_fee_type).requires_dates_attended?).to be false
+      end
+    end
+
+    describe '#quanity_is_decimal?' do
+      it 'should return false' do
+        ft = build :basic_fee_type
+        expect(ft.quantity_is_decimal).to be false
+      end
+      it 'should return true' do
+        ft = build :misc_fee_type, :spf
+        expect(ft.quantity_is_decimal).to be true
       end
     end
 

--- a/spec/models/fee/basic_fee_spec.rb
+++ b/spec/models/fee/basic_fee_spec.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/spec/models/fee/basic_fee_type_spec.rb
+++ b/spec/models/fee/basic_fee_type_spec.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/fee/fixed_fee_spec.rb
+++ b/spec/models/fee/fixed_fee_spec.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/spec/models/fee/fixed_fee_type_spec.rb
+++ b/spec/models/fee/fixed_fee_type_spec.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/fee/graduated_fee_spec.rb
+++ b/spec/models/fee/graduated_fee_spec.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/spec/models/fee/interim_fee_spec.rb
+++ b/spec/models/fee/interim_fee_spec.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/spec/models/fee/misc_fee_spec.rb
+++ b/spec/models/fee/misc_fee_spec.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/spec/models/fee/misc_fee_type_spec.rb
+++ b/spec/models/fee/misc_fee_type_spec.rb
@@ -2,16 +2,17 @@
 #
 # Table name: fee_types
 #
-#  id          :integer          not null, primary key
-#  description :string
-#  code        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  max_amount  :decimal(, )
-#  calculated  :boolean          default(TRUE)
-#  type        :string
-#  roles       :string
-#  parent_id   :integer
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/fee/transfer_fee_spec.rb
+++ b/spec/models/fee/transfer_fee_spec.rb
@@ -5,7 +5,7 @@
 #  id                    :integer          not null, primary key
 #  claim_id              :integer
 #  fee_type_id           :integer
-#  quantity              :integer
+#  quantity              :decimal(, )
 #  amount                :decimal(, )
 #  created_at            :datetime
 #  updated_at            :datetime

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,6 +21,7 @@
 #  last_name              :string
 #  failed_attempts        :integer          default(0), not null
 #  locked_at              :datetime
+#  unlock_token           :string
 #
 
 require 'rails_helper'

--- a/spec/presenters/fee_presenter_spec.rb
+++ b/spec/presenters/fee_presenter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Fee::BaseFeePresenter do
       context 'valid' do
         it 'returns an integer quantity' do
           allow(fee).to receive(:valid?).and_return(true)
-          _fee_quantity = 4.0
+          fee.quantity = 4.0
           expect(presenter.quantity).to eq '4'
         end
       end

--- a/spec/presenters/fee_presenter_spec.rb
+++ b/spec/presenters/fee_presenter_spec.rb
@@ -24,6 +24,38 @@ RSpec.describe Fee::BaseFeePresenter do
     end
   end
 
+  describe '#quantity' do
+    context 'quantity  is decimal' do
+      it 'returns a decimal quantity' do
+        allow(fee).to receive(:quantity_is_decimal?).and_return(true)
+        fee.quantity = 54.769
+        expect(presenter.quantity).to eq '54.77'
+      end
+    end
+
+    context 'quantity is not decimal' do
+
+      before(:each) { allow(fee).to receive(:quantity_is_decimal?).and_return(false) }
+
+      context 'valid' do
+        it 'returns an integer quantity' do
+          allow(fee).to receive(:valid?).and_return(true)
+          _fee_quantity = 4.0
+          expect(presenter.quantity).to eq '4'
+        end
+      end
+
+      context 'invalid' do
+        it 'returns decimal quantity' do
+          allow(fee).to receive(:valid?).and_return(false)
+          allow(fee.errors[:quantity]).to receive(:include?).with('integer').and_return true
+          fee.quantity = 3.45
+          expect(presenter.quantity).to eq '3.45'
+        end
+      end
+    end
+  end
+
   describe '#amount' do
     it 'formats as currency' do
       fee.amount = 32456.3

--- a/spec/presenters/fixed_fee_presenter_spec.rb
+++ b/spec/presenters/fixed_fee_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Fee::FixedFeePresenter do
 
-  let(:fixed_fee) { instance_double(Fee::FixedFee, claim: double) }
+  let(:fixed_fee) { instance_double(Fee::FixedFee, claim: double, quantity_is_decimal?: false, errors: {:quantity => []}) }
   let(:presenter) { Fee::FixedFeePresenter.new(fixed_fee, view) }
 
   context '#rate' do

--- a/spec/presenters/graduated_fee_presenter_spec.rb
+++ b/spec/presenters/graduated_fee_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Fee::GraduatedFeePresenter do
 
-  let(:grad_fee) { instance_double(Fee::GraduatedFee, claim: double) }
+  let(:grad_fee) { instance_double(Fee::GraduatedFee, claim: double, quantity_is_decimal?: false, errors: {quantity: []}) }
   let(:presenter) { Fee::GraduatedFeePresenter.new(grad_fee, view) }
 
   context '#rate' do
@@ -15,7 +15,7 @@ describe Fee::GraduatedFeePresenter do
   context '#quantity' do
     it 'should return fee quantity' do
       expect(grad_fee).to receive(:quantity).and_return 12
-      expect(presenter.quantity).to eq 12
+      expect(presenter.quantity).to eq '12'
     end
   end
 

--- a/spec/presenters/interim_fee_presenter_spec.rb
+++ b/spec/presenters/interim_fee_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Fee::InterimFeePresenter do
 
-  let(:interim_fee) { instance_double(Fee::InterimFee, claim: double) }
+  let(:interim_fee) { instance_double(Fee::InterimFee, claim: double, quantity_is_decimal?: false, errors: { quantity: []}) }
   let(:presenter) { Fee::InterimFeePresenter.new(interim_fee, view) }
 
   context 'retrieves fields from the claim' do

--- a/spec/presenters/misc_fee_presenter_spec.rb
+++ b/spec/presenters/misc_fee_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Fee::MiscFeePresenter do
 
-  let(:misc_fee) { instance_double(Fee::MiscFee, claim: double) }
+  let(:misc_fee) { instance_double(Fee::MiscFee, claim: double, quantity_is_decimal?: false, errors: {quantity: [] }) }
   let(:presenter) { Fee::MiscFeePresenter.new(misc_fee, view) }
 
   context '#rate' do

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -14,6 +14,7 @@ describe Fee::BaseFeeValidator do
   let(:pcm_fee)    { FactoryGirl.build :basic_fee, :pcm_fee, claim: claim }
   let(:ppe_fee)    { FactoryGirl.build :basic_fee, :ppe_fee, claim: claim }
   let(:npw_fee)    { FactoryGirl.build :basic_fee, :npw_fee, claim: claim }
+  let(:spf_fee)    { FactoryGirl.build :misc_fee, :spf_fee, claim: claim }
 
   describe '#validate_claim' do
     it { should_error_if_not_present(fee, :claim, 'blank') }
@@ -51,10 +52,10 @@ describe Fee::BaseFeeValidator do
 
     context 'with quantity greater than zero' do
       it { should_be_valid_if_equal_to_value(daf_fee, :rate, 450.00) }
-      it { should_error_if_equal_to_value(baf_fee, :rate, 0.00, 'baf_invalid') }
-      it { should_error_if_equal_to_value(daf_fee, :rate, nil,  'daf_invalid') }
-      it { should_error_if_equal_to_value(daf_fee, :rate, 0.00, 'daf_invalid') }
-      it { should_error_if_equal_to_value(daf_fee, :rate, -320, 'daf_invalid') }
+      it { should_error_if_equal_to_value(baf_fee, :rate, 0.00, 'invalid') }
+      it { should_error_if_equal_to_value(daf_fee, :rate, nil,  'invalid') }
+      it { should_error_if_equal_to_value(daf_fee, :rate, 0.00, 'invalid') }
+      it { should_error_if_equal_to_value(daf_fee, :rate, -320, 'invalid') }
     end
 
     context 'with quantity of zero and a rate greater than zero' do
@@ -152,6 +153,31 @@ describe Fee::BaseFeeValidator do
 
   describe '#validate_quantity' do
 
+    context 'integer / decimal validation' do
+      context 'integer' do
+        it 'should allow integers' do
+          npw_fee.quantity = 44
+          expect(npw_fee).to be_valid
+        end
+        it 'should not allow decimals' do
+          npw_fee.quantity = 34.57
+          expect(npw_fee).not_to be_valid
+          expect(npw_fee.errors[:quantity]).to eq(['integer'])
+        end
+      end
+
+      context 'decimal' do
+        it 'should allow integers' do
+          spf_fee.quantity = 44
+          expect(spf_fee).to be_valid
+        end
+        it 'should allow decimals' do
+          spf_fee.quantity = 21.5
+          expect(spf_fee).to be_valid
+        end
+      end
+    end
+
     context 'basic fee (BAF)' do
 
       context 'when rate present' do
@@ -182,7 +208,7 @@ describe Fee::BaseFeeValidator do
         it 'should raise invalid RATE error when quantity is one' do
           baf_fee.quantity = 1
           expect(baf_fee.valid?).to be false
-          expect(baf_fee.errors[:rate]).to include('baf_invalid')
+          expect(baf_fee.errors[:rate]).to include('invalid')
         end
       end
 


### PR DESCRIPTION
Currently all fees have an integer quantity, however some of them require decimal
quanities.  This PR adds a boolean field quantity_is_decimal to the Fee::BaseFeeType record
which indicates what type of quantity the corresponding fees require.

The data migration 'rake data:migrate:set_quanitity_is_decimal' is done as part of the schema migration.
