### PR TITLE
Using the max-age in the Cache-Control header, if any, for TTL.

### DIFF
--- a/app/services/remote/base.rb
+++ b/app/services/remote/base.rb
@@ -8,15 +8,11 @@ module Remote
         raise 'not implemented'
       end
 
-      def resource_ttl
-        86400 # override in subclasses if necessary
-      end
-
       # Add * as a temporary measure so that we can easily see in the UI
       # that it is using the API to get data, not the DB.
       #
       def all
-        client.get(resource_path, ttl: resource_ttl).map { |h| new(h.merge(name: h['name'] += ' *')) }
+        client.get(resource_path).map { |h| new(h.merge(name: h['name'] += ' *')) }
       end
 
       def find(id)

--- a/app/services/remote/http_client.rb
+++ b/app/services/remote/http_client.rb
@@ -1,6 +1,6 @@
 module Remote
   class HttpClient
-    cattr_accessor :instance, :logger, :base_url, :api_key, :read_timeout, :open_timeout
+    cattr_accessor :instance, :logger, :base_url, :api_key, :timeout, :open_timeout
     private_class_method :new
 
     class << self
@@ -17,8 +17,8 @@ module Remote
       end
     end
 
-    def get(path, options = {})
-      execute_request(:get, path, options)
+    def get(path)
+      execute_request(:get, path)
     end
 
     private
@@ -27,11 +27,10 @@ module Remote
       [self.base_url, path].join('/') + '?' + {api_key: self.api_key}.to_query
     end
 
-    def execute_request(method, path, options = {})
+    def execute_request(method, path)
       endpoint = build_endpoint(path)
-      response = Caching::ApiRequest.cache(endpoint, ttl: options[:ttl]) do
-        RestClient::Request.execute(
-            method: method, url: endpoint, read_timeout: self.read_timeout, open_timeout: self.open_timeout)
+      response = Caching::ApiRequest.cache(endpoint) do
+        RestClient::Request.execute(method: method, url: endpoint, timeout: self.timeout, open_timeout: self.open_timeout)
       end
       JSON.parse(response)
     end

--- a/config/initializers/remote_client.rb
+++ b/config/initializers/remote_client.rb
@@ -3,5 +3,5 @@ Remote::HttpClient.configure do |client|
   client.api_key = Settings.remote_api_key
   client.logger = Rails.logger
   client.open_timeout = 5
-  client.read_timeout = 15
+  client.timeout = 15
 end

--- a/lib/caching/response.rb
+++ b/lib/caching/response.rb
@@ -1,0 +1,33 @@
+module Caching
+  class Response
+    attr_accessor :response
+
+    def initialize(response)
+      self.response = response
+      validate!
+    end
+
+    def body
+      response.body
+    end
+
+    def headers
+      response.headers
+    end
+
+    def ttl
+      cache_control[/max-age=([0-9]+)/, 1]
+    end
+
+    private
+
+    def cache_control
+      headers[:cache_control] || ''
+    end
+
+    def validate!
+      raise ArgumentError, 'response object must implement a `body` method' unless response.respond_to?(:body)
+      raise ArgumentError, 'response object must implement a `headers` method' unless response.respond_to?(:headers)
+    end
+  end
+end


### PR DESCRIPTION
Refactor of the API caching mechanism to use the source Cache-Control header as TTL,
taking precedence over a locally set TTL.

Once we start using it we should ensure our API endpoints respond with an appropiate
Cache-Control header and max-age according to the resource being requested.
