### PR TITLE
Fix for missing re-allocate button when pool was selected.

### DIFF
--- a/app/assets/javascripts/modules/case_worker/ReAllocation.js
+++ b/app/assets/javascripts/modules/case_worker/ReAllocation.js
@@ -19,9 +19,9 @@ moj.Modules.ReAllocation = {
 
   showHideCaseWorkersList: function(){
     if(this.$ReAllocationRadioButtons.find(':checked').val() === 'false' ){
-      this.$CaseWorkerList.slideDown();
+      this.$CaseWorkerList.show();
     }else{
-      this.$CaseWorkerList.slideUp();
+      this.$CaseWorkerList.hide();
     }
   }
 };

--- a/app/assets/stylesheets/moj/_forms.scss
+++ b/app/assets/stylesheets/moj/_forms.scss
@@ -38,9 +38,12 @@ label {
   }
 }
 
-.js-case-worker-list{
+.case-worker-reallocation{
+  padding-bottom: 30px;
+
   .margin-spacer-sm{
-    margin-top: 25px;
+    padding: 0;
+    margin: 25px 0 0;
   }
   .column-one-quarter{
     padding: 0;

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -34,9 +34,8 @@
           Case worker
           = f.radio_button :deallocate, false, checked: true, value: false
 
-  .js-case-worker-list.grid-row.form-group
-    / .column-half
-    .column-one-quarter
+  .case-worker-reallocation.grid-row.form-group
+    .column-one-quarter.js-case-worker-list
       = f.label :case_worker_id
       = f.grouped_collection_select :case_worker_id, Location.all, :case_workers, :name, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
     .column-half.margin-spacer-sm


### PR DESCRIPTION
A layout bug was introduced as part of PR https://github.com/ministryofjustice/advocate-defence-payments/pull/1689

This fixes the button being hidden when selecting 'allocation pool'. Only the dropdown must be hidden.
Also removes the show/hide animation as it is only one element being hidden, not both.
