### PR TITLE
Implement Soft Deletions for caseworkers

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -33,7 +33,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def set_summary_values
-    @case_worker = CaseWorker.find(params[:case_worker_id]) rescue nil
+    @case_worker = CaseWorker.active.find(params[:case_worker_id]) rescue nil
     @allocated_claims = Claim::BaseClaim.find(params[:claim_ids].reject(&:blank?))
     params.delete(:case_worker_id)
     params.delete(:claim_ids)
@@ -49,7 +49,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def set_case_workers
-    @case_workers = CaseWorker.includes(:location, :user)
+    @case_workers = CaseWorker.active.includes(:location, :user)
   end
 
   def set_claims

--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -42,20 +42,14 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
   # NOTE: update_password in PasswordHelper
 
   def destroy
-    result = if @case_worker.user.messages_sent.any?
-               {alert: 'A case worker cannot be deleted if they\'ve created messages in any claim'}
-             else
-               @case_worker.destroy
-               {notice: 'Case worker deleted'}
-             end
-
-    redirect_to case_workers_admin_case_workers_url, result
+    @case_worker.soft_delete
+    redirect_to case_workers_admin_case_workers_url, {notice: 'Case worker deleted'}
   end
 
   private
 
   def set_case_worker
-    @case_worker = CaseWorker.find(params[:id])
+    @case_worker = CaseWorker.active.find(params[:id])
   end
 
   def case_worker_params

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -33,7 +33,7 @@ class FeedbackController < ApplicationController
   end
 
   def email_from_user_id
-    User.find(params[:user_id]).try(:email) rescue nil
+    User.active.find(params[:user_id]).try(:email) rescue nil
   end
 
   def after_create_url

--- a/app/interfaces/api/v1/resource_helper.rb
+++ b/app/interfaces/api/v1/resource_helper.rb
@@ -43,7 +43,7 @@ module API::V1
     end
 
     def find_user_by_email(email:, relation:)
-      User.external_users.find_by(email: email).try(:persona) || (raise API::V1::ArgumentError, "#{relation} email is invalid")
+      User.active.external_users.find_by(email: email).try(:persona) || (raise API::V1::ArgumentError, "#{relation} email is invalid")
     end
 
     def lgfs_schema?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -71,7 +71,7 @@ class Ability
     # NOTE: for destroy action, at least, the document may not be persisted/saved
     can [:show, :download, :destroy], Document do |document|
       if document.external_user_id.nil?
-        User.find(document.creator_id).persona.provider.id == persona.provider.id
+        User.active.find(document.creator_id).persona.provider.id == persona.provider.id
       else
         document.external_user.provider.id == persona.provider.id
       end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -62,7 +62,7 @@ class Allocation
   end
 
   def case_worker
-    CaseWorker.find(@case_worker_id) rescue nil #deallocation will have a nil case worker id
+    CaseWorker.active.find(@case_worker_id) rescue nil #deallocation will have a nil case worker id
   end
 
   def allocating?

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -11,7 +11,7 @@
 class Location < ActiveRecord::Base
   auto_strip_attributes :name, squish: true, nullify: true
 
-  has_many :case_workers, dependent: :destroy
+  has_many :case_workers
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,4 +89,16 @@ class User < ActiveRecord::Base
   def soft_delete
     update(deleted_at: Time.zone.now)
   end
+
+  def active?
+    self.deleted_at.nil?
+  end
+
+  def active_for_authentication?
+    super && active?
+  end
+
+  def inactive_message
+    active? ? super : 'This account has been deleted.'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,9 @@
 
 class User < ActiveRecord::Base
 
+  scope :active, -> { where(deleted_at: nil) }
+  scope :deleted, -> { where.not(deleted_at: nil) }
+
   auto_strip_attributes :first_name, :last_name, :email, squish: true, nullify: true
 
   # Include default devise modules. Others available are:
@@ -41,7 +44,7 @@ class User < ActiveRecord::Base
 
   belongs_to :persona, polymorphic: true
   has_many :messages_sent, foreign_key: 'sender_id', class_name: 'Message'
-  has_many :user_message_statuses, dependent: :destroy
+  has_many :user_message_statuses
 
   validates :first_name, :last_name, presence: true
   validates :email, confirmation: true
