### PR TITLE
Force email confirmation field to lower case

### DIFF
--- a/app/controllers/super_admins/external_users_controller.rb
+++ b/app/controllers/super_admins/external_users_controller.rb
@@ -17,6 +17,8 @@ class SuperAdmins::ExternalUsersController < ApplicationController
   end
 
   def create
+    # downcase email_confirmation - devise will downcase the email
+    params[:external_user][:user_attributes][:email_confirmation].downcase!
     @external_user = ExternalUser.new(params_with_temporary_password.merge(provider: @provider))
 
     if @external_user.save

--- a/spec/controllers/super_admins/external_users_controller_spec.rb
+++ b/spec/controllers/super_admins/external_users_controller_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe SuperAdmins::ExternalUsersController, type: :controller do
       post :create,
             provider_id: provider,
             external_user: { user_attributes: {  email: 'foo@foobar.com',
+                                                 email_confirmation: 'foo@foobar.com',
                                             first_name: options[:valid]==false ? '' : 'john',
                                             last_name: 'Smith' },
                         roles: ['advocate'],


### PR DESCRIPTION
Devise will automatically downcase the email field.  Unless we do the
same for the email  confirmation field, then the the user creation will
fail because the email does not equal the email confirmation.

The devise configuration is set to not check case sensistivity on email,
so the user will be able to log in with any combination of upper or lower case
in theemail.