### PR TITLE
Ensuring the imported json gets validated with the schema, and fixing more bugs.

### DIFF
--- a/app/controllers/external_users/json_document_importers_controller.rb
+++ b/app/controllers/external_users/json_document_importers_controller.rb
@@ -6,7 +6,7 @@ class ExternalUsers::JsonDocumentImportersController < ApplicationController
 
   def create
     @api_key = current_user.persona.provider.api_key
-    @schema = JsonSchema.generate
+    @schema = JsonSchema.claim_schema
     @json_document_importer = JsonDocumentImporter.new(json_document_importer_params.merge(schema: @schema, api_key: @api_key))
     if @json_document_importer.valid?
       @json_document_importer.import!

--- a/app/controllers/json_template_controller.rb
+++ b/app/controllers/json_template_controller.rb
@@ -3,6 +3,6 @@ class JsonTemplateController < ApplicationController
   skip_load_and_authorize_resource only: [:index]
 
   def index
-    @schema = JsonSchema.generate
+    @schema = JSON.parse(JsonSchema.claim_schema)
   end
 end

--- a/app/interfaces/api/v1/external_users/fee.rb
+++ b/app/interfaces/api/v1/external_users/fee.rb
@@ -22,6 +22,7 @@ module API
               optional :rate, type:         Float,   desc: 'REQUIRED/UNREQUIRED: The currency value per unit/quantity of the fee (quantity x rate will equal amount). NB: Leave blank for PPE and NPW fee types'
               optional :amount, type:       Float,   desc: 'REQUIRED/UNREQUIRED: The total value of the fee. NB: Leave blank for fee types other than PPE/NPW or a Transfer Fee'
               optional :case_numbers, type: String,  desc: 'REQUIRED/UNREQUIRED: Required for Miscellaneous Fee of type Case Uplift. Leave blank for other types'
+              optional :date, type:         String,  desc: 'REQUIRED/UNREQUIRED: Required for LGFS Fixed Fee or LGFS Graduated Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
               optional :warrant_issued_date, type:    String, desc: 'REQUIRED/UNREQUIRED: Required for Interim fee of type Warrant, or a Warrant Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
               optional :warrant_executed_date, type:  String, desc: 'OPTIONAL: For Interim fee of type Warrant, or a Warrant Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
             end
@@ -44,6 +45,7 @@ module API
                 rate: params[:rate],
                 amount: params[:amount],
                 case_numbers: params[:case_numbers],
+                date: params[:date],
                 warrant_issued_date: params[:warrant_issued_date],
                 warrant_executed_date: params[:warrant_executed_date]
               }

--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -58,6 +58,9 @@ class JsonDocumentImporter
   def import!
     parse_file
     @data.each_with_index do |claim_hash, index|
+      case_number = claim_hash.fetch('claim', {}).fetch('case_number', nil)
+      case_number = "Claim #{index+1} (no readable case number)" if case_number.blank?
+
       begin
         JSON::Validator.validate!(@schema, claim_hash)
         create_claim(claim_hash['claim'])
@@ -67,20 +70,22 @@ class JsonDocumentImporter
         create_expenses(@expenses, EXPENSE_CREATION)
         @imported_claims << Claim::BaseClaim.find_by(uuid: @claim_id)
       rescue ArgumentError => e
-        case_number =  claim_hash['claim']['case_number'].blank? ? "Claim #{index+1} (no readable case number)" : claim_hash['claim']['case_number']
         claim_hash['claim']['case_number'] = case_number
         @failed_imports << claim_hash
         @errors[case_number] = JSON.parse(e.message).map{ |error_hash| error_hash['error'] }
         claim = Claim::BaseClaim.find_by(uuid: @claim_id) # if an exception is raised the claim is destroyed along with all its dependent objects
         claim.destroy if claim.present?
-      rescue JSON::Schema::ValidationError => e
-        @failed_schema_validation << claim_hash
+      rescue JSON::Schema::ValidationError => error
+        @failed_schema_validation << {case_number: case_number, error: error.message}
       end
-
     end
   end
 
   private
+
+  def api_key_params
+    HashWithIndifferentAccess.new(api_key: @api_key)
+  end
 
   def create_claim(hash)
     claim_params = parse_hash(hash)
@@ -89,9 +94,9 @@ class JsonDocumentImporter
   end
 
   def parse_hash(hash)
-    params = {api_key: @api_key}
+    params = {}
     hash.each {|key, value| params[key] = value if value.class != Array}
-    params
+    params.merge(api_key_params)
   end
 
   def set_defendants_fees_and_expenses(claim)
