### PR TITLE
Add disbursements to api

### DIFF
--- a/app/interfaces/api/v1/api_helper.rb
+++ b/app/interfaces/api/v1/api_helper.rb
@@ -136,7 +136,7 @@ module API
 
         # prevent creation/basic-fee-update of sub(sub)models for claims not in a draft state
         def test_editability(model_instance)
-          if [ Fee::BasicFee, Fee::MiscFee, Fee::FixedFee, Expense, Defendant, RepresentationOrder, DateAttended ].include?(model_instance.class)
+          if [ Fee::BasicFee, Fee::MiscFee, Fee::FixedFee, Expense, Disbursement, Defendant, RepresentationOrder, DateAttended ].include?(model_instance.class)
             model_instance.errors.add(:base, 'uneditable_state') unless model_instance.claim.editable? rescue true
           end
         end

--- a/app/interfaces/api/v1/api_helper.rb
+++ b/app/interfaces/api/v1/api_helper.rb
@@ -110,7 +110,6 @@ module API
           end
 
           test_editability(model_instance)
-
           if model_instance.errors.present?
             pop_error_response(model_instance, api_response)
           elsif model_instance.valid?

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -115,6 +115,14 @@ module API
         end
       end
 
+      resource :disbursement_types do
+        desc "Return all Disbursement Types."
+        params { use :api_key_params }
+        get do
+          ::DisbursementType.all
+        end
+      end
+
     end
   end
 end

--- a/app/interfaces/api/v1/error_response.rb
+++ b/app/interfaces/api/v1/error_response.rb
@@ -20,7 +20,7 @@ class ErrorResponse
   attr :body
   attr :status
 
-  VALID_MODEL_KLASSES = [Fee::GraduatedFee, Fee::BasicFee, Fee::MiscFee, Fee::FixedFee, Expense, Claim::AdvocateClaim, Defendant, DateAttended, RepresentationOrder]
+  VALID_MODEL_KLASSES = [Fee::GraduatedFee, Fee::BasicFee, Fee::MiscFee, Fee::FixedFee, Expense, Disbursement, Claim::AdvocateClaim, Defendant, DateAttended, RepresentationOrder]
 
   def initialize(object)
     @error_messages = []

--- a/app/interfaces/api/v1/external_users/disbursement.rb
+++ b/app/interfaces/api/v1/external_users/disbursement.rb
@@ -1,0 +1,66 @@
+module API
+  module V1
+    module ExternalUsers
+
+      class Disbursement < GrapeApiHelper
+
+        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
+        format :json
+        prefix 'api/external_users'
+        content_type :json, 'application/json'
+
+        resource :disbursements, desc: 'Create or Validate' do
+
+          helpers do
+            params :disbursement_params do
+              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+              optional :api_key,              type: String,  desc: "REQUIRED: The API authentication key of the provider"
+              optional :claim_id,             type: String,  desc: "REQUIRED: Unique identifier for the claim associated with this disbursement."
+              optional :disbursement_type_id, type: Integer, desc: "REQUIRED: The unique identifier for the corresponding disbursement type."
+              optional :net_amount,           type: Float,   desc: "REQUIRED: The net amount of the disbursement."
+              optional :vat_amount,           type: Float,   desc: "REQUIRED: The VAT amount of the disbursement."
+              optional :total,                type: Float,   desc: "REQUIRED: The total amount of the disbursement."
+            end
+
+            def build_arguments
+              {
+                claim_id: ::Claim::BaseClaim.find_by(uuid: params[:claim_id]).try(:id),
+                disbursement_type_id: params[:disbursement_type_id],
+                net_amount: params[:net_amount],
+                vat_amount: params[:vat_amount],
+                total: params[:total]
+              }
+            end
+          end
+
+          desc "Create a disbursement."
+
+          params do
+            use :disbursement_params
+          end
+
+          post do
+            api_response = ApiResponse.new()
+            ApiHelper.create_resource(::Disbursement, params, api_response, method(:build_arguments).to_proc)
+            status api_response.status
+            return api_response.body
+          end
+
+          desc "Validate a disbursement."
+
+          params do
+            use :disbursement_params
+          end
+
+          post '/validate' do
+            api_response = ApiResponse.new()
+            ApiHelper.validate_resource(::Disbursement, params, api_response, method(:build_arguments).to_proc)
+            status api_response.status
+            return api_response.body
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v1/external_users/expense.rb
+++ b/app/interfaces/api/v1/external_users/expense.rb
@@ -15,7 +15,7 @@ module API
             params :expense_params do
               # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
               optional :api_key, type: String,          desc: "REQUIRED: The API authentication key of the provider"
