### PR TITLE
validate Fee types added to a Litigator Final Claim

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -693,4 +693,4 @@ DEPENDENCIES
   zendesk_api (= 1.12.1)
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/app/controllers/external_users/registrations_controller.rb
+++ b/app/controllers/external_users/registrations_controller.rb
@@ -42,12 +42,13 @@ class ExternalUsers::RegistrationsController < Devise::RegistrationsController
 
   def create_external_user
     highest_sup_no = SupplierNumber.last&.id || 1
+    supplier_number = SupplierNumber.new(supplier_number: sprintf('9X%03dX', highest_sup_no))
     provider = Provider.create!(
       name: Faker::Company.name,
       firm_agfs_supplier_number: generate_unique_supplier_number,
       provider_type: 'firm',
       roles: ['agfs', 'lgfs'],
-      lgfs_supplier_numbers: [ SupplierNumber.new(supplier_number: sprintf('9X%03dX', highest_sup_no)) ]
+      lgfs_supplier_numbers: [ supplier_number ]
     )
     external_user = ExternalUser.new(
       provider: provider,

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -53,10 +53,6 @@ class CaseType < ActiveRecord::Base
     graduated_fee_type.nil? ? false : true
   end
 
-  def is_fixed_fee?
-    fixed_fee_type.nil? ? false : true
-  end
-
   # We do not need the D.O.B of the defendant to be requested for case type "Breach of Crown Court order"
   def requires_defendant_dob?
     fee_type_code != 'FXCBR'

--- a/app/validators/fee/fixed_fee_validator.rb
+++ b/app/validators/fee/fixed_fee_validator.rb
@@ -11,6 +11,16 @@ class Fee::FixedFeeValidator < Fee::BaseFeeValidator
 
   private
 
+  def validate_claim
+    super
+    if @record.claim
+      if @record.claim.final?
+        add_error(:claim, 'Graduated fee invalid on fixed fee case types') unless @record.claim.case_type.is_fixed_fee?
+      end
+    end
+  end
+
+
   def validate_quantity
     super if run_base_fee_validators?
   end

--- a/app/validators/fee/graduated_fee_validator.rb
+++ b/app/validators/fee/graduated_fee_validator.rb
@@ -7,6 +7,17 @@ class Fee::GraduatedFeeValidator < Fee::BaseFeeValidator
     ] + super
   end
 
+  private
+
+  def validate_claim
+    super
+    if @record.claim
+      if @record.claim.final?
+        add_error(:claim, 'Fixed fee invalid on non-fixed fee case types') if @record.claim.case_type.is_fixed_fee?
+      end
+    end
+  end
+
   def self.mandatory_fields
     [:claim, :fee_type]
   end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -652,6 +652,18 @@ fee:
       short: You cannot edit this claim
       api: You cannot edit a claim that is not in draft state
 
+  claim:
+    _seq: 05
+    blank:
+      long: You must specify a claim
+      short: Enter claim
+      api: You must specify a claim
+    graduated_fee_fixed_fee_case_type:
+      long: Invalid graduated fee for a Litigator Claim with a fixed-fee case type
+      short: Invalid fee type for this claim
+      api: Invalid graduated fee for a Litigator Claim with a fixed-fee case type
+
+
 #################################################################################
 #                                                                               #
 #   BASIC FEE                                                                   #

--- a/lib/api/api_test_client.rb
+++ b/lib/api/api_test_client.rb
@@ -36,16 +36,34 @@ class ApiTestClient
     TransferClaimTest.new(client: self).test_creation!
   end
 
+  def run_debug_session
+    DebugFinalClaimTest.new(client: self).test_creation!
+  end
+
   def failure
     !@success
   end
 
-  def post_to_endpoint(resource, payload)
+  def post_to_endpoint(resource, payload, debug = false)
     endpoint = RestClient::Resource.new([api_root_url, EXTERNAL_USER_PREFIX, resource].join('/'))
+    if debug
+      puts ">>> POSTING TO #{endpoint} <<<<<"
+      puts payload
+    end
     endpoint.post(payload, {:content_type => :json, :accept => :json}) do |response, _request, _result|
+      if debug
+        puts "<<< RESPONSE #{response.code} <<<<<"
+        puts "<<< #{response.body} "
+        puts " \n"
+      end
       handle_response(response, resource)
       response
     end
+  end
+
+
+  def post_to_endpoint_with_debug(resource, payload)
+    post_to_endpoint(resource, payload, true)
   end
 
   #

--- a/lib/api/claims/base_claim_test.rb
+++ b/lib/api/claims/base_claim_test.rb
@@ -81,23 +81,42 @@ class BaseClaimTest
   end
 
   def defendant_data
-    {
-      "api_key": api_key,
-      "claim_id": claim_uuid,
-      "first_name": "case",
-      "last_name": "management",
-      "date_of_birth": "1979-12-10",
-      "order_for_judicial_apportionment": true,
-    }
+    [
+      {
+        "api_key": api_key,
+        "claim_id": claim_uuid,
+        "first_name": 'Shankura-x',
+        "last_name": 'Terhemen',
+        "date_of_birth": '1979-04-13',
+        "order_for_judicial_apportionment": false,
+      },
+      {
+        "api_key": api_key,
+        "claim_id": claim_uuid,
+        "first_name": 'Tim-x',
+        "last_name": 'Terhemen',
+        "date_of_birth": '1979-04-13',
+        "order_for_judicial_apportionment": false,
+      }
+    ]
+
   end
 
   def representation_order_data(defendant_uuid)