@@ -81,5 +84,9 @@ class User < ActiveRecord::Base
   #
   def unauthenticated_message
     override_paranoid_setting(false) { super }
+  end
+
+  def soft_delete
+    update(deleted_at: Time.zone.now)
   end
 end

--- a/app/rake_helpers/document_recloner.rb
+++ b/app/rake_helpers/document_recloner.rb
@@ -4,7 +4,7 @@ class DocumentRecloner
     @cloned_claim = Claim::BaseClaim.find claim_id
     @source_claim = Claim::BaseClaim.find @cloned_claim.clone_source_id
     @message_text = 'SYSTEM NOTICE: '
-    @sender = CaseWorker.admins.first.user
+    @sender = CaseWorker.active.admins.first.user
   end
 
   def run

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -21,7 +21,8 @@
         = number_field_tag :quantity_to_allocate, nil, { style: 'width:100%', min: 0, size: 5, class: 'form-control'}
       .form-col
         = f.label :case_worker_id, t('dictionary.models.case_worker'), {for: "allocation_case_worker_id_autocomplete"}
-        = f.grouped_collection_select :case_worker_id, Location.includes(case_workers: :user), :case_workers, :name, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
+        = f.collection_select :case_worker_id, CaseWorker.active, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
+
       .form-col{ style: 'padding: 26px 0 0' }
         = f.submit 'Allocate', class: 'button'
   - if @claims.any?

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -37,7 +37,7 @@
   .case-worker-reallocation.grid-row.form-group
     .column-one-quarter.js-case-worker-list
       = f.label :case_worker_id
-      = f.grouped_collection_select :case_worker_id, Location.all, :case_workers, :name, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
+      = f.collection_select :case_worker_id, CaseWorker.active, :id, :name, { include_blank: '&#160;'.html_safe }, { class: 'form-control autocomplete' }
     .column-half.margin-spacer-sm
       = f.submit 'Re-allocate', class: 'button'
 

--- a/app/views/case_workers/admin/case_workers/index.html.haml
+++ b/app/views/case_workers/admin/case_workers/index.html.haml
@@ -32,6 +32,9 @@
           %td
             = case_worker.location.name
           %td.user-controls
-            = link_to t('common.edit'), edit_case_workers_admin_case_worker_path(case_worker)
-            = " | "
-            = link_to t('common.delete'), case_workers_admin_case_worker_path(case_worker), method: :delete, data: { confirm: 'Are you sure?' }
+            - if case_worker.active?
+              = link_to t('common.edit'), edit_case_workers_admin_case_worker_path(case_worker)
+              = " | "
+              = link_to t('common.delete'), case_workers_admin_case_worker_path(case_worker), method: :delete, data: { confirm: 'Are you sure?' }
+            - else
+              Inactive

--- a/db/migrate/20160111111547_change_advocate_persona_type_to_external_user.rb
+++ b/db/migrate/20160111111547_change_advocate_persona_type_to_external_user.rb
@@ -1,9 +1,5 @@
 class ChangeAdvocatePersonaTypeToExternalUser < ActiveRecord::Migration
   def change
-    User.all.each do |user|
-      if user.persona_type == 'Advocate'
-        user.update_column(:persona_type, 'ExternalUser')
-      end
-    end
+    execute(%q{UPDATE users SET persona_type = 'ExternalUser' WHERE persona_type = 'Advocate'} )
   end
 end

--- a/db/migrate/20160111111547_change_advocate_persona_type_to_external_user.rb
+++ b/db/migrate/20160111111547_change_advocate_persona_type_to_external_user.rb
@@ -1,5 +1,0 @@
-class ChangeAdvocatePersonaTypeToExternalUser < ActiveRecord::Migration
-  def change
-    execute(%q{UPDATE users SET persona_type = 'ExternalUser' WHERE persona_type = 'Advocate'} )
-  end
-end

--- a/db/migrate/20160817082913_add_deleted_at_to_case_workers.rb
+++ b/db/migrate/20160817082913_add_deleted_at_to_case_workers.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToCaseWorkers < ActiveRecord::Migration
+  def change
+    add_column :case_workers, :deleted_at, :datetime, default: nil
+  end
+end

