### PR TITLE
Produce SOAP claim message.

### DIFF
--- a/lib/messaging/soap_message.rb
+++ b/lib/messaging/soap_message.rb
@@ -1,0 +1,50 @@
+module Messaging
+  class SOAPMessage
+    attr_accessor :claim, :message_uuid
+
+    WSA_ACTION = 'newCBOClaim'.freeze
+    WSA_FROM = 'http://cob.gov.uk/cccd'.freeze
+    WSA_TO = 'http://legalaid.gov.uk/infoX/gateway/ccr'.freeze
+
+    def initialize(claim)
+      self.claim = claim
+      self.message_uuid = SecureRandom.uuid
+    end
+
+    def to_xml
+      build_envelope do
+        API::Entities::FullClaim.represent(claim).to_xml(xml_options)
+      end
+    end
+
+    private
+
+    def must_understand
+      {'soapenv:mustUnderstand': '1'}
+    end
+
+    def message_id
+      'uuid:%s' % message_uuid
+    end
+
+    def build_envelope
+      Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |builder|
+        builder[:soapenv].Envelope('xmlns:soapenv': 'http://www.w3.org/2003/05/soap-envelope', 'xmlns:cbo': 'http://www.justice.gov.uk/2016/11/cbo') {
+          builder[:soapenv].Header('xmlns:wsa': 'http://www.w3.org/2005/08/addressing') {
+            builder[:wsa].Action(must_understand, WSA_ACTION)
+            builder[:wsa].From(must_understand) { builder[:wsa].Address(WSA_FROM) }
+            builder[:wsa].MessageID(must_understand, message_id)
+            builder[:wsa].To(must_understand, WSA_TO)
+          }
+          builder[:soapenv].Body {
+            builder << yield
+          }
+        }
+      end.to_xml
+    end
+
+    def xml_options
+      {dasherize: false, skip_types: true, skip_instruct: true, root: 'cbo:ClaimRequest'}
+    end
+  end
+end

--- a/spec/lib/messaging/soap_message_spec.rb
+++ b/spec/lib/messaging/soap_message_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe Messaging::SOAPMessage do
+  let(:claim) { create(:deterministic_claim, :redetermination) }
+  let(:message_uuid) { '111-222-333' }
+
+  subject { described_class.new(claim) }
+
+  before(:each) do
+    allow(subject).to receive(:message_uuid).and_return(message_uuid)
+  end
+
+  after(:all) do
+    clean_database
+  end
+
+  it 'should produce a valid SOAP message' do
+    message_xml = subject.to_xml
+    message_hash = Hash.from_xml(message_xml)
+    expected_hash = Hash.from_xml(expected_xml)
+
+    # We ignore on purpose the claim details to simplify this test
+    message_hash['Envelope']['Body']['ClaimRequest'] = nil
+
+    expect(message_hash).to eq(expected_hash)
+  end
+
+  let(:expected_xml) do
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:cbo="http://www.justice.gov.uk/2016/11/cbo">
+      <soapenv:Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
+        <wsa:Action soapenv:mustUnderstand="1">newCBOClaim</wsa:Action>
+        <wsa:From soapenv:mustUnderstand="1">
+          <wsa:Address>http://cob.gov.uk/cccd</wsa:Address>
+        </wsa:From>
+        <wsa:MessageID soapenv:mustUnderstand="1">uuid:111-222-333</wsa:MessageID>
+        <wsa:To soapenv:mustUnderstand="1">http://legalaid.gov.uk/infoX/gateway/ccr</wsa:To>
+      </soapenv:Header>
+      <soapenv:Body>
+        <cbo:ClaimRequest/>
+      </soapenv:Body>
+    </soapenv:Envelope>
+    XML
+  end
+end


### PR DESCRIPTION
Will produce a claim SOAP request within an envelope following the specification at:
https://github.com/ministryofjustice/cccd-spike-sns/blob/master/xsd_schemas/cccd/new_claim_request.xml

Only "issue" so far, although I think it is not an issue but the consequence of having namespaces is the claim XML to be injected inside the body will inherit the namespace from the root. So it will produce this (only body shown):

```xml
<soapenv:Body>
   <cbo:ClaimRequest>
      <cbo:claim_details>
          <cbo:uuid>ee8c8cfe-9c3a-4689-998c-499c2afe80a6</cbo:uuid>
          <cbo:type>Claim::TransferClaim</cbo:type>
          <cbo:provider_code>3A555Z</cbo:provider_code>
          <!-- more stuff here -->
      </cbo:claim_details>
   </cbo:ClaimRequest>
</soapenv:Body>
```