### PR TITLE
Offence seletion for Litigiators to mimic that for advocates

### DIFF
--- a/app/interfaces/api/v1/claim_params_helper.rb
+++ b/app/interfaces/api/v1/claim_params_helper.rb
@@ -9,9 +9,7 @@ module API::V1
       optional :creator_email, type: String, desc: "REQUIRED: The ADP administrator account email address that uniquely identifies the creator of the claim."
       optional :court_id, type: Integer, desc: "REQUIRED: The unique identifier for this court"
       optional :case_type_id, type: Integer, desc: "REQUIRED: The unique identifier of the case type"
-      optional :offence_id, type: Integer, desc: "REQUIRED: The unique identifier for this offence. For advocate claims, " +
-                                                 "use an id from the list provided by the /api/offences endpoint, for all " +
-                                                 "litigator claims, use the lgfs_offence_id from the list provided by the /api/offence_classes endpoint."
+      optional :offence_id, type: Integer, desc: "REQUIRED: The unique identifier for this offence."
       optional :case_number, type: String, desc: "REQUIRED: The case number"
       optional :cms_number, type: String, desc: "OPTIONAL: The CMS number"
       optional :additional_information, type: String, desc: "OPTIONAL: Any additional information"

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -20,7 +20,7 @@ class Offence < ActiveRecord::Base
 
   default_scope { includes(:offence_class).order(:description, :offence_class_id) }
 
-  scope :unique_name,   -> { unscoped.select(:description).distinct }
+  scope :unique_name,   -> { unscoped.select(:description).distinct.order(:description) }
   scope :miscellaneous, -> { where(description: 'Miscellaneous/other') }
 
   def offence_class_description

--- a/app/validators/claim/litigator_common_validations.rb
+++ b/app/validators/claim/litigator_common_validations.rb
@@ -31,7 +31,6 @@ module Claim
 
     def validate_offence
       validate_presence(:offence, "blank_class")
-      # validate_inclusion(:offence, Offence.miscellaneous.to_a, "invalid_class")
     end
 
     def validate_case_concluded_at

--- a/app/validators/claim/litigator_common_validations.rb
+++ b/app/validators/claim/litigator_common_validations.rb
@@ -31,7 +31,7 @@ module Claim
 
     def validate_offence
       validate_presence(:offence, "blank_class")
-      validate_inclusion(:offence, Offence.miscellaneous.to_a, "invalid_class")
+      # validate_inclusion(:offence, Offence.miscellaneous.to_a, "invalid_class")
     end
 
     def validate_case_concluded_at

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -67,37 +67,37 @@
   = render partial: 'external_users/claims/case_details/trial_detail_fields', locals: { f: f }
   = render partial: 'external_users/claims/case_details/retrial_detail_fields', locals: { f: f }
 
-  %fieldset
-    #offence
-      .form-row
-        .form-col.form-col-one-half{class: error_class?(@error_presenter, :offence)}
-          = f.anchored_label t('.offence_category'), 'offence_category_description_autocomplete'
-          .form-hint.xsmall.zero-vert-margin
-            = "If the offence category is not listed, choose \"Miscellaneous/other\""
-          - if @claim.new_record?
-            - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
-          - else
-            - selected_offence_category = @claim.offence.description rescue nil
-
-          = collection_select :offence_category,
-                                :description,
-                                @offence_descriptions,
-                                :description, :description,
-                                { include_blank: '&#160;'.html_safe, selected: selected_offence_category },
-                                { class: 'form-control autocomplete' }
-          = validation_error_message(@error_presenter, :offence)
-
-        .form-col
-          .offence-class-select
-            = render partial: 'external_users/claims/case_details/offence_select', locals: { offences: @offences }
-          = f.hidden_field :offence_id
-
-- unless @claim.agfs?
-  .form-row
-    .form-col.form-col-two-thirds
-      = render partial: 'external_users/claims/case_details/offence_id_select', locals: { f: f }
-
-  - unless @claim.interim?
+%fieldset
+  #offence
     .form-row
