### PR TITLE
Remove repo date validation on fixed/warned dates for cracked trials.

### DIFF
--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -103,10 +103,6 @@ class BaseValidator < ActiveModel::Validator
     @record.errors.add(attribute, message)
   end
 
-  def case_type_in(*case_types)
-    case_types.include?(@record.case_type.name) rescue false
-  end
-
   def validate_not_after(date, attribute, message)
     return if attr_nil?(attribute) || date.nil?
     add_error(attribute, message) if @record.__send__(attribute) > date.to_date

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -145,7 +145,6 @@ class Claim::BaseClaimValidator < BaseValidator
       validate_presence(:trial_fixed_notice_at, "blank")
       validate_not_after(Date.today, :trial_fixed_notice_at, "check_not_in_future")
       validate_not_before(Settings.earliest_permitted_date, :trial_fixed_notice_at, "check_not_too_far_in_past")
-      validate_not_before(earliest_rep_order, :trial_fixed_notice_at, "check_not_earlier_than_rep_order")
     end
   end
 
@@ -158,7 +157,6 @@ class Claim::BaseClaimValidator < BaseValidator
     if @record.case_type && @record.requires_cracked_dates?
       validate_presence(:trial_fixed_at, "blank")
       validate_not_before(Settings.earliest_permitted_date, :trial_fixed_at, "check_not_too_far_in_past")
-      validate_not_before(earliest_rep_order, :trial_fixed_at, "check_not_earlier_than_rep_order")
       validate_not_before(@record.trial_fixed_notice_at, :trial_fixed_at, "check_not_earlier_than_trial_fixed_notice_at")
     end
   end
@@ -173,7 +171,6 @@ class Claim::BaseClaimValidator < BaseValidator
       validate_presence(:trial_cracked_at, "blank")
       validate_not_after(Date.today, :trial_cracked_at, "check_not_in_future")
       validate_not_before(Settings.earliest_permitted_date, :trial_cracked_at, "check_not_too_far_in_past")
-      validate_not_before(earliest_rep_order, :trial_cracked_at, "check_not_earlier_than_rep_order")
       validate_not_before(@record.trial_fixed_notice_at, :trial_cracked_at, "check_not_earlier_than_trial_fixed_notice_at")
     end
   end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -317,10 +317,6 @@ trial_fixed_notice_at:
     long: 'Check the date for "Notice of 1st fixed/warned issued"'
     short: *too_far_in_past
     api: 'Check the date for "Notice of 1st fixed/warned issued"'
-  check_not_earlier_than_rep_order:
-    long: 'Check the date for "Notice of 1st fixed/warned issued"'
-    short: *before_rep_order
-    api: 'Check the date for "Notice of 1st fixed/warned issued"'
   invalid_date:
     long: 'Enter a valid date for the "Notice of 1st fixed/warned issued"'
     short: *enter_valid_date
@@ -335,10 +331,6 @@ trial_fixed_at:
   check_not_too_far_in_past:
     long: 'Check the date for "1st fixed/warned trial"'
     short: *too_far_in_past
-    api: 'Check the date for "1st fixed/warned trial"'
-  check_not_earlier_than_rep_order:
-    long: 'Check the date for "1st fixed/warned trial"'
-    short: *before_rep_order
     api: 'Check the date for "1st fixed/warned trial"'
   check_not_earlier_than_trial_fixed_notice_at:
     long: 'Check the date for "1st fixed/warned trial"'
@@ -362,10 +354,6 @@ trial_cracked_at:
   check_not_too_far_in_past:
     long: 'Check the date for "Case cracked"'
     short: *too_far_in_past
-    api: 'Check the date for "Case cracked"'
-  check_not_earlier_than_rep_order:
-    long: 'Check the date for "Case cracked"'
-    short: *before_rep_order
     api: 'Check the date for "Case cracked"'
   check_not_earlier_than_trial_fixed_notice_at:
     long: 'Check the date for "Case cracked"'

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -14,10 +14,19 @@ describe API::V1::ExternalUsers::RepresentationOrder do
   ALL_REP_ORDER_ENDPOINTS = [VALIDATE_REPRESENTATION_ORDER_ENDPOINT, CREATE_REPRESENTATION_ORDER_ENDPOINT]
   FORBIDDEN_REP_ORDER_VERBS = [:get, :put, :patch, :delete]
 
