### PR TITLE
Ensuring Offences are returned in a proper order always.

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -151,11 +151,11 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def load_offences_and_case_types
-    @offence_descriptions = Offence.unique_name.order(description: :asc)
+    @offence_descriptions = Offence.unique_name
     @offences = if @claim.offence
-                  Offence.includes(:offence_class).where(description: @claim.offence.description)
+                  Offence.where(description: @claim.offence.description)
                 else
-                  Offence.includes(:offence_class)
+                  Offence.all
                 end
     @case_types = @claim.eligible_case_types
   end

--- a/app/controllers/offences_controller.rb
+++ b/app/controllers/offences_controller.rb
@@ -13,7 +13,14 @@ class OffencesController < ApplicationController
   skip_load_and_authorize_resource only: [:index]
 
   def index
-    @offences = Offence.includes(:offence_class)
-    @offences = @offences.where(description: params[:description]) if params[:description].present?
+    @offences = Offence.where(offence_filter)
+  end
+
+  private
+
+  def offence_filter
+    {}.tap do |filters|
+      filters.merge!(description: params[:description]) if params[:description].present?
+    end
   end
 end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -18,7 +18,9 @@ class Offence < ActiveRecord::Base
   validates :offence_class, presence: true
   validates :description, presence: true
 
-  scope :unique_name,   -> { select('DISTINCT(description)') }
+  default_scope { includes(:offence_class).order(:description, :offence_class_id) }
+
+  scope :unique_name,   -> { unscoped.select(:description).distinct }
   scope :miscellaneous, -> { where(description: 'Miscellaneous/other') }
 
   def offence_class_description

--- a/spec/controllers/offences_controller_spec.rb
+++ b/spec/controllers/offences_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OffencesController, type: :controller do
     it 'should return all offences if no description present' do
       xhr :get, :index
       expect(assigns(:offences).size).to eq 3
-      expect(assigns(:offences).sort.map(&:description)).to eq( ['Offence 1', 'Offence 2', 'Offence 3' ])
+      expect(assigns(:offences).map(&:description)).to eq( ['Offence 1', 'Offence 2', 'Offence 3' ])
     end
 
     it 'should just get the matching offence' do


### PR DESCRIPTION
After the introduction of new offences, the returned list can be unordered.
This PR ensure the offences are always returned sorted by Description and then sorted by offence class.
