### PR TITLE
Small refactor and laying out the path for case worker admin actions.

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -89,24 +89,12 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   end
 
   def set_claims
-    @claims = case tab
-              when 'current', 'archived'
-                Claims::CaseWorkerClaims.new(current_user: current_user, action: tab, criteria: criteria_params).claims
-              when 'allocated'
-                # TODO: to be moved to service object and implement remote API endpoint
-                Claim::BaseClaim.active.caseworker_dashboard_under_assessment
-              when 'unallocated'
-                # TODO: to be moved to service object and implement remote API endpoint
-                Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons
-              end
+    @claims = Claims::CaseWorkerClaims.new(current_user: current_user, action: tab, criteria: criteria_params).claims
   end
 
+  # Only these 2 actions are handle in this controller. Rest of actions in the admin-namespaced controller.
   def tab
-    if current_user.persona.admin?
-      %w(allocated unallocated current archived).include?(params[:tab]) ? params[:tab] : 'allocated'
-    else
-      %w(current archived).include?(params[:tab]) ? params[:tab] : 'current'
-    end
+    %w(current archived).include?(params[:tab]) ? params[:tab] : 'current'
   end
 
   def set_claim

--- a/app/services/claims/case_worker_claims.rb
+++ b/app/services/claims/case_worker_claims.rb
@@ -11,13 +11,13 @@ module Claims
     def claims
       case action
       when 'current'
-        current_allocated_claims
+        current_claims
       when 'archived'
         archived_claims
       when 'allocated'
-        # TODO: to be implemented
+        allocated_claims
       when 'unallocated'
-        # TODO: to be implemented
+        unallocated_claims
       else
         raise ArgumentError, 'Unknown action: %s' % action
       end
@@ -29,9 +29,9 @@ module Claims
 
     private
 
-    def current_allocated_claims
+    def current_claims
       if remote?
-        Remote::Claim.allocated(current_user, criteria)
+        Remote::Claim.user_allocations(current_user, criteria)
       else
         current_user.claims.caseworker_dashboard_under_assessment
       end
@@ -42,6 +42,22 @@ module Claims
         Remote::Claim.archived(current_user, criteria)
       else
         Claim::BaseClaim.active.caseworker_dashboard_archived
+      end
+    end
+
+    def allocated_claims
+      if remote?
+        Remote::Claim.allocated(current_user, criteria)
+      else
+        Claim::BaseClaim.active.caseworker_dashboard_under_assessment
+      end
+    end
+
+    def unallocated_claims
+      if remote?
+        Remote::Claim.unallocated(current_user, criteria)
+      else
+        Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons
       end
     end
   end

--- a/app/services/remote/claim.rb
+++ b/app/services/remote/claim.rb
@@ -23,8 +23,16 @@ module Remote
         'case_workers/claims'
       end
 
+      def user_allocations(user, query = {})
+        all_by_status('current', user: user, query: query)
+      end
+
       def allocated(user, query = {})
         all_by_status('allocated', user: user, query: query)
+      end
+
+      def unallocated(user, query = {})
+        all_by_status('unallocated', user: user, query: query)
       end
 
       def archived(user, query = {})

