### PR TITLE
Optimize slow queries used by Geckoboard widgets.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -105,7 +105,6 @@ Lint/UselessAssignment:
     - 'app/models/claims/search.rb'
     - 'app/models/concerns/document_attachment.rb'
     - 'app/models/json_document_importer.rb'
-    - 'app/services/claim_reporter.rb'
     - 'lib/api_test_client.rb'
 
 # Offense count: 1
@@ -343,7 +342,6 @@ Style/MethodCallParentheses:
 Style/MethodCalledOnDoEndBlock:
   Exclude:
     - 'app/models/claim/base_claim.rb'
-    - 'app/services/claim_reporter.rb'
 
 # Offense count: 5
 # Cop supports --auto-correct.

--- a/app/services/claim_reporter.rb
+++ b/app/services/claim_reporter.rb
@@ -2,64 +2,59 @@ class ClaimReporter
   include ActionView::Helpers::DateHelper
 
   def authorised_in_full
-    claims = Claim::BaseClaim.non_draft
-    authorised_claims_this_month = claims.where{ authorised_at >= Time.now.beginning_of_month }.authorised
+    claims = non_draft_claims.count
+    authorised_claims_this_month = non_draft_claims.where{ authorised_at >= Time.now.beginning_of_month }.authorised.count
 
     {
-      count: authorised_claims_this_month.count,
+      count: authorised_claims_this_month,
       percentage: claims_percentage(authorised_claims_this_month, claims)
     }
   end
 
   def authorised_in_part
-    claims = Claim::BaseClaim.non_draft
-    part_authorised_claims_this_month = claims.where{ authorised_at >= Time.now.beginning_of_month }.part_authorised
+    claims = non_draft_claims.count
+    part_authorised_claims_this_month = non_draft_claims.where{ authorised_at >= Time.now.beginning_of_month }.part_authorised.count
 
     {
-      count: part_authorised_claims_this_month.count,
+      count: part_authorised_claims_this_month,
       percentage: claims_percentage(part_authorised_claims_this_month, claims)
     }
   end
 
   def rejected
-    claims = Claim::BaseClaim.non_draft
-    transitions = ClaimStateTransition.where{ (to == 'rejected') & (created_at >= Time.now.beginning_of_month) }
-    rejected_claims_this_month = transitions.map(&:claim).uniq
+    claims = non_draft_claims.count
+    rejected_claims_this_month = ClaimStateTransition.where{ (to == 'rejected') & (created_at >= Time.now.beginning_of_month) }.count('DISTINCT claim_id')
 
     {
-      count: rejected_claims_this_month.count,
+      count: rejected_claims_this_month,
       percentage: claims_percentage(rejected_claims_this_month, claims)
     }
   end
 
-  def rejected_count
-    rejected_claims = Claim::BaseClaim.where(state: 'rejected')
-    rejected_claims.count
-  end
-
-  def outstanding
-    Claim::BaseClaim.where(state: %w( allocated submitted redetermination )).order(original_submission_date: :asc)
-  end
-
-  def oldest_outstanding
-    outstanding.first
-  end
-
   def completion_rate
-    intentions = ClaimIntention.where{ created_at >= 16.weeks.ago }
-    claims = Claim::BaseClaim.non_draft.where{ created_at >= 16.weeks.ago }
+    intentions_form_id = ClaimIntention.where{ created_at >= 16.weeks.ago }.pluck(:form_id)
+    claims_form_id = non_draft_claims.where{ created_at >= 16.weeks.ago }.pluck(:form_id)
 
-    completed = claims.map(&:form_id) & intentions.map(&:form_id)
+    intentions = intentions_form_id.size
+    completed = (claims_form_id & intentions_form_id).size
 
     claims_percentage(completed, intentions)
   end
 
   def processing_times
-    processing_times = processed_claims.inject([]) do |times, claim|
-      processed_timestamp = claim.claim_state_transitions.first.created_at
-      submitted_timestamp = claim.original_submission_date
-      times << (submitted_timestamp - processed_timestamp)
-    end.sort
+    claims_map = processed_claims.where{ created_at >= 16.weeks.ago }.uniq.pluck(:id, :original_submission_date).to_h
+    claims_states = ClaimStateTransition.where(claim_id: claims_map.keys).order(created_at: :desc).pluck(:claim_id, :created_at)
+
+    timings = claims_states.map do |(claim_id, created_at)|
+      next unless claims_map.key?(claim_id)
+
+      processed_timestamp = created_at
+      submitted_timestamp = claims_map.delete(claim_id)
+
+      (processed_timestamp - submitted_timestamp)
+    end
+
+    timings.compact
   end
 
   def average_processing_time
@@ -74,16 +69,19 @@ class ClaimReporter
   private
 
   def calculate_average(collection)
-    collection.inject{ |sum, e| sum + e }.to_f / collection.size
+    collection.sum.to_f / collection.size
   end
 
   def processed_claims
     Claim::BaseClaim.caseworker_dashboard_completed
   end
 
-  def claims_percentage(percentage_claims, all_claims)
-    return 0.0 if percentage_claims.none? && all_claims.none?
+  def non_draft_claims
+    Claim::BaseClaim.non_draft
+  end
 
-    (percentage_claims.count.to_f / all_claims.count.to_f) * 100
+  def claims_percentage(subset_count, all_count)
+    return 0.0 if subset_count.zero? && all_count.zero?
+    (subset_count.to_f / all_count.to_f) * 100
   end
 end

--- a/spec/services/claim_reporter_spec.rb
+++ b/spec/services/claim_reporter_spec.rb
@@ -53,24 +53,6 @@ RSpec.describe ClaimReporter do
     end
   end
 
-  describe '#rejected_count' do
-    it 'returns a count of rejected claims' do
-      expect(subject.rejected_count).to eq(3)
-    end
-  end
-
-  describe '#outstanding' do
-    it 'returns all outstanding claims' do
-      expect(subject.outstanding).to match_array([@submitted_claim_1, @allocated_claim_1, @allocated_claim_2])
-    end
-  end
-
-  describe '#oldest_outstanding' do
-    it 'returns the oldest outstanding claim' do
-      expect(subject.oldest_outstanding).to eq(@submitted_claim_1)
-    end
-  end
-
   describe '#completion_rate' do
     before do
       create(:claim_intention, form_id: @submitted_claim_1.form_id)


### PR DESCRIPTION
A much needed optimisation has been done. Here are the results using the same database (8122 claims):

**PRE-REFACTOR**

/geckoboard_api/widgets/claims
- Completed 200 OK in 625ms

/geckoboard_api/widgets/claim_completion
- Completed 200 OK in 25602ms

/geckoboard_api/widgets/average_processing_time
- Completed 200 OK in 24384ms

**POST-REFACTOR**

/geckoboard_api/widgets/claims
- Completed 200 OK in 119ms

/geckoboard_api/widgets/claim_completion
- Completed 200 OK in 70ms

/geckoboard_api/widgets/average_processing_time
- Completed 200 OK in 350ms
