### PR TITLE
New ActionMailer delivery method for GOV.UK Notify service.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'kaminari',               '~> 0.16.2'
 gem 'libreconv',              '~> 0.9.0'
 gem 'logstasher',             '0.6.2'
 gem 'logstuff',               '0.0.2'
+gem 'notifications-ruby-client', '~> 0.0.1', git: 'https://github.com/alphagov/notifications-ruby-client.git'
 gem 'paperclip',              '~> 4.2.2'
 gem 'paper_trail',            '4.0.2' # version locked, https://github.com/airblade/paper_trail/issues/738
 gem 'pg',                     '~> 0.18.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/alphagov/notifications-ruby-client.git
+  revision: 17a638cfff93201254ae58e67a7b071537c8a32d
+  specs:
+    notifications-ruby-client (0.0.1)
+      jwt (~> 1.5)
+
+GIT
   remote: https://github.com/jalkoby/scheduler_daemon.git
   revision: 3ed40449777383cf38b7c814075c992974add3df
   specs:
@@ -274,6 +281,7 @@ GEM
     json (1.8.3)
     json-schema (2.6.2)
       addressable (~> 2.3.8)
+    jwt (1.5.4)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -622,6 +630,7 @@ DEPENDENCIES
   logstasher (= 0.6.2)
   logstuff (= 0.0.2)
   meta_request (~> 0.3.4)
+  notifications-ruby-client (~> 0.0.1)!
   paper_trail (= 4.0.2)
   paperclip (~> 4.2.2)
   parallel_tests

--- a/app/mailers/govuk_notify_mailer.rb
+++ b/app/mailers/govuk_notify_mailer.rb
@@ -1,0 +1,37 @@
+# Extract to gem and inherit in the app from this class
+#
+class GovukNotifyMailer < ActionMailer::Base
+  default delivery_method: :govuk_notify
+
+  attr_accessor :govuk_notify_template
+  attr_accessor :govuk_notify_personalisation
+
+  protected
+
+  def mail(headers = {})
+    _validate!
+
+    headers[:body] ||= _default_body
+
+    message = super(headers)
+    message.govuk_notify_template = govuk_notify_template
+    message.govuk_notify_personalisation = govuk_notify_personalisation
+  end
+
+  def set_template(template)
+    self.govuk_notify_template = template
+  end
+
+  def set_personalisation(personalisation)
+    self.govuk_notify_personalisation = personalisation
+  end
+
+  def _validate!
+    raise ArgumentError, 'Missing template ID. Make sure to use `set_template` before calling `mail`' if govuk_notify_template.nil?
+    raise ArgumentError, 'Missing personalisation. Make sure to use `set_personalisation` before calling `mail`' if govuk_notify_personalisation.nil?
+  end
+
+  def _default_body
+    'This is a GOV.UK Notify email with template %s and personalisation: %s' % [govuk_notify_template, govuk_notify_personalisation]
+  end
+end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,0 +1,19 @@
+class NotifyMailer < GovukNotifyMailer
+
+  # Define methods as usual, and set the template and personalisation accordingly
+  # Then just use mail() as with any other ActionMailer, with the recipient email.
+  # This is just an example:
+  #
+  def new_message_test_email(claim)
+    user = claim.external_user.user
+
+    set_template('9661d08a-486d-4c67-865e-ad976f17871d')
+    set_personalisation(
+      full_name: user.name,
+      messages_url: external_users_claim_url(claim, messages: true)
+    )
+
+    mail(to: user.email)
+  end
+
+end

--- a/config/initializers/govuk_notify_mailer.rb
+++ b/config/initializers/govuk_notify_mailer.rb
@@ -1,0 +1,16 @@
+# Extract to gem, except configuration
+#
+require_relative '../../lib/govuk_notify_delivery'
+
+# TODO: ask platforms to expose these env variables, once we have them
+#
+ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyDelivery,
+  service_id: ENV['GOVUK_NOTIFY_SERVICE_ID'],
+  secret_key: ENV['GOVUK_NOTIFY_API_SECRET']
+
+module Mail
+  class Message
+    attr_accessor :govuk_notify_template
+    attr_accessor :govuk_notify_personalisation
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,5 @@
 ---
 :logfile: ./log/sidekiq.log
