### PR TITLE
Store the author user and subject user on transition changes.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,7 +70,6 @@ Lint/UselessAccessModifier:
 # Offense count: 9
 Lint/UselessAssignment:
   Exclude:
-    - 'app/controllers/case_workers/admin/allocations_controller.rb'
     - 'app/controllers/heartbeat_controller.rb'
     - 'app/form_builders/adp_form_builder.rb'
     - 'app/models/claims/search.rb'
@@ -163,7 +162,6 @@ Style/ClassVars:
 # SupportedStyles: assign_to_condition, assign_inside_condition
 Style/ConditionalAssignment:
   Exclude:
-    - 'app/controllers/case_workers/claims_controller.rb'
     - 'app/controllers/messages_controller.rb'
     - 'app/models/concerns/number_comma_parser.rb'
 
@@ -192,7 +190,6 @@ Style/EmptyLinesAroundMethodBody:
   Exclude:
     - 'app/models/claim/transfer_brain_data_item.rb'
     - 'app/models/claims/sort.rb'
-    - 'app/models/claims/state_machine.rb'
 
 # Offense count: 26
 # Cop supports --auto-correct.
@@ -206,7 +203,6 @@ Style/ExtraSpacing:
     - 'app/models/claim/base_claim.rb'
     - 'app/models/claim/transfer_brain_data_item.rb'
     - 'app/models/claim/transfer_brain_data_item_collection.rb'
-    - 'app/models/claims/state_machine.rb'
     - 'app/models/defendant.rb'
     - 'app/models/document.rb'
     - 'app/models/fee/fixed_fee_type.rb'
@@ -222,7 +218,6 @@ Style/ExtraSpacing:
 # SupportedStyles: consistent, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
 Style/FirstParameterIndentation:
   Exclude:
-    - 'app/controllers/case_workers/admin/allocations_controller.rb'
     - 'app/controllers/case_workers/admin/case_workers_controller.rb'
     - 'app/controllers/external_users/admin/external_users_controller.rb'
     - 'app/controllers/super_admins/admin/super_admins_controller.rb'
@@ -309,7 +304,6 @@ Style/MutableConstant:
     - 'app/models/claim/transfer_claim.rb'
     - 'app/models/claims/search.rb'
     - 'app/models/claims/sort.rb'
-    - 'app/models/claims/state_machine.rb'
     - 'app/models/court.rb'
     - 'app/models/doc_type.rb'
     - 'app/models/expense.rb'
@@ -345,13 +339,6 @@ Style/ParallelAssignment:
     - 'app/presenters/base_presenter.rb'
     - 'app/presenters/error_message_translator.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: AllowSafeAssignment.
-Style/ParenthesesAroundCondition:
-  Exclude:
-    - 'app/services/claims/case_worker_claim_updater.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
@@ -359,12 +346,6 @@ Style/ParenthesesAroundCondition:
 Style/PercentQLiterals:
   Exclude:
     - 'app/form_builders/adp_form_builder.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/RedundantParentheses:
-  Exclude:
-    - 'app/controllers/case_workers/admin/allocations_controller.rb'
 
 # Offense count: 8
 # Cop supports --auto-correct.
@@ -468,8 +449,6 @@ Style/SpaceInsideHashLiteralBraces:
 # Cop supports --auto-correct.
 Style/SpaceInsideParens:
   Exclude:
-    - 'app/controllers/case_workers/admin/allocations_controller.rb'
-    - 'app/models/claims/state_machine.rb'
     - 'app/presenters/claim/base_claim_presenter.rb'
     - 'app/validators/claim/base_claim_validator.rb'
 

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -36,7 +36,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   end
 
   def update
-    updater = Claims::CaseWorkerClaimUpdater.new(params[:id], claim_params).update!
+    updater = Claims::CaseWorkerClaimUpdater.new(params[:id], claim_params.merge(current_user: current_user)).update!
     @claim = updater.claim
     @doc_types = DocType.all
     if updater.result == :ok
@@ -89,8 +89,8 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   end
 
   def set_claims
