### PR TITLE
Better handling of incomplete disbursements on drafts.

### DIFF
--- a/app/presenters/disbursement_presenter.rb
+++ b/app/presenters/disbursement_presenter.rb
@@ -2,7 +2,7 @@ class DisbursementPresenter < BasePresenter
   presents :disbursement
 
   def name
-    disbursement.disbursement_type.name
+    disbursement.disbursement_type&.name || 'not provided'
   end
 
   def net_amount

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -138,7 +138,7 @@
             - present_collection(claim.disbursements).each do |disbursement|
               %tr
                 %td{scope:'row'}
-                  = disbursement.disbursement_type.name
+                  = disbursement.name
                 %td.numeric
                   = disbursement.net_amount
                 %td.numeric

--- a/spec/presenters/disbursement_presenter_spec.rb
+++ b/spec/presenters/disbursement_presenter_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe DisbursementPresenter do
     it 'returns the disbursement type name' do
       expect(subject.name).to eq('name')
     end
+
+    context 'when disbursement type was not specified' do
+      let(:disbursement_type) { nil }
+
+      it 'returns a placeholder text' do
+        expect(subject.name).to eq('not provided')
+      end
+    end
   end
 
   describe '#net_amount' do


### PR DESCRIPTION
It is possible and some users did that to save a draft with an incomplete
disbursement record, and specifically the disbursement type, rendering the claim
impossible to open again.

This fix ensures a placeholder text is shown when no disbursement type is found.

https://sentry.service.dsd.io/mojds/private-beta/group/1444/
