### PR TITLE
Ensuring a transition audit entry is created after cloning a rejected claim.

### DIFF
--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -11,6 +11,7 @@ module Claims::Cloner
       enable
 
       nullify :last_submitted_at
+      nullify :last_edited_at
       nullify :original_submission_date
       nullify :uuid
 
@@ -103,8 +104,7 @@ module Claims::Cloner
   def clone_rejected_to_new_draft
     raise 'Can only clone claims in state "rejected"' unless rejected?
     draft = duplicate
-    draft.state = 'draft'
-    draft.save!
+    draft.transition_clone_to_draft!
     draft
   end
 end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Claims::Cloner, type: :model do
         expect(@cloned_claim.last_submitted_at).to be_nil
       end
 
+      it 'does not clone last_edited_at' do
+        expect(@cloned_claim.last_edited_at).to be_nil
+      end
+
       it 'does not clone original_submission_date' do
         expect(@cloned_claim.original_submission_date).to be_nil
       end
@@ -150,6 +154,13 @@ RSpec.describe Claims::Cloner, type: :model do
       it 'does not clone certifications' do
         expect(@rejected_claim.certification).to_not be_nil
         expect(@cloned_claim.certification).to be_nil
+      end
+
+      it 'creates the first state transition for the cloned claim' do
+        expect(@cloned_claim.claim_state_transitions.count).to eq(1)
+        expect(@cloned_claim.last_state_transition.claim_id).to eq(@cloned_claim.id)
+        expect(@cloned_claim.last_state_transition.from).to eq('rejected')
+        expect(@cloned_claim.last_state_transition.to).to eq('draft')
       end
     end
 


### PR DESCRIPTION
This will happen for new cloned claims from now on.

Not really worth doing it for old cloned claims, as the code that was failing because the transition was missing is now also fixed (1cf75e4efdb637132211f12128ec5ef00204e748)
