### PR TITLE
AdpFormBuilder#adp_text_field

### DIFF
--- a/app/form_builders/adp_form_builder.rb
+++ b/app/form_builders/adp_form_builder.rb
@@ -11,6 +11,10 @@ class AdpFormBuilder < ActionView::Helpers::FormBuilder
     result.html_safe
   end
 
+  def adp_text_field(method, options = {})
+    atf = AdpTextField.new(self, method, options)
+    atf.to_html
+  end
 
   def anchored_label(label, anchor_name = nil, options = {})
     anchor_name ||= label.gsub(' ', '_').downcase

--- a/app/form_builders/adp_text_field.rb
+++ b/app/form_builders/adp_text_field.rb
@@ -1,0 +1,134 @@
+
+# class to create specialized text field wrapped in all the GDS gubbins
+class AdpTextField
+
+  include ExternalUsers::ClaimsHelper
+  include ActionView::Helpers::TagHelper
+
+
+  # instantiate an AdpTextField object
+  # * form: the instance of AdpFormBuilder that this is called from
+  # * method: the method on the object that the form is wrapping that this input field is for
+  # * options:
+  #   * label: label to be provided for the input field
+  #   * hint_text: Hint text displayed underneath the label
+  #   * errors: An ErrorPresenter for the form object, or the form object itself
+
+  def initialize(form, method, options)
+    @form = form
+    @method = method
+    @options = options
+    @form_field_id = generate_form_field_id
+    @form_field_name = generate_form_field_name
+    @errors = options[:errors]
+    @anchor_id = generate_anchor_id
+  end
+
+
+  # the methods output_buffer= and output_buffer are required by the content_tag
+  # methods, called from the validation_error_message in ExternalUsers::ClaimsHelper
+  #
+  def output_buffer=(value)
+    @errors = value
+  end
+
+  def output_buffer
+    @errors
+  end
+
+  def has_errors?
+    @errors.errors_for?(@anchor_id.to_sym)
+  end
+
+  def to_html
+    result = div_start
+    result += anchor
+    result += label
+    result += hint
+    result += error_message
+    result += label_close
+    result += input_field
+    result += div_close
+    result.html_safe
+  end
+
+  private
+
+  def generate_form_field_id
+    # @form.object_name either returns a symbol for top level fields (e.g. :claim), or
+    # a string like "claim[defendants_attributes][0]" for cocoon nested objects
+    if @form.object_name.is_a?(Symbol)
+      "#{@form.object_name}_#{@method}"
+    else
+      # translates e.g. claim[defendants_attributes][0]_last_name to claim_defendants_attributes_0_last_name
+      @form.object_name.to_s.gsub(/\[/, '_').gsub(/\]/, '_').gsub('__', '_') + "#{@method}"
+    end
+  end
+
+  def generate_form_field_name
+    # @form.object_name either returns a symbol for top level fields (e.g. :claim), or
+    # a string like "claim[defendants_attributes][0]" for cocoon nested objects
+    "#{@form.object_name}[#{@method}]"
+  end
+
+  def generate_anchor_id
+    # translates e.g. claim_defendants_attributes_0_last_name to defendant_1_last_name
+    anchor = @form_field_id.sub(/^claim_/, '').gsub('s_attributes', '')
+    parts = anchor.split('_')
+    incremented_anchor_parts = []
+    parts.each do |part|
+      if part =~ /^[0-9]{1,2}$/
+        incremented_anchor_parts << (part.to_i + 1).to_s
+      else
+        incremented_anchor_parts << part
+      end
+    end
+    incremented_anchor_parts.join('_')
+  end
+
+  def div_start
+    result = %Q|<div class="form-group #{@method}|
+    result += %Q| field_with_errors| if has_errors?
+    result += %Q|">|
+    result
+  end
+
+  def anchor
+    %Q|<a id="#{@anchor_id}"></a>|
+  end
+
+  def label
+    %Q|<label class="form-label" for="#{@form_field_id}">#{@options[:label]}|
+  end
+
+  def label_close
+    %Q|</label>|
+  end
+
+  def error_message
+    has_errors? ? validation_error_message(@errors, @anchor_id) : ''
+  end
+
+  def hint
+    if @options[:hint_text]
+      %Q|<div class="form-hint">#{@options[:hint_text]}</div>|
+    else
+      ''
+    end
+  end
+
+  def input_field
+    result = %Q|<input class="form-control" type="text" name="#{@form_field_name}" id="#{@form_field_id}" |
+    result += %Q|value="#{@form.object.__send__(@method)}" | unless @form.object.__send__(@method).nil?
+    result += %Q|/>|
+    result
+  end
+
+  def div_close
+    '</div>'
+  end
+end
+
+
+
+

