### PR TITLE
Separate expense reasons from the expense types endpoint into a separate endpoint.

### DIFF
--- a/app/interfaces/api/entities/expense_reason_set.rb
+++ b/app/interfaces/api/entities/expense_reason_set.rb
@@ -1,0 +1,18 @@
+module API
+  module Entities
+    class ExpenseReasonSet < Grape::Entity
+      expose :reason_set
+      expose :reasons, using: API::Entities::ExpenseReason
+
+      private
+
+      def reason_set
+        object.keys.first
+      end
+
+      def reasons
+        object.values.first
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/expense_type.rb
+++ b/app/interfaces/api/entities/expense_type.rb
@@ -5,7 +5,6 @@ module API
       expose :name
       expose :roles
       expose :reason_set
-      expose :expense_reasons, using: API::Entities::ExpenseReason, as: :reasons
     end
   end
 end

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -111,6 +111,13 @@ module API
           end
         end
 
+        resource :expense_reasons do
+          desc "Return all Expense Reasons by reason set."
+          get do
+            present ExpenseType.reason_sets, with: API::Entities::ExpenseReasonSet
+          end
+        end
+
         resource :disbursement_types do
           desc "Return all Disbursement Types."
           get do

--- a/app/models/expense_type.rb
+++ b/app/models/expense_type.rb
@@ -35,6 +35,10 @@ class ExpenseType < ActiveRecord::Base
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :reason_set, inclusion: { in:  %w{ A B } }
 
+  def self.reason_sets
+    [{ 'A': REASON_SET_A.values }, { 'B': REASON_SET_B.values }]
+  end
+
   def expense_reasons_hash
     self.reason_set == 'A' ? REASON_SET_A : REASON_SET_B
   end

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -15,6 +15,7 @@ describe API::V1::DropdownData do
   OFFENCE_ENDPOINT            = "/api/offences"
   FEE_TYPE_ENDPOINT           = "/api/fee_types"
   EXPENSE_TYPE_ENDPOINT       = "/api/expense_types"
+  EXPENSE_REASONS_ENDPOINT    = "/api/expense_reasons"
   DISBURSEMENT_TYPE_ENDPOINT  = "/api/disbursement_types"
   TRANSFER_STAGES_ENDPOINT    = "/api/transfer_stages"
   TRANSFER_CASE_CONCLUSIONS_ENDPOINT = "/api/transfer_case_conclusions"
@@ -29,6 +30,7 @@ describe API::V1::DropdownData do
       OFFENCE_ENDPOINT,
       FEE_TYPE_ENDPOINT,
       EXPENSE_TYPE_ENDPOINT,
+      EXPENSE_REASONS_ENDPOINT,
       DISBURSEMENT_TYPE_ENDPOINT,
       TRANSFER_STAGES_ENDPOINT,
       TRANSFER_CASE_CONCLUSIONS_ENDPOINT
@@ -62,6 +64,7 @@ describe API::V1::DropdownData do
         OFFENCE_ENDPOINT => API::Entities::Offence.represent(Offence.all).to_json,
         FEE_TYPE_ENDPOINT => API::Entities::BaseFeeType.represent(Fee::BaseFeeType.all).to_json,
         EXPENSE_TYPE_ENDPOINT => API::Entities::ExpenseType.represent(ExpenseType.all).to_json,
+        EXPENSE_REASONS_ENDPOINT => API::Entities::ExpenseReasonSet.represent(ExpenseType.reason_sets).to_json,
         DISBURSEMENT_TYPE_ENDPOINT => API::Entities::DisbursementType.represent(DisbursementType.all).to_json,
         TRANSFER_STAGES_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::TRANSFER_STAGES.to_a).to_json,
         TRANSFER_CASE_CONCLUSIONS_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::CASE_CONCLUSIONS.to_a).to_json
@@ -219,7 +222,7 @@ describe API::V1::DropdownData do
       end
 
       it "has all the expected keys" do
-        %w{ id name roles reason_set reasons }.each do |key|
+        %w{ id name roles reason_set }.each do |key|
           expect(parsed_body.first).to have_key(key)
         end
       end
@@ -228,13 +231,6 @@ describe API::V1::DropdownData do
         expect(parsed_body.first["roles"].size).to eq(2)
         expect(parsed_body.first["roles"]).to include("agfs")
         expect(parsed_body.first["roles"]).to include("lgfs")
-      end
-
-      it "has correct reasons structure" do
-        expect(parsed_body.first["reasons"]).to be_an(Array)
-        expect(parsed_body.first["reasons"].first).to have_key("id")
-        expect(parsed_body.first["reasons"].first).to have_key("reason")
-        expect(parsed_body.first["reasons"].first).to have_key("allow_explanatory_text")
       end
     end
 


### PR DESCRIPTION
This will separate the expense reasons collection from the expense types endpoint, as it was returning ALL the reasons for each of the expense type, resulting in a huge repetition.

Now the expense types endpoint will only return the **reason_set** (A or B) as before, but the reasons for the different sets will be returned in a separate endpoint, to avoid the repetition and to be easily extended and maintained in case more sets were to be added in the future.
