### PR TITLE
Sanitise output values in custom input builder.

### DIFF
--- a/app/form_builders/adp_text_field.rb
+++ b/app/form_builders/adp_text_field.rb
@@ -6,6 +6,7 @@ class AdpTextField
 
   include ExternalUsers::ClaimsHelper
   include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::SanitizeHelper
 
 
   # instantiate an AdpTextField object
@@ -70,7 +71,7 @@ class AdpTextField
     @input_classes = options[:input_classes] || ''
     @input_type = options[:input_type] || 'text'
     @error_key = options[:error_key] || @anchor_id
-    @value = options[:value] || form.object.__send__(method)
+    @value = (options[:value] || form.object.__send__(method)).to_s
     setup_input_type
   end
 
@@ -160,7 +161,7 @@ class AdpTextField
       result += %|<span class="currency-indicator">&pound;</span>|
     end
     result += %|<input class="form-control #{@input_classes}" type="#{@input_type_string}" name="#{@form_field_name}" id="#{@form_field_id}" |
-    result += %|value="#{@value}" | unless @form.object.__send__(@method).nil?
+    result += %|value="#{strip_tags(@value)}" | unless @form.object.__send__(@method).nil?
     if @input_is_number
       result += %|min="#{@input_min}" |
       result += %|max="#{@input_max}" |

--- a/spec/form_builders/adp_text_field_spec.rb
+++ b/spec/form_builders/adp_text_field_spec.rb
@@ -22,6 +22,12 @@ describe AdpTextField do
         expect(atf.to_html).to eq a200_value_no_hint
       end
 
+      it 'should strip html tags from output value' do
+        resource.case_number = '<b>X22334455</b>'
+        atf = AdpTextField.new(builder, :case_number, label: 'Case number', errors: error_presenter)
+        expect(atf.to_html).to eq a200_value_no_hint
+      end
+
       def a100_no_value_no_hint
         html = <<-eos
         <div class="form-group case_number_wrapper">


### PR DESCRIPTION
Raised in the CCCD security review.

Several instances found where javascript payloads were injected into form fields resulting in the script being echoed in the response.

Found the issue was using html_safe in the whole string (method to_html). Solved by ensuring the only possible user-generated data (value) is sanitised stripping html tags.
