### PR TITLE
Disbursement Adapter

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -124,9 +124,9 @@ class Expense < ActiveRecord::Base
     end
   end
 
-  def laa_bill_sub_type
+  def laa_bill_type_and_sub_type
     raise "Not implemented for LGFS claims" if claim.lgfs?
-    LaaExpenseAdapter.laa_bill_sub_type(self)
+    LaaExpenseAdapter.laa_bill_type_and_sub_type(self)
   end
 
   def expense_type_unique_code=(code)

--- a/app/services/laa_disbursement_adapter.rb
+++ b/app/services/laa_disbursement_adapter.rb
@@ -1,0 +1,44 @@
+class LaaDisbursementAdapter
+
+  TRANSLATION_TABLE = {
+    'ARP' => 'ACCIDENT',
+    'ACC' => 'ACCOUNTANTS',
+    'SWX' => 'COMPUTER_EXPERT',
+    'CMR' => 'CONSULTANT_REP',
+    'CJA' => nil,
+    'CJP' => nil,
+    'DNA' => 'DNA_TESTING',
+    'ENG' => 'ENGINEER',
+    'ENQ' => 'ENQUIRY_AGENTS',
+    'FMX' => 'FACIAL_MAPPING',
+    'FIN' => 'FIN EXPERT',
+    'DIG' => 'FINGERPRINT',
+    'EXP' => 'FIRE_EXPLOSIVES',
+    'FOR' => 'FORENSICS',
+    'HWX' => 'HANDWRITING',
+    'INT' => 'INTERPRETERS',
+    'LIP' => 'LIP_READERS',
+    'MED' => 'MED EXPERT',
+    'MCF' => nil,
+    'MET' => 	'METEOROLOGIST',
+    'XXX' => 'OTHER',
+    'ONX' => 'OVERNIGHT_EXP',
+    'PTH' => 'PATHOLOGISTS',
+    'COP' => 'PHOTOCOPYING',
+    'PSY' => 'PSYCHIATRIC_REP',
+    'PLR' => 'PSYCHO_REPORTS',
+    'ARC' => 'SURVEYOR',
+    'SCR' => 'TRANSCRIPTS',
+    'TRA' => 'TRANSLATOR',
+    'TRV' => 'TRAVEL COSTS',
+    'VET' => 'VET_REPORT',
+    'VOI' => 'VOICE_RECOG'
+  }
+
+  LAA_BILL_TYPE = 'DISBURSEMENT'
+
+  def self.laa_bill_type_and_sub_type(disbursement)
+    sub_type = TRANSLATION_TABLE[disbursement.disbursement_type.unique_code]
+    sub_type.nil? ? nil : [ LAA_BILL_TYPE, sub_type ]
+  end
+end

--- a/app/services/laa_expense_adapter.rb
+++ b/app/services/laa_expense_adapter.rb
@@ -60,11 +60,15 @@ class LaaExpenseAdapter
   }
 
 
+  LAA_BILL_TYPE = 'AGFS_EXPENSES'
 
 
 
-  def self.laa_bill_sub_type(expense)
-    TRANSLATION_TABLE[expense.expense_type.name][expense.reason_id]
+
+
+  def self.laa_bill_type_and_sub_type(expense)
+    subtype = TRANSLATION_TABLE[expense.expense_type.name][expense.reason_id]
+    subtype.nil? ? nil : [ LAA_BILL_TYPE, subtype ]
   end
 
 

--- a/app/services/laa_fee_adapter.rb
+++ b/app/services/laa_fee_adapter.rb
@@ -117,7 +117,7 @@ class LaaFeeAdapter
   }
 
 
-    def laa_bill_type_and_sub_type(fee)
+  def self.laa_bill_type_and_sub_type(fee)
     if fee.fee_type.unique_code  == 'BABAF'
       translate_basic_fee_type(fee)
     else
@@ -126,9 +126,8 @@ class LaaFeeAdapter
   end
 
 
-  private
 
-  def translate_basic_fee_type(fee)
+  def self.translate_basic_fee_type(fee)
     sub_type = BASIC_FEES_MAP[fee.claim.case_type.fee_type_code]
     if sub_type.nil?
       nil
@@ -138,8 +137,10 @@ class LaaFeeAdapter
   end
   
   