-              optional :claim_id, type: String,         desc: "REQUIRED: Unique identifier for the claim associated with this defendant."
+              optional :claim_id, type: String,         desc: "REQUIRED: Unique identifier for the claim associated with this expense."
               optional :expense_type_id, type: Integer, desc: "REQUIRED: The unique identifier for the corresponding expense type."
               optional :amount, type: Float,            desc: "REQUIRED: The total amount of the expense."
               optional :location, type:  String,        desc: "REQUIRED for all expense types other than Parking. Location or destination."

--- a/app/interfaces/api/v1/external_users/root.rb
+++ b/app/interfaces/api/v1/external_users/root.rb
@@ -19,10 +19,11 @@ module API
 
         mount API::V1::ExternalUsers::Claim
         mount API::V1::ExternalUsers::Defendant
+        mount API::V1::ExternalUsers::RepresentationOrder
         mount API::V1::ExternalUsers::Fee
         mount API::V1::ExternalUsers::Expense
+        mount API::V1::ExternalUsers::Disbursement
         mount API::V1::ExternalUsers::DateAttended
-        mount API::V1::ExternalUsers::RepresentationOrder
         mount API::V1::DropdownData
 
         add_swagger_documentation(

--- a/app/validators/disbursement_validator.rb
+++ b/app/validators/disbursement_validator.rb
@@ -16,6 +16,7 @@ class DisbursementValidator < BaseValidator
 
   def validate_claim
     validate_presence(:claim, 'blank')
+    add_error(:claim,'invalid_fee_scheme') if (@record.claim.agfs? rescue false)
   end
 
   def validate_disbursement_type

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1209,9 +1209,9 @@ disbursement:
 
   claim:
     invalid_fee_scheme:
-      long: 'Claim is of an inaapropriate fee scheme type for the #{disbursement}'
+      long: 'Claim is of an inappropriate fee scheme type for the #{disbursement}'
       short: Inappropriate fee scheme
-      api: Claim is of an inaapropriate fee scheme type for the disbursement
+      api: Claim is of an inappropriate fee scheme type for the disbursement
 
   disbursement_type:
     _seq: 10

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1207,6 +1207,12 @@ disbursement:
       short: You cannot edit this claim
       api: You cannot edit a claim that is not in draft state
 
+  claim:
+    invalid_fee_scheme:
+      long: 'Claim is of an inaapropriate fee scheme type for the #{disbursement}'
+      short: Inappropriate fee scheme
+      api: Claim is of an inaapropriate fee scheme type for the disbursement
+
   disbursement_type:
     _seq: 10
     blank:

--- a/db/migrate/20160607120655_add_uuid_to_disbursements.rb
+++ b/db/migrate/20160607120655_add_uuid_to_disbursements.rb
@@ -1,0 +1,5 @@
+class AddUuidToDisbursements < ActiveRecord::Migration
+  def change
+    add_column :disbursements, :uuid, :uuid, default: 'uuid_generate_v4()', index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160527102644) do
+ActiveRecord::Schema.define(version: 20160607120655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -215,6 +215,7 @@ ActiveRecord::Schema.define(version: 20160527102644) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.decimal  "total",                default: 0.0
+    t.uuid     "uuid",                 default: "uuid_generate_v4()"
   end
 
   add_index "disbursements", ["claim_id"], name: "index_disbursements_on_claim_id", using: :btree

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -15,6 +15,7 @@ describe API::V1::DropdownData do
   OFFENCE_ENDPOINT            = "/api/offences"
   FEE_TYPE_ENDPOINT           = "/api/fee_types"
   EXPENSE_TYPE_ENDPOINT       = "/api/expense_types"
+  DISBURSEMENT_TYPE_ENDPOINT  = "/api/disbursement_types"
 
   ALL_DROPDOWN_ENDPOINTS       = [CASE_TYPE_ENDPOINT, COURT_ENDPOINT, ADVOCATE_CATEGORY_ENDPOINT, CRACKED_THIRD_ENDPOINT, OFFENCE_CLASS_ENDPOINT, OFFENCE_ENDPOINT, FEE_TYPE_ENDPOINT, EXPENSE_TYPE_ENDPOINT]
   FORBIDDEN_DROPDOWN_VERBS     = [:post, :put, :patch, :delete]
@@ -46,7 +47,8 @@ describe API::V1::DropdownData do
                         OFFENCE_CLASS_ENDPOINT => OffenceClass.all.to_json,
                         OFFENCE_ENDPOINT => Offence.all.to_json,
                         FEE_TYPE_ENDPOINT => Fee::BaseFeeType.all.to_json,
-                        EXPENSE_TYPE_ENDPOINT => ExpenseType.all_with_reasons.to_json
+                        EXPENSE_TYPE_ENDPOINT => ExpenseType.all_with_reasons.to_json,
+                        DISBURSEMENT_TYPE_ENDPOINT => DisbursementType.all.to_json
                       }
                     }
 
