### PR TITLE
Remove contempt options from fixed fees on advocate claims.

### DIFF
--- a/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
@@ -19,7 +19,7 @@ Feature: Advocate submits a claim for a Contempt case
     Then I click "Continue" in the claim form
 
     And I add a miscellaneous fee 'Adjourned appeals' with dates attended
-    And I add a fixed fee 'Contempt hearings - apportioned fee'
+    And I add a fixed fee 'Contempt'
     And I add an expense 'Parking'
     And I upload 3 documents
     And I check the boxes for the uploaded documents

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -17,8 +17,6 @@ FIXED,agfs,Appeals to the crown court against sentence uplift,ASU,nil,true,,fals
 FIXED,agfs;lgfs,Breach of a crown court order,CBR,nil,true,,false
 FIXED,agfs,Breach of a crown court order uplift,CBU,nil,true,,false
 FIXED,agfs,Contempt,ZCON,nil,true,,false
-FIXED,agfs,Contempt hearings - unapportioned fee,CON,nil,true,,false
-FIXED,agfs,Contempt hearings - apportioned fee,COA,nil,true,,false
 FIXED,agfs;lgfs,Committal for sentence hearings,CSE,nil,true,,false
 FIXED,agfs,Committal for sentence hearings uplift,CSU,nil,true,,false
 FIXED,agfs;lgfs,Cracked case discontinued,CCD,nil,true,,false

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -53,11 +53,20 @@
       Offence.where(description: 'Obtaining services dishonestly').update_all(description: 'Obtaining services by dishonesty')
     end
 
+    desc 'Remove contempt AGFS fixed fee types'
+    task :remove_contempt_fee_types => :environment do
+      old_ids = Fee::FixedFeeType.where(code: %w(CON COA)).pluck(:id)
+      new_id  = Fee::FixedFeeType.by_code('ZCON').id
+      Fee::FixedFee.where(fee_type_id: old_ids).update_all(fee_type_id: new_id)
+      Fee::FixedFeeType.delete_all(id: old_ids)
+    end
+
     desc 'Run all outstanding data migrations'
     task :all => :environment do
       {
         'rename_dishonesty_offences' => 'Rename "dishonestly" to "by dishonesty"',
-        'reseed_offences' => 'Reseed the offences as there were some missing.'
+        'reseed_offences' => 'Reseed the offences as there were some missing.',
+        'remove_contempt_fee_types' => 'Remove contempt AGFS fixed fee types'
       }.each do |task, comment|
         puts comment
         Rake::Task["data:migrate:#{task}"].invoke


### PR DESCRIPTION
The following AGFS fixed fee types will be removed:
- Contempt hearings - unapportioned fee
- Contempt hearings - apportioned fee

And any claim using them will be reassigned the following AGFS fixed fee type:
- Contempt
