### PR TITLE
Add VAT totals for fees, disbursements and expenses on claim records

### DIFF
--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -8,55 +8,59 @@ module Claims::Calculations
     end
   end
 
+  # returns totals for all klass records belonging to the named claim
+  # params:
+  # * klass: The class to be totaled
+  # * claim_id: the id of the claim
+  # * net_attribute: the name of the attribute holding the net amount to be summed
+  # * vat_attribute: the name of the attribute holding the vat amount to be summed
+  def totalize_for_claim(klass, claim_id, net_attribute, vat_attribute)
+    values = klass.where(claim_id: claim_id).where("#{net_attribute} IS NOT NULL").pluck(vat_attribute, net_attribute)
+    { vat: values.map(&:first).sum, net: values.map(&:last).sum }
+  end
+
   def calculate_expenses_total
-    # #reload prevents cloning
     Expense.where(claim_id: self.id).where.not(amount: nil).pluck(:amount).sum
   end
 
-  def calculate_disbursements_total
-    # #reload prevents cloning
-    Disbursement.where(claim_id: self.id).where.not(net_amount: nil).pluck(:net_amount).sum
-  end
-
   def calculate_total
-    calculate_fees_total + calculate_expenses_total + calculate_disbursements_total
+    a = self.fees_total
+    b = self.expenses_total
+    c = self.disbursements_total
+    a + b + c
   end
 
   def update_fees_total
     update_column(:fees_total, calculate_fees_total)
+    update_column(:fees_vat, calculate_fees_vat)
   end
 
   def update_expenses_total
-    update_column(:expenses_total, calculate_expenses_total)
+    totals = totalize_for_claim(Expense, self.id, :amount, :vat_amount)
+    update_column(:expenses_total, totals[:net])
+    update_column(:expenses_vat, totals[:vat])
   end
 
   def update_disbursements_total
-    update_column(:disbursements_total, calculate_disbursements_total)
+    totals = totalize_for_claim(Disbursement, self.id, :net_amount, :vat_amount)
+    update_column(:disbursements_vat, totals[:vat])
+    update_column(:disbursements_total, totals[:net])
   end
 
   def update_total
     update_column(:total, calculate_total)
   end
 
-  def calculate_expenses_vat
-    if lgfs?
-      Expense.where(claim_id: self.id).where.not(vat_amount: nil).pluck(:vat_amount).sum
-    else
-      VatRate.vat_amount(calculate_expenses_total, self.vat_date, calculate: self.apply_vat?)
-    end
-  end
-
   def calculate_fees_vat
-    VatRate.vat_amount(calculate_fees_total, self.vat_date, calculate: self.apply_vat?)
+    VatRate.vat_amount(self.fees_total, self.vat_date, calculate: self.apply_vat?)
   end
 
   def calculate_disbursements_vat
-    # #reload prevents cloning
     Disbursement.where(claim_id: self.id).where.not(vat_amount: nil).pluck(:vat_amount).sum
   end
 
   def calculate_total_vat
-    calculate_expenses_vat + calculate_fees_vat + calculate_disbursements_vat
+    self.vat_amount = self.expenses_vat + self.fees_vat + self.disbursements_vat
   end
 
   def update_vat

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -53,7 +53,7 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def case_type_name
-    case_type&.name || 'n/a'
+    case_type.name
   end
 
   def scheme

--- a/app/validators/expense_v2_validator.rb
+++ b/app/validators/expense_v2_validator.rb
@@ -36,11 +36,7 @@ class ExpenseV2Validator < BaseValidator
   end
 
   def validate_vat_amount
-    if @record.claim.lgfs?
-      validate_vat_numericality(:vat_amount, lower_than_field: :amount)
-    else
-      validate_absence_or_zero(:vat_amount, 'invalid')
-    end
+    validate_vat_numericality(:vat_amount, lower_than_field: :amount)
   end
 
   def validate_location

