### PR TITLE
change email address on deleted users

### DIFF
--- a/app/assets/javascripts/modules/superadmin/Provider.js
+++ b/app/assets/javascripts/modules/superadmin/Provider.js
@@ -30,7 +30,6 @@ moj.Modules.SuperAdminProvider = {
       }
       self.showHide();
     });
-    console.log('end of init');
   },
 
   cacheElems: function() {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,4 +111,8 @@ class User < ActiveRecord::Base
     save_settings! email_notification_of_message: value.to_bool
   end
 
+  def before_soft_delete
+    self.email = "#{self.email}.deleted.#{self.id}"
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe User, type: :model do
 
   context 'soft deletions' do
     before(:all) do
-      @live_user_1 = create :user
+      @live_user_1 = create :user, email: 'john.smith@example.com'
       @live_user_2 = create :user
       @dead_user_1 = create :user, :softly_deleted
       @dead_user_2 = create :user, :softly_deleted
@@ -161,6 +161,11 @@ RSpec.describe User, type: :model do
     end
 
     describe 'deleted scope' do
+      it 'changes the email of deleted records' do
+        @live_user_1.soft_delete
+        expect(@live_user_1.reload.email).to eq "john.smith@example.com.deleted.#{@live_user_1.id}"
+      end
+
       it 'should return only deleted records' do
         expect(User.softly_deleted.order(:id)).to eq([@dead_user_1, @dead_user_2])
       end


### PR DESCRIPTION
This PR fixes the bug whereby if a user was deleted, it was impossible to
create another user with the same email address.
