### PR TITLE
Rake tasks and preparation for doing anonymised db exports.

### DIFF
--- a/db/data/anonymise_db.sql
+++ b/db/data/anonymise_db.sql
@@ -1,0 +1,10 @@
+update providers set
+  name = translate(name, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZC', :translation);
+
+update users set
+  first_name = translate(first_name, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZC', :translation),
+  last_name  = translate(last_name,  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZC', :translation);
+
+update defendants set
+  first_name = translate(first_name, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZC', :translation),
+  last_name  = translate(last_name,  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZC', :translation);

--- a/db/migrate/20160719114631_remove_external_user_provider_foreign_key.rb
+++ b/db/migrate/20160719114631_remove_external_user_provider_foreign_key.rb
@@ -1,0 +1,16 @@
+class RemoveExternalUserProviderForeignKey < ActiveRecord::Migration
+
+  # Having problems sometimes to find the FK with error: Table 'external_users' has no foreign key on column 'provider_id'
+  # This will work around
+  #
+  def up
+    remove_foreign_key :external_users, :providers
+  rescue
+    add_foreign_key :external_users, :providers
+    remove_foreign_key :external_users, :providers
+  end
+
+  def down
+    add_foreign_key :external_users, :providers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160706133256) do
+ActiveRecord::Schema.define(version: 20160719114631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -493,5 +493,4 @@ ActiveRecord::Schema.define(version: 20160706133256) do
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
-  add_foreign_key "external_users", "providers"
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -17,22 +17,117 @@ namespace :db do
   task :reload do
     Rake::Task['db:clear'].invoke
     Rake::Task['db:schema:load'].invoke
-
-
-    # # exectute the migrate as a seperate shell task in order that the claims:demo_data task
-    # # doesn't have stale column information (i.e. recognises the STI columns in Claim and Fee modules)
-
-    # pipe = IO.popen('rake db:migrate')
-    # line = pipe.readline
-    # while !pipe.eof
-    #   puts line
-    #   line = pipe.readline
-    # end
-    # pipe.close
     Rake::Task['db:migrate'].invoke
-
     Rake::Task['claims:demo_data'].invoke
   end
 
+  desc 'Dumps a backup of the database'
+  task :dump => :environment do
+    sh (with_config do |host, db, user|
+      "PGPASSWORD=$DB_PASSWORD pg_dump -v -w -U #{user} -h #{host} -d #{db} -f #{Time.now.strftime('%Y%m%d%H%M%S')}_#{db}.psql"
+    end)
+  end
+
+  desc 'Dumps an anonymised backup of the database'
+  task :dump_anonymised, [:file] => :environment do |_task, args|
+    excluded_tables = %w(providers defendants users) # make sure a db:dump task exists for each of these tables (i.e. db:dump:providers)
+
+    exclusions = excluded_tables.map { |table| "--exclude-table-data #{table}" }.join(' ')
+    filename = args.file || "#{Time.now.strftime('%Y%m%d%H%M%S')}_dump.psql"
+
+    sh (with_config do |host, db, user|
+      "PGPASSWORD=$DB_PASSWORD pg_dump -w #{exclusions} -U #{user} -h #{host} -d #{db} -f #{filename}"
+    end)
+
+    # The following will export the previously excluded tables data, in an anonymised way
+    excluded_tables.each do |table|
+      task_name = "db:dump:#{table}"
+      puts "Executing task #{task_name}"
+
+      Rake::Task[task_name].invoke(filename)
+    end
+  end
+
+  desc 'Anonymise current database data (in-place, no dump)'
+  task :anonymise => :environment do
+    translation = [('a'..'z'), ('A'..'Z')].map(&:to_a).map(&:shuffle).join
+
+    sh (with_config do |host, db, user|
+      "PGPASSWORD=$DB_PASSWORD psql -v translation=\\'#{translation}\\' -U #{user} -h #{host} -d #{db} -f #{Rails.root}/db/data/anonymise_db.sql"
+    end)
+  end
+
+  desc 'Restores the database from a backup'
+  task :restore, [:file] => :environment do |_task, args|
+    unless args.file.present?
+      puts 'Please provide the file to restore to the task. Ex: rake db:restore[20160719112847_dump.psql]'
+      puts 'Note: if you are using zsh, scape the brackets. Ex: rake db:restore\[20160719112847_dump.psql\]'
+      exit(1)
+    end
+
+    puts 'Dropping database...'
+    Rake::Task['db:drop'].invoke
+    puts 'Creating database...'
+    Rake::Task['db:create'].invoke
+
+    sh (with_config do |host, db, user|
+      "PGPASSWORD=$DB_PASSWORD psql -q -b -U #{user} -h #{host} -d #{db} -f #{args.file}"
+    end)
+  end
+
+
+  namespace :dump do
+    desc 'Export anonymised providers data'
+    task :providers, [:file] => :environment do |_task, args|
+      write_to_file(args.file) do |writer|
+        Provider.find_each(batch_size: 50) do |provider|
+          provider.name = Faker::Company.name
+          writer.call(provider)
+        end
+      end
+    end
+
+    desc 'Export anonymised defendants data'
+    task :defendants, [:file] => :environment do |_task, args|
+      write_to_file(args.file) do |writer|
+        Defendant.find_each(batch_size: 50) do |defendant|
+          defendant.first_name = Faker::Name.first_name
+          defendant.last_name  = Faker::Name.last_name
+          writer.call(defendant)
+        end
+      end
+    end
+
+    desc 'Export anonymised users data'
+    task :users, [:file] => :environment do |_task, args|
+      write_to_file(args.file) do |writer|
+        User.find_each(batch_size: 50) do |user|
+          user.first_name = Faker::Name.first_name
+          user.last_name  = Faker::Name.last_name
+          writer.call(user)
+        end
+      end
+    end
+  end
+
+
+  private
+
+  def with_config
+    yield ActiveRecord::Base.connection_config[:host],
+          ActiveRecord::Base.connection_config[:database],
+          ActiveRecord::Base.connection_config[:username]
+  end
+
+  def write_to_file(name)
+    file_name = name || 'anonymised_data.sql'
+    puts 'Writing anonymised data to %s' % file_name
+
+    open(file_name, 'a') do |file|
+      yield ->(model) do
+        file.puts model.class.arel_table.create_insert.tap { |im| im.insert(model.send(:arel_attributes_with_values_for_create, model.attribute_names)) }.to_sql.gsub('"', '') + ';'
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
This will work together with a script, coming in a following PR once we test this tasks on remote envs.

A foreign_key in  external_users was removed in order to not produce errors when loading an exported database, due to the providers being anonymised, and thus no real data for providers is exported, making the foreign_key fail when another table (in this case external_users) reference it.

This has no effect in the app or the data.
