### PR TITLE
Change Times of TimedTransitions

### DIFF
--- a/app/models/concerns/softly_deletable.rb
+++ b/app/models/concerns/softly_deletable.rb
@@ -6,7 +6,7 @@ module SoftlyDeletable
   
   included do
     scope :active, -> { where(deleted_at: nil) }
-    scope :deleted, -> { where.not(deleted_at: nil) }
+    scope :softly_deleted, -> { where.not(deleted_at: nil) }
 
     # Define instance methods :before_soft_delete and :after_soft_delete if you want any methods to be
     # called before or after the soft delete of this record
@@ -20,6 +20,10 @@ module SoftlyDeletable
 
     def active?
       self.deleted_at.nil?
+    end
+
+    def softly_deleted?
+      !active?
     end
 
 

--- a/app/models/timed_transitions/batch_transitioner.rb
+++ b/app/models/timed_transitions/batch_transitioner.rb
@@ -8,7 +8,8 @@ module TimedTransitions
 
     def run
       claims_ids = Transitioner.candidate_claims_ids
-      claims_ids.each do |claim_id|
+      softly_deleted_ids = Transitioner.softly_deleted_ids
+      (claims_ids + softly_deleted_ids).each do |claim_id|
         claim = Claim::BaseClaim.find claim_id
         transitioner = Transitioner.new(claim, @dummy)
         transitioner.run

--- a/app/models/timed_transitions/specification.rb
+++ b/app/models/timed_transitions/specification.rb
@@ -2,12 +2,12 @@ module TimedTransitions
 
   class Specification
 
-    attr_reader :current_state, :number_of_days, :method
+    attr_reader :current_state, :period_in_weeks, :method
 
-    def initialize(current_state, number_of_days, method)
-      @current_state  = current_state
-      @number_of_days = number_of_days
-      @method         = method
+    def initialize(current_state, period_in_weeks, method)
+      @current_state    = current_state
+      @period_in_weeks  = period_in_weeks
+      @method           = method
     end
 
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -62,4 +62,15 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 # on their claim
 email_notification_enabled?: true
 
+
+# location to write log messages regarding timed transitions
 timed_transition_log_path: <%= File.join(Rails.root, 'log', 'timed_transitions.log') %>
+
+# number of weeks in one state before automatic transition to archived pending delete
+timed_transition_stale_weeks: 16
+
+# number of weeks in archived pending delete before hard delete of claim
+timed_transition_pending_weeks: 16
+
+# number of weeks a claim can be soft deleted before hard delete of claim
+timed_transition_soft_delete_weeks: 16

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController, type: :controller do
       it 'destroys the case worker' do
         delete :destroy, id: subject
         expect(CaseWorker.active.count).to eq(1)
-        expect(CaseWorker.deleted.count).to eq(1)
+        expect(CaseWorker.softly_deleted.count).to eq(1)
         expect(subject.reload.deleted_at).not_to be_nil
       end
 

--- a/spec/models/case_worker_spec.rb
+++ b/spec/models/case_worker_spec.rb
@@ -67,17 +67,17 @@ RSpec.describe CaseWorker, type: :model do
 
     describe 'deleted scope' do
       it 'should return only deleted records' do
-        expect(CaseWorker.deleted.order(:id)).to eq([@dead_cw1, @dead_cw2])
+        expect(CaseWorker.softly_deleted.order(:id)).to eq([@dead_cw1, @dead_cw2])
       end
 
       it 'should return ActiveRecord::RecordNotFound if find by id relates to an undeleted record' do
         expect{
-          CaseWorker.deleted.find(@live_cw1.id)
+          CaseWorker.softly_deleted.find(@live_cw1.id)
         }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find CaseWorker with 'id'=#{@live_cw1.id} [WHERE "case_workers"."deleted_at" IS NOT NULL]}
       end
 
       it 'returns an empty array if the selection criteria only reference live records' do
-        expect(CaseWorker.deleted.where(id: [@live_cw1.id, @live_cw2.id])).to be_empty
+        expect(CaseWorker.softly_deleted.where(id: [@live_cw1.id, @live_cw2.id])).to be_empty
       end
     end
 

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -352,17 +352,17 @@ RSpec.describe ExternalUser, type: :model do
 
     describe 'deleted scope' do
       it 'should return only deleted records' do
-        expect(ExternalUser.deleted.order(:id)).to eq([@dead_user_1, @dead_user_2])
+        expect(ExternalUser.softly_deleted.order(:id)).to eq([@dead_user_1, @dead_user_2])
       end
 
       it 'should return ActiveRecord::RecordNotFound if find by id relates to an undeleted record' do
         expect{
-          ExternalUser.deleted.find(@live_user_1.id)
+          ExternalUser.softly_deleted.find(@live_user_1.id)
         }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find ExternalUser with 'id'=#{@live_user_1.id} [WHERE "external_users"."deleted_at" IS NOT NULL]}
       end
 
       it 'returns an empty array if the selection criteria only reference live records' do
-        expect(User.deleted.where(id: [@live_user_1.id, @live_user_2.id])).to be_empty
+        expect(User.softly_deleted.where(id: [@live_user_1.id, @live_user_2.id])).to be_empty
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -161,17 +161,17 @@ RSpec.describe User, type: :model do
 
     describe 'deleted scope' do
       it 'should return only deleted records' do
-        expect(User.deleted.order(:id)).to eq([@dead_user_1, @dead_user_2])
+        expect(User.softly_deleted.order(:id)).to eq([@dead_user_1, @dead_user_2])
       end
 
       it 'should return ActiveRecord::RecordNotFound if find by id relates to an undeleted record' do
         expect{
-          User.deleted.find(@live_user_1.id)
+          User.softly_deleted.find(@live_user_1.id)
         }.to raise_error ActiveRecord::RecordNotFound, %Q{Couldn't find User with 'id'=#{@live_user_1.id} [WHERE "users"."deleted_at" IS NOT NULL]}
       end
 
       it 'returns an empty array if the selection criteria only reference live records' do
-        expect(User.deleted.where(id: [@live_user_1.id, @live_user_2.id])).to be_empty
+        expect(User.softly_deleted.where(id: [@live_user_1.id, @live_user_2.id])).to be_empty
       end
     end
 


### PR DESCRIPTION
The main purpose of this PR is to change the time between Timed Transitions
from 60 days to 16 weeks.  Thes values have now been put into the Settings
file.

This PR also:
- changes the 'deleted' scope to 'softly_deleted' to avoid a clash with deleted in StateMachine
- Adds softly_deleted claims to those that will be hard deleted by Timed transitions.