-    {
-      "api_key": api_key,
-      "defendant_id": defendant_uuid,
-      "maat_reference": "4546963741",
-      "representation_order_date": "2015-05-21"
-    }
+    [
+      {
+        "api_key": api_key,
+        "defendant_id": defendant_uuid,
+        "maat_reference": '1012345',
+        "representation_order_date": '2016-10-22'
+      },
+      {
+        "api_key": api_key,
+        "defendant_id": defendant_uuid,
+        "maat_reference": '1012345',
+        "representation_order_date": '2016-10-22'
+      }
+    ]
   end
 
   def date_attended_data(attended_item_uuid, attended_item_type)

--- a/lib/api/claims/debug_final_claim_test.rb
+++ b/lib/api/claims/debug_final_claim_test.rb
@@ -1,0 +1,117 @@
+require_relative 'base_claim_test'
+
+class DebugFinalClaimTest < BaseClaimTest
+
+  def test_creation!
+    puts 'starting'
+
+    # create a claim
+    endpoint = 'claims/final'
+    puts ">>>>>>>>>>>>>> POSTING CLAIM DATA TO #{endpoint} #{__FILE__}:#{__LINE__} <<<<<<<<<<<<<<<<<\n"
+    puts claim_data
+    response = client.post_to_endpoint('claims/final', claim_data)
+    puts ">>>>>>>>>>>>>> response from #{endpoint} #{__FILE__}:#{__LINE__} <<<<<<<<<<<<<<<<<\n"
+    puts response
+    return if client.failure
+
+    self.claim_uuid = id_from_json(response)
+
+    # add a defendant & rep order
+    defendant_data.each_with_index do |defendant_data, index|
+      response = client.post_to_endpoint_with_debug('defendants', defendant_data)
+      defendant_id = id_from_json(response)
+      client.post_to_endpoint_with_debug('representation_orders', representation_order_data(index, defendant_id))
+    end
+
+
+    # CREATE fees
+    [
+      {
+        fee_type_id: 77,
+        amount: 8153.22,
+        quantity: 1250,
+        date: Date.new(2016, 10, 22)
+      },
+      { fee_type_id: 27,
+        amount: 1630.64,
+        quantity: nil,
+        date: Date.new(2016, 10, 22)
+
+      }
+    ].each do |fee_data|
+      client.post_to_endpoint_with_debug('fees', fee_data.merge(api_key: api_key, claim_id: claim_uuid).to_json)
+    end
+
+
+    # add expense
+    client.post_to_endpoint_with_debug('expenses', expense_data(role: 'lgfs'))
+
+    # CREATE a disbursement
+    client.post_to_endpoint_with_debug('disbursements', disbursement_data)
+  end
+
+
+  def claim_data
+    case_type_id = json_value_at_index(client.get_dropdown_endpoint(CASE_TYPE_ENDPOINT, api_key, {role: 'lgfs'}), 'id', 12) # Trial
+    offence_id = json_value_at_index(client.get_dropdown_endpoint(OFFENCE_ENDPOINT, api_key, {offence_description: 'Solicitation for immoral purposes'}), 'id')
+    court_id = json_value_at_index(client.get_dropdown_endpoint(COURT_ENDPOINT, api_key), 'id')
+
+    {
+      "api_key": api_key,
+      "creator_email": 'litigatoradmin@example.com',
+      "user_email": 'litigator@example.com',
+      "case_number": 'T20160111',
+      "providers_ref": SecureRandom.uuid[3..15].upcase,
+      "supplier_number": supplier_number,
+      "case_type_id": case_type_id,
+      "offence_id": offence_id,
+      "court_id": court_id,
+      "cms_number": 'LGFS API 7',
+      "additional_information": 'This is the text case entered via rake api:specific',
+      "case_concluded_at":'2016-11-22',
+      "actual_trial_length": 10
+    }
+  end
+
+  def defendant_data
+    [
+      {
+        "api_key": api_key,
+        "claim_id": claim_uuid,
+        "first_name": 'Shankura-x',
+        "last_name": 'Terhemen',
+        "date_of_birth": '1979-04-13',
+        "order_for_judicial_apportionment": false,
+      },
+      {
+        "api_key": api_key,
+        "claim_id": claim_uuid,
+        "first_name": 'Tim-x',
+        "last_name": 'Terhemen',
+        "date_of_birth": '1979-04-13',
+        "order_for_judicial_apportionment": false,
+      }
+    ]
+
+  end
+
+  def representation_order_data(index, defendant_uuid)
+    raw_data = [
+      {
+        "api_key": api_key,
+        "defendant_id": defendant_uuid,
+        "maat_reference": '1012345',
+        "representation_order_date": '2016-10-22'
+      },
+      {
+        "api_key": api_key,
+        "defendant_id": defendant_uuid,
+        "maat_reference": '1012345',
+        "representation_order_date": '2016-10-22'
+      }
+    ]
+    raw_data[index]
+  end
+
+
+end

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -39,6 +39,24 @@ namespace :api do
 
   end
 
+
+
+  desc 'Run specific api test to reproduce reported bugs'
+  task :debug => :environment do
+    require "#{Rails.root.join('lib','api','api_test_client')}"
+    api_client = ApiTestClient.new
+    api_client.run_debug_session
+
+    if api_client.success
+      puts "[+] success"
+      puts api_client.messages.join("\n")
+    else
+      puts "[-] errors"
+      puts api_client.full_error_messages.join("\n")
+      raise "API Error: ADP RESTful API smoke test failure!"
+    end
+  end
+
   desc 'display useful api keys in dev'
   task :keys => :environment do
     if Rails.env.development?


### PR DESCRIPTION
Litigator Final claims for fixed fee case types can only have fixed fees added to them, not graduated.  Similarly, claims for non-fixed fee case types can only have graduated fees added to them, not fixed.  

This PR adds that validation, which prevents fees of the wrong type being added through the API.