### PR TITLE
Ensure timed transitions deletes claim and all associated records

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -110,10 +110,10 @@ module Claim
     has_many :misc_fees, foreign_key: :claim_id, class_name: 'Fee::MiscFee', dependent: :destroy, inverse_of: :claim
 
     has_many :determinations, foreign_key: :claim_id, dependent: :destroy
-    has_one  :assessment, foreign_key: :claim_id, dependent: :destroy
-    has_many :redeterminations, foreign_key: :claim_id, dependent: :destroy
+    has_one  :assessment, foreign_key: :claim_id
+    has_many :redeterminations, foreign_key: :claim_id
 
-    has_one  :certification, foreign_key: :claim_id
+    has_one  :certification, foreign_key: :claim_id, dependent: :destroy
 
     has_paper_trail on: [:update], only: [:state]
 

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -9,6 +9,9 @@ class ClaimStateTransitionReason
       no_indictment: 'No indictment attached',
       no_rep_order: 'No rep order attached (granted before 1/8/2015)',
       time_elapsed: 'More than 3 months has elapsed since case completion'
+    },
+    global: {
+      timed_transition: "TimedTransition::Transitioner"
     }
   ).freeze
 

--- a/app/models/timed_transitions/batch_transitioner.rb
+++ b/app/models/timed_transitions/batch_transitioner.rb
@@ -2,11 +2,15 @@
 module TimedTransitions
   class BatchTransitioner
 
+    def initialize(options)
+      @dummy = options[:dummy]
+    end
 
     def run
-      claims = Transitioner.candidate_claims
-      claims.each do |claim| 
-        transitioner = Transitioner.new(claim)
+      claims_ids = Transitioner.candidate_claims_ids
+      claims_ids.each do |claim_id|
+        claim = Claim::BaseClaim.find claim_id
+        transitioner = Transitioner.new(claim, @dummy)
         transitioner.run
       end
     end

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -1,6 +1,8 @@
 module TimedTransitions
   class Transitioner
 
+    @@logger = Logger.new Settings.timed_transition_log_path
+
     @@timed_transition_specifications = {
       authorised:               Specification.new(:authorised, 60, :archive),
       part_authorised:          Specification.new(:part_authorised, 60, :archive),
@@ -11,36 +13,40 @@ module TimedTransitions
 
     # generates sql to retrieve all claims in a state from which a timed transition can be made.
     #
-    def self.candidate_claims
-      Claim::BaseClaim.active.where('state in (?)', candidate_states)
+    def self.candidate_claims_ids
+      Claim::BaseClaim.where('state in (?)', candidate_states).pluck(:id)
     end
-
 
     def self.candidate_states
       @@timed_transition_specifications.keys
     end
 
-
-    def initialize(claim)
+    def initialize(claim, dummy = false)
       @claim = claim
+      @dummy = dummy
     end
 
     def run
       specification = @@timed_transition_specifications[@claim.state.to_sym]
       if @claim.last_state_transition_time < specification.number_of_days.days.ago
-        send(specification.method)
+        if @dummy
+          @@logger.debug "Dummy run: would have transitioned claim id #{@claim.id} - #{@claim.case_number} from #{@claim.state} to #{specification.method}"
+        else
+          send(specification.method, reason_code: 'timed_transition')
+        end
       end
     end
 
-
     private
 
-    def archive
-      @claim.archive_pending_delete!
+    def archive(options)
+      @@logger.info "Changing state of claim #{@claim_id}: #{@claim.case_number} from #{@claim.state} to archived_pending_delete"
+      @claim.archive_pending_delete!(options)
     end
 
 
-    def destroy
+    def destroy(_options)
+      @@logger.info "Deleting claim #{@claim_id}: #{@claim.case_number}"
       @claim.destroy
     end 
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,3 +61,5 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 # users will be able to set preference to say whether they want email notifications of outstanding messages
 # on their claim
 email_notification_enabled?: true
+
+timed_transition_log_path: <%= File.join(Rails.root, 'log', 'timed_transitions.log') %>

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -71,8 +71,21 @@ namespace :claims do
   end
 
   desc 'ADP Task: Archives or deletes stale claims'
-  task :archive_stale => :environment do
-    TimedTransition::BatchTransitioner.new.run
+  task :archive_stale, [:param] => :environment do |_task, args|
+    if args.names.size != 1
+      raise ArgumentError.new "Only valid parameter is 'dummy'"
+    end
+
+    case args[:param]
+    when 'dummy'
+      @dummy = true
+    when nil
+      @dummy = false
+    else
+      raise ArgumentError.new "Only valid parameter is 'dummy'"
+    end
+
+    TimedTransitions::BatchTransitioner.new(dummy: @dummy).run
   end
 
 

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -94,7 +94,14 @@ FactoryGirl.define do
     end
 
     factory :archived_pending_delete_claim do
-      after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.authorise!; c.archive_pending_delete! }
+      after(:create) do |c|
+        c.submit!
+        c.case_workers << create(:case_worker)
+        c.reload
+        set_amount_assessed(c)
+        c.authorise!
+        c.archive_pending_delete!
+      end
     end
 
     factory :authorised_claim do

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -40,7 +40,15 @@ def claim_state_common_traits
   end
 
   trait :archived_pending_delete do
