### PR TITLE
Claim soft delete

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -34,7 +34,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
 
   def set_summary_values
     @case_worker = CaseWorker.active.find(params[:case_worker_id]) rescue nil
-    @allocated_claims = Claim::BaseClaim.find(params[:claim_ids].reject(&:blank?))
+    @allocated_claims = Claim::BaseClaim.active.find(params[:claim_ids].reject(&:blank?))
     params.delete(:case_worker_id)
     params.delete(:claim_ids)
   end
@@ -90,7 +90,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def filter_by_claim_type
-    @claims = (scheme == 'lgfs' ? Claim::BaseClaim.where(type: [Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim] ) : Claim::BaseClaim.where(type: Claim::AdvocateClaim) )
+    @claims = (scheme == 'lgfs' ? Claim::BaseClaim.active.where(type: [Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim] ) : Claim::BaseClaim.active.where(type: Claim::AdvocateClaim) )
     load_claim_associations
   end
 

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -94,11 +94,11 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
                 when 'current'
                   current_user.claims.caseworker_dashboard_under_assessment
                 when 'archived'
-                  Claim::BaseClaim.caseworker_dashboard_archived
+                  Claim::BaseClaim.active.caseworker_dashboard_archived
                 when 'allocated'
-                  Claim::BaseClaim.caseworker_dashboard_under_assessment
+                  Claim::BaseClaim.active.caseworker_dashboard_under_assessment
                 when 'unallocated'
-                  Claim::BaseClaim.submitted_or_redetermination_or_awaiting_written_reasons
+                  Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons
                 end
     else
       @claims = case tab
@@ -119,7 +119,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   end
 
   def set_claim
-    @claim = Claim::BaseClaim.find(params[:id])
+    @claim = Claim::BaseClaim.active.find(params[:id])
   end
 
   def filter_current_claims

--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -54,7 +54,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
   end
 
   def set_claim
-    @claim = Claim::BaseClaim.find(params[:claim_id])
+    @claim = Claim::BaseClaim.active.find(params[:claim_id])
   end
 
   def claim_tracking_substitutions

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -88,7 +88,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def destroy
     if @claim.draft?
-      @claim.destroy
+      @claim.soft_delete
     else
       @claim.archive_pending_delete!
     end
@@ -207,7 +207,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def set_and_authorize_claim
-    @claim = Claim::BaseClaim.find(params[:id])
+    @claim = Claim::BaseClaim.active.find(params[:id])
     authorize! params[:action].to_sym, @claim
   end
 

--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -5,18 +5,18 @@ module CaseWorkers::ClaimsHelper
 
   def completed_claims_count
     if current_user.persona.admin?
-      Claim::BaseClaim.caseworker_dashboard_completed.count
+      Claim::BaseClaim.active.caseworker_dashboard_completed.count
     else
       current_user.claims.caseworker_dashboard_completed.count
     end
   end
 
   def allocated_claims_count
-    Claim::BaseClaim.caseworker_dashboard_under_assessment.count
+    Claim::BaseClaim.active.caseworker_dashboard_under_assessment.count
   end
 
   def unallocated_claims_count
-    Claim::BaseClaim.submitted_or_redetermination_or_awaiting_written_reasons.count
+    Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons.count
   end
 
   def claim_position_and_count

--- a/app/interfaces/api/v1/resource_helper.rb
+++ b/app/interfaces/api/v1/resource_helper.rb
@@ -11,7 +11,7 @@ module API::V1
     end
 
     def claim_id
-      ::Claim::BaseClaim.find_by(uuid: params.claim_id).try(:id) || (raise API::V1::ArgumentError, 'Claim cannot be blank')
+      ::Claim::BaseClaim.active.find_by(uuid: params.claim_id).try(:id) || (raise API::V1::ArgumentError, 'Claim cannot be blank')
     end
 
     def claim_creator

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -32,7 +32,7 @@ class Allocation
     @claim_ids = attributes[:claim_ids].reject(&:blank?) rescue nil
     @deallocate = [true, 'true'].include?(attributes[:deallocate])
     @allocating = attributes[:allocating]
-    @claims = Claim::BaseClaim.find(@claim_ids) rescue nil
+    @claims = Claim::BaseClaim.active.find(@claim_ids) rescue nil
     @successful_claims = []
   end
 

--- a/app/models/case_worker.rb
+++ b/app/models/case_worker.rb
@@ -20,8 +20,8 @@ class CaseWorker < ActiveRecord::Base
 
   belongs_to :location
   has_one :user, as: :persona, inverse_of: :persona, dependent: :destroy
