### PR TITLE
Hide the import button when there are format errors.

### DIFF
--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -3,8 +3,6 @@ var $importerResults = $('.importer-results');
 $importerResults.find('.js-import-failed').remove();
 
 <% if @json_document_importer.imported_claims.any? %>
-  ga('send', 'event', 'claims-importer', 'imported', '<%= @json_document_importer.imported_claims.count %>');
-
 	$importerResults.html(
       '<div class="results-body import-success">' +
         '<h4>Successfully imported <%= pluralize(@json_document_importer.imported_claims.count, "new claim") %> in draft state</h4>' +
@@ -44,8 +42,6 @@ $importerResults.find('.js-import-failed').remove();
 <% end %>
 
 <% if @json_document_importer.failed_imports.any? %>
-  ga('send', 'event', 'claims-importer', 'failed', '<%= @json_document_importer.failed_imports.count %>');
-
 	$importerResults.append(
     '<div class="error-summary js-import-failed" role="group" aria-labelledby="error-summary-heading" tabindex="-1" aria-live="polite">' +
       '<h1 class="heading-medium error-summary-heading" id="error-summary-heading">' +
@@ -65,8 +61,6 @@ $importerResults.find('.js-import-failed').remove();
 <% end %>
 
 <% if @json_document_importer.failed_schema_validation.any? %>
-  ga('send', 'event', 'claims-importer', 'validation-failed', '<%= @json_document_importer.failed_schema_validation.count %>');
-
   $importerResults.append(
     '<div class="error-summary js-import-failed" role="group" aria-labelledby="error-summary-heading" tabindex="-1" aria-live="polite">' +
       '<h1 class="heading-medium error-summary-heading" id="error-summary-heading">' +

--- a/app/views/external_users/json_document_importers/format_error.js.erb
+++ b/app/views/external_users/json_document_importers/format_error.js.erb
@@ -1,5 +1,6 @@
+$('#importer').find('form').addClass('no-file-selected');
 $('#importer')
   .addClass('has-errors')
   .find('.errors')
-    .html("<em><%= filename %></em> is either not JSON or contains errors");
+    .html("<em><%= filename %></em> is either not JSON or contains errors. Choose another file.");
 $('.importer-results').empty();

--- a/spec/api/v1/external_users/date_attended_spec.rb
+++ b/spec/api/v1/external_users/date_attended_spec.rb
@@ -17,7 +17,9 @@ describe API::V1::ExternalUsers::DateAttended do
   let!(:provider)     { create(:provider) }
   let!(:claim)        { create(:claim, source: 'api') }
   let!(:fee)          { create(:misc_fee, claim: claim) }
-  let!(:valid_params) { { api_key: provider.api_key, attended_item_id: fee.reload.uuid, date: '2015-05-10', date_to: '2015-05-12'} }
+  let!(:from_date)    { claim.earliest_representation_order.representation_order_date }
+  let!(:to_date)      { from_date + 2.days }
+  let!(:valid_params) { { api_key: provider.api_key, attended_item_id: fee.reload.uuid, date: from_date.as_json, date_to: to_date.as_json} }
 
   context 'when sending non-permitted verbs' do
     ALL_DATES_ATTENDED_ENDPOINTS.each do |endpoint| # for each endpoint


### PR DESCRIPTION
After trying to upload a file with format errors (i.e. not a JSON file) the import button remained visible and pressing it again was raising ActionController::ParameterMissing exceptions on Sentry quite frequently.

https://sentry.service.dsd.io/mojds/api-sandbox/group/979/

Avoid this by hiding the button on format errors and showing it again after selecting a new file.
