### PR TITLE
Code-climate readme update

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,15 +1,42 @@
-languages:
-  Ruby: true
-  JavaScript: false
-  PHP: true
-  Python: true
-exclude_paths:
-- "app/interfaces/api/entities/*"
-- "app/interfaces/api/v1/*"
-- "lib/demo_data/*"
-- "db/*"
-- "db/migrate/*"
-- "db/seeds/*"
-- "features/support/*"
-- "script/*"
-- "Gemfile*"
+engines:
+  rubocop:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        JavaScript: false
+        PHP: true
+        Python: true
+        ruby:
+          mass_threshold: 18
+  brakeman:
+    enabled: true
+  bundler-audit:
+    enabled: true
+ratings: # customize
+  paths:
+  - app/**/*
+  - lib/**/*
+exclude_paths: # customize
+- .bundle/
+- app/assets/fonts/
+- app/assets/images/
+- app/assets/javascripts/vendor/
+- app/assets/stylesheets/vendor/
+- bin/rails
+- bin/rake
+- doc/
+- files/
+- public/
+- spec/
+- tmp/
+- app/interfaces/api/entities/*
+- app/interfaces/api/v1/*
+- lib/demo_data/*
+- db/*
+- db/migrate/*
+- db/seeds/*
+- features/support/*
+- script/*
+- Gemfile*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 addons:
   postgresql: '9.3'
   code_climate:
-    repo_token: 21d4b9b324a45c24369ecf4d78711930294c191ebbb2d9e0fd7adf4bbd75b687
+    repo_token: ea73ad64ca2238324113fed1718cd5004854ddab2a3055778d7067ba7ecd09a6
 before_install:
 - export TZ=Europe/London
 before_script:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ###a.k.a Claim for crown court defence
 
 [![Build Status](https://travis-ci.org/ministryofjustice/Claim-for-Crown-Court-Defence.svg)](https://travis-ci.org/ministryofjustice/Claim-for-Crown-Court-Defence)
-[![Code Climate](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments)
-[![Test Coverage](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/advocate-defence-payments/coverage)
+[![Code Climate](https://codeclimate.com/github/ministryofjustice/Claim-for-Crown-Court-Defence/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/Claim-for-Crown-Court-Defence)
+[![Test Coverage](https://codeclimate.com/github/ministryofjustice/Claim-for-Crown-Court-Defence/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/Claim-for-Crown-Court-Defence/coverage)
 
 ## Staging
 [staging-adp.dsd.io](https://staging-adp.dsd.io)


### PR DESCRIPTION
Following the rename of the repo, the code-climate integrations were impacted.

This updates the CC badges to point at the new endpoint and reflect the correct test coverage.