### PR TITLE
UI: Mobile claims list missing sort links

### DIFF
--- a/app/assets/stylesheets/moj/_tables.scss
+++ b/app/assets/stylesheets/moj/_tables.scss
@@ -116,6 +116,9 @@ span.state {
   }
 }
 
+tr.mobile-sort{
+  display:none;
+}
  @include media($max-width: 1023px){
     table.report {
     border: 0;
@@ -136,7 +139,21 @@ span.state {
         br{
           display: none;
         }
-        padding: 15px;
+        padding: $gutter/2;
+      }
+      &.mobile-sort{
+        display: inline-block;
+        vertical-align: inherit;
+        width: 100%;
+        @include clearfix();
+        td{
+          text-align: left;
+          background-color: white !important;
+          a{
+            display: inline-block !important;
+            margin: ($gutter/6) ($gutter/2 - 3);
+          }
+        }
       }
     }
 

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -26,6 +26,16 @@
         %th.message-placeholder{scope: 'col'}
           = t('.messages')
     %tbody
+      %tr.mobile-sort
+        %td{colspan: 10}
+          Sort by:
+          = sortable 'case_number', t('.case_number')
+          = sortable 'advocate', t('.advocate_litigator')
+          = sortable 'total_inc_vat', t('.total')
+          - if params[:action] == 'archived'
+            = sortable 'state', t('.status')
+          = sortable 'case_type', t('.case_type')
+          = sortable 'last_submitted_at', t('.submission_date')
       - present_collection(claims).each do |claim|
         %tr
           %td{'aria-label' => t(".case_number")}

--- a/app/views/external_users/claims/_main_claims_list.html.haml
+++ b/app/views/external_users/claims/_main_claims_list.html.haml
@@ -42,6 +42,14 @@
       %th{scope:'col'}
         = t(".messages")
     %tbody
+      %tr.mobile-sort
+        %td{colspan: 10}
+          Sort by:
+          = sortable 'case_number', t(".case_number")
+          = sortable 'total_inc_vat', t(".total")
+          = sortable 'amount_assessed', t(".assessed")
+          = sortable 'state', t(".status")
+          = sortable 'last_submitted_at', t(".submission_date")
       - present_collection(claims).each do |claim|
         %tr{id: dom_id(claim),class: claim.state}
 


### PR DESCRIPTION
**Issue**
The responsive tables where set to start as a 1024px break point. This seems to high as there are desktop users that fall into this breakpoint

**What does PR do?**
Adds a responsive row into claims lists that contain the sort links on mobile views

**How has this been tested?**
Manual browser testing

![responsivesort](https://cloud.githubusercontent.com/assets/3668907/19729599/7aa5adec-9b8f-11e6-95fb-8829324effd2.gif)
