### PR TITLE
Ensure VAT after save of  expense, fee or disbursement

### DIFF
--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -31,6 +31,7 @@ class Disbursement < ActiveRecord::Base
   after_save do
     claim.update_disbursements_total
     claim.update_total
+    claim.update_vat
   end
 
   after_destroy do

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -63,6 +63,7 @@ class Expense < ActiveRecord::Base
   after_save do
     claim.update_expenses_total
     claim.update_total
+    claim.update_vat
   end
 
   after_destroy do

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -64,6 +64,7 @@ module Fee
     after_save do
       claim.update_fees_total
       claim.update_total
+      claim.update_vat
     end
 
     after_destroy do

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Disbursement, type: :model do
       expect(@claim.total).to eq(8.0)
     end
 
-    it 'calculates the claim vat amount (on claim submit)' do
-      expect{ @claim.submit! }.to change{ @claim.vat_amount }.by(2.5)
+    it 'calculates the claim vat amount' do
+      expect(@claim.vat_amount).to eq 2.5
     end
   end
 end


### PR DESCRIPTION
The after save hook on Disbursement, Fee and Expense models updated the claim totals, but omitted to update the VAT total.  This meant that claims submitted via JSON or API did not have the VAT calculated until the claim had been updated.  This PR fixes that.