--- a/db/migrate/20160817083149_add_deleted_at_to_users.rb
+++ b/db/migrate/20160817083149_add_deleted_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :deleted_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160726141102) do
+ActiveRecord::Schema.define(version: 20160817083149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20160726141102) do
     t.datetime "updated_at"
     t.integer  "location_id"
     t.string   "roles"
+    t.datetime "deleted_at"
   end
 
   add_index "case_workers", ["location_id"], name: "index_case_workers_on_location_id", using: :btree
@@ -469,6 +470,7 @@ ActiveRecord::Schema.define(version: 20160726141102) do
     t.datetime "locked_at"
     t.string   "unlock_token"
     t.text     "settings"
+    t.datetime "deleted_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -1,7 +1,7 @@
 module SeedHelper
 
   def self.find_or_create_caseworker!(attrs)
-    user = User.find_by(email: attrs[:email].downcase)
+    user = User.active.find_by(email: attrs[:email].downcase)
     if user.blank?
       user = User.create!(
         first_name: attrs[:first_name],

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -1,0 +1,13 @@
+@javascript
+Feature: Caseworker can log in while active, but not once inactive
+
+  Scenario: I log in as a case worker admin and I see the allocation page
+
+    Given I am a signed in case worker admin
+    Then I should be on the Allocation page
+    And I sign out as case_worker
+    And The caseworker is marked as deleted
+    And I attempt to sign in again as the deleted caseworker
+    Then I should get a page telling me my account has been deleted
+
+

--- a/features/step_definitions/claim_allocation_steps.rb
+++ b/features/step_definitions/claim_allocation_steps.rb
@@ -95,8 +95,8 @@ When(/^I enter (\d+) in the quantity text field$/) do |quantity|
 end
 
 Then(/^the first (\d+) claims in the list should be allocated to the case worker$/) do |quantity|
-  expect(CaseWorker.last.claims.count).to eq(quantity.to_i)
-  CaseWorker.last.claims.each do |claim|
+  expect(CaseWorker.active.last.claims.count).to eq(quantity.to_i)
+  CaseWorker.active.last.claims.each do |claim|
     expect(claim).to be_allocated
   end
 
@@ -105,7 +105,7 @@ Then(/^the first (\d+) claims in the list should be allocated to the case worker
 end
 
 Then(/^the first (\d+) claims should no longer be displayed$/) do |quantity|
-  CaseWorker.last.claims.each do |claim|
+  CaseWorker.active.last.claims.each do |claim|
     expect(page).to_not have_selector("#claim_#{claim.id}")
   end
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -37,8 +37,7 @@ When(/^I select the offence category '(.*?)'$/) do |offence_cat|
 end
 
 And(/^I sleep for '(.*?)' second$/) do |num_seconds|
-  puts ">>>>>>>>>>>>>> sleeping for #{num_seconds} #{__FILE__}:#{__LINE__} <<<<<<<<<<<<<<<<<\n"
-  sleep num_seconds.to_i
+  sleep num_seconds.to_f
 end
 
 Given(/^I am later on the Your claims page$/) do

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -18,6 +18,10 @@ def make_accounts(role, number = 1)
   end
 end
 
+Given(/^The caseworker is marked as deleted$/) do
+  @case_worker.soft_delete
+end
+
 Given(/an? "(.*?)" user account exists$/) do |role|
   accounts = make_accounts(role)
   instance_variable_set("@#{role.gsub(' ', '_')}", accounts.first)
@@ -71,6 +75,10 @@ When(/^I sign in as the case worker$/) do
   sign_in(@case_worker.user, @password)
 end
 
+When(/^I attempt to sign in again as the deleted caseworker$/) do
+  sign_in(@case_worker.user, 'password')
+end
+
 When(/^I sign out as/) do
   click_link "Sign out"
 end
@@ -94,4 +102,13 @@ end
 
 Given(/^I sign out$/) do
   click_link 'Sign out' rescue nil
+end
+
+When(/^I should be on the Allocation page$/) do
+  expect(find('header.main-header')).to have_content('Allocation')
+end
+
+Then(/^I should get a page telling me my account has been deleted$/) do
+  save_and_open_page
+  expect(page).to have_content('This account has been deleted.')
 end

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
       end
 
       it 'assigns @case_workers' do
-        expect(assigns(:case_workers)).to eq(CaseWorker.all)
+        expect(assigns(:case_workers)).to eq(CaseWorker.active)
       end
 
       it 'assigns @allocation' do

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -221,31 +221,17 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController, type: :controller do
       expect(response).to redirect_to(case_workers_admin_case_workers_url)
     end
 
-    context 'case worker with sent messages' do
-      before do
-        create(:message, sender_id: subject.user.id)
-        delete :destroy, id: subject
-      end
-
-      it 'doesn\'t destroy the case worker' do
-        expect(CaseWorker.count).to eq(2)
-      end
-
-      it 'redirects to case worker admin root url with alert message' do
-        expect(flash[:alert]).to eq('A case worker cannot be deleted if they\'ve created messages in any claim')
-      end
-    end
-
     context 'case worker without sent messages' do
-      before do
-        delete :destroy, id: subject
-      end
 
       it 'destroys the case worker' do
-        expect(CaseWorker.count).to eq(1)
+        delete :destroy, id: subject
+        expect(CaseWorker.active.count).to eq(1)
+        expect(CaseWorker.deleted.count).to eq(1)
+        expect(subject.reload.deleted_at).not_to be_nil
       end
 
       it 'redirects to case worker admin root url with notice message' do
+        delete :destroy, id: subject
         expect(flash[:notice]).to eq('Case worker deleted')
       end
     end

--- a/spec/factories/case_workers.rb
+++ b/spec/factories/case_workers.rb
@@ -27,5 +27,9 @@ FactoryGirl.define do
     trait :admin do
       roles ['admin']
     end
+
+    trait :softly_deleted do
+      deleted_at 10.minutes.ago
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -36,5 +36,9 @@ FactoryGirl.define do
     trait :with_settings do
       settings { {setting1: 'test1', setting2: 'test2'}.to_json }
     end
+
+    trait :softly_deleted do
+      deleted_at 10.minutes.ago
+    end
   end
 end

--- a/spec/models/case_worker_spec.rb
+++ b/spec/models/case_worker_spec.rb
@@ -12,6 +12,7 @@
 require 'rails_helper'
 
 RSpec.describe CaseWorker, type: :model do
+  include DatabaseHousekeeping
   it_behaves_like 'roles', CaseWorker, CaseWorker::ROLES
 
   it { should belong_to(:location) }
@@ -34,4 +35,87 @@ RSpec.describe CaseWorker, type: :model do
       expect(CaseWorker::ROLES).to match_array(%w( admin case_worker ))
     end
   end
+
+  context 'soft deletion scopes' do
+    before(:all) do
+      @location_1 = create :location
+      @location_2 = create :location
+      @live_cw1 = create :case_worker, location: @location_1
+      @live_cw2 = create :case_worker, location: @location_2
+      @dead_cw1 = create :case_worker, :softly_deleted, location: @location_1
+      @dead_cw2 = create :case_worker, :softly_deleted, location: @location_2
+    end
+
+    after(:all) { clean_database }
+
+    describe 'active scope' do
+      it 'should only return undeleted records' do
+        expect(CaseWorker.active.order(:id)).to eq([ @live_cw1, @live_cw2 ])
+      end
+
+      it 'should return ActiveRecord::RecordNotFound if find by id relates to a deleted record' do
+        expect{
+          CaseWorker.active.find(@dead_cw1.id)
+        }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find CaseWorker with 'id'=#{@dead_cw1.id} [WHERE "case_workers"."deleted_at" IS NULL]}
+      end
+
+      it 'returns an empty array if the selection criteria only reference deleted records' do
+        expect(CaseWorker.active.where(id: [@dead_cw1.id, @dead_cw2.id])).to be_empty
+      end
+    end
+
+    describe 'deleted scope' do
+      it 'should return only deleted records' do
+        expect(CaseWorker.deleted.order(:id)).to eq([@dead_cw1, @dead_cw2])
+      end
+
+      it 'should return ActiveRecord::RecordNotFound if find by id relates to an undeleted record' do
+        expect{
+          CaseWorker.deleted.find(@live_cw1.id)
+        }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find CaseWorker with 'id'=#{@live_cw1.id} [WHERE "case_workers"."deleted_at" IS NOT NULL]}
+      end
+
+      it 'returns an empty array if the selection criteria only reference live records' do
+        expect(CaseWorker.deleted.where(id: [@live_cw1.id, @live_cw2.id])).to be_empty
+      end
+    end
+
+    describe 'default scope' do
+      it 'should return deleted and undeleted records' do
+        expect(CaseWorker.order(:id)).to eq([ @live_cw1, @live_cw2, @dead_cw1, @dead_cw2])
+      end
+
+      it 'should return the record if find by id relates to a deleted record' do
+        expect(CaseWorker.find(@dead_cw1.id)).to eq @dead_cw1
+      end
+
+      it 'returns the deleted records if the selection criteria reference only deleted records' do
+        expect(CaseWorker.where(id: [@dead_cw1.id, @dead_cw2.id]).order(:id)).to eq([@dead_cw1, @dead_cw2])
+      end
+    end
+  end
+
+
+  describe 'soft_delete' do
+    it 'should set deleted at on the caseworker and user records' do
+      cw = create :case_worker
+      user = cw.user
+      cw.soft_delete
+      expect(cw.reload.deleted_at).not_to be_nil
+      expect(user.reload.deleted_at).not_to be_nil
+    end
+  end
+
+  describe '#active?' do
+    it 'returns false for deleted records' do
+      cw = build :case_worker, :softly_deleted
+      expect(cw.active?).to be false
+    end
+
+    it 'returns true for active records' do
+      cw = build :case_worker
+      expect(cw.active?).to be true
+    end
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -131,4 +131,61 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  context 'soft deletions' do
+    before(:all) do
+      @live_user_1 = create :user
+      @live_user_2 = create :user
+      @dead_user_1 = create :user, :softly_deleted
+      @dead_user_2 = create :user, :softly_deleted
+    end
+
+    after(:all) { clean_database }
+
+    describe 'active scope' do
+      it 'should only return undeleted records' do
+        expect(User.active.order(:id)).to eq([ @live_user_1, @live_user_2 ])
+      end
+
+      it 'should return ActiveRecord::RecordNotFound if find by id relates to a deleted record' do
+        expect{
+          User.active.find(@dead_user_1.id)
+        }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find User with 'id'=#{@dead_user_1.id} [WHERE "users"."deleted_at" IS NULL]}
+      end
+
+      it 'returns an empty array if the selection criteria only reference deleted records' do
+        expect(User.active.where(id: [@dead_user_1.id, @dead_user_2.id])).to be_empty
+      end
+    end
+
+    describe 'deleted scope' do
+      it 'should return only deleted records' do
+        expect(User.deleted.order(:id)).to eq([@dead_user_1, @dead_user_2])
+      end
+
+      it 'should return ActiveRecord::RecordNotFound if find by id relates to an undeleted record' do
+        expect{
+          User.deleted.find(@live_user_1.id)
+        }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find User with 'id'=#{@live_user_1.id} [WHERE "users"."deleted_at" IS NOT NULL]}
+      end
+
+      it 'returns an empty array if the selection criteria only reference live records' do
+        expect(User.deleted.where(id: [@live_user_1.id, @live_user_2.id])).to be_empty
+      end
+    end
+
+    describe 'default scope' do
+      it 'should return deleted and undeleted records' do
+        expect(User.order(:id)).to eq([ @live_user_1, @live_user_2, @dead_user_1, @dead_user_2])
+      end
+
+      it 'should return the record if find by id relates to a deleted record' do
+        expect(User.find(@dead_user_1.id)).to eq @dead_user_1
+      end
+
+      it 'returns the deleted records if the selection criteria reference only deleted records' do
+        expect(User.where(id: [@dead_user_1.id, @dead_user_2.id]).order(:id)).to eq([@dead_user_1, @dead_user_2])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Caseworkers are no longer deleted from the database because of claims and messages that
may reference the deleted caseworker.  Now a new 'deleted_at' field on CaseWorker and User
is given a timestamp, and any record where that field is not null is considered to be deleted.

A new scope active on CaseWorker and User will only return records where deleted_at is nil,
and Caseworker queries have been updated to use that scope where approperiate.
