### PR TITLE
Updating VAT totals according to the rules, improving cukes to support this.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -79,7 +79,6 @@ Lint/UnusedMethodArgument:
 # Offense count: 2
 Lint/UselessAccessModifier:
   Exclude:
-    - 'app/controllers/vat_rates_controller.rb'
     - 'app/models/fee/base_fee_type.rb'
 
 # Offense count: 9
@@ -475,20 +474,6 @@ Style/SpaceAfterMethodName:
   Exclude:
     - 'app/presenters/claim/base_claim_presenter.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/SpaceAfterSemicolon:
-  Exclude:
-    - 'app/models/vat_rate.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleInsidePipes, SupportedStyles.
-# SupportedStyles: space, no_space
-Style/SpaceAroundBlockParameters:
-  Exclude:
-    - 'app/models/vat_rate.rb'
-
 # Offense count: 36
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
@@ -530,7 +515,6 @@ Style/SpaceBeforeBlockBraces:
 Style/SpaceBeforeComma:
   Exclude:
     - 'app/interfaces/api/v1/external_users/claim.rb'
-    - 'app/models/determination.rb'
 
 # Offense count: 16
 # Cop supports --auto-correct.
@@ -576,7 +560,6 @@ Style/SpaceInsideParens:
     - 'app/controllers/case_workers/admin/allocations_controller.rb'
     - 'app/interfaces/api/v1/api_helper.rb'
     - 'app/models/claims/state_machine.rb'
-    - 'app/models/determination.rb'
     - 'app/presenters/claim/base_claim_presenter.rb'
     - 'app/validators/claim/base_claim_validator.rb'
     - 'lib/api_test_client.rb'

--- a/app/controllers/vat_rates_controller.rb
+++ b/app/controllers/vat_rates_controller.rb
@@ -63,7 +63,7 @@ class VatRatesController < ApplicationController
 
   def vat_amount
     if agfs?
-      apply_vat ? VatRate.vat_amount(net_amount, date) : 0
+      VatRate.vat_amount(net_amount, date, calculate: apply_vat)
     else
       lgfs_vat_amount
     end
@@ -84,8 +84,6 @@ class VatRatesController < ApplicationController
   def number_to_currency(number)
     ActionController::Base.helpers.number_to_currency(number)
   end
-
-private
 
   def agfs?
     scheme == 'agfs'

--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -42,12 +42,12 @@ module Claims::Calculations
     if lgfs?
       Expense.where(claim_id: self.id).pluck(:vat_amount).sum
     else
-      VatRate.vat_amount(calculate_expenses_total, self.vat_date)
+      VatRate.vat_amount(calculate_expenses_total, self.vat_date, calculate: self.apply_vat?)
     end
   end
 
   def calculate_fees_vat
-    VatRate.vat_amount(calculate_fees_total, self.vat_date)
+    VatRate.vat_amount(calculate_fees_total, self.vat_date, calculate: self.apply_vat?)
   end
 
   def calculate_disbursements_vat
@@ -61,12 +61,7 @@ module Claims::Calculations
 
   def update_vat
     update_column(:apply_vat, self.vat_registered?) if self.vat_registered?
-
-    if self.apply_vat?
-      update_column(:vat_amount, calculate_total_vat)
-    else
-      update_column(:vat_amount, 0.0)
-    end
+    update_column(:vat_amount, calculate_total_vat)
   end
 
 end

--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -28,17 +28,17 @@ class Determination < ActiveRecord::Base
 
 
   def calculate_total
-    self.total = [self.fees || 0.0, self.expenses || 0.0 , self.disbursements || 0.0].sum
+    self.total = [self.fees || 0.0, self.expenses || 0.0, self.disbursements || 0.0].sum
   end
 
   def calculate_vat
     if self.claim.is_a? Claim::AdvocateClaim
-      self.vat_amount = VatRate.vat_amount(self.total, self.claim.vat_date).round(2) if self.claim.apply_vat?
+      self.vat_amount = VatRate.vat_amount(self.total, self.claim.vat_date, calculate: self.claim.apply_vat?).round(2)
     end
   end
 
   def total_including_vat
-    (self.total || 0 ) + (self.vat_amount || 0)
+    (self.total || 0) + (self.vat_amount || 0)
   end
 
   def blank?

--- a/app/models/vat_rate.rb
+++ b/app/models/vat_rate.rb
@@ -18,7 +18,7 @@
 #
 class VatRate < ActiveRecord::Base
 
