### PR TITLE
Allow blank or zero values in PPE field (graduated fee and interim fee).

### DIFF
--- a/app/validators/fee/graduated_fee_validator.rb
+++ b/app/validators/fee/graduated_fee_validator.rb
@@ -12,8 +12,7 @@ class Fee::GraduatedFeeValidator < Fee::BaseFeeValidator
   end
 
   def validate_quantity
-    validate_presence(:quantity, 'blank')
-    validate_numericality(:quantity, 1, 99999, 'numericality')
+    validate_numericality(:quantity, 0, 99999, 'numericality')
   end
 
   def validate_amount

--- a/app/validators/fee/interim_fee_validator.rb
+++ b/app/validators/fee/interim_fee_validator.rb
@@ -12,8 +12,7 @@ class Fee::InterimFeeValidator < Fee::BaseFeeValidator
     if @record.is_disbursement? || @record.is_interim_warrant?
       validate_absence_or_zero(:quantity, 'present')
     else
-      validate_presence(:quantity, 'blank')
-      validate_numericality(:quantity, 1, nil, 'numericality')
+      validate_numericality(:quantity, 0, 99999, 'numericality')
     end
   end
 

--- a/spec/validators/fee/graduated_fee_validator_spec.rb
+++ b/spec/validators/fee/graduated_fee_validator_spec.rb
@@ -30,18 +30,27 @@ module Fee
     end
 
     describe '#validate_quantity' do
-      # note: before validation hook sets nil to zero
-      it { should_error_if_not_present(fee, :quantity, 'numericality') }
+      it 'numericality, must be between 0 and 999999' do
+        # note: before validation hook sets nil to zero
+        fee.quantity = nil
+        expect(fee).to be_valid
 
-      it 'numericality, must be between 1 and 999999' do
+        fee.quantity = 0
+        expect(fee).to be_valid
+
         fee.quantity = 1
         expect(fee).to be_valid
+
         fee.quantity = 99999
         expect(fee).to be_valid
-        fee.quantity = 0
-        expect(fee).to_not be_valid
+
         fee.quantity = 100000
         expect(fee).to_not be_valid
+        expect(fee.errors[:quantity]).to eq ['numericality']
+
+        fee.quantity = -10
+        expect(fee).not_to be_valid
+        expect(fee.errors[:quantity]).to eq ['numericality']
       end
     end
 

--- a/spec/validators/fee/interim_fee_validator_spec.rb
+++ b/spec/validators/fee/interim_fee_validator_spec.rb
@@ -74,15 +74,25 @@ module Fee
       end
 
       context 'other fee' do
-        it 'is invalid if absent' do
-          allow(fee).to receive(:quantity).and_return nil
+        it 'numericality, must be between 0 and 999999' do
+          # note: before validation hook sets nil to zero
           fee.quantity = nil
-          expect(fee).not_to be_valid
-          expect(fee.errors[:quantity]).to eq ['blank']
-        end
+          expect(fee).to be_valid
 
-        it 'validates numericality' do
           fee.quantity = 0
+          expect(fee).to be_valid
+
+          fee.quantity = 1
+          expect(fee).to be_valid
+
+          fee.quantity = 99999
+          expect(fee).to be_valid
+
+          fee.quantity = 100000
+          expect(fee).to_not be_valid
+          expect(fee.errors[:quantity]).to eq ['numericality']
+
+          fee.quantity = -10
           expect(fee).not_to be_valid
           expect(fee.errors[:quantity]).to eq ['numericality']
         end


### PR DESCRIPTION
When blank, it defaults to 0.

PT#129688509
