### PR TITLE
Responsive tables breakpoint

### DIFF
--- a/app/assets/stylesheets/moj/_tables.scss
+++ b/app/assets/stylesheets/moj/_tables.scss
@@ -119,7 +119,7 @@ span.state {
 tr.mobile-sort{
   display:none;
 }
- @include media($max-width: 1023px){
+ @include media($max-width: 1018px){
     table.report {
     border: 0;
     tr {


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/135532289

**What is the issue**
The responsive tables breakpoint has a few pixels margin of error. The list appears when it should not.

**What this PR does**
Setting the breakpoint to 1018px that will leave a larger margin of error to 1024px