### PR TITLE
Remove set_allocation_type() method from state machine

### DIFF
--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -212,10 +212,6 @@ module Claims::StateMachine
     self.assessment.zeroize! if self.state == 'allocated'
   end
 
-  def set_allocation_type
-    self.set_allocation_type
-  end
-
   def remove_case_workers!
     self.case_workers.destroy_all
   end


### PR DESCRIPTION
Is implemeted in the Claim model, so no need for it here