### PR TITLE
Enabling, for real, timed claim transitions.

### DIFF
--- a/app/models/timed_transitions/batch_transitioner.rb
+++ b/app/models/timed_transitions/batch_transitioner.rb
@@ -2,14 +2,18 @@
 module TimedTransitions
   class BatchTransitioner
 
-    def initialize(options)
-      @dummy = options[:dummy]
+    def initialize(options = {})
+      @dummy = options.fetch(:dummy, false)
+      @limit = options[:limit].to_i
     end
 
     def run
       claims_ids = Transitioner.candidate_claims_ids
       softly_deleted_ids = Transitioner.softly_deleted_ids
-      (claims_ids + softly_deleted_ids).each do |claim_id|
+      found_ids = (claims_ids | softly_deleted_ids)
+      limit = @limit.zero? ? found_ids.size : @limit
+
+      found_ids.sort.first(limit).each do |claim_id|
         claim = Claim::BaseClaim.find claim_id
         transitioner = Transitioner.new(claim, @dummy)
         transitioner.run

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -85,8 +85,7 @@ namespace :claims do
       raise ArgumentError.new "Only valid parameter is 'dummy'"
     end
 
-    TimedTransitions::BatchTransitioner.new(dummy: @dummy).run
+    puts "Running TimedTransitions::BatchTransitioner with dummy mode: #{@dummy}"
+    TimedTransitions::BatchTransitioner.new(limit: 7200, dummy: @dummy).run
   end
-
-
 end

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -58,7 +58,7 @@ module TimedTransitions
           context 'less than 60 days ago' do
             it 'should not call archive if last state change less than 60 days ago' do
               claim = double Claim
-              expect(claim).to receive(:last_state_transition_time).and_return(15.weeks.ago)
+              expect(claim).to receive(:last_state_transition_time).at_least(:once).and_return(15.weeks.ago)
               expect(claim).to receive(:state).and_return('authorised')
               expect(claim).to receive(:softly_deleted?).and_return(false)
               transitioner = Transitioner.new(claim)
@@ -99,10 +99,19 @@ module TimedTransitions
         end
 
         context 'destroying' do
+          context 'soft-deleted claim more than 16 weeks ago' do
+            it 'should destroy the claim' do
+              claim = instance_double(Claim::LitigatorClaim, id: 123, state: 'allocated', deleted_at: 17.weeks.ago)
+              expect(claim).to receive(:softly_deleted?).and_return(true)
+              expect(claim).to receive(:destroy)
+              Transitioner.new(claim).run
+            end
+          end
+
           context 'less than 60 days ago' do
             it 'should not call destroy if last state change less than 16 weeks ago' do
               claim = double Claim
-              expect(claim).to receive(:last_state_transition_time).and_return(15.weeks.ago)
+              expect(claim).to receive(:last_state_transition_time).at_least(:once).and_return(15.weeks.ago)
               expect(claim).to receive(:state).and_return('archived_pending_delete')
               expect(claim).to receive(:softly_deleted?).and_return(false)
               transitioner = Transitioner.new(claim)
@@ -200,7 +209,7 @@ module TimedTransitions
           context 'less than 60 days ago' do
             it 'should not call archive if last state change less than 60 days ago' do
               claim = double Claim
-              expect(claim).to receive(:last_state_transition_time).and_return(15.weeks.ago)
+              expect(claim).to receive(:last_state_transition_time).at_least(:once).and_return(15.weeks.ago)
               expect(claim).to receive(:state).and_return('authorised')
               expect(claim).to receive(:softly_deleted?).and_return(false)
               transitioner = Transitioner.new(claim, true)
@@ -243,7 +252,7 @@ module TimedTransitions
           context 'less than 60 days ago' do
             it 'should not call destroy if last state change less than 16 weeks ago' do
               claim = double Claim
-              expect(claim).to receive(:last_state_transition_time).and_return(15.weeks.ago)
+              expect(claim).to receive(:last_state_transition_time).at_least(:once).and_return(15.weeks.ago)
               expect(claim).to receive(:state).and_return('archived_pending_delete')
               expect(claim).to receive(:softly_deleted?).and_return(false)
               transitioner = Transitioner.new(claim, true)


### PR DESCRIPTION
Waiting for platforms to setup a cron job to run the rake task every day at X am.

**Command to run**: `bundle exec rake claims:archive_stale`
