### PR TITLE
Add the author of the action to message transitions.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -320,7 +320,6 @@ Style/MutableConstant:
 Style/NestedParenthesizedCalls:
   Exclude:
     - 'app/presenters/claim/base_claim_presenter.rb'
-    - 'app/presenters/message_presenter.rb'
 
 # Offense count: 1
 Style/NestedTernaryOperator:
@@ -353,7 +352,6 @@ Style/PercentQLiterals:
 Style/RedundantReturn:
   Exclude:
     - 'app/controllers/concerns/password_helpers.rb'
-    - 'app/presenters/claim_state_transition_presenter.rb'
     - 'app/presenters/error_message_translator.rb'
     - 'app/presenters/error_presenter.rb'
     - 'app/validators/base_validator.rb'
@@ -400,7 +398,6 @@ Style/SpaceAroundOperators:
     - 'app/models/expense.rb'
     - 'app/presenters/error_message_translator.rb'
     - 'app/presenters/error_presenter.rb'
-    - 'app/presenters/message_presenter.rb'
     - 'app/validators/base_validator.rb'
 
 # Offense count: 15
@@ -515,7 +512,6 @@ Style/UnlessElse:
 Style/UnneededInterpolation:
   Exclude:
     - 'app/models/date_attended.rb'
-    - 'app/presenters/claim_state_transition_presenter.rb'
 
 # Offense count: 6
 # Cop supports --auto-correct.

--- a/app/presenters/determination_presenter.rb
+++ b/app/presenters/determination_presenter.rb
@@ -7,7 +7,7 @@ class DeterminationPresenter < BasePresenter
   end
 
   def timestamp
-    " #{version.created_at.strftime('%H:%M')}"
+    version.created_at.strftime('%H:%M')
   end
 
   def itemise

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -22,9 +22,11 @@ class MessagePresenter < BasePresenter
 
   def download_file_link
     h.concat(
-      h.content_tag :a, "#{attachment_file_name} (#{attachment_file_size})",
-      href: "/messages/#{message.id}/download_attachment",
-      title: 'Download '+ attachment_file_name
+      h.content_tag(
+        :a, "#{attachment_file_name} (#{attachment_file_size})",
+        href: "/messages/#{message.id}/download_attachment",
+        title: 'Download ' + attachment_file_name
+      )
     )
   end
 
@@ -37,20 +39,15 @@ class MessagePresenter < BasePresenter
   end
 
   def sender_name
+    return '(Case worker)' if sender_is_a?(CaseWorker) && hide_author?
     message.sender.name
-  end
-
-  def sender_persona
-    case message.sender.persona
-      when CaseWorker
-        'Caseworker'
-      when ExternalUser
-        'Advocate'
-    end
   end
 
   def timestamp
     message.created_at.strftime('%H:%M')
   end
 
+  def hide_author?
+    h.current_user_is_external_user?
+  end
 end

--- a/app/views/shared/_determination.html.haml
+++ b/app/views/shared/_determination.html.haml
@@ -6,7 +6,6 @@
       .message-container
         .message-body
           = determination.event
-
           %table{summary: t('.summary')}
             %caption.visuallyhidden
               = t('.caption')
@@ -16,7 +15,3 @@
                   #{item}:
                 %td{scope:'col'}
                   #{number_to_currency(amount)}
-
-          .grid-row.message-audit
-            = "(System) "
-            = determination.timestamp

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -8,7 +8,6 @@
             = message.body
             .grid-row.message-audit
               = message.sender_name
-              (#{message.sender_persona})
               = message.timestamp
 
     .column-third
@@ -23,8 +22,5 @@
           .message-body
             = message.body
             .grid-row.message-audit
-
-              - if current_user_is_caseworker?
-                = message.sender_name
-              (#{message.sender_persona})
+              = message.sender_name
               = message.timestamp

--- a/app/views/shared/_state_change.html.haml
+++ b/app/views/shared/_state_change.html.haml
@@ -8,7 +8,7 @@
           %p
             = claim_state_transition.transition_message
           .grid-row.message-audit
-            (System)
+            = claim_state_transition.audit_users
             = claim_state_transition.timestamp
 
 

--- a/spec/presenters/claim_state_transition_presenter_spec.rb
+++ b/spec/presenters/claim_state_transition_presenter_spec.rb
@@ -2,13 +2,88 @@ require 'rails_helper'
 
 RSpec.describe ClaimStateTransitionPresenter do
 
-  let(:claim)      { create(:allocated_claim) }
-  let(:subject)    { ClaimStateTransitionPresenter.new(claim.last_state_transition, view) }
+  let(:claim) { create(:allocated_claim) }
+  let(:current_user) { create(:user, first_name: 'Brielle', last_name: 'Jenkins') }
+  let(:another_user) { create(:user, first_name: 'Madyson', last_name: 'Gibson') }
 
-  describe "#change" do
-    it 'returns a human readable string describing a state change' do
+  let(:subject) { ClaimStateTransitionPresenter.new(claim.last_state_transition, view) }
+
+  describe '#transition_message' do
+    before(:each) do
       allow(subject).to receive(:current_user_persona).and_return('CaseWorker')
+    end
+
+    it 'returns a human readable string describing a state change' do
       expect(subject.transition_message).to eq "Claim allocated"
+    end
+  end
+
+  describe '#audit_users' do
+    let(:is_external_user) { false }
+
+    before(:each) do
+      allow(view).to receive(:current_user_is_external_user?).and_return(is_external_user)
+    end
+
+    context 'without an author user' do
+      it 'returns a default string' do
+        expect(subject.audit_users).to eq('(System)')
+      end
+    end
+
+    context 'with an author user when logged in as an external user' do
+      let(:is_external_user) { true }
+      let(:claim) { create(:rejected_claim) }
+
+      before(:each) do
+        allow(view).to receive(:current_user).and_return(current_user)
+      end
+
+      context 'and the transition was triggered by the same user' do
+        before(:each) do
+          claim.archive_pending_delete!(author_id: current_user.id)
+        end
+
+        it 'returns a default string' do
+          expect(subject.audit_users).to eq('Brielle Jenkins')
+        end
+      end
+
+      context 'and the transition was triggered by a different user' do
+        before(:each) do
+          claim.archive_pending_delete!(author_id: another_user.id)
+        end
+
+        it 'returns a default string' do
+          expect(subject.audit_users).to eq('(System)')
+        end
+      end
+    end
+
+    context 'with an author user but without a subject user' do
+      let(:claim) { create(:rejected_claim) }
+
+      before(:each) do
+        claim.archive_pending_delete!(author_id: current_user.id)
+      end
+
+      it 'returns a human readable string describing who did the change' do
+        expect(claim.last_state_transition.event).to eq('archive_pending_delete')
+        expect(subject.audit_users).to eq('Brielle Jenkins')
+      end
+    end
+
+    context 'with a subject user' do
+      let(:claim) { create(:submitted_claim) }
+
+      before(:each) do
+        claim.allocate!(author_id: current_user.id, subject_id: another_user.id)
+      end
+
+      it 'returns a human readable string describing who did the change and to whom' do
+        expect(claim.last_state_transition.event).to eq('allocate')
+        expect(subject.audit_users).to eq('Brielle Jenkins to Madyson Gibson')
+      end
     end
   end
 end


### PR DESCRIPTION
External users will not see the name unless the action was triggered by themselves.
When the author is not present (older transitions) we default to 'System'.