--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -9,14 +9,14 @@ module ExternalUsers::ClaimsHelper
   end
 
   def validation_message_from_presenter(presenter, attribute)
-    content_tag :span, class: 'validation-error' do
+    content_tag :span, class: 'error' do
       presenter.field_level_error_for(attribute.to_sym)
     end
   end
 
   def validation_message_from_resource(resource, attribute)
     if resource.errors[attribute]
-      content_tag :span, class: 'validation-error' do
+      content_tag :span, class: 'error' do
         resource.errors[attribute].join(", ")
       end
     end

--- a/app/presenters/error_detail_collection.rb
+++ b/app/presenters/error_detail_collection.rb
@@ -17,6 +17,10 @@ class ErrorDetailCollection
     end
   end
 
+  def errors_for?(fieldname)
+    @error_details.key?(fieldname)
+  end
+
   def [](fieldname)
     @error_details[fieldname]
   end

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -11,6 +11,10 @@ class ErrorPresenter
     generate_messages
   end
 
+  def errors_for?(fieldname)
+    @error_details.errors_for?(fieldname)
+  end
+
   def field_level_error_for(fieldname)
     @error_details.short_messages_for(fieldname)
   end

--- a/spec/form_builders/adp_text_field_spec.rb
+++ b/spec/form_builders/adp_text_field_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+class TestHelper < ActionView::Base; end
+
+describe AdpTextField do
+
+  context 'top level text fields' do
+    let(:helper) { TestHelper.new }
+    let(:resource)  { FactoryGirl.create :claim, case_number: nil }
+    let(:error_presenter) { ErrorPresenter.new(resource) }
+    let(:builder)   { AdpFormBuilder.new(:claim, resource, helper, {} ) }
+
+    context 'simple text field without hint' do
+      it 'should produce expected html when resource is nil' do
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', errors: error_presenter)
+        expect(atf.to_html).to eq squash(a100_no_value_no_hint)
+      end
+
+      it 'should produce expected result when resource has a value' do
+        resource.case_number = 'X22334455'
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', errors: error_presenter)
+        expect(atf.to_html).to eq a200_value_no_hint
+      end
+
+      def a100_no_value_no_hint
+        html = <<-eos
+        <div class="form-group case_number">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+          </label>
+          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" />
+        </div>
+        eos
+        squash(html)
+      end
+
+      def a200_value_no_hint
+        html = <<-eos
+        <div class="form-group case_number">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+          </label>
+          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" value="X22334455" />
+        </div>
+        eos
+        squash(html)
+      end
+    end
+
+    context 'simple value with hint' do
+      it 'produces expected output with value' do
+        resource.case_number = 'X22334455'
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', hint_text: 'Hint text here', errors: error_presenter)
+        expect(atf.to_html).to eq b100_with_value_with_hint
+      end
+
+      def b100_with_value_with_hint
+        html = <<-eos
+        <div class="form-group case_number">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+            <div class="form-hint">Hint text here</div>
+          </label>
+          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" value="X22334455" />
+        </div>
+        eos
+        squash(html)
+      end
+    end
+
+    context 'errored value with hint' do
+      it 'produces error text' do
+        resource.case_number = nil
+        resource.errors[:case_number] = 'Validation error here'
+        error_presenter = ErrorPresenter.new(resource)
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', hint_text: 'Hint text here', errors: error_presenter)
+        expect(atf.to_html).to eq c100_with_value_with_hint_and_error
+      end
+
+      def c100_with_value_with_hint_and_error
+        html = <<-eos
+        <div class="form-group case_number field_with_errors">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+            <div class="form-hint">Hint text here</div>
+            <span class="error">Validation error here</span>
+          </label>
+          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" />
+        </div>
+        eos
+        squash(html)
+      end
+    end
+  end
+
+  def squash(html)
+    html.gsub("\n", '').gsub(/\>\s+/, '>').gsub(/\s+\</, '<').chomp
+  end
+end
+
+


### PR DESCRIPTION
This PR makes a method adp_text_field() avaialble on the AdpFormBuilder which outputs the HTML for a text field wrapped in all the GDS specific markup
to allow labels, hints, error messages, etc.