@@ -110,20 +115,20 @@ class JsonDocumentImporter
 
   def create(attributes_hash, rest_client_resource) # used to create defendants, fees and expenses
     obj_params = parse_hash(attributes_hash)
-    response = rest_client_resource.post(obj_params.merge(api_key: @api_key)) {|response, request, result| response }
+    response = rest_client_resource.post(obj_params.merge(api_key_params)) {|response, request, result| response }
     (response.code == 201 || response.code == 200) ? @id_of_owner = JSON.parse(response.body)['id'] : raise(ArgumentError.new(response.body))
   end
 
   def create_rep_orders(defendant)
     defendant['representation_orders'].each do |rep_order|
       rep_order['defendant_id'] = @id_of_owner
-      response = REPRESENTATION_ORDER_CREATION.post(rep_order.merge(api_key: @api_key)) {|response, request, result| response }
+      response = REPRESENTATION_ORDER_CREATION.post(rep_order.merge(api_key_params)) {|response, request, result| response }
       raise ArgumentError.new(response.body) if response.code != 201
     end
   end
 
   def create_fees_and_dates_attended(fee_array, rest_client_resource)
-    fee_array.each do |fee|
+    fee_array.to_a.each do |fee|
       fee['claim_id'] = @claim_id
       create(fee, rest_client_resource)
       create_dates_attended(fee)
@@ -131,8 +136,7 @@ class JsonDocumentImporter
   end
 
   def create_expenses(expense_array, rest_client_resource)
-    return if expense_array.nil?
-    expense_array.each do |expense|
+    expense_array.to_a.each do |expense|
       expense['claim_id'] = @claim_id
       create(expense, rest_client_resource)
     end
@@ -142,7 +146,7 @@ class JsonDocumentImporter
     fee_or_expense['dates_attended'].to_a.each do |date_attended|
       date_attended['attended_item_id'] = @id_of_owner
       date_attended['attended_item_type'].capitalize!
-      response = DATE_ATTENDED_CREATION.post(date_attended.merge(api_key: @api_key)) {|response, request, result| response }
+      response = DATE_ATTENDED_CREATION.post(date_attended.merge(api_key_params)) {|response, request, result| response }
       raise ArgumentError.new(response.body) if response.code != 201
     end
   end

--- a/app/models/json_schema.rb
+++ b/app/models/json_schema.rb
@@ -1,46 +1,9 @@
 class JsonSchema
 
-  class << self
+  CLAIM_SCHEMA_FILE = File.join(Rails.root, 'config', 'claim_schema.json').freeze
 
-    def generate
-      schema = File.read(File.join(Rails.root, 'config', 'claim_schema.json'))
-      parsed_schema = JSON.parse(schema)
-      edit_required_items(parsed_schema) # schema is used to validate data type and json structure only
-      parsed_schema
-    end
-
-    def edit_required_items(parsed_schema)
-      from_claim(parsed_schema)
-      from_defendants(parsed_schema)
-      from_representation_orders(parsed_schema)
-      from_fees(parsed_schema)
-      from_expenses(parsed_schema)
-      from_dates_attended(parsed_schema)
-    end
-
-    def from_claim(parsed_schema)
-      parsed_schema['properties']['claim'].delete('required')
-    end
-
-    def from_defendants(parsed_schema)
-      parsed_schema['properties']['claim']['properties']['defendants']['items'].delete('required')
-    end
-
-    def from_representation_orders(parsed_schema)
-      parsed_schema['properties']['claim']['properties']['defendants']['items']['properties']['representation_orders']['items'].delete('required')
-    end
-
-    def from_fees(parsed_schema)
-      parsed_schema['properties']['claim']['properties']['fees']['items'].delete('required')
-    end
-
-    def from_expenses(parsed_schema)
-      parsed_schema['properties']['claim']['properties']['expenses']['items'].delete('required')
-    end
-
-    def from_dates_attended(parsed_schema)
-      parsed_schema['properties']['claim']['properties']['fees']['items']['properties']['dates_attended']['items'].delete('required')
-    end
-
+  def self.claim_schema
+    File.read(CLAIM_SCHEMA_FILE)
   end
+
 end

--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -66,7 +66,7 @@ $importerResults.find('.js-import-failed').remove();
       '</h1>' +
       '<ul class="error-summary-list">' +
         <% @json_document_importer.failed_schema_validation.each do |fail| %>
-          '<li><%= fail["claim"]["case_number"] %></li>' +
+          '<li><%= html_escape_once('%{case_number}: %{error}' % fail) %></li>' +
         <% end %>
       '</ul>' +
     '</div>'

