### PR TITLE
Remove the option 'Travel costs' from the disbursements options.

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -117,7 +117,7 @@ module API
         resource :disbursement_types do
           desc "Return all Disbursement Types."
           get do
-            present DisbursementType.all, with: API::Entities::DisbursementType
+            present DisbursementType.allowable_types, with: API::Entities::DisbursementType
           end
         end
 

--- a/app/models/disbursement_type.rb
+++ b/app/models/disbursement_type.rb
@@ -14,4 +14,13 @@ class DisbursementType < ActiveRecord::Base
   has_many :disbursements, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  # Temporal as there are claims using this disbursement type and we can't
+  # reassign those to another one, so for new claims we hide this type from dropdowns
+  # and API but old ones will continue to work and validate.
+  # Revisit this in some weeks once all old claims have been processed.
+  #
+  def self.allowable_types
+    all.where.not(name: 'Travel costs')
+  end
 end

--- a/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
+++ b/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
@@ -7,7 +7,7 @@
         %label.form-label
           = t('.disbursement_type')
         %a{id: "disbursement_#{@disbursement_count}_disbursement_type"}
-        = f.collection_select :disbursement_type_id, DisbursementType.all, :id, :name, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete', style: 'width:350px'}
+        = f.collection_select :disbursement_type_id, DisbursementType.allowable_types, :id, :name, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete', style: 'width:350px'}
         = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")
 
       .column-one-quarter.fee-amount

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -65,7 +65,7 @@ describe API::V1::DropdownData do
         FEE_TYPE_ENDPOINT => API::Entities::BaseFeeType.represent(Fee::BaseFeeType.all).to_json,
         EXPENSE_TYPE_ENDPOINT => API::Entities::ExpenseType.represent(ExpenseType.all).to_json,
         EXPENSE_REASONS_ENDPOINT => API::Entities::ExpenseReasonSet.represent(ExpenseType.reason_sets).to_json,
-        DISBURSEMENT_TYPE_ENDPOINT => API::Entities::DisbursementType.represent(DisbursementType.all).to_json,
+        DISBURSEMENT_TYPE_ENDPOINT => API::Entities::DisbursementType.represent(DisbursementType.allowable_types).to_json,
         TRANSFER_STAGES_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::TRANSFER_STAGES.to_a).to_json,
         TRANSFER_CASE_CONCLUSIONS_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::CASE_CONCLUSIONS.to_a).to_json
       }

--- a/spec/models/disbursement_type_spec.rb
+++ b/spec/models/disbursement_type_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe DisbursementType, type: :model do
 
   it { should validate_presence_of(:name) }
   it { should validate_uniqueness_of(:name) }
+
+  describe '.allowable_types' do
+    let!(:travel_costs) { create(:disbursement_type, name: 'Travel costs') }
+
+    it 'should exclude "Travel costs" from the result set' do
+      expect(described_class.allowable_types).to_not include(travel_costs)
+    end
+  end
 end


### PR DESCRIPTION
As there are claims using this disbursement and we can't reassign those
to another disbursement, a temporal workaround was discussed to 'hide'
the option from the dropdowns and API but to continue in the database so
old claims will continue working and validating, but new ones will not
be able to select 'Travel costs'.

Sometime from now it will be safe to remove the option from the database.

PT#126855639
