### PR TITLE
Enable external users to manage their own accounts

### DIFF
--- a/app/controllers/external_users/admin/external_users_controller.rb
+++ b/app/controllers/external_users/admin/external_users_controller.rb
@@ -33,7 +33,8 @@ class ExternalUsers::Admin::ExternalUsersController < ExternalUsers::Admin::Appl
 
   def update
     if @external_user.update(external_user_params)
-      redirect_to external_users_admin_external_users_url, notice: 'User successfully updated'
+      redirect_path = @external_user.admin? ? external_users_admin_external_users_url : external_users_claims_path
+      redirect_to redirect_path, notice: 'User successfully updated'
     else
       render :edit
     end
@@ -57,12 +58,25 @@ class ExternalUsers::Admin::ExternalUsersController < ExternalUsers::Admin::Appl
   end
 
   def external_user_params
+    current_user.persona.admin? ? admin_external_user_params : non_privileged_external_user_params
+  end
+
+  def admin_external_user_params
     params.require(:external_user).permit(
      :vat_registered,
      :supplier_number,
      :email_notification_of_message,
      roles: [],
      user_attributes: [:id, :email, :email_confirmation, :password, :password_confirmation, :current_password, :first_name, :last_name]
+    )
+  end
+
+  def non_privileged_external_user_params
+    params.require(:external_user).permit(
+      :vat_registered,
+      :supplier_number,
+      :email_notification_of_message,
+      user_attributes: [:id, :email, :email_confirmation, :password, :password_confirmation, :current_password, :first_name, :last_name]
     )
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,6 +34,7 @@ class Ability
         end
 
         can_manage_own_password(persona)
+        can_manage_self(persona)
       end
 
     elsif persona.is_a? CaseWorker
@@ -105,6 +106,10 @@ class Ability
 
   def can_manage_own_password(persona)
     can [:show, :change_password, :update_password], persona.class, id: persona.id
+  end
+
+  def can_manage_self(persona)
+    can [:show, :edit, :update], persona.class, id: persona.id
   end
 
 end

--- a/app/views/external_users/admin/external_users/_form.html.haml
+++ b/app/views/external_users/admin/external_users/_form.html.haml
@@ -27,21 +27,22 @@
         =f.collection_radio_buttons(:email_notification_of_message, [true, false], :to_s, :to_s) do |b|
           - b.label(class: 'block-label') { b.radio_button + (b.value.to_s == 'true' ? 'Yes' : 'No') }
 
-    %fieldset.inline.js-advocate-roles
-      %legend
-        = 'Roles'
-      = f.collection_check_boxes(:roles, @external_user.available_roles, :to_s, :to_s) do |b|
-        - b.label(class: "block-label") { b.check_box + b.value.humanize }
+    - if current_user.persona.admin?
+      %fieldset.inline.js-advocate-roles
+        %legend
+          = 'Roles'
+        = f.collection_check_boxes(:roles, @external_user.available_roles, :to_s, :to_s) do |b|
+          - b.label(class: "block-label") { b.check_box + b.value.humanize }
 
-      - if current_user.persona.provider.chamber?
-        .js-chamber-advocates-only
-          %fieldset
-            = f.label :vat_registered, class: "form-label"
-            .form-group.inline
-              =f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
-                - b.label(class: 'block-label') { b.radio_button + (b.value.to_s == 'true' ? 'Yes' : 'No') }
+        - if current_user.persona.provider.chamber?
+          .js-chamber-advocates-only
+            %fieldset
+              = f.label :vat_registered, class: "form-label"
+              .form-group.inline
+                =f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
+                  - b.label(class: 'block-label') { b.radio_button + (b.value.to_s == 'true' ? 'Yes' : 'No') }
 
-          = f.label :supplier_number, t(".supplier_number"), class: "form-label"
-          = f.text_field :supplier_number, class: "form-control"
+            = f.label :supplier_number, t(".supplier_number"), class: "form-label"
+            = f.text_field :supplier_number, class: "form-control"
 
   = f.submit 'Save', class: "button"

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -21,6 +21,9 @@
             = link_to 'Manage users', external_users_admin_external_users_path, class: cp(external_users_admin_external_users_path)
           %li
             = link_to "Manage provider", external_users_admin_provider_path(current_user.persona.provider), class: cp(external_users_admin_provider_path(current_user.persona.provider))
+        - else
+          %li
+            = link_to "Manage your settings", edit_external_users_admin_external_user_path(current_user.persona), class: cp(edit_external_users_admin_external_user_path(current_user.persona))
       - elsif current_user.persona.is_a?(CaseWorker)
         - if current_user.persona.admin?
           %li

--- a/spec/controllers/external_users/admin/external_users_controller_spec.rb
+++ b/spec/controllers/external_users/admin/external_users_controller_spec.rb
@@ -2,199 +2,331 @@ require 'rails_helper'
 
 RSpec.describe ExternalUsers::Admin::ExternalUsersController, type: :controller do
   let(:provider)  { create(:provider) }
