### PR TITLE
Big refactor of the API to start supporting litigator claims more easily.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,7 +37,6 @@ Lint/Eval:
 # Offense count: 2
 Lint/HandleExceptions:
   Exclude:
-    - 'app/interfaces/api/logger.rb'
     - 'app/models/concerns/document_attachment.rb'
 
 # Offense count: 11
@@ -50,7 +49,6 @@ Lint/ShadowingOuterLocalVariable:
 # Cop supports --auto-correct.
 Lint/StringConversionInInterpolation:
   Exclude:
-    - 'app/interfaces/api/v1/api_helper.rb'
     - 'app/presenters/error_detail.rb'
 
 # Offense count: 19
@@ -59,7 +57,6 @@ Lint/StringConversionInInterpolation:
 Lint/UnusedBlockArgument:
   Exclude:
     - 'app/controllers/external_users/certifications_controller.rb'
-    - 'app/interfaces/api/v1/dropdown_data.rb'
     - 'app/models/claims/cloner.rb'
     - 'app/models/json_document_importer.rb'
     - 'app/presenters/claim/base_claim_presenter.rb'
@@ -87,7 +84,6 @@ Lint/UselessAssignment:
     - 'app/controllers/case_workers/admin/allocations_controller.rb'
     - 'app/controllers/heartbeat_controller.rb'
     - 'app/form_builders/adp_form_builder.rb'
-    - 'app/interfaces/api/v1/api_response.rb'
     - 'app/models/claims/search.rb'
     - 'app/models/concerns/document_attachment.rb'
     - 'app/models/json_document_importer.rb'
@@ -102,7 +98,6 @@ Lint/Void:
 # Cop supports --auto-correct.
 Performance/Casecmp:
   Exclude:
-    - 'app/interfaces/api/v1/dropdown_data.rb'
     - 'app/models/concerns/document_attachment.rb'
 
 # Offense count: 2
@@ -184,14 +179,7 @@ Style/ConditionalAssignment:
   Exclude:
     - 'app/controllers/case_workers/claims_controller.rb'
     - 'app/controllers/messages_controller.rb'
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/concerns/number_comma_parser.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/EmptyCaseCondition:
-  Exclude:
-    - 'app/interfaces/api/v1/error_response.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -223,8 +211,6 @@ Style/EmptyLinesAroundAccessModifier:
 # Cop supports --auto-correct.
 Style/EmptyLinesAroundMethodBody:
   Exclude:
-    - 'app/interfaces/api/custom_validations/date_format.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
     - 'app/models/claim/transfer_brain_data_item.rb'
     - 'app/models/claims/sort.rb'
     - 'app/models/claims/state_machine.rb'
@@ -239,7 +225,6 @@ Style/ExtraSpacing:
     - 'app/controllers/external_users/registrations_controller.rb'
     - 'app/controllers/heartbeat_controller.rb'
     - 'app/controllers/super_admins/external_users_controller.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
     - 'app/models/claim/base_claim.rb'
     - 'app/models/claim/transfer_brain_data_item.rb'
     - 'app/models/claim/transfer_brain_data_item_collection.rb'
@@ -288,8 +273,6 @@ Style/IfInsideElse:
 Style/IndentationConsistency:
   Exclude:
     - 'app/helpers/claims_helper.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/fee/basic_fee_type.rb'
     - 'app/models/message.rb'
 
@@ -302,23 +285,11 @@ Style/IndentationWidth:
     - 'app/controllers/super_admins/external_users_controller.rb'
     - 'app/controllers/super_admins/providers_controller.rb'
     - 'app/helpers/claims_helper.rb'
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/defendant.rb'
     - 'app/models/fee/basic_fee_type.rb'
     - 'app/presenters/claim_history_presenter.rb'
     - 'app/validators/base_validator.rb'
     - 'lib/api_test_client.rb'
-
-# Offense count: 12
-# Cop supports --auto-correct.
-Style/MethodCallParentheses:
-  Exclude:
-    - 'app/interfaces/api/v1/external_users/claim.rb'
-    - 'app/interfaces/api/v1/external_users/date_attended.rb'
-    - 'app/interfaces/api/v1/external_users/defendant.rb'
-    - 'app/interfaces/api/v1/external_users/expense.rb'
-    - 'app/interfaces/api/v1/external_users/fee.rb'
-    - 'app/interfaces/api/v1/external_users/representation_order.rb'
 
 # Offense count: 2
 Style/MethodCalledOnDoEndBlock:
@@ -332,7 +303,6 @@ Style/MethodCalledOnDoEndBlock:
 Style/MultilineArrayBraceLayout:
   Exclude:
     - 'app/helpers/case_workers/admin/allocations_helper.rb'
-    - 'app/interfaces/api/v1/external_users/claim.rb'
     - 'app/models/document.rb'
     - 'app/models/message.rb'
     - 'lib/api_test_client.rb'
@@ -358,7 +328,6 @@ Style/MultilineOperationIndentation:
 Style/MutableConstant:
   Exclude:
     - 'app/form_builders/adp_date_fields.rb'
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/case_type.rb'
     - 'app/models/case_worker.rb'
     - 'app/models/certification_type.rb'
@@ -433,17 +402,10 @@ Style/RedundantParentheses:
 Style/RedundantReturn:
   Exclude:
     - 'app/controllers/concerns/password_helpers.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
     - 'app/presenters/claim_state_transition_presenter.rb'
     - 'app/presenters/error_message_translator.rb'
     - 'app/presenters/error_presenter.rb'
     - 'app/validators/base_validator.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/SpaceAfterColon:
-  Exclude:
-    - 'app/interfaces/api/v1/external_users/representation_order.rb'
 
 # Offense count: 66
 # Cop supports --auto-correct.
@@ -453,9 +415,6 @@ Style/SpaceAfterComma:
     - 'app/controllers/external_users/certifications_controller.rb'
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/claims_helper.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
-    - 'app/interfaces/api/v1/dropdown_data.rb'
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/allocation.rb'
     - 'app/models/claim/transfer_brain.rb'
     - 'app/models/claims/allocation_filters.rb'
@@ -486,8 +445,6 @@ Style/SpaceAroundOperators:
     - 'app/controllers/external_users/registrations_controller.rb'
     - 'app/controllers/heartbeat_controller.rb'
     - 'app/controllers/super_admins/external_users_controller.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/claim/transfer_brain_data_item.rb'
     - 'app/models/claim/transfer_brain_data_item_collection.rb'
     - 'app/models/claims/sort.rb'
@@ -507,12 +464,6 @@ Style/SpaceAroundOperators:
 Style/SpaceBeforeBlockBraces:
   Enabled: false
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/SpaceBeforeComma:
-  Exclude:
-    - 'app/interfaces/api/v1/external_users/claim.rb'
-
 # Offense count: 16
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
@@ -525,8 +476,6 @@ Style/SpaceInsideBlockBraces:
 Style/SpaceInsideBrackets:
   Exclude:
     - 'app/helpers/case_workers/admin/allocations_helper.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