-  has_many :case_worker_claims, dependent: :destroy
-  has_many :claims, class_name: Claim::BaseClaim, through: :case_worker_claims, after_remove: :unallocate!
+  has_many :case_worker_claims
+  has_many :claims, -> { active }, class_name: Claim::BaseClaim, through: :case_worker_claims, after_remove: :unallocate!
 
 
 

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 module Claim

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 module Claim
@@ -63,6 +64,7 @@ module Claim
   end
 
   class BaseClaim < ActiveRecord::Base
+    include SoftlyDeletable
 
     self.table_name = 'claims'
 

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 module Claim

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 module Claim

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 module Claim

--- a/app/models/claims/search.rb
+++ b/app/models/claims/search.rb
@@ -32,6 +32,6 @@ module Claims::Search
       raise "Invalid state, #{state}, specified" unless Claim::BaseClaim.state_machine.states.map(&:name).include?(state.to_sym)
     end
 
-    relation.where(sql, term: "%#{term.strip.downcase}%").where(state: states).uniq
+    relation.active.where(sql, term: "%#{term.strip.downcase}%").where(state: states).uniq
   end
 end

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -15,7 +15,7 @@ class Court < ActiveRecord::Base
 
   COURT_TYPES = %w( crown magistrate )
 
-  has_many :claims, class_name: Claim::BaseClaim, dependent: :nullify
+  has_many :claims, -> { active }, class_name: Claim::BaseClaim, dependent: :nullify
 
   validates :code, presence: true, uniqueness: { case_sensitve: false, message: "Court code must be unique" }
   validates :name, presence: true, uniqueness: { case_sensitve: false, message: "Court name must be unique" }

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -25,8 +25,8 @@ class ExternalUser < ActiveRecord::Base
   belongs_to :provider
 
   has_one :user, as: :persona, inverse_of: :persona, dependent: :destroy
-  has_many :claims, dependent: :destroy, class_name: 'Claim::BaseClaim'
-  has_many :claims_created, dependent: :nullify, class_name: 'Claim::BaseClaim', foreign_key: 'creator_id', inverse_of: :creator
+  has_many :claims, -> { active }, dependent: :destroy, class_name: 'Claim::BaseClaim'
+  has_many :claims_created, -> { active }, dependent: :nullify, class_name: 'Claim::BaseClaim', foreign_key: 'creator_id', inverse_of: :creator
   has_many :documents # Do not destroy - ultimately belong to chambers.
 
   default_scope { includes(:user, :provider) }

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -34,7 +34,7 @@ module Fee
     auto_strip_attributes :code, :description, squish: true, nullify: true
 
     has_many :fees, dependent: :destroy, class_name: Fee::BaseFee, foreign_key: :fee_type_id
-    has_many :claims, through: :fees
+    has_many :claims, -> {active},  through: :fees
 
     validates :description, presence: {message: 'Fee type description cannot be blank'}, uniqueness: { case_sensitive: false, scope: :type, message: 'Fee type description must be unique' }
     validates :code, presence: {message: 'Fee type code cannot be blank'}

--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -44,7 +44,7 @@ class JsonDocumentImporter
       begin
         @schema_validator.validate_full!(claim_hash)
         create_claim_and_associations(claim_hash)
-        @imported_claims << Claim::BaseClaim.find_by(uuid: @claim_id)
+        @imported_claims << Claim::BaseClaim.active.find_by(uuid: @claim_id)
       rescue ArgumentError => ex
         claim_hash['claim']['case_number'] = case_number
         @failed_imports << claim_hash
@@ -109,7 +109,7 @@ class JsonDocumentImporter
   end
 
   def destroy_claim_if_any
-    claim = Claim::BaseClaim.find_by(uuid: @claim_id) # if an exception is raised the claim is destroyed along with all its dependent objects
+    claim = Claim::BaseClaim.active.find_by(uuid: @claim_id) # if an exception is raised the claim is destroyed along with all its dependent objects
     claim.destroy if claim.present?
   end
 

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -13,7 +13,7 @@ class Offence < ActiveRecord::Base
   auto_strip_attributes :description, squish: true, nullify: true
 
   belongs_to :offence_class
-  has_many :claims, class_name: Claim::BaseClaim, foreign_key: :offence_id, dependent: :nullify
+  has_many :claims, -> { active }, class_name: Claim::BaseClaim, foreign_key: :offence_id, dependent: :nullify
 
   validates :offence_class, presence: true
   validates :description, presence: true

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -37,8 +37,8 @@ class Provider < ActiveRecord::Base
   end
 
   has_many :supplier_numbers, dependent: :destroy
