### PR TITLE
Hotfix for cloned claims without initial transition.

### DIFF
--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -145,11 +145,11 @@ module Claims::StateMachine
   end
 
   def last_state_transition_reason
-    last_state_transition.reason
+    last_state_transition&.reason
   end
 
   def last_state_transition_time
-    last_state_transition.created_at
+    last_state_transition&.created_at
   end
 
   def filtered_last_state_transition

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -85,7 +85,7 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def state_reason_code
-    @journey.last.reason&.code
+    @journey.last.reason_code
   end
 
   def submitted_states


### PR DESCRIPTION
Cloned claims do not have the associated very first state transition, and thus there was a view assuming there was always at least 1 transition raising a nil exception.

This will be fixed properly by creating the first transition also on cloned claims, but until now this need to go **quickly** to gamma.
