### PR TITLE
API: Include 'requires_case_conclusion' in result set for transfer st…

### DIFF
--- a/app/models/claim/transfer_brain.rb
+++ b/app/models/claim/transfer_brain.rb
@@ -7,14 +7,16 @@
 module Claim
   class TransferBrain
 
+    Struct.new('TransferStage', :id, :description, :requires_case_conclusion)
+
     TRANSFER_STAGES = {
-      10 => 'Up to and including PCMH transfer',
-      20 => 'Before trial transfer',
-      30 => 'During trial transfer',
-      40 => 'Transfer after trial and before sentence hearing',
-      50 => 'Transfer before retrial',
-      60 => 'Transfer during retrial',
-      70 => 'Transfer after retrial and before sentence hearing',
+      10 => Struct::TransferStage.new(10, 'Up to and including PCMH transfer', true),
+      20 => Struct::TransferStage.new(20, 'Before trial transfer', true),
+      30 => Struct::TransferStage.new(30, 'During trial transfer', true),
+      40 => Struct::TransferStage.new(40, 'Transfer after trial and before sentence hearing', false),
+      50 => Struct::TransferStage.new(50, 'Transfer before retrial', true),
+      60 => Struct::TransferStage.new(60, 'Transfer during retrial', true),
+      70 => Struct::TransferStage.new(70, 'Transfer after retrial and before sentence hearing', false)
     }
 
     CASE_CONCLUSIONS = {
@@ -31,10 +33,10 @@ module Claim
       name
     end
 
-    def self.transfer_stage_id(name)
-      id = TRANSFER_STAGES.key(name)
-      raise ArgumentError.new "No such transfer stage: '#{name}'" if id.nil?
-      id
+    def self.transfer_stage_id(description)
+      transfer_stage = TRANSFER_STAGES.values.detect{ |ts| ts.description == description }
+      raise ArgumentError.new "No such transfer stage: '#{description}'" if transfer_stage.nil?
+      transfer_stage.id
     end
 
     def self.transfer_stage_ids
@@ -80,7 +82,7 @@ module Claim
     def self.case_conclusion_required?(detail)
       detail.litigator_type == 'new' &&
         detail.elected_case == false && # treat nil as failure i.e. non-false
-        [10,20,30,50,60].include?(detail.transfer_stage_id)
+          TRANSFER_STAGES[detail.transfer_stage_id].requires_case_conclusion
     end
 
   end

--- a/app/presenters/claim/transfer_claim_presenter.rb
+++ b/app/presenters/claim/transfer_claim_presenter.rb
@@ -25,7 +25,7 @@ class Claim::TransferClaimPresenter < Claim::BaseClaimPresenter
   end
 
   def transfer_stage_description
-    Claim::TransferBrain.transfer_stage_by_id(claim.transfer_stage_id) || ''
+    Claim::TransferBrain.transfer_stage_by_id(claim.transfer_stage_id).description || ''
   end
 
   def transfer_date

--- a/app/views/external_users/claims/transfer_fee/_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_fields.html.haml
@@ -22,6 +22,4 @@
                                 value: number_with_precision(tf.object.amount, precision: 2),
                                 errors: @error_presenter,
                                 error_key: 'transfer_fee.amount'
-
-
   = render partial: 'external_users/claims/transfer_fee/detail_fields', locals: { f: f }

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -3,6 +3,20 @@
 %section.api-documentation
 
   %hr
+  %h1 30 November 2016
+  %ul.list-bullet
+    %li
+      Transfer Stages result set updated
+
+      The result set returned from /api/transfer_stages now includes an additional field, 'requires_case_conclusion'
+      which will be either true or false.  If true, a Litigator Transfer Claim submitted with that transfer_stage_id
+      MUST also specify a case_conclusion_id.  If false, the case_conclusion_id MUST NOT be specified.
+
+      There is no change to the validation of transfer claims; the addition of this field is to make it clear to API
+      developers when a case conclusion id is or is not required.
+
+  %p
+  %hr
   %h1 November 2016
   %ul.list-bullet
     %li

--- a/spec/api/v1/external_users/claims/transfer_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/transfer_claim_spec.rb
@@ -53,7 +53,8 @@ describe API::V1::ExternalUsers::Claims::TransferClaim do
     end
   end
 
-  describe "POST #{ClaimApiEndpoints.for(:transfer).validate}" do
+
+  describe 'POST /api/external_users/claims/transfer/valid' do
 
     def post_to_validate_endpoint
       post ClaimApiEndpoints.for(:transfer).validate, valid_params, format: :json
@@ -69,7 +70,7 @@ describe API::V1::ExternalUsers::Claims::TransferClaim do
 
     context 'invalid API key' do
 
-      include_examples "invalid API key validate endpoint"
+      include_examples 'invalid API key validate endpoint'
 
       it "should return 401 and JSON error array when it is an API key from another provider's admin" do
         valid_params[:api_key] = other_provider.api_key
@@ -98,7 +99,7 @@ describe API::V1::ExternalUsers::Claims::TransferClaim do
     end
   end
 
-  describe "POST #{ClaimApiEndpoints.for(:transfer).create}" do
+  describe "/api/external_users/claims/transfer" do
 
     def post_to_create_endpoint
       post ClaimApiEndpoints.for(:transfer).create, valid_params, format: :json

--- a/spec/models/claim/transfer_brain_spec.rb
+++ b/spec/models/claim/transfer_brain_spec.rb
@@ -5,7 +5,7 @@ module Claim
 
     describe '.transfer_stage_by_id' do
       it 'returns the name of the transfer_stage with that id' do
-        expect(TransferBrain.transfer_stage_by_id(50)).to eq 'Transfer before retrial'
+        expect(TransferBrain.transfer_stage_by_id(50).description).to eq 'Transfer before retrial'
       end
 
       it 'raises if invalid id given' do

--- a/spec/presenters/transfer_claim_presenter_spec.rb
+++ b/spec/presenters/transfer_claim_presenter_spec.rb
@@ -16,18 +16,6 @@ RSpec.describe Claim::TransferClaimPresenter do
     expect(presenter.can_have_disbursements?).to eq(true)
   end
 
-  let(:transfer_stages) do
-    {
-      '10' => 'Up to and including PCMH transfer',
-      '20' => 'Before trial transfer',
-      '30' => 'During trial transfer',
-      '40' => 'Transfer after trial and before sentence hearing',
-      '50' => 'Transfer before retrial',
-      '60' => 'Transfer during retrial',
-      '70' => 'Transfer after retrial and before sentence hearing'
-    }
-  end
-
   let(:case_conclusions) do
     {
       '10' => 'Trial',
@@ -36,12 +24,6 @@ RSpec.describe Claim::TransferClaimPresenter do
       '40' => 'Cracked before retrial',
       '50' => 'Guilty plea'
     }
-  end
-
-  context '#transfer_stages' do
-    it 'returns a hash of transfer stage descriptions and ids' do
-      expect(presenter.transfer_stages).to match transfer_stages
-    end
   end
 
   context '#case_conclusions' do


### PR DESCRIPTION
The API endpoint to list transfer stages now includes an indication as to whether or not a case conclusion id should be specified.