### PR TITLE
Basic error handling on publishing and requesting status.

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -15,7 +15,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   before_action :filter_archived_claims,  only: [:archived]
   before_action :sort_claims,             only: [:index, :archived]
 
-  before_action :set_claim, only: [:show, :messages]
+  before_action :set_claim, only: [:show, :messages, :publish, :enquire]
   before_action :set_doctypes, only: [:show, :update]
 
   include ReadMessages
@@ -46,6 +46,18 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
       prepare_show_action
       render :show
     end
+  end
+
+  # TODO: temporary action for the Claim Injection PoC
+  def publish
+    Claims::ClaimInjection.new(@claim).execute
+    redirect_to case_workers_claim_path(@claim)
+  end
+
+  # TODO: temporary action for the Claim Injection PoC
+  def enquire
+    Messaging::Status::StatusUpdater.new(uuids: [@claim.uuid]).run
+    redirect_to case_workers_claim_path(@claim)
   end
 
   private

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -63,8 +63,8 @@ module Claims::StateMachine
             :deallocated
 
       after_transition on: :submit,                   do: [:set_last_submission_date!, :set_original_submission_date!]
-      after_transition on: :authorise,                do: [:set_authorised_date!, :publish_claim]
-      after_transition on: :authorise_part,           do: [:set_authorised_date!, :publish_claim]
+      after_transition on: :authorise,                do: [:set_authorised_date!]
+      after_transition on: :authorise_part,           do: [:set_authorised_date!]
       after_transition on: :redetermine,              do: [:remove_case_workers!, :set_last_submission_date!]
       after_transition on: :await_written_reasons,    do: [:remove_case_workers!, :set_last_submission_date!]
       after_transition on: :archive_pending_delete,   do: :set_valid_until!
@@ -214,11 +214,5 @@ module Claims::StateMachine
 
   def remove_case_workers!
     self.case_workers.destroy_all
-  end
-
-  # Default is to publish claims but can be overridden, example: claim.authorise!(publish: false)
-  def publish_claim(transition)
-    publish = extract_transition_option!(transition, :publish, true)
-    PublishClaimJob.perform_later(self) if Settings.claim_publishing_enabled? && publish
   end
 end

--- a/app/models/exported_claim.rb
+++ b/app/models/exported_claim.rb
@@ -2,15 +2,17 @@
 #
 # Table name: exported_claims
 #
-#  id              :integer          not null, primary key
-#  claim_id        :integer          not null
-#  claim_uuid      :uuid             not null
-#  status          :string
-#  status_code     :integer
-#  retries         :integer          default(0), not null
-#  created_at      :datetime
-#  updated_at      :datetime
-#  last_request_at :datetime
+#  id           :integer          not null, primary key
+#  claim_id     :integer          not null
+#  claim_uuid   :uuid             not null
+#  status       :string
+#  status_code  :integer
+#  status_msg   :string
+#  retries      :integer          default(0), not null
+#  created_at   :datetime
+#  updated_at   :datetime
+#  published_at :datetime
+#  retried_at   :datetime
 #
 
 class ExportedClaim < ActiveRecord::Base
@@ -18,6 +20,6 @@ class ExportedClaim < ActiveRecord::Base
   belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
 
   # TODO: we need to decide what a 'successful' (not pending) claim means
-  scope :pending, -> { where(status: nil) }
+  scope :pending, -> { where(status: 'published') }
 
 end

--- a/app/services/claims/claim_injection.rb
+++ b/app/services/claims/claim_injection.rb
@@ -1,0 +1,24 @@
+module Claims
+  class ClaimInjection
+    attr_accessor :claim
+
+    def initialize(claim)
+      self.claim = claim
+    end
+
+    def execute
+      PublishClaimJob.perform_later(claim)
+      find_or_create_exported_record
+    end
+
+    private
+
+    def find_or_create_exported_record
+      ExportedClaim.find_or_create_by(claim_id: claim.id, claim_uuid: claim.uuid).update_attributes(default_attrs)
+    end
+
+    def default_attrs
+      {status: 'enqueued', status_code: nil, status_msg: nil, retries: 0, retried_at: nil, published_at: nil}
+    end
+  end
+end

