### PR TITLE
Better cleaning of expense fields and handling of nil values.

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -11,6 +11,7 @@ moj.Modules.NewClaim = {
   $amount : {},
   $vat_amount : {},
   $reasonText : {},
+  $date : {},
   $ariaLiveRegion : {},
 
   init : function() {
@@ -100,6 +101,7 @@ moj.Modules.NewClaim = {
     this.$amount = this.$currentExpense.find('.js-expense-amount');
     this.$vat_amount = this.$currentExpense.find('.js-expense-vat-amount');
     this.$reasonText = this.$currentExpense.find('.js-expense-reason-text');
+    this.$date = this.$currentExpense.find('.js-expense-date');
     this.$ariaLiveRegion = this.$element.next();
   },
 
@@ -118,14 +120,21 @@ moj.Modules.NewClaim = {
         .add(self.$hours)
         .add(self.$reason)
         .add(self.$reasonText)
+        .add(self.$date)
         .hide();
     }else{
       self.showExpenseFields(elem);
     }
+
+    // Clear unused fields to avoid submitting them and causing validation errors server-side
+    self.clearUnusedFields(self.$currentExpense);
   },
 
   showExpenseFields : function (elem){
     var self = this;
+
+    self.$date.show();
+
     self.$amount.show();
 
     self.$vat_amount.show();
@@ -151,9 +160,6 @@ moj.Modules.NewClaim = {
 
     self.$currentExpense.find('.js-expense-amount').toggleClass('first-col', !self.dataAttribute.hours);
 
-    // Clear unused fields to avoid submitting them and causing validation errors server-side
-    self.clearUnusedFields(self.$currentExpense);
-
     self.$ariaLiveRegion.children().hide().end();
   },
 
@@ -167,6 +173,7 @@ moj.Modules.NewClaim = {
 
   clearUnusedFields: function(expenseGroup) {
     expenseGroup.find('input:hidden').not('input[type="hidden"]').not('input[type="radio"]').val('');
+    expenseGroup.find('select:hidden').not('select[type="hidden"]').val('');
     expenseGroup.find('input:hidden[type="radio"]').prop("checked", false);
   },
 

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -1,20 +1,16 @@
 class ExpensePresenter < BasePresenter
   presents :expense
 
-  # def dates_attended_delimited_string
-  #   expense.dates_attended.order(date: :asc).map(&:to_s).join(', ')
-  # end
-
   def amount
-    h.number_to_currency(expense.amount || 0)
+    h.number_to_currency(expense.amount.to_f)
   end
 
   def vat_amount
-    h.number_to_currency(expense.vat_amount || 0)
+    h.number_to_currency(expense.vat_amount.to_f)
   end
 
   def total
-    h.number_to_currency(expense.amount + expense.vat_amount)
+    h.number_to_currency(expense.amount.to_f + expense.vat_amount.to_f)
   end
 
   def distance

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -33,7 +33,7 @@
                             errors: @error_presenter
 
     .grid-row
-      .column-one-third{class: "expense_#{@expense_count}_date"}
+      .column-one-third{class: "js-expense-date expense_#{@expense_count}_date"}
         = f.gov_uk_date_field :date,
                                 legend_text: 'Date of expenses',
                                 legend_class: 'govuk-legend',


### PR DESCRIPTION
When selecting a expense type, and filling (or not) any of the values,
deselecting the expense type didn't trigger the cleaning of the fields.

Also, better handling in the presenter of nil values.

https://sentry.service.dsd.io/mojds/private-beta/group/1397/