-  def translate_fee_type(fee)
+  def self.translate_fee_type(fee)
     FEES_MAP[fee.fee_type.unique_code]
   end
+
+  private_class_method :translate_basic_fee_type, :translate_fee_type
 
 end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -107,10 +107,8 @@ RSpec.describe Expense, type: :model do
       let(:claim) { Claim::AdvocateClaim.new }
 
       it 'calls LaaExpenseAdapter to look up the bill sub type' do
-        # claim = Claim::AdvocateClaim.new
-        # expense = Expense.new(claim: claim)
-        expect(LaaExpenseAdapter).to receive(:laa_bill_sub_type).with(expense).and_return('AGFS_TCT_TRV_CR')
-        expect(expense.laa_bill_sub_type).to eq 'AGFS_TCT_TRV_CR'
+        expect(LaaExpenseAdapter).to receive(:laa_bill_type_and_sub_type).with(expense).and_return(['AGFS_EXPENSES', 'AGFS_TCT_TRV_CR'])
+        expect(expense.laa_bill_type_and_sub_type).to eq(['AGFS_EXPENSES', 'AGFS_TCT_TRV_CR'])
       end
     end
 
@@ -120,7 +118,7 @@ RSpec.describe Expense, type: :model do
 
       it 'raises' do
         expect{
-          expense.laa_bill_sub_type
+          expense.laa_bill_type_and_sub_type
         }.to raise_error RuntimeError, 'Not implemented for LGFS claims'
       end
     end

--- a/spec/services/laa_disbursement_adapter_spec.rb
+++ b/spec/services/laa_disbursement_adapter_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe LaaDisbursementAdapter do
+
+  describe '.laa_bill_type_and_sub_type' do
+    context 'existing LAA disbursements' do
+      it 'returns the correct laa bill type and sub type' do
+        expect(LaaDisbursementAdapter.laa_bill_type_and_sub_type(generate_disbursement('DNA'))).to eq [ 'DISBURSEMENT', 'DNA_TESTING']
+        expect(LaaDisbursementAdapter.laa_bill_type_and_sub_type(generate_disbursement('XXX'))).to eq [ 'DISBURSEMENT', 'OTHER']
+        expect(LaaDisbursementAdapter.laa_bill_type_and_sub_type(generate_disbursement('VOI'))).to eq [ 'DISBURSEMENT', 'VOICE_RECOG']
+      end
+    end
+
+    context 'non-existent LAA disbursements' do
+      it 'returns nil' do
+        expect(LaaDisbursementAdapter.laa_bill_type_and_sub_type(generate_disbursement('CJA'))).to be_nil
+        expect(LaaDisbursementAdapter.laa_bill_type_and_sub_type(generate_disbursement('CJP'))).to be_nil
+        expect(LaaDisbursementAdapter.laa_bill_type_and_sub_type(generate_disbursement('MCF'))).to be_nil
+      end
+    end
+
+
+    def generate_disbursement(code)
+      disbursement_type = double DisbursementType, unique_code: code
+      double Disbursement, disbursement_type: disbursement_type
+    end
+  end
+
+
+end

--- a/spec/services/laa_expense_adapter_spec.rb
+++ b/spec/services/laa_expense_adapter_spec.rb
@@ -12,12 +12,12 @@ describe 'LaaExpenseAdapter' do
 
         it 'translates Car Travel / Court hearing to Travel & Hotel - Car / AGFS_THE_TRV_CR' do
           expense.reason_id = 1
-          expect(expense.laa_bill_sub_type).to eq 'AGFS_THE_TRV_CR'
+          expect(expense.laa_bill_type_and_sub_type).to eq [ 'AGFS_EXPENSES', 'AGFS_THE_TRV_CR']
         end
 
         it 'transates Car Travel / View of crime scene to Conferences & Views - Car	/ AGFS_TCT_TRV_CR' do
           expense.reason_id = 4
-          expect(expense.laa_bill_sub_type).to eq 'AGFS_TCT_TRV_CR'
+          expect(expense.laa_bill_type_and_sub_type).to eq [ 'AGFS_EXPENSES', 'AGFS_TCT_TRV_CR' ]
         end
       end
 
@@ -26,12 +26,12 @@ describe 'LaaExpenseAdapter' do
 
         it 'translates Travel time / Court Hearing into nil' do
           expense.reason_id = 1
