### PR TITLE
Gitignore ENV files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ dump.rdb
 
 # tags used by hard core geeks to enable cool navigation within Vim
 tags
+
+.env.*


### PR DESCRIPTION
We've added `.env.development` and `.env.test` files for ENV management
in #1955, these should be gitignored so they don't accidentally get
checked in.