### PR TITLE
DAC: Alt tags and object tags

### DIFF
--- a/app/views/external_users/claims/confirmation.html.haml
+++ b/app/views/external_users/claims/confirmation.html.haml
@@ -1,7 +1,7 @@
 - present(@claim) do |claim|
   .confirmation-header
     %h1.page-title.bold-large
-      %img{:src => image_path('icons/tick-white.svg'), :class => "confirmation-tick"}/
+      %img{:src => image_path('icons/tick-white.svg'), :alt => 'Success', :class => "confirmation-tick"}/
       = t('.thanks')
 
     .normal

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -12,6 +12,4 @@
       - each_page do |page|
         - if page.left_outer? || page.right_outer? || page.inside_window?
           = page_tag page
-        - elsif !page.was_truncated?
-          = gap_tag
       = next_page_tag unless current_page.last?


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/126304947
- removed gap_tag to fix w3c validation
- object tags where removed shortly after the assesment was made
