### PR TITLE
Add validation to ensure interim trial/retrial length are at least 10 days.

### DIFF
--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -41,7 +41,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
     return if interim_fee_absent?
 
     if @record.interim_fee.is_trial_start?
-      validate_presence_and_numericality(:estimated_trial_length)
+      validate_presence_and_length(:estimated_trial_length)
     else
       validate_absence_or_zero(:estimated_trial_length, 'present')
     end
@@ -71,7 +71,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
     return if interim_fee_absent?
 
     if @record.interim_fee.is_retrial_start?
-      validate_presence_and_numericality(:retrial_estimated_length)
+      validate_presence_and_length(:retrial_estimated_length)
     else
       validate_absence_or_zero(:retrial_estimated_length, 'present')
     end
@@ -105,8 +105,9 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
     validate_not_after(Date.today, attribute, 'check_not_in_future')
   end
 
-  def validate_presence_and_numericality(attribute)
+  def validate_presence_and_length(attribute)
     validate_presence(attribute, 'blank')
-    validate_numericality(attribute, 0, nil, 'invalid')
+    # an interim fee cannot be claimed unless the trial will last 10 days or more
+    validate_numericality(attribute, 10, nil, 'interim_invalid')
   end
 end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -166,6 +166,10 @@ estimated_trial_length:
     long: Enter a whole number of days for the estimated trial length
     short: Enter a whole number of days
     api: Enter a whole number of days for the estimated trial length
+  interim_invalid:
+    long: Enter a whole number of days (minimum of 10) for the estimated trial length
+    short: Enter a minimum of 10 days
+    api: Enter a whole number of days (minimum of 10) for the estimated trial length
 
 actual_trial_length:
   _seq: 90
@@ -254,6 +258,10 @@ retrial_estimated_length:
     long: Enter a whole number of days for the estimated retrial length
     short: Enter a whole number of days
     api: Enter a whole number of days for the estimated retrial length
+  interim_invalid:
+    long: Enter a whole number of days (minimum of 10) for the estimated retrial length
+    short: Enter a minimum of 10 days
+    api: Enter a whole number of days (minimum of 10) for the estimated retrial length
 
 retrial_actual_length:
   _seq: 130

--- a/lib/demo_data/interim_fee_generator.rb
+++ b/lib/demo_data/interim_fee_generator.rb
@@ -40,12 +40,12 @@ module DemoData
 
       if fee.is_trial_start?
         @claim.first_day_of_trial = rand(1..5).months.ago
-        @claim.estimated_trial_length = rand(3..15)
+        @claim.estimated_trial_length = rand(10..15)
       end
 
       if fee.is_retrial_start?
         @claim.retrial_started_at = rand(1..5).months.ago
-        @claim.retrial_estimated_length = rand(3..15)
+        @claim.retrial_estimated_length = rand(10..15)
       end
 
       if fee.is_retrial_new_solicitor?

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -36,4 +36,40 @@ describe Claim::InterimClaimValidator do
       :total
     ]
   ]
+
+  describe 'estimated trial length and estimated retrial length fields should not accept values of less than 10 days' do
+    before do
+      allow(claim).to receive(:interim_fee).and_return(interim_fee)
+      claim.source = 'web'
+      claim.form_step = 2
+    end
+
+    context 'estimated_trial_length' do
+      let(:interim_fee) { build :interim_fee_type, :trial_start }
+
+      it 'should error if not present and interim fee type requires it' do
+        claim.estimated_trial_length = nil
+        should_error_with(claim, :estimated_trial_length, 'blank')
+      end
+
+      it 'should error if less than 10 days' do
+        claim.estimated_trial_length = 5
+        should_error_with(claim, :estimated_trial_length, 'interim_invalid')
+      end
+    end
+
+    context 'retrial_estimated_length' do
+      let(:interim_fee) { build :interim_fee_type, :retrial_start }
+
+      it 'should error if not present and interim fee type requires it' do
+        claim.retrial_estimated_length = nil
+        should_error_with(claim, :retrial_estimated_length, 'blank')
+      end
+
+      it 'should error if less than 10 days' do
+        claim.retrial_estimated_length = 5
+        should_error_with(claim, :retrial_estimated_length, 'interim_invalid')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**PT#121131279**

The estimated trial length and estimated retrial length fields should not accept values of less than 10 days - as an interim fee cannot be claimed unless the trial will last 10 days or more.
