### PR TITLE
Fix date error messages not showing

### DIFF
--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -13,7 +13,7 @@
   .form-row
     .form-col.form-col-two-thirds.dob
       %a{:id => "defendant_#{@defendant_count+1}_date_of_birth"}
-      = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count}_date_of_birth", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count}_date_of_birth"))
+      = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
 
   - unless @claim.interim?
     .form-row

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -12,7 +12,7 @@
                             legend_text: 'Representation order date',
                             legend_class: 'govuk-legend',
                             id: "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date",
-                            error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date"))
+                            error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count + 1}_representation_order_#{@representation_order_count}_representation_order_date"))
 
   .form-row
     .form-col.maat


### PR DESCRIPTION
Error messages were  not showing on some dates because the key for the error messages hash was being incorrectly set (out by 1 error).
