### PR TITLE
HTTP Producer to post claim messages to a given endpoint.

### DIFF
--- a/config/claim_request.yml
+++ b/config/claim_request.yml
@@ -1,0 +1,23 @@
+# For the Proof of Concept we are not taking into consideration the different envs we have,
+# like dev, staging, api-sandbox, demo, etc. All of them will use the production URL.
+#
+default: &default
+  client_config:
+    timeout: 10
+    open_timeout: 5
+
+production:
+  <<: *default
+  endpoint: 'http://requestb.in/1c1jb081'
+
+development:
+  <<: *default
+  endpoint: 'http://requestb.in/1biv2bw1'
+
+devunicorn:
+  <<: *default
+  endpoint: ''
+
+test:
+  <<: *default
+  endpoint: ''

--- a/config/initializers/messaging.rb
+++ b/config/initializers/messaging.rb
@@ -1,3 +1,9 @@
 Dir[File.join(Rails.root, 'lib', 'messaging', '*.rb')].each { |file| require file }
 
-Messaging::Producer.client_class = Aws::SNS::Client if Rails.env.production?
+# If you want to use Amazon SNS:
+# client_class = Rails.env.production? ? Aws::SNS::Client : Messaging::MockClient
+# Messaging::ClaimMessage.producer = Messaging::SNSProducer.new(client_class: client_class, queue: 'cccd-claims')
+
+# If you want to use HTTP Post:
+client_class = Rails.env.production? ? RestClient::Resource : Messaging::MockClient
+Messaging::ClaimMessage.producer = Messaging::HttpProducer.new(client_class: client_class)

--- a/lib/messaging/claim_message.rb
+++ b/lib/messaging/claim_message.rb
@@ -1,5 +1,6 @@
 module Messaging
   class ClaimMessage
+    cattr_accessor :producer
     attr_accessor :claim
 
     def initialize(claim)
@@ -7,30 +8,11 @@ module Messaging
     end
 
     def publish
-      Messaging::Producer.new(queue: 'cccd-claims').publish(payload)
+      self.class.producer.publish(message)
     end
 
-    def payload
-      {subject: subject, message: message}
-    end
-
-    # Subjects must be ASCII text that begins with a letter, number, or punctuation mark
-    # Must not include line breaks or control characters and be less than 100 characters long
-    #
-    def subject
-      'Claim UUID %s' % claim.uuid
-    end
-
-    # Messages must be UTF-8 encoded strings at most 256 KB in size
-    #
     def message
-      API::Entities::FullClaim.represent(claim).to_xml(xml_options)
-    end
-
-    private
-
-    def xml_options
-      {dasherize: false, skip_types: true, root: 'claim'}
+      Messaging::SOAPMessage.new(claim).to_xml
     end
   end
 end

--- a/lib/messaging/http_producer.rb
+++ b/lib/messaging/http_producer.rb
@@ -1,0 +1,28 @@
+module Messaging
+  class HttpProducer
+    attr_accessor :client
+
+    def initialize(client_class:)
+      self.client = client_class.new(endpoint, client_config)
+    end
+
+    def publish(payload)
+      Rails.logger.info "[Client: #{client.class.name}] Publishing payload: #{payload}"
+      client.post(payload, content_type: :xml)
+    end
+
+    private
+
+    def endpoint
+      config.fetch(:endpoint)
+    end
+
+    def client_config
+      config.fetch(:client_config).symbolize_keys!
+    end
+
+    def config
+      @config ||= Rails.application.config_for(:claim_request).symbolize_keys!
+    end
+  end
+end

--- a/lib/messaging/mock_client.rb
+++ b/lib/messaging/mock_client.rb
@@ -1,14 +1,11 @@
 module Messaging
   class MockClient
-    attr_accessor :config
-
-    def initialize(config = {})
-      self.config = config
+    def initialize(*)
     end
 
-    def publish(payload)
-      self.class.queue.push(payload)
-      payload
+    def method_missing(method, *args)
+      self.class.queue.push(method => args)
+      self.class.queue.last
     end
 
     def self.queue

--- a/lib/messaging/sns_producer.rb
+++ b/lib/messaging/sns_producer.rb
@@ -1,21 +1,16 @@
 module Messaging
-  class Producer
-    cattr_accessor :client_class
+  class SNSProducer
     attr_accessor :client, :queue
 