-  let(:admin)     { create(:external_user, :admin, provider: provider) }
 
-  subject { create(:external_user, provider: provider) }
+  context 'admin user' do
+    let(:admin)     { create(:external_user, :admin, provider: provider) }
 
-  before { sign_in admin.user }
+    subject { create(:external_user, provider: provider) }
 
-  describe "GET #index" do
+    before { sign_in admin.user }
 
-    it "returns http success" do
-      get :index
-      expect(response).to have_http_status(:success)
-    end
+    describe "GET #index" do
 
-    it 'assigns @eternal_users' do
-      external_user = create(:external_user, provider: admin.provider)
-      other_provider_external_user = create(:external_user)
-      get :index
-      expect(assigns(:external_users)).to match_array([admin, external_user])
-    end
-
-    it 'renders the template' do
-      get :index
-      expect(response).to render_template(:index)
-    end
-  end
-
-  describe "GET #show" do
-    before { get :show, id: subject }
-
-    it "returns http success" do
-      expect(response).to have_http_status(:success)
-    end
-
-    it 'assigns @external_user' do
-      expect(assigns(:external_user)).to eq(subject)
-    end
-
-    it 'renders the template' do
-      expect(response).to render_template(:show)
-    end
-  end
-
-  describe "GET #new" do
-    before { get :new }
-
-    it "returns http success" do
-      expect(response).to have_http_status(:success)
-    end
-
-    it 'assigns @external_user' do
-      expect(assigns(:external_user)).to be_new_record
-    end
-
-    it 'renders the template' do
-      expect(response).to render_template(:new)
-    end
-  end
-
-  describe "GET #edit" do
-    before { get :edit, id: subject }
-
-    it "returns http success" do
-      expect(response).to have_http_status(:success)
-    end
-
-    it 'assigns @external_user' do
-      expect(assigns(:external_user)).to eq(subject)
-    end
-
-    it 'renders the template' do
-      expect(response).to render_template(:edit)
-    end
-  end
-
-  describe "GET #change_password" do
-    before { get :change_password, id: subject }
-
-    it "returns http success" do
-      expect(response).to have_http_status(:success)
-    end
-
-    it 'assigns @external_user' do
-      expect(assigns(:external_user)).to eq(subject)
-    end
-
-    it 'renders the template' do
-      expect(response).to render_template(:change_password)
-    end
-  end
-
-  describe "POST #create" do
-    context 'when valid' do
-      it 'creates a external_user' do
-        expect {
-          post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'password', first_name: 'John', last_name: 'Smith' },
-                                    roles: ['advocate'],
-                                    supplier_number: 'AB124' }
-        }.to change(User, :count).by(1)
+      it "returns http success" do
+        get :index
+        expect(response).to have_http_status(:success)
       end
 
-      it 'redirects to external_users index' do
-        post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'password', first_name: 'John', last_name: 'Smith'},
-                                  roles: ['advocate'],
-                                  supplier_number: 'XY123'  }
-        expect(response).to redirect_to(external_users_admin_external_users_url)
+      it 'assigns @eternal_users' do
+        external_user = create(:external_user, provider: admin.provider)
+        other_provider_external_user = create(:external_user)
+        get :index
+        expect(assigns(:external_users)).to match_array([admin, external_user])
+      end
+
+      it 'renders the template' do
+        get :index
+        expect(response).to render_template(:index)
       end
     end
 
-    context 'when invalid' do
-      it 'does not create a external_user' do
-        expect {
-          post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'xxx' }, roles: ['advocate'] }
-        }.to_not change(User, :count)
+    describe "GET #show" do
+      before { get :show, id: subject }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
       end
 
-      it 'renders the new template' do
-        post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'xxx' }, roles: ['advocate'] }
+      it 'assigns @external_user' do
+        expect(assigns(:external_user)).to eq(subject)
+      end
+
+      it 'renders the template' do
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe "GET #new" do
+      before { get :new }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'assigns @external_user' do
+        expect(assigns(:external_user)).to be_new_record
+      end
+
+      it 'renders the template' do
         expect(response).to render_template(:new)
       end
     end
-  end
 
-  describe "PUT #update" do
+    describe "GET #edit" do
+      before { get :edit, id: subject }
 
-    context 'when valid' do
-      before(:each) { put :update, id: subject, external_user: { roles: ['admin'] } }
-
-      it 'updates a external_user' do
-        subject.reload
-        expect(subject.reload.roles).to eq(['admin'])
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
       end
 