--- a/app/views/pages/api_landing.html.haml
+++ b/app/views/pages/api_landing.html.haml
@@ -52,13 +52,17 @@
           %li
             trial cracked at thirds
           %li
-            offences (and offence classes)
+            offences
+          %li
+            offence classes
           %li
             expense types
           %li
             fee categories
           %li
             fee types
+          %li
+            disbursement types
 
         %p
           Each endpoint returns a set of JSON formatted objects, each with an id, which you can use when submitting a claim and associated fees and expenses.

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -60,5 +60,8 @@
 
     %li
       API to submit litigator claims: Work on this is starting now and expected to be available for beta testing
-      by the end of June.  We will release documentation for litigator claims within the next two weeks.
+      by the end of June. We will release documentation for litigator claims within the next two weeks.
 
+    %li
+      Submitted dates must conform to ISO 8601, being the time information and time zone offset optional.
+      Examples: 2016-12-31, 2016-12-31T11:45, 2016-12-31T11:45:30Z

--- a/config/claim_schema.json
+++ b/config/claim_schema.json
@@ -15,25 +15,7 @@
         "court_id",
         "case_type_id",
         "case_number",
-        "offence_id",
-        "first_day_of_trial",
-        "estimated_trial_length",
-        "actual_trial_length",
-        "trial_concluded_at",
-        "retrial_started_at",
-        "retrial_estimated_length",
-        "retrial_actual_length",
-        "retrial_concluded_at",
-        "cms_number",
-        "additional_information",
-        "apply_vat",
-        "trial_fixed_notice_at",
-        "trial_fixed_at",
-        "trial_cracked_at",
-        "trial_cracked_at_third",
-        "defendants",
-        "fees",
-        "expenses"
+        "defendants"
       ],
       "properties": {
         "creator_email": {
@@ -58,7 +40,7 @@
           "type": "integer"
         },
         "first_day_of_trial": {
-          "type": "string"
+          "type": "string", "format": "date"
         },
         "estimated_trial_length": {
           "type": "integer"
@@ -67,10 +49,10 @@
           "type": "integer"
         },
         "trial_concluded_at": {
-          "type": "string"
+          "type": "string", "format": "date"
         },
         "retrial_started_at": {
-          "type": "string"
+          "type": "string", "format": "date"
         },
         "retrial_estimated_length": {
           "type": "integer"
@@ -79,7 +61,7 @@
           "type": "integer"
         },
         "retrial_concluded_at": {
-          "type": "string"
+          "type": "string", "format": "date"
         },
         "cms_number": {
           "type": "string"
@@ -91,16 +73,34 @@
           "type": "boolean"
         },
         "trial_fixed_notice_at": {
-          "type": "string"
+          "type": "string", "format": "date"
         },
         "trial_fixed_at": {
-          "type": "string"
+          "type": "string", "format": "date"
         },
         "trial_cracked_at": {
-          "type": "string"
+          "type": "string", "format": "date"
         },
         "trial_cracked_at_third": {
           "type": "string"
+        },
+        "case_concluded_at": {
+          "type": "string", "format": "date"
+        },
+        "transfer_court_id": {
+          "type": "integer"
+        },
+        "transfer_case_number": {
+          "type": "string"
+        },
+        "supplier_number": {
+          "type": "string"
+        },
+        "effective_pcmh_date": {
+          "type": "string", "format": "date"
+        },
+        "legal_aid_transfer_date": {
+          "type": "string", "format": "date"
         },
         "defendants": {
           "type": "array",
@@ -112,7 +112,6 @@
               "first_name",
               "last_name",
               "date_of_birth",
-              "order_for_judicial_apportionment",
               "representation_orders"
             ],
             "properties": {
@@ -123,7 +122,7 @@
                 "type": "string"
               },
               "date_of_birth": {
-                "type": "string"
+                "type": "string", "format": "date"
               },
               "order_for_judicial_apportionment": {
                 "type": "boolean"
@@ -143,7 +142,7 @@
                       "type": "string"
                     },
                     "representation_order_date": {
-                      "type": "string"
+                      "type": "string", "format": "date"
                     }
                   }
                 }
