### PR TITLE
Fixing blue links in awesomeplete

### DIFF
--- a/app/assets/stylesheets/moj/_autocomplete.scss
+++ b/app/assets/stylesheets/moj/_autocomplete.scss
@@ -39,6 +39,7 @@
       font-weight: 700;
     }
     li {
+      color: $text-colour;
       &[aria-selected="true"] {
         background-color: $link-colour;
         color: white;


### PR DESCRIPTION
These links are now black

![screen shot 2016-06-10 at 10 59 10](https://cloud.githubusercontent.com/assets/3668907/15961220/81dabeb4-2efb-11e6-8ec9-00c8665eabba.png)
