### PR TITLE
Changing expense hours and distance fields to be decimals.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -251,7 +251,6 @@ Style/IfInsideElse:
   Exclude:
     - 'app/helpers/application_helper.rb'
     - 'app/presenters/error_message_translator.rb'
-    - 'app/validators/expense_v2_validator.rb'
 
 # Offense count: 7
 # Cop supports --auto-correct.
@@ -405,7 +404,6 @@ Style/SpaceAfterComma:
     - 'app/presenters/claim/base_claim_presenter.rb'
     - 'app/presenters/error_message_translator.rb'
     - 'app/validators/base_validator.rb'
-    - 'app/validators/expense_v2_validator.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/app/interfaces/api/v1/external_users/expense.rb
+++ b/app/interfaces/api/v1/external_users/expense.rb
@@ -18,9 +18,9 @@ module API
           optional :location, type: String, desc: "REQUIRED for all expense types other than Parking. Location or destination."
           optional :reason_id, type: Integer, desc: "REQUIRED: Unique identifier for the reason for this travel: must be one of the valid reason ids associated with the expense type."
           optional :reason_text, type: String, desc: "REQUIRED when reason is Other oitherwise must be absent."
-          optional :distance, type: Integer, desc: "REQUIRED for expense type Car Travel, otherwise must be absent. Distance in miles."
+          optional :distance, type: Float, desc: "REQUIRED for expense type Car Travel, otherwise must be absent. Distance in miles."
           optional :mileage_rate_id, type: Integer, desc: "REQUIRED for expense type Car Travel, otherwise must be absent: Where applicable. Values should be 1 for 25p per mile, 2 for 45p per mile."
-          optional :hours, type: Integer, desc: "REQUIRED for expense type Travel Time, otherwise must be absent. Time in hours."
+          optional :hours, type: Float, desc: "REQUIRED for expense type Travel Time, otherwise must be absent. Time in hours."
           optional :date, type: String, desc: "REQUIRED: The date applicable to this Expense (YYYY-MM-DD)", standard_json_format: true
         end
 

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -15,10 +15,10 @@
 #  reason_id       :integer
 #  reason_text     :string
 #  schema_version  :integer
-#  distance        :integer
+#  distance        :decimal(, )
 #  mileage_rate_id :integer
 #  date            :date
-#  hours           :integer
+#  hours           :decimal(, )
 #  vat_amount      :decimal(, )      default(0.0)
 #
 
@@ -34,7 +34,7 @@ class Expense < ActiveRecord::Base
 
   include NumberCommaParser
   include Duplicable
-  numeric_attributes :rate, :amount, :vat_amount, :quantity
+  numeric_attributes :rate, :amount, :vat_amount, :quantity, :distance, :hours
 
   belongs_to :expense_type
   belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
@@ -56,7 +56,7 @@ class Expense < ActiveRecord::Base
 
   before_validation do
     self.schema_version ||= 2
-    round_hours
+    round_quantity
     self.amount = ((self.rate || 0) * (self.quantity || 0)).abs unless schema_version_2?
   end
 
@@ -84,10 +84,10 @@ class Expense < ActiveRecord::Base
   end
 
   def perform_validation?
-    claim && claim.perform_validation?
+    claim&.perform_validation?
   end
 
-  def round_hours
+  def round_quantity
     self.quantity = (self.quantity*4).round/4.0 if self.quantity
   end
 

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -17,6 +17,14 @@ class ExpensePresenter < BasePresenter
     h.number_to_currency(expense.amount + expense.vat_amount)
   end
 
+  def distance
+    h.number_with_precision(expense.distance, precision: 2, strip_insignificant_zeros: true)
+  end
+
+  def hours
+    h.number_with_precision(expense.hours, precision: 1, strip_insignificant_zeros: true)
+  end
+
   def name
     if expense.expense_type.blank?
       "Not selected"

