### PR TITLE
Disabling import button on submit and re-enabling it after import finishes.

### DIFF
--- a/app/assets/javascripts/modules/CustomFileUpload.js
+++ b/app/assets/javascripts/modules/CustomFileUpload.js
@@ -29,6 +29,9 @@ moj.Modules.CustomFileUpload = {
           .find('.file-upload-name').text(fileName)
           .parent()
           .find('.errors').empty();
+      })
+      .on('submit', function() {
+        $('input.btn-import-file').prop('disabled', true).val('Please wait...');
       });
   },
 

--- a/app/views/external_users/claims/_json_document_importer.haml
+++ b/app/views/external_users/claims/_json_document_importer.haml
@@ -2,5 +2,5 @@
   .claim-importer-header
     = f.label :json_file, t('.import_claim'), class: 'form-hint'
   = f.file_field :json_file, class: 'custom-uploader'
-  = f.submit t('common.upload'), class: "btn-gray external-user-json-export"
+  = f.submit t('common.upload'), class: "btn-gray external-user-json-export btn-import-file"
   .errors

--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -1,7 +1,9 @@
 var $importerResults = $('.importer-results');
+var $importButton = $('input.btn-import-file');
 var resetUploaderForm = function() { $('#importer').find('form').addClass('no-file-selected').find('.file-upload-name').empty(); };
 
 $importerResults.find('.js-import-failed').remove();
+$importButton.prop('disabled', false).val('Import claim(s)');
 
 <% if @json_document_importer.imported_claims.any? %>
 	$importerResults.html(

--- a/app/views/external_users/json_document_importers/format_error.js.erb
+++ b/app/views/external_users/json_document_importers/format_error.js.erb
@@ -9,3 +9,4 @@ $('#importer')
     .html("<em><%= filename %></em> is either not JSON or contains errors. Choose another file.");
 
 $('.importer-results').empty();
+$('input.btn-import-file').prop('disabled', false).val('Import claim(s)');


### PR DESCRIPTION
This will avoid users clicking the import button repeatedly while the import is still in progress, which was triggering the following (innocuous but annoying) exception on Sentry:

https://sentry.service.dsd.io/mojds/private-beta/group/738/

ActionController::ParameterMissing: param is missing or the value is empty: json_document_importer