@@ -158,11 +157,7 @@
           "items": {
             "type": "object",
             "required": [
-              "fee_type_id",
-              "quantity",
-              "rate",
-              "amount",
-              "dates_attended"
+              "fee_type_id"
             ],
             "properties": {
               "fee_type_id": {
@@ -177,6 +172,18 @@
               "amount": {
                 "type": "number"
               },
+              "case_numbers": {
+                "type": "string"
+              },
+              "date": {
+                "type": "string", "format": "date"
+              },
+              "warrant_issued_date": {
+                "type": "string", "format": "date"
+              },
+              "warrant_executed_date": {
+                "type": "string", "format": "date"
+              },
               "dates_attended": {
                 "type": "array",
                 "minItems": 1,
@@ -185,18 +192,17 @@
                   "type": "object",
                   "required": [
                     "attended_item_type",
-                    "date",
-                    "date_to"
+                    "date"
                   ],
                   "properties": {
                     "attended_item_type": {
                       "type": "string"
                     },
                     "date": {
-                      "type": "string"
+                      "type": "string", "format": "date"
                     },
                     "date_to": {
-                      "type": "string"
+                      "type": "string", "format": "date"
                     }
                   }
                 }
@@ -211,16 +217,13 @@
           "items": {
             "type": "object",
             "required": [
-              "expense_type_id",
-              "amount",
-              "reason_id",
-              "date"
+              "expense_type_id"
             ],
             "properties": {
               "amount":           { "type": "number" },
               "expense_type_id":  { "type": "integer" },
               "location":         { "type": "string" },
-              "date":             { "type": "string"},
+              "date":             { "type": "string", "format": "date" },
               "distance":         { "type": "integer" },
               "hours":            { "type": "integer" },
               "mileage_rate_id":  { "type": "integer" },

--- a/spec/examples/exported_claim.json
+++ b/spec/examples/exported_claim.json
@@ -51,7 +51,9 @@
           "expense_type_id": 1,
           "quantity": 1,
           "amount": 235.46,
+          "distance": 300,
           "reason_id": 4,
+          "mileage_rate_id": 1,
           "location": "London",
           "date": "2015-06-01"
         }

--- a/spec/examples/exported_claim_with_errors.json
+++ b/spec/examples/exported_claim_with_errors.json
@@ -1,8 +1,10 @@
-// This is invalid due to the absensce of an advocate email address, but the test in which this is used is stubbed to always raise an error
+// This is invalid due to the advocate email address, but the test in which this is used is stubbed to always raise an error
 [
   {
     "claim": {
       "creator_email": "advocateadmin@example.com",
+      "advocate_email": "advocate",
+      "case_number": "",
       "case_type_id": 1,
       "first_day_of_trial": "2015-06-01",
       "estimated_trial_length": 3,

--- a/spec/models/json_document_importer_spec.rb
+++ b/spec/models/json_document_importer_spec.rb
@@ -2,29 +2,32 @@ require 'rails_helper'
 
 describe JsonDocumentImporter do
 
-  let(:schema)                              { JsonSchema.generate }
+  let(:schema)                              { JsonSchema.claim_schema }
   let(:exported_claim)                      { double 'cms_export', tempfile: './spec/examples/exported_claim.json', content_type: 'application/json'}
   let(:exported_claim_with_errors)          { double 'cms_export', tempfile: './spec/examples/exported_claim_with_errors.json', content_type: 'application/json'}
   let(:exported_claims)                     { double 'cms_export', tempfile: './spec/examples/exported_claims.json', content_type: 'application/json'}
   let(:wrong_format_file)                   { double 'erroneous_file_selection', tempfile: './features/examples/shorter_lorem.pdf', content_type: 'application/pdf' }
   let(:exported_claim_with_schema_error)    { double 'invalid_json_file', tempfile: './spec/examples/exported_claim_with_schema_error.json', content_type: 'application/json'}
   let(:exported_claim_with_nulls)           { double 'cms_export_with_nulls', tempfile: './spec/examples/exported_claim_with_nulls.json', content_type: 'application/json'}
-  let(:claim_params)                        { {:source=>'json_import', 'creator_email'=>'advocateadmin@example.com', 'advocate_email'=>'advocate@example.com', 'case_number'=>'A12345678', 'case_type_id'=>1, 'first_day_of_trial'=>'2015-06-01', 'estimated_trial_length'=>3, 'actual_trial_length'=>3, 'trial_concluded_at'=>'2015-06-03', 'advocate_category'=>'QC', 'offence_id'=>1, 'court_id'=>1, 'cms_number'=>'12345678', 'additional_information'=>'string', 'apply_vat'=>true, 'trial_fixed_notice_at'=>'2015-06-01', 'trial_fixed_at'=>'2015-06-01', 'trial_cracked_at'=>'2015-06-01', api_key: 'test_key'} }
-  let(:defendant_params)                    { {'first_name'=>'Angela', 'last_name'=>'Merkel', 'date_of_birth'=>'1979-12-10', 'order_for_judicial_apportionment'=>true, 'claim_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', api_key: 'test_key'} }
-  let(:rep_order_params)                    { {'maat_reference'=>'1234567891', 'representation_order_date'=>'2015-05-01', 'defendant_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', api_key: 'test_key'} }
-  let(:fee_params)                          { {'fee_type_id'=>2, 'quantity'=>1, 'rate'=>1.1, 'claim_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', api_key: 'test_key'} }
+
+  let(:claim_params)                        { {:source=>'json_import', 'creator_email'=>'advocateadmin@example.com', 'advocate_email'=>'advocate@example.com', 'case_number'=>'A12345678', 'case_type_id'=>1, 'first_day_of_trial'=>'2015-06-01', 'estimated_trial_length'=>3, 'actual_trial_length'=>3, 'trial_concluded_at'=>'2015-06-03', 'advocate_category'=>'QC', 'offence_id'=>1, 'court_id'=>1, 'cms_number'=>'12345678', 'additional_information'=>'string', 'apply_vat'=>true, 'trial_fixed_notice_at'=>'2015-06-01', 'trial_fixed_at'=>'2015-06-01', 'trial_cracked_at'=>'2015-06-01', 'api_key'=>'test_key'} }
+  let(:defendant_params)                    { {'first_name'=>'Angela', 'last_name'=>'Merkel', 'date_of_birth'=>'1979-12-10', 'order_for_judicial_apportionment'=>true, 'claim_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', 'api_key'=>'test_key'} }
+  let(:rep_order_params)                    { {'maat_reference'=>'1234567891', 'representation_order_date'=>'2015-05-01', 'defendant_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', 'api_key'=>'test_key'} }
+  let(:fee_params)                          { {'fee_type_id'=>2, 'quantity'=>1, 'rate'=>1.1, 'claim_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', 'api_key'=>'test_key'} }
   let(:expense_params)                      { {
                                                 'expense_type_id' => 1,
                                                 'quantity' => 1,
                                                 'amount' => 235.46,
+                                                'distance' => 300,
                                                 'reason_id' => 4,
+                                                'mileage_rate_id' => 1,
                                                 'location'=>'London',
                                                 'claim_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7',
                                                 'date'=>'2015-06-01',
-                                                api_key: 'test_key'
+                                                'api_key'=>'test_key'
                                               }
                                             }
-  let(:date_attended_params)                { {'attended_item_type'=>/Fee|Expense/, 'date'=>'2015-06-01', 'date_to'=>'2015-06-01', 'attended_item_id'=>'1234', api_key: 'test_key'} }
+  let(:date_attended_params)                { {'attended_item_type'=>/Fee|Expense/, 'date'=>'2015-06-01', 'date_to'=>'2015-06-01', 'attended_item_id'=>'1234', 'api_key'=>'test_key'} }
   let(:successful_claim_response)           { double 'api_response', code: 201, body: {'id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7'}.to_json }
   let(:successful_defendant_response)       { double 'api_response', code: 201, body: {'id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7'}.to_json }
   let(:successful_rep_order_response)       { double 'api_response', code: 201 }
@@ -63,17 +66,15 @@ describe JsonDocumentImporter do
         subject.import!
       end
 
-    context 'validates the data against our schema' do
+      context 'validates the data against our schema' do
+        let(:subject) { JsonDocumentImporter.new(json_file: exported_claim_with_schema_error, schema: schema, api_key: 'test_key') }
 
-      let(:subject) { JsonDocumentImporter.new(json_file: exported_claim_with_schema_error, schema: schema, api_key: 'test_key') }
-
-      it 'and adds invalid claim hashes to an array' do
-        subject.import!
-        expect(subject.failed_schema_validation.count).to eq 1
+        it 'and adds invalid claim hashes to an array' do
+          subject.import!
+          expect(subject.failed_schema_validation.count).to eq 1
+          expect(subject.failed_schema_validation).to eq([{case_number: "A12345678", error: "The property '#/claim/defendants' of type Hash did not match the following type: array"}])
+        end
       end
-
-    end
-
     end
 
     context 'each claim is processed as an atomic transaction' do


### PR DESCRIPTION
- The JSON schema validator was not actually validating the required items (_facepalm_). Now it will.
- Relaxed the number of required items (as now those are being enforced!) and added the format 'date' to fields that require it.
- Fixed a pesky bug where passing an api_key might take precedence over the actual logged in user provider api_key.
