### PR TITLE
Fix defendant dob error message bug when not required

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -23,7 +23,7 @@ class Defendant < ActiveRecord::Base
   validates_with DefendantValidator
   validates_with DefendantSubModelValidator
 
-  acts_as_gov_uk_date :date_of_birth, validate_if: :perform_validation?
+  acts_as_gov_uk_date :date_of_birth, validate_if: :validate_date?
 
   accepts_nested_attributes_for :representation_orders, reject_if: :all_blank, allow_destroy: true
 
@@ -37,6 +37,14 @@ class Defendant < ActiveRecord::Base
 
   def representation_order_details
     representation_orders.map(&:detail)
+  end
+
+  def validate_date?
+    self.perform_validation? && case_type_requires_date?
+  end
+
+  def case_type_requires_date?
+    claim&.case_type&.requires_defendant_dob?
   end
 
 end

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -45,7 +45,35 @@ RSpec.describe Defendant, type: :model do
     end
   end
 
+  describe '#validate_date?' do
 
+    let(:defendant) { Defendant.new(claim: Claim::AdvocateClaim.new(case_type: CaseType.new)) }
+
+    before(:each) do
+      expect(defendant).to receive(:perform_validation?).and_return(true)
+    end
+
+    
+    it 'should return false if there is no associated claim' do
+      defendant.claim = nil
+      expect(defendant.validate_date?).to be_falsey
+    end
+
+    it 'should return false if there is a claim but no case type' do
+      defendant.claim.case_type = nil
+      expect(defendant.validate_date?).to be_falsey
+    end
+
+    it 'should return false if there is a claim with a case type that does not require a date of birth' do
+      expect(defendant.claim.case_type).to receive(:requires_defendant_dob?).and_return false
+      expect(defendant.validate_date?).to be_falsey
+    end
+
+    it 'should return true if there is a claim with a case type that requires a date of birth' do
+      expect(defendant.claim.case_type).to receive(:requires_defendant_dob?).and_return true
+      expect(defendant.validate_date?).to be true
+    end
+  end
 
   context 'representation orders' do
 


### PR DESCRIPTION
There was a bug whereby if you specified an invalid defendant date of birth and then subsequently selected a case_type of "Breach of Court Order" which does not require defendant date of birth and hides the fields, validation of the date was still occurring, and producing an error message but no way to erase the date.

This is fixed by telling gov_uk_date_fields not to perform date format validation if the selected case type does not require a date of birth.
