### PR TITLE
Geckoboard stats update

### DIFF
--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -24,7 +24,7 @@ class ClaimStateTransition < ActiveRecord::Base
     ClaimStateTransitionReason.get(reason_code)
   end
 
-  def self.decided_this_month
+  def self.decided_this_month(state)
     self.where{ (to == state.to_s) & (created_at >= Time.now.beginning_of_month) }.count('DISTINCT claim_id')
   end
 

--- a/app/services/stats/claim_percentage_authorised_generator.rb
+++ b/app/services/stats/claim_percentage_authorised_generator.rb
@@ -47,7 +47,7 @@ module Stats
     end
 
     def claims_decided_this_month(state)
-      ClaimStateTransition.decided_this_month
+      ClaimStateTransition.decided_this_month(state)
     end
   end
 end


### PR DESCRIPTION
Passing the state to be returned was omitted from the refactoring

This meant that gecko board was showing a blank report

