### PR TITLE
A helper to provide a way to expose an error class when there are field errors.

### DIFF
--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -27,4 +27,9 @@ module ExternalUsers::ClaimsHelper
     presenter.field_level_error_for(attribute.to_sym).split(',').each { |e| e.strip! }
   end
 
+  def error_class?(presenter, *attributes)
+    return if presenter.nil?
+    options = {name: 'error'}.merge(attributes.extract_options!)
+    options[:name] if attributes.detect { |att| presenter.field_level_error_for(att.to_sym).present? }
+  end
 end

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -27,7 +27,7 @@
         = f.select :case_type_id, @case_types.map{ |ct| [ct.name, ct.id, {data: {'is-fixed-fee' => ct.is_fixed_fee?}}] }, { include_blank: true }, { class: 'autocomplete' }
         = validation_error_message(@error_presenter, :case_type)
 
-    .form-row
+    %div.form-row{class: error_class?(@error_presenter, :court, :case_number)}
       .form-col
         = f.anchored_label t('.court'), 'court_id_autocomplete'
         .form-hint.xsmall.zero-vert-margin

--- a/spec/helpers/external_users/claims_helper_spec.rb
+++ b/spec/helpers/external_users/claims_helper_spec.rb
@@ -1,4 +1,53 @@
-require "rails_helper"
+require 'rails_helper'
 
 describe ExternalUsers::ClaimsHelper do
+
+  describe '#error_class?' do
+    let(:presenter) { instance_double(ErrorPresenter) }
+
+    context 'with errors' do
+      before do
+        allow(presenter).to receive(:field_level_error_for).with(kind_of(Symbol)).and_return('an error')
+      end
+
+      it 'should return the default error class if there are any errors in the provided field' do
+        returned_class = error_class?(presenter, :test_field)
+        expect(returned_class).to eq('error')
+      end
+
+      it 'should return the specified class if provided' do
+        returned_class = error_class?(presenter, :test_field, name: 'custom-error')
+        expect(returned_class).to eq('custom-error')
+      end
+    end
+
+    context 'with errors and multiple fields' do
+      before do
+        allow(presenter).to receive(:field_level_error_for).with(:test_field_1).and_return(nil)
+        allow(presenter).to receive(:field_level_error_for).with(:test_field_2).and_return('an error')
+      end
+
+      it 'should return the error class if there are errors in any of the provided field' do
+        returned_class = error_class?(presenter, :test_field_1, :test_field_2)
+        expect(returned_class).to eq('error')
+      end
+
+      it 'should return the specified class if provided' do
+        returned_class = error_class?(presenter, :test_field_1, :test_field_2, name: 'custom-error')
+        expect(returned_class).to eq('custom-error')
+      end
+    end
+
+    context 'without errors' do
+      before do
+        allow(presenter).to receive(:field_level_error_for).with(kind_of(Symbol)).and_return(nil)
+      end
+
+      it 'should return nil if there are no errors in the provided field' do
+        returned_class = error_class?(presenter, :test_field)
+        expect(returned_class).to be_nil
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
As per @cleargif request.

An example is provided in the file `case_details/_fields.html.haml`
One or more attributes is supported.

An optional, last argument, hash can provide extra configuration. For now only configuration is the class name, by default is 'error', but another name can be provided via this options hash.
