### PR TITLE
Mechanism to abstract the analytics data tracking.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,7 +97,7 @@ class ApplicationController < ActionController::Base
   end
 
   def track_visit(*args)
-    (flash.now[:ga] ||= []) << GoogleAnalytics::DataLayer.new(:virtual_page, *args)
+    (flash.now[:ga] ||= []) << GoogleAnalytics::DataTracking.track(:virtual_page, *args)
   end
 
   def suppress_hotline_link

--- a/app/models/google_analytics/data_adapter.rb
+++ b/app/models/google_analytics/data_adapter.rb
@@ -1,29 +1,28 @@
 module GoogleAnalytics
-  class UnknownDataLayerTemplate < ArgumentError; end
+  class UnknownDataTemplate < ArgumentError; end
 
-  class DataLayer
-
-    TEMPLATES = {
-      virtual_page: {event: 'VirtualPageview', virtualPageURL: '%{url}', virtualPageTitle: '%{title}'}
-    }.freeze
-
+  class DataAdapter
 
     def initialize(template_id, template_data, interpolation_data = {})
       @template_id = template_id
       @template_data = template_data
       @interpolation_data = interpolation_data
-      raise UnknownDataLayerTemplate.new("Unknown template '#{@template_id}'") if template.nil?
+      raise UnknownDataTemplate.new("Unknown template '#{@template_id}'") if template.nil?
     end
 
     def to_s
-      "dataLayer.push(#{template_data.to_json});"
+      raise 'implement in subclasses'
     end
 
     def template
-      TEMPLATES[@template_id]
+      templates[@template_id]
     end
 
-    private
+    protected
+
+    def templates
+      raise 'implement in subclasses'
+    end
 
     def template_data
       interpolate(template, interpolated_data)

--- a/app/models/google_analytics/data_tracking.rb
+++ b/app/models/google_analytics/data_tracking.rb
@@ -1,0 +1,24 @@
+module GoogleAnalytics
+  class DataTracking
+    cattr_accessor :adapter, :adapter_name
+
+    class << self
+      def enabled?
+        adapter.present? && Rails.env.production? && (Rails.host.staging? || Rails.host.gamma?)
+      end
+
+      def track(*args)
+        if enabled?
+          raise ArgumentError, 'Uninitialized adapter' unless adapter
+          adapter.new(*args)
+        end
+      end
+
+      def adapter=(name)
+        @@adapter_name, @@adapter = name, "GoogleAnalytics::#{name.upcase}DataAdapter".constantize
+      end
+    end
+
+    private_class_method :new
+  end
+end

--- a/app/models/google_analytics/ga_data_adapter.rb
+++ b/app/models/google_analytics/ga_data_adapter.rb
@@ -1,0 +1,15 @@
+module GoogleAnalytics
+  class GADataAdapter < DataAdapter
+
+    def templates
+      {
+        virtual_page: {hitType: 'pageview', page: '%{url}', title: '%{title}'}
+      }.freeze
+    end
+
+    def to_s
+      "ga('send', #{template_data.to_json});"
+    end
+
+  end
+end

--- a/app/models/google_analytics/gtm_data_adapter.rb
+++ b/app/models/google_analytics/gtm_data_adapter.rb
@@ -1,0 +1,15 @@
+module GoogleAnalytics
+  class GTMDataAdapter < DataAdapter
+
+    def templates
+      {
+        virtual_page: {event: 'VirtualPageview', virtualPageURL: '%{url}', virtualPageTitle: '%{title}'}
+      }.freeze
+    end
+
+    def to_s
+      "dataLayer.push(#{template_data.to_json});"
+    end
+
+  end
+end

--- a/app/views/layouts/_analytics.js.haml
+++ b/app/views/layouts/_analytics.js.haml
@@ -1,0 +1,17 @@
+- if adapter == :gtm
+  :javascript
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KCWHDK');
+
+- if adapter == :ga
+  :javascript
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', "#{ENV['GA_TRACKER_ID']}", 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('send', 'pageview');

--- a/app/views/layouts/_ga_tag_manager.js.haml
+++ b/app/views/layouts/_ga_tag_manager.js.haml
@@ -1,6 +1,0 @@
-:javascript
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KCWHDK');

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,8 +10,8 @@
   = "controller-" + controller.controller_name
 
 - content_for :body_start do