@@ -57,6 +59,7 @@ describe API::V1::DropdownData do
       create_list(:offence, 2)
       create_list(:basic_fee_type, 2)
       create_list(:expense_type, 2)
+      create_list(:disbursement_type, 2)
     end
 
     it "should return a JSON formatted list of the required information" do

--- a/spec/api/v1/external_users/disbursement_spec.rb
+++ b/spec/api/v1/external_users/disbursement_spec.rb
@@ -16,8 +16,8 @@ describe API::V1::ExternalUsers::Disbursement do
 
   let(:parsed_body) { JSON.parse(last_response.body) }
 
-  let!(:provider)            { create(:provider) }
-  let!(:claim)               { create(:claim, source: 'api').reload }
+  let!(:provider)           { create(:provider) }
+  let!(:claim)              { create(:litigator_claim, source: 'api').reload }
   let!(:disbursement_type)  { create(:disbursement_type) }
 
   let!(:params) do
@@ -176,11 +176,11 @@ describe API::V1::ExternalUsers::Disbursement do
     end
 
     context 'AGFS claims' do
-      before { allow(claim).to receive(:agfs?).and_return true }
+      let(:claim)              { create(:advocate_claim, source: 'api').reload }
       it 'should return 400 and JSON error array' do
         post_to_validate_endpoint
         expect(last_response.status).to eq 400
-        expect(last_response.body).to eq "[{\"error\":\"Claim is of an inaapropriate fee scheme type for the disbursement\"}]"
+        expect(last_response.body).to eq "[{\"error\":\"Claim is of an inappropriate fee scheme type for the disbursement\"}]"
       end
     end
   end

