### PR TITLE
Removing and cleaning unnecessary lgfs schemes feature flags.

### DIFF
--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -60,10 +60,7 @@ class ExternalUser < ActiveRecord::Base
   end
 
   def litigator_claim_types
-    litigator_claim_types = [Claim::LitigatorClaim]
-    litigator_claim_types << Claim::InterimClaim if Settings.allow_lgfs_interim_fees?
-    litigator_claim_types << Claim::TransferClaim if Settings.allow_lgfs_transfer_fees?
-    litigator_claim_types
+    [Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim]
   end
 
   def available_claim_types

--- a/app/views/external_users/claim_types/selection.html.haml
+++ b/app/views/external_users/claim_types/selection.html.haml
@@ -17,12 +17,12 @@
           = radio_button_tag :scheme_chosen, "lgfs_final", !@claim_types.include?(Claim::AdvocateClaim)
           = t('.lgfs_final_rb')
 
-      - if @claim_types.include?(Claim::InterimClaim) && Settings.allow_lgfs_interim_fees?
+      - if @claim_types.include?(Claim::InterimClaim)
         = label_tag :scheme_chosen_lgfs_interim, nil, class: "block-label" do
           = radio_button_tag :scheme_chosen, "lgfs_interim", false
           = t('.lgfs_interim_rb')
 
-      - if @claim_types.include?(Claim::TransferClaim) && Settings.allow_lgfs_transfer_fees?
+      - if @claim_types.include?(Claim::TransferClaim)
         = label_tag :scheme_chosen_lgfs_transfer, nil, class: "block-label" do
           = radio_button_tag :scheme_chosen, "lgfs_transfer", false
           = t('.lgfs_transfer_rb')

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,12 +49,6 @@ claim_csv_headers:
 
 expense_schema_version: 2
 
-# temporary feature toggle til interim fees ready
-allow_lgfs_interim_fees?: true
-
-# temporary feature toggle til lgfs transfer ready
-allow_lgfs_transfer_fees?: true
-
 # Feature flag to enable or disable API promo banner in the claims page
 # If enabled, users will see it, and will have a 'dismiss' link to hide and do not show it again
 api_promo_enabled?: false

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -4,7 +4,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
   Scenario: I create an interim claim, save it to draft and later complete it
 
     Given I am a signed in litigator
-    And I am allowed to submit interim claims
     And My provider has supplier numbers
     And I am on the 'Your claims' page
 

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -4,10 +4,10 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
   Scenario: I create a final fee claim, save it to draft and later complete it
 
     Given I am a signed in litigator
-    And I am not allowed to submit interim or transfer claims
     And My provider has supplier numbers
     And I am on the 'Your claims' page
     And I click 'Start a claim'
+    And I select the fee scheme 'Litigator final fee'
     Then I should be on the litigator new claim page
 
     When I select the supplier number '1A222Z'

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -4,10 +4,10 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
   Scenario: I create a final fee claim with an error, fixing it
 
     Given I am a signed in litigator
-    And I am not allowed to submit interim or transfer claims
     And My provider has supplier numbers
     And I am on the 'Your claims' page
     And I click 'Start a claim'
+    And I select the fee scheme 'Litigator final fee'
     Then I should be on the litigator new claim page
 
     When I select the supplier number '1A222Z'

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -4,7 +4,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
   Scenario: I create a transfer claim, save it to draft and later complete it
 
     Given I am a signed in litigator
-    And I am allowed to submit transfer claims
     And My provider has supplier numbers
     And I am on the 'Your claims' page
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -88,22 +88,6 @@ Then(/^Claim '(.*?)' should be listed with a status of '(.*?)'(?: and a claimed 
   expect(my_claim.claimed.text).to eq(claimed) if claimed
 end
 
-# The following steps are needed until we open the different LGFS claims
-# to the general users. At the moment the options are behind a feature flag.
-#
-Given(/^I am allowed to submit interim claims$/) do
-  allow(Settings).to receive(:allow_lgfs_interim_fees?).and_return(true)
-end
-
-Given(/^I am allowed to submit transfer claims$/) do
-  allow(Settings).to receive(:allow_lgfs_transfer_fees?).and_return(true)
-end
-
-Given(/^I am not allowed to submit interim or transfer claims$/) do
-  allow(Settings).to receive(:allow_lgfs_interim_fees?).and_return(false)
-  allow(Settings).to receive(:allow_lgfs_transfer_fees?).and_return(false)
-end
-
 Then(/^I should see the error '(.*?)'$/) do |error_message|
   within('div.error-summary') do
     expect(page).to have_content(error_message)

--- a/spec/controllers/external_users/claim_types_controller_spec.rb
+++ b/spec/controllers/external_users/claim_types_controller_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe ExternalUsers::ClaimTypesController, type: :controller, focus: tr
 
   let(:agfs_lgfs_admin) { create(:external_user, :agfs_lgfs_admin) }
   before { sign_in agfs_lgfs_admin.user }
-  before { allow(Settings).to receive(:allow_lgfs_interim_fees?).and_return true }
-  before { allow(Settings).to receive(:allow_lgfs_transfer_fees?).and_return true }
 
   describe 'GET #selection' do
     context 'admin of AGFS and LGFS provider' do

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -261,11 +261,6 @@ RSpec.describe ExternalUser, type: :model do
     let(:admin)               { build(:external_user, :admin) }
     let(:advocate_litigator)  { build(:external_user, :advocate_litigator) }
 
-    before(:each) do
-      allow(Settings).to receive(:allow_lgfs_interim_fees?).and_return true
-      allow(Settings).to receive(:allow_lgfs_transfer_fees?).and_return true
-    end
-
     it 'returns advocate claims for advocates' do
       expect(advocate.available_claim_types).to match_array([Claim::AdvocateClaim])
     end

--- a/spec/services/claims/context_mapper_spec.rb
+++ b/spec/services/claims/context_mapper_spec.rb
@@ -11,11 +11,6 @@ RSpec.describe Claims::ContextMapper do
     let(:advocate)      { create(:external_user, :advocate) }
     let(:litigator)     { create(:external_user, :litigator) }
 
-    before(:each) do
-      allow(Settings).to receive(:allow_lgfs_interim_fees?).and_return true
-      allow(Settings).to receive(:allow_lgfs_transfer_fees?).and_return true
-    end
-
     it 'should return advocate claims for users in AGFS only provider' do
       context = Claims::ContextMapper.new(advocate)
       expect(context.available_claim_types).to match_array([Claim::AdvocateClaim])

--- a/spec/views/external_users/claim_types/selection_spec.rb
+++ b/spec/views/external_users/claim_types/selection_spec.rb
@@ -5,8 +5,6 @@ describe 'external_users/claim_types/selection.html.haml', type: :view do
   include ViewSpecHelper
 
   before(:each) do
-    allow(Settings).to receive(:allow_lgfs_interim_fees?).and_return true
-    allow(Settings).to receive(:allow_lgfs_transfer_fees?).and_return true
     initialize_view_helpers(view)
   end
 


### PR DESCRIPTION
These feature flags and the code that uses them are no longer necessary because we've released the functionality to all users long time ago.
- allow_lgfs_interim_fees?
- allow_lgfs_transfer_fees?
