### PR TITLE
Update API fee endpoint to support new kind of fees.

### DIFF
--- a/app/interfaces/api/v1/api_helper.rb
+++ b/app/interfaces/api/v1/api_helper.rb
@@ -135,7 +135,7 @@ module API
 
         # prevent creation/basic-fee-update of sub(sub)models for claims not in a draft state
         def test_editability(model_instance)
-          if [ Fee::BasicFee, Fee::MiscFee, Fee::FixedFee, Expense, Disbursement, Defendant, RepresentationOrder, DateAttended ].include?(model_instance.class)
+          if (Fee::BaseFee.subclasses + [ Expense, Disbursement, Defendant, RepresentationOrder, DateAttended ]).include?(model_instance.class)
             model_instance.errors.add(:base, 'uneditable_state') unless model_instance.claim.editable? rescue true
           end
         end
@@ -151,14 +151,12 @@ module API
         end
 
         def is_a_fee?(model_klass)
-          [ ::Fee::BaseFee, ::Fee::BasicFee, ::Fee::MiscFee, ::Fee::FixedFee ].include?(model_klass)
+          Fee::BaseFee.subclasses.include?(model_klass)
         end
 
         def is_a_basic_fee_type?(args)
           Fee::BaseFeeType.find(args[:fee_type_id]).is_a?(::Fee::BasicFeeType)
         end
-
-
       end
     end
   end

--- a/app/interfaces/api/v1/error_response.rb
+++ b/app/interfaces/api/v1/error_response.rb
@@ -20,7 +20,10 @@ class ErrorResponse
   attr :body
   attr :status
 
-  VALID_MODEL_KLASSES = [Fee::GraduatedFee, Fee::BasicFee, Fee::MiscFee, Fee::FixedFee, Expense, Disbursement, Claim::AdvocateClaim, Defendant, DateAttended, RepresentationOrder]
+  VALID_MODEL_KLASSES = [
+      Fee::GraduatedFee, Fee::InterimFee, Fee::TransferFee, Fee::BasicFee, Fee::MiscFee, Fee::FixedFee,
+      Expense, Disbursement, Claim::AdvocateClaim, Defendant, DateAttended, RepresentationOrder
+  ].freeze
 
   def initialize(object)
     @error_messages = []
@@ -54,16 +57,7 @@ private
     m = @model
 
     if m.is_a?(Fee::BaseFee)
-      case
-      when m.is_basic?
-        submodel ='basic_fee'
-      when m.is_misc?
-        submodel ='misc_fee'
-      when m.is_fixed?
-        submodel ='fixed_fee'
-      else
-        submodel = 'fee' # no fee type may have been specified
-      end
+      submodel = m.class.name.demodulize.underscore
       submodel_instance_num = "#{submodel}_1_"
     elsif !m.try(:claim).nil?
       submodel_instance_num = "#{m.class.name.underscore}_1_"

--- a/spec/api/v1/error_response_spec.rb
+++ b/spec/api/v1/error_response_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ErrorResponse do
 
-    VALID_MODEL_KLASSES = [::Fee, ::Expense, ::Claim, ::Defendant, ::DateAttended, ::RepresentationOrder]
+    VALID_MODEL_KLASSES = [::Fee, ::Expense, ::Disbursement, ::Claim, ::Defendant, ::DateAttended, ::RepresentationOrder]
     EXCEPTION_KLASSES = [RuntimeError, ArgumentError, API::V1::ArgumentError]
 
     let(:claim) { FactoryGirl.build :claim, case_number: 'A123456' }

--- a/spec/api/v1/external_users/date_attended_spec.rb
+++ b/spec/api/v1/external_users/date_attended_spec.rb
@@ -17,7 +17,9 @@ describe API::V1::ExternalUsers::DateAttended do
   let!(:provider)     { create(:provider) }
   let!(:claim)        { create(:claim, source: 'api') }
   let!(:fee)          { create(:misc_fee, claim: claim) }
-  let!(:valid_params) { { api_key: provider.api_key, attended_item_id: fee.reload.uuid, date: '2015-05-10', date_to: '2015-05-12'} }
+  let!(:from_date)    { claim.earliest_representation_order.representation_order_date }
+  let!(:to_date)      { from_date + 2.days }
+  let!(:valid_params) { { api_key: provider.api_key, attended_item_id: fee.reload.uuid, date: from_date.as_json, date_to: to_date.as_json} }
 
   context 'when sending non-permitted verbs' do
     ALL_DATES_ATTENDED_ENDPOINTS.each do |endpoint| # for each endpoint


### PR DESCRIPTION
**PT#120970089**

For now there is no validation for creating a LGFS fee on an AGFS claim, but eventually we might want to introduce this validation.

This validation will be easier to implement and test once we evolve a bit more the changes needed for the Litigators API, specially the changes needed to the /claim endpoint, because at the moment, the API code is very coupled to one specific kind of claim: AdvocateClaim.
