### PR TITLE
Add contextual page titles.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,4 +106,11 @@ module ApplicationHelper
     current_user.persona.has_roles?('admin') || current_user.persona.has_roles?('litigator')
   end
 
+  def title(page_title)
+    content_for :page_title, [page_title, 'Claim for crown court defence', 'Gov.uk'].join(' - ')
+  end
+
+  def contextual_title
+    title [controller_name, action_name].join(' ').titleize
+  end
 end

--- a/app/views/external_users/claim_types/selection.html.haml
+++ b/app/views/external_users/claim_types/selection.html.haml
@@ -1,3 +1,5 @@
+- title 'Fee scheme selection'
+
 = render partial: 'layouts/header', locals: {page_heading: 'What would you like to do?'}
 
 = form_tag(types_external_users_claims_path, method: "post") do

--- a/app/views/external_users/claims/show.html.haml
+++ b/app/views/external_users/claims/show.html.haml
@@ -1,4 +1,5 @@
-- present(@claim) do |claim|
+- title 'Claim details'
 
+- present(@claim) do |claim|
   = render partial: 'shared/claim_header', locals: {  claim: claim }
   = render partial: 'shared/claim_accordion', locals: { claim: claim, status_disabled: true }

--- a/app/views/feedback/bug_report.html.haml
+++ b/app/views/feedback/bug_report.html.haml
@@ -1,5 +1,6 @@
-= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: 'The form you submitted has '}
+- title 'Bug report'
 
+= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: 'The form you submitted has '}
 = render partial: 'layouts/header', locals: {page_heading: 'Help us improve this service'}
 
 .body-content

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -1,5 +1,6 @@
-= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: 'This feedback has '}
+- title 'Feedback'
 
+= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: 'This feedback has '}
 = render partial: 'layouts/header', locals: {page_heading: 'Help us improve this service'}
 
 .body-content

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,3 +1,5 @@
+- title(page_heading) unless content_for?(:page_title)
+
 %header.main-header{role: 'banner'}
   %h1
     = page_heading

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,4 +1,7 @@
 - @disable_logo_link  = true
+
+- content_for?(:page_title) ? yield(:page_title) : contextual_title
+
 - content_for :head do
   %meta{:name =>"format-detection", :content => "telephone=no"}
   = stylesheet_link_tag "application", media: "all"

--- a/app/views/layouts/statistics.html.haml
+++ b/app/views/layouts/statistics.html.haml
@@ -1,4 +1,7 @@
 - @disable_logo_link  = true
+
+- content_for?(:page_title) ? yield(:page_title) : contextual_title
+
 - content_for :head do
   %meta{:name =>"format-detection", :content => "telephone=no"}
   = stylesheet_link_tag "application", media: "all"

--- a/app/views/pages/tandcs.haml
+++ b/app/views/pages/tandcs.haml
@@ -1,3 +1,5 @@
+- title 'Terms and Conditions'
+
 = render partial: 'layouts/header', locals: {page_heading: 'THE “CLAIM FOR CROWN COURT DEFENCE” APPLICATION TERMS OF USE'}
 
 %section.tandcs


### PR DESCRIPTION
**PT#126305035**

As raised by DAC report. The way it works, by order of precedence:
1. Setting it explicitly in the view, calling **title** helper. Example:

``` ruby
title 'Change your password'
```
1. If the partial layouts/header is called, the title will use the local var **page_heading** automatically (unless a explicit title was set as described before). Example:

``` ruby
= render partial: 'layouts/header', locals: {page_heading: 'Change your password'} 
```
1. If none of the previous 2 options are found, a contextual page title based on the **controller** and the **action** being called will be used. This is not ideal but better than no title or generic one.

The end result in any of the 2 first options will be like this example:

> Change your password - Claim for crown court defence - Gov.uk

And if option 3 was used, like this (controller 'claims', action 'archived'):

> Claims Archived - Claim for crown court defence - Gov.uk
