### PR TITLE
UI: Error spans are visible

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -104,3 +104,9 @@ form{
 }
 
 
+
+.js-cw-claim-assessment{
+  .error{
+    display: none;
+  }
+}


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/133088567

**Issue**
Due to a change in the helper these spans became visible in a non error state

**What this PR does?**
empty error message wrappers should be hidden when no error