+:queues:
+  - default
+  - mailers

--- a/lib/govuk_notify_delivery.rb
+++ b/lib/govuk_notify_delivery.rb
@@ -1,0 +1,38 @@
+# Extract to gem
+#
+require 'notifications/client'
+
+class GovukNotifyDelivery
+  attr_accessor :settings
+
+  def initialize(settings)
+    self.settings = settings
+  end
+
+  def deliver!(message)
+    notify_client.send_email(payload_for(message))
+  end
+
+
+  private
+
+  def service_id
+    settings[:service_id]
+  end
+
+  def secret_key
+    settings[:secret_key]
+  end
+
+  def payload_for(message)
+    {
+      to: message.to.first,
+      template: message.govuk_notify_template,
+      personalisation: message.govuk_notify_personalisation
+    }.to_json
+  end
+
+  def notify_client
+    @notify_client ||= Notifications::Client.new(service_id, secret_key)
+  end
+end

--- a/spec/lib/govuk_notify_delivery_spec.rb
+++ b/spec/lib/govuk_notify_delivery_spec.rb
@@ -1,0 +1,32 @@
+# Extract to gem
+#
+require 'rails_helper'
+
+describe GovukNotifyDelivery do
+
+  describe '#deliver!' do
+    let(:service_id) { 'service-123' }
+    let(:secret_key) { 'secret' }
+    let(:notify_client) { double('NotifyClient') }
+
+    let(:message) do
+      instance_double(Mail::Message,
+                      to: ['email@example.com'],
+                      govuk_notify_template: 'template-123',
+                      govuk_notify_personalisation: {name: 'John'})
+    end
+
+    subject { described_class.new(service_id: service_id, secret_key: secret_key) }
+
+    before(:each) do
+      allow(notify_client).to receive(:new).with(service_id, secret_key).and_return(notify_client)
+      allow(subject).to receive(:notify_client).and_return(notify_client)
+    end
+
+    it 'should deliver the message payload' do
+      expect(notify_client).to receive(:send_email).with("{\"to\":\"email@example.com\",\"template\":\"template-123\",\"personalisation\":{\"name\":\"John\"}}")
+      subject.deliver!(message)
+    end
+  end
+
+end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe NotifyMailer, type: :mailer do
+
+  describe 'new_message_test_email' do
+    let(:template) { '9661d08a-486d-4c67-865e-ad976f17871d' }
+
+    let(:user) { instance_double(User, name: 'Test Name', email: 'test@example.com') }
+    let(:external_user) { instance_double(ExternalUser, user: user) }
+    let(:claim) { instance_double(Claim::BaseClaim, external_user: external_user) }
+
+    let(:mail) { described_class.new_message_test_email(claim) }
+
+    it 'is a govuk_notify delivery' do
+      expect(mail.delivery_method).to be_a(GovukNotifyDelivery)
+    end
+
+    it 'sets the recipient' do
+      expect(mail.to).to eq(['test@example.com'])
+    end
+
+    it 'sets the subject' do
+      expect(mail.body).to match("This is a GOV.UK Notify email with template #{template}")
+    end
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template).to eq(template)
+    end
+
+    it 'sets the personalisation' do
+      expect(mail.govuk_notify_personalisation.keys.sort).to eq([:full_name, :messages_url])
+    end
+  end
+
+end

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -1,0 +1,8 @@
+class NotifyMailerPreview < ActionMailer::Preview
+
+  def new_message_test_email
+    claim = Claim::BaseClaim.last
+    NotifyMailer.new_message_test_email(claim)
+  end
+
+end


### PR DESCRIPTION
This PR prepare the work to be able to send emails via an external
service (GOV.UK Notify) maintaining the same interface as any other
standard ActionMailer.
Also it will use ActiveJob, and the standard delivery configuration
for enqueued deliveries.

The way it is done will simplify extracting to a gem as there is no
coupling with our own app.

An example 'NotifyMailer' is included with a test email method.