+  let(:representation_order_date) { 10.days.ago }
+
   let!(:provider)      { create(:provider) }
   let!(:claim)         { create(:claim, source: 'api') }
   let!(:defendant)     { create(:defendant, claim: claim).reload }
-  let!(:valid_params)  { {api_key: provider.api_key, defendant_id: defendant.uuid, representation_order_date: '2015-06-10', maat_reference: '0123456789' } }
+  let!(:valid_params)  {
+    {
+        api_key: provider.api_key,
+        defendant_id: defendant.uuid,
+        representation_order_date: representation_order_date.as_json,
+        maat_reference: '0123456789'
+    }
+  }
 
   context 'when sending non-permitted verbs' do
     ALL_REP_ORDER_ENDPOINTS.each do |endpoint| # for each endpoint

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -387,14 +387,12 @@ describe Claim::BaseClaimValidator do
         it { should_error_if_not_present(cracked_trial_claim, :trial_fixed_notice_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_in_future(cracked_trial_claim, :trial_fixed_notice_at, 'check_not_in_future', translated_message: 'Can\'t be in the future')}
         it { should_error_if_too_far_in_the_past(cracked_trial_claim, :trial_fixed_notice_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_earliest_repo_date(cracked_trial_claim, :trial_fixed_notice_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
       end
 
       context 'cracked_before_retrial claim' do
         it { should_error_if_not_present(cracked_before_retrial_claim, :trial_fixed_notice_at, 'blank') }
         it { should_error_if_in_future(cracked_before_retrial_claim, :trial_fixed_notice_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_before_retrial_claim, :trial_fixed_notice_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_earliest_repo_date(cracked_before_retrial_claim, :trial_fixed_notice_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
       end
     end
 
@@ -402,14 +400,12 @@ describe Claim::BaseClaimValidator do
       context 'cracked trial claim' do
         it { should_error_if_not_present(cracked_trial_claim, :trial_fixed_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_too_far_in_the_past(cracked_trial_claim, :trial_fixed_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_earliest_repo_date(cracked_trial_claim, :trial_fixed_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
         it { should_error_if_earlier_than_other_date(cracked_trial_claim, :trial_fixed_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
       end
 
       context 'cracked before retrial' do
         it { should_error_if_not_present(cracked_before_retrial_claim, :trial_fixed_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_too_far_in_the_past(cracked_before_retrial_claim, :trial_fixed_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_earliest_repo_date(cracked_before_retrial_claim, :trial_fixed_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
         it { should_error_if_earlier_than_other_date(cracked_before_retrial_claim, :trial_fixed_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
       end
     end
@@ -419,7 +415,6 @@ describe Claim::BaseClaimValidator do
         it { should_error_if_not_present(cracked_trial_claim, :trial_cracked_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_in_future(cracked_trial_claim, :trial_cracked_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_trial_claim, :trial_cracked_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_earliest_repo_date(cracked_trial_claim, :trial_cracked_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
         it { should_error_if_earlier_than_other_date(cracked_trial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
       end
 
@@ -427,7 +422,6 @@ describe Claim::BaseClaimValidator do
         it { should_error_if_not_present(cracked_before_retrial_claim, :trial_cracked_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_in_future(cracked_before_retrial_claim, :trial_cracked_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_before_retrial_claim, :trial_cracked_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_earliest_repo_date(cracked_before_retrial_claim, :trial_cracked_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
         it { should_error_if_earlier_than_other_date(cracked_before_retrial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
       end
     end


### PR DESCRIPTION
**PT#126318253**

We have found through litigator use that the fixed and warned dates for cracked trials can be before the date of the rep order.  

We therefore need to remove the validation on these fields that says it must be after.  