-  class MissingVatRateError < RuntimeError;end
+  class MissingVatRateError < RuntimeError; end
 
   validates :effective_date, uniqueness: true
 
@@ -28,8 +28,8 @@ class VatRate < ActiveRecord::Base
     end
 
     # Calculate VAT amount for amount_excluding_vat on a given date
-    def vat_amount(amount_excluding_vat, date)
-      rate = VatRate.for_date(date)
+    def vat_amount(amount_excluding_vat, date, calculate: true)
+      rate = calculate ? VatRate.for_date(date) : 0
       (amount_excluding_vat * rate / 10000.0).round(2)
     end
 
@@ -50,7 +50,7 @@ class VatRate < ActiveRecord::Base
 
     def rate_for_date(date)
       result = nil
-      rates.each do | rec |
+      rates.each do |rec|
         unless date < rec.effective_date
           result = rec
           break

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -55,4 +55,4 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     When I click View your claims
     Then I should be on the your claims page
-    And Claim 'A12345678' should be listed with a status of 'Submitted' and a claimed amount of '£433.62'
+    And Claim 'A12345678' should be listed with a status of 'Submitted' and a claimed amount of '£464.12'

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -53,4 +53,4 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     When I click View your claims
     Then I should be on the your claims page
-    And Claim 'A12345678' should be listed with a status of 'Submitted' and a claimed amount of '£589.99'
+    And Claim 'A12345678' should be listed with a status of 'Submitted' and a claimed amount of '£620.49'

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -23,17 +23,20 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
 
     And I fill '100.75' as the fixed fee total
     And I enter the fixed fee date
-    Then I should see the sidebar total '£100.75'
+    Then I should see in the sidebar total '£100.75'
+    Then I should see in the sidebar vat total '£0.00'
 
-    And I add an expense 'Parking' with invalid date
-    Then I should see the sidebar total '£135.31'
+    And I add an expense 'Parking' with total '99.25' and VAT '15.50' with invalid date
+    Then I should see in the sidebar total '£215.50'
+    Then I should see in the sidebar vat total '£15.50'
 
     Then I click "Continue" in the claim form
 
     Then I should see the error 'Expense 1 date invalid date'
-    And I should see the sidebar total '£135.31'
-    And I enter the date for the first expense '2016-01-02'
+    And I should see in the sidebar total '£215.50'
+    Then I should see in the sidebar vat total '£15.50'
 
+    And I enter the date for the first expense '2016-01-02'
     Then I click "Continue" in the claim form
 
     And I should be on the check your claim page

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -62,4 +62,4 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     When I click View your claims
     Then I should be on the your claims page
-    And Claim 'A12345678' should be listed with a status of 'Submitted' and a claimed amount of '£610.95'
+    And Claim 'A12345678' should be listed with a status of 'Submitted' and a claimed amount of '£643.45'

--- a/features/page_objects/sections/expense_section.rb
+++ b/features/page_objects/sections/expense_section.rb
@@ -1,9 +1,16 @@
 class ExpenseSection < SitePrism::Section
+  #
+  # TODO: Fix this.
+  # This will only work for 1 expense. If there are more than 1 expense,
+  # it will always populate the first expense, because the way we are referencing
+  # the elements by ID pointing to the first (zero-index) one.
+  #
   element :expense_type_dropdown, "#claim_expenses_attributes_0_expense_type_id"
   element :destination, "#claim_expenses_attributes_0_location"
   element :quantity, "#claim_expenses_attributes_0_distance"
   element :reason_for_travel_dropdown, "#claim_expenses_attributes_0_reason_id"
   element :amount, "#claim_expenses_attributes_0_amount"
+  element :vat_amount, "#claim_expenses_attributes_0_vat_amount"
 
   section :expense_date, "fieldset#expense_1_date" do
     include DateHelper

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -56,6 +56,7 @@ end
 When(/^I add another defendant, representation order and MAAT reference$/) do
   using_wait_time 3 do
     @claim_form_page.add_another_defendant.click
+    wait_for_ajax
     @claim_form_page.defendants.last.first_name.set "Ned"
     @claim_form_page.defendants.last.last_name.set "Kelly"
     @claim_form_page.defendants.last.dob.set_date "1912-12-12"
@@ -67,6 +68,7 @@ When(/^I add another defendant, representation order and MAAT reference$/) do
 end
 
 When(/^I add a basic fee with dates attended$/) do
