### PR TITLE
Ensure we validate fees when importing a claim via JSON.

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -275,10 +275,6 @@ module Claim
       source == 'api'
     end
 
-    def originally_from_api?
-      !source.match(/^api/).nil?
-    end
-
     def api_web_edited?
       source == 'api_web_edited'
     end
@@ -289,6 +285,10 @@ module Claim
 
     def from_json_import?
       source == 'json_import'
+    end
+
+    def json_import_web_edited?
+      source == 'json_import_web_edited'
     end
 
     def api_draft?

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -92,8 +92,11 @@ module Fee
 
     def is_transfer?; false; end
 
+    # Prevent invalid fees from being created through the JSON importer,
+    # because once created they cannot be amended on the web UI.
+    #
     def perform_validation?
-      claim && claim.perform_validation?
+      claim && (claim.perform_validation? || claim.from_json_import?)
     end
 
     def calculated?

--- a/app/services/claims/claim_actions_service.rb
+++ b/app/services/claims/claim_actions_service.rb
@@ -44,6 +44,11 @@ module Claims
       end
     end
 
+    def update_source
+      claim.source = 'api_web_edited' if claim.from_api?
+      claim.source = 'json_import_web_edited' if claim.from_json_import?
+    end
+
     def rollback!
       set_error_code(:rollback)
       raise ActiveRecord::Rollback

--- a/app/services/claims/update_claim.rb
+++ b/app/services/claims/update_claim.rb
@@ -14,7 +14,7 @@ module Claims
       end
 
       claim.assign_attributes(params)
-      claim.source = 'api_web_edited' if claim.from_api?
+      update_source
 
       save_claim!(validate?)
 

--- a/app/services/claims/update_draft.rb
+++ b/app/services/claims/update_draft.rb
@@ -9,7 +9,7 @@ module Claims
 
     def call
       claim.assign_attributes(params)
-      claim.source = 'api_web_edited' if claim.from_api?
+      update_source
 
       save_draft!(validate?)
 

--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -1,4 +1,5 @@
 var $importerResults = $('.importer-results');
+var resetUploaderForm = function() { $('#importer').find('form').addClass('no-file-selected').find('.file-upload-name').empty(); };
 
 $importerResults.find('.js-import-failed').remove();
 
@@ -31,7 +32,8 @@ $importerResults.find('.js-import-failed').remove();
       );
 		<% end %>
 	<% end %>
-  $('#importer').removeClass('has-errors').find('form').addClass('no-file-selected').find('.file-upload-name').empty();
+  $('#importer').removeClass('has-errors');
+  resetUploaderForm();
 <% else %>
 	$importerResults.find('.import-success').remove();
 <% end %>
@@ -52,7 +54,8 @@ $importerResults.find('.js-import-failed').remove();
         <% end %>
       '</ul>' +
     '</div>');
-  $('#importer').addClass('has-errors').find('form').addClass('no-file-selected').find('.file-upload-name').empty();
+  $('#importer').addClass('has-errors');
+  resetUploaderForm();
 <% end %>
 
 <% if @json_document_importer.failed_schema_validation.any? %>
@@ -68,7 +71,8 @@ $importerResults.find('.js-import-failed').remove();
       '</ul>' +
     '</div>'
   );
-  $('#importer').addClass('has-errors').find('form').addClass('no-file-selected').find('.file-upload-name').empty();
+  $('#importer').addClass('has-errors');
+  resetUploaderForm();
 <% end %>
 
 // empty the field where format errors would occur, regardless of the result here, incase a previous error is shown

--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -31,12 +31,7 @@ $importerResults.find('.js-import-failed').remove();
       );
 		<% end %>
 	<% end %>
-  $('#importer')
-    .removeClass('has-errors')
-    .find('form')
-      .addClass('no-file-selected')
-      .find('.file-upload-name')
-        .empty();
+  $('#importer').removeClass('has-errors').find('form').addClass('no-file-selected').find('.file-upload-name').empty();
 <% else %>
 	$importerResults.find('.import-success').remove();
 <% end %>
