### PR TITLE
Add deleted_at to User and CaseWorker

### DIFF
--- a/app/models/case_worker.rb
+++ b/app/models/case_worker.rb
@@ -21,7 +21,9 @@ class CaseWorker < ActiveRecord::Base
   has_many :case_worker_claims, dependent: :destroy
   has_many :claims, class_name: Claim::BaseClaim, through: :case_worker_claims, after_remove: :unallocate!
 
-  default_scope { includes(:user) }
+  default_scope { includes(:user).where(deleted_at: nil) }
+
+  scope :including_deleted, -> {unscoped.includes(:user) }
 
   validates :location, presence: {message: 'Location cannot be blank'}
   validates :user, presence: {message: 'User cannot be blank'}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@
 
 class User < ActiveRecord::Base
 
+  default_scope { where(deleted_at: nil) }
+
+  scope :including_deleted, -> { unscoped }
+
   auto_strip_attributes :first_name, :last_name, :email, squish: true, nullify: true
 
   # Include default devise modules. Others available are:

--- a/db/migrate/20160817082913_add_deleted_at_to_case_workers.rb
+++ b/db/migrate/20160817082913_add_deleted_at_to_case_workers.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToCaseWorkers < ActiveRecord::Migration
+  def change
+    add_column :case_workers, :deleted_at, :datetime, default: nil
+  end
+end

--- a/db/migrate/20160817083149_add_deleted_at_to_users.rb
+++ b/db/migrate/20160817083149_add_deleted_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :deleted_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160726141102) do
+ActiveRecord::Schema.define(version: 20160817083149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20160726141102) do
     t.datetime "updated_at"
     t.integer  "location_id"
     t.string   "roles"
+    t.datetime "deleted_at"
   end
 
   add_index "case_workers", ["location_id"], name: "index_case_workers_on_location_id", using: :btree
@@ -469,6 +470,7 @@ ActiveRecord::Schema.define(version: 20160726141102) do
     t.datetime "locked_at"
     t.string   "unlock_token"
     t.text     "settings"
+    t.datetime "deleted_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/factories/case_workers.rb
+++ b/spec/factories/case_workers.rb
@@ -27,5 +27,9 @@ FactoryGirl.define do
     trait :admin do
       roles ['admin']
     end
+
+    trait :softly_deleted do
+      deleted_at 10.minutes.ago
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -36,5 +36,9 @@ FactoryGirl.define do
     trait :with_settings do
       settings { {setting1: 'test1', setting2: 'test2'}.to_json }
     end
+
+    trait :softly_deleted do
+      deleted_at 10.minutes.ago
+    end
   end
 end

--- a/spec/models/case_worker_spec.rb
+++ b/spec/models/case_worker_spec.rb
@@ -12,6 +12,7 @@
 require 'rails_helper'
 
 RSpec.describe CaseWorker, type: :model do
+  include DatabaseHousekeeping
   it_behaves_like 'roles', CaseWorker, CaseWorker::ROLES
 
   it { should belong_to(:location) }
@@ -34,4 +35,49 @@ RSpec.describe CaseWorker, type: :model do
       expect(CaseWorker::ROLES).to match_array(%w( admin case_worker ))
     end
   end
+
+  context 'soft deletions' do
+    before(:all) do
+      @location_1 = create :location
+      @location_2 = create :location
+      @live_cw1 = create :case_worker, location: @location_1
+      @live_cw2 = create :case_worker, location: @location_2
+      @dead_cw1 = create :case_worker, :softly_deleted, location: @location_1
+      @dead_cw2 = create :case_worker, :softly_deleted, location: @location_2
+    end
+
+    after(:all) { clean_database }
+
+    describe 'default scope' do
+      it 'should only return undeleted records' do
+        expect(CaseWorker.all.order(:id)).to eq([ @live_cw1, @live_cw2 ])
+      end
+
+      it 'should return ActiveRecord::RecordNotFound if find by id relates to a deleted record' do
+        expect{
+          CaseWorker.find(@dead_cw1.id)
+        }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find CaseWorker with 'id'=#{@dead_cw1.id} [WHERE "case_workers"."deleted_at" IS NULL]}
+      end
+
+      it 'returns an empty array if the selection criteria only reference deleted records' do
+        expect(CaseWorker.where(id: [@dead_cw1.id, @dead_cw2.id])).to be_empty
+      end
+
+    end
+
+    describe 'including_deleted scope' do
+      it 'should return deleted and undeleted records' do
+        expect(CaseWorker.including_deleted.order(:id)).to eq([ @live_cw1, @live_cw2, @dead_cw1, @dead_cw2])
+      end
+
+      it 'should return the record if find by id relates to a deleted record' do
+        expect(CaseWorker.including_deleted.find(@dead_cw1.id)).to eq @dead_cw1
+      end
+
+      it 'returns the deleted records if the selection criteria reference only deleted records' do
+        expect(CaseWorker.including_deleted.where(id: [@dead_cw1.id, @dead_cw2.id]).order(:id)).to eq([@dead_cw1, @dead_cw2])
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This PR sets up the framework for soft delete of caseworkers and users.

It adds a 'deleted_at' field to CaseWorker and User models, and sets the
default scope to exclude any records where deleted at is not null.  Also
adds an including_deleted scope which returns all records.

This has no effect on the current deletion process as that hasn't yet been
changed to use the deleted_at fields.
