### PR TITLE
Get AGFS supplier number from provider if nil on external user

### DIFF
--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -92,6 +92,10 @@ class ExternalUser < ActiveRecord::Base
     self.user.soft_delete
   end
 
+  def supplier_number
+    self[:supplier_number] || self.provider.firm_agfs_supplier_number
+  end
+
 
   private
 

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -93,7 +93,7 @@ class ExternalUser < ActiveRecord::Base
   end
 
   def supplier_number
-    self[:supplier_number] || self.provider.firm_agfs_supplier_number
+    self[:supplier_number] || self.provider&.firm_agfs_supplier_number
   end
 
 

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -404,6 +404,26 @@ RSpec.describe ExternalUser, type: :model do
     end
   end
 
+  describe 'supplier_number' do
+    context 'supplier number present' do
+      let(:external_user) { create :external_user, :advocate, supplier_number: 'ZZ114' }
+
+      it 'returns the supplier number from the external user record' do
+        expect(external_user.supplier_number).to eq 'ZZ114'
+      end
+    end
+
+    context 'supplier number not present but provider is a firm' do
+
+      let(:provider) { create :provider, :agfs_lgfs, firm_agfs_supplier_number: '999XX' }
+      let(:external_user) { create :external_user, :advocate, supplier_number: nil, provider: provider }
+
+      it 'returns the firm_agfs_supplier_number from the provider' do
+        expect(external_user.supplier_number).to eq '999XX'
+      end
+    end
+  end
+
   context 'email notification of messages preferences' do
     context 'settings on user record are nil' do
 


### PR DESCRIPTION
Advocates working for Firms do not have supplier numbers on their external user records.  In this case, the supplier number should be fetched from the firm_agfs_supplier_number field on the advocates provider record.