--- a/spec/api/v1/external_users/disbursement_spec.rb
+++ b/spec/api/v1/external_users/disbursement_spec.rb
@@ -1,0 +1,188 @@
+require 'rails_helper'
+require 'spec_helper'
+require_relative 'api_spec_helper'
+require_relative 'shared_examples_for_all'
+
+describe API::V1::ExternalUsers::Disbursement do
+
+  include Rack::Test::Methods
+  include ApiSpecHelper
+
+  CREATE_DISBURSEMENT_ENDPOINT = "/api/external_users/disbursements"
+  VALIDATE_DISBURSEMENT_ENDPOINT = "/api/external_users/disbursements/validate"
+
+  ALL_DISBURSEMENT_ENDPOINTS = [VALIDATE_DISBURSEMENT_ENDPOINT, CREATE_DISBURSEMENT_ENDPOINT]
+  FORBIDDEN_DISBURSEMENT_VERBS = [:get, :put, :patch, :delete]
+
+  let(:parsed_body) { JSON.parse(last_response.body) }
+
+  let!(:provider)            { create(:provider) }
+  let!(:claim)               { create(:claim, source: 'api').reload }
+  let!(:disbursement_type)  { create(:disbursement_type) }
+
+  let!(:params) do
+    {
+      api_key: provider.api_key,
+      claim_id: claim.uuid,
+      disbursement_type_id: disbursement_type.id,
+      net_amount: 100.01,
+      vat_amount: 17.51,
+      total: 117.51
+    }
+  end
+
+  let(:json_error_response) do
+    [
+      {"error" => "Choose a type for the disbursement"},
+      {"error" => "Enter a net amount for the disbursement"},
+      {"error" => "Enter a VAT amount for the disbursement"},
+      {"error" => "Enter a total amount for the disbursement"}
+    ].to_json
+  end
+
+  context 'sending non-permitted verbs' do
+    ALL_DISBURSEMENT_ENDPOINTS.each do |endpoint| # for each endpoint
+      context "to endpoint #{endpoint}" do
+        FORBIDDEN_DISBURSEMENT_VERBS.each do |api_verb| # test that each FORBIDDEN_VERB returns 405
+          it "#{api_verb.upcase} should return a status of 405" do
+            response = send api_verb, endpoint, format: :json
+            expect(response.status).to eq 405
+          end
+        end
+      end
+    end
+  end
+
+  # Constant so we can refer to it outside of "it" blocks
+  FIELDS_AND_ERRORS = {
+    claim_id: "Claim cannot be blank",
+    disbursement_type_id: "Choose a type for the disbursement",
+    net_amount: "Enter a net amount for the disbursement",
+    vat_amount: "Enter a VAT amount for the disbursement"
+    # total: "Enter a total amount for the disbursement", # SET to zero by model if absent
+  }
+
+  describe "POST #{CREATE_DISBURSEMENT_ENDPOINT}" do
+
+    def post_to_create_endpoint
+      post CREATE_DISBURSEMENT_ENDPOINT, params, format: :json
+    end
+
+    include_examples "should NOT be able to amend a non-draft claim"
+
+    context 'when disbursement params are valid' do
+      it "should create disbursement, return 201 and disbursement JSON output including UUID" do
+        post_to_create_endpoint
+        expect(last_response.status).to eq 201
+        json = JSON.parse(last_response.body)
+        expect(json['id']).not_to be_nil
+        expect(Disbursement.find_by(uuid: json['id']).uuid).to eq(json['id'])
+        expect(Disbursement.find_by(uuid: json['id']).claim.uuid).to eq(json['claim_id'])
+      end
+
+      it "should create one new disbursement" do
+        expect{ post_to_create_endpoint }.to change { Disbursement.count }.by(1)
+      end
+
+      it "should create a new record using the params provided" do
+        post_to_create_endpoint
+        new_disbursement = Disbursement.last
+        expect(new_disbursement.claim_id).to eq claim.id
+        expect(new_disbursement.disbursement_type_id).to eq disbursement_type.id
+      end
+    end
+
+    context 'when disbursement params are invalid' do
+      context 'invalid API key' do
+        let(:valid_params) { params }
+        include_examples "invalid API key create endpoint"
+      end
+
+      context "missing expected params" do
+        FIELDS_AND_ERRORS.each do |field, expected_message|
+          it "should give the correct error message when #{field} is blank" do
+            params.delete(field)
+            post_to_create_endpoint
+            expect(last_response.status).to eq 400
+            expect(parsed_body.first).to eq({"error" => expected_message})
+          end
+        end
+      end
+
+      context "unexpected error" do
+        it "should return 400 and JSON error array of error message" do
+          allow_any_instance_of(Disbursement).to receive(:save!).and_raise(RangeError, "out of range for ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer")
+          post_to_create_endpoint
+          expect(last_response.status).to eq(400)
+          json = JSON.parse(last_response.body)
+          expect(json[0]['error']).to include("out of range for ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer")
+        end
+      end
+
+      context 'invalid claim id' do
+        it 'should return 400 and a JSON error array' do
+          params[:claim_id] = SecureRandom.uuid
+          post_to_create_endpoint
+          expect(last_response.status).to eq 400
+          expect(last_response.body).to eq "[{\"error\":\"Claim cannot be blank\"}]"
+        end
+      end
+
+      context "malformed claim UUID" do
+        it "should reject invalid uuids" do
+          params[:claim_id] = 'any-old-rubbish'
+          post_to_create_endpoint
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to eq "[{\"error\":\"Claim cannot be blank\"}]"
+        end
+      end
+    end
+
+  end
+
+  describe "POST #{VALIDATE_DISBURSEMENT_ENDPOINT}" do
+    def post_to_validate_endpoint
+      post VALIDATE_DISBURSEMENT_ENDPOINT, params, format: :json
+    end
+
+    it 'valid requests should return 200 and String true' do
+      post_to_validate_endpoint
+      expect(last_response.status).to eq 200
+      json = JSON.parse(last_response.body)
+      expect(json).to eq({ "valid" => true })
+    end
+
+    context 'invalid API key' do
+      let(:valid_params) { params }
+      include_examples "invalid API key validate endpoint"
+    end
+
+    context "missing expected params" do
+      FIELDS_AND_ERRORS.each do |field, expected_message|
+        it "should give the correct error message when #{field} is blank" do
+          params.delete(field)
+          post_to_validate_endpoint
+          expect(last_response.status).to eq 400
+          expect(parsed_body.first).to eq({"error" => expected_message})
+        end
+      end
+    end
+
+    it 'invalid claim id should return 400 and a JSON error array' do
+      params[:claim_id] = SecureRandom.uuid
+      post_to_validate_endpoint
+      expect(last_response.status).to eq 400
+      expect(last_response.body).to eq "[{\"error\":\"Claim cannot be blank\"}]"
+    end
+
+    context 'AGFS claims' do
+      before { allow(claim).to receive(:agfs?).and_return true }
+      it 'should return 400 and JSON error array' do
+        post_to_validate_endpoint
+        expect(last_response.status).to eq 400
+        expect(last_response.body).to eq "[{\"error\":\"Claim is of an inaapropriate fee scheme type for the disbursement\"}]"
+      end
+    end
+  end
+
+end

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -16,5 +16,12 @@ FactoryGirl.define do
       end
       after(:create) { |c| c.submit! }
     end
