### PR TITLE
Fix catch-all route not matching POST requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,6 @@ Rails.application.routes.draw do
 
   # catch-all route
   unless Rails.env.development?
-    get '*any', to: 'errors#not_found'
+    match '*path', to: 'errors#not_found', via: :all
   end
 end


### PR DESCRIPTION
Fixes one of the secondary issues discovered yesterday where the user saw an exception message sending a POST request to an invalid route.

https://www.pivotaltracker.com/story/show/121928563
