### PR TITLE
Fix intermittently broken Remote::CaseWorker spec

### DIFF
--- a/spec/services/remote/case_worker_spec.rb
+++ b/spec/services/remote/case_worker_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 module Remote
-
-  describe CaseWorker do
+  describe Remote::CaseWorker do
     describe '.resource_path' do
       it 'returns case_wokers' do
-        expect(CaseWorker.resource_path).to eq 'case_workers'
+        expect(described_class.resource_path).to eq 'case_workers'
       end
     end
   end


### PR DESCRIPTION
Depending on spec run order this spec would fail because it doesn't
absolutely reference the class it's setting expectations on, and there
is another class of the same name in a different module namespace.