### PR TITLE
Changes to namespace and other small tweaks to the SOAP message.

### DIFF
--- a/spec/lib/messaging/export_message_spec.rb
+++ b/spec/lib/messaging/export_message_spec.rb
@@ -27,20 +27,19 @@ describe Messaging::ExportMessage do
 
   let(:expected_xml) do
     <<-XML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
-      <soapenv:Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
-        <wsa:Action soapenv:mustUnderstand="1">newCBOClaim</wsa:Action>
-        <wsa:From soapenv:mustUnderstand="1">
+    <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+      <env:Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
+        <wsa:To env:mustUnderstand="1">http://legalaid.gov.uk/infoX/gateway/ccr</wsa:To>
+        <wsa:From env:mustUnderstand="1">
           <wsa:Address>http://cob.gov.uk/cccd</wsa:Address>
         </wsa:From>
-        <wsa:MessageID soapenv:mustUnderstand="1">uuid:111-222-333</wsa:MessageID>
-        <wsa:To soapenv:mustUnderstand="1">http://legalaid.gov.uk/infoX/gateway/ccr</wsa:To>
-      </soapenv:Header>
-      <soapenv:Body>
+        <wsa:Action>newCBOClaim</wsa:Action>
+        <wsa:MessageID>uuid:111-222-333</wsa:MessageID>
+      </env:Header>
+      <env:Body>
         <cbo:claim_request xmlns:cbo="http://www.justice.gov.uk/2016/11/cbo"/>
-      </soapenv:Body>
-    </soapenv:Envelope>
+      </env:Body>
+    </env:Envelope>
     XML
   end
 end


### PR DESCRIPTION
The XML top instruct has been removed, as well as renamed the `soapenv` namespace to `env`.
Some other small changes.