--- a/app/views/shared/_ccr_injection.html.haml
+++ b/app/views/shared/_ccr_injection.html.haml
@@ -1,0 +1,12 @@
+- if Settings.claim_publishing_enabled?
+  %p
+    = link_to 'Send to CCR', publish_case_workers_claim_path(claim), method: :put
+    |
+    = link_to 'Request status', enquire_case_workers_claim_path(claim), method: :put
+  %p
+    [CCR status]
+    - if (ec = claim.exported_claim).present?
+      = 'status: %s; created_at: %s; published_at: %s; retries: %s; retried_at: %s' % [ec.status, ec.created_at, ec.published_at, ec.retries, ec.retried_at]
+      = 'status_code: %s; status_msg: %s' % [ec.status_code, ec.status_msg] if ec.status_msg
+    - else
+      = 'not submitted'

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -4,15 +4,6 @@
       %h3.heading-medium
         = t('.h2_messages')
 
-      -# BEGIN. This is just for the Proof of Concept.
-      %p
-        CCR status:
-        - if (ec = claim.exported_claim).present?
-          = 'status: %s; created_at: %s; last_request_at: %s; retries: %s' % [ec.status, ec.created_at, ec.last_request_at, ec.retries]
-        - else
-          = 'not submitted'
-      -# END. This is just for the Proof of Concept.
-
     .column-one-half
       - if current_user.persona.is_a?(CaseWorker)
         .other-claims
@@ -22,6 +13,10 @@
             = "claims"
             - unless last_claim?
               = next_claim_link 'Next claim &gt;'.html_safe, class: 'next-claim'
+
+  -# BEGIN. This is just for the Proof of Concept.
+  = render partial: 'shared/ccr_injection', locals: { claim: claim }
+  -# END. This is just for the Proof of Concept.
 
   = render partial: 'shared/claim_history', locals: {claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }

--- a/config/claim_request.yml
+++ b/config/claim_request.yml
@@ -8,11 +8,11 @@ default: &default
 
 production:
   <<: *default
-  endpoint: 'http://requestb.in/xjm3zaxj'
+  endpoint: 'http://requestb.in/16hgh1d1' # These URLs only last 48h once created
 
 development:
   <<: *default
-  endpoint: 'http://requestb.in/y5ker6y5'
+  endpoint: 'http://requestb.in/olamvhol' # These URLs only last 48h once created
 
 devunicorn:
   <<: *default

--- a/config/claim_status.yml
+++ b/config/claim_status.yml
@@ -8,11 +8,11 @@ default: &default
 
 production:
   <<: *default
-  endpoint: 'http://requestb.in/18f1i1j1'
+  endpoint: 'http://requestb.in/rcemvxrc' # These URLs only last 48h once created
 
 development:
   <<: *default
-  endpoint: 'http://requestb.in/x6x3lix6'
+  endpoint: 'http://requestb.in/1haud0l1' # These URLs only last 48h once created
 
 devunicorn:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,8 @@ Rails.application.routes.draw do
       get 'show_message_controls', on: :member
       get 'messages', on: :member
       get 'archived', on: :collection
+      put 'publish', on: :member
+      put 'enquire', on: :member
     end
 
     namespace :admin do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,5 +87,6 @@ case_workers_remote_allocations?: true
 # contact email address
 laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
 
-# Claim publishing to Amazon SNS queue. Not yet ready for production, only enabled in DEV.
+# Claim injecting PoC stuff that might be exposed to the user, we don't want that on DEV
+# Override this setting in your settings.local.yml to see the stuff on local
 claim_publishing_enabled?: <%= ENV['ENV'] == 'dev' %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,6 +3,3 @@
 #
 remote_api_key: 'not-provided'
 remote_api_url: 'http://localhost:3001/api'
-
-# Queue is mocked so this is safe to be true so tests are as realistic as possible
-claim_publishing_enabled?: true

--- a/db/migrate/20161114093442_create_exported_claims.rb
+++ b/db/migrate/20161114093442_create_exported_claims.rb
@@ -5,9 +5,11 @@ class CreateExportedClaims < ActiveRecord::Migration
       t.uuid :claim_uuid, index: true, null: false
       t.string :status
       t.integer :status_code