-  has_many :claims_created, through: :external_users
-  has_many :claims, through: :external_users
+  has_many :claims_created, -> { active }, through: :external_users
+  has_many :claims, -> { active }, through: :external_users
 
   accepts_nested_attributes_for :supplier_numbers, allow_destroy: true
 

--- a/app/models/stats/collector/claim_creation_source_collector.rb
+++ b/app/models/stats/collector/claim_creation_source_collector.rb
@@ -18,7 +18,7 @@ module Stats
       private
 
       def created_claims_for_day_and_source(source)
-        Claim::BaseClaim.where(created_at: @date.beginning_of_day..@date.end_of_day).where(source: source).count
+        Claim::BaseClaim.active.where(created_at: @date.beginning_of_day..@date.end_of_day).where(source: source).count
       end
 
     end

--- a/app/models/stats/collector/claim_submissions_collector.rb
+++ b/app/models/stats/collector/claim_submissions_collector.rb
@@ -15,7 +15,7 @@ module Stats
       private
 
       def count_claims(claim_type)
-        claim_type.where('last_submitted_at between ? and ?', @date.beginning_of_day, @date.end_of_day).count
+        claim_type.active.where('last_submitted_at between ? and ?', @date.beginning_of_day, @date.end_of_day).count
       end
     end
 

--- a/app/models/stats/collector/completion_rate_collector.rb
+++ b/app/models/stats/collector/completion_rate_collector.rb
@@ -13,7 +13,7 @@ module Stats
         begin
           form_ids_created_at_period_start = ClaimIntention.where(created_at: @start_date.beginning_of_day..@start_date.end_of_day).pluck(:form_id)
           num_started = form_ids_created_at_period_start.size
-          num_completed = Claim::BaseClaim.where(form_id: form_ids_created_at_period_start).where.not(last_submitted_at: nil).count
+          num_completed = Claim::BaseClaim.active.where(form_id: form_ids_created_at_period_start).where.not(last_submitted_at: nil).count
           percentage_completed_e2 = num_started == 0 ? 1000 : ((num_completed.to_f / num_started) * 10000).to_i # 0.2546, i.e. 25.46% is stored as 2546
           Statistic.create_or_update(@date, 'completion_percentage', 'Claim::BaseClaim', percentage_completed_e2, num_completed)
         rescue => err

--- a/app/models/stats/collector/money_claimed_per_month_collector.rb
+++ b/app/models/stats/collector/money_claimed_per_month_collector.rb
@@ -26,7 +26,7 @@ module Stats
 
 
       def submitted_claims_this_period
-        Claim::BaseClaim.where(last_submitted_at: @period_start..@period_end)
+        Claim::BaseClaim.active.where(last_submitted_at: @period_start..@period_end)
       end
     end
   end

--- a/app/models/stats/collector/money_to_date_collector.rb
+++ b/app/models/stats/collector/money_to_date_collector.rb
@@ -9,8 +9,8 @@ module Stats
       end
 
       def collect
-        total_money_to_date_inc_vat = Claim::BaseClaim.where.not(state: 'draft').where(clone_source_id: nil).pluck(:total, :vat_amount).flatten.sum
-        num_claims = Claim::BaseClaim.where.not(state: 'draft').where(clone_source_id: nil).count
+        total_money_to_date_inc_vat = Claim::BaseClaim.active.where.not(state: 'draft').where(clone_source_id: nil).pluck(:total, :vat_amount).flatten.sum
+        num_claims = Claim::BaseClaim.active.where.not(state: 'draft').where(clone_source_id: nil).count
         Statistic.create_or_update(@date, "money_to_date", Claim::BaseClaim, total_money_to_date_inc_vat, num_claims)
       end
     end

--- a/app/models/stats/collector/multi_session_submission_collector.rb
+++ b/app/models/stats/collector/multi_session_submission_collector.rb
@@ -12,7 +12,7 @@ module Stats
       private
 
       def submitted_claims_for_day
-        Claim::BaseClaim.where('last_submitted_at between ? and ?', @date.beginning_of_day, @date.end_of_day)
+        Claim::BaseClaim.active.where('last_submitted_at between ? and ?', @date.beginning_of_day, @date.end_of_day)
       end
 
 

--- a/app/models/stats/collector/time_from_reject_to_auth_collector.rb
+++ b/app/models/stats/collector/time_from_reject_to_auth_collector.rb
@@ -35,12 +35,12 @@ module Stats
       end
 
       def claims_authorised_in_rolling_average_period