-    - 'app/interfaces/api/v1/external_users/claim.rb'
     - 'app/models/ability.rb'
     - 'app/models/claim/litigator_claim.rb'
     - 'app/models/claim/transfer_claim.rb'
@@ -555,7 +504,6 @@ Style/SpaceInsideHashLiteralBraces:
 Style/SpaceInsideParens:
   Exclude:
     - 'app/controllers/case_workers/admin/allocations_controller.rb'
-    - 'app/interfaces/api/v1/api_helper.rb'
     - 'app/models/claims/state_machine.rb'
     - 'app/presenters/claim/base_claim_presenter.rb'
     - 'app/validators/claim/base_claim_validator.rb'
@@ -611,7 +559,6 @@ Style/TrailingWhitespace:
 # Whitelist: to_ary, to_a, to_c, to_enum, to_h, to_hash, to_i, to_int, to_io, to_open, to_path, to_proc, to_r, to_regexp, to_str, to_s, to_sym
 Style/TrivialAccessors:
   Exclude:
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/claim/base_claim.rb'
     - 'lib/api_test_client.rb'
 
@@ -619,7 +566,6 @@ Style/TrivialAccessors:
 # Cop supports --auto-correct.
 Style/UnlessElse:
   Exclude:
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/date_attended.rb'
     - 'app/presenters/claim_csv_presenter.rb'
 
@@ -627,7 +573,6 @@ Style/UnlessElse:
 # Cop supports --auto-correct.
 Style/UnneededInterpolation:
   Exclude:
-    - 'app/interfaces/api/v1/error_response.rb'
     - 'app/models/date_attended.rb'
     - 'app/presenters/claim_state_transition_presenter.rb'
 

--- a/app/interfaces/api/authorisation.rb
+++ b/app/interfaces/api/authorisation.rb
@@ -1,0 +1,18 @@
+module API
+  module Authorisation
+    class AuthorisationError < StandardError; end
+
+    def authorise_claim!
+      if claim_creator.provider != current_provider || claim_user.provider != current_provider
+        raise AuthorisationError, 'Creator and advocate/litigator must belong to the provider'
+      end
+    end
+
+    def authenticate_key!
+      if current_provider.nil? || current_provider.api_key.blank?
+        raise AuthorisationError, 'Unauthorised'
+      end
+    end
+
+  end
+end

--- a/app/interfaces/api/v1/api_response.rb
+++ b/app/interfaces/api/v1/api_response.rb
@@ -2,7 +2,7 @@ class ApiResponse
   attr_accessor :status, :body
 
   def success?(status_code=nil)
-    code = status_code ||= '2'
+    code = status_code || '2'
     status.to_s =~ /^#{code}/ ? true : false
   end
 end

--- a/app/interfaces/api/v1/claim_helper.rb
+++ b/app/interfaces/api/v1/claim_helper.rb
@@ -1,0 +1,21 @@
+module API::V1
+  module ClaimHelper
+    extend Grape::API::Helpers
+
+    params :common_params do
+      # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+      optional :api_key, type: String, desc: "REQUIRED: The API authentication key of the provider"
+      optional :creator_email, type: String, desc: "REQUIRED: The ADP administrator account email address that uniquely identifies the creator of the claim."
+      optional :court_id, type: Integer, desc: "REQUIRED: The unique identifier for this court"
+      optional :case_type_id, type: Integer, desc: "REQUIRED: The unique identifier of the case type"
+      optional :case_number, type: String, desc: "REQUIRED: The case number"
+      optional :cms_number, type: String, desc: "OPTIONAL: The CMS number"
+      optional :additional_information, type: String, desc: "OPTIONAL: Any additional information"
+      optional :apply_vat, type: Boolean, desc: "OPTIONAL: Include VAT (JSON Boolean data type: true or false)"
+    end
+
+    def build_arguments
+      declared_params.merge(source: claim_source, creator_id: claim_creator.id, external_user_id: claim_user.id)
+    end
+  end
+end

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -1,7 +1,5 @@
 module API
   module V1
-
-    # -----------------------
     class DropdownData < GrapeApiHelper
 
       version 'v1', using: :header, vendor: 'Advocate Defence Payments'
@@ -9,121 +7,99 @@ module API
       prefix 'api'
       content_type :json, 'application/json'
 
-      helpers do
-        params :api_key_params do
-          optional :api_key, type: String, desc: "REQUIRED: The API authentication key of the provider"
-        end
-
-        def authenticate!(params)
-          ApiHelper.authenticate_key!(params)
-        rescue API::V1::ArgumentError
-          error!('Unauthorised', 401)
-        end
+      params do
+        optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the provider'
       end
 
-      before do
-        authenticate!(params)
-      end
-
-      resource :case_types do
-        desc "Return all Case Types"
-        params { use :api_key_params }
-        get do
-          present CaseType.agfs, with: API::Entities::CaseType
-        end
-      end
-
-      resource :courts do
-        desc "Return all Courts"
-        params { use :api_key_params }
-        get do
-          present Court.all, with: API::Entities::Court
-        end
-      end
-
-      resource :advocate_categories do
-        desc "Return all Advocate Categories"
-        params { use :api_key_params }
-        get do
-          Settings.advocate_categories
-        end
-      end
-
-      resource :trial_cracked_at_thirds do
-        desc "Return all Trial Cracked at Third values (i.e. first, second, final)"
-        params { use :api_key_params }
-        get do
-          Settings.trial_cracked_at_third
-        end
-      end
-
-      resource :offence_classes do
-        desc "Return all Offence Class Types."
-        params { use :api_key_params }
-        get do
-          present OffenceClass.all, with: API::Entities::OffenceClass
-        end
-      end
-
-      resource :offences do
-        desc "Return all Offence Types."
-
-        params do
-          use :api_key_params
-          optional :offence_description, type:  String, desc: "Offences matching description"
+      group do
+        resource :case_types do
+          desc "Return all Case Types"
+          get do
+            present CaseType.agfs, with: API::Entities::CaseType
+          end
         end
 
-        get do
-          offences = if params[:offence_description].present?
-                       Offence.where(description: params[:offence_description])
-                     else
-                       Offence.all
-                     end
-
-          present offences, with: API::Entities::Offence
+        resource :courts do
+          desc "Return all Courts"
+          get do
+            present Court.all, with: API::Entities::Court
+          end
         end
-      end
 