+
+    trait :without_fees do
+      after(:build) do |claim|
+        claim.fees.destroy_all
+      end
+    end
+
   end
 end

--- a/spec/factories/disbursement_types.rb
+++ b/spec/factories/disbursement_types.rb
@@ -10,6 +10,47 @@
 
 FactoryGirl.define do
   factory :disbursement_type do
-    sequence(:name) { |n| "#{Faker::Lorem.word}-#{n}" }
+    sequence(:name) { |n| "Disbursment type, #{random_description} - #{n}" }
   end
+end
+
+def random_description
+  disbursement_descriptions.sample
+end
+
+def disbursement_descriptions
+  [
+    'Accident reconstruction report',
+    'Accounts',
+    'Computer experts',
+    'Consultant medical reports',
+    'Costs judge application fee',
+    'Costs judge preparation award',
+    'DNA testing',
+    'Engineer',
+    'Enquiry agents',
+    'Facial mapping expert',
+    'Financial expert',
+    'Fingerprint expert',
+    'Fire assessor/explosives expert',
+    'Forensic scientists',
+    'Handwriting expert',
+    'Interpreter',
+    'Lip readers',
+    'Medical expert',
+    'Memorandum of conviction fee',
+    'Meteorologist',
+    'Other',
+    'Overnight expenses',
+    'Pathologist',
+    'Photocopying',
+    'Psychiatric reports',
+    'Psychological report',
+    'Surveyor/architect',
+    'Transcripts',
+    'Translator',
+    'Travel costs',
+    'Vet report',
+    'Voice recognition'
+  ]
 end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Claims::Cloner, type: :model do
         expense.dates_attended << create(:date_attended)
       end
 
