### PR TITLE
Sidekiq will use REDIS_URL env var if set.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,5 @@ module AdvocateDefencePayments
     end
 
     config.active_job.queue_adapter = :sidekiq
-    Sidekiq.default_worker_options = { retry: 1 }
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,12 @@
+# Sidekiq uses Redis to store all of its job and operational data.
+# By default, Sidekiq tries to connect to Redis at localhost:6379
+#
+# You can also set the Redis url using environment variables.
+# The generic REDIS_URL may be set to specify the Redis server.
+#
+# Otherwise it can be configured here using both the blocks
+# Sidekiq.configure_server and Sidekiq.configure_client
+#
+# https://github.com/mperham/sidekiq/wiki/Using-Redis
+
+Sidekiq.default_worker_options = { retry: 1 }

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# last modified 12-09-2015
+# last modified 03-08-2016
 set -ex
 
 echo "DEBUG: *************************************************************"
@@ -77,8 +77,13 @@ reseed)
     ;;
 esac
 
-echo "starting redis server"
-service redis-server start
+# if REDIS_URL is not set then we start redis-server locally
+if [ -z ${REDIS_URL+x} ]; then
+    echo "starting redis server"
+    service redis-server start
+else
+    echo "using remote redis server"
+fi
 
 echo "starting scheduler daemon"
 bundle exec scheduler_daemon start


### PR DESCRIPTION
Moved Sidekiq config to their own initializer to follow the conventions and to add some explanation about Redis configuration.
