### PR TITLE
Add audit.rake

### DIFF
--- a/lib/tasks/audit.rake
+++ b/lib/tasks/audit.rake
@@ -1,0 +1,19 @@
+namespace :audit do
+
+  desc 'display list of claims with nulls in numeric fields'
+  task nulls: :environment do
+    fields = %w{ fees_total expenses_total disbursements_total total vat_amount fees_vat expenses_vat disbursements_vat }
+    fields_clause = fields.map{ |f| "#{f} is null"}.join(' or ')
+    query = "select id, #{fields.join(', ')} from claims where #{fields_clause}"
+    result_set = ActiveRecord::Base.connection.execute(query)
+    puts "#{result_set.ntuples} found with nulls."
+    str = ''
+    result_set.each do |row|
+      str += "Claim #{row['id']} has nil values:\n"
+      row.select{ |f, v| v.nil? }.each do |field, _value|
+        str += "    #{field}\n"
+      end
+    end
+    puts str
+  end
+end


### PR DESCRIPTION
This rake task allows us to get a list of all claims which have nulls in numeric fields where they shouldn't have.  This is to test that the issue has been solved, and is not re-occurring with new claims as they are created.