### PR TITLE
Do not submit invalid expense fields, clear unused fields on expense type change.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,6 @@
 languages:
   Ruby: true
-  JavaScript: true
+  JavaScript: false
   PHP: true
   Python: true
 exclude_paths:

--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -104,7 +104,6 @@ moj.Modules.NewClaim = {
         .add(self.$vat_amount)
         .add(self.$distance)
         .add(self.$mileage)
-        .add(self.$mileage)
         .add(self.$hours)
         .add(self.$reason)
         .add(self.$reasonText)
@@ -141,6 +140,9 @@ moj.Modules.NewClaim = {
 
     self.$currentExpense.find('.js-expense-amount').toggleClass('first-col', !self.dataAttribute.hours);
 
+    // Clear unused fields to avoid submitting them and causing validation errors server-side
+    self.clearUnusedFields(self.$currentExpense);
+
     self.$ariaLiveRegion.children().hide().end().append('<div>Great this works</div>');
   },
 
@@ -150,6 +152,11 @@ moj.Modules.NewClaim = {
     self.$expenses.on('change', '.js-expense-reason select', function(){
       self.showHideExpenseReasonsText(this);
     });
+  },
+
+  clearUnusedFields: function(expenseGroup) {
+    expenseGroup.find('input:hidden').not('input[type="hidden"]').not('input[type="radio"]').val('');
+    expenseGroup.find('input:hidden[type="radio"]').prop("checked", false);
   },
 
   buildReasonSelectOptions : function(expenseType) {

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -71,6 +71,7 @@
         %legend
           ='Cost'
         -#  (only visible for Car Travel):
+        = f.hidden_field :mileage_rate_id, value: ''
         = f.collection_radio_buttons(:mileage_rate_id, Expense::MILEAGE_RATES.values, :id, :description) do |b|
           - b.label(class: "block-label") { b.radio_button + b.object.description }
         = validation_error_message(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")


### PR DESCRIPTION
When editing a draft and changing some of the expenses type to another one, previous filled fields remained, making some combinations to raise validation errors.

With this fix, on expense type change, we clear any unused fields so those are not sent on form submit.