--- a/vcr/cassettes/features/case_workers/claims/allocation.yml
+++ b/vcr/cassettes/features/case_workers/claims/allocation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=7bdeb0e5-8786-4662-9ac5-ee2802f44a68&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=7bdeb0e5-8786-4662-9ac5-ee2802f44a68&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/features/case_workers/claims/authorise.yml
+++ b/vcr/cassettes/features/case_workers/claims/authorise.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=ce635a1c-fd44-49cc-b56e-119bd19b0ff4&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=ce635a1c-fd44-49cc-b56e-119bd19b0ff4&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 06 Oct 2016 10:51:42 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=ce635a1c-fd44-49cc-b56e-119bd19b0ff4&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=ce635a1c-fd44-49cc-b56e-119bd19b0ff4&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/features/case_workers/claims/messaging.yml
+++ b/vcr/cassettes/features/case_workers/claims/messaging.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=384cc8a8-de99-4100-9c3b-7db1420b76ad&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=384cc8a8-de99-4100-9c3b-7db1420b76ad&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 06 Oct 2016 10:52:44 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=384cc8a8-de99-4100-9c3b-7db1420b76ad&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=384cc8a8-de99-4100-9c3b-7db1420b76ad&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/features/case_workers/claims/reject.yml
+++ b/vcr/cassettes/features/case_workers/claims/reject.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=70aff7c8-5665-4063-9632-75214a705d26&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=70aff7c8-5665-4063-9632-75214a705d26&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 06 Oct 2016 10:52:49 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=70aff7c8-5665-4063-9632-75214a705d26&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=70aff7c8-5665-4063-9632-75214a705d26&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=821c90af-a0f4-4929-82fc-e8fff4283e05&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=821c90af-a0f4-4929-82fc-e8fff4283e05&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_pagination.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_pagination.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=5a0a95de-f4f4-49ad-b1a5-be072e1b9c14&direction=asc&limit=2&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=5a0a95de-f4f4-49ad-b1a5-be072e1b9c14&direction=asc&limit=2&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_search_by_case_number.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_search_by_case_number.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=14b13c61-e925-4ef3-91cd-57956db1ef76&direction=asc&limit=10&page=0&search=A00000001&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=14b13c61-e925-4ef3-91cd-57956db1ef76&direction=asc&limit=10&page=0&search=A00000001&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_search_by_defendant.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_search_by_defendant.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=eae07151-cac2-4b38-9afc-f7ecf87e27ac&direction=asc&limit=10&page=0&search=Mya%20Keeling&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=eae07151-cac2-4b38-9afc-f7ecf87e27ac&direction=asc&limit=10&page=0&search=Mya%20Keeling&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_search_by_maat.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_search_by_maat.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=6878c62d-540c-417e-aea0-3f7bbfc5aeba&direction=asc&limit=10&page=0&search=0802551537&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=6878c62d-540c-417e-aea0-3f7bbfc5aeba&direction=asc&limit=10&page=0&search=0802551537&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_advocate_asc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_advocate_asc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=c7ad1f6e-9ace-4026-93da-9655ce0b6f59&direction=asc&limit=10&page=0&search=&sorting=advocate&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=c7ad1f6e-9ace-4026-93da-9655ce0b6f59&direction=asc&limit=10&page=0&search=&sorting=advocate&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_advocate_desc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_advocate_desc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=2e18ff94-ab8a-40c5-b2b3-6f4c49102101&direction=desc&limit=10&page=0&search=&sorting=advocate&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=2e18ff94-ab8a-40c5-b2b3-6f4c49102101&direction=desc&limit=10&page=0&search=&sorting=advocate&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_amount_asc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_amount_asc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=cc76414e-a3b9-4a2a-850f-6d09a85e3832&direction=asc&limit=10&page=0&search=&sorting=total_inc_vat&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=cc76414e-a3b9-4a2a-850f-6d09a85e3832&direction=asc&limit=10&page=0&search=&sorting=total_inc_vat&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_amount_desc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_amount_desc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=7500337d-7cf5-4130-931d-968d3b2625cf&direction=desc&limit=10&page=0&search=&sorting=total_inc_vat&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=7500337d-7cf5-4130-931d-968d3b2625cf&direction=desc&limit=10&page=0&search=&sorting=total_inc_vat&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_case_number_asc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_case_number_asc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=76863e27-12e8-4416-9280-17598c23212b&direction=asc&limit=10&page=0&search=&sorting=case_number&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=76863e27-12e8-4416-9280-17598c23212b&direction=asc&limit=10&page=0&search=&sorting=case_number&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_case_number_desc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_case_number_desc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=f392b487-e268-4712-91c4-994b2d80ecaa&direction=desc&limit=10&page=0&search=&sorting=case_number&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=f392b487-e268-4712-91c4-994b2d80ecaa&direction=desc&limit=10&page=0&search=&sorting=case_number&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_casetype_asc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_casetype_asc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=2f5dd456-2aef-463b-90ff-6983d01712c6&direction=asc&limit=10&page=0&search=&sorting=case_type&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=2f5dd456-2aef-463b-90ff-6983d01712c6&direction=asc&limit=10&page=0&search=&sorting=case_type&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_casetype_desc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_casetype_desc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=77878d35-1cd8-4201-b63e-9d9156409bd8&direction=desc&limit=10&page=0&search=&sorting=case_type&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=77878d35-1cd8-4201-b63e-9d9156409bd8&direction=desc&limit=10&page=0&search=&sorting=case_type&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_date_asc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_date_asc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=f5e1cbd0-c5cb-4a9f-b33a-d3942f2a7d45&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=f5e1cbd0-c5cb-4a9f-b33a-d3942f2a7d45&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''

--- a/vcr/cassettes/spec/case_workers/claims/index_sort_by_date_desc.yml
+++ b/vcr/cassettes/spec/case_workers/claims/index_sort_by_date_desc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=04389574-253e-42f1-9584-0e84b664f76e&direction=desc&limit=10&page=0&search=&sorting=last_submitted_at&status=allocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=04389574-253e-42f1-9584-0e84b664f76e&direction=desc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
This is mainly a small refactor, code cleaning and preparing for the case worker admin actions (allocate and deallocate claims).

Not yet tied up to the web interface as the 'allocation' and 're-allocation' pages are handled by the admin-namespaced case workers controllers which will need quite a big refactor/cleaning.
But working fine when calling directly the API endpoints.

Some VCR cassettes needed to be updated.
