### PR TITLE
Ensuring we catch early json import failures before trying to process the claim(s).

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,7 +35,6 @@ Lint/HandleExceptions:
 Lint/ShadowingOuterLocalVariable:
   Exclude:
     - 'app/models/claims/cloner.rb'
-    - 'app/models/json_document_importer.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -50,7 +49,6 @@ Lint/UnusedBlockArgument:
   Exclude:
     - 'app/controllers/external_users/certifications_controller.rb'
     - 'app/models/claims/cloner.rb'
-    - 'app/models/json_document_importer.rb'
     - 'app/presenters/claim/base_claim_presenter.rb'
     - 'app/presenters/error_detail_collection.rb'
 
@@ -77,7 +75,6 @@ Lint/UselessAssignment:
     - 'app/form_builders/adp_form_builder.rb'
     - 'app/models/claims/search.rb'
     - 'app/models/concerns/document_attachment.rb'
-    - 'app/models/json_document_importer.rb'
 
 # Offense count: 1
 Lint/Void:
@@ -189,12 +186,6 @@ Style/EmptyLineBetweenDefs:
     - 'app/models/claim/transfer_claim.rb'
     - 'app/presenters/claim/base_claim_presenter.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/EmptyLinesAroundAccessModifier:
-  Exclude:
-    - 'app/controllers/external_users/json_document_importers_controller.rb'
-
 # Offense count: 12
 # Cop supports --auto-correct.
 Style/EmptyLinesAroundMethodBody:
@@ -219,7 +210,6 @@ Style/ExtraSpacing:
     - 'app/models/defendant.rb'
     - 'app/models/document.rb'
     - 'app/models/fee/fixed_fee_type.rb'
-    - 'app/models/json_document_importer.rb'
     - 'app/models/redetermination.rb'
     - 'app/presenters/error_message_translator.rb'
     - 'app/presenters/error_presenter.rb'
@@ -428,7 +418,6 @@ Style/SpaceAroundOperators:
     - 'app/models/claims/sort.rb'
     - 'app/models/document.rb'
     - 'app/models/expense.rb'
-    - 'app/models/json_document_importer.rb'
     - 'app/presenters/error_message_translator.rb'
     - 'app/presenters/error_presenter.rb'
     - 'app/presenters/message_presenter.rb'

--- a/app/controllers/external_users/json_document_importers_controller.rb
+++ b/app/controllers/external_users/json_document_importers_controller.rb
@@ -2,12 +2,22 @@ class ExternalUsers::JsonDocumentImportersController < ApplicationController
 
   skip_before_filter :verify_authenticity_token, :only => :create
   skip_load_and_authorize_resource only: [:create]
-  respond_to :js, :html
 
   def create
-    @api_key = current_user.persona.provider.api_key
-    @schema = JsonSchema.claim_schema
-    @json_document_importer = JsonDocumentImporter.new(json_document_importer_params.merge(schema: @schema, api_key: @api_key))
+    api_key = current_user.persona.provider.api_key
+    schema_validator = ClaimJsonSchemaValidator
+
+    @json_document_importer = JsonDocumentImporter.new(
+      json_document_importer_params.merge(schema_validator: schema_validator, api_key: api_key)
+    )
+
+    # valid? will trigger the following validations:
+    #
+    #  file_parses_to_json:
+    #     will ensure the uploaded file is a well formed json and can be parsed to a hash.
+    #  file_conforms_to_basic_json_schema:
+    #     will validate the parsed json against a basic schema to know if we should continue with the import.
+    #
     if @json_document_importer.valid?
       @json_document_importer.import!
       respond_to do |format|
@@ -15,12 +25,13 @@ class ExternalUsers::JsonDocumentImportersController < ApplicationController
       end
     else
       respond_to do |format|
-        format.js { render :format_error, locals: { filename: json_document_importer_params[:json_file].original_filename } }
+        format.js { render :format_error, locals: {errors: @json_document_importer.errors} }
       end
     end
   end
 
-private
+  private
+
   def json_document_importer_params
     params.require(:json_document_importer).permit(:json_file)
   end

--- a/app/controllers/json_template_controller.rb
+++ b/app/controllers/json_template_controller.rb
@@ -3,6 +3,6 @@ class JsonTemplateController < ApplicationController
   skip_load_and_authorize_resource only: [:index]
 
   def index
-    @schema = JSON.parse(JsonSchema.claim_schema)
+    @schema = JSON.parse(ClaimJsonSchemaValidator.full_schema)
   end
 end

--- a/app/models/claim_json_schema_validator.rb
+++ b/app/models/claim_json_schema_validator.rb
@@ -1,0 +1,27 @@
+class ClaimJsonSchemaValidator
+
+  FULL_SCHEMA_FILE = File.join(Rails.root, 'config', 'schemas', 'full_claim_schema.json').freeze
+  BASIC_SCHEMA_FILE = File.join(Rails.root, 'config', 'schemas', 'basic_claim_schema.json').freeze
+
+  class << self
+    def full_schema
+      File.read(FULL_SCHEMA_FILE)
+    end
+
+    def basic_schema
+      File.read(BASIC_SCHEMA_FILE)
+    end
+
+    def validate_full!(data)
+      JSON::Validator.validate!(full_schema, data)
+    end
+
+    # Only checks for the object 'claim' in the JSON. Used to fail early in the JSON importer.
+    # It can validate single objects {} or collections [{}, {}] in the JSON.
+    #
+    def validate_basic!(data)
+      JSON::Validator.validate!(basic_schema, data, list: data.is_a?(Array))
+    end
+  end
+
+end