-      # TODO: allow 'graduated, interim and transfer' categories once we open the API to litigator claims
-      resource :fee_types do
-        helpers do
-          params :category_filter do
-            use :api_key_params
+        resource :advocate_categories do
+          desc "Return all Advocate Categories"
+          get do
+            Settings.advocate_categories
+          end
+        end
+
+        resource :trial_cracked_at_thirds do
+          desc "Return all Trial Cracked at Third values (i.e. first, second, final)"
+          get do
+            Settings.trial_cracked_at_third
+          end
+        end
+
+        resource :offence_classes do
+          desc "Return all Offence Class Types."
+          get do
+            present OffenceClass.all, with: API::Entities::OffenceClass
+          end
+        end
+
+        resource :offences do
+          desc "Return all Offence Types."
+          params do
+            optional :offence_description, type: String, desc: "Offences matching description"
+          end
+          get do
+            offences = if params[:offence_description].present?
+                         Offence.where(description: params[:offence_description])
+                       else
+                         Offence.all
+                       end
+
+            present offences, with: API::Entities::Offence
+          end
+        end
+
+        # TODO: allow 'graduated, interim and transfer' categories once we open the API to litigator claims
+        resource :fee_types do
+          helpers do
+            def category
+              params.category.try(:downcase)
+            end
+          end
+
+          params do
             optional :category, type: String, values: %w(all basic misc fixed ), default: 'all',
                      desc: "[optional] category - #{%w(all basic misc fixed).to_sentence}. Default: all"
           end
 
-          def category
-            params.category.try(:downcase)
+          desc "Return all AGFS Fee Types (optional category filter)."
+          get do
+            fee_types = if category.blank? || category == 'all'
+                          Fee::BaseFeeType.agfs
+                        else
+                          Fee::BaseFeeType.__send__(category).agfs
+                        end
+
+            present fee_types, with: API::Entities::BaseFeeType
           end
         end
 
-        desc "Return all AGFS Fee Types (optional category filter)."
-        params { use :category_filter }
-        get do
-          fee_types = if category.blank? || category == 'all'
-                        Fee::BaseFeeType.agfs
-                      else
-                        Fee::BaseFeeType.__send__(category).agfs
-                      end
-
-          present fee_types, with: API::Entities::BaseFeeType
+        resource :expense_types do
+          desc "Return all Expense Types."
+          get do
+            present ExpenseType.agfs, with: API::Entities::ExpenseType
+          end
         end
-      end
 
-      resource :expense_types do
-        desc "Return all Expense Types."
-        params { use :api_key_params }
-        get do
-          present ExpenseType.agfs, with: API::Entities::ExpenseType
-        end
-      end
-
-      resource :disbursement_types do
-        desc "Return all Disbursement Types."
-        params { use :api_key_params }
-        get do
-          present DisbursementType.all, with: API::Entities::DisbursementType
+        resource :disbursement_types do
+          desc "Return all Disbursement Types."
+          get do
+            present DisbursementType.all, with: API::Entities::DisbursementType
+          end
         end
       end
 

--- a/app/interfaces/api/v1/error_response.rb
+++ b/app/interfaces/api/v1/error_response.rb
@@ -22,7 +22,8 @@ class ErrorResponse
 
   VALID_MODEL_KLASSES = [
       Fee::GraduatedFee, Fee::InterimFee, Fee::TransferFee, Fee::BasicFee, Fee::MiscFee, Fee::FixedFee,
-      Expense, Disbursement, Claim::AdvocateClaim, Defendant, DateAttended, RepresentationOrder
+      Expense, Disbursement, Defendant, DateAttended, RepresentationOrder,
+      Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim
   ].freeze
 
   def initialize(object)
@@ -44,7 +45,7 @@ private
   end
 
   def translations
-    message_file ||= Rails.root.join('config','locales',"error_messages.#{I18n.locale}.yml")
+    message_file ||= Rails.root.join('config', 'locales', "error_messages.#{I18n.locale}.yml")
     YAML.load_file(message_file)
   end
 
@@ -68,7 +69,7 @@ private
 
   # format of field name determines lookup in translations
   def format_field_name(field_name)
-    "#{submodel_prefix + field_name.to_s}".to_sym
+    (submodel_prefix + field_name.to_s).to_s.to_sym
   end
 
   def fetch_and_translate_error_messages
@@ -84,12 +85,12 @@ private
   end
 
   def build_error_response
-    unless @model.errors.empty?
+    if @model.errors.empty?
+      raise "unable to build error response as no errors were found"
+    else
       fetch_and_translate_error_messages
       @body = error_messages
       @status = 400
-    else
-      raise "unable to build error response as no errors were found"
     end
   end
 end

--- a/app/interfaces/api/v1/external_users/claim.rb
+++ b/app/interfaces/api/v1/external_users/claim.rb
@@ -1,107 +1,23 @@
 module API
   module V1
     module ExternalUsers
-      class Claim < GrapeApiHelper
-
+      class Claim < Grape::API
         version 'v1', using: :header, vendor: 'Advocate Defence Payments'
         format :json
         prefix 'api/external_users'
         content_type :json, 'application/json'
 
         resource :claims, desc: 'Create or Validate' do
-
-          helpers do
-
-            params :claim_params do
-              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
-              optional :api_key, type: String,                    desc: "REQUIRED: The API authentication key of the provider"
-              optional :creator_email, type: String,              desc: "REQUIRED: The ADP administrator account email address that uniquely identifies the creator of the claim."
-              optional :advocate_email, type: String,             desc: "REQUIRED: The ADP account email address that uniquely identifies the advocate to whom this claim belongs."
-              optional :advocate_category, type: String,          desc: "REQUIRED: The category of the advocate", values: Settings.advocate_categories
-              optional :court_id, type: Integer,                  desc: "REQUIRED: The unique identifier for this court"
-              optional :case_type_id, type: Integer,              desc: "REQUIRED: The unique identifier of the case type"
-              optional :case_number, type: String,                desc: "REQUIRED: The case number"
-              optional :offence_id, type: Integer,                desc: "REQUIRED: The unique identifier for this offence"
-              optional :first_day_of_trial, type: String,         desc: "REQUIRED: YYYY-MM-DD", standard_json_format: true
-              optional :estimated_trial_length, type: Integer,    desc: "REQUIRED: The estimated trial length in days"
-              optional :actual_trial_length, type: Integer,       desc: "REQUIRED: The actual trial length in days"
-              optional :trial_concluded_at, type: String,         desc: "REQUIRED: The date the trial concluded (YYYY-MM-DD)", standard_json_format: true
-              optional :retrial_started_at, type: String,         desc: "REQUIRED for retrials: YYYY-MM-DD", standard_json_format: true
-              optional :retrial_estimated_length, type: Integer,  desc: "REQUIRED for retrials: The estimated retrial length in days"
-              optional :retrial_actual_length, type: Integer,     desc: "REQUIRED for retrials: The actual retrial length in days"
-              optional :retrial_concluded_at, type: String,       desc: "REQUIRED for retrials: YYYY-MM-DD", standard_json_format: true
-
-              # OPTIONAL params
-              optional :cms_number, type: String,               desc: "OPTIONAL: The CMS number"
-              optional :additional_information , type: String,  desc: "OPTIONAL: Any additional information"
-              optional :apply_vat , type: Boolean,              desc: "OPTIONAL: Include VAT (JSON Boolean data type: true or false)"
-              optional :trial_fixed_notice_at, type: String,    desc: "OPTIONAL: YYYY-MM-DD", standard_json_format: true
-              optional :trial_fixed_at, type: String,           desc: "OPTIONAL: YYYY-MM-DD", standard_json_format: true
-              optional :trial_cracked_at, type: String,         desc: "OPTIONAL: YYYY-MM-DD", standard_json_format: true
-              optional :trial_cracked_at_third, type: String,   desc: "OPTIONAL: The third in which this case was cracked.", values: Settings.trial_cracked_at_third
-            end
-
-            def build_arguments
-              authenticated = ApiHelper.authenticate_claim!(params)
-              non_date_fields = {
-                creator_id:               authenticated[:creator].id,
-                external_user_id:         authenticated[:advocate].id,
-                source:                   params[:source] || 'api',
-                case_number:              params[:case_number],
-                case_type_id:             params[:case_type_id],
-                estimated_trial_length:   params[:estimated_trial_length],
-                actual_trial_length:      params[:actual_trial_length],
-                advocate_category:        params[:advocate_category],
-                cms_number:               params[:cms_number],
-                additional_information:   params[:additional_information],
-                apply_vat:                params[:apply_vat],
-                trial_cracked_at_third:   params[:trial_cracked_at_third],
-                offence_id:               params[:offence_id],
-                court_id:                 params[:court_id],
-                retrial_estimated_length: params[:retrial_estimated_length],
-                retrial_actual_length:    params[:retrial_actual_length]
-              }
-              args = Hash.new
-              date_fields = [ :first_day_of_trial,
-                              :trial_concluded_at,
-                              :trial_fixed_notice_at,
-                              :trial_fixed_at,
-                              :trial_cracked_at,
-                              :retrial_started_at,
-                              :retrial_concluded_at
-                            ]
-              args.merge!(non_date_fields).merge_date_fields!(date_fields, params)
-              args
-            end
+          before do
+            authorise_claim!
           end
 
