### PR TITLE
Make the JSON importer more resilient to some errors.

### DIFF
--- a/app/interfaces/api/custom_validations/date_format.rb
+++ b/app/interfaces/api/custom_validations/date_format.rb
@@ -1,13 +1,28 @@
 class StandardJsonFormat < Grape::Validations::Base
-  def validate_param!(attr_name, params)
 
-    #
-    # regex pattern: "sortable" e.g.
-    #   match     - 2015-05-21
-    #   match     - 2015-05-21T14:00:00
-    #
-    unless params[attr_name] =~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$/
-      fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: "is not in an acceptable date format (YYYY-MM-DD[T00:00:00])"
-    end
+  # ISO 8601 format
+  #
+  # Valid examples:
+  #
+  #   2016-12-01
+  #   2016-12-01T00:00:00
+  #   2016-12-01T00:00:00Z
+  #   2016-12-01T19:20+01:00
+  #
+  # Invalid examples:
+  #
+  #   2016
+  #   2016-12
+  #   2016-14-01
+  #   2016-12-01Z
+  #
+  def validate_param!(attr_name, params)
+    date_str = params[attr_name]
+
+    date_str =~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}(.*)?$/ || (raise ArgumentError)
+    Date.iso8601(date_str) # if date is not valid iso8601 it will raise an ArgumentError
+
+  rescue ArgumentError
+    fail Grape::Exceptions::Validation, params: [@scope.full_name(attr_name)], message: 'is not in an acceptable date format (YYYY-MM-DD[T00:00:00])'
   end
 end

--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -30,7 +30,8 @@ class JsonDocumentImporter
 
   def parse_file
     temp_file = File.open(@file.tempfile)
-    @data     = JSON.parse(temp_file.read)
+    @data = JSON.parse(temp_file.read)
+    @data = [@data].flatten
     process_claim_hashes
     temp_file.rewind
   end
@@ -56,7 +57,7 @@ class JsonDocumentImporter
 
   def import!
     parse_file
-    data.each_with_index do |claim_hash, index|
+    @data.each_with_index do |claim_hash, index|
       begin
         JSON::Validator.validate!(@schema, claim_hash)
         create_claim(claim_hash['claim'])
@@ -138,7 +139,7 @@ class JsonDocumentImporter
   end
 
   def create_dates_attended(fee_or_expense)
-    fee_or_expense['dates_attended'].each do |date_attended|
+    fee_or_expense['dates_attended'].to_a.each do |date_attended|
       date_attended['attended_item_id'] = @id_of_owner
       date_attended['attended_item_type'].capitalize!
       response = DATE_ATTENDED_CREATION.post(date_attended.merge(api_key: @api_key)) {|response, request, result| response }

--- a/spec/api/v1/external_users/date_attended_spec.rb
+++ b/spec/api/v1/external_users/date_attended_spec.rb
@@ -107,13 +107,7 @@ describe API::V1::ExternalUsers::DateAttended do
         end
       end
 
-      context 'malformed date format' do
-          it 'rejects malformed dates' do
-            valid_params[:date] = '2015-05-32'
-            post_to_create_endpoint
-            expect_error_response("Enter a valid date for the date attended (from)",1)
-          end
-      end
+      include_examples "malformed or not iso8601 compliant dates", action: :create, attributes: [:date, :date_to]
     end
   end
 
@@ -144,14 +138,6 @@ describe API::V1::ExternalUsers::DateAttended do
       expect_error_response("Attended item cannot be blank")
     end
 
-    it 'returns 400 and JSON error when dates are not in acceptable format' do
-      valid_params[:date] = '10-05-2015'
-      valid_params[:date_to] = '12-05-2015'
-      post_to_validate_endpoint
-      expect_error_response("date is not in an acceptable date format (YYYY-MM-DD[T00:00:00])",0)
-      expect_error_response("date_to is not in an acceptable date format (YYYY-MM-DD[T00:00:00])",1)
-    end
+    include_examples "malformed or not iso8601 compliant dates", action: :validate, attributes: [:date, :date_to]
   end
-
 end
-

--- a/spec/api/v1/external_users/shared_examples_for_all.rb
+++ b/spec/api/v1/external_users/shared_examples_for_all.rb
@@ -49,3 +49,14 @@ shared_examples "should NOT be able to amend a non-draft claim" do
     end
   end
 end
+
+shared_examples "malformed or not iso8601 compliant dates" do |options|
+  action = options[:action]
+  options[:attributes].each do |attribute|
+    it "returns 400 and JSON error when '#{attribute}' field is not in acceptable format" do
+      valid_params[attribute] = '10-05-2015'
+      action == :create ? post_to_create_endpoint : post_to_validate_endpoint
+      expect_error_response("#{attribute} is not in an acceptable date format (YYYY-MM-DD[T00:00:00])")
+    end
+  end
+end


### PR DESCRIPTION
Based on a JSON example provided by a vendor, some issues were discovered:
- Our parser was expecting a collection of claims (even if it was only one claim). This has been improved to deal with single elements as well as collections.
- Dates were being validated too rigidly even when the date was valid ISO 8601. Fixed.
- Dates attended element was expected for each fee. This is now optional and will not break if missing.

This will hopefully reduce the number of `undefined method each for nil:NilClass` exceptions on Sentry:
https://sentry.service.dsd.io/mojds/api-sandbox/group/980/
