### PR TITLE
Provider Switcher Rake task

### DIFF
--- a/lib/tasks/provider_switcher.rake
+++ b/lib/tasks/provider_switcher.rake
@@ -1,0 +1,37 @@
+namespace :provider  do
+  desc "Debug task for provider"
+  task :switch, [:claim_id] => :environment do | _task, args|
+    claim_id = args[:claim_id]
+    ProviderSwitcher.new(claim_id).switch!
+  end
+
+  task :reset => :environment do
+    ProviderSwitcher.new.reset!
+  end
+end
+
+
+class ProviderSwitcher
+  def initialize(claim_id = nil)
+    @claim_id = claim_id
+  end
+
+  def switch!
+    claim = Claim::BaseClaim.find(@claim_id)
+    provider = claim.provider
+
+    user = User.where(email: 'advocateadmin@example.com').first
+    external_user = user.persona
+    external_user.provider_id = provider.id
+    external_user.save!
+    puts "Test user switched to belong to Provider #{provider.id}  #{provider.name}"
+  end
+
+  def reset!
+    advocate_external_user = User.where(email: 'advocate@example.com').first.persona
+    admin_external_user = User.where(email: 'advocateadmin@example.com').first.persona
+    admin_external_user.provider_id = advocate_external_user.provider_id
+    admin_external_user.save!
+    puts "Test user reset to belong to Provider #{admin_external_user.provider_id} #{admin_external_user.provider.name}"
+  end
+end


### PR DESCRIPTION
When debugging an issue raised by a user, we need to be able to view the claim
as the advocate is seeing it.  In order to do this, we need to be able to log in
as an advocate admin in the same provider.  This PR provides two tasks:

```
rake provider:switch[nnn]   Switch the advocateadmin@example.com user to the same provider as claim nnn
rake provider:reset         Switch the advocateadmin@example.com user back to the test chamber/firm
```