-    after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.authorise!; c.archive_pending_delete! }
+    # after(:create) { |c| c.submit!; c.allocate!; set_amount_assessed(c); c.authorise!; c.archive_pending_delete! }
+    after(:create) do |c|
+      c.submit!
+      c.case_workers << create(:case_worker)
+      c.reload
+      set_amount_assessed(c)
+      c.authorise!
+      c.archive_pending_delete!
+    end
   end
 
   trait :authorised do

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -25,3 +25,7 @@ FactoryGirl.define do
 
   end
 end
+
+
+
+

--- a/spec/models/timed_state_transitions/batch_transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/batch_transitioner_spec.rb
@@ -3,22 +3,44 @@ require 'rails_helper'
 
 module TimedTransitions
 
-  describe BatchTransitioner do 
+  describe BatchTransitioner do
 
-    it 'should instantiate a Transitioner and run it for each claim' do
-      bt = BatchTransitioner.new
+    let(:claim_ids) { [ 22, 878 ] }
+    let(:claim_22) { double'Claim 22', state: 'authorised', last_state_transition_time: 2.days.ago }
+    let(:claim_878) { double 'Claim 878', state: 'authorised', last_state_transition_time: 2.days.ago }
+    let(:transitioner_22) {double 'Transitioner 22' }
+    let(:transitioner_878) {double 'Transitioner 878' }
 
-      claims = %w{mock_claim_1 mock_claim_2}
-      expect(Transitioner).to receive(:candidate_claims).and_return(claims)
-      transitioner_1 = double Transitioner
-      transitioner_2 = double Transitioner
-      expect(Transitioner).to receive(:new).with('mock_claim_1').and_return(transitioner_1)
-      expect(Transitioner).to receive(:new).with('mock_claim_2').and_return(transitioner_2)
-      expect(transitioner_1).to receive(:run)
-      expect(transitioner_2).to receive(:run)
+    context 'non dummy' do
+      let(:batch_transitioner) { BatchTransitioner.new(dummy: false) }
 
-      bt.run
+      it 'only selects claims in correct states' do
+        expect(Transitioner).to receive(:candidate_claims_ids).and_return(claim_ids)
+        expect(Claim::BaseClaim).to receive(:find).with(22).and_return(claim_22)
+        expect(Claim::BaseClaim).to receive(:find).with(878).and_return(claim_878)
+        expect(Transitioner).to receive(:new).with(claim_22, false).and_return transitioner_22
+        expect(Transitioner).to receive(:new).with(claim_878, false).and_return transitioner_878
+        expect(transitioner_22).to receive(:run)
+        expect(transitioner_878).to receive(:run)
+
+        batch_transitioner.run
+      end
     end
 
+    context 'dummy' do
+      let(:batch_transitioner) { BatchTransitioner.new(dummy: true) }
+
+      it 'only selects claims in correct states' do
+        expect(Transitioner).to receive(:candidate_claims_ids).and_return(claim_ids)
+        expect(Claim::BaseClaim).to receive(:find).with(22).and_return(claim_22)
+        expect(Claim::BaseClaim).to receive(:find).with(878).and_return(claim_878)
+        expect(Transitioner).to receive(:new).with(claim_22, true).and_return transitioner_22
+        expect(Transitioner).to receive(:new).with(claim_878, true).and_return transitioner_878
+        expect(transitioner_22).to receive(:run)
+        expect(transitioner_878).to receive(:run)
+
+        batch_transitioner.run
+      end
+    end
   end
 end

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 
 module TimedTransitions
+  include DatabaseHousekeeping
 
   describe Transitioner do
 
@@ -19,61 +20,171 @@ module TimedTransitions
       end
     end
 
