### PR TITLE
Move force_ssl configuration from app level to controller level.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception unless ENV['DISABLE_CSRF'] == '1'
 
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Excluding some endpoints due to ELB only talking HTTP on port 80 and not following redirects to https.
+  force_ssl except: [:ping, :healthcheck], if: :ssl_enabled?
+
   helper_method :current_user_messages_count
   helper_method :signed_in_user_profile_path
   helper_method :current_user_persona_is?
@@ -64,6 +68,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def ssl_enabled?
+    Rails.env.production?
+  end
 
   def after_sign_in_path_for_super_admin
     super_admins_root_url

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,9 +52,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
-
   # Set to :debug to see everything in the log.
   config.log_level = :info
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     before do
       allow(Rails).to receive(:env).and_return(double(development?: false, production?: true))
+      request.env['HTTPS'] = 'on'
     end
 
     context 'ActiveRecord::RecordNotFound' do
@@ -168,6 +169,24 @@ RSpec.describe ApplicationController, type: :controller do
         get :another_exception
         expect(response).to redirect_to(error_500_url)
       end
+    end
+  end
+
+  context 'force_ssl when in production' do
+    controller do
+      def test_endpoint; end
+    end
+
+    before do
+      allow(Rails).to receive(:env).and_return(double(development?: false, production?: true))
+    end
+
+    it 'should redirect to https' do
+      routes.draw { get 'test_endpoint' => 'anonymous#test_endpoint' }
+
+      get :test_endpoint
+      expect(response.status).to eq(301)
+      expect(response.location).to start_with('https:')
     end
   end
 end

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe HeartbeatController, type: :controller do
+
+  describe 'ping and heartbeat do not force ssl' do
+    before do
+      allow(Rails).to receive(:env).and_return(double(development?: false, production?: true))
+    end
+
+    after do
+      expect(response.status).not_to eq(301)
+    end
+
+    it 'ping endpoint' do
+      get :ping
+    end
+
+    it 'healthcheck endpoint' do
+      get :healthcheck
+    end
+  end
+
   describe '#ping' do
     context 'when environment variables not set' do
       before do


### PR DESCRIPTION
This is so we have a greater flexibility to exclude some endpoints like ping,
due to ELB only talking HTTP on port 80 and not following redirects to https.
