### PR TITLE
Fee date validation changes

### DIFF
--- a/app/models/date_attended.rb
+++ b/app/models/date_attended.rb
@@ -29,6 +29,10 @@ class DateAttended < ActiveRecord::Base
     claim.try(:perform_validation?)
   end
 
+  def earliest_date_before_reporder
+    attended_item.try(:claim).try(:earliest_representation_order).try(:representation_order_date)
+  end
+
   def to_s
     return '' if date.nil?
     unless date_to.nil?

--- a/app/validators/date_attended_validator.rb
+++ b/app/validators/date_attended_validator.rb
@@ -12,11 +12,11 @@ class DateAttendedValidator < BaseValidator
   # must be present
   # must not be in the future
   # must not be before 1st day of trial
-  # must not be before 1st reporder date
+  # must not be earlier than 2 years before the first rep order date
   # must not be before the earliest_permitted_date
   def validate_date
     validate_presence(:date, 'blank')
-    validate_not_before(@record.attended_item.claim.try(:earliest_representation_order).try(:representation_order_date), :date, 'not_before_earliest_representation_order_date')
+    validate_not_before(@record.earliest_date_before_reporder - 2.years, :date, 'too_long_before_earliest_reporder')
     validate_not_before(Settings.earliest_permitted_date, :date, 'not_before_earliest_permitted_date')
   end
 

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -157,7 +157,7 @@ private
 
   def validate_single_attendance_date
     validate_presence(:date, 'blank')
-    validate_not_before(@record.claim.try(:earliest_representation_order).try(:representation_order_date), :date, 'not_before_earliest_representation_order_date')
+    validate_not_before(@record.claim.try(:earliest_representation_order).try(:representation_order_date), :date, 'too_long_before_earliest_reporder')
     validate_not_before(Settings.earliest_permitted_date, :date, 'check_not_too_far_in_past')
     validate_not_after(Date.today, :date, 'check_not_in_future')
   end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -969,10 +969,10 @@ fixed_fee:
       long: Check the fixed fee date
       short: *too_far_in_past
       api: Check the fixed fee date
-    not_before_earliest_representation_order_date:
-      long: The fixed fee date must be after the earliest representation order date
+    too_long_before_earliest_reporder:
+      long: The fixed fee date must be no earlier than two years before the earliest representation order date
       short: *enter_valid_date
-      api: The fixed fee date must be after the earliest representation order date
+      api: The fixed fee date must be no earlier than two years before the earliest representation order date
 
 #################################################################################
 #                                                                               #
@@ -1259,14 +1259,14 @@ date_attended:
       long: 'Enter the #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense}'
       short: *enter_date
       api: 'Enter the date attended (from)'
-    not_before_earliest_representation_order_date:
-      long: 'The #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} is invalid'
-      short: Enter a date after the earliest representation order date
-      api: The date attended (from) must be after the earliest representation order date
+    too_long_before_earliest_reporder:
+      long: The fixed fee date must not be more than two years before the earliest representation order date
+      short: *enter_valid_date
+      api: The fixed fee date must not be more than two years before the earliest representation order date
     not_before_earliest_permitted_date:
-      long: 'The #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} is more than 5 years ago'
-      short: Enter a date less than 5 years ago
-      api: The date attended (from) must be less than 5 years ago
+      long: 'The #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} is invalid'
+      short: Enter a date later than two years before the earliest representation order date
+      api: The date attended (from) must be later than two years before the earliest representation order date
     invalid_date:
       long: 'Enter a valid date for the #{date_attended} (from) of the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense}'
       short: *enter_valid_date
@@ -1411,10 +1411,10 @@ graduated_fee:
       long: Check the graduated fee date
       short: *too_far_in_past
       api: Check the graduated fee date
-    not_before_earliest_representation_order_date:
-      long: The fixed fee date must be after the earliest representation order date
+    too_long_before_earliest_reporder:
+      long: The fixed fee date must be no earlier than two years before the earliest representation order date
       short: *enter_valid_date
-      api: The fixed fee date must be after the earliest representation order date
+      api: The fixed fee date must be no earlier than two years before the earliest representation order date
 
 #################################################################################
 #                                                                               #

--- a/spec/validators/date_attended_validator_spec.rb
+++ b/spec/validators/date_attended_validator_spec.rb
@@ -24,8 +24,13 @@ describe DateAttendedValidator do
 
   context 'date' do
     it { should_error_if_not_present(date_attended, :date, 'blank') }
-    it { should_error_if_before_specified_date(date_attended, :date, earliest_reporder_date, 'not_before_earliest_representation_order_date') }
+    it { should_error_if_before_specified_date(date_attended, :date, earliest_reporder_date - 2.years - 1.day, 'too_long_before_earliest_reporder') }
     it { should_error_if_too_far_in_the_past(date_attended, :date, 'not_before_earliest_permitted_date') }
+    it 'should not error if less than two years before earliest rep order date' do
+      date_attended.date = earliest_reporder_date - 369.days
+      date_attended.date_to = nil
+      expect(date_attended).to be_valid
+    end
   end
 
   context 'date to' do

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -403,5 +403,5 @@ describe Fee::BaseFeeValidator do
     end
 
   end
-
+  
 end

--- a/spec/validators/fee/shared_examples_for_fee_validators_spec.rb
+++ b/spec/validators/fee/shared_examples_for_fee_validators_spec.rb
@@ -21,7 +21,7 @@ shared_examples 'common fee date validations' do
 
       fee.date = Date.today - 3.days
       expect(fee).not_to be_valid
-      expect(fee.errors[:date]).to include 'not_before_earliest_representation_order_date'
+      expect(fee.errors[:date]).to include 'too_long_before_earliest_reporder'
     end
   end
 end


### PR DESCRIPTION
Amend Fee and expense date validation to allow up to 2 years before earliest reporder date