### PR TITLE
Catch JSON::ParserErrors when parsing errors

### DIFF
--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -72,7 +72,11 @@ class JsonDocumentImporter
       rescue ArgumentError => e
         claim_hash['claim']['case_number'] = case_number
         @failed_imports << claim_hash
-        @errors[case_number] = JSON.parse(e.message).map{ |error_hash| error_hash['error'] }
+        begin
+          @errors[case_number] = JSON.parse(e.message).map{ |error_hash| error_hash['error'] }
+        rescue JSON::ParserError => jpe
+          @errors[case_number] = [jpe.message]
+        end
         claim = Claim::BaseClaim.find_by(uuid: @claim_id) # if an exception is raised the claim is destroyed along with all its dependent objects
         claim.destroy if claim.present?
       rescue JSON::Schema::ValidationError => error

--- a/spec/examples/invalid-syntax.json
+++ b/spec/examples/invalid-syntax.json
@@ -1,0 +1,63 @@
+[
+  {
+    "claim": {
+      "creator_email" "advocateadmin@example.com",
+      "advocate_email": "advocate@example.com",
+      "case_number": "A12345678",
+      "case_type_id": 1,
+      "first_day_of_trial": "2015-06-01",
+      "estimated_trial_length": 3,
+      "actual_trial_length": 3,
+      "trial_concluded_at": "2015-06-03",
+      "advocate_category": "QC",
+      "offence_id": 1,
+      "court_id": 1,
+      "cms_number": "12345678",
+      "additional_information": "string",
+      "apply_vat": true,
+      "trial_fixed_notice_at": "2015-06-01",
+      "trial_fixed_at": "2015-06-01",
+      "trial_cracked_at": "2015-06-01",
+      "defendants":
+        {
+          "first_name": "Angela",
+          "last_name": "Merkel",
+          "date_of_birth": "1979-12-10",
+          "order_for_judicial_apportionment": true,
+          "representation_orders": [
+            {
+              "maat_reference": "1234567891",
+              "representation_order_date": "2015-05-01"
+            }
+          ]
+
+      ],
+      "fees": [
+        {
+          "fee_type_id": 2,
+          "quantity": 1,
+          "rate": 1.1,
+          "dates_attended": [
+            {
+              "attended_item_type": "fee",
+              "date": "2015-06-01",
+              "date_to": "2015-06-01"
+            }
+          ]
+        }
+      ],
+      "expenses": [
+        {
+          "expense_type_id": 1,
+          "quantity": 1,
+          "amount": 235.46,
+          "distance": 300,
+          "reason_id": 4,
+          "mileage_rate_id": 1,
+          "location": "London",
+          "date": "2015-06-01"
+        }
+      ]
+    }
+  }
+]

--- a/spec/examples/invalid_utf8.json
+++ b/spec/examples/invalid_utf8.json
@@ -1,0 +1,63 @@
+[
+  {
+    "claim": {
+      "creator_email": "advocateadmin@example.com",
+      "advocate_email": "advocate@example.com",
+      "case_number": "A12345678",
+      "case_type_id": 1,
+      "first_day_of_trial": "2015-06-01",
+      "estimated_trial_length": 3,
+      "actual_trial_length": 3,
+      "trial_concluded_at": "2015-06-03",
+      "advocate_category": "QC",
+      "offence_id": 1,
+      "court_id": 1,
+      "cms_number": "12345678",
+      "additional_information": "string",
+      "apply_vat": true,
+      "trial_fixed_notice_at": "2015-06-01",
+      "trial_fixed_at": "2015-06-01",
+      "trial_cracked_at": "2015-06-01",
+      "defendants": [
+        {
+          "first_name": "abc�def",
+          "last_name": "Merkel",
+          "date_of_birth": "1979-12-10",
+          "order_for_judicial_apportionment": true,
+          "representation_orders": [
+            {
+              "maat_reference": "1234567891",
+              "representation_order_date": "2015-05-01"
+            }
+          ]
+        }
+      ],
+      "fees": [
+        {
+          "fee_type_id": 2,
+          "quantity": 1,
+          "rate": 1.1,
+          "dates_attended": [
+            {
+              "attended_item_type": "fee",
+              "date": "2015-06-01",
+              "date_to": "2015-06-01"
+            }
+          ]
+        }
+      ],
+      "expenses": [
+        {
+          "expense_type_id": 1,
+          "quantity": 1,
+          "amount": 235.46,
+          "distance": 300,
+          "reason_id": 4,
+          "mileage_rate_id": 1,
+          "location": "London",
+          "date": "2015-06-01"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
There have been many instances of 500 errors caused by uncaught exceptions in the rescue block for JSON validation errors when parsing a JSON document (probably the original document has invalid UTF-8 characters in it, and these are copied into the error hash, which is then parsed in the rescue block and fails).

This PR resuces JSON::ParserErrors within the rescue block and populates the error hash with the exceptions message, thus preventing the 500 exception.
