### PR TITLE
UI: media queries breakpoints

### DIFF
--- a/app/assets/stylesheets/moj/_tables.scss
+++ b/app/assets/stylesheets/moj/_tables.scss
@@ -116,10 +116,8 @@ span.state {
   }
 }
 
-
-// Responsive tables code
-@media screen and (max-width: 1024px) {
-  table.report {
+ @include media($max-width: 1023px){
+    table.report {
     border: 0;
     tr {
       border-bottom: 3px solid #ddd;
@@ -177,3 +175,4 @@ span.state {
     }
   }
 }
+

--- a/app/views/external_users/claims/_main_claims_list.html.haml
+++ b/app/views/external_users/claims/_main_claims_list.html.haml
@@ -77,7 +77,7 @@
               = claim.state.humanize
 
           %td.numeric{'aria-label' => t(".submission_date")}
-            = claim.submitted_at
+            = claim.submitted_at.blank? ? "-" : claim.submitted_at
 
           %td.messages{'aria-label' => t(".messages")}
             - if claim.messages.any?


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/133085271

**Issue**
The responsive tables where set to start as a 1024px break point. This seems to high as there are desktop users that fall into this breakpoint

**What does PR do?**
Sets the break point to 1023px so that desktop users see the full table.
Tablet will change the view based on landscape vs portrait perspectives

**How has this been tested?**
Manual browser testing

GDS Guidance notes:
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/mixins.md#conditionals
