### PR TITLE
Enabled test suite to be run in any time zone

### DIFF
--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -51,8 +51,8 @@ module Stats
     end
 
     describe '#download_filename' do
-      it 'generates a filename incorportating the report name and started at time' do\
-        report = build :stats_report, report_name: 'my_new_report', started_at: Time.new(2016, 2, 3, 4, 55, 12)
+      it 'generates a filename incorportating the report name and started at time' do
+        report = build :stats_report, report_name: 'my_new_report', started_at: Time.zone.local(2016, 2, 3, 4, 55, 12)
         expect(report.download_filename).to eq 'my_new_report_2016_02_03_04_55_12.csv'
       end
     end

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -81,21 +81,21 @@ RSpec.describe ClaimCsvPresenter do
 
         it 'date submitted' do
           subject.present! do |claim_journeys|
-            expect(claim_journeys.first).to include((Time.now - 3.day).to_s)
-            expect(claim_journeys.second).to include((Time.now).to_s)
+            expect(claim_journeys.first).to include((Time.zone.now - 3.day).to_s)
+            expect(claim_journeys.second).to include((Time.zone.now).to_s)
           end
         end
 
         it 'date allocated' do
           subject.present! do |claim_journeys|
-            expect(claim_journeys.first).to include((Time.now - 2.day).to_s)
+            expect(claim_journeys.first).to include((Time.zone.now - 2.day).to_s)
             expect(claim_journeys.second).to include('n/a', 'n/a')
           end
         end
 
         it 'date of last assessment' do
           subject.present! do |claim_journeys|
-            expect(claim_journeys.first).to include((Time.now - 1.day).to_s)
+            expect(claim_journeys.first).to include((Time.zone.now - 1.day).to_s)
             expect(claim_journeys.second).to include('n/a', 'n/a')
           end
         end


### PR DESCRIPTION
Rails stores all dates on the database in UTC and converts them to the Time
Zone specified in the configuration, in our case London.

If tests are written comparing various DB dates to Time.now, or Time.now - 2.days
these will fail if the machine running the tests is in any timezone other than
London.  These fix that by making the tests use Time.zone.now, which will
use the rails config time.
