### PR TITLE
Clean up stats report

### DIFF
--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -4,17 +4,20 @@ module Stats
 
   class ManagementInformationGenerator
 
+    REPORT_NAME = 'management_information'
+
     def run
-      unless StatsReport.generation_in_progress?('management_information')
-        begin
-          report_record = Stats::StatsReport.record_start('management_information')
+      begin
+        StatsReport.clean_up(REPORT_NAME)
+        unless StatsReport.generation_in_progress?(REPORT_NAME)
+          report_record = Stats::StatsReport.record_start(REPORT_NAME)
           report_contents = generate_new_report
           report_record.write_report(report_contents)
-        rescue => err
-          report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
-          report_record.write_error(report_contents)
-          raise err
         end
+      rescue => err
+        report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
+        report_record.write_error(report_contents)
+        raise err
       end
     end
 

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -24,6 +24,11 @@ module Stats
 
     scope :management_information, -> { not_errored.where(report_name: 'management_information') }
 
+    def self.clean_up(report_name)
+      destroy_reports_older_than(report_name, 1.month.ago)
+      destroy_unfinished_reports_older_than(report_name, 2.hours.ago)
+    end
+
     def self.most_recent_management_information
       self.management_information.completed.first
     end
@@ -47,6 +52,14 @@ module Stats
 
     def download_filename
       "#{self.report_name}_#{self.started_at.strftime('%Y_%m_%d_%H_%M_%S')}.csv"
+    end
+
+    def self.destroy_reports_older_than(report_name, timestamp)
+      self.where(report_name: report_name, started_at: Time.at(0)..timestamp).destroy_all
+    end
+
+    def self.destroy_unfinished_reports_older_than(report_name, timestamp)
+      self.where(report_name: report_name, status: 'started', started_at: Time.at(0)..timestamp).destroy_all
     end
 
   end

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -16,77 +16,107 @@ module Stats
 
   describe StatsReport do
 
-    before(:all) do
-      @mi_old = create :stats_report, started_at: 10.days.ago
-      @mi_complete = create :stats_report
-      @mi_incomplete = create :stats_report, :incomplete
-      @other_report = create :stats_report, :other_report
-      @error_report = create :stats_report, :error
-    end
-
-    after(:all) do
-      StatsReport.delete_all
-    end
-
-    it 'returns all management information reports' do
-      results = StatsReport.management_information
-      expect(results.size).to eq 3
-      expect(results).to include(@mi_complete)
-      expect(results).to include(@mi_incomplete)
-      expect(results).to include(@mi_old  )
-    end
- 
-    it 'returns the latest completed management information report' do
-      expect(StatsReport.most_recent_management_information).to eq @mi_complete
-    end
-
-    describe '.report_generation_in_progress?' do
-      it 'returns true for management information' do
-        expect(StatsReport.generation_in_progress?('management_information')).to be true
+    context 'management information reports' do
+      before(:all) do
+        @mi_old = create :stats_report, started_at: 10.days.ago
+        @mi_complete = create :stats_report
+        @mi_incomplete = create :stats_report, :incomplete
+        @other_report = create :stats_report, :other_report
+        @error_report = create :stats_report, :error
       end
 
-      it 'returns false for other reports' do
-        expect(StatsReport.generation_in_progress?('other_report')).to be false
+      after(:all) do
+        StatsReport.delete_all
       end
-    end
 
-    describe '#download_filename' do
-      it 'generates a filename incorportating the report name and started at time' do
-        report = build :stats_report, report_name: 'my_new_report', started_at: Time.zone.local(2016, 2, 3, 4, 55, 12)
-        expect(report.download_filename).to eq 'my_new_report_2016_02_03_04_55_12.csv'
+      it 'returns all management information reports' do
+        results = StatsReport.management_information
+        expect(results.size).to eq 3
+        expect(results).to include(@mi_complete)
+        expect(results).to include(@mi_incomplete)
+        expect(results).to include(@mi_old  )
       end
-    end
 