-        Claim::BaseClaim.where('authorised_at between ? and ?', @rolling_period_start, @rolling_period_end)
+        Claim::BaseClaim.active.where('authorised_at between ? and ?', @rolling_period_start, @rolling_period_end)
       end
 
       def days_reject_to_auth(claim_id)
-        cloned_claim = Claim::BaseClaim.find claim_id
-        source_claim = Claim::BaseClaim.find cloned_claim.clone_source_id
+        cloned_claim = Claim::BaseClaim.active.find claim_id
+        source_claim = Claim::BaseClaim.active.find cloned_claim.clone_source_id
         cloned_claim.authorised_at - rejected_date_for(source_claim)
       end
 

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -23,7 +23,7 @@ module Stats
     def generate_new_report
       csv_string = CSV.generate do |csv|
         csv << Settings.claim_csv_headers.map {|header| header.to_s.humanize}
-        Claim::BaseClaim.non_draft.find_each do |claim|
+        Claim::BaseClaim.active.non_draft.find_each do |claim|
           ClaimCsvPresenter.new(claim, 'view').present! do |claim_journeys|
             claim_journeys.each do |claim_journey|
               csv << claim_journey

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -12,7 +12,7 @@ module TimedTransitions
     # generates sql to retrieve all claims in a state from which a timed transition can be made.
     #
     def self.candidate_claims
-      Claim::BaseClaim.where('state in (?)', candidate_states)
+      Claim::BaseClaim.active.where('state in (?)', candidate_states)
     end
 
 

--- a/app/services/claim_reporter.rb
+++ b/app/services/claim_reporter.rb
@@ -33,7 +33,7 @@ class ClaimReporter
 
   def completion_rate
     intentions_form_id = ClaimIntention.where(created_at: 16.weeks.ago..3.weeks.ago).pluck(:form_id)
-    completed = Claim::BaseClaim.where.not(state: 'draft').where(form_id: intentions_form_id).where.not(last_submitted_at: nil).size
+    completed = Claim::BaseClaim.active.where.not(state: 'draft').where(form_id: intentions_form_id).where.not(last_submitted_at: nil).size
     intentions = intentions_form_id.size
 
     claims_percentage(completed, intentions)
@@ -42,7 +42,7 @@ class ClaimReporter
   private
 
   def non_draft_claims
-    Claim::BaseClaim.non_draft
+    Claim::BaseClaim.active.non_draft
   end
 
   def claims_percentage(subset_count, all_count)

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -5,7 +5,7 @@ module Claims
 
     def initialize(claim_id, params)
       @params = params
-      @claim = Claim::BaseClaim.find(claim_id)
+      @claim = Claim::BaseClaim.active.find(claim_id)
       @messages = @claim.messages.most_recent_last
       extract_transition_params
       extract_assessment_params

--- a/db/migrate/20160819092435_add_deleted_at_to_claims.rb
+++ b/db/migrate/20160819092435_add_deleted_at_to_claims.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToClaims < ActiveRecord::Migration
+  def change
+    add_column :claims, :deleted_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818080705) do
+ActiveRecord::Schema.define(version: 20160819092435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 20160818080705) do
     t.string   "transfer_case_number"
     t.integer  "clone_source_id"
     t.datetime "last_edited_at"
+    t.datetime "deleted_at"
   end
 
   add_index "claims", ["case_number"], name: "index_claims_on_case_number", using: :btree

--- a/lib/api/claims/base_claim_test.rb
+++ b/lib/api/claims/base_claim_test.rb
@@ -71,7 +71,7 @@ class BaseClaimTest
   def clean_up
     puts 'cleaning up'
 
-    if (claim = Claim::BaseClaim.find_by(uuid: claim_uuid))
+    if (claim = Claim::BaseClaim.active.find_by(uuid: claim_uuid))
       if claim.destroy
         puts 'claim destroyed'
       else

--- a/lib/tasks/provider_switcher.rake
+++ b/lib/tasks/provider_switcher.rake
@@ -17,7 +17,7 @@ class ProviderSwitcher
   end
 
   def switch!
-    claim = Claim::BaseClaim.find(@claim_id)
+    claim = Claim::BaseClaim.active.find(@claim_id)
     provider = claim.provider
 
     user = User.where(email: 'advocateadmin@example.com').first
@@ -28,8 +28,8 @@ class ProviderSwitcher
   end
 
   def reset!
-    advocate_external_user = User.where(email: 'advocate@example.com').first.persona
-    admin_external_user = User.where(email: 'advocateadmin@example.com').first.persona
+    advocate_external_user = User.active.where(email: 'advocate@example.com').first.persona
+    admin_external_user = User.active.where(email: 'advocateadmin@example.com').first.persona
     admin_external_user.provider_id = advocate_external_user.provider_id
     admin_external_user.save!
     puts "Test user reset to belong to Provider #{admin_external_user.provider_id} #{admin_external_user.provider.name}"

