### PR TITLE
Update README codeclimate badges to use proper repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 cache: bundler
 addons:
   postgresql: '9.3'
+  code_climate:
+    repo_token: 21d4b9b324a45c24369ecf4d78711930294c191ebbb2d9e0fd7adf4bbd75b687
 before_install:
 - export TZ=Europe/London
 before_script:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ###a.k.a Claim for crown court defence
 
 [![Build Status](https://travis-ci.org/ministryofjustice/advocate-defence-payments.svg)](https://travis-ci.org/ministryofjustice/advocate-defence-payments)
-[![Code Climate](https://codeclimate.com/github/ministryofjustice/crime-billing-online/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/crime-billing-online)
-[![Test Coverage](https://codeclimate.com/github/ministryofjustice/crime-billing-online/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/crime-billing-online)
+[![Code Climate](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments)
+[![Test Coverage](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments/coverage)
 
 ## Staging
 [staging-adp.dsd.io](https://staging-adp.dsd.io)


### PR DESCRIPTION
The codeclimate badges were using the old crime billing repo.