-          expect(expense.laa_bill_sub_type).to be_nil
+          expect(expense.laa_bill_type_and_sub_type).to be_nil
         end
 
         it 'translates Travel time / Pre-trial conference defendant to Conferences & Views - Travel Time/ AGFS_TCT_CNF_VW' do
           expense.reason_id = 3
-          expect(expense.laa_bill_sub_type).to eq 'AGFS_TCT_CNF_VW'
+          expect(expense.laa_bill_type_and_sub_type).to eq [ 'AGFS_EXPENSES', 'AGFS_TCT_CNF_VW' ]
         end
       end
     end

--- a/spec/services/laa_fee_adapter_spec.rb
+++ b/spec/services/laa_fee_adapter_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'LaaFeeAdapter' do
   context 'AGFS' do
 
-    let(:adapter) { LaaFeeAdapter.new }
     let(:basic_fee_type) { double Fee::BasicFeeType, unique_code: 'BABAF' }
     let(:basaf_fee_type) { double Fee::BasicFeeType, unique_code: 'BASAF' }
     let(:midth_fee_type) { double Fee::MiscFeeType, unique_code: 'MIDTH' }
@@ -16,33 +15,33 @@ describe 'LaaFeeAdapter' do
 
         it 'returns AGFS_APPEAL_CON for basic fee where case type is Appeal against conviction FXACV' do
           fee = generate_basic_fee_with_claim_and_case_type('FXACV')
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_APPEAL_CON'] )
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_APPEAL_CON'] )
         end
 
         it 'returns AGFS_APPEAL_SEN for basic fee where case type is Appeal against sentence FXASE' do
           fee = generate_basic_fee_with_claim_and_case_type('FXASE')
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_APPEAL_SEN'] )
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_APPEAL_SEN'] )
         end
 
         it 'returns AGFS_ORDER_BRCH for basic fee where case type is Breach of Crown Court order FXCBR' do
           fee = generate_basic_fee_with_claim_and_case_type('FXCBR')
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_ORDER_BRCH'] )
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_ORDER_BRCH'] )
         end
 
         it 'returns AGFS_COMMITTAL for basic fee where case type is Committal for Sentence FXCSE' do
           fee = generate_basic_fee_with_claim_and_case_type('FXCSE')
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_COMMITTAL'] )
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_COMMITTAL'] )
         end
 
         it 'returns nil for basic fee where case type is Contempt FXCON' do
           fee = generate_basic_fee_with_claim_and_case_type('FXCON')
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to be_nil
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to be_nil
         end
 
         it 'returns AGFS_FEE for everything else' do
           %w{ GRRAK  GRCBR GRDIS FXENP GRGLT FXH2S GRRTR GRRTR}.each do |code|
           fee = generate_basic_fee_with_claim_and_case_type(code)
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_FEE'] )
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to eq ( [ 'AGFS_FEE', 'AGFS_FEE'] )
           end
         end
 
@@ -58,19 +57,19 @@ describe 'LaaFeeAdapter' do
       context 'regular fees with counterparts in LAA system' do
         it 'returns the correct code for BASAF' do
           allow(fee).to receive(:fee_type).and_return(basaf_fee_type)
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to eq ([ 'AGFS_MISC_FEES', 'AGFS_STD_APPRNC'])
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to eq ([ 'AGFS_MISC_FEES', 'AGFS_STD_APPRNC'])
         end
 
         it 'returns the correct code for MIDTH' do
           allow(fee).to receive(:fee_type).and_return(midth_fee_type)
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to eq ([ 'AGFS_MISC_FEES', 'AGFS_CONFISC_HF'])
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to eq ([ 'AGFS_MISC_FEES', 'AGFS_CONFISC_HF'])
         end
       end
 
       context 'regular fees with no counterparts in LAA system' do
         it 'returns nil for INWAR fee type' do
           allow(fee).to receive(:fee_type).and_return(inwar_fee_type)
-          expect(adapter.laa_bill_type_and_sub_type(fee)).to be_nil
+          expect(LaaFeeAdapter.laa_bill_type_and_sub_type(fee)).to be_nil
         end
       end
 


### PR DESCRIPTION
This PR adds the class LaaDisbursemenAdapter to translate CCCD disbursement
codes into CCR Bill type and sub types.

This PR also changes the LaaExpenseAdapter and LaaFeeAdapter so that all
three adapters have the same interface.