### PR TITLE
Support 2 places of decimals in expense hours.

### DIFF
--- a/app/interfaces/api/v1/external_users/expense.rb
+++ b/app/interfaces/api/v1/external_users/expense.rb
@@ -15,7 +15,7 @@ module API
           optional :reason_text, type: String, desc: "REQUIRED when reason is Other oitherwise must be absent."
           optional :distance, type: Float, desc: "REQUIRED for expense type Car Travel, otherwise must be absent. Distance in miles."
           optional :mileage_rate_id, type: Integer, desc: "REQUIRED for expense type Car Travel, otherwise must be absent: Where applicable. Values should be 1 for 25p per mile, 2 for 45p per mile."
-          optional :hours, type: Float, desc: "REQUIRED for expense type Travel Time, otherwise must be absent. Time in hours to a maximum of 1 decimal place."
+          optional :hours, type: Float, desc: "REQUIRED for expense type Travel Time, otherwise must be absent. Time in hours to a maximum of 2 decimal places."
           optional :date, type: String, desc: "REQUIRED: The date applicable to this Expense (YYYY-MM-DD)", standard_json_format: true
           optional :amount, type: Float, desc: "REQUIRED: The total amount of the expense."
           optional :vat_amount, type: Float, desc: "OPTIONAL: The VAT amount of the expense. For LGFS claims."

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -18,7 +18,7 @@ class ExpensePresenter < BasePresenter
   end
 
   def hours
-    h.number_with_precision(expense.hours, precision: 1, strip_insignificant_zeros: true)
+    h.number_with_precision(expense.hours, precision: 2, strip_insignificant_zeros: true)
   end
 
   def name

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -177,9 +177,9 @@ class BaseValidator < ActiveModel::Validator
     validate_amount_greater_than(field, lower_than_field, 'greater_than')
   end
 
-  def validate_one_place_of_decimals(field)
+  def validate_two_decimals(field)
     value = @record.__send__(field)
-    rounded = value.round(1)
+    rounded = value.round(2)
     unless value == rounded
       add_error(field, 'decimal')
     end

--- a/app/validators/expense_v2_validator.rb
+++ b/app/validators/expense_v2_validator.rb
@@ -97,7 +97,7 @@ class ExpenseV2Validator < BaseValidator
   def validate_hours
     if @record.travel_time?
       validate_presence_and_numericality(:hours, minimum: 0.1)
-      validate_one_place_of_decimals(:hours) if @record.errors[:hours].empty?
+      validate_two_decimals(:hours) if @record.errors[:hours].empty?
     else
       validate_absence(:hours, 'invalid')
     end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1192,9 +1192,9 @@ expense:
       short: *enter_valid_amount
       api: Enter valid hours for the expense
     decimal:
-      long: 'Travel time for #{expense} can be maximum one place of decimals'
-      short: 'Max 1 decimal'
-      api: 'Travel time for #{expense} can be maximum one place of decimals'
+      long: 'Travel time for #{expense} can be maximum 2 decimal places'
+      short: 'Max 2 decimals'
+      api: 'Travel time for #{expense} can be maximum 2 decimal places'
 
 
   reason_text:

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe ExpensePresenter do
   end
 
   describe '#hours' do
-    it 'formats as decimal number, 1 decimal precision with rounding' do
-      expense.hours = 35.22
-      expect(presenter.hours).to eq '35.2'
+    it 'formats as decimal number, 2 decimals precision with rounding' do
+      expense.hours = 35.239
+      expect(presenter.hours).to eq '35.24'
     end
 
     it 'strips insignificant zeros' do

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -132,14 +132,19 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
           expect(travel_time_expense.errors[:hours]).to include('numericality')
         end
 
-        it 'is invalid if more than one place of decimals' do
-          travel_time_expense.hours = 6.78
+        it 'is invalid if more than two places of decimals' do
+          travel_time_expense.hours = 6.789
           expect(travel_time_expense).not_to be_valid
           expect(travel_time_expense.errors[:hours]).to include('decimal')
         end
 
         it 'is valid if present and above zero with one place of decimals' do
           travel_time_expense.hours = 1.5
+          expect(travel_time_expense).to be_valid
+        end
+
+        it 'is valid if present and above zero with two places of decimals' do
+          travel_time_expense.hours = 1.52
           expect(travel_time_expense).to be_valid
         end
 


### PR DESCRIPTION
API was already accepting 2 decimals, but the web interface would show it rounded to 1 place.
The web UI didn't accept 2 decimals.

Changed to be consistent all over the app and API to accept and show as 2 decimals.