-      claim.disbursements << create(:disbursement)
+      create(:disbursement, claim: claim)
       create(:redetermination, claim: claim)
 
       claim.documents << create(:document, :verified)

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Disbursement, type: :model do
 
   describe 'update claim totals' do
     before :all do
-      @claim = create(:claim, :without_fees)
+      @claim = create(:litigator_claim, :without_fees, apply_vat: true)
 
       [[5.0, 1.5], [3.0, 1.0]].each do |net, vat|
         create(:disbursement, claim: @claim, net_amount: net, vat_amount: vat)

--- a/spec/validators/disbursement_validator_spec.rb
+++ b/spec/validators/disbursement_validator_spec.rb
@@ -9,10 +9,26 @@ describe DisbursementValidator do
   let(:disbursement)  { FactoryGirl.build :disbursement, claim: claim }
 
   describe '#validate_claim' do
+
     it { should_error_if_not_present(disbursement, :claim, 'blank') }
+    
+    context "AGFS claims" do
+      before { allow(claim).to receive(:agfs?).and_return true }
+      it 'should raise invalid fee scheme error' do
+        expect(disbursement).to_not be_valid
+        expect(disbursement.errors[:claim]).to include 'invalid_fee_scheme'
+      end
+    end
+
+    context "LGFS claims" do
+      before { allow(claim).to receive(:agfs?).and_return false }
+      it 'should NOT raise invalid fee scheme error' do
+        expect(disbursement).to be_valid
+      end
+    end
   end
 
-  describe '#validate_expense_type' do
+  describe '#validate_disbursement_type' do
     it { should_error_if_not_present(disbursement, :disbursement_type, 'blank') }
   end
 
@@ -34,5 +50,6 @@ describe DisbursementValidator do
       it { should_error_if_equal_to_value(disbursement, :vat_amount, 10, 'greater_than') }
     end
   end
+
 end
 

--- a/spec/validators/disbursement_validator_spec.rb
+++ b/spec/validators/disbursement_validator_spec.rb
@@ -5,7 +5,7 @@ describe DisbursementValidator do
 
   include ValidationHelpers
 
-  let(:claim)         { FactoryGirl.build :claim, force_validation: true }
+  let(:claim)         { FactoryGirl.build :litigator_claim, force_validation: true }
   let(:disbursement)  { FactoryGirl.build :disbursement, claim: claim }
 
   describe '#validate_claim' do

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -75,7 +75,6 @@ describe Fee::BaseFeeValidator do
     # TODO: to be removed after gamma/private beta claims archived/deleted
     # context 'for fees entered before rate was reintroduced' do
     #   it 'should NOT require a rate of more than zero' do
-    #     byebug
     #     fee.amount = 255
     #     fee.rate = nil
     #     expect(fee).to be_valid


### PR DESCRIPTION
Includes:
- disbursement types lookup data GET endpoint
- disbursement creation/validation POST endpoint 
- validation on disbursement model to prevent creation of disbursements on AGFS claims.
- migration to add UUID column to disbursement (for return to API consumer)
