### PR TITLE
Tidy up API versioning strategy.

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -1,11 +1,7 @@
 module API
   module V1
     class DropdownData < GrapeApiHelper
-
-      version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-      format :json
       prefix 'api'
-      content_type :json, 'application/json'
 
       params do
         optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the provider'

--- a/app/interfaces/api/v1/external_users/claim.rb
+++ b/app/interfaces/api/v1/external_users/claim.rb
@@ -2,10 +2,7 @@ module API
   module V1
     module ExternalUsers
       class Claim < Grape::API
-        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-        format :json
         prefix 'api/external_users'
-        content_type :json, 'application/json'
 
         resource :claims, desc: 'Create or Validate' do
           before do

--- a/app/interfaces/api/v1/external_users/date_attended.rb
+++ b/app/interfaces/api/v1/external_users/date_attended.rb
@@ -3,11 +3,7 @@ module API
     module ExternalUsers
 
       class DateAttended < Grape::API
-
-        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-        format :json
         prefix 'api/external_users'
-        content_type :json, 'application/json'
 
         params do
           # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)

--- a/app/interfaces/api/v1/external_users/defendant.rb
+++ b/app/interfaces/api/v1/external_users/defendant.rb
@@ -3,11 +3,7 @@ module API
     module ExternalUsers
 
       class Defendant < Grape::API
-
-        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-        format :json
         prefix 'api/external_users'
-        content_type :json, 'application/json'
 
         params do
           optional :api_key, type: String, desc: "REQUIRED: The API authentication key of the provider"

--- a/app/interfaces/api/v1/external_users/disbursement.rb
+++ b/app/interfaces/api/v1/external_users/disbursement.rb
@@ -3,11 +3,7 @@ module API
     module ExternalUsers
 
       class Disbursement < Grape::API
-
-        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-        format :json
         prefix 'api/external_users'
-        content_type :json, 'application/json'
 
         params do
           # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)

--- a/app/interfaces/api/v1/external_users/expense.rb
+++ b/app/interfaces/api/v1/external_users/expense.rb
@@ -3,11 +3,7 @@ module API
     module ExternalUsers
 
       class Expense < Grape::API
-
-        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-        format :json
         prefix 'api/external_users'
-        content_type :json, 'application/json'
 
         params do
           # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)

--- a/app/interfaces/api/v1/external_users/fee.rb
+++ b/app/interfaces/api/v1/external_users/fee.rb
@@ -3,11 +3,7 @@ module API
     module ExternalUsers
 
       class Fee < Grape::API
-
-        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-        format :json
         prefix 'api/external_users'
-        content_type :json, 'application/json'
 
         params do
           # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)

--- a/app/interfaces/api/v1/external_users/representation_order.rb
+++ b/app/interfaces/api/v1/external_users/representation_order.rb
@@ -3,11 +3,7 @@ module API
     module ExternalUsers
 
       class RepresentationOrder < Grape::API
-
-        version 'v1', using: :header, vendor: 'Advocate Defence Payments'
-        format :json
         prefix 'api/external_users'
-        content_type :json, 'application/json'
 
         params do
           # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)

--- a/app/interfaces/api/v1/external_users/root.rb
+++ b/app/interfaces/api/v1/external_users/root.rb
@@ -6,6 +6,10 @@ module API
     module ExternalUsers
       class Root < API::V1::GrapeApiHelper
 
+        version 'v1', using: :accept_version_header, cascade: false
+        format :json
+        content_type :json, 'application/json'
+
         helpers API::Authorisation
         helpers API::V1::ResourceHelper
 

--- a/lib/tasks/routes.rake
+++ b/lib/tasks/routes.rake
@@ -1,13 +1,11 @@
-# lib/tasks/routes.rake
 namespace :api do
   desc "API Routes"
   task :routes => :environment do
     API::V1::ExternalUsers::Root.routes.each do |api|
       method = api.route_method.ljust(10)
-      if !api.route_version.nil?
-        path = api.route_path.gsub(":version", api.route_version)
-        puts "     #{method} #{path}"
-      end
+      path = api.route_path.sub('(.:format)', '')
+      version = api.route_version
+      puts " #{version}   #{method} #{path}"
     end
   end
 end

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -99,6 +99,16 @@ describe API::V1::DropdownData do
         expect(last_response.body).to include('Unauthorised')
       end
     end
+
+    it 'should return 406 Not Acceptable if requested API version via header is not supported' do
+      header 'Accept-Version', 'v2'
+
+      results.each do |endpoint, _|
+        get endpoint, params, format: :json
+        expect(last_response.status).to eq 406
+        expect(last_response.body).to include('The requested version is not supported.')
+      end
+    end
   end
 
   context 'GET api/offences' do

--- a/spec/api/v1/external_users/claim_spec.rb
+++ b/spec/api/v1/external_users/claim_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe API::V1::ExternalUsers::Claim do
+  include Rack::Test::Methods
 
   CLAIM_ENDPOINTS = %w(
     /api/external_users/claims
@@ -29,6 +30,18 @@ describe API::V1::ExternalUsers::Claim do
     CLAIM_ENDPOINTS.each do |endpoint|
       it "should expose #{endpoint}" do
         expect(@declared_routes).to include(endpoint)
+      end
+    end
+  end
+
+  describe 'Support versioning via header' do
+    it 'should return 406 Not Acceptable if requested API version via header is not supported' do
+      header 'Accept-Version', 'v2'
+
+      CLAIM_ENDPOINTS.each do |endpoint|
+        post endpoint, {}, format: :json
+        expect(last_response.status).to eq 406
+        expect(last_response.body).to include('The requested version is not supported.')
       end
     end
   end


### PR DESCRIPTION
**PT#121931779**

Changing API versioning strategy from header to `accept_version_header` and making sure `406 Not Acceptable` is raised when a not supported version is provided.

By default the behaviour continues to be the same as before. If no '`Accept-Version`' header is sent, the the first matching version is used (v1).