--- a/spec/api/v1/external_users/claims/advocate_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocate_claim_spec.rb
@@ -135,7 +135,7 @@ describe API::V1::ExternalUsers::Claims::AdvocateClaim do
         expect(last_response.status).to eq(201)
         json = JSON.parse(last_response.body)
         expect(json['id']).not_to be_nil
-        expect(Claim::AdvocateClaim.find_by(uuid: json['id']).uuid).to eq(json['id'])
+        expect(Claim::AdvocateClaim.active.find_by(uuid: json['id']).uuid).to eq(json['id'])
       end
 
       it "should exclude API key, creator email and advocate email from response" do
@@ -148,14 +148,14 @@ describe API::V1::ExternalUsers::Claims::AdvocateClaim do
       end
 
       it "should create one new claim" do
-        expect{ post_to_create_endpoint }.to change { Claim::AdvocateClaim.count }.by(1)
+        expect{ post_to_create_endpoint }.to change { Claim::AdvocateClaim.active.count }.by(1)
       end
 
       context "the new claim should" do
 
         before(:each) {
           post_to_create_endpoint
-          @new_claim = Claim::AdvocateClaim.last
+          @new_claim = Claim::AdvocateClaim.active.last
         }
 
         it "have the same attributes as described in params" do

--- a/spec/api/v1/external_users/claims/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/final_claim_spec.rb
@@ -107,7 +107,7 @@ describe API::V1::ExternalUsers::Claims::FinalClaim do
         expect(last_response.status).to eq(201)
         json = JSON.parse(last_response.body)
         expect(json['id']).not_to be_nil
-        expect(Claim::LitigatorClaim.find_by(uuid: json['id']).uuid).to eq(json['id'])
+        expect(Claim::LitigatorClaim.active.find_by(uuid: json['id']).uuid).to eq(json['id'])
       end
 
       it "should exclude API key, creator email and user email from response" do
@@ -120,14 +120,14 @@ describe API::V1::ExternalUsers::Claims::FinalClaim do
       end
 
       it "should create one new claim" do
-        expect{ post_to_create_endpoint }.to change { Claim::LitigatorClaim.count }.by(1)
+        expect{ post_to_create_endpoint }.to change { Claim::LitigatorClaim.active.count }.by(1)
       end
 
       context "the new claim should" do
 
         before(:each) {
           post_to_create_endpoint
-          @new_claim = Claim::LitigatorClaim.last
+          @new_claim = Claim::LitigatorClaim.active.last
         }
 
         it "have the same attributes as described in params" do

--- a/spec/api/v1/external_users/claims/interim_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/interim_claim_spec.rb
@@ -85,7 +85,7 @@ describe API::V1::ExternalUsers::Claims::InterimClaim do
           post_to_create_endpoint
           expect(last_response.status).to eq 201
           response_hash = JSON.parse( last_response.body)
-          claim = Claim::InterimClaim.find_by(uuid: response_hash['id'])
+          claim = Claim::InterimClaim.active.find_by(uuid: response_hash['id'])
           expect(claim).not_to be_nil, "Unable to locate claim with uuid #{response_hash['id']}"
 
           valid_params.each do |parameter_key, parameter_value|
@@ -98,7 +98,7 @@ describe API::V1::ExternalUsers::Claims::InterimClaim do
           post_to_create_endpoint
           expect(last_response.status).to eq 201
           response_hash = JSON.parse( last_response.body)
-          claim = Claim::InterimClaim.find_by(uuid: response_hash['id'])
+          claim = Claim::InterimClaim.active.find_by(uuid: response_hash['id'])
           expect(claim).not_to be_nil, "Unable to locate claim with uuid #{response_hash['id']}"
 
           expected_owner = User.find_by(email: valid_params[:user_email])

--- a/spec/api/v1/external_users/claims/transfer_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/transfer_claim_spec.rb
@@ -111,7 +111,7 @@ describe API::V1::ExternalUsers::Claims::TransferClaim do
         expect(last_response.status).to eq(201)
         json = JSON.parse(last_response.body)
         expect(json['id']).not_to be_nil
-        expect(Claim::TransferClaim.find_by(uuid: json['id']).uuid).to eq(json['id'])
+        expect(Claim::TransferClaim.active.find_by(uuid: json['id']).uuid).to eq(json['id'])
       end
 
       it "should exclude API key, creator email and user email from response" do