-      .form-col.form-col-two-thirds.case-concluded-date
-        = render partial: 'external_users/claims/case_details/case_concluded_date', locals: { f: f }
+      .form-col.form-col-one-half{class: error_class?(@error_presenter, :offence)}
+        = f.anchored_label t('.offence_category'), 'offence_category_description_autocomplete'
+        .form-hint.xsmall.zero-vert-margin
+          = "If the offence category is not listed, choose \"Miscellaneous/other\""
+        - if @claim.new_record?
+          - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
+        - else
+          - selected_offence_category = @claim.offence.description rescue nil
+
+        = collection_select :offence_category,
+                              :description,
+                              @offence_descriptions,
+                              :description, :description,
+                              { include_blank: '&#160;'.html_safe, selected: selected_offence_category },
+                              { class: 'form-control autocomplete' }
+        = validation_error_message(@error_presenter, :offence)
+
+      .form-col
+        .offence-class-select
+          = render partial: 'external_users/claims/case_details/offence_select', locals: { offences: @offences }
+        = f.hidden_field :offence_id
+
+-#- unless @claim.agfs?
+-#  .form-row
+-#    .form-col.form-col-two-thirds
+-#      = render partial: 'external_users/claims/case_details/offence_id_select', locals: { f: f }
+
+- unless @claim.interim?
+  .form-row
+    .form-col.form-col-two-thirds.case-concluded-date
+      = render partial: 'external_users/claims/case_details/case_concluded_date', locals: { f: f }

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -92,11 +92,6 @@
           = render partial: 'external_users/claims/case_details/offence_select', locals: { offences: @offences }
         = f.hidden_field :offence_id
 
--#- unless @claim.agfs?
--#  .form-row
--#    .form-col.form-col-two-thirds
--#      = render partial: 'external_users/claims/case_details/offence_id_select', locals: { f: f }
-
 - unless @claim.interim?
   .form-row
     .form-col.form-col-two-thirds.case-concluded-date

--- a/app/views/external_users/claims/case_details/_offence_id_select.html.haml
+++ b/app/views/external_users/claims/case_details/_offence_id_select.html.haml
@@ -1,7 +1,0 @@
-%fieldset
-  %div{class: error_class?(@error_presenter, :offence)}
-    = f.anchored_label t('.offence_class'), :offence
-    .form-hint.xsmall.zero-vert-margin
-      = t('.offence_class_hint')
-    = f.collection_select :offence_id, Offence.miscellaneous, :id, :offence_class_description, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
-    = validation_error_message(@error_presenter, :offence)

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -1,6 +1,7 @@
 = render partial: 'layouts/header', locals: {page_heading: 'API release notes'}
 
 %section.api-documentation
+  %hr
   %h2
     July 2015
 
@@ -8,6 +9,7 @@
     %li
       created
 
+  %hr
   %h2
     October 2015
 
@@ -15,6 +17,7 @@
     %li
       first significant release
 
+  %hr
   %h2
     February 2016
 
@@ -31,6 +34,7 @@
     %li retrial fields added - required for Retrial case type claims
     %li claim importer - reports specific errors for valid JSON files that contain model validation errors
 
+  %hr
   %h2 June 2016
 
   %ul.list-bullet
@@ -66,6 +70,7 @@
       Submitted dates must conform to ISO 8601, being the time information and time zone offset optional.
       Examples: 2016-12-31, 2016-12-31T11:45, 2016-12-31T11:45:30Z
 
+  %hr
   %h2 July 2016
 
   %ul.list-bullet
@@ -172,3 +177,12 @@
       %strong MUST
       be one of the lgfs_offence_ids returned in the offence_classes list. You should still use the offence ids returned from the /api/offences
       endpoint for advocate claims.
