### PR TITLE
Changing this condition to fix potential bug.

### DIFF
--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -90,10 +90,10 @@ module Fee
     end
 
     def self.find_by_id_or_unique_code(id_or_code)
-      if id_or_code.to_s.alpha?
-        find_by(unique_code: id_or_code)
-      else
+      if id_or_code.to_s.digit?
         find_by(id: id_or_code)
+      else
+        find_by(unique_code: id_or_code)
       end
     end
   end

--- a/lib/extensions/string_extension.rb
+++ b/lib/extensions/string_extension.rb
@@ -22,6 +22,10 @@ module StringExtension
     !!match(/^[[:alpha:]]+$/)
   end
 
+  def digit?
+    !!match(/^[[:digit:]]+$/)
+  end
+
   def strftime(format)
     Time.zone.parse(self).strftime(format)
   end

--- a/spec/lib/extensions/string_extension_spec.rb
+++ b/spec/lib/extensions/string_extension_spec.rb
@@ -81,4 +81,32 @@ describe String do
       end
     end
   end
+
+  context 'digit?' do
+    context 'for blank values' do
+      it 'should be false for empty string' do
+        expect(''.digit?).to eq(false)
+      end
+
+      it 'should be false for only spaces string' do
+        expect(' '.digit?).to eq(false)
+      end
+    end
+
+    context 'truthy values' do
+      %w(0 1 123).each do |value|
+        it "should be true for '#{value}'" do
+          expect(value.digit?).to eq(true)
+        end
+      end
+    end
+
+    context 'falsey values' do
+      %w(a a1b z1 1z 1.5).each do |value|
+        it "should be false for '#{value}'" do
+          expect(value.digit?).to eq(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Unique codes might contain numbers, which would make the original condition mistakenly think it is NOT a unique code but instead an ID.

Changing the condition to check for digits values instead.