-          desc "Create a claim."
+          mount API::V1::ExternalUsers::Claims::AdvocateClaim
 
-          params do
-            use :claim_params
-          end
-
-          post do
-            api_response = ApiResponse.new()
-            ApiHelper.create_resource(::Claim::AdvocateClaim, params, api_response, method(:build_arguments).to_proc)
-            status api_response.status
-            return api_response.body
-          end
-
-          # ------------------------
-          desc "Validate a claim."
-
-          params do
-            use :claim_params
-          end
-
-          post '/validate' do
-            api_response = ApiResponse.new()
-            ApiHelper.validate_resource(::Claim::AdvocateClaim, params, api_response, method(:build_arguments).to_proc)
-            status api_response.status
-            return api_response.body
-          end
-
+          # TODO: uncomment to enable the new types
+          #mount API::V1::ExternalUsers::Claims::FinalClaim
+          #mount API::V1::ExternalUsers::Claims::InterimClaim
+          #mount API::V1::ExternalUsers::Claims::TransferClaim
         end
       end
     end

--- a/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
@@ -1,0 +1,47 @@
+module API::V1::ExternalUsers
+  module Claims
+    class AdvocateClaim < Grape::API
+      helpers API::V1::ClaimHelper
+
+      params do
+        use :common_params
+
+        optional :advocate_email, type: String, desc: "REQUIRED: The ADP account email address that uniquely identifies the advocate to whom this claim belongs."
+        optional :advocate_category, type: String, desc: "REQUIRED: The category of the advocate", values: Settings.advocate_categories
+        optional :offence_id, type: Integer, desc: "REQUIRED: The unique identifier for this offence"
+        optional :first_day_of_trial, type: String, desc: "REQUIRED: YYYY-MM-DD", standard_json_format: true
+        optional :estimated_trial_length, type: Integer, desc: "REQUIRED: The estimated trial length in days"
+        optional :actual_trial_length, type: Integer, desc: "REQUIRED: The actual trial length in days"
+        optional :trial_concluded_at, type: String, desc: "REQUIRED: The date the trial concluded (YYYY-MM-DD)", standard_json_format: true
+        optional :retrial_started_at, type: String, desc: "REQUIRED for retrials: YYYY-MM-DD", standard_json_format: true
+        optional :retrial_estimated_length, type: Integer, desc: "REQUIRED for retrials: The estimated retrial length in days"
+        optional :retrial_actual_length, type: Integer, desc: "REQUIRED for retrials: The actual retrial length in days"
+        optional :retrial_concluded_at, type: String, desc: "REQUIRED for retrials: YYYY-MM-DD", standard_json_format: true
+        optional :cms_number, type: String, desc: "OPTIONAL: The CMS number"
+        optional :additional_information, type: String, desc: "OPTIONAL: Any additional information"
+        optional :apply_vat, type: Boolean, desc: "OPTIONAL: Include VAT (JSON Boolean data type: true or false)"
+        optional :trial_fixed_notice_at, type: String, desc: "OPTIONAL: YYYY-MM-DD", standard_json_format: true
+        optional :trial_fixed_at, type: String, desc: "OPTIONAL: YYYY-MM-DD", standard_json_format: true
+        optional :trial_cracked_at, type: String, desc: "OPTIONAL: YYYY-MM-DD", standard_json_format: true
+        optional :trial_cracked_at_third, type: String, desc: "OPTIONAL: The third in which this case was cracked.", values: Settings.trial_cracked_at_third
+      end
+
+      namespace '/' do
+        desc 'Create an Advocate claim.'
+        post do
+          create_resource(::Claim::AdvocateClaim)
+          status api_response.status
+          api_response.body
+        end
+
+        desc 'Validate an Advocate claim.'
+        post '/validate' do
+          validate_resource(::Claim::AdvocateClaim)
+          status api_response.status
+          api_response.body
+        end
+      end
+
+    end
+  end
+end

--- a/app/interfaces/api/v1/external_users/claims/final_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/final_claim.rb
@@ -1,0 +1,28 @@
+module API::V1::ExternalUsers
+  module Claims
+    class FinalClaim < Grape::API
+      helpers API::V1::ClaimHelper
+
+      params do
+        use :common_params
+      end
+
+      namespace :final do
+        desc 'Create a Litigator final claim.'
+        post do
+          create_resource(::Claim::LitigatorClaim)
+          status api_response.status
+          api_response.body
+        end
+
+        desc 'Validate a Litigator final claim.'
+        post '/validate' do
+          validate_resource(::Claim::LitigatorClaim)
+          status api_response.status
+          api_response.body
+        end
+      end
+
+    end
+  end
+end

--- a/app/interfaces/api/v1/external_users/claims/interim_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/interim_claim.rb
@@ -1,0 +1,28 @@
+module API::V1::ExternalUsers
+  module Claims
+    class InterimClaim < Grape::API
+      helpers API::V1::ClaimHelper
+
+      params do
+        use :common_params
+      end
+
+      namespace :interim do
+        desc 'Create a Litigator interim claim.'
+        post do
+          create_resource(::Claim::InterimClaim)
+          status api_response.status
+          api_response.body
+        end
+
+        desc 'Validate a Litigator interim claim.'
+        post '/validate' do
+          validate_resource(::Claim::InterimClaim)
+          status api_response.status
+          api_response.body
+        end
+      end
+
+    end
+  end
+end

