### PR TITLE
Fix written reasons behaviour.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,10 @@ module ApplicationHelper
     current_user.persona.is_a?(CaseWorker)
   end
 
+  def current_user_is_external_user?
+    current_user.persona.is_a?(ExternalUser)
+  end
+
   #
   # Can be called in views in order to instantiate a presenter for a partilcular model
   # following the <Model>Presenter naming convention or, optionally, a named presenter
@@ -93,10 +97,6 @@ module ApplicationHelper
 
   def strip_params(path)
     URI.parse(path).path rescue nil
-  end
-
-  def advocate_messaging_permitted?(message)
-    (current_user.persona.is_a?(ExternalUser) && !@claim.redeterminable?) || message.claim_action.present?
   end
 
   def your_claims_header

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -21,4 +21,13 @@ module ClaimsHelper
   def show_claim_list_scheme_filters?(available_schemes)
     Settings.scheme_filters_enabled? && available_schemes.size > 1
   end
+
+  def show_message_controls?(claim)
+    (current_user_is_caseworker? || current_user_is_external_user?) &&
+      %w(draft rejected archived_pending_delete).exclude?(claim.state)
+  end
+
+  def messaging_permitted?(message)
+    (current_user_is_external_user? && !message.claim.redeterminable?) || message.claim_action.present?
+  end
 end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -94,7 +94,7 @@ module Claims::StateMachine
       end
 
       event :authorise_part do
-        transition [:allocated] => :part_authorised
+        transition [:allocated, :awaiting_written_reasons] => :part_authorised
       end
 
       event :authorise do
@@ -102,11 +102,11 @@ module Claims::StateMachine
       end
 
       event :refuse do
-        transition [:allocated] => :refused
+        transition [:allocated, :awaiting_written_reasons] => :refused
       end
 
       event :reject do
-        transition [:allocated] => :rejected, :if => :rejectable?
+        transition [:allocated, :awaiting_written_reasons] => :rejected, :if => :rejectable?
       end
 
       event :submit do
@@ -155,8 +155,12 @@ module Claims::StateMachine
     last_state_transition&.created_at
   end
 
+  def filtered_state_transitions
+    claim_state_transitions.where.not(to: %w(allocated deallocated))
+  end
+
   def filtered_last_state_transition
-    claim_state_transitions.where.not(to: %w(allocated deallocated)).first
+    filtered_state_transitions.first
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -95,7 +95,7 @@ class Message < ActiveRecord::Base
     return unless self.claim.written_reasons_outstanding?
 
     if self.written_reasons_submitted == '1'
-      self.claim.send("#{self.claim.claim_state_transitions[2].event}!")
+      self.claim.send("#{self.claim.filtered_state_transitions.second.event}!")
     end
   end
 end

--- a/app/presenters/claim_state_transition_presenter.rb
+++ b/app/presenters/claim_state_transition_presenter.rb
@@ -3,8 +3,7 @@ class ClaimStateTransitionPresenter < BasePresenter
   presents :claim_state_transition
 
   def transition_message
-    state = new_state
-    return "#{transition_messages[state][current_user_persona]}"
+    transition_messages[claim_state_transition.to][current_user_persona]
   end
 
   def timestamp
@@ -17,7 +16,6 @@ private
     {
       'redetermination'               => {"CaseWorker" => "Redetermination requested",     "ExternalUser" => "You requested redetermination"},
       'awaiting_written_reasons'      => {"CaseWorker" => "Written reasons requested",     "ExternalUser" => "You requested written reasons"},
-      'written_reasons_provided'      => {"CaseWorker" => "Written reasons provided",      "ExternalUser" => "You received written reasons"},
       'submitted'                     => {"CaseWorker" => "Claim submitted",               "ExternalUser" => "Your claim has been submitted"},
       'allocated'                     => {"CaseWorker" => "Claim allocated",               "ExternalUser" => "Your claim has been allocated"},
       'authorised'                    => {"CaseWorker" => "Claim authorised",              "ExternalUser" => "Your claim has been authorised"},
@@ -32,24 +30,17 @@ private
     @view.current_user.persona.class.to_s
   end
 
-  def new_state
-    previous_transition.from == 'awaiting_written_reasons' ? 'written_reasons_provided' : claim_state_transition.to
-  end
-
   def all_transitions
-    claim_state_transition.claim.claim_state_transitions
+    @all_transitions ||= claim_state_transition.claim.reload.claim_state_transitions
   end
 
   def current_index
     all_transitions.index(claim_state_transition)
   end
 
-  def previous_index
-    current_index - 1
-  end
-
+  # Transitions are ordered: 'created_at desc'
   def previous_transition
-    all_transitions[previous_index]
+    all_transitions[current_index + 1]
   end
 
 end

--- a/app/views/shared/_claim_history.html.haml
+++ b/app/views/shared/_claim_history.html.haml
@@ -14,6 +14,6 @@
     = "Status:"
     %span.message-success
     %span.message-error
-  - if (current_user.persona.is_a?(CaseWorker) || (current_user.persona.is_a?(ExternalUser) && claim.rejected? == false && claim.draft? == false)) && claim.archived_pending_delete? == false
+  - if show_message_controls?(claim)
     .js-controls.message-controls{"data-auth-url" => message_controls_url }
       = render partial: "shared/message_controls", locals: {message: @message }

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -8,11 +8,11 @@
         = f.collection_radio_buttons(:claim_action, Settings.claim_actions, :to_s, :to_s) do |b|
           - b.label(class: "block-label") { b.radio_button + b.value.humanize }
 
-  - if advocate_messaging_permitted?(message) || current_user_is_caseworker?
+  - if messaging_permitted?(message) || current_user_is_caseworker?
     .grid-row.js-test-send-buttons
       Enter a message below and optionally attach a file (maximum 1 file per message).
       .message-column
-        = f.text_area :body, as: :text, rows: 10, placeholder: t('.message_placeholder'), label: false, class: 'form-control'
+        = f.text_area :body, as: :text, rows: 5, placeholder: t('.message_placeholder'), label: false, class: 'form-control'
 
         - if current_user_is_caseworker? && @claim.written_reasons_outstanding?
           .written-reasons-checkbox

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -113,13 +113,13 @@ RSpec.describe Message, type: :model do
     let(:claim)     { create :part_authorised_claim }
     let(:user)      { create :user }
 
-    it 'should change claim state from back to what it was three back if written reasons submitted' do
+    it 'should change claim state back to what it was before, if written reasons submitted' do
       claim.messages.build(sender: user, body: 'xxxxx', claim_action: 'Request written reasons')
       claim.messages.first.written_reasons_submitted = '1'
       claim.save
-      expect(claim.claim_state_transitions.reorder(created_at: :asc).map(&:event)).to eq( [ nil, 'submit', 'allocate', 'authorise_part', 'await_written_reasons', 'allocate' ] )
-      expect(claim.state).to eq 'allocated'
+      claim.reload
+      expect(claim.claim_state_transitions.reorder(created_at: :asc).map(&:event)).to eq( [ nil, 'submit', 'allocate', 'authorise_part', 'await_written_reasons', 'authorise_part' ] )
+      expect(claim.state).to eq 'part_authorised'
     end
-
   end
 end


### PR DESCRIPTION
Previously, after a case worker gave written reasons, the claim would go
back to under certain circunstances to allocated or unallocated state and
also it might remains in awaiting written reasons state.

Now it is consisten and once written reasons are provided, the claim will go
back to the previous state it was before asking for written reasons.

A bit of refactor done extracting complex conditions to helper methods.
