### PR TITLE
Return LGFS offence id for each Offence Class

### DIFF
--- a/app/interfaces/api/entities/offence_class.rb
+++ b/app/interfaces/api/entities/offence_class.rb
@@ -4,6 +4,7 @@ module API
       expose :id
       expose :class_letter
       expose :description
+      expose :lgfs_offence_id
     end
   end
 end

--- a/app/interfaces/api/v1/claim_helper.rb
+++ b/app/interfaces/api/v1/claim_helper.rb
@@ -8,7 +8,9 @@ module API::V1
       optional :creator_email, type: String, desc: "REQUIRED: The ADP administrator account email address that uniquely identifies the creator of the claim."
       optional :court_id, type: Integer, desc: "REQUIRED: The unique identifier for this court"
       optional :case_type_id, type: Integer, desc: "REQUIRED: The unique identifier of the case type"
-      optional :offence_id, type: Integer, desc: "REQUIRED: The unique identifier for this offence"
+      optional :offence_id, type: Integer, desc: "REQUIRED: The unique identifier for this offence. For advocate claims, " +
+                                                 "use an id from the list provided by the /api/offences endpoint, for all " +
+                                                  "litigator claims, use the lgfs_offence_id from the list provided by the /api/offence_classes endpoint."
       optional :case_number, type: String, desc: "REQUIRED: The case number"
       optional :cms_number, type: String, desc: "OPTIONAL: The CMS number"
       optional :additional_information, type: String, desc: "OPTIONAL: Any additional information"

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -41,14 +41,14 @@ module API
         end
 
         resource :offence_classes do
-          desc "Return all Offence Class Types."
+          desc "Return all Offence Class Types, with the matching offence_id for LGFS claims."
           get do
             present OffenceClass.all, with: API::Entities::OffenceClass
           end
         end
 
         resource :offences do
-          desc "Return all Offence Types."
+          desc "Return all Offence-ids to be used in advocate claims (see OffenceClasses for Litigator claims)."
           params do
             optional :offence_description, type: String, desc: "Offences matching description"
           end

--- a/app/models/offence_class.rb
+++ b/app/models/offence_class.rb
@@ -28,4 +28,9 @@ class OffenceClass < ActiveRecord::Base
   def letter_and_description
     "#{class_letter}: #{description}"
   end
+
+  def lgfs_offence_id
+    offences.miscellaneous.first.id
+  end
+
 end

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -71,7 +71,7 @@ describe API::V1::DropdownData do
     before do
       create_list(:case_type, 2)
       create_list(:court, 2)
-      create_list(:offence_class, 2)
+      create_list(:offence_class, 2, :with_lgfs_offence)
       create_list(:offence, 2)
       create_list(:basic_fee_type, 2)
       create_list(:expense_type, 2)
@@ -102,6 +102,7 @@ describe API::V1::DropdownData do
 
       let!(:offence)                        { create(:offence) }
       let!(:other_offence)                  { create(:offence) }
+      let!(:misc_offence)                   { create(:offence, :miscellaneous, offence_class: offence.offence_class) }
       let!(:offence_with_same_description)  { create(:offence, description: offence.description) }
       let!(:response)                       { get OFFENCE_ENDPOINT, params }
 
@@ -116,6 +117,7 @@ describe API::V1::DropdownData do
     it 'should only return offences matching description when offence_description param is present' do
       params.merge!(offence_description: offence.description)
       response = get OFFENCE_ENDPOINT, params
+      
       returned_offences = JSON.parse(response.body, symbolize_names: true)
       expect(returned_offences).to include(exposed_offence[offence], exposed_offence[offence_with_same_description])
       expect(returned_offences).to_not include(exposed_offence[other_offence])

--- a/spec/factories/offence_classes.rb
+++ b/spec/factories/offence_classes.rb
@@ -19,6 +19,12 @@ FactoryGirl.define do
     sequence(:class_letter)   { generate_random_unused_class_letter(%w{ E F H I }) }
   end
 
+  trait :with_lgfs_offence do
+    after(:create) do |record|
+      create :offence, :miscellaneous, offence_class: record
+    end
+  end
+
 end
 
 def generate_random_unused_class_letter(letters=%w{ A B C D E F G H I J K })


### PR DESCRIPTION
LGFS claims need to supply an offence id which corresponds to the Miscellaneous/other offence for
each Offence Class.  This PR adds the id of the corresponding offence to each OffenceClass in the
result hash of the /api/offence_classes endpoint.
