### PR TITLE
Reintroduce this until we figure out a better solution.

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -64,6 +64,8 @@ moj.Modules.NewClaim = {
         $('.offence-class-select').hide();
       }
     });
+
+    $('#offence_class_description').change();
   },
 
   attachEventsForExpenseTypes : function() {


### PR DESCRIPTION
Fix for bug being reported on Zendesk where (on Advocate claims) no matter which offence you select, it always default to the first one.
