### PR TITLE
Validate earliest permitted repo date for interim claims.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -411,7 +411,6 @@ Style/ParallelAssignment:
 Style/ParenthesesAroundCondition:
   Exclude:
     - 'app/services/claims/case_worker_claim_updater.rb'
-    - 'app/validators/representation_order_validator.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -427,7 +426,6 @@ Style/RedundantParentheses:
   Exclude:
     - 'app/controllers/case_workers/admin/allocations_controller.rb'
     - 'app/models/feedback.rb'
-    - 'app/validators/representation_order_validator.rb'
 
 # Offense count: 8
 # Cop supports --auto-correct.

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -13,12 +13,13 @@ class RepresentationOrderValidator < BaseValidator
   # must not be too far in the past
   # must not be in the future
   # must not be earlier than the first rep order date
+  # must not be earlier than the earliest permitted date
   def validate_representation_order_date
     validate_presence(:representation_order_date, "blank")
-    validate_not_after(Date.today, :representation_order_date, "check")
-    validate_not_before(Settings.earliest_permitted_date, :representation_order_date, "check")
+    validate_not_after(Date.today, :representation_order_date, 'in_future')
+    validate_not_before(earliest_permitted[:date], :representation_order_date, earliest_permitted[:error])
 
-    unless (@record.is_first_reporder_for_same_defendant?)
+    unless @record.is_first_reporder_for_same_defendant?
       first_reporder_date = @record.first_reporder_for_same_defendant.try(:representation_order_date)
       unless first_reporder_date.nil?
         validate_not_before(first_reporder_date, :representation_order_date, "check")
@@ -29,10 +30,21 @@ class RepresentationOrderValidator < BaseValidator
   # mandatory where case type isn't breach of crown court order
   # must be exactly 7 - 10 numeric digits
   def validate_maat_reference
-    case_type = @record.defendant.claim.case_type rescue nil
+    case_type = claim.try(:case_type)
     if case_type && case_type.requires_maat_reference?
       validate_presence(:maat_reference, "invalid")
       validate_pattern(:maat_reference, /^[0-9]{7,10}$/, 'invalid')
     end
+  end
+
+  # helper methods
+  #
+  def claim
+    @record.defendant.claim
+  end
+
+  def earliest_permitted
+    return {date: Settings.interim_earliest_permitted_repo_date, error: 'not_before_interim_earliest_permitted_date'} if claim.try(:interim?)
+    {date: Settings.earliest_permitted_date, error: 'not_before_earliest_permitted_date'}
   end
 end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -9,6 +9,7 @@ dictionary:
     too_far_in_past: &too_far_in_past "Can't be too far in the past"
     before_rep_order: &before_rep_order "Can't be before the earliest rep. order"
     in_future: &in_future "Can't be in the future"
+    check_date: &check_date 'Check this date'
     enter_date: &enter_date 'Enter a date'
     enter_valid_date: &enter_valid_date 'Enter a valid date'
     date_not_allowed: &date_not_allowed 'Date not allowed'
@@ -596,12 +597,24 @@ representation_order:
       api: 'Enter a representation order date for the representation order of the defendant'
     check:
       long: 'Representation orders should be entered in chronological order. Please check representation order dates of the #{defendant}'
-      short: Check this date
+      short: *check_date
       api: 'Representation orders should be entered in chronological order. Please check representation order dates of the defendant'
     invalid_date:
       long: 'Enter a valid date for the representation order date of the #{representation_order} of the #{defendant}'
       short: *enter_valid_date
       api: 'Enter a valid date for the representation order date of the representation order of the defendant'
+    in_future:
+      long: 'Check the representation order date for the #{representation_order} of the #{defendant}'
+      short: *in_future
+      api: 'Check the representation order date for the representation order of the defendant'
+    not_before_earliest_permitted_date:
+      long: 'Representation order date of the #{defendant} is too far in the past. Please check this date'
+      short: *check_date
+      api: 'Representation order date of the defendant is too far in the past. Please check this date'
+    not_before_interim_earliest_permitted_date:
+      long: 'Representation order date of the #{defendant} cannot be prior to 02/10/14. Please check this date'
+      short: *check_date
+      api: 'Representation order date of the defendant cannot be prior to 02/10/14. Please check this date'
 
   maat_reference:
     _seq: 30

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,6 +25,8 @@ high_value_claim_threshold: 20000
 earliest_permitted_date: <%= 5.years.ago.to_date %>
 earliest_permitted_date_in_words: 5 years ago
 
+interim_earliest_permitted_repo_date: <%= Date.new(2014,10,2) %>
+
 max_document_upload_size_mb: 400
 max_document_upload_count: 20
 

--- a/spec/validators/claim/base_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/base_claim_sub_model_validator_spec.rb
@@ -71,7 +71,7 @@ describe Claim::BaseClaimSubModelValidator do
     context 'bubbling up errors two levels to the claim' do
       let(:expected_results) do
         {
-          defendant_1_representation_order_1_representation_order_date: 'check',
+          defendant_1_representation_order_1_representation_order_date: 'not_before_earliest_permitted_date',
           defendant_1_date_of_birth:                                    'blank',
         }
       end

--- a/spec/validators/representation_order_date_validator_spec.rb
+++ b/spec/validators/representation_order_date_validator_spec.rb
@@ -11,8 +11,17 @@ describe RepresentationOrderValidator do
 
   context 'representation_order_date' do
     it { should_error_if_not_present(reporder, :representation_order_date, "blank") }
-    it { should_error_if_in_future(reporder, :representation_order_date, "check") }
-    it { should_error_if_too_far_in_the_past(reporder, :representation_order_date, "check") }
+    it { should_error_if_in_future(reporder, :representation_order_date, "in_future") }
+    it { should_error_if_too_far_in_the_past(reporder, :representation_order_date, "not_before_earliest_permitted_date") }
+  end
+
+  context 'for an interim claim' do
+    let(:claim) { FactoryGirl.build :interim_claim, force_validation: true }
+
+    context 'representation_order_date' do
+      let(:earliest_permitted_date) { Date.new(2014,10,2) }
+      it { should_error_if_before_specified_date(reporder, :representation_order_date, earliest_permitted_date, 'not_before_interim_earliest_permitted_date') }
+    end
   end
 
   context 'stand-alone rep order' do


### PR DESCRIPTION
**PT#121133165**

None of the interim fee types are claimable where the original rep order date is prior to 02/10/14.  When an earlier rep order date is entered on page 1 there should be a validation message for this.

Some rewording on the other repo date error validations to be more accurate.