-    if current_user.persona.admin?
-      @claims = case tab
+    @claims = if current_user.persona.admin?
+                case tab
                 when 'current'
                   current_user.claims.caseworker_dashboard_under_assessment
                 when 'archived'
@@ -100,14 +100,14 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
                 when 'unallocated'
                   Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons
                 end
-    else
-      @claims = case tab
+              else
+                case tab
                 when 'current'
                   current_user.claims.caseworker_dashboard_under_assessment
                 when 'archived'
                   current_user.claims.caseworker_dashboard_archived
                 end
-    end
+              end
   end
 
   def tab

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -11,8 +11,8 @@ class Allocation
   #
   VALID_STATES_FOR_TRANSITION = {
     allocation: Claims::StateMachine::VALID_STATES_FOR_ALLOCATION + ['allocated'],
-    deallocation: Claims::StateMachine::VALID_STATES_FOR_DEALLOCATION + ['allocated'],
-    reallocation: Claims::StateMachine::VALID_STATES_FOR_DEALLOCATION + ['allocated'],
+    deallocation: Claims::StateMachine::VALID_STATES_FOR_DEALLOCATION,
+    reallocation: Claims::StateMachine::VALID_STATES_FOR_DEALLOCATION,
   }.freeze
 
   class << self
@@ -21,43 +21,47 @@ class Allocation
     end
   end
 
-  attr_accessor :case_worker_id, :claim_ids, :claims, :deallocate, :allocating, :successful_claims
+  attr_accessor :current_user, :case_worker_id, :claim_ids, :deallocate, :allocating, :successful_claims
 
   validates :case_worker_id, presence: true, unless: :deallocating?
   validates :claim_ids, presence: true
 
 
   def initialize(attributes = {})
+    @current_user = attributes[:current_user]
     @case_worker_id = attributes[:case_worker_id]
-    @claim_ids = attributes[:claim_ids].reject(&:blank?) rescue nil
+    @claim_ids = attributes[:claim_ids]&.reject(&:blank?)
     @deallocate = [true, 'true'].include?(attributes[:deallocate])
     @allocating = attributes[:allocating]
-    @claims = Claim::BaseClaim.active.find(@claim_ids) rescue nil
     @successful_claims = []
   end
 
   def save
     return false unless valid?
     if allocating?
-      allocate_all_claims_or_none!(@claims) if claims_in_correct_state_for?(:allocation)
+      allocate_all_claims_or_none! if claims_in_correct_state_for?(:allocation)
     elsif deallocating?
-      deallocate_claims(@claims) if claims_in_correct_state_for?(:deallocation)
+      deallocate_claims if claims_in_correct_state_for?(:deallocation)
     elsif reallocating?
-      reallocate_claims(@claims) if claims_in_correct_state_for?(:reallocation)
+      reallocate_claims if claims_in_correct_state_for?(:reallocation)
     else
       raise "Should never get here!"
     end
     errors.empty?
   end
 
+  def claims
+    @claims ||= Claim::BaseClaim.active.find(@claim_ids)
+  end
+
   def claims_in_correct_state_for?(new_state)
-    @claims.each do |claim|
+    claims.each do |claim|
       errors[:base] << "Claim #{claim.id} cannot be transitioned to #{new_state} from #{claim.state}" unless claim.state.in?(VALID_STATES_FOR_TRANSITION[new_state])
     end
     errors[:base].empty?
   end
 
-  def reallocate_claims(claims)
+  def reallocate_claims
     claims.each { |claim| allocate_claim!(claim) }
   end
 
@@ -71,7 +75,7 @@ class Allocation
 
   private
 
-  def allocate_all_claims_or_none!(claims)
+  def allocate_all_claims_or_none!
     ActiveRecord::Base.transaction do
       claims.each do |claim|
         allocate_or_error_claim! claim
@@ -107,21 +111,26 @@ class Allocation
     !deallocating? && !allocating?
   end
 
-  def deallocate_claims(claims)
+  def deallocate_claims
     claims.each { |claim| deallocate_claim!(claim)}
   end
 
   def deallocate_claim!(claim)
-    claim.case_workers.destroy_all
-    claim.deallocate!
+    claim.deallocate!(audit_attributes)
     successful_claims << claim
   end
 
   def allocate_claim!(claim)
