### PR TITLE
Extend validity of rep orders

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,8 +22,8 @@ date_time_format: "%d/%m/%Y %H:%M"
 
 high_value_claim_threshold: 20000
 
-earliest_permitted_date: <%= 5.years.ago.to_date %>
-earliest_permitted_date_in_words: 5 years ago
+earliest_permitted_date: <%= 10.years.ago.to_date %>
+earliest_permitted_date_in_words: 10 years ago
 
 interim_earliest_permitted_repo_date: <%= Date.new(2014,10,2) %>
 

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -79,7 +79,7 @@ module Claim
       end
 
       it 'errors if too far in the past' do
-        expect_invalid_attribute_with_message(claim, :transfer_date, 6.years.ago, 'check_not_too_far_in_past')
+        expect_invalid_attribute_with_message(claim, :transfer_date, 11.years.ago, 'check_not_too_far_in_past')
       end
 
       it 'is valid if in the recent past' do

--- a/spec/validators/fee/interim_fee_validator_spec.rb
+++ b/spec/validators/fee/interim_fee_validator_spec.rb
@@ -162,7 +162,7 @@ module Fee
         end
 
         it 'should be invalid if present and too far in the past' do
-          fee.warrant_issued_date = 6.years.ago
+          fee.warrant_issued_date = 11.years.ago
           expect(fee).to_not be_valid
           expect(fee.errors[:warrant_issued_date]).to include 'check_not_too_far_in_past'
         end

--- a/spec/validators/fee/shared_examples_for_fee_validators_spec.rb
+++ b/spec/validators/fee/shared_examples_for_fee_validators_spec.rb
@@ -4,7 +4,7 @@ shared_examples 'common fee date validations' do
     it { should_error_if_not_present(fee, :date, 'blank') }
 
     it 'should be invalid if too far in the past' do
-      fee.date = 6.years.ago
+      fee.date = 11.years.ago
       expect(fee).to_not be_valid
       expect(fee.errors[:date]).to include 'check_not_too_far_in_past'
     end

--- a/spec/validators/fee/warrant_fee_validator_spec.rb
+++ b/spec/validators/fee/warrant_fee_validator_spec.rb
@@ -21,7 +21,7 @@ module Fee
       end
 
       it 'should be invalid if present and too far in the past' do
-        fee.warrant_issued_date = 6.years.ago
+        fee.warrant_issued_date = 11.years.ago
         expect(fee).to_not be_valid
         expect(fee.errors[:warrant_issued_date]).to include 'check_not_too_far_in_past'
       end
@@ -48,7 +48,7 @@ module Fee
       end
 
       it 'should be invalid if present and too far in the past' do
-        fee.warrant_executed_date = 6.years.ago
+        fee.warrant_executed_date = 11.years.ago
         expect(fee).to_not be_valid
         expect(fee.errors[:warrant_executed_date]).to include 'check_not_too_far_in_past'
       end


### PR DESCRIPTION
Claims with rep orders older than 5 years could not be allocated to case workers because they failed validity tests.  This has been changed to 10 years
