### PR TITLE
Remove litigator selector from the lgfs claim forms.

### DIFF
--- a/app/controllers/external_users/advocates/claims_controller.rb
+++ b/app/controllers/external_users/advocates/claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Advocates::ClaimsController < ExternalUsers::ClaimsControll
 
 private
 
-  def load_external_users_in_provider
-    @advocates_in_provider = @provider.advocates if @external_user.admin?
-  end
-
   def build_nested_resources
     @claim.fixed_fees.build if @claim.fixed_fees.none?
 

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -16,7 +16,6 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   before_action :initialize_json_document_importer, only: [:index]
 
   before_action :set_and_authorize_claim, only: [:show, :edit, :update, :unarchive, :clone_rejected, :destroy, :summary, :confirmation, :show_message_controls, :messages]
-  before_action :load_external_users_in_provider, only: [:new, :create, :edit, :update]
   before_action :set_doctypes, only: [:show]
   before_action :generate_form_id, only: [:new, :edit]
   before_action :initialize_submodel_counts
@@ -340,7 +339,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def params_with_external_user_and_creator
     form_params = claim_params
-    form_params[:external_user_id] = @external_user.id unless @external_user.admin?
+    form_params[:external_user_id] ||= @external_user.id
     form_params[:creator_id] = @external_user.id
     form_params
   end

--- a/app/controllers/external_users/litigators/claims_controller.rb
+++ b/app/controllers/external_users/litigators/claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Litigators::ClaimsController < ExternalUsers::ClaimsControl
 
 private
 
-  def load_external_users_in_provider
-    @litigators_in_provider = @provider.litigators if @external_user.admin?
-  end
-
   def build_nested_resources
     @claim.build_graduated_fee if @claim.graduated_fee.nil?
     @claim.build_warrant_fee if @claim.warrant_fee.nil?

--- a/app/controllers/external_users/litigators/interim_claims_controller.rb
+++ b/app/controllers/external_users/litigators/interim_claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Litigators::InterimClaimsController < ExternalUsers::Claims
 
 private
 
-  def load_external_users_in_provider
-    @litigators_in_provider = @provider.litigators if @external_user.admin?
-  end
-
   def build_nested_resources
     @claim.build_interim_fee if @claim.interim_fee.nil?
     @claim.build_warrant_fee if @claim.warrant_fee.nil?

--- a/app/controllers/external_users/litigators/transfer_claims_controller.rb
+++ b/app/controllers/external_users/litigators/transfer_claims_controller.rb
@@ -14,10 +14,6 @@ class ExternalUsers::Litigators::TransferClaimsController < ExternalUsers::Claim
 
 private
 
-  def load_external_users_in_provider
-    @litigators_in_provider = @provider.litigators if @external_user.admin?
-  end
-
   def build_nested_resources
     @claim.build_transfer_detail if @claim.transfer_detail.nil?
     @claim.build_transfer_fee    if @claim.transfer_fee.nil?

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -113,9 +113,11 @@ class BaseValidator < ActiveModel::Validator
     add_error(attribute, message) if @record.__send__(attribute) < date.to_date
   end
 
-  def validate_has_role(object, role, error_message_key, error_message)
+  def validate_has_role(object, role_or_roles, error_message_key, error_message)
     return if object.nil?
-    unless object.is?(role)
+
+    roles = *role_or_roles
+    unless roles.any? { |role| object.is?(role) }
       @record.errors[error_message_key] << error_message
     end
   end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -31,7 +31,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def validate_external_user_has_required_role
-    validate_has_role(@record.external_user, @record.external_user_type, :external_user,  "must have #{@record.external_user_type} role")
+    validate_has_role(@record.external_user, [@record.external_user_type, :admin], :external_user,  "must have #{@record.external_user_type} role")
   end
 
   def validate_creator_and_external_user_have_same_provider

--- a/app/views/external_users/claims/case_details/_case_owner_select.html.haml
+++ b/app/views/external_users/claims/case_details/_case_owner_select.html.haml
@@ -1,7 +1,0 @@
-.form-row
-  .form-col{class: error_class?(@error_presenter, :external_user)}
-    %a{:id => :external_user}
-    %label{:for => "claim_external_user_id_autocomplete"}
-      = label
-    = f.collection_select :external_user_id, external_users_collection, :id, :name_and_number, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete'}
-    = validation_error_message(@error_presenter, :external_user)

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -1,11 +1,5 @@
-- external_user_label = @claim.agfs? ? t('.advocate') : t('.litigator')
-
 %h2.bold-medium
-  - if current_user.persona.admin?
-    = t('.case_instructed_offence', type: external_user_label.downcase)
-  - else
-    = t('.case_offence')
-
+  = t('.case_offence')
 
 - if @claim.agfs?
   %fieldset
@@ -19,9 +13,14 @@
 
 %fieldset
   .form-group
-    - if current_user.persona.admin?
-      - external_users_collection = @claim.agfs? ? @advocates_in_provider : @litigators_in_provider
-      = render partial: 'external_users/claims/case_details/case_owner_select', locals: { f: f, label: external_user_label, external_users_collection: external_users_collection }
+    - if @claim.agfs? && @external_user.admin?
+      .form-row
+        .form-col{class: error_class?(@error_presenter, :external_user)}
+          %a{:id => :external_user}
+          %label{:for => "claim_external_user_id_autocomplete"}
+            = t('.advocate')
+          = f.collection_select :external_user_id, @provider.advocates, :id, :name_and_number, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete'}
+          = validation_error_message(@error_presenter, :external_user)
 
     .form-row
       .form-col{class: error_class?(@error_presenter, :case_type)}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,7 +453,6 @@ en:
           advocate: *advocate
           advocate_category: 'Advocate category'
           case_offence: 'Case & offence'
-          case_instructed_offence: 'Case, instructed %{type} & offence'
           case_number: 'Case number'
           transfer_case_number: 'Transfer case number (optional)'
           case_type: 'Case type'

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -518,7 +518,6 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
   HashWithIndifferentAccess.new(
     {
      "source" => 'web',
-     "external_user_id" => "4",
      "case_type_id" => case_type.id.to_s,
      "court_id" => court.id.to_s,
      "case_number" => "CASE98989",

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -474,7 +474,6 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
        "case_number" => "A12345678",
        "offence_class_id" => offence.offence_class.id.to_s,
        "offence_id" => offence.id.to_s,
-       "external_user_id" => external_user.id.to_s,
        "first_day_of_trial_dd" => '13',
        "first_day_of_trial_mm" => '5',
        "first_day_of_trial_yyyy" => '2015',


### PR DESCRIPTION
**PT#126855405**

Only advocate admins will continue to have the dropdown selector in the claim form.
Litigator admins do not require this dropdown anymore.

Some code cleaning, as now much of the code is limited to advocates.
