### PR TITLE
Spike to implement a backend-agnostic caching wrapper.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'paperclip',              '~> 4.2.2'
 gem 'paper_trail',            '4.0.2' # version locked, https://github.com/airblade/paper_trail/issues/738
 gem 'pg',                     '~> 0.18.2'
 gem 'rails',                  '~> 4.2.7.1'
+gem 'redis',                  '~> 3.3.1'
 gem 'config',                 '~> 1.2.1' # this gem provides our Settings.xxx mechanism
 gem 'remotipart',             '~> 1.2'
 gem 'rest-client',            '~> 1.8' # needed for scheduled smoke testing plus others

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -648,6 +648,7 @@ DEPENDENCIES
   rack-livereload (~> 0.3.16)
   rails (~> 4.2.7.1)
   rails_12factor (= 0.0.3)
+  redis (~> 3.3.1)
   remotipart (~> 1.2)
   rest-client (~> 1.8)
   rspec-collection_matchers

--- a/config/initializers/caching.rb
+++ b/config/initializers/caching.rb
@@ -1,0 +1,8 @@
+require 'caching'
+require 'memory_caching'
+
+# REDIS_URL env variable will be used automatically if set,
+# otherwise, default will be 'redis://127.0.0.1:6379'
+#
+# Caching.backend = Redis.current
+Caching.backend = MemoryCaching.current

--- a/lib/api/api_test_client.rb
+++ b/lib/api/api_test_client.rb
@@ -14,6 +14,7 @@
 #   end
 # ---------------------------------------
 #
+require 'cached_api_request'
 require 'rest-client'
 Dir[File.join(Rails.root, 'lib', 'api', 'claims', '*.rb')].each { |file| require file }
 
@@ -54,9 +55,12 @@ class ApiTestClient
   def get_dropdown_endpoint(resource, api_key, params = {})
     query_params = '?' + params.merge(api_key: api_key).to_query
     endpoint = RestClient::Resource.new([api_root_url, 'api', resource].join('/') + query_params)
-    endpoint.get do |response, _request, _result|
-      handle_response(response, resource)
-      response
+
+    CachedApiRequest.cache(endpoint.url) do
+      endpoint.get do |response, _request, _result|
+        handle_response(response, resource)
+        response
+      end
     end
   end
 

--- a/lib/cached_api_request.rb
+++ b/lib/cached_api_request.rb
@@ -77,15 +77,15 @@ class CachedApiRequest
   end
 
   def processed_url(url)
-    parsed = URI::parse(url)
-    parsed.query = filter_query(parsed.query)
-    parsed.fragment = nil
-    parsed.to_s
+    uri = URI::parse(url.downcase)
+    uri.query = filter_query(uri.query)
+    uri.fragment = nil
+    uri.to_s
   end
 
   def filter_query(query)
     return nil unless query.present?
-    params = query.downcase.split('&').reject { |param| options[:ignore_params].include?(param.split('=')[0]) }
+    params = query.split('&').reject { |param| options[:ignore_params].include?(param.split('=')[0]) }
     params.any? ? params.sort.join('&') : nil
   end
 end

--- a/lib/cached_api_request.rb
+++ b/lib/cached_api_request.rb
@@ -1,0 +1,62 @@
+require 'caching'
+require 'digest/sha1'
+
+class CachedApiRequest
+  attr_accessor :url
+
+  VERSION = 1 # cache version, not necessarily matching API version
+
+  class << self
+    def cache(url, cache_policy = -> { 15.minutes.ago })
+      new(url).cache(cache_policy) do
+        yield if block_given?
+      end
+    end
+  end
+
+  def initialize(url)
+    self.url = url
+  end
+
+  def cache(cache_policy)
+    if new_record? || created_at < cache_policy.call
+      puts "caching response for url: #{url}"
+      Caching.set(policy_key, Time.zone.now.to_s)
+      Caching.set(cache_key, yield)
+    else
+      puts "reading response for url: #{url}"
+    end
+    content
+  end
+
+
+  private
+
+  def url_digest
+    @url_digest ||= Digest::SHA1.hexdigest(url)
+  end
+
+  def cache_key
+    "api:#{version}:#{url_digest}"
+  end
+
+  def policy_key
+    "api:#{version}:#{url_digest}:created_at"
+  end
+
+  def version
+    VERSION
+  end
+
+  def content
+    Caching.get(cache_key)
+  end
+
+  def created_at
+    Time.zone.parse(Caching.get(policy_key)) rescue nil
+  end
+
+  def new_record?
+    content.nil? || created_at.nil?
+  end
+end

--- a/lib/caching.rb
+++ b/lib/caching.rb
@@ -1,0 +1,15 @@
+module Caching
+  class << self
+    def backend=(backend)
+      @backend = backend
+    end
+
+    def backend
+      @backend
+    end
+
+    def method_missing(method, *args, &block)
+      backend.send(method, *args, &block)
+    end
+  end
+end

--- a/lib/caching.rb
+++ b/lib/caching.rb
@@ -8,6 +8,15 @@ module Caching
       @backend
     end
 