-    describe '.record_start' do
-      it 'creates and incomplete record' do
-        frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
-        Timecop.freeze(frozen_time) do
-          record = StatsReport.record_start('my_new_report')
-          expect(record.report_name).to eq 'my_new_report'
-          expect(record.started_at).to eq frozen_time
-          expect(record.completed_at).to be_nil
-          expect(record.report).to be_nil
+      it 'returns the latest completed management information report' do
+        expect(StatsReport.most_recent_management_information).to eq @mi_complete
+      end
+
+      describe '.report_generation_in_progress?' do
+        it 'returns true for management information' do
+          expect(StatsReport.generation_in_progress?('management_information')).to be true
+        end
+
+        it 'returns false for other reports' do
+          expect(StatsReport.generation_in_progress?('other_report')).to be false
+        end
+      end
+
+      describe '#download_filename' do
+        it 'generates a filename incorportating the report name and started at time' do
+          report = build :stats_report, report_name: 'my_new_report', started_at: Time.zone.local(2016, 2, 3, 4, 55, 12)
+          expect(report.download_filename).to eq 'my_new_report_2016_02_03_04_55_12.csv'
+        end
+      end
+
+      describe '.record_start' do
+        it 'creates and incomplete record' do
+          frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
+          Timecop.freeze(frozen_time) do
+            record = StatsReport.record_start('my_new_report')
+            expect(record.report_name).to eq 'my_new_report'
+            expect(record.started_at).to eq frozen_time
+            expect(record.completed_at).to be_nil
+            expect(record.report).to be_nil
+          end
+        end
+      end
+
+      describe '#write_report' do
+        it 'updates with report contents and completed_at time' do
+          frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
+          record = nil
+          Timecop.freeze(frozen_time) do
+            record = StatsReport.record_start('my_new_report')
+          end
+
+          Timecop.freeze(frozen_time + 2.minutes) do
+            record.write_report('The contents of my new report')
+          end
+
+          report = StatsReport.completed.where(report_name: 'my_new_report').first
+          expect(report.report).to eq 'The contents of my new report'
+          expect(report.started_at).to eq frozen_time
+          expect(report.completed_at).to eq frozen_time + 2.minutes
         end
       end
     end
 
-    describe '#write_report' do
-      it 'updates with report contents and completed_at time' do
-        frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
-        record = nil
-        Timecop.freeze(frozen_time) do
-          record = StatsReport.record_start('my_new_report')
-        end
+    context 'housekeeping' do
 
-        Timecop.freeze(frozen_time + 2.minutes) do
-          record.write_report('The contents of my new report')
-        end
+      describe '.destroy_reports_older_than' do
+        it 'destroys all reports for named report older than specified time' do
+          _my_report_old = create :stats_report, started_at: 63.days.ago
+          my_report_new = create :stats_report, started_at: 53.days.ago
+          other_report_old = create :stats_report, :other_report, started_at: 63.days.ago
+          other_report_new = create :stats_report, :other_report, started_at: 53.days.ago
 
-        report = StatsReport.completed.where(report_name: 'my_new_report').first
-        expect(report.report).to eq 'The contents of my new report'    
-        expect(report.started_at).to eq frozen_time
-        expect(report.completed_at).to eq frozen_time + 2.minutes
+          StatsReport.destroy_reports_older_than('management_information', 62.days.ago)
+          expect(StatsReport.all).to match_array [my_report_new, other_report_old, other_report_new]
+        end
       end
+
+      describe '.destroy_unfinished_reports_older_than' do
+        it 'destroys incomplete reports started before the timestamp' do
+          _my_report_old = create :stats_report, :incomplete, started_at: 121.minutes.ago
+          my_report_new = create :stats_report, :incomplete, started_at: 119.minutes.ago
+          other_report_old = create :stats_report, :other_report, :incomplete, started_at: 121.minutes.ago
+          other_report_new = create :stats_report, :other_report, :incomplete, started_at: 119.minutes.ago
+
+          StatsReport.destroy_unfinished_reports_older_than('management_information', 2.hours.ago)
+          expect(StatsReport.all).to match_array [my_report_new, other_report_old, other_report_new]
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
If a management information report is in the middle of being generated when the server is restarted, the record will be left in the database with a status of 'started'.  This currently prevents subsequent management information generators from running (it checks to see if other reports are in the process of being generated, and immediately exits if that is the case).

This PR cleans up old reports (older than 2 months), and stalled reports that were started more than 2  hours ago and never finished.