--- a/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
@@ -1,0 +1,28 @@
+module API::V1::ExternalUsers
+  module Claims
+    class TransferClaim < Grape::API
+      helpers API::V1::ClaimHelper
+
+      params do
+        use :common_params
+      end
+
+      namespace :transfer do
+        desc 'Create a Litigator transfer claim.'
+        post do
+          create_resource(::Claim::TransferClaim)
+          status api_response.status
+          api_response.body
+        end
+
+        desc 'Validate a Litigator transfer claim.'
+        post '/validate' do
+          validate_resource(::Claim::TransferClaim)
+          status api_response.status
+          api_response.body
+        end
+      end
+
+    end
+  end
+end

--- a/app/interfaces/api/v1/external_users/date_attended.rb
+++ b/app/interfaces/api/v1/external_users/date_attended.rb
@@ -2,79 +2,47 @@ module API
   module V1
     module ExternalUsers
 
-      class DateAttended < GrapeApiHelper
+      class DateAttended < Grape::API
 
         version 'v1', using: :header, vendor: 'Advocate Defence Payments'
         format :json
         prefix 'api/external_users'
         content_type :json, 'application/json'
 
+        params do
+          # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+          optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the provider'
+          optional :attended_item_id, type: String, desc: 'REQUIRED: The UUID of the corresponding Fee.'
+          optional :date, type: String, desc: 'REQUIRED: The date, or first date in the date-range, applicable to this Fee (YYYY-MM-DD)', standard_json_format: true
+          optional :date_to, type: String, desc: 'OPTIONAL: The last date in the date-range (YYYY-MM-DD)', standard_json_format: true
+        end
+
         resource :dates_attended, desc: 'Create or Validate' do
-
           helpers do
-            params :date_attended_params do
-              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
-              optional :api_key, type: String,            desc: "REQUIRED: The API authentication key of the provider"
-              optional :attended_item_id, type: String,   desc: 'REQUIRED: The UUID of the corresponding Fee.'
-              optional :date, type: String,               desc: 'REQUIRED: The date, or first date in the date-range, applicable to this Fee (YYYY-MM-DD)', standard_json_format: true
-              optional :date_to, type: String,            desc: 'OPTIONAL: The last date in the date-range (YYYY-MM-DD)', standard_json_format: true
-            end
-
-            # NOTE: explicit error raising because attended_id's presence is
-            # not validated by model due to instatiation issues# TODO review in
-            # code review
-            def validate_attended_item_presence
-              attended_item_id = ::Fee::BaseFee.find_by(uuid: params[:attended_item_id]).try(:id)
-              if attended_item_id.nil?
-                raise API::V1::ArgumentError, 'Attended item cannot be blank'
-              end
-              attended_item_id
+            def attended_item_id
+              ::Fee::BaseFee.find_by(uuid: params[:attended_item_id]).try(:id) || (raise API::V1::ArgumentError, 'Attended item cannot be blank')
             end
 
             def build_arguments
-              non_date_fields = {
-                attended_item_id: validate_attended_item_presence,
-                attended_item_type: "Fee::BaseFee"
-              }
-              args = Hash.new
-              args.merge!(non_date_fields).merge_date_fields!([:date, :date_to], params)
-              args
+              declared_params.merge(attended_item_id: attended_item_id, attended_item_type: 'Fee::BaseFee')
             end
-
           end
 
-          desc "Create a date_attended."
-
-          params do
-            use :date_attended_params
-          end
-
+          desc 'Create a date_attended.'
           post do
-            api_response = ApiResponse.new()
-            ApiHelper.create_resource(::DateAttended, params, api_response, method(:build_arguments).to_proc)
+            create_resource(::DateAttended)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
 
-          desc "Validate a date_attended."
-
-          params do
-            use :date_attended_params
-          end
-
+          desc 'Validate a date_attended.'
           post '/validate' do
-            api_response = ApiResponse.new()
-            ApiHelper.validate_resource(::DateAttended, params, api_response, method(:build_arguments).to_proc)
+            validate_resource(::DateAttended)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
-
         end
-
-
       end
-
     end
-
   end
 end

--- a/app/interfaces/api/v1/external_users/defendant.rb
+++ b/app/interfaces/api/v1/external_users/defendant.rb
@@ -2,73 +2,45 @@ module API
   module V1
     module ExternalUsers
 
-      class Defendant < GrapeApiHelper
+      class Defendant < Grape::API
 
         version 'v1', using: :header, vendor: 'Advocate Defence Payments'
         format :json
         prefix 'api/external_users'
         content_type :json, 'application/json'
 
-        resource :defendants, desc: 'Create or Validate' do
-
-          helpers do
-
-            params :defendant_params do
-              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
-              optional :api_key, type: String,                            desc: "REQUIRED: The API authentication key of the provider"
-              optional :claim_id, type: String,                           desc: "REQUIRED: Unique identifier for the claim associated with this defendant."
-              optional :first_name, type: String,                         desc: "REQUIRED: First name of the defedant."
-              optional :last_name, type: String,                          desc: "REQUIRED: Last name of the defendant."
-              optional :date_of_birth, type: String,                      desc: "REQUIRED: Defendant's date of birth (YYYY-MM-DD).", standard_json_format: true
-              optional :order_for_judicial_apportionment, type: Boolean,  desc: "OPTIONAL: whether or not the defendant is impacted by an order for judicial apportionment (JSON Boolean data type: true or false)"
-            end
-
-            def build_arguments
-              non_date_fields = {
-                claim_id:       ::Claim::BaseClaim.find_by(uuid: params[:claim_id]).try(:id),
-                first_name:     params[:first_name],
-                last_name:      params[:last_name],
-                order_for_judicial_apportionment: params[:order_for_judicial_apportionment]
-              }
-              args = Hash.new
-              args.merge!(non_date_fields).merge_date_fields!([:date_of_birth], params)
-              args
-            end
-
-          end
-
-          desc "Create a defendant."
-
-          params do
-            use :defendant_params
-          end
-
-          post do
-            api_response = ApiResponse.new()
-            ApiHelper.create_resource(::Defendant, params, api_response, method(:build_arguments).to_proc)
-            status api_response.status
-            return api_response.body
-          end
-
-          desc "Validate a defendant."
-
-          params do
-            use :defendant_params
-          end
-
-          post '/validate' do
-            api_response = ApiResponse.new()
-            ApiHelper.validate_resource(::Defendant, params, api_response, method(:build_arguments).to_proc)
-            status api_response.status
-            return api_response.body
-          end
-
+        params do
+          optional :api_key, type: String, desc: "REQUIRED: The API authentication key of the provider"
+          optional :claim_id, type: String, desc: "REQUIRED: Unique identifier for the claim associated with this defendant."
+          optional :first_name, type: String, desc: "REQUIRED: First name of the defedant."
+          optional :last_name, type: String, desc: "REQUIRED: Last name of the defendant."
+          optional :date_of_birth, type: String, desc: "REQUIRED: Defendant's date of birth (YYYY-MM-DD).", standard_json_format: true
+          optional :order_for_judicial_apportionment, type: Boolean, desc: "OPTIONAL: whether or not the defendant is impacted by an order for judicial apportionment (JSON Boolean data type: true or false)"
         end
 