+      t.string :status_msg
       t.integer :retries, default: 0, null: false
-      t.timestamps
-      t.datetime :last_request_at
+      t.timestamps null: true
+      t.datetime :published_at
+      t.datetime :retried_at
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -295,14 +295,16 @@ ActiveRecord::Schema.define(version: 20161114093442) do
   add_index "expenses", ["expense_type_id"], name: "index_expenses_on_expense_type_id", using: :btree
 
   create_table "exported_claims", force: :cascade do |t|
-    t.integer  "claim_id",                    null: false
-    t.uuid     "claim_uuid",                  null: false
+    t.integer  "claim_id",                 null: false
+    t.uuid     "claim_uuid",               null: false
     t.string   "status"
     t.integer  "status_code"
-    t.integer  "retries",         default: 0, null: false
+    t.string   "status_msg"
+    t.integer  "retries",      default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "last_request_at"
+    t.datetime "published_at"
+    t.datetime "retried_at"
   end
 
   add_index "exported_claims", ["claim_id"], name: "index_exported_claims_on_claim_id", using: :btree

--- a/lib/messaging/http_producer.rb
+++ b/lib/messaging/http_producer.rb
@@ -9,11 +9,23 @@ module Messaging
 
     def publish(payload)
       Rails.logger.info "[Client: #{client.class.name}] Posting payload: #{payload}"
-      client.post(payload, content_type: :xml)
+      build_response do_post(payload)
     end
     alias post publish
 
     private
+
+    # TODO: the producers could extract this and other common methods to a superclass, TBC.
+    def do_post(payload, format = :xml)
+      client.post(payload, content_type: format)
+    rescue RestClient::ExceptionWithResponse => ex
+      ex.response
+    end
+
+    # TODO: the producers could extract this and other common methods to a superclass, TBC.
+    def build_response(res)
+      Messaging::ProducerResponse.new(code: res.code, body: res, description: res.description)
+    end
 
     def endpoint
       config.fetch(:endpoint)

--- a/lib/messaging/mock_client.rb
+++ b/lib/messaging/mock_client.rb
@@ -5,11 +5,17 @@ module Messaging
 
     def method_missing(method, *args)
       self.class.queue.push(method => args)
-      self.class.queue.last
+      build_response(self.class.queue.last)
     end
 
     def self.queue
       @@queue ||= Array.new
+    end
+
+    private
+
+    def build_response(res)
+      Messaging::ProducerResponse.new(code: 200, body: res, description: 'ok')
     end
   end
 end

--- a/lib/messaging/producer_response.rb
+++ b/lib/messaging/producer_response.rb
@@ -1,0 +1,19 @@
+module Messaging
+  class ProducerResponse
+    attr_accessor :code, :body, :description
+
+    def initialize(code:, body:, description:)
+      self.code = code
+      self.body = body
+      self.description = description
+    end
+
+    def success?
+      (200..201).include?(code)
+    end
+
+    def error?
+      !success?
+    end
+  end
+end

--- a/lib/messaging/sns_producer.rb
+++ b/lib/messaging/sns_producer.rb
@@ -10,7 +10,7 @@ module Messaging
 
     def publish(payload)
       Rails.logger.info "[Client: #{client.class.name}] [ARN: #{target_arn}] Publishing payload: #{payload}"
-      client.publish(target_arn: target_arn, subject: 'Claim', message: payload)
+      build_response client.publish(target_arn: target_arn, subject: 'Claim', message: payload)
     end
 
     def queue_name
@@ -22,6 +22,12 @@ module Messaging
     end
 
     private
+
+    # TODO: check what attributes SNS actually returns to retrieve the code and description, if any
+    # TODO: also, the producers could extract this and other common methods to a superclass, TBC.
+    def build_response(res)
+      Messaging::ProducerResponse.new(code: res.code, body: res, description: res.description)
+    end
 
     def host
       Rails.host.env || 'local'

--- a/spec/factories/exported_claims.rb
+++ b/spec/factories/exported_claims.rb
@@ -2,20 +2,30 @@
 #
 # Table name: exported_claims
 #
