### PR TITLE
Disallow lowercase letters in supplier numbers and better exception handling

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -385,7 +385,6 @@ Style/SpaceAfterComma:
     - 'app/controllers/external_users/certifications_controller.rb'
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/claims_helper.rb'
-    - 'app/models/allocation.rb'
     - 'app/models/claim/transfer_brain.rb'
     - 'app/models/claims/allocation_filters.rb'
     - 'app/presenters/claim/base_claim_presenter.rb'

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -85,10 +85,12 @@ class Allocation
 
   def allocate_or_error_claim!(claim)
     if claim.case_workers.exists?
-      errors.add(:base,"Claim #{claim.case_number} has already been allocated to #{claim.case_workers.first.name}")
+      errors.add(:base, "Claim #{claim.case_number} has already been allocated to #{claim.case_workers.first.name}")
     else
       allocate_claim! claim
     end
+  rescue => ex
+    errors.add(:base, "Claim #{claim.case_number} has errors: #{ex.message}")
   end
 
   def rollback_all_allocations!

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -13,7 +13,7 @@
 #
 
 class ExternalUser < ActiveRecord::Base
-  SUPPLIER_NUMBER_REGEX ||= /\A[0-9a-zA-Z]{5}\z/
+  SUPPLIER_NUMBER_REGEX ||= /\A[0-9A-Z]{5}\z/
 
   auto_strip_attributes :supplier_number, squish: true, nullify: true
 

--- a/app/models/supplier_number.rb
+++ b/app/models/supplier_number.rb
@@ -8,7 +8,7 @@
 #
 
 class SupplierNumber < ActiveRecord::Base
-  SUPPLIER_NUMBER_REGEX ||= /\A[0-9][a-zA-Z][0-9]{3}[a-zA-Z]\z/
+  SUPPLIER_NUMBER_REGEX ||= /\A[0-9][A-Z][0-9]{3}[A-Z]\z/
 
   auto_strip_attributes :supplier_number, squish: true, nullify: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
     errors:
       blank: &blank "cannot be blank"
       inclusion: &inclusion 'is not included in the list'
+      invalid_supplier_number: &invalid_supplier_number 'invalid format or lowercase'
     actions:
       edit: &edit 'Edit'
       delete: &delete 'Delete'
@@ -114,6 +115,14 @@ en:
               blank: "can't be blank"
             claim_ids:
               blank: "can't be blank"
+        supplier_number:
+          attributes:
+            supplier_number:
+              invalid: *invalid_supplier_number
+        provider:
+          attributes:
+            supplier_number:
+              invalid: *invalid_supplier_number
         external_user:
           attributes:
             roles:
@@ -121,7 +130,7 @@ en:
               inclusion: *inclusion
             supplier_number:
               blank: cannot be blank
-              invalid: 'must be 5 alpha-numeric characters'
+              invalid: 'must be 5 alpha-numeric uppercase characters'
         case_worker:
           attributes:
             roles:

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe ExternalUser, type: :model do
       context 'for advocate' do
         before { subject.roles = ['advocate'] }
 
+        let(:format_error) { ['must be 5 alpha-numeric uppercase characters'] }
+
         it { should validate_presence_of(:supplier_number) }
 
         it 'should not be valid without a supplier number' do
@@ -106,19 +108,19 @@ RSpec.describe ExternalUser, type: :model do
         it 'should fail validation if too long' do
           a = build :external_user, supplier_number: 'ACC123', provider: provider
           expect(a).not_to be_valid
-          expect(a.errors[:supplier_number]).to eq( ['must be 5 alpha-numeric characters'] )
+          expect(a.errors[:supplier_number]).to eq(format_error)
         end
 
         it 'should fail validation if too short' do
           a = build :external_user, supplier_number: 'AC12', provider: provider
           expect(a).not_to be_valid
-          expect(a.errors[:supplier_number]).to eq( ['must be 5 alpha-numeric characters'] )
+          expect(a.errors[:supplier_number]).to eq(format_error)
         end
 
         it 'should fail validation if not alpha-numeric' do
           a = build :external_user, supplier_number: 'AC-12', provider: provider
           expect(a).not_to be_valid
-          expect(a.errors[:supplier_number]).to eq( ['must be 5 alpha-numeric characters'] )
+          expect(a.errors[:supplier_number]).to eq(format_error)
         end
 
         it 'should pass validation if 5 alpha-numeric' do

--- a/spec/models/supplier_number_spec.rb
+++ b/spec/models/supplier_number_spec.rb
@@ -17,9 +17,18 @@ RSpec.describe SupplierNumber, type: :model do
   subject { build(:supplier_number) }
 
   context 'validates supplier number format' do
+    let(:format_error) { ['invalid format or lowercase'] }
+
     it 'fails for incorrect format' do
-      allow(subject).to receive(:supplier_number).and_return('abc123')
+      allow(subject).to receive(:supplier_number).and_return('ABC123')
       expect(subject).not_to be_valid
+      expect(subject.errors[:supplier_number]).to eq(format_error)
+    end
+
+    it 'fails for correct format but lowercase' do
+      allow(subject).to receive(:supplier_number).and_return('1b222z')
+      expect(subject).not_to be_valid
+      expect(subject.errors[:supplier_number]).to eq(format_error)
     end
 
     it 'pass for correct format' do


### PR DESCRIPTION
Make sure all current supplier numbers in database are uppercase and do not
allow future ones to contain lower case letters.

Also, a not handled exception could be raised when allocating claims with
validations not met (like in this case supplier numbers). Now we handle
the exception and gives the user feedback (no more 500 error page).
