### PR TITLE
Do not allow deleting case workers with sent messages.

### DIFF
--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -42,8 +42,14 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
   # NOTE: update_password in PasswordHelper
 
   def destroy
-    @case_worker.destroy
-    redirect_to case_workers_admin_case_workers_url, notice: 'Case worker deleted'
+    result = if @case_worker.user.messages_sent.any?
+               {alert: 'A case worker cannot be deleted if they\'ve created messages in any claim'}
+             else
+               @case_worker.destroy
+               {notice: 'Case worker deleted'}
+             end
+
+    redirect_to case_workers_admin_case_workers_url, result
   end
 
   private

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -197,6 +197,8 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
     describe "GET #show" do
       subject { create(:claim) }
 
+      let(:another_case_worker) { create(:case_worker) }
+
       it "returns http success" do
         get :show, id: subject
         expect(response).to have_http_status(:success)
@@ -215,14 +217,11 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
       it 'automatically marks unread messages on claim for current user as "read"' do
         subject.case_workers << @case_worker
 
-        message_1 = create(:message, claim_id: subject.id, sender_id: @case_worker.user.id)
-        message_2 = create(:message, claim_id: subject.id, sender_id: @case_worker.user.id)
-        message_3 = create(:message, claim_id: subject.id, sender_id: @case_worker.user.id)
+        create_list(:message, 3, claim_id: subject.id, sender_id: another_case_worker.user.id)
 
         expect(subject.unread_messages_for(@case_worker.user).count).to eq(3)
 
         get :show, id: subject
-
 
         expect(subject.unread_messages_for(@case_worker.user).count).to eq(0)
       end

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -477,6 +477,8 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
   describe "GET #show" do
     subject { create(:claim, external_user: advocate) }
 
+    let(:case_worker) { create(:case_worker) }
+
     it "returns http success" do
       get :show, id: subject
       expect(response).to have_http_status(:success)
@@ -493,9 +495,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
     end
 
     it 'automatically marks unread messages on claim for current user as "read"' do
-      message_1 = create(:message, claim_id: subject.id, sender_id: advocate.user.id)
-      message_2 = create(:message, claim_id: subject.id, sender_id: advocate.user.id)
-      message_3 = create(:message, claim_id: subject.id, sender_id: advocate.user.id)
+      create_list(:message, 3, claim_id: subject.id, sender_id: case_worker.user.id)
 
       expect(subject.unread_messages_for(advocate.user).count).to eq(3)
 

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
     claim
 
     after(:build) do |message|
-      message.sender_id = create(:user, email: Faker::Internet.email, password: 'password', password_confirmation: 'password').id
+      message.sender_id ||= create(:user, email: Faker::Internet.email, password: 'password', password_confirmation: 'password').id
     end
   end
 


### PR DESCRIPTION
This is a safety mechanism to ensure no case workers can be deleted
if they have created any message in any claim, so no claims can be
rendered orphaned, and thus not possible to process.

A soft-delete will be a better way of handle this situations, and will
be implemented in the coming weeks.

As a side note, while creating the tests for this, I found some tests we had already were not working properly because the messages factory was overriding whatever sender_id you pass and always creating a new User (and thus a new sender_id each time).
