### PR TITLE
Guard against trying to sum nil amounts

### DIFF
--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -10,12 +10,12 @@ module Claims::Calculations
 
   def calculate_expenses_total
     # #reload prevents cloning
-    Expense.where(claim_id: self.id).pluck(:amount).sum
+    Expense.where(claim_id: self.id).where.not(amount: nil).pluck(:amount).sum
   end
 
   def calculate_disbursements_total
     # #reload prevents cloning
-    Disbursement.where(claim_id: self.id).pluck(:net_amount).sum
+    Disbursement.where(claim_id: self.id).where.not(net_amount: nil).pluck(:net_amount).sum
   end
 
   def calculate_total


### PR DESCRIPTION
Exceptions were being generated when caclulating totals in the after save callback
when expenses had nil amounts.  This guards against that happening. Ditto disbursements.
