### PR TITLE
Claim scheme filters in the main claim list for external users.

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/SchemeFilter.js
+++ b/app/assets/javascripts/modules/external_users/claims/SchemeFilter.js
@@ -1,0 +1,17 @@
+moj.Modules.SchemeFilter = {
+  init: function() {
+    var self = this;
+
+    $('.js-claim-scheme-filter')
+      .on('change', ':radio', function() {
+        window.location = self.pathWithFilter($(this).val());
+      });
+  },
+
+  // pathname returns the current url location without any query params
+  pathWithFilter: function(scheme) {
+    var param  = scheme !== 'all' ? '?scheme='+scheme : '';
+    var anchor = '#listanchor';
+    return window.location.pathname + param + anchor;
+  }
+};

--- a/app/assets/stylesheets/moj/_shame.scss
+++ b/app/assets/stylesheets/moj/_shame.scss
@@ -41,6 +41,7 @@ caption {
 // claim detail page
 
 .financial-summary{
+  padding-bottom: 56px;
   @include span(8 of 12);
   @include first;
   div{

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
 
   load_and_authorize_resource
 
-  unless Rails.env.development?
+  unless Rails.env.development? || Rails.env.devunicorn?
     rescue_from Exception do |exception|
       if exception.is_a?(ActiveRecord::RecordNotFound)
         redirect_to error_404_url

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -6,7 +6,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   skip_load_and_authorize_resource
 
-  helper_method :sort_column, :sort_direction
+  helper_method :sort_column, :sort_direction, :scheme
 
   respond_to :html
 
@@ -169,8 +169,9 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def set_claims_context
-    context = Claims::ContextMapper.new(@external_user)
+    context = Claims::ContextMapper.new(@external_user, scheme: scheme)
     @claims_context = context.available_claims
+    @available_schemes = context.available_schemes
   end
 
   def set_financial_summary
@@ -204,6 +205,10 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def sort_and_paginate(options={})
     set_sort_defaults(options)
     @claims = @claims.sort(sort_column, sort_direction).page(current_page).per(@sort_defaults[:pagination])
+  end
+
+  def scheme
+    %w(agfs lgfs).include?(params[:scheme]) ? params[:scheme].to_sym : :all
   end
 
   def set_and_authorize_claim

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -17,4 +17,8 @@ module ClaimsHelper
   def show_api_promo_to_user?
     Settings.api_promo_enabled? && current_user.setting?(:api_promo_seen).nil?
   end
+
+  def show_claim_list_scheme_filters?(available_schemes)
+    Settings.scheme_filters_enabled? && available_schemes.size > 1
+  end
 end

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -99,7 +99,7 @@ module Claim
     end
 
     def agfs?
-      true
+      self.class.agfs?
     end
 
     def update_claim_document_owners

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -129,6 +129,9 @@ module Claim
 
     scope :cloned, -> { where.not(clone_source_id: nil) }
 
+    scope :agfs, -> { where(type: 'Claim::AdvocateClaim') }
+    scope :lgfs, -> { where.not(type: 'Claim::AdvocateClaim') }
+
     accepts_nested_attributes_for :misc_fees,         reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :expenses,          reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :disbursements,     reject_if: all_blank_or_zero, allow_destroy: true
@@ -172,6 +175,14 @@ module Claim
     def final?; false; end
     def requires_cracked_dates?; false; end
     def requires_case_concluded_date?; false; end
+
+    def self.agfs?
+      [Claim::AdvocateClaim].include?(self)
+    end
+
+    def self.lgfs?
+      [Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim].include?(self)
+    end
 
     def pretty_type
       type.demodulize.sub('Claim', '').downcase

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -68,7 +68,7 @@ module Claim
     accepts_nested_attributes_for :interim_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
 
-    def lgfs?; true; end
+    def lgfs?; self.class.lgfs?; end
     def interim?; true; end
 
     def eligible_case_types

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -70,7 +70,7 @@ module Claim
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :graduated_fee, reject_if: :all_blank, allow_destroy: false
 
-    def lgfs?; true; end
+    def lgfs?; self.class.lgfs?; end
     def final?; true; end
 
     # Fixed Fee Adder requires a fixed_fees method

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -84,7 +84,7 @@ module Claim
       end
     end
 
-    def lgfs?; true; end
+    def lgfs?; self.class.lgfs?; end
     def transfer?; true; end
     def requires_trial_dates?; false; end
     def requires_retrial_dates?; false; end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -102,8 +102,7 @@ class Expense < ActiveRecord::Base
   end
 
   def allow_reason_text?
-    return false if self.reason_id.nil?
-    expense_reason.allow_explanatory_text?
+    !!expense_reason&.allow_explanatory_text?
   end
 
   def expense_reasons

--- a/app/views/external_users/claims/index.html.haml
+++ b/app/views/external_users/claims/index.html.haml
@@ -5,13 +5,15 @@
     = render partial: 'financial_summary', locals: { financial_summary: @financial_summary }
   .claims-actions
     = link_to t('link.add_claim'), types_external_users_claims_path, class: 'button button-start', role:'button'
-    .claims-importer#importer
-      = render partial: 'json_document_importer'
+    - unless scheme == :lgfs
+      .claims-importer#importer
+        = render partial: 'json_document_importer'
 
 .container.search-wrapper#listanchor
   - if params[:search].present?
     = render partial: 'shared/search_summary'
   #report-options
+    = render partial: 'shared/scheme_filters', locals: { available_schemes: @available_schemes }
     = render partial: 'shared/search_form', locals: { search_path: defined?(archived) && archived ? archived_external_users_claims_path : external_users_claims_path, hint_text: t('hint.search') }
 .container
   .importer-results{'aria-live': 'polite'}

--- a/app/views/external_users/json_document_importers/create.js.erb
+++ b/app/views/external_users/json_document_importers/create.js.erb
@@ -55,7 +55,10 @@ $importButton.prop('disabled', false).val('Import claims');
     <% present(imported_claim) do |claim| %>
       $('table.report').prepend(
         '<tr class="<%= claim.state %>">' +
-          '<td><%= link_to claim.case_number, external_users_claim_path(claim) %></td>' +
+          <% if user_requires_scheme_column? %>
+            '<td><%= claim.pretty_type %></td>' +
+          <% end %>
+          '<td><%= link_to claim.case_number, external_users_claim_path(claim) %><div class="unique-id-small"><%= claim.unique_id %></div></td>' +
           <% if current_user.persona.admin? %>
             '<td><%= claim.external_user.name %></td>' +
           <% end %>

--- a/app/views/shared/_scheme_filters.html.haml
+++ b/app/views/shared/_scheme_filters.html.haml
@@ -1,4 +1,4 @@
-- unless available_schemes.one?
+- if show_claim_list_scheme_filters?(available_schemes)
 
   %fieldset.inline.js-claim-scheme-filter
     .column-half.form-group

--- a/app/views/shared/_scheme_filters.html.haml
+++ b/app/views/shared/_scheme_filters.html.haml
@@ -1,0 +1,12 @@
+- unless available_schemes.one?
+
+  %fieldset.inline.js-claim-scheme-filter
+    .column-half.form-group
+      %legend
+        = t('.scheme_filter')
+      .form-hint.xsmall.zero-vert-margin
+        = t('.scheme_filter_hint')
+      - [:all].concat(available_schemes).each do |filter_scheme|
+        = label_tag "scheme_#{filter_scheme}", nil, class: "block-label" do
+          = radio_button_tag :scheme, filter_scheme, scheme.blank? ? filter_scheme == :all : scheme == filter_scheme
+          = filter_scheme == :all ? t('.scheme_filter_all') : filter_scheme.upcase

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-if Rails.env.development?
+if Rails.env.development? || Rails.env.devunicorn?
   Rails.application.config.filter_parameters += [
     :password,
     :document

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -899,6 +899,10 @@ en:
       print_messages: Print all messages
     assessment:
       claimed_by: "Claimed by %{type}"
+    scheme_filters:
+      scheme_filter_hint: 'Configure list below by AGFS and LGFS claims'
+      scheme_filter: 'Filter list by:'
+      scheme_filter_all: 'All'
   case_workers:
     table_headings:
       your_claims: Your claims

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,7 @@ Rails.application.routes.draw do
 
 
   # catch-all route
-  unless Rails.env.development?
+  unless Rails.env.development? || Rails.env.devunicorn?
     match '*path', to: 'errors#not_found', via: :all
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,3 +52,7 @@ expense_schema_version: 2
 # Feature flag to enable or disable API promo banner in the claims page
 # If enabled, users will see it, and will have a 'dismiss' link to hide and do not show it again
 api_promo_enabled?: true
+
+# Feature flag to enable or disable the scheme filters in the claims list page
+# If enabled, users with proper roles will see scheme radio buttons to filter the list
+scheme_filters_enabled?: false

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -99,6 +99,37 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
         end
       end
 
+      context 'scheme filtering' do
+        before do
+          sign_in advocate_admin.user
+          get :index, query_params
+        end
+
+        context 'ALL filter' do
+          let(:query_params) { {scheme: 'all'} }
+
+          it 'should assign context to claims for the provider' do
+            expect(assigns(:claims_context)).to eq(advocate_admin.provider.claims_created)
+          end
+        end
+
+        context 'AGFS filter' do
+          let(:query_params) { {scheme: 'agfs'} }
+
+          it 'should assign context to claims for the provider' do
+            expect(assigns(:claims_context)).to eq(advocate_admin.provider.claims_created)
+          end
+        end
+
+        context 'LGFS filter' do
+          let(:query_params) { {scheme: 'lgfs'} }
+
+          it 'should assign context to claims for the provider' do
+            expect(assigns(:claims_context)).to eq([])
+          end
+        end
+      end
+
       context 'sorting' do
         let(:query_params) { {} }
         let(:limit) { 10 }

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -86,6 +86,20 @@ module Claim
       end
     end
 
+    describe '.agfs?' do
+      it 'returns true if class is advocate claim, false otherwise' do
+        expect(agfs_claim.class.agfs?).to eql true
+        expect(lgfs_claim.class.agfs?).to eql false
+      end
+    end
+
+    describe '.lgfs?' do
+      it 'returns true if claim is litigator/lgfs claim, false for advocate/agfs claims' do
+        expect(lgfs_claim.class.lgfs?).to eql true
+        expect(agfs_claim.class.lgfs?).to eql false
+      end
+    end
+
     describe 'has_many documents association' do
       it 'should return a collection of verified documents only' do
         claim = create :claim


### PR DESCRIPTION
The filters will only appear when the user has the ability to create AGFS
and LGFS claims, otherwise it doesn't make sense to show the filters.

When LGFS filter is selected, the JSON importer is hidden, as we don't
support yet LGFS claim imports and it creates a confusing experience.
- ALL/AGFS selected (JSON importer available)
  <img width="972" alt="screen shot 2016-08-22 at 17 26 08" src="https://cloud.githubusercontent.com/assets/687910/17862711/5190caba-688e-11e6-9f1e-5b76e0d93027.png">
- LGFS selected (JSON importer hidden)
  <img width="974" alt="screen shot 2016-08-22 at 17 26 43" src="https://cloud.githubusercontent.com/assets/687910/17862728/6b432e80-688e-11e6-9cca-4b88fafe9fd7.png">