--- a/app/models/json_schema.rb
+++ b/app/models/json_schema.rb
@@ -1,9 +1,0 @@
-class JsonSchema
-
-  CLAIM_SCHEMA_FILE = File.join(Rails.root, 'config', 'claim_schema.json').freeze
-
-  def self.claim_schema
-    File.read(CLAIM_SCHEMA_FILE)
-  end
-
-end

--- a/app/validators/json_format_validator.rb
+++ b/app/validators/json_format_validator.rb
@@ -1,9 +1,0 @@
-class JsonFormatValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    begin
-      JSON.parse(File.open(value.tempfile).read)
-    rescue
-      record.errors[attribute.to_s.capitalize] = "is either not JSON or contains errors"
-    end
-  end
-end

--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -12,11 +12,9 @@ $importButton.prop('disabled', false).val('Import claims');
         'There were errors in the following <%= pluralize(@json_document_importer.failed_imports.count, "claim") %> and these were not imported' +
       '</h1>' +
       '<ul class="error-summary-list">' +
-        <% @json_document_importer.errors.each do |case_number, error_messages| %>
+        <% @json_document_importer.errors.each do |case_number, error_message| %>
           '<li><%= "#{case_number}:" %><ul>' +
-          <% error_messages.each do |msg| %>
-            '<li><%= msg %></li>' +
-          <% end %>
+            '<li><%= html_escape_once(error_message) %></li>' +
           '</ul></li>' +
         <% end %>
       '</ul>' +
@@ -66,7 +64,7 @@ $importButton.prop('disabled', false).val('Import claims');
           '<td class="numeric"><%= claim.amount_assessed %></td>' +
           '<td><span class="state state-<%= claim.state %>"><%= claim.state.humanize %></td>' +
           '<td class="numeric"><%= claim.last_submitted_at %></td>' +
-          '<td class="messages"><span class="none">None</span></td>' +
+          '<td class="messages"><span class="none">No Messages</span></td>' +
         '</tr>'
       );
     <% end %>

--- a/app/views/external_users/json_document_importers/format_error.js.erb
+++ b/app/views/external_users/json_document_importers/format_error.js.erb
@@ -5,7 +5,7 @@ $('#importer').find('form')
 $('#importer')
   .addClass('has-errors')
   .find('.errors')
-    .html("<em><%= filename %></em> is either not JSON or contains errors. Choose another file.");
+    .html("<%= html_escape_once(errors[:file].to_sentence) %>");
 
 $('.importer-results').empty();
 $('input.btn-import-file').prop('disabled', false).val('Import claims').prop('aria-hidden', false).hide();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,8 +99,6 @@ Rails.application.routes.draw do
 
     resources :json_document_importers, only: [:create], format: :js
 
-    post '/external_users/json_importer' => 'json_document_importer#create'
-
     resources :claims, except: [:new, :create, :edit, :update] do
       get 'confirmation',           on: :member
       get 'summary',                on: :member

--- a/config/schemas/basic_claim_schema.json
+++ b/config/schemas/basic_claim_schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "claim"
+  ],
+  "properties": {
+    "claim": {
+      "type": "object"
+    }
+  }
+}

--- a/config/schemas/full_claim_schema.json
+++ b/config/schemas/full_claim_schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Generated from Claim for crown court defence - claim import with shasum d906843941f10e978fb08a852865cd757b961033",
   "type": "object",
   "required": [
     "claim"

--- a/spec/examples/exported_claim_with_basic_error.json
+++ b/spec/examples/exported_claim_with_basic_error.json
@@ -1,0 +1,36 @@
+// This is invalid due to the claim object not specified
+[
+  {
+    "creator_email": "advocateadmin@example.com",
+    "advocate_email": "advocate@example.com",
+    "case_number": "",
+    "case_type_id": 1,
+    "first_day_of_trial": "2015-06-01",
+    "estimated_trial_length": 3,
+    "actual_trial_length": 3,
+    "trial_concluded_at": "2015-06-03",
+    "advocate_category": "QC",
+    "offence_id": 1,
+    "court_id": 1,
+    "cms_number": "12345678",
+    "additional_information": "string",
+    "apply_vat": true,
+    "trial_fixed_notice_at": "2015-06-01",
+    "trial_fixed_at": "2015-06-01",
+    "trial_cracked_at": "2015-06-01",
+    "defendants": [
+      {
+        "first_name": "case",
+        "last_name": "system",
+        "date_of_birth": "1979-12-10",
+        "order_for_judicial_apportionment": true,
+        "representation_orders": [
+          {
+            "maat_reference": "1234567890",
+            "representation_order_date": "2015-05-01"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Some bits of code have been refactor to make it easier to validate against 2 different schemas,
one is a basic version to fail as early as possible, the other is a full schema to validate
against each of the claims found in the JSON imported.
