### PR TITLE
Fix for dynamic number of claims to allocate/reallocate when using API.

### DIFF
--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -318,8 +318,8 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
           expect(transition.subject_id).to eq(@case_worker.user.id)
         end
 
-        it 'renders the new template' do
-          expect(response).to render_template(:new)
+        it 'redirects back to the allocations page' do
+          expect(response).to redirect_to(case_workers_admin_allocations_path(tab: :unallocated, scheme: :agfs))
         end
       end
 
@@ -353,7 +353,7 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
 
       before(:each) do
         @claims = create_list(:allocated_claim, 1)
-        post :create, allocation: allocation_params, commit: 'Re-Allocate'
+        post :create, allocation: allocation_params, tab: 'allocated', commit: 'Re-Allocate'
       end
 
       it 're-allocates claims to case worker' do
@@ -366,8 +366,8 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
         expect(transition.subject_id).to eq(@case_worker.user.id)
       end
 
-      it 'renders new allocation template' do
-        expect(response).to render_template :new
+      it 'redirects back to the re-allocations page' do
+        expect(response).to redirect_to(case_workers_admin_allocations_path(tab: :allocated, scheme: :agfs))
       end
 
       it 'tells the user how many claims were successfully re-allocated' do
@@ -377,10 +377,6 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
       it 're-allocates already allocated claims to the case worker' do
         expect(assigns(:allocation).claims.count).to eql 1
         expect(@case_worker.claims.count).to eql 1
-      end
-
-      it 'renders the new template' do
-        expect(response).to render_template(:new)
       end
     end
 

--- a/vcr/cassettes/spec/case_workers/admin/TODO_reallocate.yml
+++ b/vcr/cassettes/spec/case_workers/admin/TODO_reallocate.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers?api_key=3ef82a03-5fea-4425-ad32-ea1f2d05447f
+    uri: http://localhost:3001/api/case_workers?api_key=3ab0d19e-dfaf-42ab-82cc-a8951cfb4cb7
     body:
       encoding: US-ASCII
       string: ''
@@ -21,29 +21,29 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '273'
+      - '269'
       Etag:
-      - W/"8153d7b15d3857281aa160a84087c1a2"
+      - W/"d6263592e2b42c232a6fdcaac0f4e984"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - d3079af4-c7f3-4a3a-80aa-39a4fb2cb8c2
+      - 53b4ffb7-f2f1-4833-85fa-441d09da1f0f
       X-Runtime:
-      - '0.008339'
+      - '1.064236'
       Server:
       - WEBrick/1.3.1 (Ruby/2.3.0/2015-12-25)
       Date:
-      - Wed, 26 Oct 2016 14:52:26 GMT
+      - Thu, 27 Oct 2016 12:18:47 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '[{"id":1,"uuid":"bec23036-0d75-4d22-aacf-01e3edf9d2ed","first_name":"Krista","last_name":"Gutkowski","email":"krista.gutkowski@laa.gov.uk"},{"id":2,"uuid":"14113c15-fd1e-4d58-ab2b-87dcdc7cd57e","first_name":"Emily","last_name":"McClure","email":"emily.mcclure@laa.gov.uk"}]'
+      string: '[{"id":1,"uuid":"6137102c-e52f-41bd-bdd2-cd5221fc4975","first_name":"Tremaine","last_name":"King","email":"tremaine.king@laa.gov.uk"},{"id":2,"uuid":"a50760d2-3fac-409c-9a43-754d6a3579f1","first_name":"Adell","last_name":"Schuster","email":"adell.schuster@laa.gov.uk"}]'
     http_version: 
-  recorded_at: Wed, 26 Oct 2016 14:52:26 GMT
+  recorded_at: Thu, 27 Oct 2016 12:18:47 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=3ef82a03-5fea-4425-ad32-ea1f2d05447f&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated
+    uri: http://localhost:3001/api/case_workers/claims?api_key=3ab0d19e-dfaf-42ab-82cc-a8951cfb4cb7&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=allocated
     body:
       encoding: US-ASCII
       string: ''
@@ -68,18 +68,18 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ac27577c-a1eb-46f5-98b4-7ec1f96a01ea
+      - 77084171-2182-49ea-aab1-d197e05c26b9
       X-Runtime:
-      - '0.012779'
+      - '0.054177'
       Server:
       - WEBrick/1.3.1 (Ruby/2.3.0/2015-12-25)
       Date:
-      - Wed, 26 Oct 2016 14:52:26 GMT
+      - Thu, 27 Oct 2016 12:18:47 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: UTF-8
       string: '{"pagination":{"current_page":1,"total_pages":0,"total_count":0,"limit_value":25},"items":[]}'
     http_version: 
-  recorded_at: Wed, 26 Oct 2016 14:52:26 GMT
+  recorded_at: Thu, 27 Oct 2016 12:18:47 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Due to the way remote API calls work, and how the allocations was originally done, very coupled to ActiveRecord, a bug existed whereby trying to allocate a dynamic number of claims (i.e. filling a number in the input) instead of individually selecting claims to allocate, would raise an exception, as the returned collection from the API was already paginated.

This will make it work with both, remote API and local ActiveRecord, by reworking a bit the code.

A known limitation when using remote API (it doesn't exists when using ActiveRecord) is the max amount of claims to be dynamically allocated, can't exceed the page size (25 currently). If, for example, a number of 30 is used, then only the first 25 claims will be allocated. The feedback message will correctly give the user the exact number of allocated claims in any case.

Future improvements might be done to bypass this limitation, in case CaseWorkers start complaining.