-    def self.client_class
-      @@client_class ||= Messaging::MockClient
-    end
-
-    def initialize(queue:)
-      self.client = self.class.client_class.new(client_config)
+    def initialize(client_class:, queue:)
+      self.client = client_class.new
       self.queue = queue
       raise ArgumentError, "Queue `#{queue}` not found" unless queue_present?
     end
 
     def publish(payload)
-      Rails.logger.info "[Client: #{self.class.client_class.name}] [ARN: #{target_arn}] Publishing payload: #{payload}"
-      client.publish({target_arn: target_arn}.merge(payload))
+      Rails.logger.info "[Client: #{client.class.name}] [ARN: #{target_arn}] Publishing payload: #{payload}"
+      client.publish(target_arn: target_arn, subject: 'Claim', message: payload)
     end
 
     def queue_name

--- a/spec/lib/messaging/claim_message_spec.rb
+++ b/spec/lib/messaging/claim_message_spec.rb
@@ -5,16 +5,29 @@ describe Messaging::ClaimMessage do
 
   subject { described_class.new(claim) }
 
-  it 'should have a subject' do
-    expect(subject.subject).to eq('Claim UUID %s' % claim.uuid)
-  end
-
   it 'should have a message' do
-    expect(subject.message).to match(/<claim_details>/)
+    expect(subject.message).to match(/<cbo:claim_uuid>#{claim.uuid}<\/cbo:claim_uuid>/)
   end
 
-  it 'should publish' do
-    expect_any_instance_of(Messaging::Producer).to receive(:publish).with(hash_including(:subject, :message))
-    subject.publish
+  context 'when using SNS producer' do
+    before do
+      Messaging::ClaimMessage.producer = Messaging::SNSProducer.new(client_class: Messaging::MockClient, queue: 'cccd-claims')
+    end
+
+    it 'should publish' do
+      expect_any_instance_of(Messaging::SNSProducer).to receive(:publish)
+      subject.publish
+    end
+  end
+
+  context 'when using HTTP producer' do
+    before do
+      Messaging::ClaimMessage.producer = Messaging::HttpProducer.new(client_class: Messaging::MockClient)
+    end
+
+    it 'should publish' do
+      expect_any_instance_of(Messaging::HttpProducer).to receive(:publish)
+      subject.publish
+    end
   end
 end

--- a/spec/lib/messaging/http_producer_spec.rb
+++ b/spec/lib/messaging/http_producer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Messaging::HttpProducer do
+  subject { described_class.new(client_class: client_class) }
+
+  let(:client_class) { Messaging::MockClient }
+  let(:queue) { client_class.queue }
+
+  before(:each) do
+    queue.clear
+  end
+
+  context 'publishing a message' do
+    before(:each) do
+      allow(ENV).to receive(:[]).with('ENV').and_return('test')
+    end
+
+    it 'should publish a message' do
+      subject.publish('test message')
+
+      expect(queue.size).to eq(1)
+      expect(queue.last).to eq(post: ['test message', {content_type: :xml}])
+    end
+  end
+end

--- a/spec/lib/messaging/sns_producer_spec.rb
+++ b/spec/lib/messaging/sns_producer_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
-describe Messaging::Producer do
-  subject { described_class.new(queue: 'cccd-claims') }
+describe Messaging::SNSProducer do
+  subject { described_class.new(client_class: client_class, queue: 'cccd-claims') }
 
-  let(:queue) { Messaging::MockClient.queue }
+  let(:client_class) { Messaging::MockClient }
+  let(:queue) { client_class.queue }
 
   before(:each) do
     queue.clear
@@ -21,10 +22,10 @@ describe Messaging::Producer do
     end
 
     it 'should publish a message' do
-      subject.publish(message: 'test message')
+      subject.publish('test message')
 
       expect(queue.size).to eq(1)
-      expect(queue.last).to eq(target_arn: 'arn:aws:sns:eu-west-1:016649511486:cccd-claims-test', message: 'test message')
+      expect(queue.last).to eq(publish: [target_arn: 'arn:aws:sns:eu-west-1:016649511486:cccd-claims-test', subject: 'Claim', message: 'test message'])
     end
   end
 end


### PR DESCRIPTION
This can be used instead of SNS queues. For now, the endpoint is a placeholder,
until we have the real one. The posting is only enabled on DEV environment.