### PR TITLE
Prepare backend to support claim transition reasons.

### DIFF
--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -2,16 +2,21 @@
 #
 # Table name: claim_state_transitions
 #
-#  id         :integer          not null, primary key
-#  claim_id   :integer
-#  namespace  :string
-#  event      :string
-#  from       :string
-#  to         :string
-#  created_at :datetime
+#  id          :integer          not null, primary key
+#  claim_id    :integer
+#  namespace   :string
+#  event       :string
+#  from        :string
+#  to          :string
+#  created_at  :datetime
+#  reason_code :string
 #
 
 class ClaimStateTransition < ActiveRecord::Base
 
   belongs_to :claim, class_name: ::Claim::BaseClaim, foreign_key: :claim_id
+
+  def reason
+    ClaimStateTransitionReason.get(reason_code)
+  end
 end

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -1,0 +1,51 @@
+class ClaimStateTransitionReason
+  class ReasonNotFoundError < StandardError; end
+  class StateNotFoundError < StandardError; end
+
+  attr_accessor :code, :description
+
+  TRANSITION_REASONS = HashWithIndifferentAccess.new(
+    rejected: {
+      no_indictment: 'No indictment attached',
+      no_rep_order: 'No rep order attached (granted before 1.8.15)',
+      time_elapsed: 'More than 3 months has elapsed since case completion'
+    }
+  ).freeze
+
+  def initialize(code, description)
+    self.code = code
+    self.description = description
+  end
+
+  def ==(other)
+    (self.code == other.code) && (self.description == other.description)
+  end
+
+  class << self
+    def get(code)
+      new(code, description_for(code)) unless code.blank?
+    end
+
+    def reasons(state)
+      reasons_for(state)
+    end
+
+    private
+
+    def description_for(code)
+      reasons_map.values.reduce({}, :merge).fetch(code)
+    rescue KeyError
+      raise ReasonNotFoundError, "Reason with code '#{code}' not found"
+    end
+
+    def reasons_for(state)
+      reasons_map.fetch(state).map { |code, desc| new(code, desc) }
+    rescue KeyError
+      raise StateNotFoundError, "State with name '#{state}' not found"
+    end
+
+    def reasons_map
+      TRANSITION_REASONS
+    end
+  end
+end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -47,7 +47,7 @@ module Claims::StateMachine
 
   def self.included(klass)
     klass.state_machine :state, initial: :draft do
-      audit_trail class: ClaimStateTransition
+      audit_trail class: ClaimStateTransition, context: [:reason_code]
 
       state :allocated,
             :archived_pending_delete,
@@ -131,6 +131,10 @@ module Claims::StateMachine
     klass.scope :caseworker_dashboard_under_assessment,   -> { klass.where(state: CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES) }
     klass.scope :caseworker_dashboard_archived,           -> { klass.where(state: CASEWORKER_DASHBOARD_ARCHIVED_STATES) }
 
+    def reason_code(transition)
+      options = transition.args&.extract_options! || {}
+      options[:reason_code]
+    end
   end
 
   private

--- a/db/migrate/20160628141647_add_reason_code_to_claim_state_transitions.rb
+++ b/db/migrate/20160628141647_add_reason_code_to_claim_state_transitions.rb
@@ -1,0 +1,5 @@
+class AddReasonCodeToClaimStateTransitions < ActiveRecord::Migration
+  def change
+    add_column :claim_state_transitions, :reason_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160627083153) do
+ActiveRecord::Schema.define(version: 20160628141647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20160627083153) do
     t.string   "from"
     t.string   "to"
     t.datetime "created_at"
