### PR TITLE
Sort claims without last_submitted_at dates be id asc

### DIFF
--- a/app/models/claims/sort.rb
+++ b/app/models/claims/sort.rb
@@ -43,7 +43,7 @@ module Claims::Sort
   end
 
   def sort_submitted_at(direction)
-    order("last_submitted_at #{direction} #{nulls_at_top_asc(direction)}")
+    order("last_submitted_at #{direction} #{nulls_at_top_asc(direction)}, id desc")
   end
 
   def sort_advocates(direction)

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
 
           it 'should assign claims to dashboard displayable state claims for all members of the provder' do
             get :index
-            expect(assigns(:claims)).to eq(litigator_admin.provider.claims_created.dashboard_displayable_states)
+            expect(assigns(:claims)).to eq(litigator_admin.provider.claims_created.dashboard_displayable_states.order('last_submitted_at asc NULLS FIRST, id desc'))
           end
         end
       end


### PR DESCRIPTION
The "Your claims" view was sorting claims by last submitted date ascending, with draft claims (which don't have a last submitted date) at the top in whatever order the database decided to return them.  This ensures that the draft claims are returned in id desc sequence, i.e. most recently created at the top.

PT: https://www.pivotaltracker.com/story/show/121144759