+
+%hr
+%h1 August 2016
+
+%ul.list-bullet
+  %li
+    Offence Ids on LGFS claims (Litigator Final Claim, Litigator Transfer Claim, Litigator Interim Claim) are no longer limited to those ids derived from the Offence Class.  Previously,
+    the only offence ids that were considered valid on an LGFS claim were those that were derived from the litigator_offence_id on the relevant Offence Class.  This is no longer that case,
+    any offence id may be used.

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -27,7 +27,8 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the litigator offence class 'E: Burglary'
+    And I select the offence category 'Handling stolen goods'
+    And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -27,7 +27,8 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I enter the case concluded date
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the litigator offence class 'E: Burglary'
+    And I select the offence category 'Handling stolen goods'
+    And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -17,8 +17,8 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     And I enter the case concluded date
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the litigator offence class 'E: Burglary'
-
+    And I select the offence category 'Activities relating to opium'
+    And I sleep for '1' second
     Then I click "Continue" in the claim form
 
     And I fill '100.75' as the fixed fee total

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -28,7 +28,8 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I enter the case concluded date
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the litigator offence class 'E: Burglary'
+    And I select the offence category 'Handling stolen goods'
+    And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     And I click "Continue" in the claim form
 
@@ -53,7 +54,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     Then I click Submit to LAA
     And I should be on the check your claim page
-    And I should see 'E: Burglary'
+    And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     When I click "Continue"
     Then I should be on the certification page

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -36,6 +36,11 @@ When(/^I select the offence category '(.*?)'$/) do |offence_cat|
   @claim_form_page.select_offence_category offence_cat
 end
 
+And(/^I sleep for '(.*?)' second$/) do |num_seconds|
+  puts ">>>>>>>>>>>>>> sleeping for #{num_seconds} #{__FILE__}:#{__LINE__} <<<<<<<<<<<<<<<<<\n"
+  sleep num_seconds.to_i
+end
+
 Given(/^I am later on the Your claims page$/) do
   @external_user_home_page.load
 end

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -83,7 +83,6 @@ describe API::V1::DropdownData do
 
     it "should return a JSON formatted list of the required information" do
       results.each do |endpoint, json|
-        # ap "#{endpoint}"
         response = get endpoint, params, format: :json
         expect(response.status).to eq 200
         expect(JSON.parse(response.body).count).to be > 0

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+  require 'rails_helper'
 require_relative '../validation_helpers'
 require_relative 'shared_examples_for_advocate_litigator'
 require_relative 'shared_examples_for_step_validators'

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -173,10 +173,10 @@ shared_examples "common litigator validations" do
       should_error_with(claim, :offence, 'blank_class')
     end
 
-    it 'should error if NOT a Miscellaneous/other offence' do
-      claim.offence = offence
-      should_error_with(claim, :offence, 'invalid_class')
-    end
+    # it 'should error if NOT a Miscellaneous/other offence' do
+    #   claim.offence = offence
+    #   should_error_with(claim, :offence, 'invalid_class')
+    # end
 
     it 'should NOT error if a Miscellaneous/other offence' do
       claim.offence = misc_offence

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -173,11 +173,6 @@ shared_examples "common litigator validations" do
       should_error_with(claim, :offence, 'blank_class')
     end
 
-    # it 'should error if NOT a Miscellaneous/other offence' do
-    #   claim.offence = offence
-    #   should_error_with(claim, :offence, 'invalid_class')
-    # end
-
     it 'should NOT error if a Miscellaneous/other offence' do
       claim.offence = misc_offence
       expect(claim).to be_valid


### PR DESCRIPTION
Previsouly, litigators just selected the offence class, and an offence category of miscellaneous/other
relating to that class was automatically selected.

Now, the process has been changed to be exactly the same as for advocates: i.e. the category is selected
and then the class, (or auto selected if there is only one class for the selected category).  The valiation
for misc/other category for LGFS claims has been removed.
