### PR TITLE
Add debug code to help with tracking root cause of flickers

### DIFF
--- a/features/allocation.feature
+++ b/features/allocation.feature
@@ -1,4 +1,4 @@
-@no-seeding @javascript
+@javascript
 Feature: Case worker admin allocates claims 
 
   Scenario: I allocate claims, case worker sees them

--- a/features/authorise_claim.feature
+++ b/features/authorise_claim.feature
@@ -1,4 +1,4 @@
-@no-seeding @javascript
+@javascript
 Feature: Case worker fully authorises claim
 
   Scenario: I fully authorise a claim

--- a/features/messaging.feature
+++ b/features/messaging.feature
@@ -1,4 +1,4 @@
-@no-seeding @javascript
+@javascript
 Feature: Case worker messages advocate and advocate responds
 
   Scenario: I message advocate and advocate responds

--- a/features/page_objects/litigator_claim_form_page.rb
+++ b/features/page_objects/litigator_claim_form_page.rb
@@ -22,13 +22,7 @@ class LitigatorClaimFormPage < ClaimFormPage
   end
 
   def select_offence_class(name)
-    begin
-      select2 name, from: "claim_offence_id"
-    rescue Capybara::ElementNotFound => err
-      puts "ERROR #{err.class}    #{err.message}"
-      puts self.body
-      raise err
-    end
+    select2 name, from: "claim_offence_id"
   end
 
   def add_disbursement_if_required

--- a/features/page_objects/litigator_claim_form_page.rb
+++ b/features/page_objects/litigator_claim_form_page.rb
@@ -22,7 +22,13 @@ class LitigatorClaimFormPage < ClaimFormPage
   end
 
   def select_offence_class(name)
-    select2 name, from: "claim_offence_id"
+    begin
+      select2 name, from: "claim_offence_id"
+    rescue Capybara::ElementNotFound => err
+      puts "ERROR #{err.class}    #{err.message}"
+      puts self.body
+      raise err
+    end
   end
 
   def add_disbursement_if_required

--- a/features/reject_claim.feature
+++ b/features/reject_claim.feature
@@ -1,4 +1,4 @@
-@no-seeding @javascript
+@javascript
 Feature: Case worker rejects a claim, providing a reason
 
   Scenario: I reject a claim providing a reason

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -17,8 +17,7 @@ When(/^I select the supplier number '(.*)'$/) do |number|
   @litigator_claim_form_page.select_supplier_number(number)
 end
 
-And(/^I select the litigator offence class '(.*)'$/) do |name|
-  sleep 1
+And(/^I select the offence class '(.*)'$/) do |name|
   @litigator_claim_form_page.select_offence_class(name)
 end
 

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -17,7 +17,7 @@ When(/^I select the supplier number '(.*)'$/) do |number|
   @litigator_claim_form_page.select_supplier_number(number)
 end
 
-And(/^I select the offence class '(.*)'$/) do |name|
+And(/^I select the litigator offence class '(.*)'$/) do |name|
   @litigator_claim_form_page.select_offence_class(name)
 end
 
@@ -72,3 +72,4 @@ end
 And(/^I enter the date for the (\w+) expense '(.*?)'$/) do |ordinal, date|
   @claim_form_page.expenses.send(ordinal.to_sym).expense_date.set_date date
 end
+

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -20,7 +20,7 @@ Before('~@no-site-prism') do
   @allocation_page = AllocationPage.new
 end
 
-Before('~@no-seeding') do
+Before do
   unless ($seed_done ||= false)
 
     load "#{Rails.root}/db/seeds/courts.rb"
@@ -31,14 +31,12 @@ Before('~@no-seeding') do
     load "#{Rails.root}/db/seeds/certification_types.rb"
     load "#{Rails.root}/db/seeds/disbursement_types.rb"
     load "#{Rails.root}/db/seeds/expense_types.rb"
+    load "#{Rails.root}/db/seeds/vat_rates.rb"
 
     $seed_done = true
   end
 end
 
-Before do
-  load "#{Rails.root}/db/seeds/vat_rates.rb"
-end
 
 AfterConfiguration do
   # Possible values are :truncation and :transaction


### PR DESCRIPTION
Cukes were occasionally flickering because the offence class "E: Burglary" couldn't
be found.  This was caused the cukes which were marked as no-seeding running before
the ones marked as requiring seeding, and creating a random offence class.  When the
cukes that required seeding ran later, they don't overwrite existing offence classes
in the database.  The cuke flickered when the randomly created offence class was E,
with a different name.

The solution was to require seeding for all cukes.  This does not add to the running
time of the cucumber suite, because it is only ever carried out once.
