### PR TITLE
Fix the limit in the batch transitioner task.

### DIFF
--- a/app/models/timed_transitions/batch_transitioner.rb
+++ b/app/models/timed_transitions/batch_transitioner.rb
@@ -1,24 +1,36 @@
-
 module TimedTransitions
   class BatchTransitioner
+    attr_accessor :transitions_counter
 
     def initialize(options = {})
       @dummy = options.fetch(:dummy, false)
       @limit = options[:limit].to_i
+      @transitions_counter = 0
     end
 
     def run
       claims_ids = Transitioner.candidate_claims_ids
       softly_deleted_ids = Transitioner.softly_deleted_ids
       found_ids = (claims_ids | softly_deleted_ids)
-      limit = @limit.zero? ? found_ids.size : @limit
 
-      found_ids.sort.first(limit).each do |claim_id|
+      found_ids.each do |claim_id|
         claim = Claim::BaseClaim.find claim_id
+
         transitioner = Transitioner.new(claim, @dummy)
         transitioner.run
+        increment_counter if transitioner.success?
+
+        break if limit_reached?
       end
     end
 
+    def increment_counter
+      @transitions_counter += 1
+    end
+
+    def limit_reached?
+      return false if @limit.zero?
+      @transitions_counter >= @limit
+    end
   end
 end

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -86,6 +86,6 @@ namespace :claims do
     end
 
     puts "Running TimedTransitions::BatchTransitioner with dummy mode: #{@dummy}"
-    TimedTransitions::BatchTransitioner.new(limit: 7200, dummy: @dummy).run
+    TimedTransitions::BatchTransitioner.new(limit: 5000, dummy: @dummy).run
   end
 end

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -23,17 +23,24 @@ module TimedTransitions
 
     describe '.candidate_claim_ids' do
       it 'returns a list of ids in the target states' do
-        draft_claim = create :advocate_claim
-        create :submitted_claim
-        create :allocated_claim
-        authorised_claim = create :authorised_claim
-        archived_claim = create :archived_pending_delete_claim
-        create :redetermination_claim
-        part_authorised_claim = create :part_authorised_claim
-        refused_claim = create :refused_claim
-        rejected_claim = create :rejected_claim
-        expected_ids = [ draft_claim.id, authorised_claim.id, archived_claim.id, part_authorised_claim.id, refused_claim.id, rejected_claim.id ].sort
+        draft_claim = authorised_claim = archived_claim = part_authorised_claim = refused_claim = rejected_claim = nil
 
+        Timecop.freeze(18.weeks.ago) do
+          draft_claim = create :advocate_claim
+          create :submitted_claim
+          create :allocated_claim
+          authorised_claim = create :authorised_claim
+          archived_claim = create :archived_pending_delete_claim
+          create :redetermination_claim
+          part_authorised_claim = create :part_authorised_claim
+          refused_claim = create :refused_claim
+          rejected_claim = create :rejected_claim
+        end
+
+        # This claim will not meet the time scope
+        create :advocate_claim
+
+        expected_ids = [ draft_claim.id, authorised_claim.id, archived_claim.id, part_authorised_claim.id, refused_claim.id, rejected_claim.id ].sort
         expect(Transitioner.candidate_claims_ids.sort).to eq expected_ids
       end
     end


### PR DESCRIPTION
Turns out the way we implemented the limit was not doing what we thought after the second run.

These changes will use a different approach and the limit will work in future task runs.