-      it 'redirects to external_users index' do
-        expect(response).to redirect_to(external_users_admin_external_users_url)
-      end
-    end
-
-    context 'when invalid' do
-      before(:each) { put :update, id: subject, external_user: { roles: ['foo'] } }
-
-      it 'does not update external_user' do
-        subject.reload
-        expect(subject.roles).to eq(['advocate'])
-        expect(subject.email).to_not eq('emailexample.com')
+      it 'assigns @external_user' do
+        expect(assigns(:external_user)).to eq(subject)
       end
 
-      it 'renders the edit template' do
+      it 'renders the template' do
         expect(response).to render_template(:edit)
       end
     end
-  end
 
-  describe "PUT #update_password" do
+    describe "GET #change_password" do
+      before { get :change_password, id: subject }
 
-    before do
-      subject.user.update(password: 'password', password_confirmation: 'password')
-      sign_in subject.user #need to sign in again after password change
-    end
-
-    context 'when valid' do
-      before(:each) do
-        put :update_password, id: subject, external_user: { user_attributes: { current_password: 'password', password: 'password123', password_confirmation: 'password123' } }
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
       end
 
-      it 'redirects to external_user show action' do
-        # put :update_password, id: external_user, external_user: { user_attributes: { current_password: 'password', password: 'password123', password_confirmation: 'password123' } }
-        expect(response).to redirect_to(external_users_admin_external_user_path(subject))
+      it 'assigns @external_user' do
+        expect(assigns(:external_user)).to eq(subject)
       end
-    end
 
-    context 'when invalid' do
-      before(:each) { put :update_password, id: subject, external_user: { user_attributes: { } } }
-
-      it 'renders the change password template' do
+      it 'renders the template' do
         expect(response).to render_template(:change_password)
       end
     end
+
+    describe "POST #create" do
+      context 'when valid' do
+        it 'creates a external_user' do
+          expect {
+            post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'password', first_name: 'John', last_name: 'Smith' },
+                                      roles: ['advocate'],
+                                      supplier_number: 'AB124' }
+          }.to change(User, :count).by(1)
+        end
+
+        it 'redirects to external_users index' do
+          post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'password', first_name: 'John', last_name: 'Smith'},
+                                    roles: ['advocate'],
+                                    supplier_number: 'XY123'  }
+          expect(response).to redirect_to(external_users_admin_external_users_url)
+        end
+      end
+
+      context 'when invalid' do
+        it 'does not create a external_user' do
+          expect {
+            post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'xxx' }, roles: ['advocate'] }
+          }.to_not change(User, :count)
+        end
+
+        it 'renders the new template' do
+          post :create, external_user: { user_attributes: { email: 'foo@foobar.com', password: 'password', password_confirmation: 'xxx' }, roles: ['advocate'] }
+          expect(response).to render_template(:new)
+        end
+      end
+    end
+
+    describe "PUT #update" do
+
+      context 'when valid' do
+        before(:each) { put :update, id: subject, external_user: { roles: ['admin'] } }
+
+        it 'updates a external_user' do
+          subject.reload
+          expect(subject.reload.roles).to eq(['admin'])
+        end
+
+        it 'redirects to external_users index' do
+          expect(response).to redirect_to(external_users_admin_external_users_url)
+        end
+      end
+
+      context 'when invalid' do
+        before(:each) { put :update, id: subject, external_user: { roles: ['foo'] } }
+
+        it 'does not update external_user' do
+          subject.reload
+          expect(subject.roles).to eq(['advocate'])
+          expect(subject.email).to_not eq('emailexample.com')
+        end
+
+        it 'renders the edit template' do
+          expect(response).to render_template(:edit)
+        end
+      end
+    end
+
+    describe "PUT #update_password" do
+
+      before do
+        subject.user.update(password: 'password', password_confirmation: 'password')
+        sign_in subject.user #need to sign in again after password change
+      end
+
+      context 'when valid' do
+        before(:each) do
+          put :update_password, id: subject, external_user: { user_attributes: { current_password: 'password', password: 'password123', password_confirmation: 'password123' } }
+        end
+
+        it 'redirects to external_user show action' do
+          # put :update_password, id: external_user, external_user: { user_attributes: { current_password: 'password', password: 'password123', password_confirmation: 'password123' } }
+          expect(response).to redirect_to(external_users_admin_external_user_path(subject))
+        end
+      end
+
+      context 'when invalid' do
+        before(:each) { put :update_password, id: subject, external_user: { user_attributes: { } } }
+
+        it 'renders the change password template' do
+          expect(response).to render_template(:change_password)
+        end
+      end
+    end
+
+    describe "DELETE #destroy" do
+
+
+      it 'destroys the external user' do
+        subject     # create an additional External user
+        expect{
+          delete :destroy, id: subject
+        }.to change{ExternalUser.active.count}.by(-1)
+        expect(subject.reload.deleted_at).not_to be_nil
+      end
+
+      it 'redirects to external_user admin root url' do
+        delete :destroy, id: subject
+        expect(response).to redirect_to(external_users_admin_external_users_url)
+      end
+    end
   end
 
