### PR TITLE
Attempt to fix flakey cukes

### DIFF
--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -61,6 +61,9 @@ When(/^I add another defendant, representation order and MAAT reference$/) do
     @claim_form_page.defendants.last.last_name.set "Kelly"
     @claim_form_page.defendants.last.dob.set_date "1912-12-12"
     @claim_form_page.defendants.last.add_another_representation_order.click
+    sleep 1
+    # do it again if the first click failed
+    @claim_form_page.defendants.last.add_another_representation_order.click if @claim_form_page.defendants.last.representation_orders.first.nil?
     @claim_form_page.defendants.last.representation_orders.first.date.set_date "2016-01-01"
     @claim_form_page.defendants.last.representation_orders.first.maat_reference.set "1234567890"
   end


### PR DESCRIPTION
One persistant error is that the add representation order link is clicked, but the date is not
on the page afterwards.  This tests to see if it is there, and if not, clicks the link again.
It seems to work, at least locally.