-    describe '.candidate_claims' do
+    describe '.candidate_claim_ids' do
       it 'should generate the correct sql' do
-        expect(Transitioner.candidate_claims.to_sql).to eq(
-          %q<SELECT "claims".* FROM "claims" WHERE "claims"."deleted_at" IS NULL AND (state in ('authorised','part_authorised','refused','rejected','archived_pending_delete'))>)
+        create :advocate_claim
+        create :submitted_claim
+        create :allocated_claim
+        authorised_claim = create :authorised_claim
+        archived_claim = create :archived_pending_delete_claim
+        create :redetermination_claim
+        part_authorised_claim = create :part_authorised_claim
+        refused_claim = create :refused_claim
+        rejected_claim = create :rejected_claim
+        expected_ids = [ authorised_claim.id, archived_claim.id, part_authorised_claim.id, refused_claim.id, rejected_claim.id ].sort
+
+        expect(Transitioner.candidate_claims_ids.sort).to eq expected_ids
       end
     end
 
-    describe '.process' do
-      it 'should not call archive if last state change less than 60 days ago' do
-        claim = double Claim
-        expect(claim).to receive(:last_state_transition_time).and_return(59.days.ago)
-        expect(claim).to receive(:state).and_return('authorised')
-        transitioner = Transitioner.new(claim)
-        expect(transitioner).not_to receive(:archive)
-        transitioner.run
-      end
+    describe '#run' do
+      context 'non dummy run' do
+        context 'transitioning to archived pending delete' do
+          context 'less than 60 days ago' do
+            it 'should not call archive if last state change less than 60 days ago' do
+              claim = double Claim
+              expect(claim).to receive(:last_state_transition_time).and_return(59.days.ago)
+              expect(claim).to receive(:state).and_return('authorised')
+              transitioner = Transitioner.new(claim)
+              expect(transitioner).not_to receive(:archive)
+              transitioner.run
+            end
+          end
 
-      it 'should call archive if last state change more than 60 days ago' do
-        expect(claim).to receive(:last_state_transition_time).and_return(61.days.ago)
-        expect(claim).to receive(:state).and_return('authorised')
-        transitioner = Transitioner.new(claim)
-        expect(transitioner).to receive(:archive)
-        transitioner.run
-      end
+          context 'more than 60 days ago' do
+            before(:each) do
+              Timecop.freeze(61.days.ago) do
+                @claim = create :authorised_claim, case_number: 'Z88299822'
+              end
+            end
 
-      it 'should not call destroy if last state change less than 60 days ago' do
-        expect(claim).to receive(:last_state_transition_time).and_return(59.days.ago)
-        expect(claim).to receive(:state).and_return('archived_pending_delete')
-        transitioner = Transitioner.new(claim)
-        expect(transitioner).not_to receive(:destroy)
-        transitioner.run
-      end
+            after(:all) { clean_database }
 
