### PR TITLE
Protect against possible nil values in vat or totals.

### DIFF
--- a/app/presenters/assessment_presenter.rb
+++ b/app/presenters/assessment_presenter.rb
@@ -15,15 +15,24 @@ class AssessmentPresenter < BasePresenter
   end
 
   def vat_amount
-    h.number_to_currency(assessment.vat_amount)
+    h.number_to_currency(assessment_vat_amount)
   end
 
   def total
-    h.number_to_currency(assessment.total || 0)
+    h.number_to_currency(assessment_total)
   end
 
   def total_inc_vat
-    h.number_to_currency((assessment.total || 0) + assessment.vat_amount)
+    h.number_to_currency(assessment_total + assessment_vat_amount)
   end
 
+  private
+
+  def assessment_total
+    assessment.total || 0
+  end
+
+  def assessment_vat_amount
+    assessment.vat_amount || 0
+  end
 end


### PR DESCRIPTION
This fix exception:

https://sentry.service.dsd.io/mojds/private-beta/issues/1930/
```
TypeErrorapp/presenters/assessment_presenter.rb in + at line 26
nil can't be coerced into BigDecimal
```