### PR TITLE
Hiding the judicial apportionment section for interim claims.

### DIFF
--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -69,7 +69,7 @@
       %td
         = claim.offence ? claim.offence.offence_class : t("general.not_provided")
 
-    - if claim.lgfs? || claim.interim?
+    - if claim.final? || claim.transfer?
       %tr
         %th{scope: 'row'}
           = t('external_users.claims.case_details.case_concluded_date.case_concluded_at')

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -24,12 +24,13 @@
     .form-col.form-col-two-thirds.dob
       = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count}_date_of_birth", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count}_date_of_birth".to_sym))
 
-  .form-row
-    .form-col.form-col-two-thirds
-      %label.block-label.judicial-apportionment-notice
-        = f.check_box :order_for_judicial_apportionment
-        = raw t('.order_for_judicial_apportionment')
-        = validation_error_message(f.object, :order_for_judicial_apportionment)
+  - unless @claim.interim?
+    .form-row
+      .form-col.form-col-two-thirds
+        %label.block-label.judicial-apportionment-notice
+          = f.check_box :order_for_judicial_apportionment
+          = raw t('.order_for_judicial_apportionment')
+          = validation_error_message(f.object, :order_for_judicial_apportionment)
 
   .documents
     %a{id: "defendant_#{@defendant_count}_representation_orders"}

--- a/app/views/external_users/claims/defendants/_summary.html.haml
+++ b/app/views/external_users/claims/defendants/_summary.html.haml
@@ -6,38 +6,41 @@
     %col.summary-headings
     %col.summary-desc
   %tbody
-    - claim.defendants.each_with_index do | defendant, index|
+    - claim.defendants.each.with_index(1) do | defendant, index|
       %tr
         %th{scope:'row'}
-          = "#{t('common.defendant')} #{index + 1}"
+          = "#{t('common.defendant')} #{index}"
         %td
           = defendant.name
       %tr
         %th{scope:'row'}
           %span.visuallyhidden
-            = "#{t('common.defendant')} #{index + 1}"
+            = "#{t('common.defendant')} #{index}"
           = t('external_users.claims.defendants.defendant_fields.date_of_birth')
         %td
           = defendant.date_of_birth.strftime('%d/%m/%Y') rescue ''
-      %tr
-        %th{scope:'row'}
-          %span.visuallyhidden
-            = "#{t('common.defendant')} #{index + 1}"
-          = t('external_users.claims.defendants.defendant_fields.judical_apportionment')
-        %td
-          = defendant.order_for_judicial_apportionment == true ? 'Yes' : 'No'
-      - defendant.representation_orders.each_with_index do | representation_order, index |
+
+      - unless claim.interim?
         %tr
           %th{scope:'row'}
             %span.visuallyhidden
-              = "#{t('common.defendant')} #{index + 1} representation order #{index + 1}"
+              = "#{t('common.defendant')} #{index}"
+            = t('external_users.claims.defendants.defendant_fields.judical_apportionment')
+          %td
+            = defendant.order_for_judicial_apportionment == true ? 'Yes' : 'No'
+
+      - defendant.representation_orders.each.with_index(1) do | representation_order, index|
+        %tr
+          %th{scope:'row'}
+            %span.visuallyhidden
+              = "#{t('common.defendant')} #{index} representation order #{index}"
             = t('external_users.claims.defendants.representation_order_fields.representation_order')
           %td
             = representation_order.representation_order_date.strftime('%d/%m/%Y') rescue ''
         %tr
           %th{scope: 'row'}
             %span.visuallyhidden
-              = "#{t('common.defendant')} #{index + 1} representation order #{index + 1}"
+              = "#{t('common.defendant')} #{index} representation order #{index}"
             = t('external_users.claims.defendants.representation_order_fields.maat_reference_number')
           %td
             = representation_order.maat_reference

--- a/app/views/shared/_claim_defendant_details.html.haml
+++ b/app/views/shared/_claim_defendant_details.html.haml
@@ -1,7 +1,7 @@
 .defendant-card
   .bold-normal.title
     = t('common.defendant')
-    = index + 1
+    = index
   .grid-row
     .column-half
       .full-name.bold-xsmall
@@ -13,11 +13,14 @@
         = t('external_users.claims.defendants.defendant_fields.date_of_birth')
       .xsmall
         = defendant.date_of_birth.strftime('%d/%m/%Y') rescue ''
-  .judical_apportionment
-    %span.bold-xsmall
-      Judicial apportionment:
-    %span.xsmall
-      = defendant.order_for_judicial_apportionment == true ? 'Yes' : 'No'
+
+  - unless @claim.interim?
+    .judical_apportionment
+      %span.bold-xsmall
+        Judicial apportionment:
+      %span.xsmall
+        = defendant.order_for_judicial_apportionment == true ? 'Yes' : 'No'
+
   .rep-orders
     - if defendant.representation_orders.any?
       %table

--- a/app/views/shared/_claim_defendants.html.haml
+++ b/app/views/shared/_claim_defendants.html.haml
@@ -1,15 +1,12 @@
 - defendant_count = 0
-- defendants.each_slice(2).with_index do |(defendant_left, defendant_right), index |
+- defendants.each_slice(2) do |(defendant_left, defendant_right)|
 
-  -# start a new row for every odd defendant
-  - defendant_count = defendant_count + 1
   .grid-row.defendant-row
     .column-half
-      = render partial: 'shared/claim_defendant_details', locals: {defendant: defendant_left, index: defendant_count - 1 }
+      = render partial: 'shared/claim_defendant_details', locals: {defendant: defendant_left, index: defendant_count += 1 }
 
-    - defendant_count = defendant_count + 1
     .column-half
       - if defendant_right
-        = render partial: 'shared/claim_defendant_details', locals: {defendant: defendant_right, index: defendant_count - 1 }
+        = render partial: 'shared/claim_defendant_details', locals: {defendant: defendant_right, index: defendant_count += 1 }
       - else
         &nbsp;


### PR DESCRIPTION
**PT#121135775**

As per ticket description, `Judicial apportionment` occurs at the end of the case so this is not relevant ever on an interim fee claim.

Also, hiding the `case concluded at` in the summary page for interim claims, because this field doesn't apply to those claims.
