### PR TITLE
Accessibility / W3C validation changes

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -143,7 +143,7 @@ moj.Modules.NewClaim = {
     // Clear unused fields to avoid submitting them and causing validation errors server-side
     self.clearUnusedFields(self.$currentExpense);
 
-    self.$ariaLiveRegion.children().hide().end().append('<div>Great this works</div>');
+    self.$ariaLiveRegion.children().hide().end();
   },
 
   attachToExpenseReason : function() {

--- a/app/assets/stylesheets/moj/_forms.scss
+++ b/app/assets/stylesheets/moj/_forms.scss
@@ -1,5 +1,11 @@
 form {
   fieldset {
+    &.error{
+      border-left-width: 3px;
+      .form-control{
+        border-width: 2px;
+      }
+    }
     label {
       margin-top: 0;
     }
@@ -11,6 +17,9 @@ form {
 }
 //  label
 label {
+  .field_with_errors{
+    border-left-width: 0;
+  }
   &.form-label {
     @include clearfix;
   }
@@ -36,10 +45,12 @@ input.form-control[type=number],
   &.short-input{
     @include span(4 of 12);
     margin-left: 0;
+    float: none;
   }
   &.medium-input{
     @include span(6 of 12);
     margin-left: 0;
+    float: none;
   }
   &.search{
     @include span(10 of 12);
@@ -233,6 +244,13 @@ select.form-control {
   .fee-quantity,
   .fee-rate{
     width: 20%;
+  }
+
+  .fee-quantity{
+    &.js-interim-ppe{
+      float:right;
+      width: 32%;
+    }
   }
 
   .fee-vat,
@@ -483,6 +501,7 @@ label.form-date-spacing {
 .js-enabled {
   select.autocomplete {
     @include visually-hidden;
+    width:1px !important;
   }
 }
 
@@ -501,5 +520,37 @@ label.form-date-spacing {
 .checklist{
   label.block-label{
     width: 77%;
+  }
+}
+
+
+.field_with_errors{
+  // border-left: 3px solid $error-colour;
+  // padding: 0 0 0 15px;
+
+  .error{
+    font-size: 16px;
+    line-height: 1.25;
+    font-weight: 400;
+    text-transform: none;
+    display: block;
+    color: $error-colour;
+    padding-left: 0;
+    border:0;
+    margin-right: 0;
+    clear:both;
+  }
+
+  input, select, textarea{
+    border: 2px solid $error-colour;
+  }
+}
+
+.form-row .cssfix.field_with_errors{
+  @include span(5 of 12);
+  input.form-control[type=text].medium-input{
+    @include span(8.5 of 12);
+    float: none;
+    margin-left:0;
   }
 }

--- a/app/assets/stylesheets/moj/_shame.scss
+++ b/app/assets/stylesheets/moj/_shame.scss
@@ -1,3 +1,10 @@
+.field_with_errors{
+  .field_with_errors{
+    border: none;
+    padding:0;
+  }
+}
+
 .search-wrapper {
   @include container;
   position: relative;
@@ -207,7 +214,7 @@ form {
 }
 
 .field_with_errors {
-  display:inline;
+  display:inline-block;
 }
 
 .remove-expense:first-child a {

--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -9,8 +9,12 @@ module ExternalUsers::ClaimsHelper
   end
 
   def validation_message_from_presenter(presenter, attribute)
-    content_tag :span, class: 'validation-error' do
-      presenter.field_level_error_for(attribute.to_sym)
+    if presenter.errors_for?(attribute.to_sym)
+      content_tag :span, class: 'error' do
+        presenter.field_level_error_for(attribute.to_sym)
+      end
+    else
+      ''
     end
   end
 
@@ -19,6 +23,8 @@ module ExternalUsers::ClaimsHelper
       content_tag :span, class: 'validation-error' do
         resource.errors[attribute].join(", ")
       end
+    else
+      ''
     end
   end
 
@@ -29,7 +35,7 @@ module ExternalUsers::ClaimsHelper
 
   def error_class?(presenter, *attributes)
     return if presenter.nil?
-    options = {name: 'error'}.merge(attributes.extract_options!)
+    options = {name: 'field_with_errors'}.merge(attributes.extract_options!)
     options[:name] if attributes.detect { |att| presenter.field_level_error_for(att.to_sym).present? }
   end
 end

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -21,7 +21,7 @@
         = number_field_tag :quantity_to_allocate, nil, { style: 'width:100%', min: 0, size: 5, class: 'form-control'}
       .form-col
         = f.label :case_worker_id, t('dictionary.models.case_worker')
-        = f.grouped_collection_select :case_worker_id, Location.includes(case_workers: :user), :case_workers, :name, :id, :name, { include_blank: true }, { class: 'form-control autocomplete' }
+        = f.grouped_collection_select :case_worker_id, Location.includes(case_workers: :user), :case_workers, :name, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
       .form-col{ style: 'padding: 26px 0 0' }
         = f.submit 'Allocate', class: 'button'
   - if @claims.any?

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -36,7 +36,7 @@
   .js-case-worker-list
     .column-half
       = f.label :case_worker_id
-      = f.grouped_collection_select :case_worker_id, Location.all, :case_workers, :name, :id, :name, { include_blank: true }, { class: 'form-control autocomplete' }
+      = f.grouped_collection_select :case_worker_id, Location.all, :case_workers, :name, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
 
   .grid-row
     .column-quarter

--- a/app/views/external_users/claims/basic_fees/_basic_fee_calculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_calculated_fields.html.haml
@@ -12,20 +12,20 @@
         = raw t('.saf_prompt_text')
 
   .column-one-quarter.fee-quantity
-    %label.form-label
-      = t('.quantity')
-      %a{id: "basic_fee_#{@basic_fee_count}_quantity"}
-      = f.number_field :quantity, value: number_with_precision_or_default(fee.quantity) , class: 'form-control quantity', min: 0, max: 99999
-      = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
+    = f.adp_text_field :quantity,
+                        label: t('.quantity'),
+                        input_classes:'quantity',
+                        input_type: 'number',
+                        value: fee.quantity,
+                        errors: @error_presenter
 
   .column-one-quarter.fee-rate
-    %label.form-label
-      = t('.rate')
-    %a{id: "basic_fee_#{@basic_fee_count}_rate"}
-    %span.currency-indicator>< &pound;
-    = f.number_field :rate, value: fee.fee.rate, precision: 2, class: 'form-control rate', size: 10, min: 0, max: 99999
-    = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_rate")
-
+    = f.adp_text_field :rate,
+                        label: t('.rate'),
+                        input_classes:'rate',
+                        input_type: 'currency',
+                        errors: @error_presenter,
+                        value: number_with_precision(f.object.rate, precision: 2)
 .grid-row
   .column-one-third.fee-total
     %label.form-label Total

--- a/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
@@ -5,16 +5,17 @@
     = fee.section_hint('external_users.claims.basic_fees.basic_fee_uncalculated_fields')
 
   .column-one-quarter.fee-quantity
-    %label.form-label
-      = t('.quantity')
-      %a{id: "basic_fee_#{@basic_fee_count}_quantity"}
-      = f.number_field :quantity, value: number_with_precision_or_default(fee.quantity) , class: 'form-control quantity', min: 0, max: 99999
-      = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_quantity")
+    = f.adp_text_field :quantity,
+                        label: t('.quantity'),
+                        input_classes:'quantity',
+                        input_type: 'number',
+                        value: fee.quantity,
+                        errors: @error_presenter
 
   .column-one-quarter.fee-rate
-    %label.form-label
-      = t('.total')
-      %a{id: "basic_fee_#{@basic_fee_count}_amount"}
-    %span.currency-indicator>< &pound;
-    = f.number_field :amount, value: number_with_precision(fee.fee.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
-    = validation_error_message(@error_presenter, "basic_fee_#{@basic_fee_count}_amount")
+    = f.adp_text_field :amount,
+                        label: t('.total'),
+                        input_classes:'total',
+                        input_type: 'currency',
+                        value: number_with_precision(f.object.rate, precision: 2),
+                        errors: @error_presenter

--- a/app/views/external_users/claims/case_details/_case_owner_select.html.haml
+++ b/app/views/external_users/claims/case_details/_case_owner_select.html.haml
@@ -1,5 +1,7 @@
 .form-row
-  .form-col
-    = f.anchored_label label, 'external_user_id_autocomplete'
-    = f.collection_select :external_user_id, external_users_collection, :id, :name_and_number, {include_blank: true}, {class: 'form-control autocomplete'}
+  .form-col{class: error_class?(@error_presenter, :external_user)}
+    %a{:id => :external_user}
+    %label{:for => "claim_external_user_id_autocomplete"}
+      = label
+    = f.collection_select :external_user_id, external_users_collection, :id, :name_and_number, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete'}
     = validation_error_message(@error_presenter, :external_user)

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -18,9 +18,12 @@
       .form-col.form-col-two-thirds
         = f.gov_uk_date_field(:trial_cracked_at, legend_text: t('.trial_cracked_at'), legend_class: 'govuk-legend', id: "trial_cracked_at", error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_cracked_at))
 
-    %legend.govuk-legend
-      = t('.trial_cracked_at_third')
+
     %div.form-group.inline
-      = f.collection_radio_buttons(:trial_cracked_at_third, Settings.trial_cracked_at_third, :to_s, :humanize) do |b|
-        - b.label(class: "block-label") { b.radio_button + b.text }
+      %fieldset
+        %legend.govuk-legend
+          = t('.trial_cracked_at_third')
+
+        = f.collection_radio_buttons(:trial_cracked_at_third, Settings.trial_cracked_at_third, :to_s, :humanize) do |b|
+          - b.label(class: "block-label") { b.radio_button + b.text }
     = validation_error_message(@error_presenter, :trial_cracked_at_third)

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -7,7 +7,7 @@
     %legend.xsmall
       = f.anchored_without_label t('.advocate_category')
       = t('.advocate_category')
-    .form-group.inline
+    .form-group.inline{class: error_class?(@error_presenter, :advocate_category)}
       = f.collection_radio_buttons(:advocate_category, Settings.advocate_categories.sort, :to_s, :to_s) do |b|
         - b.label(class: "block-label") { b.radio_button + b.value.to_s }
       = validation_error_message(@error_presenter, :advocate_category)
@@ -20,42 +20,42 @@
       = render partial: 'external_users/claims/case_details/case_owner_select', locals: { f: f, label: label, external_users_collection: external_users_collection }
 
     .form-row
-      .form-col
-        = f.anchored_label t('.case_type'), 'case_type_id_autocomplete'
+      .form-col{class: error_class?(@error_presenter, :case_type)}
+        %a{:id => "case_type"}
+        %label{:for => "claim_case_type_id_autocomplete"}
+          = t('.case_type')
         .form-hint.xsmall.zero-vert-margin
           = "eg Trial"
-        = f.select :case_type_id, @case_types.map{ |ct| [ct.name, ct.id, {data: {'is-fixed-fee' => ct.is_fixed_fee?}}] }, { include_blank: true }, { class: 'autocomplete' }
+        = f.select :case_type_id, @case_types.map{ |ct| [ct.name, ct.id, {data: {'is-fixed-fee' => ct.is_fixed_fee?}}] }, { include_blank: '&#160;'.html_safe }, { class: 'autocomplete' }
         = validation_error_message(@error_presenter, :case_type)
 
     .form-row
-      .form-col
-        = f.anchored_label t('.court'), 'court_id_autocomplete'
+      .form-col{class: error_class?(@error_presenter, :court)}
+        %a{:id => "court"}
+        %label{:for => "claim_court_id_autocomplete"}
+          = t('.court')
+
         .form-hint.xsmall.zero-vert-margin
           = "eg Cardiff"
-        = f.collection_select :court_id, Court.alphabetical, :id, :name, { include_blank: true }, { class: 'autocomplete' }
+        = f.collection_select :court_id, Court.alphabetical, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'autocomplete' }
         = validation_error_message(@error_presenter, :court)
 
       .form-col
-        = f.anchored_label t('.case_number'), nil, { label_attributes: {class: 'form-label'} }
-        .form-hint.xsmall.zero-vert-margin
-          = "eg A12345678"
-        = f.text_field :case_number, {class: 'form-control'}
-        = validation_error_message(@error_presenter, :case_number)
+        = f.adp_text_field :case_number,
+                            label: t('.case_number'),
+                            hint_text: 'eg A12345678',
+                            errors: @error_presenter
 
     .form-row
-      .form-col
+      .form-col{class: error_class?(@error_presenter, :transfer_court)}
         = f.anchored_label t('.transfer_court'), 'transfer_court_id_autocomplete'
         .form-hint.xsmall.zero-vert-margin
           = "eg Cardiff"
-        = f.collection_select :transfer_court_id, Court.alphabetical, :id, :name, { include_blank: true }, { class: 'autocomplete' }
+        = f.collection_select :transfer_court_id, Court.alphabetical, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'autocomplete' }
         = validation_error_message(@error_presenter, :transfer_court)
 
-      .form-col.form-col-two-thirds
-        = f.anchored_label t('.transfer_case_number'), :transfer_case_number
-        .form-hint.xsmall.zero-vert-margin
-          = "eg A12345678"
-        = f.text_field :transfer_case_number, {class: 'form-control medium-input'}
-        = validation_error_message(@error_presenter, :transfer_case_number)
+      .cssfix.form-col.form-col-two-thirds{class: error_class?(@error_presenter, :transfer_case_number)}
+        = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number'), hint_text: 'eg A12345678', input_classes: 'medium-input',  errors: @error_presenter
 
 
 - if @claim.agfs?
@@ -74,8 +74,7 @@
         - else
           - selected_offence_category = @claim.offence.description rescue nil
 
-        = collection_select :offence_category, :description, @offence_descriptions, :description, :description, { include_blank: true, prompt: true, selected: selected_offence_category }, { class: 'form-control autocomplete' }
-
+        = collection_select :offence_category, :description, @offence_descriptions, :description, :description, { include_blank: '&#160;'.html_safe, selected: selected_offence_category }, { class: 'form-control autocomplete', id: 'claim_offence_category_description' }
         = validation_error_message(@error_presenter, :offence)
 
       .form-col

--- a/app/views/external_users/claims/case_details/_offence_id_select.html.haml
+++ b/app/views/external_users/claims/case_details/_offence_id_select.html.haml
@@ -1,5 +1,6 @@
-= f.anchored_label t('.offence_class'), :offence
-.form-hint.xsmall.zero-vert-margin
-  = t('.offence_class_hint')
-= f.collection_select :offence_id, Offence.miscellaneous, :id, :offence_class_description, { include_blank: true }, { class: 'form-control autocomplete' }
-= validation_error_message(@error_presenter, :offence)
+%div{class: error_class?(@error_presenter, :offence)}
+  = f.anchored_label t('.offence_class'), :offence
+  .form-hint.xsmall.zero-vert-margin
+    = t('.offence_class_hint')
+  = f.collection_select :offence_id, Offence.miscellaneous, :id, :offence_class_description, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
+  = validation_error_message(@error_presenter, :offence)

--- a/app/views/external_users/claims/case_details/_offence_select.html.haml
+++ b/app/views/external_users/claims/case_details/_offence_select.html.haml
@@ -1,4 +1,4 @@
-= label_tag t('.offence_class')
+= label_tag 'offence_class_description', t('.offence_class')
 .form-hint.xsmall.zero-vert-margin
   &nbsp;<br/><br/>
 - selected_offence = @claim.try(:offence) ? @claim.offence.id : (offences.count == 1 ? offences.first : nil)

--- a/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
@@ -19,9 +19,7 @@
             = t('.estimated_retrial_length_hint')
 
         .form-group.form-group-day
-          = f.anchored_label t('.days'), 'retrial_estimated_length'
-          = f.number_field :retrial_estimated_length, step: 1, min: 1, class: 'form-control short-input'
-          = validation_error_message(@error_presenter, :retrial_estimated_length)
+          = f.adp_text_field :retrial_estimated_length, label: t('.days'), input_classes:'short-input', input_type: 'number', errors: @error_presenter
 
   .form-row
 
@@ -37,9 +35,7 @@
             = t('.actual_retrial_length_hint')
 
         .form-group.form-group-day
-          = f.anchored_label t('.days'), 'retrial_actual_length'
-          = f.number_field :retrial_actual_length, step: 1, min: 0, class: 'form-control short-input'
-          = validation_error_message(@error_presenter, :retrial_actual_length)
+          = f.adp_text_field :retrial_actual_length, label: t('.days'), input_classes:'short-input', input_type: 'number', errors: @error_presenter
 
 
 

--- a/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
@@ -19,9 +19,7 @@
             = t('.estimated_trial_length_hint')
 
         .form-group.form-group-day
-          = f.anchored_label t('.days'), 'estimated_trial_length'
-          = f.number_field :estimated_trial_length, step: 1, min: 1, class: 'form-control short-input'
-          = validation_error_message(@error_presenter, :estimated_trial_length)
+          = f.adp_text_field :estimated_trial_length, label: t('.days'), input_classes:'short-input', input_type: 'number', errors: @error_presenter
 
   .form-row
 
@@ -37,8 +35,6 @@
             = t('.actual_trial_length_hint')
 
         .form-group.form-group-day
-          = f.anchored_label t('.days'), 'actual_trial_length'
-          = f.number_field :actual_trial_length, step: 1, min: 0, class: 'form-control short-input'
-          = validation_error_message(@error_presenter, :actual_trial_length)
+          = f.adp_text_field :actual_trial_length, label: t('.days'), input_classes:'short-input', input_type: 'number', errors: @error_presenter
 
 

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -3,24 +3,13 @@
   .form-row
     .form-col.first-name
       - @representation_order_count = 0
-
-      %a{:id => "defendant_#{@defendant_count+1}_first_name"}
-      = f.label :first_name, t('.first_name'), {class: "form-label"}
-      = f.text_field :first_name, class: 'form-control', id: "claim_defendants_attributes_#{@defendant_count}_first_name"
-      = validation_error_message(@error_presenter, "defendant_#{@defendant_count+1}_first_name".to_sym)
+      = f.adp_text_field :first_name, label: t('.first_name'), errors: @error_presenter
 
   .form-row
     .form-col.last-name
-      %a{:id => "defendant_#{@defendant_count+1}_last_name"}
-      = f.label :last_name, t('.last_name'), {class: "form-label"}
-      = f.text_field :last_name, class: 'form-control', id: "claim_defendants_attributes_#{@defendant_count}_last_name"
-      = validation_error_message(@error_presenter, "defendant_#{@defendant_count+1}_last_name".to_sym)
+      = f.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
 
-      / = f.anchored_label(t('.last_name'), "defendant_#{@defendant_count}_last_name", { label_attributes: {class: 'form-label'} })
-      / = f.text_field :last_name, {class: 'form-control'}
-      / = validation_error_message(@error_presenter, "defendant_#{@defendant_count}_last_name".to_sym)
   .form-row
-
     .form-col.form-col-two-thirds.dob
       = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count}_date_of_birth", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count}_date_of_birth".to_sym))
 
@@ -30,7 +19,8 @@
         %label.block-label.judicial-apportionment-notice
           = f.check_box :order_for_judicial_apportionment
           = raw t('.order_for_judicial_apportionment')
-          = validation_error_message(f.object, :order_for_judicial_apportionment)
+          = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
+
 
   .documents
     %a{id: "defendant_#{@defendant_count}_representation_orders"}

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -7,14 +7,17 @@
   .form-row
 
     .form-col.form-col-two-thirds.ro-date
-      = f.gov_uk_date_field(:representation_order_date, legend_text: 'Representation order date', legend_class: 'govuk-legend', id: "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date"))
+      = f.gov_uk_date_field(:representation_order_date,
+                            legend_text: 'Representation order date',
+                            legend_class: 'govuk-legend',
+                            id: "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date",
+                            error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date"))
 
   .form-row
     .form-col.maat
-      = f.anchored_label t('maat_reference_number'), "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_maat_reference"
-      .form-hint.xsmall.zero-vert-margin
-        = t("maat_reference_number_eg")
-      = f.text_field :maat_reference, {class: 'form-control'}
-      = validation_error_message(@error_presenter, "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_maat_reference")
+      = f.adp_text_field :maat_reference,
+                          label: t('.maat_reference_number'),
+                          hint_text: t('.maat_reference_number_eg'),
+                          errors: @error_presenter
 
   = link_to_remove_association t('link.remove_rep_order'), f

--- a/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
+++ b/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
@@ -1,28 +1,27 @@
 .form-group.disbursement-group.nested-fields.js-block{data:{"block-type": "FeeBlockManualAmounts", type:"disbursements", autovat: "false"}}
   .grid-row
-    .column-half.disbursement-type
+    .column-half.disbursement-type{class: error_class?(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")}
       %label.form-label
         = t('.disbursement_type')
       %a{id: "disbursement_#{@disbursement_count}_disbursement_type"}
-      = f.collection_select :disbursement_type_id, DisbursementType.all, :id, :name, {include_blank: true}, {class: 'form-control autocomplete', style: 'width:350px'}
+      = f.collection_select :disbursement_type_id, DisbursementType.all, :id, :name, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete', style: 'width:350px'}
       = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")
 
     .column-one-quarter.fee-amount
-      %label.form-label
-        = t('.net_amount')
-      %a{id: "disbursement_#{@disbursement_count}_net_amount"}
-      %span.currency-indicator>< &pound;
-      = f.number_field :net_amount, value: number_with_precision(f.object.net_amount, precision: 2), class: 'form-control amount', size: 10, min:0, max:99999
-      = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_net_amount")
+      = f.adp_text_field :net_amount,
+                          label: t('.net_amount'),
+                          input_classes:'amount',
+                          input_type: 'number',
+                          value: number_with_precision(f.object.net_amount, precision: 2),
+                          errors: @error_presenter
 
     .column-one-quarter.fee-vat
-      %label.form-label
-        = t('.vat_amount')
-      %a{id: "disbursement_#{@disbursement_count}_vat_amount"}
-
-      %span.currency-indicator>< &pound;
-      = f.number_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control vat', size: 10, min:0, max: 99999999
-      = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_vat_amount")
+      = f.adp_text_field :vat_amount,
+                          label: t('.vat_amount'),
+                          input_classes:'vat',
+                          input_type: 'number',
+                          value: number_with_precision(f.object.vat_amount, precision: 2),
+                          errors: @error_presenter
 
   .grid-row
     .column-one-quarter.fee-total

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -5,7 +5,7 @@
       = "Expense"
 
     .grid-row
-      .column-one-third
+      .column-one-third{class: error_class?(@error_presenter, "expense_#{@expense_count}_expense_type")}
         %a{id: "expense_#{@expense_count}_expense_type"}
         = f.label :expense_type_id, 'Expense type'
         - expense_types_collection = present_collection(ExpenseType.for_claim_type(@claim))
@@ -14,28 +14,33 @@
         = validation_error_message(@error_presenter, "expense_#{@expense_count}_expense_type")
 
       .column-one-third{class: "js-expense-location"}
-        %a{id: "expense_#{@expense_count}_location"}
-        = f.label :location, 'Destination'
-        = f.text_field :location, {class: 'form-control'}
-        = validation_error_message(@error_presenter, "expense_#{@expense_count}_location")
+        = f.adp_text_field :location,
+                            label: t('.destination'),
+                            errors: @error_presenter
 
       .column-one-third.condensed{class: "js-expense-distance expense-distance"}
-        %a{id: "expense_#{@expense_count}_distance"}
-        = f.label :distance, 'Distance'
-        = f.number_field :distance, value: number_with_precision(f.object.distance, precision: 2, strip_insignificant_zeros: true), max: 99999, min: 0, class: 'form-control'
-        = validation_error_message(@error_presenter, "expense_#{@expense_count}_distance")
+        = f.adp_text_field :distance,
+                            label: t('.distance'),
+                            input_type: 'number',
+                            value: number_with_precision(f.object.distance, precision: 2),
+                            errors: @error_presenter
 
       .column-one-third.condensed{class: "js-expense-hours expense-hours"}
-        %a{id: "expense_#{@expense_count}_hours"}
-        = f.label :hours, 'Hours'
-        = f.number_field :hours, value: number_with_precision(f.object.hours, precision: 1, strip_insignificant_zeros: true), max: 9999, min: 0, class: 'form-control short-input'
-        = validation_error_message(@error_presenter, "expense_#{@expense_count}_hours")
+        = f.adp_text_field :hours,
+                            label: t('.hours'),
+                            input_classes:'short-input',
+                            input_type: 'number',
+                            errors: @error_presenter
 
     .grid-row
       .column-one-third{class: "expense_#{@expense_count}_date"}
-        = f.gov_uk_date_field(:date, legend_text: 'Date of expenses', legend_class: 'govuk-legend', id: "expense_#{@expense_count}_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, "expense_#{@expense_count}_date"))
+        = f.gov_uk_date_field :date,
+                                legend_text: 'Date of expenses',
+                                legend_class: 'govuk-legend',
+                                id: "expense_#{@expense_count}_date",
+                                error_messages: gov_uk_date_field_error_messages(@error_presenter, "expense_#{@expense_count}_date")
 
-      .column-one-third{class: "js-expense-reason"}
+      .column-one-third.js-expense-reason{class: error_class?(@error_presenter, "expense_#{@expense_count}_reason_id")}
         %a{id: "expense_#{@expense_count}_reason_id"}
         = f.label :reason_id, 'Reason for travel'
         -# (hardcoded for now, dependent on chosen Expense Type):
@@ -51,21 +56,23 @@
             = validation_error_message(@error_presenter, "expense_#{@expense_count}_reason_text")
 
       .column-one-third.condensed{class: "js-expense-amount fee-total"}
-        %a{id: "expense_#{@expense_count}_amount"}
-        = f.label :amount, 'Total'
-        %span.currency-indicator>< &pound;
-        = f.number_field :amount, max:99999, min:0, value: number_with_precision(f.object.amount, precision: 2), class: 'total form-control large-input'
-        = validation_error_message(@error_presenter, "expense_#{@expense_count}_amount")
+        = f.adp_text_field :amount,
+                            label: t('.total'),
+                            input_classes:'total',
+                            input_type: 'currency',
+                            errors: @error_presenter,
+                            value: number_with_precision(f.object.amount, precision: 2)
 
         - if @claim.lgfs?
           .js-expense-vat-amount
-            %a{id: "expense_#{@expense_count}_vat_amount"}
-            = f.label :vat_amount, 'VAT'
-            %span.currency-indicator>< &pound;
-            = f.number_field :vat_amount, max:99999, min:0, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'vat form-control'
-            = validation_error_message(@error_presenter, "expense_#{@expense_count}_vat_amount")
+            = f.adp_text_field :vat_amount,
+                          label: t('.vat'),
+                          input_classes:'vat',
+                          input_type: 'currency',
+                          errors: @error_presenter,
+                          value: number_with_precision(f.object.vat_amount, precision: 2)
 
-    .grid-row.js-expense-mileage.expense-cost
+    .grid-row.js-expense-mileage.expense-cost{class: error_class?(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")}
       %a{id: "expense_#{@expense_count}_mileage_rate_id"}
       %fieldset{class: "inline"}
         %legend

--- a/app/views/external_users/claims/fixed_fees/_fixed_fee_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/_fixed_fee_fields.html.haml
@@ -5,23 +5,24 @@
       %label.form-label
         = t('.fee_type')
       %a{id: "fixed_fee_#{@fixed_fee_count}_fee_type"}
-      = f.collection_select :fee_type_id, @claim.eligible_fixed_fee_types, :id, :description, {include_blank: true}, {class: 'form-control autocomplete', style: 'width:400px'}
+      = f.collection_select :fee_type_id, @claim.eligible_fixed_fee_types, :id, :description, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete', style: 'width:400px'}
       = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_fee_type")
 
     .column-one-quarter.fee-quantity
-      %label.form-label
-        = t('.quantity')
-      %a{id: "fixed_fee_#{@fixed_fee_count}_quantity"}
-      = f.number_field :quantity, value: fee.quantity, min: 0, max: 99999, class: 'form-control quantity'
-      = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_quantity")
+      = f.adp_text_field :quantity,
+                          label: t('.quantity'),
+                          input_classes:'quantity',
+                          input_type: 'number',
+                          value: fee.quantity,
+                          errors: @error_presenter
 
     .column-one-quarter.fee-rate
-      %label.form-label
-        = t('.rate')
-      %a{id: "fixed_fee_#{@fixed_fee_count}_rate"}
-      %span.currency-indicator>< &pound;
-      = f.number_field :rate, min: 0, max: 99999, value: fee.rate_as_float, class: 'form-control rate', size: 10
-      = validation_error_message(@error_presenter, "fixed_fee_#{@fixed_fee_count}_rate")
+      = f.adp_text_field :rate,
+                          label: t('.rate'),
+                          input_classes:'rate',
+                          input_type: 'currency',
+                          errors: @error_presenter,
+                          value: number_with_precision(f.object.rate, precision: 2)
 
   .grid-row
     .column-one-third.fee-total

--- a/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
@@ -22,7 +22,7 @@
             %label.form-label
               = t('.select_sub_type')
             = ff.anchored_attribute 'sub_type'
-            = ff.collection_select :sub_type_id, @claim.case_type.fixed_fee_type.children, :id, :description, { include_blank: true }, { class: 'form-control autocomplete' }
+            = ff.collection_select :sub_type_id, @claim.case_type.fixed_fee_type.children, :id, :description, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
             = validation_error_message(@error_presenter, 'fixed_fee.sub_type')
 
           .column-one-quarter.condensed.js-expense-location
@@ -33,9 +33,10 @@
             = ff.gov_uk_date_field(:date, legend_text: t('.date'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'fixed_fee.date'))
 
           .column-one-quarter.condensed.js-expense-amount.fee-total
-            %label.form-label Total
-
-            = ff.anchored_attribute 'amount'
-            %span.currency-indicator>< &pound;
-            = ff.number_field :amount, value: number_with_precision(ff.object.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 999999
-            = validation_error_message(@error_presenter, 'fixed_fee.amount')
+            = ff.adp_text_field :amount,
+                                  label: t('.total'),
+                                  input_classes:'total',
+                                  input_type: 'currency',
+                                  errors: @error_presenter,
+                                  error_key: 'fixed_fee.amount',
+                                  value: number_with_precision(ff.object.amount, precision: 2)

--- a/app/views/external_users/claims/interim_fee/_fields.html.haml
+++ b/app/views/external_users/claims/interim_fee/_fields.html.haml
@@ -10,7 +10,7 @@
     .interim-fee-group.nested-fields.mod-fees.js-block{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false"}}
       %fieldset
         .form-row
-          .column-half
+          .column-half{class: error_class?(@error_presenter, "interim_fee.fee_type")}
             = inf.label :fee_type, t('.fee_type')
             = inf.anchored_attribute 'fee_type'
             - interim_fee_types_collection = present_collection(@claim.eligible_interim_fee_types)
@@ -19,12 +19,14 @@
 
 
           .column-half.fee-quantity.js-interim-ppe.visually-hidden
-            = inf.label :quantity, t('.ppe_total')
-            .form-hint.xsmall
-              = t('.ppe_total_hint')
-            = inf.anchored_attribute 'quantity'
-            = inf.number_field :quantity, value: fee.quantity, class: 'form-control quantity', min: 0, max: 99999
-            = validation_error_message(@error_presenter, 'interim_fee.quantity')
+            = inf.adp_text_field :quantity,
+                          label: t('.ppe_total'),
+                          input_classes:'quantity',
+                          hint_text: t('.ppe_total_hint'),
+                          input_type: 'number',
+                          value: fee.quantity,
+                          error_key:'interim_fee.quantity',
+                          errors: @error_presenter
 
         .form-row
           .column-first-child.column-three-quarters.js-interim-effectivePcmh.visually-hidden
@@ -39,11 +41,12 @@
               = f.gov_uk_date_field(:retrial_started_at, legend_text: t('.retrial_started_at'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :retrial_started_at))
 
             .column-half
-              = f.anchored_label(t('.retrial_estimated_length'), :retrial_estimated_length, { label_attributes: {class: 'form-label form-date-spacing with-hint'} })
-              .form-hint.xsmall
-                = t('.number_days_hint')
-              = f.number_field :retrial_estimated_length, step: 1, min: 1, class: 'form-control'
-              = validation_error_message(@error_presenter, :retrial_estimated_length)
+              = f.adp_text_field :retrial_estimated_length,
+                          label: t('.retrial_estimated_length'),
+                          input_classes:'form-date-spacing with-hint',
+                          hint_text: t('.number_days_hint'),
+                          errors: @error_presenter
+
 
           .column-first-child.column-three-quarters.js-interim-trialDates.visually-hidden
             .column-half
@@ -51,11 +54,12 @@
               = f.gov_uk_date_field(:first_day_of_trial, legend_text: t('.first_day_of_trial'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :first_day_of_trial))
 
             .column-half
-              = f.anchored_label(t('.estimated_trial_length'), :estimated_trial_length, { label_attributes: {class: 'form-label form-date-spacing with-hint'} })
-              .form-hint.xsmall
-                = t('.number_days_hint')
-              = f.number_field :estimated_trial_length, step: 1, min: 1, class: 'form-control'
-              = validation_error_message(@error_presenter, :estimated_trial_length)
+              = f.adp_text_field :estimated_trial_length,
+                          label: t('.estimated_trial_length'),
+                          input_classes:'form-date-spacing with-hint',
+                          input_type: 'number',
+                          hint_text: t('.number_days_hint'),
+                          errors: @error_presenter
 
           .column-first-child.column-three-quarters.js-interim-legalAidTransfer.visually-hidden
             .column-half
@@ -76,11 +80,13 @@
               = inf.gov_uk_date_field :warrant_executed_date, legend_text: t('.warrant_executed'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_fee.warrant_executed_date')
 
           .column-quarter.fee-amount.js-interim-feeTotal.visually-hidden
-            = inf.label :amount, t('.total'), {class: 'form-label form-date-spacing'}
-            = inf.anchored_attribute 'amount'
-            %span.currency-indicator>< &pound;
-            = inf.number_field :amount, value: number_with_precision(inf.object.amount, precision: 2), class: 'total form-control', size: 10, min: 0, max: 99999999
-            = validation_error_message(@error_presenter, 'interim_fee.amount')
+            = inf.adp_text_field :amount,
+                          label: t('.total'),
+                          input_classes:'total',
+                          input_type: 'number',
+                          error_key: 'interim_fee.amount',
+                          value: number_with_precision(inf.object.amount, precision: 2),
+                          errors: @error_presenter
 
     .js-interim-disbursements.visually-hidden
       = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }

--- a/app/views/external_users/claims/misc_fees/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/_misc_fee_fields.html.haml
@@ -1,27 +1,28 @@
 - fee = present(f.object)
 .form-group.misc-fee-group.nested-fields.js-block{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false", "block-type": "FeeBlockCalculator"}}
   .grid-row
-    .column-one-half.fee-type
+    .column-one-half.fee-type{class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")}
       %label.form-label
         = t('.fee_type')
       %a{id: "misc_fee_#{@misc_fee_count}_fee_type"}
-      = f.collection_select :fee_type_id, @claim.eligible_misc_fee_types, :id, :description, {prompt: true}, {class: 'autocomplete js-misc-fee-type', style: 'width:350px'}
+      = f.collection_select :fee_type_id, @claim.eligible_misc_fee_types, :id, :description, {include_blank: '&#160;'.html_safe}, {class: 'autocomplete js-misc-fee-type', style: 'width:350px'}
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
     .column-one-quarter.fee-quantity
-      %label.form-label
-        = t('.quantity')
-      %a{id: "misc_fee_#{@misc_fee_count}_quantity"}
-      = f.number_field :quantity, value: fee.quantity, min: 0, max: 99999, class: 'form-control quantity'
-      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_quantity")
+      = f.adp_text_field :quantity,
+                          label: t('.quantity'),
+                          input_classes:'quantity',
+                          input_type: 'number',
+                          value: fee.quantity,
+                          errors: @error_presenter
 
     .column-one-quarter.fee-rate
-      %label.form-label
-        = t('.rate')
-      %a{id: "misc_fee_#{@misc_fee_count}_rate"}
-      %span.currency-indicator>< &pound;
-      = f.number_field :rate, value: number_with_precision(f.object.rate, precision: 2), class: 'form-control rate', size: 10, min: 0, max: 99999
-      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_rate")
+      = f.adp_text_field :rate,
+                          label: t('.rate'),
+                          input_classes:'rate',
+                          input_type: 'currency',
+                          errors: @error_presenter,
+                          value: number_with_precision(f.object.rate, precision: 2)
 
   .grid-row
     .column-one-third.fee-total

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -1,33 +1,31 @@
 .form-group.misc-fee-group.js-block.nested-fields{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false"}}
   .grid-row
     .column-three-quarters
-      .column-half
+      .column-half{class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")}
         %label.form-label
           = t('.fee_type')
           %span.form-hint.xsmall.zero-vert-margin
             &nbsp;<br/>
         %a{id: "misc_fee_#{@misc_fee_count}_fee_type"}
         - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
-        = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, {include_blank: true}, {class: 'form-control autocomplete js-misc-fee-type', style: 'width:100%'}
+        = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete js-misc-fee-type', style: 'width:100%'}
         = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
       .column-half
-        %label.form-label
-          = t('.case_numbers')
-          %span.form-hint.xsmall.zero-vert-margin
-            Separate by commas
-        %a{id: "misc_fee_#{@misc_fee_count}_case_numbers"}
-        = f.text_field :case_numbers, {class: 'form-control js-misc-fee-case-numbers'}
-        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_case_numbers")
+        = f.adp_text_field :case_numbers,
+                            label: t('.case_numbers'),
+                            input_classes:'js-misc-fee-case-numbers',
+                            hint_text:'Separate by commas',
+                            errors: @error_presenter
+
 
     .column-one-quarter.fee-rate
-      %label.form-label
-        = t('.amount')
-        %span.form-hint.xsmall.zero-vert-margin
-          &nbsp;<br/>
-      %a{id: "misc_fee_#{@misc_fee_count}_amount"}
-      %span.currency-indicator>< &pound;
-      = f.number_field :amount, value: number_with_precision(f.object.amount, precision: 2), class: 'form-control total', size: 10, min: 0, max: 99999
-      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_amount")
+      = f.adp_text_field :amount,
+                          label: t('.amount'),
+                          input_classes:'total',
+                          input_type:'currency',
+                          hint_text:'&nbsp;<br />',
+                          value: number_with_precision(f.object.amount, precision: 2),
+                          errors: @error_presenter
 
   = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group' }

--- a/app/views/external_users/claims/supplier_number/_fields.html.haml
+++ b/app/views/external_users/claims/supplier_number/_fields.html.haml
@@ -1,6 +1,6 @@
 .form-group
   .form-row
-    .form-col
+    .form-col{class: error_class?(@error_presenter, :supplier_number)}
       = f.anchored_label(t('.supplier_number'), 'supplier_number', { label_attributes: {class: 'form-label'} })
       = f.collection_select :supplier_number, current_user.persona.provider.supplier_numbers, :supplier_number, :supplier_number, {prompt: true}, {class: 'form-control'}
       = validation_error_message(@error_presenter, :supplier_number)

--- a/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
@@ -5,7 +5,7 @@
 
   .js-case-conclusion-effectors
     %fieldset
-      .form-row
+      .form-row{class: error_class?(@error_presenter, :litigator_type)}
         %fieldset.inline
           = f.anchored_label t('.litigator_type'), 'litigator_type'
           = f.collection_radio_buttons(:litigator_type, ['original','new'], :to_s, :humanize) do |b|
@@ -13,7 +13,7 @@
         = validation_error_message(@error_presenter, :litigator_type)
 
     %fieldset
-      .form-row
+      .form-row{class: error_class?(@error_presenter, :elected_case)}
         %fieldset.inline
           = f.anchored_label t('.elected_case'), 'elected_case'
           = f.collection_radio_buttons(:elected_case, [['Yes','true'],['No','false']], :last, :first ) do |b|
@@ -35,7 +35,7 @@
   .js-case-conclusions-select
     %fieldset
       .form-row
-        .form-col.form-col-one-half
+        .form-col.form-col-one-half{class: error_class?(@error_presenter, 'case_conclusion_id')}
           = f.anchored_label t('.case_conclusions'), 'case_conclusion_id'
-          = f.collection_select :case_conclusion_id, claim.case_conclusions, :first, :last,{ prompt: true, include_blank: true }, { class: 'form-control autocomplete medium-input'}
+          = f.collection_select :case_conclusion_id, claim.case_conclusions, :first, :last,{ include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete medium-input'}
           = validation_error_message(@error_presenter, 'case_conclusion_id')

--- a/app/views/external_users/claims/transfer_fee/_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_fields.html.haml
@@ -15,11 +15,13 @@
             = @claim.transfer_fee.description
 
           .column-quarter.fee-amount
-            = tf.label :amount, t('.total')
-            = tf.anchored_attribute 'amount'
-            %span.currency-indicator>< &pound;
-            = tf.number_field :amount, value: number_with_precision(tf.object.amount, precision: 2), class: 'form-control total', size: 10
-            = validation_error_message(@error_presenter, 'transfer_fee.amount')
-            = validation_error_message(@error_presenter, 'transfer_fee')
+            = tf.adp_text_field :amount,
+                                label: t('.total'),
+                                input_classes:'total',
+                                input_type: 'currency',
+                                value: number_with_precision(tf.object.amount, precision: 2),
+                                errors: @error_presenter,
+                                error_key: 'transfer_fee.amount'
+
 
   = render partial: 'external_users/claims/transfer_fee/detail_fields', locals: { f: f }

--- a/app/views/external_users/claims/warrant_fee/_fields.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_fields.html.haml
@@ -1,5 +1,4 @@
 #warrant_fee.mod-fees
-  = f.anchored_without_label 'warrant_fee'
   %h2.bold-medium
     = t('.warrant_fee')
 
@@ -8,18 +7,25 @@
     .form-group.nested-fields.js-block{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false"}}
       .grid-row
         .column-one-half
-          = wf.gov_uk_date_field :warrant_issued_date, legend_text: t('.date_issued'), legend_class: 'govuk-legend',
-            id: 'warrant_fee.warrant_issued_date', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_issued_date')
+          = wf.gov_uk_date_field :warrant_issued_date,
+                                  legend_text: t('.date_issued'),
+                                  legend_class: 'govuk-legend',
+                                  id: 'warrant_fee.warrant_issued_date',
+                                  error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_issued_date')
 
         .column-one-half
-          = wf.gov_uk_date_field :warrant_executed_date, legend_text: t('.date_executed'), legend_class: 'govuk-legend',
-            id: 'warrant_fee.warrant_executed_date', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_executed_date')
+          = wf.gov_uk_date_field :warrant_executed_date,
+                                  legend_text: t('.date_executed'),
+                                  legend_class: 'govuk-legend',
+                                  id: 'warrant_fee.warrant_executed_date',
+                                  error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_executed_date')
 
       .grid-row
         .column-quarter
-          %label.form-label{:for => "claim_warrant_fee_attributes_amount"}
-            = t('.total')
-          %a{id: "amount"}
-          %span.currency-indicator>< &pound;
-          = wf.number_field :amount, value: number_with_precision(wf.object.amount, precision: 2), class: 'total form-control', size: 10
-          = validation_error_message(@error_presenter, 'interim_fee.amount')
+          = wf.adp_text_field :amount,
+                                label: t('.total'),
+                                input_classes:'total',
+                                input_type: 'currency',
+                                errors: @error_presenter,
+                                value: number_with_precision(wf.object.amount, precision: 2),
+                                error_key: 'warrant_fee.amount'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -499,7 +499,8 @@ en:
           add_another_defendant: 'Add another defendant'
         representation_order_fields:
           representation_order: Representation order
-          maat_reference_number: MAAT reference number
+          maat_reference_number: MAAT reference
+          maat_reference_number_eg: 'eg. 1234567890'
       agfs_claims:
         show_count: 'Showing %{page_count} of %{total} claims'
         table_caption: 'Claims'
@@ -569,6 +570,11 @@ en:
         expense_fields:
           add_date_attended: 'Add date(s)'
           remove: Remove Expense <span class="js-expense-remove-count"></span>
+          vat: VAT
+          destination: Destination
+          distance: Distance
+          hours: Hours
+          total: Total
         fields:
           add_another_expense: 'Add another expense'
           amount: 'Amount'

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -24,14 +24,14 @@ class ClaimFormPage < SitePrism::Page
   element :offence_category, "#s2id_autogen3"
 
   sections :defendants, "div.defendants > div.js-test-defendant" do
-    element :first_name, "div.first-name > input"
-    element :last_name, "div.last-name > input"
+    element :first_name, "div.first-name input"
+    element :last_name, "div.last-name input"
 
     section :dob, CommonDateSection, 'div.dob'
 
     sections :representation_orders, "div.js-test-rep-order" do
       section :date, CommonDateSection, 'div.ro-date'
-      element :maat_reference, "div.maat > input"
+      element :maat_reference, "div.maat input"
     end
 
     element :add_another_representation_order, "div.links > a"
@@ -94,7 +94,7 @@ class ClaimFormPage < SitePrism::Page
   end
 
   def select_offence_category(name)
-    select2 name, from: "offence_category_description"
+    select2 name, from: "claim_offence_category_description"
   end
 
   def add_misc_fee_if_required

--- a/spec/form_builders/adp_text_field_spec.rb
+++ b/spec/form_builders/adp_text_field_spec.rb
@@ -24,12 +24,12 @@ describe AdpTextField do
 
       def a100_no_value_no_hint
         html = <<-eos
-        <div class="form-group case_number">
+        <div class="form-group case_number_wrapper">
           <a id="case_number"></a>
           <label class="form-label" for="claim_case_number">
             Case number
           </label>
-          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" />
+          <input class="form-control " type="text" name="claim[case_number]" id="claim_case_number" />
         </div>
         eos
         squash(html)
@@ -37,19 +37,99 @@ describe AdpTextField do
 
       def a200_value_no_hint
         html = <<-eos
-        <div class="form-group case_number">
+        <div class="form-group case_number_wrapper">
           <a id="case_number"></a>
           <label class="form-label" for="claim_case_number">
             Case number
           </label>
-          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" value="X22334455" />
+          <input class="form-control " type="text" name="claim[case_number]" id="claim_case_number" value="X22334455" />
         </div>
         eos
         squash(html)
       end
     end
 
-    context 'simple value with hint' do
+    context 'simple number field without hint' do
+      it 'should produce expected html when resource is nil' do
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', input_type: 'number', errors: error_presenter)
+        expect(atf.to_html).to eq squash(a100_no_value_no_hint)
+      end
+
+      it 'should produce expected result when resource has a value' do
+        resource.case_number = '555'
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', input_type: 'number', errors: error_presenter)
+        expect(atf.to_html).to eq a200_value_no_hint
+      end
+
+      def a100_no_value_no_hint
+        html = <<-eos
+        <div class="form-group case_number_wrapper">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+          </label>
+          <input class="form-control " type="number" name="claim[case_number]" id="claim_case_number" min="0" max="99999" />
+        </div>
+        eos
+        squash(html)
+      end
+
+      def a200_value_no_hint
+        html = <<-eos
+        <div class="form-group case_number_wrapper">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+          </label>
+          <input class="form-control " type="number" name="claim[case_number]" id="claim_case_number" value="555" min="0" max="99999" />
+        </div>
+        eos
+        squash(html)
+      end
+    end
+
+    context 'simple currency field without hint' do
+      it 'should produce expected html when resource is nil' do
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', input_type: 'currency', errors: error_presenter)
+        expect(atf.to_html).to eq squash(a100_no_value_no_hint)
+      end
+
+      it 'should produce expected result when resource has a value' do
+        resource.case_number = '555'
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', input_type: 'currency', errors: error_presenter)
+        expect(atf.to_html).to eq a200_value_no_hint
+      end
+
+      def a100_no_value_no_hint
+        html = <<-eos
+        <div class="form-group case_number_wrapper">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+          </label>
+          <span class="currency-indicator">&pound;</span>
+          <input class="form-control " type="number" name="claim[case_number]" id="claim_case_number" min="0" max="99999" />
+        </div>
+        eos
+        squash(html)
+      end
+
+      def a200_value_no_hint
+        html = <<-eos
+        <div class="form-group case_number_wrapper">
+          <a id="case_number"></a>
+          <label class="form-label" for="claim_case_number">
+            Case number
+          </label>
+          <span class="currency-indicator">&pound;</span>
+          <input class="form-control " type="number" name="claim[case_number]" id="claim_case_number" value="555" min="0" max="99999" />
+        </div>
+        eos
+        squash(html)
+      end
+    end
+
+    context 'simple text with hint' do
       it 'produces expected output with value' do
         resource.case_number = 'X22334455'
         atf = AdpTextField.new(builder, :case_number, label: 'Case number', hint_text: 'Hint text here', errors: error_presenter)
@@ -58,13 +138,13 @@ describe AdpTextField do
 
       def b100_with_value_with_hint
         html = <<-eos
-        <div class="form-group case_number">
+        <div class="form-group case_number_wrapper">
           <a id="case_number"></a>
           <label class="form-label" for="claim_case_number">
             Case number
-            <div class="form-hint">Hint text here</div>
+            <span class="form-hint">Hint text here</span>
           </label>
-          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" value="X22334455" />
+          <input class="form-control " type="text" name="claim[case_number]" id="claim_case_number" value="X22334455" />
         </div>
         eos
         squash(html)
@@ -82,14 +162,14 @@ describe AdpTextField do
 
       def c100_with_value_with_hint_and_error
         html = <<-eos
-        <div class="form-group case_number field_with_errors">
+        <div class="form-group case_number_wrapper field_with_errors">
           <a id="case_number"></a>
           <label class="form-label" for="claim_case_number">
             Case number
-            <div class="form-hint">Hint text here</div>
-            <span class="validation-error">Validation error here</span>
+            <span class="form-hint">Hint text here</span>
           </label>
-          <input class="form-control" type="text" name="claim[case_number]" id="claim_case_number" />
+          <input class="form-control " type="text" name="claim[case_number]" id="claim_case_number" />
+          <span class="error">Validation error here</span>
         </div>
         eos
         squash(html)

--- a/spec/helpers/external_users/claims_helper_spec.rb
+++ b/spec/helpers/external_users/claims_helper_spec.rb
@@ -12,7 +12,7 @@ describe ExternalUsers::ClaimsHelper do
 
       it 'should return the default error class if there are any errors in the provided field' do
         returned_class = error_class?(presenter, :test_field)
-        expect(returned_class).to eq('error')
+        expect(returned_class).to eq('field_with_errors')
       end
 
       it 'should return the specified class if provided' do
@@ -29,7 +29,7 @@ describe ExternalUsers::ClaimsHelper do
 
       it 'should return the error class if there are errors in any of the provided field' do
         returned_class = error_class?(presenter, :test_field_1, :test_field_2)
-        expect(returned_class).to eq('error')
+        expect(returned_class).to eq('field_with_errors')
       end
 
       it 'should return the specified class if provided' do


### PR DESCRIPTION
css tweaks
adp_text_field
- added input_classes
- added input_type
- added value (PSR)

claims_helper
- validation methods

UI Updates:
- updated text + number fields with new builder
- include_blank to insert &#160; entity
- layout tweaks for cracked trial
- implemented error wrapper on awesomeplete fields
- updated spec helpers
