### PR TITLE
Add Fee Scheme Manager to determine which fee scheme version to use

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -285,6 +285,10 @@ module Claim
       end.first
     end
 
+    def earliest_representation_order_date
+      earliest_representation_order.try(:representation_order_date)
+    end
+
     def evidence_doc_types
       DocType.find_by_ids(evidence_checklist_ids)
     end
@@ -481,6 +485,10 @@ module Claim
 
     def disbursements_without_vat_gross
       disbursements_without_vat_net
+    end
+
+    def fee_scheme_version
+      FeeSchemeManager.version(self)
     end
 
     private

--- a/app/models/date_attended.rb
+++ b/app/models/date_attended.rb
@@ -30,7 +30,7 @@ class DateAttended < ActiveRecord::Base
   end
 
   def earliest_date_before_reporder
-    attended_item.try(:claim).try(:earliest_representation_order).try(:representation_order_date)
+    attended_item.try(:claim).earliest_representation_order_date
   end
 
   def to_s

--- a/app/services/fee_scheme_manager.rb
+++ b/app/services/fee_scheme_manager.rb
@@ -1,0 +1,42 @@
+class FeeSchemeManager
+
+  DEFAULT_LGFS_FEE_SCHEME = :lgfs_v6
+  DEFAULT_AGFS_FEE_SCHEME = :agfs_v9
+
+  AGFS_FEE_SCHEME_10_DATE = Date.new(2017, 1, 1)
+
+  class << self
+    def version(claim)
+      case claim.class.to_s
+      when 'Claim::AdvocateClaim'
+        get_agfs_version(claim.earliest_representation_order_date)
+      else
+        get_lgfs_version
+      end
+    end
+
+    private
+
+    def get_lgfs_version
+      DEFAULT_LGFS_FEE_SCHEME
+    end
+
+    def get_agfs_version(date)
+      if date.nil? || RailsHost.gamma?
+        DEFAULT_AGFS_FEE_SCHEME
+      else
+        agfs_version_by_date(date)
+      end
+    end
+
+    def agfs_version_by_date(date)
+      if date < AGFS_FEE_SCHEME_10_DATE
+        DEFAULT_AGFS_FEE_SCHEME
+      else
+        :agfs_v10
+      end
+    end
+  end
+
+
+end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -264,7 +264,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def earliest_rep_order
-    @record.try(:earliest_representation_order).try(:representation_order_date)
+    @record.earliest_representation_order_date
   end
 
   def validate_trial_start_and_end(start_attribute, end_attribute, inverse=false)

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -157,7 +157,7 @@ private
 
   def validate_single_attendance_date
     validate_presence(:date, 'blank')
-    validate_not_before(@record.claim.try(:earliest_representation_order).try(:representation_order_date), :date, 'too_long_before_earliest_reporder')
+    validate_not_before(@record.claim.try(:earliest_representation_order_date), :date, 'too_long_before_earliest_reporder')
     validate_not_before(Settings.earliest_permitted_date, :date, 'check_not_too_far_in_past')
     validate_not_after(Date.today, :date, 'check_not_in_future')
   end

--- a/spec/api/v1/external_users/date_attended_spec.rb
+++ b/spec/api/v1/external_users/date_attended_spec.rb
@@ -17,7 +17,7 @@ describe API::V1::ExternalUsers::DateAttended do
   let!(:provider)     { create(:provider) }
   let!(:claim)        { create(:claim, source: 'api') }
   let!(:fee)          { create(:misc_fee, claim: claim) }
-  let!(:from_date)    { claim.earliest_representation_order.representation_order_date }
+  let!(:from_date)    { claim.earliest_representation_order_date }
   let!(:to_date)      { from_date + 2.days }
   let!(:valid_params) { { api_key: provider.api_key, attended_item_id: fee.reload.uuid, date: from_date.as_json, date_to: to_date.as_json} }
 

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -8,6 +8,13 @@ FactoryGirl.define do
       claim.fees << build(:misc_fee, :lgfs, claim: claim) # fees required for valid claims
     end
 
+    trait(:without_defendants) do
+      after(:create) do |claim|
+        claim.defendants.clear
+      end
+
+    end
+
     # Risk based bills are litigator claims of case type guilty plea, with offences of class E,F,H,I and a graduated fee PPE/quantity of 50 or less
     trait :risk_based_bill do
       offence { create(:offence, :miscellaneous, offence_class: create(:offence_class, :risk_based_bill_class)) }

--- a/spec/factories/defendants.rb
+++ b/spec/factories/defendants.rb
@@ -20,6 +20,10 @@ FactoryGirl.define do
     date_of_birth                     30.years.ago
     order_for_judicial_apportionment  false
     representation_orders             { [ FactoryGirl.create(:representation_order, representation_order_date: 400.days.ago) ] }
+
+    trait :without_reporder do
+      representation_orders           { [] }
+    end
   end
 
 end

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -243,5 +243,44 @@ module Claim
       expect(claim.evidence_doc_types.map(&:name)).to match_array( [ 'Representation order', 'Order in respect of judicial apportionment', 'Special preparation form'])
     end
   end
