### PR TITLE
Spike to import supplier data from LAA

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160930085910) do
+ActiveRecord::Schema.define(version: 20161020133346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -339,6 +339,33 @@ ActiveRecord::Schema.define(version: 20160930085910) do
 
   add_index "fees", ["claim_id"], name: "index_fees_on_claim_id", using: :btree
   add_index "fees", ["fee_type_id"], name: "index_fees_on_fee_type_id", using: :btree
+
+  create_table "laa_imported_suppliers", force: :cascade do |t|
+    t.string   "accCode",      null: false
+    t.string   "accName",      null: false
+    t.datetime "dateCreated"
+    t.string   "userCreated"
+    t.datetime "dateModified"
+    t.string   "userModified"
+    t.string   "regiRegion"
+    t.string   "parent"
+    t.string   "sutySuppType"
+    t.string   "vatReg"
+    t.string   "extAcRef"
+    t.string   "address1"
+    t.string   "address2"
+    t.string   "address3"
+    t.string   "address4"
+    t.string   "county"
+    t.string   "postCode"
+    t.string   "country"
+    t.string   "highRisk"
+    t.string   "pstyHigh"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "laa_imported_suppliers", ["accCode"], name: "index_laa_imported_suppliers_on_accCode", using: :btree
 
   create_table "locations", force: :cascade do |t|
     t.string   "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -340,33 +340,6 @@ ActiveRecord::Schema.define(version: 20160930085910) do
   add_index "fees", ["claim_id"], name: "index_fees_on_claim_id", using: :btree
   add_index "fees", ["fee_type_id"], name: "index_fees_on_fee_type_id", using: :btree
 
-  create_table "laa_imported_suppliers", force: :cascade do |t|
-    t.string   "accCode",      null: false
-    t.string   "accName",      null: false
-    t.datetime "dateCreated"
-    t.string   "userCreated"
-    t.datetime "dateModified"
-    t.string   "userModified"
-    t.string   "regiRegion"
-    t.string   "parent"
-    t.string   "sutySuppType"
-    t.string   "vatReg"
-    t.string   "extAcRef"
-    t.string   "address1"
-    t.string   "address2"
-    t.string   "address3"
-    t.string   "address4"
-    t.string   "county"
-    t.string   "postCode"
-    t.string   "country"
-    t.string   "highRisk"
-    t.string   "pstyHigh"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "laa_imported_suppliers", ["accCode"], name: "index_laa_imported_suppliers_on_accCode", using: :btree
-
   create_table "locations", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161020133346) do
+ActiveRecord::Schema.define(version: 20160930085910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spikes/supplier_import/laa_supplier_data_importer.rb
+++ b/spikes/supplier_import/laa_supplier_data_importer.rb
@@ -1,0 +1,30 @@
+require 'xmlsimple'
+
+
+class LaaImportedSupplier < ActiveRecord::Base
+
+end
+
+class LaaSupplierDataImporter
+
+  def initialize
+    file_path = File.join(ENV['HOME'], 'Downloads', 'DtSuppData1.xml')
+    @doc = XmlSimple.xml_in(file_path)
+  end
+
+
+  def run
+    @doc['record'].each do |rec|
+      lis = LaaImportedSupplier.new
+      rec.each do |attr, values|
+        lis.send "#{attr}=", values.first
+      end
+      lis.save!
+      puts "saved #{lis.accCode}"
+    end
+  end
+end
+
+
+# load "#{Rails.root}/spikes/supplier_import/laa_supplier_data_importer.rb"
+# LaaSupplierDataImporter.new.run

--- a/spikes/supplier_import/migrate/20161020133346_laa_imported_suppliers.rb
+++ b/spikes/supplier_import/migrate/20161020133346_laa_imported_suppliers.rb
@@ -1,0 +1,30 @@
+
+class LaaImportedSuppliers < ActiveRecord::Migration
+  def change
+    create_table :laa_imported_suppliers do |t|
+      t.string :accCode, index: true, null: false
+      t.string :accName, null: false
+      t.datetime :dateCreated
+      t.string :userCreated
+      t.datetime :dateModified
+      t.string :userModified
+      t.string :regiRegion
+      t.string :parent
+      t.string :sutySuppType
+      t.string :vatReg
+      t.string :extAcRef
+      t.string :address1
+      t.string :address2
+      t.string :address3
+      t.string :address4
+      t.string :county
+      t.string :postCode
+      t.string :country
+      t.string :highRisk
+      t.string :pstyHigh
+
+      t.timestamps
+    end
+  end
+end
+

--- a/spikes/supplier_import/suppdata.xsd
+++ b/spikes/supplier_import/suppdata.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  PLACEHOLDER ATTRIBUTES FOR NAMESPACE - CHANGE -->
+<xs:schema
+        elementFormDefault="qualified"
+        attributeFormDefault="qualified"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <!--  ***************************** -->
+    <!--  ***    maat_reporders     *** -->
+    <!--  ***************************** -->
+    <xs:complexType name="cboSuppliers">
+        <xs:sequence>
+            <xs:element name="accCode" type="xs:string" nillable="false"/>
+            <xs:element name="accName" type="xs:string" nillable="false"/>
+            <xs:element name="dateCreated" type="xs:dateTime" nillable="false"/>
+            <xs:element name="userCreated" type="xs:string" nillable="false"/>
+            <xs:element name="dateModified" type="xs:dateTime" nillable="true"/>
+            <xs:element name="userModified" type="xs:string" nillable="true"/>
+            <xs:element name="regiRegion" type="xs:string" nillable="true"/>
+            <xs:element name="parent" type="xs:string" nillable="true"/>
+            <xs:element name="sutySuppType" type="xs:string" nillable="false"/>
+            <xs:element name="vatRegistered" type="xs:string" nillable="true"/>
+            <xs:element name="extAccRef" type="xs:string" nillable="true"/>
+            <xs:element name="address1" type="xs:string" nillable="true"/>
+            <xs:element name="address2" type="xs:string" nillable="true"/>
+            <xs:element name="address3" type="xs:string" nillable="true"/>
+            <xs:element name="address4" type="xs:string" nillable="true"/>
+            <xs:element name="county" type="xs:string" nillable="true"/>
+            <xs:element name="postCode" type="xs:string" nillable="true"/>
+            <xs:element name="country" type="xs:string" nillable="true"/>
+            <xs:element name="highRisk" type="xs:string" nillable="true"/>
+            <xs:element name="pstyHighLevel" type="xs:string" nillable="true"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!--  ********************* -->
+    <!--  ***   Fault       *** -->
+    <!--  ********************* -->
+
+    <!--  Soap fault - error message container -->
+    <xs:complexType name="cboSuppFaultException">
+        <xs:sequence>
+            <xs:element name="MessageCode" nillable="false" type="xs:string"/>
+            <xs:element name="MessageText" nillable="false" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
This is a spike to import the XML file of supplier data from LAA, and create a table laa_imported_suppliers.  This was done for analysis purposes.

The original XML file is located at https://drive.google.com/drive/folders/0B0UkEMi5Ln_DYVpEelJqWlh0S3c

This requires the xml-simple gem to be added to the Gemfile.
