### PR TITLE
Do not show input fields when no needed on assessments.

### DIFF
--- a/app/assets/javascripts/modules/case_worker/claims/DeterminationCalculator.js
+++ b/app/assets/javascripts/modules/case_worker/claims/DeterminationCalculator.js
@@ -71,11 +71,13 @@ moj.Modules.DeterminationCalculator = {
     var $element = $(element);
     var $table = $element.closest('table');
     var $fees = $table.find('.js-fees');
-    var fees = parseFloat($fees.val().replace(/,/g, ''));
     var $expenses = $table.find('.js-expenses');
     var $disbursements = $table.find('.js-disbursements');
-    var expenses = parseFloat($expenses.val().replace(/,/g, ''));
+
+    var fees = $fees.exists() ? parseFloat($fees.val().replace(/,/g, '')) : 0;
+    var expenses = $expenses.exists() ? parseFloat($expenses.val().replace(/,/g, '')) : 0;
     var disbursements = $disbursements.exists() ? parseFloat($disbursements.val().replace(/,/g, '')) : 0;
+
     var total = this.calculateAmount(fees, expenses, disbursements);
 
     this.applyVAT(total);

--- a/app/presenters/claim/interim_claim_presenter.rb
+++ b/app/presenters/claim/interim_claim_presenter.rb
@@ -12,6 +12,10 @@ class Claim::InterimClaimPresenter < Claim::BaseClaimPresenter
     false
   end
 
+  def disbursement_only?
+    claim.interim_fee&.is_disbursement?
+  end
+
   def pretty_type
     'Interim'
   end

--- a/app/views/case_workers/claims/_determination_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_fields.html.haml
@@ -1,25 +1,27 @@
-%tr.determination-form-fields
-  %td
-    Fees
-  %td
-    %span.currency-symbol
-    = claim.fees_total
-  %td
-    %div.pound-wrapper
-      = f.text_field :fees, value: number_with_precision(f.object.fees, precision: 2), class: 'form-control js-fees', size: 10, maxlength: 8
-    = validation_error_message(f.object, :fees)
+- unless claim.interim? && claim.disbursement_only?
+  %tr.determination-form-fields
+    %td
+      Fees
+    %td
+      %span.currency-symbol
+      = claim.fees_total
+    %td
+      %div.pound-wrapper
+        = f.text_field :fees, value: number_with_precision(f.object.fees, precision: 2), class: 'form-control js-fees', size: 10, maxlength: 8
+      = validation_error_message(f.object, :fees)
 
-%tr.determination-form-fields
-  %td
-    Expenses
-  %td
-    = claim.expenses_total
-  %td
-    %div.pound-wrapper
-      = f.text_field :expenses, value: number_with_precision(f.object.expenses, precision: 2), class: 'form-control js-expenses', size: 10, maxlength: 8
-    = validation_error_message(f.object, :expenses)
+- if claim.can_have_expenses?
+  %tr.determination-form-fields
+    %td
+      Expenses
+    %td
+      = claim.expenses_total
+    %td
+      %div.pound-wrapper
+        = f.text_field :expenses, value: number_with_precision(f.object.expenses, precision: 2), class: 'form-control js-expenses', size: 10, maxlength: 8
+      = validation_error_message(f.object, :expenses)
 
-- if claim.disbursements.any?
+- if claim.can_have_disbursements?
   %tr.determination-form-fields
     %td
       Disbursements

--- a/app/views/shared/_determination_amounts.html.haml
+++ b/app/views/shared/_determination_amounts.html.haml
@@ -1,9 +1,10 @@
 - present(determination) do |determination|
-  %tr.determination-display
-    %th{scope:'row'} Fees
-    %td.numeric
-      = claim.fees_total
-    %td.numeric#determination-fees= determination.fees_total
+  - unless claim.interim? && claim.disbursement_only?
+    %tr.determination-display
+      %th{scope:'row'} Fees
+      %td.numeric
+        = claim.fees_total
+      %td.numeric#determination-fees= determination.fees_total
   - if claim.can_have_expenses?
     %tr.determination-display
       %th{scope:'row'} Expenses

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -15,10 +15,10 @@
       %tbody
         -if current_user_is_caseworker? && @claim.enable_assessment_input?
           = f.fields_for :assessment do |af|
-            = render partial: 'determination_fields', locals: { f: af, claim: claim}
+            = render partial: 'case_workers/claims/determination_fields', locals: { f: af, claim: claim}
         -elsif current_user_is_caseworker? && @claim.enable_determination_input?
           = f.fields_for :redeterminations, claim.redeterminations.build do |rf|
-            = render partial: 'determination_fields', locals: { f: rf, claim: claim}
+            = render partial: 'case_workers/claims/determination_fields', locals: { f: rf, claim: claim}
         - elsif claim.redeterminations.any?
           = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.redeterminations.last }
         - else


### PR DESCRIPTION
**PT#121147051**
- Do not show expenses input field on assessment for interim claims, as those can't have expenses.
- Do not show fees input field on assessment for interim claims of type disbursement only, as those can't have other fees.