--- a/app/validators/expense_v2_validator.rb
+++ b/app/validators/expense_v2_validator.rb
@@ -2,15 +2,15 @@ class ExpenseV2Validator < BaseValidator
 
   def self.fields
     [
+      :expense_type,
       :distance,
       :hours,
       :location,
-      :mileage_rate_id,
-      :reason_text,
       :amount,
       :date,
-      :expense_type,
-      :reason_id
+      :reason_id,
+      :reason_text,
+      :mileage_rate_id
     ]
   end
 

--- a/app/validators/expense_v2_validator.rb
+++ b/app/validators/expense_v2_validator.rb
@@ -55,17 +55,14 @@ class ExpenseV2Validator < BaseValidator
   def validate_reason_text
     if @record.expense_reason_other?
       validate_presence(:reason_text, 'blank_for_other')
-    else
-      if @record.reason_id.present? && @record.expense_type.present?
-        validate_absence(:reason_text, 'invalid')
-      end
+    elsif @record.reason_id.present? && @record.expense_type.present?
+      validate_absence(:reason_text, 'invalid')
     end
   end
 
   def validate_distance
     if @record.car_travel?
-      validate_presence(:distance, 'blank')
-      validate_numericality(:distance, 1, nil, 'zero')
+      validate_presence_and_numericality(:distance)
     else
       validate_absence(:distance, 'invalid')
     end
@@ -84,18 +81,22 @@ class ExpenseV2Validator < BaseValidator
 
   def validate_date
     validate_presence(:date, 'blank')
-    validate_not_after(Date.today,:date,'future')
+    validate_not_after(Date.today, :date, 'future')
     validate_not_before(Settings.earliest_permitted_date, :date, 'check_not_too_far_in_past')
   end
 
   def validate_hours
     if @record.travel_time?
-      validate_presence(:hours, 'blank')
-      unless @record.hours.blank?
-        add_error(:hours, 'zero_or_negative') if @record.hours < 1
-      end
+      validate_presence_and_numericality(:hours)
     else
       validate_absence(:hours, 'invalid')
     end
+  end
+
+  # helpers for common validation combos
+  #
+  def validate_presence_and_numericality(attribute)
+    validate_presence(attribute, 'blank')
+    validate_float_numericality(attribute, 0.1, nil, 'numericality')
   end
 end

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -22,13 +22,13 @@
       .column-one-third.condensed{class: "js-expense-distance expense-distance"}
         %a{id: "expense_#{@expense_count}_distance"}
         = f.label :distance, 'Distance'
-        = f.number_field :distance, {max: 99999, min: 0, class: 'form-control'}
+        = f.number_field :distance, value: number_with_precision(f.object.distance, precision: 2, strip_insignificant_zeros: true), max: 99999, min: 0, class: 'form-control'
         = validation_error_message(@error_presenter, "expense_#{@expense_count}_distance")
 
       .column-one-third.condensed{class: "js-expense-hours expense-hours"}
         %a{id: "expense_#{@expense_count}_hours"}
         = f.label :hours, 'Hours'
-        = f.number_field :hours, { max: 9999, min: 0, class: 'form-control short-input' }
+        = f.number_field :hours, value: number_with_precision(f.object.hours, precision: 1, strip_insignificant_zeros: true), max: 9999, min: 0, class: 'form-control short-input'
         = validation_error_message(@error_presenter, "expense_#{@expense_count}_hours")
 
     .grid-row

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1128,7 +1128,7 @@ expense:
       long: 'Enter a location for the #{expense}'
       short: Enter a location
       api: Enter a location for the expenses
-    numericality:
+    invalid:
       long: 'Enter a valid location for the #{expense}'
       short: Enter a valid location
       api: Enter a valid location for the expense
@@ -1136,9 +1136,32 @@ expense:
   distance:
     _seq: 40
     blank:
