### PR TITLE
Timed retention banner with explanation page.

### DIFF
--- a/app/assets/stylesheets/moj/_forms.scss
+++ b/app/assets/stylesheets/moj/_forms.scss
@@ -561,11 +561,11 @@ label.form-date-spacing {
   }
 }
 
-.api-promo-alert {
+.js-callout-banner {
   border: 1px solid #2E2F30;
   padding: 20px;
   padding-bottom: 10px;
-  margin-bottom: 20px;
+  margin-bottom: 50px;
   margin-right: 20px;
 }
 

--- a/app/assets/stylesheets/moj/_typography.scss
+++ b/app/assets/stylesheets/moj/_typography.scss
@@ -135,3 +135,16 @@ header.main-header {
     }
   }
 }
+
+.timed-retention-states {
+  padding-left: 20px;
+
+  li {
+    list-style: disc inside;
+    line-height: 30px;
+
+    &.last-element {
+      margin-bottom: 30px;
+    }
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,4 +12,5 @@ class PagesController < ApplicationController
 
   def servicedown; end
 
+  def timed_retention; end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,13 +29,14 @@
 class UsersController < ApplicationController
 
   def update_settings
-    @result = current_user.save_settings!(settings_params)
+    @settings = settings_params
+    @result = current_user.save_settings!(@settings)
     respond_to :js
   end
 
   private
 
   def settings_params
-    params.except(:id).permit(:api_promo_seen)
+    params.except(:id).permit(:api_promo_seen, :timed_retention_banner_seen)
   end
 end

--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -45,4 +45,8 @@ module ExternalUsers::ClaimsHelper
     options = {name: 'dropdown_field_with_errors'}.merge(attributes.extract_options!)
     options[:name] if attributes.detect { |att| presenter.field_level_error_for(att.to_sym).present? }
   end
+
+  def show_timed_retention_banner_to_user?
+    Settings.timed_retention_banner_enabled? && current_user_is_external_user? && current_user.setting?(:timed_retention_banner_seen).nil?
+  end
 end

--- a/app/views/external_users/claims/_api_promo_banner.html.haml
+++ b/app/views/external_users/claims/_api_promo_banner.html.haml
@@ -1,11 +1,11 @@
 - if claim.new_record? && show_api_promo_to_user?
 
-  .api-promo-alert.js-api-promo-container
+  .js-callout-banner{'data-setting': 'api_promo_seen'}
     %p
       If you use a case management system, you may be able to import claims directly without re-typing them.
     %p
       Many case management systems have this capability; if yours doesn't, or hasn't been set up to make use of it, contact your software vendor.
       = link_to 'See here for details', api_landing_page_path, target: '_blank'
 
-    %p.js-api-promo-hide-link
+    %p.hide-link
       = link_to 'Do not show me again', settings_user_path(current_user.id, api_promo_seen: 1), method: :put, remote: true

--- a/app/views/external_users/claims/archived.html.haml
+++ b/app/views/external_users/claims/archived.html.haml
@@ -1,6 +1,5 @@
-%header.main-header{role: 'banner'}
-  %h1
-    = t('.archived_claims')
+= render partial: 'layouts/header', locals: {page_heading: t('.archived_claims')}
+= render partial: 'external_users/shared/timed_retention_banner'
 
 .container.search-wrapper#listanchor
   - if params[:search].present?

--- a/app/views/external_users/claims/index.html.haml
+++ b/app/views/external_users/claims/index.html.haml
@@ -1,4 +1,5 @@
 = render partial: 'layouts/header', locals: {page_heading: your_claims_header}
+= render partial: 'external_users/shared/timed_retention_banner'
 
 .container.sub-header
   .financial-summary

--- a/app/views/external_users/shared/_timed_retention_banner.html.haml
+++ b/app/views/external_users/shared/_timed_retention_banner.html.haml
@@ -1,0 +1,11 @@
+- if show_timed_retention_banner_to_user?
+
+  .js-callout-banner{'data-setting': 'timed_retention_banner_seen'}
+    %p
+      Time-limited retention of claims is being introduced from {DATE} 2016.
+    %p
+      From {DATE} 2016, claims made through the Claim for crown court defence service will be retained for a limited period only, and not indefinitely.
+      = link_to 'See here for details', timed_retention_page_path
+
+    %p.hide-link
+      = link_to 'Do not show me again', settings_user_path(current_user.id, timed_retention_banner_seen: 1), method: :put, remote: true

--- a/app/views/pages/timed_retention.html.haml
+++ b/app/views/pages/timed_retention.html.haml
@@ -1,0 +1,32 @@
+= render partial: 'layouts/header', locals: {page_heading: 'Time-limited retention of claims'}
+
+- stale_weeks     = Settings.timed_transition_stale_weeks
+- archived_weeks  = Settings.timed_transition_pending_weeks
+
+- contact_name    = 'Bethany Henshaw'
+- contact_email   = 'bethany.henshaw@legalaid.gsi.gov.uk'
+
+%section.timed-retention
+  %p
+    Starting from {DATE} 2016, claims will only be retained on the system for a limited period, and not indefinitely.
+  %p
+    Claims that are in one of the following states for #{stale_weeks} weeks, AND have had no messages added to the claim for #{stale_weeks} weeks will have their status changed to archived:
+
+  %ul.timed-retention-states
+    %li
+      draft
+    %li
+      authorised
+    %li
+      part-authorised
+    %li
+      refused
+    %li.last-element
+      rejected
+
+  %p
+    Claims in archived state can be viewed by clicking the Archive link at the top of the page from anywhere in the application, and can be unarchived, ie. returned to their original state.
+  %p
+    Claims that have been in archived state for #{archived_weeks} weeks, along with any attached documents, will be deleted from the database and will no longer be retrievable.
+  %p
+    Contact #{contact_name} #{mail_to contact_email, contact_email} if you have any questions about this policy.

--- a/app/views/users/update_settings.js.haml
+++ b/app/views/users/update_settings.js.haml
@@ -1,4 +1,7 @@
-- if @result
-  $('.js-api-promo-container').slideUp(300);
-- else
-  $('.js-api-promo-hide-link').html('There was a problem. Try again later.');
+- @settings.each do |name, _value|
+  - callout = "div.js-callout-banner[data-setting=#{name}]"
+
+  - if @result
+    $("#{callout}").slideUp(300);
+  - else
+    $("#{callout} p.hide-link").html('There was a problem. Try again later.');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get 'servicedown',    to: 'pages#servicedown',      as: :service_down_page
   get '/tandcs',        to: 'pages#tandcs',           as: :tandcs_page
   get '/contact_us',    to: 'pages#contact_us',       as: :contact_us_page
+  get '/timed_retention', to: 'pages#timed_retention', as: :timed_retention_page
   get '/api/landing',   to: 'pages#api_landing',      as: :api_landing_page
   get '/api/release_notes',   to: 'pages#api_release_notes', as: :api_release_notes
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,10 @@ expense_schema_version: 2
 # If enabled, users will see it, and will have a 'dismiss' link to hide and do not show it again
 api_promo_enabled?: true
 
+# Feature flag to enable or disable the timed retention banner
+# If enabled, external users will see it, and will have a 'dismiss' link to hide and do not show it again
+timed_retention_banner_enabled?: false
+
 # Feature flag to enable or disable the scheme filters in the claims list page
 # If enabled, users with proper roles will see scheme radio buttons to filter the list
 scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>

--- a/features/claims/timed_retention_banner.feature
+++ b/features/claims/timed_retention_banner.feature
@@ -1,0 +1,14 @@
+@javascript
+Feature: A timed retention banner will appear on the claims list, until the user dismisses it
+
+  Scenario: I go to the claims page, should see the timed retention banner, dismiss it and do not see it again
+
+    Given I am a signed in advocate
+    And The timed retention banner feature flag is enabled
+    And I am on the 'Your claims' page
+
+    Then The timed retention banner is visible
+    When I click the link 'Do not show me again'
+    Then The timed retention banner is not visible
+    When I reload the page
+    Then The timed retention banner is not visible

--- a/features/step_definitions/api_promo_steps.rb
+++ b/features/step_definitions/api_promo_steps.rb
@@ -4,5 +4,5 @@ end
 
 And(/^The API promo banner (is|is not) visible$/) do |visibility|
   visible = visibility == 'is'
-  expect(page).to have_selector('.js-api-promo-container', visible: visible)
+  expect(page).to have_selector('div.js-callout-banner[data-setting=api_promo_seen]', visible: visible)
 end

--- a/features/step_definitions/timed_retention_banner_steps.rb
+++ b/features/step_definitions/timed_retention_banner_steps.rb
@@ -1,0 +1,8 @@
+Given(/^The timed retention banner feature flag is enabled$/) do
+  allow(Settings).to receive(:timed_retention_banner_enabled?).and_return(true)
+end
+
+And(/^The timed retention banner (is|is not) visible$/) do |visibility|
+  visible = visibility == 'is'
+  expect(page).to have_selector('div.js-callout-banner[data-setting=timed_retention_banner_seen]', visible: visible)
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe UsersController, type: :controller do
 
     it 'updates the setting' do
       do_put(api_promo_seen: 'test')
+      expect(assigns(:settings).to_a).to eq([%w(api_promo_seen test)])
       expect(user.settings).to eq({'api_promo_seen' => 'test'})
     end
   end


### PR DESCRIPTION
Hidden for now behind a feature flag. Will only show to external users in the
claims list page and the archive page.

**Dates need to be confirmed**

Works identical to the API promo banner and allows the user to hide the banner
and do not show it again.

<img width="964" alt="screen shot 2016-09-08 at 17 07 59" src="https://cloud.githubusercontent.com/assets/687910/18357013/308adb74-75e7-11e6-8d06-63507578bc0c.png">
