### PR TITLE
Claim status enquiry mechanism.

### DIFF
--- a/app/interfaces/api/v2/claim.rb
+++ b/app/interfaces/api/v2/claim.rb
@@ -24,7 +24,7 @@ module API
           end
           get do
             if soap_format?
-              body Messaging::SOAPMessage.new(claim).to_xml
+              body Messaging::ExportMessage.new(claim).to_xml
             else
               present claim, with: API::Entities::FullClaim, root: 'claim'
             end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -115,6 +115,7 @@ module Claim
     has_many :redeterminations, foreign_key: :claim_id
 
     has_one  :certification, foreign_key: :claim_id, dependent: :destroy
+    has_one  :exported_claim, foreign_key: :claim_id, dependent: :destroy
 
     has_paper_trail on: [:update], only: [:state]
 

--- a/app/models/exported_claim.rb
+++ b/app/models/exported_claim.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: exported_claims
+#
+#  id              :integer          not null, primary key
+#  claim_id        :integer          not null
+#  claim_uuid      :uuid             not null
+#  status          :string
+#  status_code     :integer
+#  retries         :integer          default(0), not null
+#  created_at      :datetime
+#  updated_at      :datetime
+#  last_request_at :datetime
+#
+
+class ExportedClaim < ActiveRecord::Base
+
+  belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
+
+  # TODO: we need to decide what a 'successful' (not pending) claim means
+  scope :pending, -> { where(status: nil) }
+
+end

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -4,6 +4,15 @@
       %h3.heading-medium
         = t('.h2_messages')
 
+      -# BEGIN. This is just for the Proof of Concept.
+      %p
+        CCR status:
+        - if (ec = claim.exported_claim).present?
+          = 'status: %s; created_at: %s; last_request_at: %s; retries: %s' % [ec.status, ec.created_at, ec.last_request_at, ec.retries]
+        - else
+          = 'not submitted'
+      -# END. This is just for the Proof of Concept.
+
     .column-one-half
       - if current_user.persona.is_a?(CaseWorker)
         .other-claims

--- a/config/claim_status.yml
+++ b/config/claim_status.yml
@@ -8,11 +8,11 @@ default: &default
 
 production:
   <<: *default
-  endpoint: 'http://requestb.in/xjm3zaxj'
+  endpoint: 'http://requestb.in/18f1i1j1'
 
 development:
   <<: *default
-  endpoint: 'http://requestb.in/y5ker6y5'
+  endpoint: 'http://requestb.in/x6x3lix6'
 
 devunicorn:
   <<: *default

--- a/config/initializers/messaging.rb
+++ b/config/initializers/messaging.rb
@@ -1,4 +1,4 @@
-Dir[File.join(Rails.root, 'lib', 'messaging', '*.rb')].each { |file| require file }
+Dir[File.join(Rails.root, 'lib', 'messaging', '**/*.rb')].each { |file| require file }
 
 # If you want to use Amazon SNS:
 # client_class = Rails.env.production? ? Aws::SNS::Client : Messaging::MockClient
