### PR TITLE
Enable soft deletion of disbursement types

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -115,7 +115,7 @@ module API
         resource :disbursement_types do
           desc "Return all Disbursement Types."
           get do
-            present DisbursementType.allowable_types, with: API::Entities::DisbursementType
+            present DisbursementType.active, with: API::Entities::DisbursementType
           end
         end
 

--- a/app/models/disbursement_type.rb
+++ b/app/models/disbursement_type.rb
@@ -9,18 +9,14 @@
 #
 
 class DisbursementType < ActiveRecord::Base
+  include SoftlyDeletable
+
+  default_scope -> { order(name: :asc) }
+
   auto_strip_attributes :name, squish: true, nullify: true
 
   has_many :disbursements, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
-  # Temporal as there are claims using this disbursement type and we can't
-  # reassign those to another one, so for new claims we hide this type from dropdowns
-  # and API but old ones will continue to work and validate.
-  # Revisit this in some weeks once all old claims have been processed.
-  #
-  def self.allowable_types
-    all.where.not(name: 'Travel costs')
-  end
 end

--- a/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
+++ b/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
@@ -7,7 +7,7 @@
         %label.form-label
           = t('.disbursement_type')
         %a{id: "disbursement_#{@disbursement_count}_disbursement_type"}
-        = f.collection_select :disbursement_type_id, DisbursementType.allowable_types, :id, :name, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete', style: 'width:350px'}
+        = f.collection_select :disbursement_type_id, DisbursementType.active, :id, :name, { include_blank: '&#160;'.html_safe }, {class: 'form-control autocomplete', style: 'width:350px'}
         = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")
 
       .column-one-quarter.fee-amount

--- a/db/migrate/20160902084750_add_deleted_at_to_disbursement_type.rb
+++ b/db/migrate/20160902084750_add_deleted_at_to_disbursement_type.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToDisbursementType < ActiveRecord::Migration
+  def change
+    add_column :disbursement_types, :deleted_at, :datetime, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160824095519) do
+ActiveRecord::Schema.define(version: 20160902084750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,6 +208,7 @@ ActiveRecord::Schema.define(version: 20160824095519) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "deleted_at"
   end
 
   add_index "disbursement_types", ["name"], name: "index_disbursement_types_on_name", using: :btree

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -25,7 +25,12 @@
       end
     end
 
-
+    desc 'softly delete Travel costs disbursement type'
+    task :delete_travel_costs => :environment do
+      dt = DisbursementType.where(name: 'Travel costs').first
+      dt.deleted_at = Time.now
+      dt.save!
+    end
 
     desc 'Run all outstanding data migrations'
     task :all => :environment do

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -65,7 +65,7 @@ describe API::V1::DropdownData do
         FEE_TYPE_ENDPOINT => API::Entities::BaseFeeType.represent(Fee::BaseFeeType.all).to_json,
         EXPENSE_TYPE_ENDPOINT => API::Entities::ExpenseType.represent(ExpenseType.all).to_json,
         EXPENSE_REASONS_ENDPOINT => API::Entities::ExpenseReasonSet.represent(ExpenseType.reason_sets).to_json,
-        DISBURSEMENT_TYPE_ENDPOINT => API::Entities::DisbursementType.represent(DisbursementType.allowable_types).to_json,
+        DISBURSEMENT_TYPE_ENDPOINT => API::Entities::DisbursementType.represent(DisbursementType.active).to_json,
         TRANSFER_STAGES_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::TRANSFER_STAGES.to_a).to_json,
         TRANSFER_CASE_CONCLUSIONS_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::CASE_CONCLUSIONS.to_a).to_json
       }

--- a/spec/models/disbursement_type_spec.rb
+++ b/spec/models/disbursement_type_spec.rb
@@ -17,11 +17,26 @@ RSpec.describe DisbursementType, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_uniqueness_of(:name) }
 
-  describe '.allowable_types' do
-    let!(:travel_costs) { create(:disbursement_type, name: 'Travel costs') }
+  context 'scopes' do
 
-    it 'should exclude "Travel costs" from the result set' do
-      expect(described_class.allowable_types).to_not include(travel_costs)
+    before(:all) do
+      create :disbursement_type, name: 'Zebras'
+      create :disbursement_type, name: 'Travel Costs', deleted_at: 3.minutes.ago
+      create :disbursement_type, name: 'Aardvarks'
+    end
+
+    after(:all) { DisbursementType.delete_all }
+
+    describe 'default scope' do
+      it 'returns in alphabetical order by name' do
+        expect(DisbursementType.all.map(&:name)).to eq([ 'Aardvarks', 'Travel Costs', 'Zebras' ])
+      end
+    end
+
+    describe 'active scope' do
+      it 'excludes records with non-nil deleted_at' do
+        expect(DisbursementType.active.map(&:name)).to eq([ 'Aardvarks', 'Zebras' ])
+      end
     end
   end
 end


### PR DESCRIPTION
This PR replaces the hack that suppressed display of the Travel costs disbursement types
with a soft delete mechanism for disbursement types.

Note that this PR involves a database migration, and the following rake task
should also be run as part of the deploy:

   rake data:migration:delete_travel_costs
