### PR TITLE
Allow letter U in case numbers.

### DIFF
--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -1,6 +1,6 @@
 class BaseValidator < ActiveModel::Validator
 
-  CASE_NUMBER_PATTERN ||= /^[AST](199|20\d)\d{5}$/i
+  CASE_NUMBER_PATTERN ||= /^[ASTU](199|20\d)\d{5}$/i
 
   # Override this method in the derived class
   def validate_step_fields; end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -138,7 +138,7 @@ describe Claim::BaseClaimValidator do
     end
 
     it 'validates against the regex' do
-      %w(A S T).each do |letter|
+      %w(A S T U).each do |letter|
         (1990..2020).each do |year|
           %w(0001 1111 9999).each do |number|
             case_number = [letter, year, number].join


### PR DESCRIPTION
Case workers are using U letters in some case, we need to allow them and when exporting in the future to CCR we will need to convert them to another letter.