+        resource :defendants, desc: 'Create or Validate' do
+          helpers do
+            def build_arguments
+              declared_params.merge(claim_id: claim_id)
+            end
+          end
+
+          desc 'Create a defendant.'
+          post do
+            create_resource(::Defendant)
+            status api_response.status
+            api_response.body
+          end
+
+          desc 'Validate a defendant.'
+          post '/validate' do
+            validate_resource(::Defendant)
+            status api_response.status
+            api_response.body
+          end
+        end
 
       end
-
     end
-
   end
 end

--- a/app/interfaces/api/v1/external_users/disbursement.rb
+++ b/app/interfaces/api/v1/external_users/disbursement.rb
@@ -2,61 +2,42 @@ module API
   module V1
     module ExternalUsers
 
-      class Disbursement < GrapeApiHelper
+      class Disbursement < Grape::API
 
         version 'v1', using: :header, vendor: 'Advocate Defence Payments'
         format :json
         prefix 'api/external_users'
         content_type :json, 'application/json'
 
+        params do
+          # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+          optional :api_key, type: String, desc: "REQUIRED: The API authentication key of the provider"
+          optional :claim_id, type: String, desc: "REQUIRED: Unique identifier for the claim associated with this disbursement."
+          optional :disbursement_type_id, type: Integer, desc: "REQUIRED: The unique identifier for the corresponding disbursement type."
+          optional :net_amount, type: Float, desc: "REQUIRED: The net amount of the disbursement."
+          optional :vat_amount, type: Float, desc: "REQUIRED: The VAT amount of the disbursement."
+          optional :total, type: Float, desc: "REQUIRED: The total amount of the disbursement."
+        end
+
         resource :disbursements, desc: 'Create or Validate' do
-
           helpers do
-            params :disbursement_params do
-              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
-              optional :api_key,              type: String,  desc: "REQUIRED: The API authentication key of the provider"
-              optional :claim_id,             type: String,  desc: "REQUIRED: Unique identifier for the claim associated with this disbursement."
-              optional :disbursement_type_id, type: Integer, desc: "REQUIRED: The unique identifier for the corresponding disbursement type."
-              optional :net_amount,           type: Float,   desc: "REQUIRED: The net amount of the disbursement."
-              optional :vat_amount,           type: Float,   desc: "REQUIRED: The VAT amount of the disbursement."
-              optional :total,                type: Float,   desc: "REQUIRED: The total amount of the disbursement."
-            end
-
             def build_arguments
-              {
-                claim_id: ::Claim::BaseClaim.find_by(uuid: params[:claim_id]).try(:id),
-                disbursement_type_id: params[:disbursement_type_id],
-                net_amount: params[:net_amount],
-                vat_amount: params[:vat_amount],
-                total: params[:total]
-              }
+              declared_params.merge(claim_id: claim_id)
             end
           end
 
-          desc "Create a disbursement."
-
-          params do
-            use :disbursement_params
-          end
-
+          desc 'Create a disbursement.'
           post do
-            api_response = ApiResponse.new()
-            ApiHelper.create_resource(::Disbursement, params, api_response, method(:build_arguments).to_proc)
+            create_resource(::Disbursement)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
 
-          desc "Validate a disbursement."
-
-          params do
-            use :disbursement_params
-          end
-
+          desc 'Validate a disbursement.'
           post '/validate' do
-            api_response = ApiResponse.new()
-            ApiHelper.validate_resource(::Disbursement, params, api_response, method(:build_arguments).to_proc)
+            validate_resource(::Disbursement)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
 
         end

--- a/app/interfaces/api/v1/external_users/expense.rb
+++ b/app/interfaces/api/v1/external_users/expense.rb
@@ -2,79 +2,51 @@ module API
   module V1
     module ExternalUsers
 
-      class Expense < GrapeApiHelper
+      class Expense < Grape::API
 
         version 'v1', using: :header, vendor: 'Advocate Defence Payments'
         format :json
         prefix 'api/external_users'
         content_type :json, 'application/json'
 
-        resource :expenses, desc: 'Create or Validate' do
-
-          helpers do
-            params :expense_params do
-              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
-              optional :api_key, type: String,          desc: "REQUIRED: The API authentication key of the provider"
-              optional :claim_id, type: String,         desc: "REQUIRED: Unique identifier for the claim associated with this expense."
-              optional :expense_type_id, type: Integer, desc: "REQUIRED: The unique identifier for the corresponding expense type."
-              optional :amount, type: Float,            desc: "REQUIRED: The total amount of the expense."
-              optional :location, type:  String,        desc: "REQUIRED for all expense types other than Parking. Location or destination."
-              optional :reason_id, type: Integer,       desc: "REQUIRED: Unique identifier for the reason for this travel: must be one of the valid reason ids associated with the expense type."
-              optional :reason_text, type: String,      desc: "REQUIRED when reason is Other oitherwise must be absent."
-              optional :distance, type: Integer,        desc: "REQUIRED for expense type Car Travel, otherwise must be absent. Distance in miles."
-              optional :mileage_rate_id, type: Integer, desc: "REQUIRED for expense type Car Travel, otherwise must be absent: Where applicable. Values should be 1 for 25p per mile, 2 for 45p per mile."
-              optional :hours, type: Integer,           desc: "REQUIRED for expense type Travel Time, otherwise must be absent. Time in hours."
-              optional :date, type: String,             desc: "REQUIRED: The date applicable to this Expense (YYYY-MM-DD)", standard_json_format: true
-            end
-
-            def build_arguments
-              {
-                claim_id: ::Claim::BaseClaim.find_by(uuid: params[:claim_id]).try(:id),
-                expense_type_id: params[:expense_type_id],
-                location: params[:location],
-                amount: params[:amount],
-                reason_id: params[:reason_id],
-                reason_text: params[:reason_text],
-                distance: params[:distance],
-                mileage_rate_id: params[:mileage_rate_id],
-                hours: params[:hours],
-                date: params[:date]
-              }
-            end
-          end
-
-          desc "Create an expense."
-
-          params do
-            use :expense_params
-          end
-
-          post do
-            api_response = ApiResponse.new()
-            ApiHelper.create_resource(::Expense, params, api_response, method(:build_arguments).to_proc)
-            status api_response.status
-            return api_response.body
-          end
-
-          desc "Validate an expense."
-
-          params do
-            use :expense_params
-          end
-
-          post '/validate' do
-            api_response = ApiResponse.new()
-            ApiHelper.validate_resource(::Expense, params, api_response, method(:build_arguments).to_proc)
-            status api_response.status
-            return api_response.body
-          end
-
+        params do
+          # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+          optional :api_key, type: String, desc: "REQUIRED: The API authentication key of the provider"
+          optional :claim_id, type: String, desc: "REQUIRED: Unique identifier for the claim associated with this expense."
+          optional :expense_type_id, type: Integer, desc: "REQUIRED: The unique identifier for the corresponding expense type."
+          optional :amount, type: Float, desc: "REQUIRED: The total amount of the expense."
+          optional :location, type: String, desc: "REQUIRED for all expense types other than Parking. Location or destination."
+          optional :reason_id, type: Integer, desc: "REQUIRED: Unique identifier for the reason for this travel: must be one of the valid reason ids associated with the expense type."
+          optional :reason_text, type: String, desc: "REQUIRED when reason is Other oitherwise must be absent."
+          optional :distance, type: Integer, desc: "REQUIRED for expense type Car Travel, otherwise must be absent. Distance in miles."
+          optional :mileage_rate_id, type: Integer, desc: "REQUIRED for expense type Car Travel, otherwise must be absent: Where applicable. Values should be 1 for 25p per mile, 2 for 45p per mile."
+          optional :hours, type: Integer, desc: "REQUIRED for expense type Travel Time, otherwise must be absent. Time in hours."
+          optional :date, type: String, desc: "REQUIRED: The date applicable to this Expense (YYYY-MM-DD)", standard_json_format: true
         end
 
