### PR TITLE
Revert validation class change until styling is fixed

### DIFF
--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -9,14 +9,14 @@ module ExternalUsers::ClaimsHelper
   end
 
   def validation_message_from_presenter(presenter, attribute)
-    content_tag :span, class: 'error' do
+    content_tag :span, class: 'validation-error' do
       presenter.field_level_error_for(attribute.to_sym)
     end
   end
 
   def validation_message_from_resource(resource, attribute)
     if resource.errors[attribute]
-      content_tag :span, class: 'error' do
+      content_tag :span, class: 'validation-error' do
         resource.errors[attribute].join(", ")
       end
     end


### PR DESCRIPTION
changing the validation error class in claims_helper.rb back to its original value until the styling is sorted out for the new class.

Original and new screenshots attached.

![screenshot 2016-06-21 11 05 10](https://cloud.githubusercontent.com/assets/115617/16225790/47e1b2e6-37a0-11e6-833e-19c305a88cf3.png)

![screenshot 2016-06-21 11 04 48](https://cloud.githubusercontent.com/assets/115617/16225793/4f7d717a-37a0-11e6-846f-b96bdeb88561.png)