@@ -124,7 +124,7 @@ describe API::V1::ExternalUsers::Claims::TransferClaim do
       end
 
       it "should create one new claim" do
-        expect{ post_to_create_endpoint }.to change { Claim::TransferClaim.count }.by(1)
+        expect{ post_to_create_endpoint }.to change { Claim::TransferClaim.active.count }.by(1)
       end
 
       it "should create one transfer detail" do
@@ -135,7 +135,7 @@ describe API::V1::ExternalUsers::Claims::TransferClaim do
 
         before(:each) {
           post_to_create_endpoint
-          @new_claim = Claim::TransferClaim.last
+          @new_claim = Claim::TransferClaim.active.last
         }
 
         it "have the same attributes as described in params" do

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -99,12 +99,12 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
 
         context 'create draft' do
           before(:each) do
-            expect(Claim::AdvocateClaim.count).to eq(0)
+            expect(Claim::AdvocateClaim.active.count).to eq(0)
             post :create, commit_save_draft: 'Save to drafts', claim: claim_params
           end
 
           it 'creates the claim and sets the state to "draft"' do
-            expect(Claim::AdvocateClaim.first).to be_draft
+            expect(Claim::AdvocateClaim.active.first).to be_draft
           end
 
           it 'redirects to claims list' do
@@ -112,8 +112,8 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
           end
 
           it 'sets the created claim\'s external_user/"owner" to the signed in advocate' do
-            expect(Claim::AdvocateClaim.first.external_user).to eq(advocate)
-            expect(Claim::AdvocateClaim.first.creator).to eq(advocate)
+            expect(Claim::AdvocateClaim.active.first.external_user).to eq(advocate)
+            expect(Claim::AdvocateClaim.active.first.creator).to eq(advocate)
           end
         end
 
@@ -126,19 +126,19 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
 
           it 'redirects to claim summary if no validation errors present' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
-            expect(response).to redirect_to(summary_external_users_claim_path(Claim::AdvocateClaim.first))
+            expect(response).to redirect_to(summary_external_users_claim_path(Claim::AdvocateClaim.active.first))
           end
 
           it 'sets the created claim\'s external_user/owner to the signed in advocate' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
-            expect(Claim::AdvocateClaim.first.external_user).to eq(advocate)
-            expect(Claim::AdvocateClaim.first.creator).to eq(advocate)
+            expect(Claim::AdvocateClaim.active.first.external_user).to eq(advocate)
+            expect(Claim::AdvocateClaim.active.first.creator).to eq(advocate)
           end
 
           it 'leaves the claim\'s state in "draft"' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
             expect(response).to have_http_status(:redirect)
-            expect(Claim::AdvocateClaim.first).to be_draft
+            expect(Claim::AdvocateClaim.active.first).to be_draft
           end
 
           context 'blank expenses' do
@@ -208,7 +208,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
             }
           end
 
-          let(:subject_claim) { Claim::AdvocateClaim.where(case_number: case_number).first }
+          let(:subject_claim) { Claim::AdvocateClaim.active.where(case_number: case_number).first }
 
           it 'validates step fields and move to next steps' do
             post :create, commit_continue: 'Continue', claim: claim_params_step1

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -300,11 +300,11 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
           before { sign_in litigator_admin.user }
           it 'should assign context to claims created by all members of the provider' do
             get :archived
-            expect(assigns(:claims_context).sort_by{|c| c.id}).to eq(litigator_admin.provider.claims_created.sort_by{|c| c.id})
+            expect(assigns(:claims_context).sort_by{|c| c.id}).to eq(litigator_admin.provider.claims_created.active.sort_by{|c| c.id})
           end
           it 'should retrieve archived state claims only' do
             get :archived
-            expect(assigns(:claims).sort_by{|c| c.id}).to eq(litigator_admin.provider.claims_created.archived_pending_delete.sort_by{|c| c.id})
+            expect(assigns(:claims).sort_by{|c| c.id}).to eq(litigator_admin.provider.claims_created.active.archived_pending_delete.sort_by{|c| c.id})
           end
         end
       end
@@ -514,12 +514,12 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
       end
 
       it 'creates a draft from the rejected claim' do
-        expect(Claim::BaseClaim.last).to be_draft
-        expect(Claim::BaseClaim.last.case_number).to eq(subject.case_number)
+        expect(Claim::BaseClaim.active.last).to be_draft
+        expect(Claim::BaseClaim.active.last.case_number).to eq(subject.case_number)
       end
 
       it 'redirects to the draft\'s edit page' do
