### PR TITLE
Gecko widget Authorisations with/without requests for further information

### DIFF
--- a/app/controllers/geckoboard_api/widgets_controller.rb
+++ b/app/controllers/geckoboard_api/widgets_controller.rb
@@ -15,6 +15,11 @@ class GeckoboardApi::WidgetsController < GeckoboardApi::ApplicationController
     respond_with_json_payload_from_class(Stats::MultiSessionSubmissionDataGenerator)
   end
 
+  def requests_for_further_info
+    respond_with_json_payload_from_class(Stats::RequestForFurtherInfoDataGenerator)
+  end
+
+
   private
 
   def respond_with_json_payload_from_class(klass)

--- a/app/models/stats/collector/info_request_count_collector.rb
+++ b/app/models/stats/collector/info_request_count_collector.rb
@@ -1,0 +1,65 @@
+module Stats
+  module Collector
+
+    # This class counts the number of claims authorised to day that where the caseworker requested extra information vs the number
+    # that were authorised without further info being needed.
+    #
+    class InfoRequestCountCollector
+
+      STRFTIME_MASK = '%Y-%m-%d %H:%M:%S.%6N'
+
+      def initialize(date = Date.today)
+        @date = date
+        @beginning_of_day = @date.beginning_of_day.utc.strftime(STRFTIME_MASK)
+        @end_of_day = @date.end_of_day.utc.strftime(STRFTIME_MASK)
+      end
+
+      def collect
+        count = get_count_for_claims_authorised_without_further_info_requested
+        Statistic.create_or_update(@date, 'claims_authorised_without_further_info', 'Claim::BaseClaim', count)
+
+        count = get_count_for_claims_authorised_after_further_info_requested
+        Statistic.create_or_update(@date, 'claims_authorised_after_info_requested', 'Claim::BaseClaim', count)
+      end
+
+      private
+
+      def get_count_for_claims_authorised_without_further_info_requested
+        sql = "
+          select
+            date(c.authorised_at),
+            count(*)
+          from claims c
+          left outer join messages m on (m.claim_id = c.id)
+          left outer join users u on (m.sender_id = u.id)
+          where c.authorised_at between '#{@beginning_of_day}' and '#{@end_of_day}'
+          and (u.persona_type is null or u.persona_type !='ExternalUser')
+          and m.id is null
+          group by date(c.authorised_at)
+        "
+        execute_query(sql)
+      end
+
+      def get_count_for_claims_authorised_after_further_info_requested
+        sql = "
+          select
+          date(c.authorised_at),
+            count(*)
+          from claims c
+          left outer join messages m on (m.claim_id = c.id)
+          inner join users u on (m.sender_id = u.id)
+          where c.authorised_at between '#{@beginning_of_day}' and '#{@end_of_day}'
+          and (u.persona_type is null or u.persona_type !='ExternalUser')
+          and m.id is not null
+          group by date(c.authorised_at)
+        "
+        execute_query(sql)
+      end
+
+      def execute_query(sql)
+        result_set = ActiveRecord::Base.connection.execute(sql)
+        result_set.ntuples == 0 ? 0 : result_set.first['count'].to_i
+      end
+    end
+  end
+end

--- a/app/services/stats/request_for_further_info_data_generator.rb
+++ b/app/services/stats/request_for_further_info_data_generator.rb
@@ -1,0 +1,26 @@
+module Stats
+  class RequestForFurtherInfoDataGenerator
+
+    NUM_DAYS_TO_SHOW = 21
+
+    SUBMISSION_TYPES = {
+      'claims_authorised_after_info_requested' => 'requested',
+      'claims_authorised_without_further_info' => 'not requested'
+    }
+
+
+    def initialize(date = Date.yesterday)
+      @date = date
+      @start_date = date - NUM_DAYS_TO_SHOW.days
+    end
+
+    def run
+      line_graph = Stats::GeckoWidgets::LineGraph.new
+
+      SUBMISSION_TYPES.each do |report_name, description|
+        line_graph.add_dataset(description,  Statistic.report(report_name, 'Claim::BaseClaim', @start_date, @date).pluck(:value_1))
+      end
+      line_graph.to_json
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,7 @@ Rails.application.routes.draw do
     get 'widgets/average_processing_time', to: 'widgets#average_processing_time'
     get 'widgets/claim_submisions', to: 'widgets#claim_submissions'
     get 'widgets/multi_session_submissions', to: 'widgets#multi_session_submissions'
+    get 'widgets/requests_for_further_info', to: 'widgets#requests_for_further_info'
   end
 
   # catch-all route

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,10 +1,12 @@
 
 namespace :stats do
+  desc 'run all collectors for the past 21 days'
   task :collect => :environment do
     (1..21).each do |offset|
       date = Date.today - offset.days
       Stats::Collector::ClaimSubmissionsCollector.new(date).collect
       Stats::Collector::MultiSessionSubmissionCollector.new(date).collect
+      Stats::Collector::InfoRequestCountCollector.new(date).collect
     end
   end
 end

--- a/scheduled_tasks/daily_stats_generator.rb
+++ b/scheduled_tasks/daily_stats_generator.rb
@@ -9,6 +9,7 @@ class DailyStatsGenerator < Scheduler::SchedulerTask
     log('Daily stats generation started')
     Stats::Collector::ClaimSubmissionsCollector.new(Date.yesterday).collect
     Stats::Collector::MultiSessionSubmissionCollector.new(Date.yesterday).collect
+    Stats::Collector::InfoRequestCountCollector.new(Date.yesterday).collect
   rescue => ex
     log('There was an error: ' + ex.message)
   ensure


### PR DESCRIPTION
This PR adds the stats collector and geckoboard-api endpoints to populate the
Geckoboard widget which graphs the number of authorisations with and without requests
for further information over the last 21 days.
