### PR TITLE
Only configuring Sentry on prod and when token is available.

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,11 +1,9 @@
 require 'raven'
 
-unless %w( test ).include?(Rails.env)
-  if Rails.host.gamma? || Rails.host.staging? || Rails.host.api_sandbox?
-    Raven.configure do |config|
-      config.dsn = ENV['SENTRY_DSN']
-      config.environments = %w( production )
-      config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-    end
+if %w( production ).include?(Rails.env) && ENV['SENTRY_DSN'].present?
+  Raven.configure do |config|
+    config.dsn = ENV['SENTRY_DSN']
+    config.environments = %w( production )
+    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   end
 end


### PR DESCRIPTION
If the token is not present, raven configure would fail and the server will not startup.
This change will protect against that.