+  wait_for_ajax
   @claim_form_page.initial_fees.basic_fee.quantity.set "1"
   @claim_form_page.initial_fees.basic_fee.rate.set "3.45"
   # @claim_form_page.initial_fees.basic_fee.add_dates.click
@@ -96,25 +98,6 @@ When(/^I add a fixed fee '(.*?)'$/) do |name|
   @claim_form_page.fixed_fees.last.select_fee_type name
   @claim_form_page.fixed_fees.last.quantity.set 1
   @claim_form_page.fixed_fees.last.rate.set "12.34"
-end
-
-When(/^I add an expense '(.*?)'( with invalid date)?$/) do |name, invalid_date|
-  @claim_form_page.expenses.last.expense_type_dropdown.select name
-  if name == 'Hotel accommodation'
-    @claim_form_page.expenses.last.destination.set 'Liverpool'
-  end
-  @claim_form_page.expenses.last.reason_for_travel_dropdown.select 'View of crime scene'
-  @claim_form_page.expenses.last.amount.set '34.56'
-
-  if invalid_date.present?
-    @claim_form_page.expenses.last.expense_date.set_invalid_date
-  else
-    @claim_form_page.expenses.last.expense_date.set_date '2016-01-02'
-  end
-end
-
-And(/^I enter the date for the (\w+) expense '(.*?)'$/) do |ordinal, date|
-  @claim_form_page.expenses.send(ordinal.to_sym).expense_date.set_date date
 end
 
 When(/^I upload (\d+) documents?$/) do |count|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -97,8 +97,14 @@ Then(/^I should see the error '(.*?)'$/) do |error_message|
   end
 end
 
-And(/^I should see the sidebar total '(.*?)'$/) do |total|
+And(/^I should see in the sidebar total '(.*?)'$/) do |total|
   within('div.totals-summary') do
     expect(page.find('span.total-grandTotal')).to have_content(total)
+  end
+end
+
+And(/^I should see in the sidebar vat total '(.*?)'$/) do |total|
+  within('div.totals-summary') do
+    expect(page.find('span.total-vat')).to have_content(total)
   end
 end

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -52,3 +52,25 @@ end
 And(/^I enter the fixed fee date$/) do
   @litigator_claim_form_page.fixed_fee_date.set_date "2016-01-01"
 end
+
+When(/^I add an expense '(.*?)'(?: with total '(.*?)')?(?: and VAT '(.*?)')?( with invalid date)?$/) do |name, total, vat, invalid_date|
+  @claim_form_page.expenses.last.expense_type_dropdown.select name
+
+  if name == 'Hotel accommodation'
+    @claim_form_page.expenses.last.destination.set 'Liverpool'
+  end
+  @claim_form_page.expenses.last.reason_for_travel_dropdown.select 'View of crime scene'
+
+  @claim_form_page.expenses.last.amount.set(total || '34.56')
+  @claim_form_page.expenses.last.vat_amount.set(vat) if vat.present?
+
+  if invalid_date.present?
+    @claim_form_page.expenses.last.expense_date.set_invalid_date
+  else
+    @claim_form_page.expenses.last.expense_date.set_date '2016-01-02'
+  end
+end
+
+And(/^I enter the date for the (\w+) expense '(.*?)'$/) do |ordinal, date|
+  @claim_form_page.expenses.send(ordinal.to_sym).expense_date.set_date date
+end

--- a/spec/models/vat_rate_spec.rb
+++ b/spec/models/vat_rate_spec.rb
@@ -61,7 +61,6 @@ describe VatRate do
 
   describe '.vat_amount' do
     context '22.25% VAT' do
-
       it 'should return 25.75 for 115.75' do
         vat_amount = VatRate.vat_amount(BigDecimal.new("115.75"), 6.months.ago)
         expect(vat_amount).to eq 25.75
@@ -70,6 +69,11 @@ describe VatRate do
       it 'should return 25.76 for 115.76' do
         vat_amount = VatRate.vat_amount(BigDecimal.new("115.76"), 6.months.ago)
         expect(vat_amount).to eq 25.76
+      end
+
+      it 'should return 0 when calculate option is false' do
+        vat_amount = VatRate.vat_amount(BigDecimal.new("100.00"), 6.months.ago, calculate: false)
+        expect(vat_amount).to eq 0.0
       end
     end
   end


### PR DESCRIPTION
**PT#120431811**

VAT totals were not being updated on the backend when **apply_vat** was false on the claim, but some of them (like expenses or disbursements) need to be calculated even if apply_vat as a whole is false.

This fixes the problem.