-        expect(response).to redirect_to(edit_advocates_claim_path(Claim::BaseClaim.last))
+        expect(response).to redirect_to(edit_advocates_claim_path(Claim::BaseClaim.active.last))
       end
     end
 
@@ -535,7 +535,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
       end
 
       it 'does not create a draft claim' do
-        expect(Claim::BaseClaim.last).to_not be_draft
+        expect(Claim::BaseClaim.active.last).to_not be_draft
       end
     end
   end
@@ -547,7 +547,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
       let(:claim) { create(:draft_claim, external_user: advocate) }
 
       it 'deletes the claim' do
-        expect(Claim::BaseClaim.count).to eq(0)
+        expect(Claim::BaseClaim.active.count).to eq(0)
       end
 
       it 'redirects to advocates root url' do
@@ -559,7 +559,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
       let(:claim) { create(:authorised_claim, external_user: advocate) }
 
       it "sets the claim's state to 'archived_pending_delete'" do
-        expect(Claim::BaseClaim.count).to eq(1)
+        expect(Claim::BaseClaim.active.count).to eq(1)
         expect(claim.reload.state).to eq 'archived_pending_delete'
       end
     end

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -130,12 +130,12 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
 
           it 'sets the created claim\'s creator/"owner" to the signed in litigator' do
             post :create, claim: claim_params, commit_save_draft: 'Save to drafts'
-            expect(Claim::LitigatorClaim.first.creator).to eq(litigator)
+            expect(Claim::LitigatorClaim.active.first.creator).to eq(litigator)
           end
 
           it 'sets the claim\'s state to "draft"' do
             post :create, claim: claim_params, commit_save_draft: 'Save to drafts'
-            expect(Claim::LitigatorClaim.first).to be_draft
+            expect(Claim::LitigatorClaim.active.first).to be_draft
           end
         end
 
@@ -148,13 +148,13 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
 
           it 'redirects to claim summary if no validation errors present' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
-            expect(response).to redirect_to(summary_external_users_claim_path(Claim::LitigatorClaim.first))
+            expect(response).to redirect_to(summary_external_users_claim_path(Claim::LitigatorClaim.active.first))
           end
 
           it 'leaves the claim\'s state in "draft"' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
             expect(response).to have_http_status(:redirect)
-            expect(Claim::LitigatorClaim.first).to be_draft
+            expect(Claim::LitigatorClaim.active.first).to be_draft
           end
         end
 

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
 
           it 'sets the claim\'s state to "draft"' do
             post :create, claim: claim_params, commit_save_draft: 'Save to drafts'
-            expect(Claim::InterimClaim.first).to be_draft
+            expect(Claim::InterimClaim.active.first).to be_draft
           end
         end
 
@@ -96,13 +96,13 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
 
           it 'redirects to claim summary if no validation errors present' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
-            expect(response).to redirect_to(summary_external_users_claim_path(Claim::InterimClaim.first))
+            expect(response).to redirect_to(summary_external_users_claim_path(Claim::InterimClaim.active.first))
           end
 
           it 'leaves the claim\'s state in "draft"' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
             expect(response).to have_http_status(:redirect)
-            expect(Claim::InterimClaim.first).to be_draft
+            expect(Claim::InterimClaim.active.first).to be_draft
           end
         end
 

--- a/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
 
           it 'sets the claim\'s state to "draft"' do
             post :create, claim: claim_params, commit_save_draft: 'Save to drafts'
-            expect(Claim::TransferClaim.first).to be_draft
+            expect(Claim::TransferClaim.active.first).to be_draft
           end
         end
 
@@ -99,13 +99,13 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
 
           it 'redirects to claim summary if no validation errors present' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
-            expect(response).to redirect_to(summary_external_users_claim_path(Claim::TransferClaim.first))
+            expect(response).to redirect_to(summary_external_users_claim_path(Claim::TransferClaim.active.first))
           end
 
           it 'leaves the claim\'s state in "draft"' do
             post :create, claim: claim_params, commit_submit_claim: 'Submit to LAA'
             expect(response).to have_http_status(:redirect)
-            expect(Claim::TransferClaim.first).to be_draft
+            expect(Claim::TransferClaim.active.first).to be_draft
           end
         end
 
@@ -205,7 +205,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
             merge(expenses_params)
           end
 
-          let(:claim) { Claim::TransferClaim.where(case_number: case_number).first }
+          let(:claim) { Claim::TransferClaim.active.where(case_number: case_number).first }
 
           context 'step 1 Continue' do
             render_views

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -1,7 +1,7 @@
 class NotifyMailerPreview < ActionMailer::Preview
 
   def new_message_test_email