-      long: 'Enter distance for the #{expense}'
-      short: 'Enter distance'
-      api: Enter distance for the expense
+      long: 'Enter the distance for the #{expense}'
+      short: 'Enter the distance'
+      api: Enter the distance for the expense
+    invalid:
+      long: 'Enter a valid distance for the #{expense}'
+      short: Enter a valid distance
+      api: Enter a valid distance for the expense
+    numericality:
+      long: 'Enter a valid distance for the #{expense}'
+      short: *enter_valid_amount
+      api: Enter a valid distance for the expense
+
+  hours:
+    _seq: 45
+    blank:
+      long: 'Enter the hours for the #{expense}'
+      short: 'Enter the hours'
+      api: Enter the hours for the expense
+    invalid:
+      long: 'Enter valid hours for the #{expense}'
+      short: Enter valid hours
+      api: Enter valid hours for the expense
+    numericality:
+      long: 'Enter valid hours for the #{expense}'
+      short: *enter_valid_amount
+      api: Enter valid hours for the expense
 
   reason_text:
     _seq: 50
@@ -1148,7 +1171,7 @@ expense:
       api: Enter a reason for the expense
 
   reason_id:
-    _seq: 45
+    _seq: 55
     blank:
       long: 'Enter a reason for the #{expense}'
       short: 'Enter a reason'

--- a/db/migrate/20160627083153_change_expense_hours_and_distance_to_decimal.rb
+++ b/db/migrate/20160627083153_change_expense_hours_and_distance_to_decimal.rb
@@ -1,0 +1,11 @@
+class ChangeExpenseHoursAndDistanceToDecimal < ActiveRecord::Migration
+  def up
+    change_column :expenses, :hours, :decimal
+    change_column :expenses, :distance, :decimal
+  end
+
+  def down
+    change_column :expenses, :hours, :integer
+    change_column :expenses, :distance, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160609114327) do
+ActiveRecord::Schema.define(version: 20160627083153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -271,10 +271,10 @@ ActiveRecord::Schema.define(version: 20160609114327) do
     t.integer  "reason_id"
     t.string   "reason_text"
     t.integer  "schema_version"
-    t.integer  "distance"
+    t.decimal  "distance"
     t.integer  "mileage_rate_id"
     t.date     "date"
-    t.integer  "hours"
+    t.decimal  "hours"
     t.decimal  "vat_amount",      default: 0.0
   end
 

--- a/lib/api/claims/base_claim_test.rb
+++ b/lib/api/claims/base_claim_test.rb
@@ -142,14 +142,12 @@ class BaseClaimTest
       "api_key": api_key,
       "claim_id": claim_uuid,
       "expense_type_id": expense_type_id,
-      "rate": 1.1,
-      "quantity": 1,
-      "amount": 1.1,
+      "amount": 500.15,
       "location": "London",
       "reason_id": 5,
       "reason_text": "Foo",
       "date": "2016-01-01",
-      "distance": 1,
+      "distance": 100.58,
       "mileage_rate_id": 1
     }
   end

--- a/spec/api/v1/external_users/expense_spec.rb
+++ b/spec/api/v1/external_users/expense_spec.rb
@@ -24,19 +24,19 @@ describe API::V1::ExternalUsers::Expense do
 
     let!(:provider)       { create(:provider) }
     let!(:claim)          { create(:claim, source: 'api').reload }
-    let!(:expense_type)   { create(:expense_type) }
+    let!(:expense_type)   { create(:expense_type, :car_travel) }
 
     let!(:params) do
       {
         api_key: provider.api_key,
         claim_id: claim.uuid,
         expense_type_id: expense_type.id,
-        rate: 1,
-        quantity: 2,
-        amount: 2,
+        amount: 500.79,
         location: 'London',
+        distance: 300.58,
         reason_id: 5,
         reason_text: "Foo",
+        mileage_rate_id: 1,
         date: "2016-01-01T12:30:00"
       }
     end
@@ -68,7 +68,8 @@ describe API::V1::ExternalUsers::Expense do
       claim_id: "Claim cannot be blank",
       date: "Enter a date for the expense",
       expense_type_id: "Choose a type for the expense",
-      reason_id: "Enter a reason for the expense"
+      reason_id: "Enter a reason for the expense",
+      distance: "Enter the distance for the expense"
     }
 
     describe "POST #{CREATE_EXPENSE_ENDPOINT}" do
@@ -100,8 +101,9 @@ describe API::V1::ExternalUsers::Expense do
           expect(new_expense.claim_id).to eq claim.id
           expect(new_expense.expense_type_id).to eq expense_type.id
           expect(new_expense.location).to eq params[:location]