-#  id              :integer          not null, primary key
-#  claim_id        :integer          not null
-#  claim_uuid      :uuid             not null
-#  status          :string
-#  status_code     :integer
-#  retries         :integer          default(0), not null
-#  created_at      :datetime
-#  updated_at      :datetime
-#  last_request_at :datetime
+#  id           :integer          not null, primary key
+#  claim_id     :integer          not null
+#  claim_uuid   :uuid             not null
+#  status       :string
+#  status_code  :integer
+#  status_msg   :string
+#  retries      :integer          default(0), not null
+#  created_at   :datetime
+#  updated_at   :datetime
+#  published_at :datetime
+#  retried_at   :datetime
 #
 
 FactoryGirl.define do
   factory :exported_claim do
     claim
     claim_uuid { claim.uuid || SecureRandom.uuid }
+
+    trait :enqueued do
+      status 'enqueued'
+    end
+
+    trait :published do
+      status 'published'
+    end
   end
 end

--- a/spec/lib/messaging/status/status_updater_spec.rb
+++ b/spec/lib/messaging/status/status_updater_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 describe Messaging::Status::StatusUpdater do
   let(:uuid) { '08ce9459-b34b-4af5-a7f5-c178f7990b0c' }
-  let(:response) { success_response_xml }
+  let(:response_body) { success_response_xml }
+  let(:response) { Messaging::ProducerResponse.new(code: 200, body: response_body, description: '') }
 
   subject { described_class.new }
 
@@ -16,15 +17,15 @@ describe Messaging::Status::StatusUpdater do
   end
 
   describe 'updating the exported claim database record' do
-    let(:exported_claim) { create(:exported_claim, claim_uuid: uuid) }
+    let(:exported_claim) { create(:exported_claim, :published, claim_uuid: uuid) }
 
     before(:each) { ExportedClaim.delete_all }
 
     context 'for a successful response' do
-      let(:response) { success_response_xml }
+      let(:response_body) { success_response_xml }
 
       it 'should update the database record' do
-        expect(exported_claim.status).to be_nil
+        expect(exported_claim.status).to eq('published')
         subject.run
         exported_claim.reload
         expect(exported_claim.status).to eq('success')
@@ -32,10 +33,10 @@ describe Messaging::Status::StatusUpdater do
     end
 
     context 'for a failure response' do
-      let(:response) { error_response_xml }
+      let(:response_body) { error_response_xml }
 
       it 'should update the database record' do
-        expect(exported_claim.status).to be_nil
+        expect(exported_claim.status).to eq('published')
         subject.run
         exported_claim.reload
         expect(exported_claim.status).to eq('error')

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -318,45 +318,4 @@ RSpec.describe Claims::StateMachine, type: :model do
       expect(transition.reason_code).to eq(reason_code)
     end
   end
-
-  describe 'claim publishing' do
-    describe 'when authorised' do
-      subject { create(:allocated_claim) }
-
-      before(:each) do
-        subject.assessment.update(fees: 100.00, expenses: 23.45)
-      end
-
-      it 'should enqueue the claim to be published' do
-        expect(PublishClaimJob).to receive(:perform_later).with(subject)
-        subject.authorise!
-      end
-    end
-
-    describe 'when part-authorised' do
-      subject { create(:allocated_claim) }
-
-      before(:each) do
-        subject.assessment.update(fees: 100.00, expenses: 23.45)
-      end
-
-      it 'should enqueue the claim to be published' do
-        expect(PublishClaimJob).to receive(:perform_later).with(subject)
-        subject.authorise_part!
-      end
-    end
-
-    describe 'override the publishing for the transition' do
-      subject { create(:allocated_claim) }
-
-      before(:each) do
-        subject.assessment.update(fees: 100.00, expenses: 23.45)
-      end
-
-      it 'should not enqueue the claim to be published' do
-        expect(PublishClaimJob).not_to receive(:perform_later)
-        subject.authorise!(publish: false)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Preliminary and rough error handling until we know more.

This will catch http 404 errors, as well as handling XML response errors (we need more detail about the format of those and what to do in each case tho).

Also this PR introduce 2 links in the case worker side claim view to submit claim to CCR and to enquiry for the status.