+
+  describe '#earliest_representation_order_date' do
+
+    let(:april_1) { Date.new(2016, 4, 1) }
+    let(:march_10) { Date.new(2016, 3, 10) }
+    let(:jun_30) { Date.new(2016, 6, 30) }
+    let(:claim) { create :claim }
+
+    before(:each) do
+      claim.defendants.clear
+      claim.save
+    end
+
+    it 'returns nil if there are no reporders' do
+      expect(claim.representation_orders).to be_empty
+      expect(claim.earliest_representation_order_date).to be nil
+    end
+
+    it 'returns the date of the only rep order' do
+      defendant = create :defendant, :without_reporder, claim: claim
+      create :representation_order, defendant: defendant, representation_order_date: april_1
+
+      claim.reload
+      expect(claim.representation_orders.size).to eq 1
+      expect(claim.earliest_representation_order_date).to eq april_1
+    end
+
+    it 'returns the date of the earliest reporder across multiple defendants' do
+      defendant_1 = create :defendant, :without_reporder, claim: claim
+      create :representation_order, defendant: defendant_1, representation_order_date: april_1
+      create :representation_order, defendant: defendant_1, representation_order_date: jun_30
+      defendant_2 = create :defendant, :without_reporder, claim: claim
+      create :representation_order, defendant: defendant_2, representation_order_date: march_10
+
+      claim.reload
+      expect(claim.representation_orders.size).to eq 3
+      expect(claim.earliest_representation_order_date).to eq march_10
+    end
+  end
 end
 

--- a/spec/services/fee_scheme_manager_spec.rb
+++ b/spec/services/fee_scheme_manager_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe FeeSchemeManager do
+
+  describe '.version' do
+
+    it 'returns :lgfs_v6 for Litigator Final Claims' do
+      claim = build :litigator_claim
+      expect(FeeSchemeManager.version(claim)).to eq :lgfs_v6
+    end
+
+    it 'returns :lgfs_v6 for Litigator Transfer claims' do
+      claim = build :transfer_claim
+      expect(FeeSchemeManager.version(claim)).to eq :lgfs_v6
+    end
+
+    it 'returns :lgfs_v6 for Litigator Interim claims' do
+      claim = build :interim_claim
+      expect(FeeSchemeManager.version(claim)).to eq :lgfs_v6
+    end
+
+    it 'returns :agfs_v9 for dates before AGFS_FEE_SCHEME_DATES' do
+      claim = build :advocate_claim
+      expect(claim).to receive(:earliest_representation_order_date).and_return(FeeSchemeManager::AGFS_FEE_SCHEME_10_DATE - 1.day)
+      expect(FeeSchemeManager.version(claim)).to eq :agfs_v9
+    end
+
+    it 'returns :agfs_v10 for rep order date on the date of validity' do
+      claim = build :advocate_claim
+      expect(claim).to receive(:earliest_representation_order_date).and_return(FeeSchemeManager::AGFS_FEE_SCHEME_10_DATE)
+      expect(FeeSchemeManager.version(claim)).to eq :agfs_v10
+    end
+
+    it 'returns :agfs_v10 for rep order date after the date of validity' do
+      claim = build :advocate_claim
+      expect(claim).to receive(:earliest_representation_order_date).and_return(FeeSchemeManager::AGFS_FEE_SCHEME_10_DATE + 1.day)
+      expect(FeeSchemeManager.version(claim)).to eq :agfs_v10
+    end
+
+    it 'returns :agfs_v9 on gamma even for rep order date after the date of validity' do
+      claim = build :advocate_claim
+      expect(claim).to receive(:earliest_representation_order_date).and_return(FeeSchemeManager::AGFS_FEE_SCHEME_10_DATE)
+      allow(RailsHost).to receive(:env).and_return('gamma')
+      expect(FeeSchemeManager.version(claim)).to eq :agfs_v9
+    end
+  end
+end

--- a/spec/validators/fee/shared_examples_for_fee_validators_spec.rb
+++ b/spec/validators/fee/shared_examples_for_fee_validators_spec.rb
@@ -16,7 +16,7 @@ shared_examples 'common fee date validations' do
     end
 
     it 'should be invalid if before the first repo order date' do
-      allow(claim).to receive(:earliest_representation_order).and_return(instance_double(RepresentationOrder, representation_order_date: Date.today))
+      allow(claim).to receive(:earliest_representation_order_date).and_return(Date.today)
       allow(fee).to receive(:claim).and_return(claim)
 
       fee.date = Date.today - 3.days

--- a/spec/validators/validation_helpers.rb
+++ b/spec/validators/validation_helpers.rb
@@ -118,7 +118,7 @@ module ValidationHelpers
 
   def stub_earliest_rep_order(claim, date)
     repo = double RepresentationOrder
-    allow(claim).to receive_message_chain(:earliest_representation_order,:representation_order_date).and_return(date)
+    allow(claim).to receive(:earliest_representation_order_date).and_return(date)
   end
 
   def nulify_fields_on_record(record, *fields)


### PR DESCRIPTION
The FeeSchemeManager class provides a central point in which to decide which fee scheme to use.

Whilst the new fee scheme is under development, on gamma, it will only ever return the old fee scheme, :afgs_v9 or :lgfs_v6, otherwise it takes the earliest reporder date into account