### PR TITLE
Add api_key to the User model in preparation for new API endpoints.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@
 #  unlock_token           :string
 #  settings               :text
 #  deleted_at             :datetime
+#  api_key                :uuid
 #
 
 class UsersController < ApplicationController

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@
 #  unlock_token           :string
 #  settings               :text
 #  deleted_at             :datetime
+#  api_key                :uuid
 #
 
 class User < ActiveRecord::Base

--- a/db/migrate/20160930085910_add_api_key_to_users.rb
+++ b/db/migrate/20160930085910_add_api_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :api_key, :uuid, default: 'uuid_generate_v4()', index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160926133641) do
+ActiveRecord::Schema.define(version: 20160930085910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -457,12 +457,12 @@ ActiveRecord::Schema.define(version: 20160926133641) do
   add_index "user_message_statuses", ["user_id"], name: "index_user_message_statuses_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",                   null: false
+    t.string   "encrypted_password",     default: "",                   null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,                    null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -473,11 +473,12 @@ ActiveRecord::Schema.define(version: 20160926133641) do
     t.datetime "updated_at"
     t.string   "first_name"
     t.string   "last_name"
-    t.integer  "failed_attempts",        default: 0,  null: false
+    t.integer  "failed_attempts",        default: 0,                    null: false
     t.datetime "locked_at"
     t.string   "unlock_token"
     t.text     "settings"
     t.datetime "deleted_at"
+    t.uuid     "api_key",                default: "uuid_generate_v4()"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -24,6 +24,7 @@
 #  unlock_token           :string
 #  settings               :text
 #  deleted_at             :datetime
+#  api_key                :uuid
 #
 
 require 'rails_helper'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,6 +24,7 @@
 #  unlock_token           :string
 #  settings               :text
 #  deleted_at             :datetime
+#  api_key                :uuid
 #
 
 FactoryGirl.define do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,6 +24,7 @@
 #  unlock_token           :string
 #  settings               :text
 #  deleted_at             :datetime
+#  api_key                :uuid
 #
 
 require 'rails_helper'


### PR DESCRIPTION
In order for endpoints like 'get my allocated claims' to work, we need to be able to identify who is the user, and our current api_key is attached to the **Provider**, not to a user-level, which makes this impossible.

Until we have a better auth mechanism for the API and to be able to continue developing new v2 endpoints and using them in our own app, add an api_key or similar at the user-level and use it for these endpoints.