+        resource :expenses, desc: 'Create or Validate' do
+          helpers do
+            def build_arguments
+              declared_params.merge(claim_id: claim_id)
+            end
+          end
+
+          desc 'Create an expense.'
+          post do
+            create_resource(::Expense)
+            status api_response.status
+            api_response.body
+          end
+
+          desc 'Validate an expense.'
+          post '/validate' do
+            validate_resource(::Expense)
+            status api_response.status
+            api_response.body
+          end
+        end
 
       end
-
     end
-
   end
 end

--- a/app/interfaces/api/v1/external_users/fee.rb
+++ b/app/interfaces/api/v1/external_users/fee.rb
@@ -2,88 +2,50 @@ module API
   module V1
     module ExternalUsers
 
-      class Fee < GrapeApiHelper
+      class Fee < Grape::API
 
         version 'v1', using: :header, vendor: 'Advocate Defence Payments'
         format :json
         prefix 'api/external_users'
         content_type :json, 'application/json'
 
+        params do
+          # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+          optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the provider'
+          optional :claim_id, type: String, desc: 'REQUIRED: The unique identifier for the corresponding claim.'
+          optional :fee_type_id, type: Integer, desc: 'REQUIRED: The unique identifier for the corresponding fee type'
+          optional :quantity, type: Float, desc: 'REQUIRED/UNREQUIRED: The number of fees of this fee type that are being claimed (quantity x rate will equal amount). NB: Leave blank if not applicable'
+          optional :rate, type: Float, desc: 'REQUIRED/UNREQUIRED: The currency value per unit/quantity of the fee (quantity x rate will equal amount). NB: Leave blank for PPE and NPW fee types'
+          optional :amount, type: Float, desc: 'REQUIRED/UNREQUIRED: The total value of the fee. NB: Leave blank for fee types other than PPE/NPW or a Transfer Fee'
+          optional :case_numbers, type: String, desc: 'REQUIRED/UNREQUIRED: Required for Miscellaneous Fee of type Case Uplift. Leave blank for other types'
+          optional :date, type: String, desc: 'REQUIRED/UNREQUIRED: Required for LGFS Fixed Fee or LGFS Graduated Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
+          optional :warrant_issued_date, type: String, desc: 'REQUIRED/UNREQUIRED: Required for Interim fee of type Warrant, or a Warrant Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
+          optional :warrant_executed_date, type: String, desc: 'OPTIONAL: For Interim fee of type Warrant, or a Warrant Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
+        end
+
         resource :fees, desc: 'Create or Validate' do
-
           helpers do
-
-            params :fee_params do
-              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
-              optional :api_key, type:      String,  desc: 'REQUIRED: The API authentication key of the provider'
-              optional :claim_id, type:     String,  desc: 'REQUIRED: The unique identifier for the corresponding claim.'
-              optional :fee_type_id, type:  Integer, desc: 'REQUIRED: The unique identifier for the corresponding fee type'
-              optional :quantity, type:     Float,   desc: 'REQUIRED/UNREQUIRED: The number of fees of this fee type that are being claimed (quantity x rate will equal amount). NB: Leave blank if not applicable'
-              optional :rate, type:         Float,   desc: 'REQUIRED/UNREQUIRED: The currency value per unit/quantity of the fee (quantity x rate will equal amount). NB: Leave blank for PPE and NPW fee types'
-              optional :amount, type:       Float,   desc: 'REQUIRED/UNREQUIRED: The total value of the fee. NB: Leave blank for fee types other than PPE/NPW or a Transfer Fee'
-              optional :case_numbers, type: String,  desc: 'REQUIRED/UNREQUIRED: Required for Miscellaneous Fee of type Case Uplift. Leave blank for other types'
-              optional :date, type:         String,  desc: 'REQUIRED/UNREQUIRED: Required for LGFS Fixed Fee or LGFS Graduated Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
-              optional :warrant_issued_date, type:    String, desc: 'REQUIRED/UNREQUIRED: Required for Interim fee of type Warrant, or a Warrant Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
-              optional :warrant_executed_date, type:  String, desc: 'OPTIONAL: For Interim fee of type Warrant, or a Warrant Fee, otherwise leave blank (YYYY-MM-DD)', standard_json_format: true
-            end
-
-            # NOTE: explicit error raising because claim_id's presence is not validated by model due to instatiation issues # TODO review in code review
-            def validate_claim_presence
-              claim_id = ::Claim::BaseClaim.find_by(uuid: params[:claim_id]).try(:id)
-              if claim_id.nil?
-                raise API::V1::ArgumentError, 'Claim cannot be blank'
-              end
-              claim_id
-            end
-
             def build_arguments
-              claim_id = validate_claim_presence
-              {
-                claim_id: claim_id,
-                fee_type_id: params[:fee_type_id],
-                quantity: params[:quantity],
-                rate: params[:rate],
-                amount: params[:amount],
-                case_numbers: params[:case_numbers],
-                date: params[:date],
-                warrant_issued_date: params[:warrant_issued_date],
-                warrant_executed_date: params[:warrant_executed_date]
-              }
+              declared_params.merge(claim_id: claim_id)
             end
-
           end
 
-          desc "Create a fee."
-
-          params do
-            use :fee_params
-          end
-
+          desc 'Create a fee.'
           post do
-            api_response = ApiResponse.new
-            ApiHelper.create_resource(::Fee::BaseFee, params, api_response, method(:build_arguments).to_proc)
+            create_resource(::Fee::BaseFee)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
 
-          desc "Validate a fee."
-
-          params do
-            use :fee_params
-          end
-
+          desc 'Validate a fee.'
           post '/validate' do
-            api_response = ApiResponse.new
-            ApiHelper.validate_resource(::Fee::BaseFee, params, api_response, method(:build_arguments).to_proc)
+            validate_resource(::Fee::BaseFee)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
-
         end
 
       end
-
     end
-
   end
 end

--- a/app/interfaces/api/v1/external_users/representation_order.rb
+++ b/app/interfaces/api/v1/external_users/representation_order.rb
@@ -2,76 +2,47 @@ module API
   module V1
     module ExternalUsers
 