-      it 'should call destroy if last state change more than 60 days ago' do
-        expect(claim).to receive(:last_state_transition_time).and_return(61.days.ago)
-        expect(claim).to receive(:state).and_return('archived_pending_delete')
-        transitioner = Transitioner.new(claim)
-        expect(transitioner).to receive(:destroy)
-        transitioner.run
+            it 'should call archive if last state change more than 60 days ago' do
+              Transitioner.new(@claim).run
+              expect(@claim.reload.state).to eq 'archived_pending_delete'
+            end
+
+            it 'writes to the log file' do
+              expect_any_instance_of(Logger).to receive(:info).with("Changing state of claim #{@claim_id}: Z88299822 from authorised to archived_pending_delete")
+              Transitioner.new(@claim).run
+            end
+
+
+            it 'records the transition in claim state transitions' do
+              Transitioner.new(@claim).run
+              last_transition = @claim.claim_state_transitions.first
+              expect(last_transition.reason_code).to eq('timed_transition')
+            end
+          end
+        end
+
+        context 'destroying' do
+          context 'less than 60 days ago' do
+            it 'should not call destroy if last state change less than 60 days ago' do
+              claim = double Claim
+              expect(claim).to receive(:last_state_transition_time).and_return(59.days.ago)
+              expect(claim).to receive(:state).and_return('archived_pending_delete')
+              transitioner = Transitioner.new(claim)
+              expect(transitioner).not_to receive(:destroy)
+              transitioner.run
+            end
+          end
+
+          context 'more than 60 days ago' do
+            before(:each) do
+              Timecop.freeze(61.days.ago) do
+                @claim = create :litigator_claim, :archived_pending_delete, case_number: 'Z88299822'
+              end
+            end
+
+            after(:all) { clean_database }
+
+            it 'should destroy if last state change more than 60 days ago' do
+              Transitioner.new(@claim).run
+              expect(Claim::BaseClaim.where(id: @claim.id)).to be_empty
+            end
+
+            it 'should destroy all associated records' do
+              setup_associations
+              Transitioner.new(@claim).run
+              expect_claim_and_all_associations_to_be_gone
+            end
+
+
+            it 'writes to the log file' do
+              expect_any_instance_of(Logger).to receive(:info).with("Deleting claim : Z88299822")
+              Transitioner.new(@claim).run
+            end
+
+            def setup_associations
+              @claim.defendants.first.representation_orders << RepresentationOrder.new
+              2.times { @claim.expenses << Expense.new }
+              2.times { @claim.disbursements << create(:disbursement, claim: @claim) }
+              2.times { @claim.messages << create(:message, claim: @claim) }
+              @claim.expenses.first.dates_attended << DateAttended.new
+              @claim.documents << create(:document, claim: @claim, verified: true)
+              @claim.certification = create(:certification, claim: @claim)
+              @claim.save!
+              @claim.reload
+
+              @expense = @claim.expenses.first
+              @defendant = @claim.defendants.first
+              @document = @claim.documents.first
+
+              expect(@claim.case_worker_claims).not_to be_empty
+              expect(@claim.case_workers).not_to be_empty
+              expect(@claim.fees).not_to be_empty
+              expect(@claim.expenses).not_to be_empty
+              expect(@claim.expenses.first.dates_attended).not_to be_empty
+              expect(@claim.disbursements).not_to be_empty
+              expect(@claim.defendants).not_to be_empty
+              expect(@claim.defendants.first.representation_orders).not_to be_empty
+              expect(@claim.documents).not_to be_empty
+              expect(File.exist?(@claim.documents.first.document.path)).to be true
+              expect(@claim.messages).not_to be_empty
+              expect(@claim.claim_state_transitions).not_to be_empty
+              expect(@claim.determinations).not_to be_empty
+              expect(@claim.certification).not_to be_nil
+            end
+
+            def expect_claim_and_all_associations_to_be_gone
+              expect{ Claim::BaseClaim.find(@claim.id) }.to raise_error ActiveRecord::RecordNotFound, "Couldn't find Claim::BaseClaim with 'id'=#{@claim.id}"
+              expect(CaseWorkerClaim.where(claim_id: @claim.id)).to be_empty
+              expect(Fee::BaseFee.where(claim_id: @claim_id)).to be_empty
+              expect(Expense.where(claim_id: @claim_id)).to be_empty
+              expect(DateAttended.where(attended_item_id: @expense_id, attended_item_type: 'Expense')).to be_empty
+              expect(Disbursement.where(claim_id: @claim_id)).to be_empty
+              expect(Defendant.where(claim_id: @claim_id)).to be_empty
+              expect(RepresentationOrder.where(defendant_id: @defendant.id)).to be_empty
+              expect(Document.where(claim_id: @claim.id)).to be_empty
+              # expect(File.exist?(@document.document.path)).to be false
+              expect(Message.where(claim_id: @claim_id)).to be_empty
+              expect(ClaimStateTransition.where(claim_id: @claim.id)).to be_empty
+              expect(Determination.where(claim_id: @claim.id)).to be_empty
+              expect(Certification.where(claim_id: @claim.id)).to be_empty
+            end
+          end
+        end
       end
     end
 
     describe '#archive' do
       it 'should call archive pending delete on the claim' do
         transitioner = Transitioner.new(claim)
+        expect(claim).to receive(:case_number).and_return('A12345678')
+        expect(claim).to receive(:state).and_return('part_authorised')
         expect(claim).to receive(:archive_pending_delete!)
-        transitioner.send(:archive)
+        transitioner.send(:archive, false)
       end
     end
 
     describe '#destroy' do
       it 'should call destroy on the claim' do
         transitioner = Transitioner.new(claim)
+        expect(claim).to receive(:case_number).and_return('A12345678')
         expect(claim).to receive(:destroy)
-        transitioner.send(:destroy)
+        transitioner.send(:destroy, false)
       end
     end
 


### PR DESCRIPTION
There is one line commented out in the test - the line that tests that the underlying document is deleted from the filestore when the Document model is destroyed.  This still needs to be implemented as a separate PR