+          expect(new_expense.amount).to eq params[:amount]
+          expect(new_expense.distance).to eq params[:distance]
         end
-
       end
 
       context 'when expense params are invalid' do

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -15,10 +15,10 @@
 #  reason_id       :integer
 #  reason_text     :string
 #  schema_version  :integer
-#  distance        :integer
+#  distance        :decimal(, )
 #  mileage_rate_id :integer
 #  date            :date
-#  hours           :integer
+#  hours           :decimal(, )
 #  vat_amount      :decimal(, )      default(0.0)
 #
 

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -15,10 +15,10 @@
 #  reason_id       :integer
 #  reason_text     :string
 #  schema_version  :integer
-#  distance        :integer
+#  distance        :decimal(, )
 #  mileage_rate_id :integer
 #  date            :date
-#  hours           :integer
+#  hours           :decimal(, )
 #  vat_amount      :decimal(, )      default(0.0)
 #
 

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -46,6 +46,30 @@ RSpec.describe ExpensePresenter do
     end
   end
 
+  describe '#distance' do
+    it 'formats as decimal number, 2 decimals precision, with rounding' do
+      expense.distance = 324.479
+      expect(presenter.distance).to eq '324.48'
+    end
+
+    it 'strips insignificant zeros' do
+      expense.distance = 324.00
+      expect(presenter.distance).to eq '324'
+    end
+  end
+
+  describe '#hours' do
+    it 'formats as decimal number, 1 decimal precision with rounding' do
+      expense.hours = 35.22
+      expect(presenter.hours).to eq '35.2'
+    end
+
+    it 'strips insignificant zeros' do
+      expense.hours = 35.0
+      expect(presenter.hours).to eq '35'
+    end
+  end
+
   describe '#name' do
     it 'outputs "Not selected" if there is no expense type' do
       expense.expense_type_id = nil

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -55,17 +55,17 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
         it 'is invalid if zero' do
           travel_time_expense.hours = 0
           expect(travel_time_expense).not_to be_valid
-          expect(travel_time_expense.errors[:hours]).to include('zero_or_negative')
+          expect(travel_time_expense.errors[:hours]).to include('numericality')
         end
 
         it 'is invalid if negative' do
           travel_time_expense.hours = -5
           expect(travel_time_expense).not_to be_valid
-          expect(travel_time_expense.errors[:hours]).to include('zero_or_negative')
+          expect(travel_time_expense.errors[:hours]).to include('numericality')
         end
 
         it 'is valid if present and above zero' do
-          travel_time_expense.hours = 1
+          travel_time_expense.hours = 1.5
           expect(travel_time_expense).to be_valid
         end
       end
@@ -237,6 +237,11 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
           expect(car_travel_expense).to be_valid
         end
 
+        it 'is valid when distance is decimal' do
+          car_travel_expense.distance = 30.52
+          expect(car_travel_expense).to be_valid
+        end
+
         it 'is valid when absent for train' do
           train_expense.distance = nil
           expect(train_expense).to be_valid
@@ -263,7 +268,13 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
         it 'is invalid when zero for car travel' do
           car_travel_expense.distance = 0
           expect(car_travel_expense).not_to be_valid
-          expect(car_travel_expense.errors[:distance]).to include('zero')
+          expect(car_travel_expense.errors[:distance]).to include('numericality')
+        end
+
+        it 'is invalid when negative for car travel' do
+          car_travel_expense.distance = -5
+          expect(car_travel_expense).not_to be_valid
+          expect(car_travel_expense.errors[:distance]).to include('numericality')
         end
 
         it 'is invalid when present for train' do


### PR DESCRIPTION
**PT#121928119**

Expense hours and distance were defined in the database as integers but there is a requirement to allow to enter decimal values.

This PR change the database fields and required view/presenter to support decimals (2 decimals for distance, 1 decimal for hours), **stripping insignificant zeros** (so 1.0 in hours will show as 1, for instance).

The API has been also updated to support decimals in those fields.