@@ -6,4 +6,4 @@ Dir[File.join(Rails.root, 'lib', 'messaging', '*.rb')].each { |file| require fil
 
 # If you want to use HTTP Post:
 client_class = Rails.env.production? ? RestClient::Resource : Messaging::MockClient
-Messaging::ClaimMessage.producer = Messaging::HttpProducer.new(client_class: client_class)
+Messaging::ClaimMessage.producer = Messaging::HttpProducer.new(:claim_request, client_class: client_class)

--- a/config/schemas/claim_status.xsd
+++ b/config/schemas/claim_status.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding='UTF-8' ?>
+
+<xsd:schema xmlns="http://www.justice.gov.uk/2016/11/cbo"
+            xmlns:tns="http://www.justice.gov.uk/2016/11/cbo"
+            targetNamespace="http://www.justice.gov.uk/2016/11/cbo"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified"
+            elementFormDefault="qualified">
+
+  <!-- ============================================================================ -->
+  <!-- =====                                                            =========== -->
+  <!-- =====  Operation: Status Enquiry Request and Response            =========== -->
+  <!-- =====                                                            =========== -->
+  <!-- ============================================================================ -->
+  <xsd:element name="status_request">
+    <xsd:complexType>
+      <xsd:sequence>
+
+
+        <xsd:element name="ClaimUUIDs" minOccurs="1" maxOccurs="50">
+          <xsd:annotation>
+            <xsd:documentation>A list of CBO CCCD Claim UUIds</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:length value="36"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+
+
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/db/migrate/20161114093442_create_exported_claims.rb
+++ b/db/migrate/20161114093442_create_exported_claims.rb
@@ -1,0 +1,13 @@
+class CreateExportedClaims < ActiveRecord::Migration
+  def change
+    create_table :exported_claims do |t|
+      t.references :claim, index: true, null: false
+      t.uuid :claim_uuid, index: true, null: false
+      t.string :status
+      t.integer :status_code
+      t.integer :retries, default: 0, null: false
+      t.timestamps
+      t.datetime :last_request_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161101093559) do
+ActiveRecord::Schema.define(version: 20161114093442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -293,6 +293,20 @@ ActiveRecord::Schema.define(version: 20161101093559) do
 
   add_index "expenses", ["claim_id"], name: "index_expenses_on_claim_id", using: :btree
   add_index "expenses", ["expense_type_id"], name: "index_expenses_on_expense_type_id", using: :btree
+
+  create_table "exported_claims", force: :cascade do |t|
+    t.integer  "claim_id",                    null: false
+    t.uuid     "claim_uuid",                  null: false
+    t.string   "status"
+    t.integer  "status_code"
+    t.integer  "retries",         default: 0, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "last_request_at"
+  end
+
+  add_index "exported_claims", ["claim_id"], name: "index_exported_claims_on_claim_id", using: :btree
+  add_index "exported_claims", ["claim_uuid"], name: "index_exported_claims_on_claim_uuid", using: :btree
 
   create_table "external_users", force: :cascade do |t|
     t.datetime "created_at"

--- a/lib/messaging/export_message.rb
+++ b/lib/messaging/export_message.rb
@@ -1,0 +1,32 @@
+require_relative 'soap_message'
+
+module Messaging
+  class ExportMessage < Messaging::SOAPMessage
+    attr_accessor :claim, :message_uuid
+
+    def initialize(claim, _options = {})
+      self.claim = claim
+      self.message_uuid = SecureRandom.uuid
+    end
+
+    def payload_schema
+      File.join(Rails.root, 'config', 'schemas', 'claim_request.xsd').freeze
+    end
+
+    def action
+      'newCBOClaim'.freeze
+    end
+
+    def root
+      'cbo:claim_request'.freeze
+    end
+
+    def message_id
+      'uuid:%s' % message_uuid
+    end
+
+    def message_content
+      API::Entities::FullClaim.represent(claim)
+    end
+  end
+end

--- a/lib/messaging/http_producer.rb
+++ b/lib/messaging/http_producer.rb
@@ -1,15 +1,17 @@
 module Messaging
   class HttpProducer
-    attr_accessor :client
+    attr_accessor :client, :config_name
 
-    def initialize(client_class:)
+    def initialize(config_name, client_class:)
+      self.config_name = config_name
       self.client = client_class.new(endpoint, client_config)
     end
 
     def publish(payload)
-      Rails.logger.info "[Client: #{client.class.name}] Publishing payload: #{payload}"
+      Rails.logger.info "[Client: #{client.class.name}] Posting payload: #{payload}"
       client.post(payload, content_type: :xml)
     end
+    alias post publish
 
     private
 

--- a/lib/messaging/soap_message.rb
+++ b/lib/messaging/soap_message.rb
@@ -1,18 +1,29 @@
 module Messaging
   class SOAPMessage
-    attr_accessor :claim, :message_uuid, :schema, :errors
+    attr_accessor :errors
 
-    PAYLOAD_SCHEMA = File.join(Rails.root, 'config', 'schemas', 'claim_request.xsd').freeze
-
-    WSA_ACTION = 'newCBOClaim'.freeze
     WSA_FROM = 'http://cob.gov.uk/cccd'.freeze
     WSA_TO = 'http://legalaid.gov.uk/infoX/gateway/ccr'.freeze
     CBO_NS = %w(cbo http://www.justice.gov.uk/2016/11/cbo).freeze
 
-    def initialize(claim, options = {})
-      self.claim = claim
-      self.schema = options[:schema] || PAYLOAD_SCHEMA
-      self.message_uuid = SecureRandom.uuid
+    def payload_schema
+      raise 'not implemented'
+    end
+
+    def action
+      raise 'not implemented'
+    end
+
+    def root
+      raise 'not implemented'
+    end
+
+    def message_id
+      raise 'not implemented'
+    end
+
+    def message_content
+      raise 'not implemented'
     end
 
     def to_xml
@@ -21,7 +32,7 @@ module Messaging
 
     def valid?
       errors.clear
-      xsd = Nokogiri::XML::Schema(File.open(schema))
+      xsd = Nokogiri::XML::Schema(File.open(payload_schema))
       xsd.validate(request_message).each { |error| errors << error.message }
       errors.empty?
     end
@@ -33,18 +44,14 @@ module Messaging
     private
 
     def must_understand
-      {'soapenv:mustUnderstand': '1'}
-    end
-
-    def message_id
-      'uuid:%s' % message_uuid
+      {'soapenv:mustUnderstand': '1'}.freeze
     end
 
     def build_envelope
       Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |builder|
         builder[:soapenv].Envelope('xmlns:soapenv': 'http://www.w3.org/2003/05/soap-envelope') {
           builder[:soapenv].Header('xmlns:wsa': 'http://www.w3.org/2005/08/addressing') {
-            builder[:wsa].Action(must_understand, WSA_ACTION)
+            builder[:wsa].Action(must_understand, action)
             builder[:wsa].From(must_understand) { builder[:wsa].Address(WSA_FROM) }
             builder[:wsa].MessageID(must_understand, message_id)
             builder[:wsa].To(must_understand, WSA_TO)
@@ -58,7 +65,7 @@ module Messaging
 
     def payload_message
       @payload_message ||= begin
-        doc = Nokogiri::XML(API::Entities::FullClaim.represent(claim).to_xml(xml_options))
+        doc = Nokogiri::XML(message_content.to_xml(xml_options))
         doc.root.add_namespace_definition(*CBO_NS)
         doc.root.to_xml
       end
@@ -70,7 +77,7 @@ module Messaging
     end
 
     def xml_options
-      {dasherize: false, skip_types: true, skip_instruct: true, skip_nils: true, root: 'cbo:claim_request'}.freeze
+      {dasherize: false, skip_types: true, skip_instruct: true, skip_nils: true, root: root}.freeze
     end
   end
 end

--- a/lib/messaging/status/status_request.rb
+++ b/lib/messaging/status/status_request.rb
@@ -1,0 +1,38 @@
+require_relative '../soap_message'
+
+module Messaging
+  module Status
+    class StatusRequest < Messaging::SOAPMessage
+      attr_accessor :uuids, :message_uuid
+
+      def initialize(uuids, _options = {})
+        self.uuids = uuids
+        self.message_uuid = SecureRandom.uuid
+      end
+
+      def payload_schema
+        File.join(Rails.root, 'config', 'schemas', 'claim_status.xsd').freeze
+      end
+
+      # TODO: we need to confirm this
+      def action
+        'statusRequest'.freeze
+      end
+
+      # TODO: we need to confirm this
+      def root
+        'cbo:status_request'.freeze
+      end
+
+      # TODO: not sure we need a sequence/id/uuid here, we might omit it
+      def message_id
+        'uuid:%s' % message_uuid
+      end
+
+      # TODO: we need to confirm this
+      def message_content
+        {'ClaimUUIDs': uuids}
+      end
+    end
+  end
+end

--- a/lib/messaging/status/status_response.rb
+++ b/lib/messaging/status/status_response.rb
@@ -1,0 +1,43 @@
+module Messaging
+  module Status
+    class StatusResponse
+      attr_accessor :response, :ack_id, :claim_uuid, :processing_result, :errors
+
+      def initialize(response)
+        self.response = response
+      end
+
+      def ack_id
+        @ack_id ||= document.at_xpath('//ack_id')&.content
+      end
+
+      def claim_uuid
+        @claim_uuid ||= document.at_xpath('//claim_details/uuid')&.content
+      end
+
+      def processing_result
+        @processing_result ||= document.at_xpath('//processing_result/success')&.content.to_s.to_bool
+      end
+
+      def errors
+        @errors ||= errors_content.map do |error|
+          {code: error.at_xpath('code').content.to_i, detail: error.at_xpath('detail').content}
+        end
+      end
+
+      def status
+        processing_result ? 'success' : 'error'
+      end
+
+      private
+
+      def errors_content
+        document.xpath('//processing_result/errors/*') rescue []
+      end
+
+      def document
+        @document ||= Nokogiri::XML(response)
+      end
+    end
+  end
+end

--- a/lib/messaging/status/status_updater.rb
+++ b/lib/messaging/status/status_updater.rb
@@ -1,0 +1,55 @@
+module Messaging
+  module Status
+    class StatusUpdater
+      cattr_accessor :client_class
+      attr_accessor :batch_limit
+
+      MAX_RETRIES = 3
+
+      def initialize(batch_limit: 1)
+        self.batch_limit = batch_limit
+      end
+
+      def run
+        return unless pending_claims.any?
+        process_response(client.post(payload))
+      end
+
+      def payload
+        Messaging::Status::StatusRequest.new(pending_claim_uuids).to_xml
+      end
+
+      def client
+        Messaging::HttpProducer.new(:claim_status, client_class: client_class)
+      end
+
+      private
+
+      def pending_claims
+        @pending_claim ||= ExportedClaim.pending.where { retries < MAX_RETRIES }.limit(batch_limit).to_a
+      end
+
+      def pending_claim_uuids
+        ids = pending_claims.map(&:id)
+        uuids = pending_claims.map(&:claim_uuid)
+        update_records!(ids)
+        uuids
+      end
+
+      def update_records!(ids)
+        ExportedClaim.where(id: ids).update_all(last_request_at: 'now()', updated_at: 'now()')
+        ExportedClaim.update_counters(ids, retries: 1)
+      end
+
+      # TODO: decide what to store and when we assume not to query again for this same claim
+      def process_response(xml)
+        response = Messaging::Status::StatusResponse.new(xml)
+        ExportedClaim.find_by!(claim_uuid: response.claim_uuid).update_attributes(status: response.status)
+      end
+
+      def client_class
+        self.class.client_class || RestClient::Resource
+      end
+    end
+  end
+end

--- a/spec/factories/exported_claims.rb
+++ b/spec/factories/exported_claims.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: exported_claims
+#
+#  id              :integer          not null, primary key
+#  claim_id        :integer          not null
+#  claim_uuid      :uuid             not null
+#  status          :string
+#  status_code     :integer
+#  retries         :integer          default(0), not null
+#  created_at      :datetime
+#  updated_at      :datetime
+#  last_request_at :datetime
+#
+
+FactoryGirl.define do
+  factory :exported_claim do
+    claim
+    claim_uuid { claim.uuid || SecureRandom.uuid }
+  end
+end

--- a/spec/lib/messaging/claim_message_spec.rb
+++ b/spec/lib/messaging/claim_message_spec.rb
@@ -5,29 +5,59 @@ describe Messaging::ClaimMessage do
 
   subject { described_class.new(claim) }
 
-  it 'should have a message' do
-    expect(subject.message).to match(/<cbo:claim_uuid>#{claim.uuid}<\/cbo:claim_uuid>/)
+  it 'should have a payload' do
+    expect(subject.payload).to match(/<cbo:claim_uuid>#{claim.uuid}<\/cbo:claim_uuid>/)
   end
 
-  context 'when using SNS producer' do
-    before do
-      Messaging::ClaimMessage.producer = Messaging::SNSProducer.new(client_class: Messaging::MockClient, queue: 'cccd-claims')
+  describe 'publishing claims' do
+    context 'when message is not valid' do
+      before(:each) do
+        allow(subject).to receive(:valid_message?).and_return(false)
+      end
+
+      it 'should raise an exception' do
+        expect { subject.publish }.to raise_exception(Messaging::MessageValidationError)
+      end
     end
 
-    it 'should publish' do
-      expect_any_instance_of(Messaging::SNSProducer).to receive(:publish)
-      subject.publish
-    end
-  end
+    context 'when message is valid' do
+      before(:each) do
+        allow(subject).to receive(:valid_message?).and_return(true)
+      end
 
-  context 'when using HTTP producer' do
-    before do
-      Messaging::ClaimMessage.producer = Messaging::HttpProducer.new(client_class: Messaging::MockClient)
-    end
+      context 'when using SNS producer' do
+        before do
+          Messaging::ClaimMessage.producer = Messaging::SNSProducer.new(client_class: Messaging::MockClient, queue: 'cccd-claims')
+        end
 
-    it 'should publish' do
-      expect_any_instance_of(Messaging::HttpProducer).to receive(:publish)
-      subject.publish
+        it 'should publish' do
+          expect_any_instance_of(Messaging::SNSProducer).to receive(:publish)
+          subject.publish
+        end
+
+        it 'should create an export database entry' do
+          subject.publish
+          entry = ExportedClaim.find_by(claim_uuid: claim.uuid)
+          expect(entry).not_to be_nil
+        end
+      end
+
+      context 'when using HTTP producer' do
+        before do
+          Messaging::ClaimMessage.producer = Messaging::HttpProducer.new(:claim_request, client_class: Messaging::MockClient)
+        end
+
+        it 'should publish' do
+          expect_any_instance_of(Messaging::HttpProducer).to receive(:publish)
+          subject.publish
+        end
+
+        it 'should create an export database entry' do
+          subject.publish
+          entry = ExportedClaim.find_by(claim_uuid: claim.uuid)
+          expect(entry).not_to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/lib/messaging/export_message_spec.rb
+++ b/spec/lib/messaging/export_message_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Messaging::SOAPMessage do
+describe Messaging::ExportMessage do
   let(:claim) { create(:deterministic_claim, :redetermination) }
   let(:message_uuid) { '111-222-333' }
 

--- a/spec/lib/messaging/http_producer_spec.rb
+++ b/spec/lib/messaging/http_producer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Messaging::HttpProducer do
-  subject { described_class.new(client_class: client_class) }
+  subject { described_class.new(:claim_request, client_class: client_class) }
 
   let(:client_class) { Messaging::MockClient }
   let(:queue) { client_class.queue }

--- a/spec/lib/messaging/status/status_response_spec.rb
+++ b/spec/lib/messaging/status/status_response_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe Messaging::Status::StatusResponse do
+  let(:ack_id) { '6c80319d-3e9e-4c78-add6-8c896c56be04' }
+  let(:claim_uuid) { '08ce9459-b34b-4af5-a7f5-c178f7990b0c' }
+
+  subject { described_class.new(response) }
+
+  describe 'success response' do
+    let(:response) { success_response_xml }
+
+    it 'populates the ack_id attribute' do
+      expect(subject.ack_id).to eq(ack_id)
+    end
+
+    it 'populates the claim_uuid attribute' do
+      expect(subject.claim_uuid).to eq(claim_uuid)
+    end
+
+    it 'populates the processing_result attribute' do
+      expect(subject.processing_result).to eq(true)
+    end
+
+    it 'populates the errors attribute' do
+      expect(subject.errors).to eq([])
+    end
+  end
+
+  describe 'failure response' do
+    let(:response) { error_response_xml }
+
+    it 'populates the ack_id attribute' do
+      expect(subject.ack_id).to eq(ack_id)
+    end
+
+    it 'populates the claim_uuid attribute' do
+      expect(subject.claim_uuid).to eq(claim_uuid)
+    end
+
+    it 'populates the processing_result attribute' do
+      expect(subject.processing_result).to eq(false)
+    end
+
+    it 'populates the errors attribute' do
+      expect(subject.errors).to eq([{code: 100, detail: 'Detail of the 100 error'}, {code: 200, detail: 'Detail of the 200 error'}])
+    end
+  end
+
+  #------------------------------------------------------
+  #
+  def success_response_xml
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <claim>
+      <ack_id>#{ack_id}</ack_id>
+      <claim_details>
+        <uuid>#{claim_uuid}</uuid>
+      </claim_details>
+      <processing_result>
+        <success>true</success>
+      </processing_result>
+    </claim>
+    XML
+  end
+
+  def error_response_xml
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <claim>
+      <ack_id>#{ack_id}</ack_id>
+      <claim_details>
+        <uuid>#{claim_uuid}</uuid>
+      </claim_details>
+      <processing_result>
+        <success>false</success>
+        <errors>
+          <error>
+            <code>100</code>
+            <detail>Detail of the 100 error</detail>
+          </error>
+          <error>
+            <code>200</code>
+            <detail>Detail of the 200 error</detail>
+          </error>
+        </errors>
+      </processing_result>
+    </claim>
+    XML
+  end
+end

--- a/spec/lib/messaging/status/status_updater_spec.rb
+++ b/spec/lib/messaging/status/status_updater_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+describe Messaging::Status::StatusUpdater do
+  let(:uuid) { '08ce9459-b34b-4af5-a7f5-c178f7990b0c' }
+  let(:response) { success_response_xml }
+
+  subject { described_class.new }
+
+  before(:each) do
+    allow(subject).to receive(:pending_claim_uuids).and_return([uuid])
+    allow(subject).to receive(:client).and_return(double(post: response))
+  end
+
+  it 'should build the expect payload' do
+    expect(subject.payload).to match(/<cbo:ClaimUUID>#{uuid}<\/cbo:ClaimUUID>/)
+  end
+
+  describe 'updating the exported claim database record' do
+    let(:exported_claim) { create(:exported_claim, claim_uuid: uuid) }
+
+    before(:each) { ExportedClaim.delete_all }
+
+    context 'for a successful response' do
+      let(:response) { success_response_xml }
+
+      it 'should update the database record' do
+        expect(exported_claim.status).to be_nil
+        subject.run
+        exported_claim.reload
+        expect(exported_claim.status).to eq('success')
+      end
+    end
+
+    context 'for a failure response' do
+      let(:response) { error_response_xml }
+
+      it 'should update the database record' do
+        expect(exported_claim.status).to be_nil
+        subject.run
+        exported_claim.reload
+        expect(exported_claim.status).to eq('error')
+      end
+    end
+  end
+
+  #------------------------------------------------------
+  #
+  def success_response_xml
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <claim>
+      <ack_id>6c80319d-3e9e-4c78-add6-8c896c56be04</ack_id>
+      <claim_details>
+        <uuid>#{uuid}</uuid>
+      </claim_details>
+      <processing_result>
+        <success>true</success>
+      </processing_result>
+    </claim>
+    XML
+  end
+
+  def error_response_xml
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <claim>
+      <ack_id>6c80319d-3e9e-4c78-add6-8c896c56be04</ack_id>
+      <claim_details>
+        <uuid>#{uuid}</uuid>
+      </claim_details>
+      <processing_result>
+        <success>false</success>
+        <errors>
+          <error>
+            <code>100</code>
+            <detail>Detail of the error goes here</detail>
+          </error>
+          <error>
+            <code>200</code>
+            <detail>Detail of the 200 error code goes here</detail>
+          </error>
+        </errors>
+      </processing_result>
+    </claim>
+    XML
+  end
+end
+

--- a/spec/support/database_housekeeping.rb
+++ b/spec/support/database_housekeeping.rb
@@ -29,7 +29,8 @@ module DatabaseHousekeeping
       Provider,
       Disbursement,
       DisbursementType,
-      Stats::Statistic
+      Stats::Statistic,
+      ExportedClaim
     ]
 
     models.each do |model|

--- a/spikes/processed_claim_response.xml
+++ b/spikes/processed_claim_response.xml
@@ -18,6 +18,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <claim>
+    <ack_id>6c80319d-3e9e-4c78-add6-8c896c56be04</ack_id>
     <claim_details>
         <uuid>96869c1d-8b9b-448e-9a6c-144b115f83fe</uuid>
     </claim_details>


### PR DESCRIPTION
Pending endpoints and confirming the XML message.

For now this is manually run, with task: `rake claims:status_updater`
Eventually this will be an scheduled task (but we need to ensure only runs in 1 instance).