@@ -57,7 +52,7 @@ $importerResults.find('.js-import-failed').remove();
         <% end %>
       '</ul>' +
     '</div>');
-  $('#importer').addClass('has-errors');
+  $('#importer').addClass('has-errors').find('form').addClass('no-file-selected').find('.file-upload-name').empty();
 <% end %>
 
 <% if @json_document_importer.failed_schema_validation.any? %>
@@ -73,7 +68,7 @@ $importerResults.find('.js-import-failed').remove();
       '</ul>' +
     '</div>'
   );
-  $('#importer').addClass('has-errors');
+  $('#importer').addClass('has-errors').find('form').addClass('no-file-selected').find('.file-upload-name').empty();
 <% end %>
 
 // empty the field where format errors would occur, regardless of the result here, incase a previous error is shown

--- a/app/views/external_users/json_document_importers/format_error.js.erb
+++ b/app/views/external_users/json_document_importers/format_error.js.erb
@@ -1,6 +1,11 @@
-$('#importer').find('form').addClass('no-file-selected');
+$('#importer').find('form')
+  .addClass('no-file-selected')
+  .find('.file-upload-name')
+    .empty();
+
 $('#importer')
   .addClass('has-errors')
   .find('.errors')
     .html("<em><%= filename %></em> is either not JSON or contains errors. Choose another file.");
+
 $('.importer-results').empty();

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -784,13 +784,13 @@ basic_fee:
       short: *enter_valid_rate
       api: Enter a valid rate for pages of prosecution evidence fees
     npw_must_be_blank:
-      long: Number of prosecution witnesses fees must not a have rate
+      long: Number of prosecution witnesses fees must not have a rate
       short:  Remove the rate
-      api: Number of prosecution witnesses fees must not a have rate
+      api: Number of prosecution witnesses fees must not have a rate
     ppe_must_be_blank:
-      long: Pages of prosecution evidence fees must not a have rate
+      long: Pages of prosecution evidence fees must not have a rate
       short: Remove the rate
-      api: Pages of prosecution evidence fees must not a have rate
+      api: Pages of prosecution evidence fees must not have a rate
     invalid:
       long: Enter a valid rate for the initial fee
       short: *enter_valid_rate

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -148,7 +148,7 @@ describe API::V1::ExternalUsers::Fee do
         basic_fee_type.update(code: 'PPE', calculated: false) # need to use real basic fee codes to trigger code specific validation and errors
         post_to_create_endpoint
         expect(last_response.status).to eq 400
-        expect_error_response("Pages of prosecution evidence fees must not a have rate",0)
+        expect_error_response("Pages of prosecution evidence fees must not have a rate",0)
       end
 
       it 'should raise error if case numbers are not provided for miscellaneous fee of type Case Uplift' do

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -414,7 +414,6 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
       end
 
       context 'and editing an API created claim' do
-
         before(:each) do
           subject.update(source: 'api')
         end
@@ -430,6 +429,28 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
           before { put :update, id: subject, claim: { additional_information: 'foo' }, summary: true, commit_submit_claim: 'Submit to LAA' }
           it 'sets API created claims source to indicate it is from API but has been edited in web' do
             expect(subject.reload.source).to eql 'api_web_edited'