-    claim = Claim::BaseClaim.last
+    claim = Claim::BaseClaim.active.last
     NotifyMailer.new_message_test_email(claim)
   end
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -53,6 +53,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 require 'rails_helper'

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 require 'rails_helper'

--- a/spec/models/claim/interim_claim_spec.rb
+++ b/spec/models/claim/interim_claim_spec.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 require 'rails_helper'

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 require 'rails_helper'

--- a/spec/models/claim/transfer_claim_spec.rb
+++ b/spec/models/claim/transfer_claim_spec.rb
@@ -52,6 +52,7 @@
 #  transfer_case_number     :string
 #  clone_source_id          :integer
 #  last_edited_at           :datetime
+#  deleted_at               :datetime
 #
 
 require "rails_helper"

--- a/spec/models/claims/state_machine_scopes_spec.rb
+++ b/spec/models/claims/state_machine_scopes_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Claims::StateMachine, type: :model do
 
     describe '.non_draft' do
       it 'only returns non-draft claims' do
-        expect(Claim::BaseClaim.non_draft).to match_array([allocated_claim, submitted_claim, redetermination_claim, awaiting_written_reasons_claim, deleted_claim])
+        expect(Claim::BaseClaim.active.non_draft).to match_array([allocated_claim, submitted_claim, redetermination_claim, awaiting_written_reasons_claim, deleted_claim])
       end
     end
 
     describe '.submitted_or_redetermination_or_awaiting_written_reasons' do
       it 'only returns submitted or redetermination or awaiting_written_reasons claims' do
-        expect(Claim::BaseClaim.submitted_or_redetermination_or_awaiting_written_reasons).to match_array([submitted_claim, redetermination_claim, awaiting_written_reasons_claim])
+        expect(Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons).to match_array([submitted_claim, redetermination_claim, awaiting_written_reasons_claim])
       end
     end
   end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Claims::StateMachine, type: :model do
       ]
     end
 
-    it('exist') { expect(Claim::BaseClaim.state_machine.states.map(&:name).sort).to eq(states.sort) }
+    it('exist') { expect(Claim::BaseClaim.active.state_machine.states.map(&:name).sort).to eq(states.sort) }
   end
 
   describe 'valid transitions' do

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -22,7 +22,7 @@ module TimedTransitions
     describe '.candidate_claims' do
       it 'should generate the correct sql' do
         expect(Transitioner.candidate_claims.to_sql).to eq(
-          %q<SELECT "claims".* FROM "claims" WHERE (state in ('authorised','part_authorised','refused','rejected','archived_pending_delete'))>)
+          %q<SELECT "claims".* FROM "claims" WHERE "claims"."deleted_at" IS NULL AND (state in ('authorised','part_authorised','refused','rejected','archived_pending_delete'))>)
       end
     end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -329,7 +329,7 @@ describe Claim::BaseClaimValidator do
       claim.evidence_checklist_ids = doc_types
       should_not_error(claim,:evidence_checklist_ids)
       claim.save!
-      dup = Claim::BaseClaim.find claim.id
+      dup = Claim::BaseClaim.active.find claim.id
       expect(dup.evidence_checklist_ids).to eq( doc_types )
 
     end

--- a/spikes/stats/collector/draft_to_submitted_time.rb
+++ b/spikes/stats/collector/draft_to_submitted_time.rb
@@ -11,7 +11,7 @@ module Stats
       end
 
       def run
-        claim_ids = Claim::BaseClaim.all.pluck(:id)
+        claim_ids = Claim::BaseClaim.active.pluck(:id)
         claim_ids.each { |claim_id| calculate_time_draft_to_submitted(claim_id) }
         print_results
       end
@@ -25,7 +25,7 @@ module Stats
       end
 
       def calculate_time_draft_to_submitted(claim_id)
-        claim = Claim::BaseClaim.find claim_id
+        claim = Claim::BaseClaim.active.find claim_id
         if claim.state != 'draft'
           period_in_secs = first_submitted_at(claim) - claim.created_at
           period_in_days = (period_in_secs / SECONDS_IN_DAY).to_i


### PR DESCRIPTION
This PR implements soft deletes from claims.

As with the User, CaseWorker and ExternalUser model, queries on the Claim model should always be performed with the 'active' scope, unless you particularly want to get claims which have also been soft deleted. So:
  Claim::BaseClaim.active.find(...) 
  Claim::BaseClaim.active.where(.....)

There is not need to insert the 'active' scope if retrieving a collection of claims through the association of another model, as these associations have the 'active' scope already applied, e.g.:
  CaseWorker.first.claims   # only returns active claims.