-  describe "DELETE #destroy" do
 
+  ######################## NON ADMIN USER #################
 
-    it 'destroys the external user' do
-      subject     # create an additional External user
-      expect{
-        delete :destroy, id: subject
-      }.to change{ExternalUser.active.count}.by(-1)
-      expect(subject.reload.deleted_at).not_to be_nil
+  context 'non-admin user' do
+    let(:external_user)         { create(:external_user, provider: provider) }
+    let(:other_external_user)   { create(:external_user, provider: provider) }
+
+    before do
+      2.times { create :user }
+      sign_in external_user.user
     end
 
-    it 'redirects to external_user admin root url' do
-      delete :destroy, id: subject
-      expect(response).to redirect_to(external_users_admin_external_users_url)
+    describe "GET #index" do
+      it 'redirects to all claims page with Unauthorised in flash' do
+        get :index
+        expect(response).to redirect_to(external_users_root_path)
+        expect(flash[:alert]).to eq "Unauthorised"
+      end
     end
+
+    describe "GET #show" do
+      it 'displays the show page for the current user' do
+        get :show, id: external_user
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'doesnt show the details for a different user' do
+        get :show, id: other_external_user
+        expect(response).to redirect_to(external_users_root_path)
+        expect(flash[:alert]).to eq "Unauthorised"
+      end
+    end
+
+    describe "GET #new" do
+      it 'redirects to all claims page with Unauthorised in flash' do
+        get :new
+        expect(response).to redirect_to(external_users_root_path)
+        expect(flash[:alert]).to eq "Unauthorised"
+      end
+    end
+
+    describe "POST #create" do
+      it 'redirects to all claims page with Unauthorised in flash' do
+        get :new
+        expect(response).to redirect_to(external_users_root_path)
+        expect(flash[:alert]).to eq "Unauthorised"
+      end
+    end
+
+    describe "GET #edit" do
+      it 'displays the edit form' do
+        get :edit, id: external_user
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "PUT #update" do
+      context 'current user' do
+        it 'updates non-roles attributes' do
+          expect(external_user.email).to_not eq 'bobsmith@example.com'
+          put :update, params_updating_email(external_user)
+          expect(external_user.user.reload.email).to eq 'bobsmith@example.com'
+
+        end
+
+        it 'ignores roles attributes' do
+          expect(external_user.roles).to eq(['advocate'])
+          expect(external_user.email).to_not eq 'bobsmith@example.com'
+          put :update, params_updating_roles(external_user)
+          expect(external_user.reload.roles).to eq(['advocate'])
+          expect(external_user.user.reload.email).to eq 'bobsmith@example.com'
+        end
+
+        it 'redirects to external_users index' do
+          put :update, id: external_user,  external_user: { email: 'bobsmith@example.com' }
+          expect(response).to redirect_to(external_users_claims_path)
+        end
+      end
+
+      context 'other user' do
+        it 'does not allow any updates' do
+          put :update, params_updating_email(other_external_user)
+          expect(response).to redirect_to(external_users_root_path)
+          expect(flash[:alert]).to eq "Unauthorised"
+        end
+      end
+
+    end
+    describe "DELETE #destroy" do
+      it 'does not allow user to delete himself' do
+        delete :destroy, id: external_user
+        expect(response).to redirect_to(external_users_root_path)
+        expect(flash[:alert]).to eq "Unauthorised"
+      end
+
+      it 'does not allow user to delete other user' do
+        delete :destroy, id: other_external_user
+        expect(response).to redirect_to(external_users_root_path)
+        expect(flash[:alert]).to eq "Unauthorised"
+      end
+    end
+
+    def params_updating_roles(external_user)
+      HashWithIndifferentAccess.new(
+        { id: external_user,
+          external_user: {
+            user_attributes: {
+              id: external_user.user.id,
+              email: 'bobsmith@example.com'
+            }
+          },
+          roles: %w{ admin advocate litigator}
+        })
+    end
+
+    def params_updating_email(external_user)
+      HashWithIndifferentAccess.new(
+        {id: external_user,
+          external_user: {
+            user_attributes: {
+              id: external_user.user.id,
+              email: 'bobsmith@example.com'
+            }
+          }
+        })
+    end
+
   end
 end

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
           before { sign_in litigator_admin.user }
           it 'should assign context to claims for the provider' do
             get :index
-            expect(assigns(:claims_context)).to eq(litigator_admin.provider.claims_created)
+            expect(assigns(:claims_context)).to eq(litigator_admin.provider.claims)
           end
 
           it 'should assign claims to dashboard displayable state claims for all members of the provder' do


### PR DESCRIPTION
Prior to this PR, external users who didn't have admin rights couldn't manage their own accounts. Now they can.