+          end
+        end
+      end
+
+      context 'and editing a JSON imported claim' do
+        before(:each) do
+          subject.update(source: 'json_import')
+        end
+
+        context 'and saving to draft' do
+          before { put :update, id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' }
+
+          it 'updates the source to indicate it was originally from JSON import but has been edited via web' do
+            expect(subject.reload.source).to eql 'json_import_web_edited'
+          end
+        end
+
+        context 'and submitted to LAA' do
+          before { put :update, id: subject, claim: { additional_information: 'foo' }, summary: true, commit_submit_claim: 'Submit to LAA' }
+
+          it 'updates the source to indicate it was originally from JSON import but has been edited via web' do
+            expect(subject.reload.source).to eql 'json_import_web_edited'
           end
         end
       end

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -256,28 +256,6 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
         end
       end
 
-      context 'and editing an API created claim' do
-        before(:each) do
-          subject.update(source: 'api')
-        end
-
-        context 'and saving to draft' do
-          before { put :update, id: subject, claim: { case_number: 'A12345677' }, commit_save_draft: 'Save to drafts' }
-          it 'sets API created claims source to indicate it is from API but has been edited in web' do
-            expect(subject.reload.source).to eql 'api_web_edited'
-            expect(subject.reload.case_number).to eql 'A12345677'
-          end
-        end
-
-        context 'and continuing from step 1' do
-          before { put :update, id: subject, claim: { case_number: 'A12345679' }, commit_continue: 'Continue' }
-          it 'sets API created claims source to indicate it is from API but has been edited in web' do
-            expect(subject.reload.source).to eql 'api_web_edited'
-            expect(subject.reload.case_number).to eql 'A12345679'
-          end
-        end
-      end
-
       context 'and saving to draft' do
         before { put :update, id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' }
         it 'updates a claim' do

--- a/spec/services/claims/update_claim_spec.rb
+++ b/spec/services/claims/update_claim_spec.rb
@@ -32,6 +32,12 @@ describe Claims::UpdateClaim do
         expect(subject.claim.source).to eq('api_web_edited')
       end
 
+      it 'updates the source when editing a JSON imported claim' do
+        allow(subject.claim).to receive(:from_json_import?).and_return(true)
+        subject.call
+        expect(subject.claim.source).to eq('json_import_web_edited')
+      end
+
       it 'is successful' do
         expect(subject.claim.case_number).to eq('A12345678')
         expect(subject.claim).to receive(:update_claim_document_owners)

--- a/spec/services/claims/update_draft_spec.rb
+++ b/spec/services/claims/update_draft_spec.rb
@@ -46,6 +46,12 @@ describe Claims::UpdateDraft do
         expect(subject.claim.source).to eq('api_web_edited')
       end
 
+      it 'updates the source when editing a JSON imported claim' do
+        allow(subject.claim).to receive(:from_json_import?).and_return(true)
+        subject.call
+        expect(subject.claim.source).to eq('json_import_web_edited')
+      end
+
       it 'is successful' do
         expect(subject.claim.case_number).to eq('A12345678')
 

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -16,6 +16,18 @@ describe Fee::BaseFeeValidator do
   let(:npw_fee)    { FactoryGirl.build :basic_fee, :npw_fee, claim: claim }
   let(:spf_fee)    { FactoryGirl.build :misc_fee, :spf_fee, claim: claim }
 
+  context 'for a JSON imported claim (and no forced validation)' do
+    let(:claim) { FactoryGirl.build :advocate_claim, source: 'json_import' }
+
+    it 'should not perform claim validation' do
+      expect(claim.perform_validation?).to be_falsey
+    end
+
+    it 'should perform fee validation' do
+      expect(ppe_fee.perform_validation?).to be_truthy
+    end
+  end
+
   describe '#validate_claim' do
     it { should_error_if_not_present(fee, :claim, 'blank') }
   end


### PR DESCRIPTION
**PT#121584253**

Some fees are rigidly validated on the backend when created via web, but with the JSON importer, these validations were not triggered, generating a draft impossible to modify (i.e. the rate field is not visible/editable for PPE on the web but was populated in the JSON), rendering the draft unusable.

The issue has been addressed at the time of parsing the JSON file and generating the fees, raising an error when there are invalid fees.

**NOTE**: we don't really want to rigidly validate the whole claim and associated objects on import, only those that can render the draft impossible to edit, like in this case Fees.
Otherwise it can be very frustrating to use the JSON importer. Missing or invalid fields can be filled/fixed via web at a later stage by the user, that's the point of a Draft.
