### PR TITLE
Setting up the publishing of claim messages to Amazon queue.

### DIFF
--- a/app/jobs/publish_claim_job.rb
+++ b/app/jobs/publish_claim_job.rb
@@ -1,0 +1,7 @@
+class PublishClaimJob < ActiveJob::Base
+  queue_as :claims
+
+  def perform(claim)
+    Messaging::ClaimMessage.new(claim).publish
+  end
+end

--- a/config/aws_queues.yml
+++ b/config/aws_queues.yml
@@ -1,0 +1,22 @@
+# ARN will be suffixed with the host name of the environment, or 'local' if none
+# List of possible hosts in file: lib/rails_host.rb
+# Examples: 'cccd-claims-staging' or 'cccd-claims-local'
+#
+default: &default
+  sns_arn: arn:aws:sns:eu-west-1:016649511486
+  queues:
+    - cccd-claims
+  client_config:
+    region: eu-west-1
+
+production:
+  <<: *default
+
+development:
+  <<: *default
+
+devunicorn:
+  <<: *default
+
+test:
+  <<: *default

--- a/config/initializers/messaging.rb
+++ b/config/initializers/messaging.rb
@@ -1,0 +1,3 @@
+Dir[File.join(Rails.root, 'lib', 'messaging', '*.rb')].each { |file| require file }
+
+Messaging::Producer.client_class = Aws::SNS::Client if Rails.env.production?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,3 +83,6 @@ remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') +
 
 # Use remote API calls to retrieve the list of allocated/archived claims for case workers
 case_workers_remote_allocations?: true
+
+# Claim publishing to Amazon SNS queue. Not yet ready for production, only enabled in DEV.
+claim_publishing_enabled?: <%= ENV['ENV'] == 'dev' %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,3 +3,6 @@
 #
 remote_api_key: 'not-provided'
 remote_api_url: 'http://localhost:3001/api'
+
+# Queue is mocked so this is safe to be true so tests are as realistic as possible
+claim_publishing_enabled?: true

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,4 @@
 :queues:
   - default
   - mailers
+  - claims

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,6 +11,7 @@ require 'selenium-webdriver'
 require 'cucumber/rails'
 require 'cucumber/rspec/doubles'
 require 'site_prism'
+require 'sidekiq/testing'
 require_relative '../../spec/vcr_helper'
 
 Capybara.javascript_driver = :poltergeist

--- a/lib/demo_data/claim_state_advancer.rb
+++ b/lib/demo_data/claim_state_advancer.rb
@@ -67,7 +67,7 @@ module DemoData
           expenses: claim.expenses_total * rand(0.5..0.8),
           disbursements: claim.disbursements_total * rand(0.5..0.8))
       claim.reload
-      claim.authorise_part!(case_worker_author)
+      claim.authorise_part!({publish: false}.merge(case_worker_author))
     end
 
     def authorise(claim)
@@ -78,7 +78,7 @@ module DemoData
           expenses: claim.expenses_total,
           disbursements: claim.disbursements_total)
       claim.reload
-      claim.authorise!(case_worker_author)
+      claim.authorise!({publish: false}.merge(case_worker_author))
     end
 
     def refuse(claim)

--- a/lib/messaging/claim_message.rb
+++ b/lib/messaging/claim_message.rb
@@ -1,0 +1,36 @@
+module Messaging
+  class ClaimMessage
+    attr_accessor :claim
+
+    def initialize(claim)
+      self.claim = claim
+    end
+
+    def publish
+      Messaging::Producer.new(queue: 'cccd-claims').publish(payload)
+    end
+
+    def payload
+      {subject: subject, message: message}
+    end
+
+    # Subjects must be ASCII text that begins with a letter, number, or punctuation mark
+    # Must not include line breaks or control characters and be less than 100 characters long
+    #
+    def subject
+      'Claim UUID %s' % claim.uuid
+    end
+
+    # Messages must be UTF-8 encoded strings at most 256 KB in size
+    #
+    def message
+      API::Entities::FullClaim.represent(claim).to_xml(xml_options)
+    end
+
+    private
+
+    def xml_options
+      {dasherize: false, skip_types: true, root: 'claim'}
+    end
+  end
+end

--- a/lib/messaging/mock_client.rb
+++ b/lib/messaging/mock_client.rb
@@ -1,0 +1,18 @@
+module Messaging
+  class MockClient
+    attr_accessor :config
+
+    def initialize(config = {})
+      self.config = config
+    end
+
+    def publish(payload)
+      self.class.queue.push(payload)
+      payload
+    end
+
+    def self.queue
+      @@queue ||= Array.new
+    end
+  end
+end

--- a/lib/messaging/producer.rb
+++ b/lib/messaging/producer.rb
@@ -1,0 +1,47 @@
+module Messaging
+  class Producer
+    cattr_accessor :client_class
+    attr_accessor :client, :queue
+
+    def self.client_class
+      @@client_class ||= Messaging::MockClient
+    end
+
+    def initialize(queue:)
+      self.client = self.class.client_class.new(client_config)
+      self.queue = queue
+      raise ArgumentError, "Queue `#{queue}` not found" unless queue_present?
+    end
+
+    def publish(payload)
+      Rails.logger.info "[Client: #{self.class.client_class.name}] [ARN: #{target_arn}] Publishing payload: #{payload}"
+      client.publish({target_arn: target_arn}.merge(payload))
+    end
+
+    def queue_name
+      [queue, host].join('-')
+    end
+
+    def target_arn
+      [config.fetch(:sns_arn), queue_name].join(':')
+    end
+
+    private
+
+    def host
+      Rails.host.env || 'local'
+    end
+
+    def queue_present?
+      config.fetch(:queues).include?(queue)
+    end
+
+    def client_config
+      config.fetch(:client_config).symbolize_keys!
+    end
+
+    def config
+      @config ||= Rails.application.config_for(:aws_queues).symbolize_keys!
+    end
+  end
+end