-      class RepresentationOrder < GrapeApiHelper
+      class RepresentationOrder < Grape::API
 
         version 'v1', using: :header, vendor: 'Advocate Defence Payments'
         format :json
         prefix 'api/external_users'
         content_type :json, 'application/json'
 
+        params do
+          # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+          optional :api_key, type: String, desc: "REQUIRED: The API authentication key of the provider"
+          optional :defendant_id, type: String, desc: 'REQUIRED: ID of the defendant'
+          optional :maat_reference, type: String, desc: "REQUIRED: The unique identifier for this representation order"
+          optional :representation_order_date, type: String, desc: "REQUIRED: The date on which this representation order was granted (YYYY-MM-DD)", standard_json_format: true
+        end
+
         resource :representation_orders, desc: 'Create or Validate' do
-
           helpers do
-            # include ExtractDate
-            # include API::V1::ApiHelper
-
-            params :representation_order_params do
-              # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
-              optional :api_key, type: String,                    desc: "REQUIRED: The API authentication key of the provider"
-              optional :defendant_id, type: String,               desc: 'REQUIRED: ID of the defendant'
-              optional :maat_reference, type: String,             desc: "REQUIRED: The unique identifier for this representation order"
-              optional :representation_order_date, type: String,  desc: "REQUIRED: The date on which this representation order was granted (YYYY-MM-DD)", standard_json_format:true
-            end
-
-            # NOTE: explicit error raising because defendant_id's presence is not validated by model due to instatiation issues # TODO review in code review
-            def validate_defendant_presence
-              defendant_id = ::Defendant.find_by(uuid: params[:defendant_id]).try(:id)
-              if defendant_id.nil?
-                raise API::V1::ArgumentError, 'Defendant cannot be blank'
-              end
-              defendant_id
+            def defendant_id
+              ::Defendant.find_by(uuid: params[:defendant_id]).try(:id) || (raise API::V1::ArgumentError, 'Defendant cannot be blank')
             end
 
             def build_arguments
-              defendant_id = validate_defendant_presence
-              non_date_fields = {
-                defendant_id: defendant_id,
-                maat_reference: params[:maat_reference]
-              }
-              args = Hash.new
-              args.merge!(non_date_fields).merge_date_fields!([:representation_order_date], params)
-              args
+              declared_params.merge(defendant_id: defendant_id)
             end
-
           end
 
-          desc "Create a representation_order."
-
-          params do
-            use :representation_order_params
-          end
-
+          desc 'Create a representation_order.'
           post do
-            api_response = ApiResponse.new()
-            ApiHelper.create_resource(::RepresentationOrder, params, api_response, method(:build_arguments).to_proc)
+            create_resource(::RepresentationOrder)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
 
-
-          desc "Validate a representation_order."
-
-          params do
-            use :representation_order_params
-          end
-
+          desc 'Validate a representation_order.'
           post '/validate' do
-            api_response = ApiResponse.new()
-            ApiHelper.validate_resource(::RepresentationOrder, params, api_response, method(:build_arguments).to_proc)
+            validate_resource(::RepresentationOrder)
             status api_response.status
-            return api_response.body
+            api_response.body
           end
         end
+
       end
     end
   end

--- a/app/interfaces/api/v1/resource_helper.rb
+++ b/app/interfaces/api/v1/resource_helper.rb
@@ -1,0 +1,51 @@
+module API::V1
+  module ResourceHelper
+    extend Grape::API::Helpers
+
+    def declared_params
+      declared(params, include_missing: false)
+    end
+
+    def claim_source
+      params.source || 'api'
+    end
+
+    def claim_id
+      ::Claim::BaseClaim.find_by(uuid: params.claim_id).try(:id) || (raise API::V1::ArgumentError, 'Claim cannot be blank')
+    end
+
+    def claim_creator
+      @claim_creator ||= find_user_by_email(email: params.delete(:creator_email), relation: 'Creator')
+    end
+
+    # TODO: support user_email param (litigators)
+    def claim_user
+      @claim_user ||= find_user_by_email(email: params.delete(:advocate_email), relation: 'Advocate')
+    end
+
+    def current_provider
+      @current_provider ||= Provider.find_by(api_key: params.delete(:api_key))
+    end
+
+    def create_resource(klass)
+      API::V1::ApiHelper.create_resource(klass, params, api_response, arguments_proc)
+    end
+
+    def validate_resource(klass)
+      API::V1::ApiHelper.validate_resource(klass, api_response, arguments_proc)
+    end
+
+    def arguments_proc
+      method(:build_arguments).to_proc
+    end
+
+    def api_response
+      @api_response ||= ApiResponse.new
+    end
+
+    def find_user_by_email(email:, relation:)
+      User.external_users.find_by(email: email).try(:persona) || (raise API::V1::ArgumentError, "#{relation} email is invalid")
+    end
+
+  end
+end

--- a/spec/api/v1/external_users/api_spec_helper.rb
+++ b/spec/api/v1/external_users/api_spec_helper.rb
@@ -12,10 +12,10 @@ module ApiSpecHelper
     expect(json[idx]['error']).to include(message)
   end
 
-  def expect_unauthorised_error
+  def expect_unauthorised_error(message = 'Unauthorised')
     expect(last_response.status).to eq(401)
     json = JSON.parse(last_response.body)
-    expect(json[0]['error']).to eql("Unauthorised")
+    expect(json[0]['error']).to eql(message)
   end
 
 end

--- a/spec/api/v1/external_users/claim_spec.rb
+++ b/spec/api/v1/external_users/claim_spec.rb
@@ -72,10 +72,10 @@ describe API::V1::ExternalUsers::Claim do
 
       include_examples "invalid API key validate endpoint"
 
-      it "should return 400 and JSON error array when it is an API key from another provider's admin" do
+      it "should return 401 and JSON error array when it is an API key from another provider's admin" do
         valid_params[:api_key] = other_provider.api_key
         post_to_validate_endpoint
-        expect_error_response("Creator and advocate must belong to the provider")
+        expect_unauthorised_error("Creator and advocate/litigator must belong to the provider")
       end
 
     end
@@ -184,10 +184,10 @@ describe API::V1::ExternalUsers::Claim do
       context 'invalid API key' do
         include_examples "invalid API key create endpoint"
 
-        it "should return 400 and JSON error array when it is an API key from another provider" do
+        it "should return 401 and JSON error array when it is an API key from another provider" do
           valid_params[:api_key] = other_provider.api_key
           post_to_create_endpoint
-          expect_error_response("Creator and advocate must belong to the provider")
+          expect_unauthorised_error("Creator and advocate/litigator must belong to the provider")
         end
       end
 


### PR DESCRIPTION
Lots of code reorganisation and extracting common functionality used by all endpoints or claim endpoints to be easily shared.

Everything should continue working as before as there are no changes to the requests or the responses.

The only change introduced is changing the error message:

> "Creator and advocate must belong to the provider"

to be generic,

> "Creator and advocate/litigator must belong to the provider"

And instead of returning 400 status code for this error, it is now returning 401 to be consistent with other authorisation errors.