--- a/db/migrate/20161209113727_add_vat_amounts_to_claims.rb
+++ b/db/migrate/20161209113727_add_vat_amounts_to_claims.rb
@@ -1,0 +1,7 @@
+class AddVatAmountsToClaims < ActiveRecord::Migration
+  def change
+    add_column :claims, :fees_vat, :decimal, default: 0.0
+    add_column :claims, :expenses_vat, :decimal, default: 0.0
+    add_column :claims, :disbursements_vat, :decimal, default: 0.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161206103052) do
+ActiveRecord::Schema.define(version: 20161209113727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,9 @@ ActiveRecord::Schema.define(version: 20161206103052) do
     t.datetime "deleted_at"
     t.string   "providers_ref"
     t.boolean  "disk_evidence",            default: false
+    t.decimal  "fees_vat",                 default: 0.0
+    t.decimal  "expenses_vat",             default: 0.0
+    t.decimal  "disbursements_vat",        default: 0.0
   end
 
   add_index "claims", ["case_number"], name: "index_claims_on_case_number", using: :btree

--- a/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
@@ -399,8 +399,6 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
 
       it 'renders edit template' do
         put :update, id: subject, claim: { additional_information: 'foo', court_id: nil }, commit_continue: 'Submit to LAA'
-        puts response.status
-        puts response.body
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -34,7 +34,10 @@ FactoryGirl.define do
     end
 
     trait :without_fees do
-      after(:build) { |claim| make_claim_creator_advocate_admin(claim) }
+      after(:build) do |claim|
+        make_claim_creator_advocate_admin(claim)
+        claim.fees.clear
+      end
     end
 
 

--- a/spec/factories/claim/claim_factory_helpers.rb
+++ b/spec/factories/claim/claim_factory_helpers.rb
@@ -40,7 +40,7 @@ module ClaimFactoryHelpers
   end
 
   def make_claim_creator_advocate_admin(claim)
-    advocate_admin = claim.external_user.provider.external_users.where(role:'admin').sample
+    advocate_admin = claim.external_user.provider.external_users.admins.sample
     advocate_admin ||= create(:external_user, :admin, provider: claim.external_user.provider)
     claim.creator = advocate_admin
   end

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1043,7 +1043,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       allow(VatRate).to receive(:vat_amount).and_return(10)
       claim = FactoryGirl.build :unpersisted_claim, total: 100
       claim.submit!
-      expect(claim.vat_amount).to eq 20
+      expect(claim.vat_amount).to eq 10
     end
 
     it 'should zeroise the vat amount if vat is not applied' do

--- a/spec/models/claims/totals_spec.rb
+++ b/spec/models/claims/totals_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Claim, type: :model do
 
       it 'calculates the claim expenses VAT' do
         # rate 17.5, see rails_helper
-        expect(subject.calculate_expenses_vat).to eq(25.64)
+        expect(subject.expenses_vat).to eq(25.64)
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Claim, type: :model do
       let!(:expenses) { [3.5, 1.0, 142.0].each { |amount| create(:expense, claim_id: subject.id, amount: amount, vat_amount: 2) } }
 
       it 'calculates the claim expenses VAT' do
-        expect(subject.calculate_expenses_vat).to eq(6.0)
+        expect(subject.expenses_vat).to eq(6.0)
       end
     end
   end
@@ -90,7 +90,8 @@ RSpec.describe Claim, type: :model do
 
     describe '#calculate_total' do
       it 'calculates the fees and expenses total' do
-        create(:expense, claim_id: subject.id, amount: 3)
+        create(:expense, claim_id: subject.id, amount: 3.0)
+        subject.reload
         expect(subject.calculate_total).to eq(174.5)
       end
     end
@@ -109,6 +110,118 @@ RSpec.describe Claim, type: :model do
         subject.reload
         expect(subject.total).to eq(143.00)
       end
+    end
+  end
+
+  context 'combined totals spec' do
+    context 'LGFS' do
+      context 'with VAT' do
+        it 'should add totals and calculate VAT as and when submodels are added or removed' do
+          claim = create :litigator_claim, :without_fees
+          allow(claim).to receive(:vat_registered?).and_return(true)
+          claim.apply_vat = true
+          expect(claim.vat_registered?).to be true
+          expect_totals_to_be(claim, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+          # add misc fees for 31.5, and 6.25 - VAT should be added in
+          claim.fees << create(:misc_fee, rate: 10.5, quantity: 3)
+          claim.fees << create(:misc_fee, rate: 6.25, quantity: 1)
+          claim.save!
+          expect_totals_to_be(claim, 0.0, 0.0, 37.75, 6.61, 0.0, 0.0)  # VAT £6.61 calculated using the test VAT rate of 17.5%
+
+          # add expenses for 9.99
+          claim.expenses << create(:expense, amount: 9.99, vat_amount: 1.75)
+          expect_totals_to_be(claim, 9.99, 1.75, 37.75, 6.61, 0.0, 0.0)
+
+          # add disbursements for 55.33 & 100
+          claim.disbursements << create(:disbursement, claim: claim, net_amount: 55.33, vat_amount: 9.68)
+          claim.disbursements << create(:disbursement, claim: claim, net_amount: 100.0, vat_amount: 10.0)
+          expect_totals_to_be(claim, 9.99, 1.75, 37.75, 6.61, 155.33, 19.68)
+
+          # remove the fee for 31.5
+          claim.fees.detect{ |f| f.amount == 31.5 }.destroy
+          expect_totals_to_be(claim, 9.99, 1.75, 6.25, 1.09, 155.33, 19.68)
+
+          # remove the disbursement for 100
+          claim.disbursements.detect{ |d| d.net_amount == 100.0 }.destroy
+          expect_totals_to_be(claim, 9.99, 1.75, 6.25, 1.09, 55.33, 9.68)
+
+          claim.expenses.first.destroy
+          expect_totals_to_be(claim, 0.0, 0.0, 6.25, 1.09, 55.33, 9.68)
+        end
+      end
+
+      context 'without VAT' do
+        it 'should add totals with explicit VAT amounts for expenses and disbursements as and when submodels are added or removed' do
+          claim = create :litigator_claim, :without_fees
+          allow(claim).to receive(:vat_registered?).and_return(false)
+          claim.apply_vat = false
+          expect_totals_to_be(claim, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+          # add misc fees for 31.5, and 6.25 - VAT should not be added in
+          claim.fees << create(:misc_fee, rate: 10.5, quantity: 3)
+          claim.fees << create(:misc_fee, rate: 6.25, quantity: 1)
+          claim.save!
+          expect_totals_to_be(claim, 0.0, 0.0, 37.75, 0.0, 0.0, 0.0)
+
+          # add expenses for 9.99 with specific vat amount
+          claim.expenses << create(:expense, claim: claim, amount: 9.99, vat_amount: 0.45)
+          expect_totals_to_be(claim, 9.99, 0.45, 37.75, 0.0, 0.0, 0.0)
+
+          # add disbursements for 55.33 & 100 with specific VAT amounts
+          claim.disbursements << create(:disbursement, claim: claim, net_amount: 55.33, vat_amount: 2.35)
+          claim.disbursements << create(:disbursement, claim: claim, net_amount: 100.0, vat_amount: 4.00)
+          expect_totals_to_be(claim, 9.99, 0.45, 37.75, 0.0, 155.33, 6.35)
+        end
+      end
+    end
+
+    context 'AGFS' do
+      context 'with VAT' do
+        it 'should automatically add VAT' do
+          claim = create :advocate_claim, :without_fees
+          allow(claim).to receive(:vat_registered?).and_return(true)
+          claim.apply_vat = true
+          expect_totals_to_be(claim, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+          # add basic fee and VAT should be calculated and added in
+          claim.basic_fees << create(:basic_fee, claim: claim, quantity: 1, rate: 200)
+          expect_totals_to_be(claim, 0.0, 0.0, 200.0, 35.0, 0.0, 0.0)   # VAT £35.00 calculated using the test VAT rate of 17.5%
+
+          # add expense and VAT should be calculated and added in
+          claim.expenses << create(:expense, claim: claim, amount: 9.99)
+          expect_totals_to_be(claim, 9.99, 1.75, 200.0, 35.0, 0.0, 0.0)
+        end
+      end
+
+      context 'without VAT' do
+        it 'should not add VAT' do
+          claim = create :advocate_claim, :without_fees
+          claim.apply_vat = false
+          allow(claim).to receive(:vat_registered?).and_return(false)
+
+          expect_totals_to_be(claim, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+          # add basic fee and VAT should be calculated and added in
+          claim.basic_fees << create(:basic_fee, claim: claim, quantity: 1, rate: 200)
+          expect_totals_to_be(claim, 0.0, 0.0, 200.0, 0.0, 0.0, 0.0)
+
+          # add expense and VAT should be calculated and added in
+          claim.expenses << create(:expense, claim: claim, amount: 9.99)
+          expect_totals_to_be(claim, 9.99, 0.0, 200.0, 0.0, 0.0, 0.0)
+        end
+      end
+    end
+
+    def expect_totals_to_be(claim, et, ev, ft, fv, dt, dv)
+      expect(claim.expenses_total).to eq et
+      expect(claim.expenses_vat).to eq ev
+      expect(claim.fees_total).to eq ft
+      expect(claim.fees_vat).to eq fv
+      expect(claim.disbursements_total).to eq dt
+      expect(claim.disbursements_vat).to eq dv
+      expect(claim.total).to eq BigDecimal.new(et + ft + dt, 8)
+      expect(claim.vat_amount).to eq BigDecimal.new(ev + fv + dv, 8)
     end
   end
 end

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Disbursement, type: :model do
   describe 'update claim totals' do
     before :all do
       @claim = create(:litigator_claim, :without_fees, apply_vat: true)
-
       [[5.0, 1.5], [3.0, 1.0]].each do |net, vat|
         create(:disbursement, claim: @claim, net_amount: net, vat_amount: vat)
       end
@@ -47,6 +46,10 @@ RSpec.describe Disbursement, type: :model do
 
     it 'calculates the disbursements total amount' do
       expect(@claim.disbursements_total).to eq(8.0)
+    end
+
+    it 'calculates the disbursement vat amount' do
+      expect(@claim.disbursements_vat).to eq 2.5
     end
 
     it 'calculates the claim total amount' do

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -23,29 +23,6 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
 
     it { should_error_if_equal_to_value(expense, :amount, 200_001, 'item_max_amount') }
 
-    describe '#validate_vat_amount for AGFS claims' do
-      it 'is valid if absent' do
-        expense.vat_amount = nil
-        expect(expense).to be_valid
-      end
-
-      it 'is valid if blank' do
-        expense.vat_amount = ''
-        expect(expense).to be_valid
-      end
-
-      it 'is valid if zero' do
-        expense.vat_amount = 0
-        expect(expense).to be_valid
-      end
-
-      it 'is invalid if any other value' do
-        expense.vat_amount = 3
-        expect(expense).not_to be_valid
-        expect(expense.errors[:vat_amount]).to include('invalid')
-      end
-    end
-
     describe '#validate_vat_amount for LGFS claims' do
       let(:claim) { build :litigator_claim, force_validation: true }
 


### PR DESCRIPTION
Prior to this PR, the total VAT for a claim was calculated by adding
up the VAT amounts on the individual expenses and disbursements, and
calculating the VAT from the fees records.

In order to be able to display individual VAT totals on the claim
summary page, we now calculate the VAT totals individually and store on
the claim record.