-  - unless Rails.env.test?
-    = render partial: 'layouts/ga_tag_manager', :formats => [:js]
+  - if GoogleAnalytics::DataTracking.enabled?
+    = render partial: 'layouts/analytics', :formats => [:js], locals: { adapter: GoogleAnalytics::DataTracking.adapter_name }
     %script
       != ga_outlet
 

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -1,0 +1,6 @@
+# Sets the analytics engine data layer adapter. Currently it supports:
+#
+#   :ga  -> Google Analytics
+#   :gtm -> Google Tag Manager
+#
+GoogleAnalytics::DataTracking.adapter = :gtm

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+module GoogleAnalytics
+
+  describe DataTracking do
+    context '#enabled?' do
+      before do
+        allow(Rails).to receive(:env).and_return(double(production?: true))
+      end
+
+      context 'with an adapter set' do
+        before do
+          allow(described_class).to receive(:adapter).and_return('Adapter')
+        end
+
+        %w(staging gamma).each do |host|
+          it "returns true when host is #{host}" do
+            allow(RailsHost).to receive(:env).and_return(host)
+            expect(described_class.enabled?).to be_truthy
+          end
+        end
+
+        it 'returns false when host is demo' do
+          allow(RailsHost).to receive(:env).and_return('demo')
+          expect(described_class.enabled?).to be_falsey
+        end
+      end
+
+      context 'with no adapter set' do
+        before do
+          allow(described_class).to receive(:adapter).and_return(nil)
+        end
+
+        it 'returns false when host is demo' do
+          allow(RailsHost).to receive(:env).and_return('gamma')
+          expect(described_class.enabled?).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/models/google_analytics/ga_data_adapter_spec.rb
+++ b/spec/models/google_analytics/ga_data_adapter_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 module GoogleAnalytics
 
-  describe DataLayer do
+  describe GADataAdapter do
     describe '.new' do
       it 'raises an exception if the template is unknown' do
-        expect { described_class.new(:test, {}) }.to raise_exception(UnknownDataLayerTemplate)
+        expect { described_class.new(:test, {}) }.to raise_exception(UnknownDataTemplate)
       end
     end
 
@@ -13,7 +13,7 @@ module GoogleAnalytics
       context 'for virtual_page' do
         it 'returns the expected hash for this template' do
           expect(described_class.new(:virtual_page, {}).template).to \
-            eq({event: 'VirtualPageview', virtualPageURL: '%{url}', virtualPageTitle: '%{title}'})
+            eq({hitType: 'pageview', page: '%{url}', title: '%{title}'})
         end
       end
     end
@@ -22,12 +22,12 @@ module GoogleAnalytics
       context 'for virtual_page' do
         it 'returns the expected javascript string for this template' do
           expect(described_class.new(:virtual_page, url: '/test', title: 'Test').to_s).to \
-            eq %q{dataLayer.push({"event":"VirtualPageview","virtualPageURL":"/test","virtualPageTitle":"Test"});}
+            eq %q{ga('send', {"hitType":"pageview","page":"/test","title":"Test"});}
         end
 
         it 'returns the expected javascript string for this template with the data for interpolation provided' do
           expect(described_class.new(:virtual_page, {url: '/test/%{id}/%{action}', title: 'Test %{id} %{action}'}, {id: 123, action: 'new'}).to_s).to \
-            eq %q{dataLayer.push({"event":"VirtualPageview","virtualPageURL":"/test/123/new","virtualPageTitle":"Test 123 new"});}
+            eq %q{ga('send', {"hitType":"pageview","page":"/test/123/new","title":"Test 123 new"});}
         end
       end
     end

--- a/spec/models/google_analytics/gtm_data_adapter_spec.rb
+++ b/spec/models/google_analytics/gtm_data_adapter_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+module GoogleAnalytics
+
+  describe GTMDataAdapter do
+    describe '.new' do
+      it 'raises an exception if the template is unknown' do
+        expect { described_class.new(:test, {}) }.to raise_exception(UnknownDataTemplate)
+      end
+    end
+
+    describe '#template' do
+      context 'for virtual_page' do
+        it 'returns the expected hash for this template' do
+          expect(described_class.new(:virtual_page, {}).template).to \
+            eq({event: 'VirtualPageview', virtualPageURL: '%{url}', virtualPageTitle: '%{title}'})
+        end
+      end
+    end
+
+    describe '#to_s' do
+      context 'for virtual_page' do
+        it 'returns the expected javascript string for this template' do
+          expect(described_class.new(:virtual_page, url: '/test', title: 'Test').to_s).to \
+            eq %q{dataLayer.push({"event":"VirtualPageview","virtualPageURL":"/test","virtualPageTitle":"Test"});}
+        end
+
+        it 'returns the expected javascript string for this template with the data for interpolation provided' do
+          expect(described_class.new(:virtual_page, {url: '/test/%{id}/%{action}', title: 'Test %{id} %{action}'}, {id: 123, action: 'new'}).to_s).to \
+            eq %q{dataLayer.push({"event":"VirtualPageview","virtualPageURL":"/test/123/new","virtualPageTitle":"Test 123 new"});}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We can swap the between GA and GTM at any time, in case we decide to go with one or the other.
Also it simplifies adding new data tracking adapters in case we wanted to.

A new initializer sets up the adapter (:ga or :gtm):

`GoogleAnalytics::DataTracking.adapter = :gtm`
