### PR TITLE
Store the author user and subject user on transition changes (external users).

### DIFF
--- a/app/controllers/external_users/application_controller.rb
+++ b/app/controllers/external_users/application_controller.rb
@@ -46,4 +46,7 @@ private
     ]
   end
 
+  def claim_updater
+    Claims::ExternalUserClaimUpdater.new(@claim, current_user: current_user)
+  end
 end

--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -19,7 +19,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
 
   def create
     @claim.build_certification(certification_params)
-    if @claim.certification.save && @claim.submit
+    if @claim.certification.save && claim_updater.submit
       redirect_to confirmation_external_users_claim_path(@claim)
     else
       @certification = @claim.certification

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -79,7 +79,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def clone_rejected
     begin
-      draft = @claim.clone_rejected_to_new_draft
+      draft = claim_updater.clone_rejected
       redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
     rescue
       redirect_to external_users_claims_url, alert: 'Can only clone rejected claims'
@@ -88,10 +88,10 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def destroy
     if @claim.draft?
-      @claim.soft_delete
+      claim_updater.delete
       flash[:notice] = 'Claim deleted'
     elsif @claim.can_archive_pending_delete?
-      @claim.archive_pending_delete!
+      claim_updater.archive
       flash[:notice] = 'Claim archived'
     else
       flash[:alert] = 'This claim cannot be deleted'

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -101,10 +101,10 @@ module Claims::Cloner
     end
   end
 
-  def clone_rejected_to_new_draft
+  def clone_rejected_to_new_draft(author_id:)
     raise 'Can only clone claims in state "rejected"' unless rejected?
     draft = duplicate
-    draft.transition_clone_to_draft!
+    draft.transition_clone_to_draft!(author_id: author_id)
     draft
   end
 

--- a/app/services/claims/external_user_claim_updater.rb
+++ b/app/services/claims/external_user_claim_updater.rb
@@ -1,0 +1,42 @@
+module Claims
+  class ExternalUserClaimUpdater
+
+    attr_accessor :claim, :current_user
+
+    def initialize(claim, current_user:)
+      self.claim = claim
+      self.current_user = current_user
+    end
+
+    def delete
+      claim.soft_delete
+    end
+
+    def archive
+      claim.archive_pending_delete!(audit_attributes)
+    end
+
+    def clone_rejected
+      claim.clone_rejected_to_new_draft(audit_attributes)
+    end
+
+    def request_redetermination
+      claim.redetermine!(audit_attributes)
+    end
+
+    def request_written_reasons
+      claim.await_written_reasons!(audit_attributes)
+    end
+
+    def submit
+      claim.submit(audit_attributes)
+    end
+
+
+    private
+
+    def audit_attributes
+      {author_id: current_user&.id}
+    end
+  end
+end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -53,8 +53,9 @@ RSpec.describe Claims::Cloner, type: :model do
 
     context 'rejected_claims' do
       before(:all) do
+        @current_user = create(:external_user)
         @original_claim = create_rejected_claim
-        @cloned_claim = @original_claim.clone_rejected_to_new_draft
+        @cloned_claim = @original_claim.clone_rejected_to_new_draft(author_id: @current_user.id)
       end
 
       after(:all) do
@@ -166,9 +167,13 @@ RSpec.describe Claims::Cloner, type: :model do
 
       it 'creates the first state transition for the cloned claim' do
         expect(@cloned_claim.claim_state_transitions.count).to eq(1)
-        expect(@cloned_claim.last_state_transition.claim_id).to eq(@cloned_claim.id)
-        expect(@cloned_claim.last_state_transition.from).to eq('rejected')
-        expect(@cloned_claim.last_state_transition.to).to eq('draft')
+
+        transition = @cloned_claim.last_state_transition
+        expect(transition.claim_id).to eq(@cloned_claim.id)
+        expect(transition.from).to eq('rejected')
+        expect(transition.to).to eq('draft')
+        expect(transition.event).to eq('transition_clone_to_draft')
+        expect(transition.author_id).to eq(@current_user.id)
       end
     end
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -118,7 +118,9 @@ RSpec.describe Message, type: :model do
       claim.messages.first.written_reasons_submitted = '1'
       claim.save
       claim.reload
+
       expect(claim.claim_state_transitions.reorder(created_at: :asc).map(&:event)).to eq( [ nil, 'submit', 'allocate', 'authorise_part', 'await_written_reasons', 'authorise_part' ] )
+      expect(claim.last_state_transition.author_id).to eq(user.id)
       expect(claim.state).to eq 'part_authorised'
     end
   end

--- a/spec/services/claims/external_user_claim_updater_spec.rb
+++ b/spec/services/claims/external_user_claim_updater_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+module Claims
+  describe ExternalUserClaimUpdater do
+    let(:current_user) { double(User, id: 12345) }
+
+    subject { described_class.new(claim, current_user: current_user) }
+
+    describe '#delete' do
+      let(:claim) { create :advocate_claim }
+
+      it 'soft-deletes the claim' do
+        subject.delete
+        expect(claim.deleted_at).not_to be_nil
+      end
+    end
+
+    describe '#archive' do
+      let(:claim) { create :rejected_claim }
+
+      after(:each) do
+        expect(claim.last_state_transition.author_id).to eq(current_user.id)
+      end
+
+      it 'archives the claim' do
+        subject.archive
+        expect(claim.archived_pending_delete?).to be_truthy
+      end
+    end
+
+    describe '#request_redetermination' do
+      let(:claim) { create :part_authorised_claim }
+
+      after(:each) do
+        expect(claim.last_state_transition.author_id).to eq(current_user.id)
+      end
+
+      it 'sends a redetermination request' do
+        subject.request_redetermination
+        expect(claim.redetermination?).to be_truthy
+      end
+    end
+
+    describe '#request_written_reasons' do
+      let(:claim) { create :part_authorised_claim }
+
+      after(:each) do
+        expect(claim.last_state_transition.author_id).to eq(current_user.id)
+      end
+
+      it 'sends a request for reasons' do
+        subject.request_written_reasons
+        expect(claim.awaiting_written_reasons?).to be_truthy
+      end
+    end
+
+    describe '#submit' do
+      let(:claim) { create :advocate_claim }
+
+      after(:each) do
+        expect(claim.last_state_transition.author_id).to eq(current_user.id)
+      end
+
+      it 'submits the claim' do
+        subject.submit
+        expect(claim.submitted?).to be_truthy
+      end
+    end
+
+    describe '#clone_rejected' do
+      let(:claim) { create :rejected_claim }
+
+      it 'clones the claim' do
+        expect { subject.clone_rejected }.to change{ Claim::BaseClaim.where(state: 'draft').count }.by(1)
+      end
+
+      it 'saves audit attributes in the new draft' do
+        draft = subject.clone_rejected
+        expect(draft.last_state_transition.author_id).to eq(current_user.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Following PR https://github.com/ministryofjustice/advocate-defence-payments/pull/1775

This will introduce the author for actions triggered by external users.
