### PR TITLE
Hide quantity column on fee section of interim claims.

### DIFF
--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -9,21 +9,15 @@
       %table.indent-sides
         %caption.visually-hidden
           = t('common.fees')
-        %colgroup
-          %col
-          %col
-          %col
-          %col
-          - if claim.agfs?
-            %col
         %thead
           %tr
             %th{ scope: 'col'}
               = t('.fee_category')
             %th{ scope: 'col'}
               = t('.fee_type')
-            %th.numeric{ scope: 'col'}
-              = t('.quantity')
+            - unless claim.interim?
+              %th.numeric{ scope: 'col'}
+                = t('.quantity')
             - if claim.agfs?
               %th.numeric{ scope: 'col'}
                 = t('.rate')
@@ -44,8 +38,9 @@
                   = fee.date
               %td
                 = fee.fee_type.description
-              %td.numeric
-                = fee.quantity
+              - unless claim.interim?
+                %td.numeric
+                  = fee.quantity
               - if claim.agfs?
                 %td.numeric
                   = fee.rate


### PR DESCRIPTION
**PT#121131691**

Quantity doesn't apply to any interim fee. Removing the column completely.
