### PR TITLE
Allowing email addresses containing plus characters.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,8 +46,6 @@ class User < ActiveRecord::Base
   validates :email, confirmation: true
   attr_accessor :email_confirmation
 
-  validate :validate_no_plus_suffix
-
   # enable current_user to directly call persona methods (in controllers)
   delegate :claims, to: :persona
   delegate :claims_created, to: :persona
@@ -70,13 +68,4 @@ class User < ActiveRecord::Base
   def unauthenticated_message
     override_paranoid_setting(false) { super }
   end
-
-  private
-
-  def validate_no_plus_suffix
-    if self.email =~ /\+/
-      errors[:email] << '"+" not allowed in addresses'
-    end
-  end
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,16 +35,6 @@ RSpec.describe User, type: :model do
 
   it { should delegate_method(:claims).to(:persona) }
 
-  describe 'email "+" character validation' do
-    subject { build(:user) }
-
-    it 'is not valid with a "+" in the email address' do
-      subject.email = 'user+1@example.com'
-      subject.valid?
-      expect(subject.errors.full_messages).to include('Email "+" not allowed in addresses')
-    end
-  end
-
   describe '#name' do
     subject { build(:user) }
 


### PR DESCRIPTION
To prepare for potential users having to rely on this.