-    #NOTE: associating a case worker implicitly changes the state of the claim and saves via the state machine allocate! event method
-    claim.case_workers.destroy_all
+    claim.deallocate!(audit_attributes) if claim.allocated?
+    claim.allocate!(audit_attributes)
+
     claim.case_workers << case_worker
     successful_claims << claim
   end
 
+  def audit_attributes
+    author_user = current_user
+    subject_user = case_worker&.user
+    {author_id: author_user&.id, subject_id: subject_user&.id}
+  end
 end

--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -15,6 +15,8 @@
 class ClaimStateTransition < ActiveRecord::Base
 
   belongs_to :claim, class_name: ::Claim::BaseClaim, foreign_key: :claim_id
+  belongs_to :author, class_name: User, foreign_key: :author_id
+  belongs_to :subject, class_name: User, foreign_key: :subject_id
 
   def reason
     ClaimStateTransitionReason.get(reason_code)

--- a/db/migrate/20160909150238_add_author_and_subject_to_claim_state_transitions.rb
+++ b/db/migrate/20160909150238_add_author_and_subject_to_claim_state_transitions.rb
@@ -1,0 +1,6 @@
+class AddAuthorAndSubjectToClaimStateTransitions < ActiveRecord::Migration
+  def change
+    add_column :claim_state_transitions, :author_id, :integer
+    add_column :claim_state_transitions, :subject_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160902084750) do
+ActiveRecord::Schema.define(version: 20160909150238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,8 @@ ActiveRecord::Schema.define(version: 20160902084750) do
     t.string   "to"
     t.datetime "created_at"
     t.string   "reason_code"
+    t.integer  "author_id"
+    t.integer  "subject_id"
   end
 
   add_index "claim_state_transitions", ["claim_id"], name: "index_claim_state_transitions_on_claim_id", using: :btree

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -232,6 +232,12 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
           expect(flash[:notice]).to match /\d claim[s]{0,1} allocated to.*/
         end
 
+        it 'saves audit attributes' do
+          transition = @claims.first.last_state_transition
+          expect(transition.author_id).to eq(@admin.user.id)
+          expect(transition.subject_id).to eq(@case_worker.user.id)
+        end
+
         it 'renders the new template' do
           expect(response).to render_template(:new)
         end
@@ -272,6 +278,12 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
 
       it 're-allocates claims to case worker' do
         expect(@case_worker.claims.map(&:id)).to match_array(@claims.map(&:id))
+      end
+
+      it 'saves audit attributes' do
+        transition = @claims.first.last_state_transition
+        expect(transition.author_id).to eq(@admin.user.id)
+        expect(transition.subject_id).to eq(@case_worker.user.id)
       end
 
       it 'renders new allocation template' do

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe Claims::StateMachine, type: :model do
       }.to change{ subject.state }.to('authorised') }
 
       it { expect{ subject.archive_pending_delete! }.to raise_error }
+
+      it 'should be able to deallocate' do
+        expect{
+          subject.deallocate!
+        }.to change{ subject.state }.to('submitted')
+      end
+
+      it 'should unlink case workers on deallocate' do
+        expect(subject.case_workers).to receive(:destroy_all)
+        subject.deallocate!
+      end
     end
 
     describe 'from draft' do

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -113,9 +113,9 @@ RSpec.describe ClaimCsvPresenter do
 
         before {
           case_worker = claim.case_workers.first
-          claim.case_workers.destroy_all; claim.deallocate!
-          claim.case_workers << case_worker; claim.allocate!
-          claim.case_workers.destroy_all; claim.deallocate!
+          claim.deallocate!
+          claim.case_workers << case_worker
+          claim.reload.deallocate!
         }
 
         it 'should not be reflected in the MI' do


### PR DESCRIPTION
Whenever possible, store the ID of the user triggering a state change (author_id),
and the ID of the user receiving the action (subject_id).

For example for allocations, it will store the id of the user triggering the allocation action,
and the id of the user who was allocated said claim.

For transitions not involving another user, only the author_id will be filled (i.e. rejections)