+    def get(key)
+      backend.get(key)
+    end
+
+    def set(key, value)
+      backend.set(key, value)
+      value
+    end
+
     def method_missing(method, *args, &block)
       backend.send(method, *args, &block)
     end

--- a/lib/memory_caching.rb
+++ b/lib/memory_caching.rb
@@ -17,4 +17,8 @@ class MemoryCaching
   def set(key, value)
     self.store[key] = value
   end
+
+  def clear
+    self.store.clear
+  end
 end

--- a/lib/memory_caching.rb
+++ b/lib/memory_caching.rb
@@ -1,0 +1,20 @@
+class MemoryCaching
+  cattr_accessor :instance, :store
+
+  def initialize
+    self.store = Hash.new
+  end
+  private_class_method :new
+
+  def self.current
+    self.instance ||= new
+  end
+
+  def get(key)
+    self.store[key]
+  end
+
+  def set(key, value)
+    self.store[key] = value
+  end
+end

--- a/spec/lib/cached_api_request_spec.rb
+++ b/spec/lib/cached_api_request_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+require 'cached_api_request'
+
+describe CachedApiRequest do
+  let(:store) { MemoryCaching.current }
+  let(:url) { 'http://test.com/ping.json' }
+  let(:value) { 'test value' }
+  let(:cache_request) { described_class.cache(url) { value } }
+
+  before(:each) do
+    Caching.backend = store
+  end
+
+  after(:each) do
+    store.clear
+  end
+
+  describe 'options' do
+    subject { described_class.new(url, options) }
+
+    context 'default set' do
+      let(:options) { {} }
+
+      it 'should have a default set of options, if none provided' do
+        expect(subject.options[:ttl]).to eq(900)
+        expect(subject.options[:ignore_params]).to eq(['api_key'])
+      end
+    end
+
+    context 'custom set' do
+      let(:options) { {ttl: 180, ignore_params: ['sorting']} }
+
+      it 'should override default options if provided' do
+        expect(subject.options[:ttl]).to eq(180)
+        expect(subject.options[:ignore_params]).to eq(['sorting'])
+      end
+    end
+  end
+
+  describe 'url normalization and param filtering' do
+    [
+      %w(http://test.com                http://test.com),
+      %w(http://Test.Com                http://test.com),
+      %w(http://test.com?               http://test.com),
+      %w(http://test.com/               http://test.com/),
+      %w(http://test.com/?              http://test.com/),
+      %w(http://test.com?123            http://test.com?123),
+      %w(http://test.com/?123           http://test.com/?123),
+      %w(http://test.com/?321           http://test.com/?321),
+      %w(http://test.com?test=1         http://test.com?test=1),
+      %w(http://test.com?api_key=1      http://test.com),
+      %w(http://test.com?API_KEY=1      http://test.com),
+      %w(http://test.com?api_key=1&a=b  http://test.com?a=b),
+      %w(http://test.com?b=1&a=2        http://test.com?a=2&b=1),
+      %w(http://test.com?a=1#anchor     http://test.com?a=1),
+    ].each do |(url, processed_url)|
+      it "should process #{url} and return #{processed_url}" do
+        instance = described_class.new(url)
+        expect(instance.url).to eq(processed_url)
+      end
+    end
+  end
+
+  describe 'writing and reading from the cache' do
+    context 'caching new content' do
+      it 'should write to the cache and return the content' do
+        expect(store).to receive(:set).with(/api:/, /value/).once.and_call_original
+        expect(cache_request).to eq(value)
+      end
+
+      it 'should cache again a stale content' do
+        Timecop.freeze(1.day.ago) do
+          returned = described_class.cache(url) { 'old value' }
+          expect(returned).to eq('old value')
+        end
+
+        returned = described_class.cache(url) { 'new value' }
+        expect(returned).to eq('new value')
+      end
+    end
+
+    context 'reading from cache existing content' do
+      it 'should read from the cache and return the content' do
+        expect(store).to receive(:set).with(/api:/, /value/).once.and_call_original
+        expect(store).to receive(:get).with(/api:/).twice.and_call_original
+
+        returned_1 = described_class.cache(url) { 'test value' }
+        returned_2 = described_class.cache(url) { 'another value' }
+
+        expect(returned_1).to eq(returned_2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to cache API requests, using as unique keys the endpoints (urls)
including parameters. Future improvement involve filtering out some parameters to
make the hit/miss ratio better (i.e. api_key should be filtered out).

As an example, there is a **Redis** cache and a **Memory** cache. Swapping between them
is done via an initialization file.

A caching policy can be provided to enable the cached content to stale after N mins, for example.

**To test it, run the API smoke tests (unicorn must be running).** `rake api:smoke_test`

The dropdowns will be cached. Run it several times with Redis server started to see the caching in action.
With Memory caching, each run will wipe the cache so the hit/miss is worse.

Some `puts` left on purpose to see the caching/reading easily.

**UPDATE (20/09/2016)**
- Support for custom TTL (in seconds) - default is 900 (15 mins).
- Support for filtering out query params - api_key is filtered by default.
- Improved URL digest: downcase, param sorting and fragment removal.

Example:

``` ruby
CachedApiRequest.cache('url', ttl: 60, ignore_params: ['api_key', 'test']) do
   ... request ...
end
```
