### PR TITLE
replaced name with id in anchor tags

### DIFF
--- a/app/form_builders/adp_form_builder.rb
+++ b/app/form_builders/adp_form_builder.rb
@@ -35,7 +35,7 @@ class AdpFormBuilder < ActionView::Helpers::FormBuilder
   private
 
   def anchor_and_label_markup(anchor_name, label, options = {})
-    anchor_html = content_tag(:a, nil, { name: anchor_name }.merge(options[:anchor_attributes] || {}))
+    anchor_html = content_tag(:a, nil, { id: anchor_name }.merge(options[:anchor_attributes] || {}))
     label_html  = nil
 
     if label

--- a/spec/form_builders/adp_form_builder_spec.rb
+++ b/spec/form_builders/adp_form_builder_spec.rb
@@ -8,26 +8,26 @@ describe AdpFormBuilder do
   describe 'anchored_label' do
     context 'no anchor name supplied' do
       it 'should take the label as the anchor name' do
-        expected_html = %Q[<a name="advocate_category"></a><label for="claim_advocate_category">Advocate category</label>]
+        expected_html = %Q[<a id="advocate_category"></a><label for="claim_advocate_category">Advocate category</label>]
         expect(builder.anchored_label('Advocate category')).to eq expected_html
       end
     end
 
     context 'anchor name supplied' do
       it 'should use anchor name supplied' do
-        expected_html = %Q[<a name="ad_cat"></a><label for="claim_ad_cat">Advocate category</label>]
+        expected_html = %Q[<a id="ad_cat"></a><label for="claim_ad_cat">Advocate category</label>]
         expect(builder.anchored_label('Advocate category', 'ad_cat')).to eq expected_html
       end
     end
 
     context 'extra html attributes supplied' do
       it 'should use the attributes when anchor name supplied' do
-        expected_html = %Q[<a name="ad_cat" class="red"></a><label class="blue" for="claim_ad_cat">Advocate category</label>]
+        expected_html = %Q[<a id="ad_cat" class="red"></a><label class="blue" for="claim_ad_cat">Advocate category</label>]
         expect(builder.anchored_label('Advocate category', 'ad_cat', { anchor_attributes: {class: 'red'}, label_attributes: {class: 'blue'} })).to eq expected_html
       end
 
       it 'should use the attributes when no anchor name provided' do
-        expected_html = %Q[<a name="advocate_category" class="red"></a><label class="blue" for="claim_advocate_category">Advocate category</label>]
+        expected_html = %Q[<a id="advocate_category" class="red"></a><label class="blue" for="claim_advocate_category">Advocate category</label>]
         expect(builder.anchored_label('Advocate category', nil, { anchor_attributes: {class: 'red'}, label_attributes: {class: 'blue'} })).to eq expected_html
       end
     end
@@ -36,21 +36,21 @@ describe AdpFormBuilder do
   describe 'anchored_without_label' do
     context 'no anchor name supplied' do
       it 'should take the label as the anchor name' do
-        expected_html = %Q[<a name="advocate_category"></a>]
+        expected_html = %Q[<a id="advocate_category"></a>]
         expect(builder.anchored_without_label('Advocate category')).to eq expected_html
       end
     end
 
     context 'anchor name supplied' do
       it 'should use anchor name supplied' do
-        expected_html = %Q[<a name="ad_cat"></a>]
+        expected_html = %Q[<a id="ad_cat"></a>]
         expect(builder.anchored_without_label('Advocate category', 'ad_cat')).to eq expected_html
       end
     end
 
     context 'extra html attributes supplied' do
       it 'should use the attributes' do
-        expected_html = %Q[<a name="ad_cat" class="red"></a>]
+        expected_html = %Q[<a id="ad_cat" class="red"></a>]
         expect(builder.anchored_without_label('Advocate category', 'ad_cat', anchor_attributes: {class: 'red'})).to eq expected_html
       end
     end
@@ -58,12 +58,12 @@ describe AdpFormBuilder do
 
   describe 'anchored_attribute' do
     it 'should build the label from the object and label' do
-      expected_html = %Q[<a name="advocate_claim.test"></a>]
+      expected_html = %Q[<a id="advocate_claim.test"></a>]
       expect(builder.anchored_attribute('test')).to eq expected_html
     end
 
     it 'should use any provided attributes' do
-      expected_html = %Q[<a name="advocate_claim.test" class="red"></a>]
+      expected_html = %Q[<a id="advocate_claim.test" class="red"></a>]
       expect(builder.anchored_attribute('test', anchor_attributes: {class: 'red'})).to eq expected_html
     end
   end


### PR DESCRIPTION
<a> tags should not have a name, but an id, according to the latest W3C standards
