### PR TITLE
Fixes for the offence dropdown behaving for advocate claims.

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -35,10 +35,6 @@ moj.Modules.NewClaim = {
       $('.offence-class-select').hide();
     }
 
-    if ($('#offence_class_description').val()) {
-      $('#claim_offence_id').val($('#offence_class_description').val());
-    }
-
     self.attachToOffenceClassSelect();
   },
 
@@ -62,10 +58,9 @@ moj.Modules.NewClaim = {
 
       if (!$(this).val()) {
         $('.offence-class-select').hide();
+        $('#claim_offence_id').val('');
       }
     });
-
-    $('#offence_class_description').change();
   },
 
   attachEventsForExpenseTypes : function() {

--- a/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
@@ -14,7 +14,8 @@ Feature: Advocate admin submits a claim for a Trial case
     And I select the court 'Blackfriars Crown'
     And I select a case type of 'Trial'
     And I enter a case number of 'A12345678'
-    And I select an offence category
+    And I select the offence category 'Handling stolen goods'
+    And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
     And I enter defendant, representation order and MAAT reference
     And I enter trial start and end dates
     And I add another defendant, representation order and MAAT reference

--- a/features/claims/advocate/advocate_claim_draft_edit_submit.feature
+++ b/features/claims/advocate/advocate_claim_draft_edit_submit.feature
@@ -12,7 +12,8 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     And I select the court 'Blackfriars Crown'
     And I select a case type of 'Trial'
     And I enter a case number of 'A12345678'
-    And I select an offence category
+    And I select the offence category 'Handling stolen goods'
+    And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
     And I enter defendant, representation order and MAAT reference
     And I save as draft
     Then I should see 'Draft claim saved'

--- a/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
@@ -12,7 +12,8 @@ Feature: Advocate submits a claim for a Contempt case
     And I select the court 'Blackfriars Crown'
     And I select a case type of 'Contempt'
     And I enter a case number of 'A12345678'
-    And I select an offence category
+    And I select the offence category 'Handling stolen goods'
+    And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
 
@@ -24,8 +25,11 @@ Feature: Advocate submits a claim for a Contempt case
     And I upload 3 documents
     And I check the boxes for the uploaded documents
     And I add some additional information
-    And I click Submit to LAA
-    Then I should be on the check your claim page
+
+    Then I click Submit to LAA
+    And I should be on the check your claim page
+    And I should see 'Handling stolen goods'
+    And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     When I click "Continue"
     Then I should be on the certification page

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -28,7 +28,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the offence class 'E: Burglary'
+    And I select the litigator offence class 'E: Burglary'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -27,7 +27,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I enter the case concluded date
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the offence class 'E: Burglary'
+    And I select the litigator offence class 'E: Burglary'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -17,7 +17,7 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     And I enter the case concluded date
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the offence class 'E: Burglary'
+    And I select the litigator offence class 'E: Burglary'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -29,7 +29,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I enter the case concluded date
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the offence class 'E: Burglary'
+    And I select the litigator offence class 'E: Burglary'
 
     And I click "Continue" in the claim form
 
@@ -51,8 +51,10 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I upload 1 document
     And I check the boxes for the uploaded documents
     And I add some additional information
-    And I click Submit to LAA
-    Then I should be on the check your claim page
+
+    Then I click Submit to LAA
+    And I should be on the check your claim page
+    And I should see 'E: Burglary'
 
     When I click "Continue"
     Then I should be on the certification page

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -21,8 +21,6 @@ class ClaimFormPage < SitePrism::Page
     element :actual_trial_length, "#claim_actual_trial_length"
   end
 
-  element :offence_category, "#s2id_autogen3"
-
   sections :defendants, "div.defendants > div.js-test-defendant" do
     element :first_name, "div.first-name input"
     element :last_name, "div.last-name input"
@@ -95,6 +93,10 @@ class ClaimFormPage < SitePrism::Page
 
   def select_offence_category(name)
     select2 name, from: "offence_category_description"
+  end
+
+  def select_offence_class(name)
+    select2 name, from: "offence_class_description"
   end
 
   def add_misc_fee_if_required

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -29,8 +29,9 @@ When(/^I enter a case number of '(.*?)'$/) do |number|
   @claim_form_page.case_number.set number
 end
 
-When(/^I select an offence category$/) do
-  @claim_form_page.select_offence_category "Murder"
+When(/^I select the advocate offence class '(.*)'$/) do |offence_class|
+  sleep 1
+  @claim_form_page.select_offence_class(offence_class)
 end
 
 When(/I enter trial start and end dates$/) do

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -28,6 +28,10 @@ Then(/^I should see '(.*?)'$/) do |content|
   expect(page).to have_content(content)
 end
 
+When(/^I select the offence category '(.*?)'$/) do |offence_cat|
+  @claim_form_page.select_offence_category offence_cat
+end
+
 Given(/^I am later on the Your claims page$/) do
   @external_user_home_page.load
 end

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -17,7 +17,7 @@ When(/^I select the supplier number '(.*)'$/) do |number|
   @litigator_claim_form_page.select_supplier_number(number)
 end
 
-And(/^I select the offence class '(.*)'$/) do |name|
+And(/^I select the litigator offence class '(.*)'$/) do |name|
   sleep 1
   @litigator_claim_form_page.select_offence_class(name)
 end


### PR DESCRIPTION
This will, again, avoid creating Claim Intentions only by visiting the new advocate claim page, which was reintroduced as a temporary hotfix in PR https://github.com/ministryofjustice/advocate-defence-payments/pull/1611

Also, it fixes the bug where (for advocate claims) leaving the offence dropdown blank (not selecting any) would default to the first offence, which is wrong, the correct behaviour is to not default to none, as advocate claims can leave the offence blank, it is not a mandatory field.

Also, making the cukes more specific.
