### PR TITLE
Open feedback and bug report links in separate tabs.

### DIFF
--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,2 +1,7 @@
 module FeedbackHelper
+
+  def referrer_is_claim?(referrer)
+    referrer =~ /claims/
+  end
+
 end

--- a/app/views/feedback/_claim_edit_alert.html.haml
+++ b/app/views/feedback/_claim_edit_alert.html.haml
@@ -1,0 +1,2 @@
+%p
+  Your claim is still available on a separate tab.

--- a/app/views/feedback/bug_report.html.haml
+++ b/app/views/feedback/bug_report.html.haml
@@ -7,6 +7,7 @@
   .panel.panel-border-wide
     %p
       Tell us about your experience of using this service today. Your answers to the following questions will help us improve the service.
+      = render partial: 'feedback/claim_edit_alert' if referrer_is_claim?(@feedback.referrer)
 
   = form_for @feedback, builder: AdpFormBuilder, url: feedback_index_path, html: { novalidate: 'novalidate', class: 'normal'} do |f|
     = f.hidden_field :type

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -7,6 +7,7 @@
   .panel.panel-border-wide
     %p
       We will use your answers to the questions below to help us build a better service.
+      = render partial: 'feedback/claim_edit_alert' if referrer_is_claim?(@feedback.referrer)
 
   = form_for @feedback, url: feedback_index_path(email: params[:email]), html: { novalidate: 'novalidate', class: 'normal'} do |f|
     = f.hidden_field :type

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -6,7 +6,7 @@
   %li
     = link_to 'Terms and Conditions', tandcs_page_path
   %li
-    = link_to "Feedback", new_feedback_path
+    = link_to "Feedback", new_feedback_path, target: '_blank'
   %li
     %span="Built by"
     %a{:href => "https://mojdigital.blog.gov.uk/"}

--- a/app/views/shared/_phase_banner.haml
+++ b/app/views/shared/_phase_banner.haml
@@ -4,7 +4,7 @@
       = "BETA"
     %span
       This is a new service – your
-      = link_to content_tag(:span, 'Give your ', class: 'visuallyhidden') + "feedback", new_feedback_path(type: 'feedback')
+      = link_to content_tag(:span, 'Give your ', class: 'visuallyhidden') + "feedback", new_feedback_path, target: '_blank'
       will help us to improve it.
       You can
-      = link_to "report a fault here.", new_feedback_path(type: 'bug_report')
+      = link_to "report a fault here.", new_feedback_path(type: 'bug_report'), target: '_blank'

--- a/spec/helpers/feedback_helper_spec.rb
+++ b/spec/helpers/feedback_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe FeedbackHelper do
+
+  describe '#referrer_is_claim?' do
+    %w(claims /claims claims/ /claims/).each do |path|
+      it "should be truthy for path containing `#{path}`" do
+        expect(helper.referrer_is_claim?(path)).to be_truthy
+      end
+    end
+
+    it 'should be falsey for path not containing `claims` string' do
+      expect(helper.referrer_is_claim?('/claim_intention')).to be_falsey
+    end
+  end
+
+end


### PR DESCRIPTION
Also if we detect they came from a claims page we add a note to indicate
that the claim is still available in another tab.

This is however not 100% reliable due to how referrer works, but should
catch most of the important cases (giving feedback while creating a claim).

PT#127165105
