### PR TITLE
Allow change of provider role

### DIFF
--- a/app/controllers/super_admins/providers_controller.rb
+++ b/app/controllers/super_admins/providers_controller.rb
@@ -37,6 +37,7 @@ class SuperAdmins::ProvidersController < ApplicationController
   end
 
   def filtered_params
-    [:provider_type]
+    # [:provider_type]
+    []
   end
 end

--- a/spec/controllers/super_admins/providers_controller_spec.rb
+++ b/spec/controllers/super_admins/providers_controller_spec.rb
@@ -48,11 +48,6 @@ RSpec.describe SuperAdmins::ProvidersController, type: :controller do
   end
 
   describe "PUT #update" do
-    it 'does not allow updating of provider type' do
-      provider = create(:provider, :firm)
-      put :update, id: provider, provider: {provider_type: 'chamber'}
-      expect(provider.reload).to be_firm
-    end
 
     context 'when valid' do
       before(:each) { put :update, id: subject, provider: {name: 'test firm'} }


### PR DESCRIPTION
Prior to this PR, changes to the role of a provider made by the superadmin's provider controller were silently ignored.  We don't wan't this behaviour, and it and it's test is removed in this PR.