### PR TITLE
Remove n+1 query from claims

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -53,9 +53,9 @@ class Assessment < Determination
   end
 
   def update_values!(fees, expenses, disbursements, time = Time.now)
-    self.fees = fees
-    self.expenses = expenses
-    self.disbursements = disbursements
+    self.fees = fees unless fees.nil?
+    self.expenses = expenses unless expenses.nil?
+    self.disbursements = disbursements unless disbursements.nil?
     self.created_at = time
     save!
   end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -159,8 +159,11 @@ module Claim
 
     after_initialize :ensure_not_abstract_class,
                      :default_values,
-                     :instantiate_assessment,
                      :set_force_validation_to_false
+
+    before_create do
+      self.build_assessment if self.assessment.nil?
+    end
 
     after_save :find_and_associate_documents, :update_vat
 
@@ -194,6 +197,11 @@ module Claim
       else
         raise 'unknown filter: %s' % filter
       end
+    end
+
+    def set_amount_assessed(options)
+      self.build_assessment if self.assessment.nil?
+      self.assessment.update_values(options[:fees], options[:expenses], options[:disbursements])
     end
 
     def pretty_type
@@ -433,8 +441,5 @@ module Claim
       self.form_step ||= 1
     end
 
-    def instantiate_assessment
-      self.build_assessment if self.assessment.nil?
-    end
   end
 end

--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -57,6 +57,17 @@ class Determination < ActiveRecord::Base
     !blank?
   end
 
+  def to_s
+    "  id:            #{id}\n" +
+    "  type           #{type}\n" +
+    "  claim_id:      #{claim_id}\n" +
+    "  expenses:      #{expenses.to_s}\n" +
+    "  fees:          #{fees.to_s}\n" +
+    "  disbursements: #{disbursements.to_s}\n" +
+    "  vat_amount:    #{vat_amount.to_s}\n" +
+    "  total:         #{total}\n\n"
+  end
+
   private
 
   def fees_valid

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -1,14 +1,26 @@
-FactoryGirl.define do
-  factory :assessment do
-    claim         { FactoryGirl.create :claim, :without_assessment }
-    fees          250.33
-    expenses      845.89
-    disbursements 150.00
 
-    trait :blank do
-      fees 0
-      expenses 0
-      disbursements 0
+# creates a claim and associated assessment
+#
+FactoryGirl.define do
+
+  factory :assessment do
+    skip_create
+
+    initialize_with do
+      claim = create :submitted_claim
+      claim.assessment
+    end
+
+    trait :random_amounts do
+      expenses { rand(0.0..999.99).round(2) }
+      fees { rand(0.0..999.99).round(2) }
+      disbursements { rand(0.0..999.99).round(2) }
+    end
+
+    # saving makes sure we update the total
+    after(:create) do |assessment|
+      assessment.save!
     end
   end
+
 end

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -145,7 +145,7 @@ def random_case_number
 end
 
 def set_amount_assessed(claim)
-  claim.assessment.update(fees: random_amount, expenses: random_amount)
+  claim.set_amount_assessed(fees: random_amount, expenses: random_amount)
 end
 
 def random_amount

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -70,7 +70,8 @@ describe Assessment do
 
   context 'automatic calculation of total' do
     it 'should calculate the total on save' do
-      ass = FactoryGirl.create :assessment
+      ass = create :assessment, expenses: 102.33, fees: 44.86
+      ass = claim.assessment
       expect(ass.total).to eq(ass.fees + ass.expenses + ass.disbursements)
     end
   end
@@ -98,7 +99,7 @@ describe Assessment do
 
   context '#zeroize!' do
     it 'should zeroize values and save' do
-      assessment = FactoryGirl.create :assessment
+      assessment = FactoryGirl.create :assessment, :random_amounts
       expect(assessment.fees).not_to eq 0
       expect(assessment.expenses).not_to eq 0
       expect(assessment.disbursements).not_to eq 0
@@ -115,14 +116,14 @@ describe Assessment do
 
   describe '.update' do
     it 'should raise error if assessment not blank' do
-      assessment = create :assessment
+      assessment = create :assessment, expenses: 1, fees: 2, disbursements: 3
       expect {
         assessment.update_values(100.00, 200.22, 150.00, DateTime.new(2016, 1, 2, 3, 4, 5))
       }.to raise_error RuntimeError, "Cannot update a non-blank assessment"
     end
 
     it 'should update the fields' do
-      assessment = create :assessment, :blank
+      assessment = create :assessment
       assessment.update_values(888.88, 333.33, 150.00, DateTime.new(2016, 1, 2, 3, 4, 5))
       assessment.reload
       expect(assessment.fees).to eq 888.88

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Claims::Cloner, type: :model do
         expect(@cloned_claim.redeterminations.count).to eq(0)
 
         expect(@original_claim.assessment.nil?).to eq(false)
-        expect(@cloned_claim.assessment.nil?).to eq(true)
+        expect(@cloned_claim.assessment.zero?).to eq(true)
       end
 
       it 'does not clone certifications' do

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -286,10 +286,10 @@ describe Claim::BaseClaimValidator do
   context 'amount_assessed' do
     before { claim.submit!; claim.allocate! }
 
-    let(:assessed_claim)  {
-     claim.assessment = FactoryGirl.build(:assessment, claim: claim)
-     claim
-    }
+    let(:assessed_claim)  do
+      claim.set_amount_assessed(fees: 101.22, expenses: 28.55, disbursements: 92.66)
+      claim
+    end
 
     it 'should NOT error if assessment provided prior to authorise! or part_authorise! transistions' do
       expect{ assessed_claim.authorise! }.to_not raise_error


### PR DESCRIPTION
There was an after_initialize callback on Claim::BaseClaim that instantiated an
assessment if not already there.  This meant that when finding a collection of
claims, an query was made to get the assessment for each claim in the collection.

This PR replace that with an after_save hook to create a blank assessment when
the claim is created, and rewrite the assessment factory to cater for this.