--- a/spec/jobs/publish_claim_job_spec.rb
+++ b/spec/jobs/publish_claim_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe PublishClaimJob, type: :job do
+
+  let(:message_class) { Messaging::ClaimMessage }
+  let(:claim) { instance_double(Claim::BaseClaim, uuid: '123-456') }
+
+  it 'should create a message and publish to the queue' do
+    expect(message_class).to receive(:new).with(claim).and_call_original
+    expect_any_instance_of(message_class).to receive(:publish)
+    described_class.perform_now(claim)
+  end
+end

--- a/spec/lib/messaging/claim_message_spec.rb
+++ b/spec/lib/messaging/claim_message_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe Messaging::ClaimMessage do
+  let(:claim) { create(:authorised_claim) }
+
+  subject { described_class.new(claim) }
+
+  it 'should have a subject' do
+    expect(subject.subject).to eq('Claim UUID %s' % claim.uuid)
+  end
+
+  it 'should have a message' do
+    expect(subject.message).to match(/<claim_details>/)
+  end
+
+  it 'should publish' do
+    expect_any_instance_of(Messaging::Producer).to receive(:publish).with(hash_including(:subject, :message))
+    subject.publish
+  end
+end

--- a/spec/lib/messaging/producer_spec.rb
+++ b/spec/lib/messaging/producer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Messaging::Producer do
+  subject { described_class.new(queue: 'cccd-claims') }
+
+  let(:queue) { Messaging::MockClient.queue }
+
+  before(:each) do
+    queue.clear
+  end
+
+  it 'should raise an exception when no queue config found' do
+    expect {
+      described_class.new(queue: 'xxx')
+    }.to raise_exception(ArgumentError)
+  end
+
+  it 'should publish a message' do
+    subject.publish(message: 'test message')
+
+    expect(queue.size).to eq(1)
+    expect(queue.last).to eq(target_arn: 'arn:aws:sns:eu-west-1:016649511486:cccd-claims-local', message: 'test message')
+  end
+end

--- a/spec/lib/messaging/producer_spec.rb
+++ b/spec/lib/messaging/producer_spec.rb
@@ -15,10 +15,16 @@ describe Messaging::Producer do
     }.to raise_exception(ArgumentError)
   end
 
-  it 'should publish a message' do
-    subject.publish(message: 'test message')
+  context 'publishing a message' do
+    before(:each) do
+      allow(ENV).to receive(:[]).with('ENV').and_return('test')
+    end
 
-    expect(queue.size).to eq(1)
-    expect(queue.last).to eq(target_arn: 'arn:aws:sns:eu-west-1:016649511486:cccd-claims-local', message: 'test message')
+    it 'should publish a message' do
+      subject.publish(message: 'test message')
+
+      expect(queue.size).to eq(1)
+      expect(queue.last).to eq(target_arn: 'arn:aws:sns:eu-west-1:016649511486:cccd-claims-test', message: 'test message')
+    end
   end
 end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -345,5 +345,18 @@ RSpec.describe Claims::StateMachine, type: :model do
         subject.authorise_part!
       end
     end
+
+    describe 'override the publishing for the transition' do
+      subject { create(:allocated_claim) }
+
+      before(:each) do
+        subject.assessment.update(fees: 100.00, expenses: 23.45)
+      end
+
+      it 'should not enqueue the claim to be published' do
+        expect(PublishClaimJob).not_to receive(:perform_later)
+        subject.authorise!(publish: false)
+      end
+    end
   end
 end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -318,4 +318,32 @@ RSpec.describe Claims::StateMachine, type: :model do
       expect(transition.reason_code).to eq(reason_code)
     end
   end
+
+  describe 'claim publishing' do
+    describe 'when authorised' do
+      subject { create(:allocated_claim) }
+
+      before(:each) do
+        subject.assessment.update(fees: 100.00, expenses: 23.45)
+      end
+
+      it 'should enqueue the claim to be published' do
+        expect(PublishClaimJob).to receive(:perform_later).with(subject)
+        subject.authorise!
+      end
+    end
+
+    describe 'when part-authorised' do
+      subject { create(:allocated_claim) }
+
+      before(:each) do
+        subject.assessment.update(fees: 100.00, expenses: 23.45)
+      end
+
+      it 'should enqueue the claim to be published' do
+        expect(PublishClaimJob).to receive(:perform_later).with(subject)
+        subject.authorise_part!
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,7 @@ require 'paperclip/matchers'
 require 'webmock/rspec'
 require 'kaminari_rspec'
 require 'vcr_helper'
+require 'sidekiq/testing'
 
 include ActionDispatch::TestProcess #required for fixture_file_upload
 


### PR DESCRIPTION
**Enabled only in DEV for now.**

Quick usage in the console:
- Mock queue:

``` ruby
Messaging::Producer.client_class = Messaging::MockClient
producer = Messaging::Producer.new(queue: 'cccd-claims')
producer.publish(subject: 'test', message: 'hello world')
producer.client.class.queue  # stores the published messages
```
- Real Amazon service:

``` ruby
Messaging::Producer.client_class = Aws::SNS::Client
producer = Messaging::Producer.new(queue: 'cccd-claims')
producer.publish(subject: 'test', message: 'hello world')
```

To test in local you will need:
- set the setting `claim_publishing_enabled?` to true in your settings.local.yml (overriding the one in settings.yml)
- comment out the client_class assignment in `initializers/messaging.rb`
- create a `~/.aws/credentials` file
