### PR TITLE
Fix uncalculated fees not showing on draft edit.

### DIFF
--- a/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
@@ -17,5 +17,5 @@
                         label: t('.total'),
                         input_classes:'total',
                         input_type: 'currency',
-                        value: number_with_precision(f.object.rate, precision: 2),
+                        value: number_with_precision(fee.fee.amount, precision: 2),
                         errors: @error_presenter


### PR DESCRIPTION
Fix for bug reported on Zendesk ticket #28048

> When I left the claim and have later gone back into it it has not retained the PPE fee in it's particular box, even though the overall total is still showing as correct.
