### PR TITLE
Copy change advocate/litigator.

### DIFF
--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -1,5 +1,10 @@
+- external_user_label = @claim.agfs? ? t('.advocate') : t('.litigator')
+
 %h2.bold-medium
-  = t('.case_advocate_offence')
+  - if current_user.persona.admin?
+    = t('.case_instructed_offence', type: external_user_label.downcase)
+  - else
+    = t('.case_offence')
 
 
 - if @claim.agfs?
@@ -15,9 +20,8 @@
 %fieldset
   .form-group
     - if current_user.persona.admin?
-      - label = @claim.agfs? ? t('.advocate') : t('.litigator')
       - external_users_collection = @claim.agfs? ? @advocates_in_provider : @litigators_in_provider
-      = render partial: 'external_users/claims/case_details/case_owner_select', locals: { f: f, label: label, external_users_collection: external_users_collection }
+      = render partial: 'external_users/claims/case_details/case_owner_select', locals: { f: f, label: external_user_label, external_users_collection: external_users_collection }
 
     .form-row
       .form-col{class: error_class?(@error_presenter, :case_type)}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,7 +443,8 @@ en:
         fields:
           advocate: *advocate
           advocate_category: 'Advocate category'
-          case_advocate_offence: 'Case, instructed advocate & offence'
+          case_offence: 'Case & offence'
+          case_instructed_offence: 'Case, instructed %{type} & offence'
           case_number: 'Case number'
           transfer_case_number: 'Transfer case number (optional)'
           case_type: 'Case type'


### PR DESCRIPTION
**PT#126854925**

'Instructed advocate' still was appearing on litigator claims (see screenshot).

Also now, when the user filling the claim is not an admin, and thus can't select an instructed advocate/litigator, the title of the section will be just 'Case & offence' to be consistent.

![pasted image at 2016_07_22_11_19 am](https://cloud.githubusercontent.com/assets/687910/17206752/36a3fcf2-54a9-11e6-8e77-ce89c0f46a77.png)