+    t.string   "reason_code"
   end
 
   add_index "claim_state_transitions", ["claim_id"], name: "index_claim_state_transitions_on_claim_id", using: :btree

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe ClaimStateTransitionReason, type: :model do
+
+  describe '.new' do
+    let(:reason) { described_class.new('code', 'description') }
+
+    it 'initialize a reason object with provided code and description' do
+      expect(reason.code).to eq('code')
+      expect(reason.description).to eq('description')
+    end
+  end
+
+  describe '.reasons' do
+    let(:reasons) { described_class.reasons(state) }
+    let(:reasons_hash) { {example_state: {test: 'description'}} }
+
+    before do
+      allow(described_class).to receive(:reasons_map).and_return(reasons_hash)
+    end
+
+    context 'for an existing state' do
+      let(:state) { :example_state }
+
+      it 'returns a collection of reason objects for the given state' do
+        expect(reasons).to be_kind_of(Array)
+        expect(reasons.size).to eq(1)
+        expect(reasons.first.code).to eq(:test)
+        expect(reasons.first.description).to eq('description')
+      end
+    end
+
+    context 'for an unknown state' do
+      let(:state) { :another_state }
+
+      it 'raises an exception' do
+        expect { reasons }.to raise_exception(ClaimStateTransitionReason::StateNotFoundError)
+      end
+    end
+  end
+
+  describe '.get' do
+    let(:code) { 'code' }
+    let(:reason) { described_class.get(code) }
+
+    context 'for an existing code' do
+      before do
+        allow(described_class).to receive(:description_for).with(code).and_return('description')
+      end
+
+      it 'initializes and retrieve a reason object if code exists' do
+        expect(reason.code).to eq('code')
+        expect(reason.description).to eq('description')
+      end
+    end
+
+    context 'for an unknown code' do
+      it 'raises an exception' do
+        expect { reason }.to raise_exception(ClaimStateTransitionReason::ReasonNotFoundError)
+      end
+    end
+
+    context 'for an empty string code' do
+      let(:code) { '' }
+
+      it 'returns nil' do
+        expect(reason).to be_nil
+      end
+    end
+
+    context 'for a nil code' do
+      let(:code) { nil }
+
+      it 'returns nil' do
+        expect(reason).to be_nil
+      end
+    end
+  end
+
+  describe '#==' do
+    let(:reason_1) { described_class.new('code1', 'description 1') }
+    let(:reason_2) { described_class.new('code1', 'description 1') }
+    let(:reason_3) { described_class.new('code1', 'description 3') }
+
+    it 'considers as equal two reasons with the same reason code and description' do
+      expect(reason_1).to eq(reason_2)
+    end
+
+    it 'considers as different two reasons with different reason codes or different descriptions' do
+      expect(reason_1).not_to eq(reason_3)
+    end
+  end
+end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -257,7 +257,8 @@ RSpec.describe Claims::StateMachine, type: :model do
       {
         event: 'submit',
         from: 'draft',
-        to: 'submitted'
+        to: 'submitted',
+        reason_code: nil
       }
     end
 
@@ -270,6 +271,7 @@ RSpec.describe Claims::StateMachine, type: :model do
       expect(ClaimStateTransition.last.event).to eq(expected[:event])
       expect(ClaimStateTransition.last.from).to eq(expected[:from])
       expect(ClaimStateTransition.last.to).to eq(expected[:to])
+      expect(ClaimStateTransition.last.reason_code).to eq(expected[:reason_code])
     end
   end
 
@@ -279,6 +281,30 @@ RSpec.describe Claims::StateMachine, type: :model do
       expect(claim.allocation_type).to be nil
       claim.submit!
       expect(claim.allocation_type).to eq 'Grad'
+    end
+  end
+
+  describe 'reject! supports a reason code' do
+    before { subject.submit!; subject.allocate!; subject.reject!(reason_code: reason_code) }
+
+    let(:reason_code) { 'reason' }
+
+    it 'updates the transition reason code' do
+      transition = subject.claim_state_transitions.first
+      expect(transition.to).to eq('rejected')
+      expect(transition.reason_code).to eq(reason_code)
+    end
+  end
+
+  describe 'refuse! supports a reason code' do
+    before { subject.submit!; subject.allocate!; subject.refuse!(reason_code: reason_code) }
+
+    let(:reason_code) { 'reason' }
+
+    it 'updates the transition reason code' do
+      transition = subject.claim_state_transitions.first
+      expect(transition.to).to eq('refused')
+      expect(transition.reason_code).to eq(reason_code)
     end
   end
 end


### PR DESCRIPTION
This PR prepares the backend to support claim transition reasons, that can be used in the future for analytics (starting with rejection reasons but any other is supported).

The way it works, basically, is for each state transition an (optional) `reason_code` can be provided that will be stored as part of the audit trail.

Example:

``` ruby
claim.reject!(reason_code: 'no_rep_order')
```
