### PR TITLE
Add cycling as expense type 🚴

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -1,20 +1,20 @@
 moj.Modules.NewClaim = {
-  $expenses : $('#expenses'),
-  $element : {},
-  $currentExpense : {},
-  dataAttribute : {},
-  $location : {},
-  $distance : {},
-  $mileage : {},
-  $hours : {},
-  $reason : {},
-  $amount : {},
-  $vat_amount : {},
-  $reasonText : {},
-  $date : {},
-  $ariaLiveRegion : {},
+  $expenses: $('#expenses'),
+  $element: {},
+  $currentExpense: {},
+  dataAttribute: {},
+  $location: {},
+  $distance: {},
+  $mileage: {},
+  $hours: {},
+  $reason: {},
+  $amount: {},
+  $vat_amount: {},
+  $reasonText: {},
+  $date: {},
+  $ariaLiveRegion: {},
 
-  init : function() {
+  init: function() {
 
     //Claim basic section
     this.initBasicClaim();
@@ -24,13 +24,15 @@ moj.Modules.NewClaim = {
     this.initSubmitValidation();
   },
 
-  initBasicClaim : function() {
+  initBasicClaim: function() {
     var self = this;
 
     self.$offenceCategorySelect = $('#claim_offence_category_description');
 
     self.$offenceCategorySelect.change(function() {
-      var param = $.param({description : $(this).find(':selected').text()});
+      var param = $.param({
+        description: $(this).find(':selected').text()
+      });
       $.getScript('/offences?' + param);
     });
 
@@ -41,12 +43,12 @@ moj.Modules.NewClaim = {
     self.attachToOffenceClassSelect();
   },
 
-  initSubmitValidation: function () {
+  initSubmitValidation: function() {
     //
     // Warn the user if 'A copy of the indictment' is not selected in the supporting evidence checklist.
     // Tests in /spec/javascripts/supporting-evidence_spec.js
     //
-    $('input[name="commit_submit_claim"]').on('click', function () {
+    $('input[name="commit_submit_claim"]').on('click', function() {
       if ($('#claim_evidence_checklist_ids_4').exists() && !$('#claim_evidence_checklist_ids_4').prop('checked')) {
         return confirm(
           "The evidence checklist suggests that no indictment has been attached.\n" +
@@ -57,7 +59,7 @@ moj.Modules.NewClaim = {
     });
   },
 
-  initExpense : function() {
+  initExpense: function() {
     var self = this;
     self.attachEventsForExpenseTypes();
     self.attachToExpenseReason();
@@ -66,12 +68,12 @@ moj.Modules.NewClaim = {
     self.setNumberOfExpenses();
 
     //Show/hide expense elements on page load
-    self.$expenses.find('select.js-expense-type').each(function (){
+    self.$expenses.find('select.js-expense-type').each(function() {
       self.showHideExpenseFields(this);
     });
   },
 
-  attachToOffenceClassSelect : function() {
+  attachToOffenceClassSelect: function() {
     $('#offence_class_description').on('change', function() {
       $('#claim_offence_id').val($(this).val());
 
@@ -82,20 +84,22 @@ moj.Modules.NewClaim = {
     });
   },
 
-  attachEventsForExpenseTypes : function() {
+  attachEventsForExpenseTypes: function() {
     var self = this;
     this.$expenses.on('change', 'select.js-expense-type', function() {
       self.showHideExpenseFields(this);
     });
   },
 
-  getCurrentExpenseSection : function(elem) {
+  getCurrentExpenseSection: function(elem) {
     this.$element = $(elem);
     this.$currentExpense = this.$element.closest('.expense-group');
     this.dataAttribute = this.$element.find('option:selected').data();
     this.$location = this.$currentExpense.find('.js-expense-location');
     this.$distance = this.$currentExpense.find('.js-expense-distance');
     this.$mileage = this.$currentExpense.find('.js-expense-mileage');
+    this.$mileage_car = this.$currentExpense.find('.js-expense-type-car');
+    this.$mileage_bike = this.$currentExpense.find('.js-expense-type-bike');
     this.$hours = this.$currentExpense.find('.js-expense-hours');
     this.$reason = this.$currentExpense.find('.js-expense-reason');
     this.$amount = this.$currentExpense.find('.js-expense-amount');
@@ -105,13 +109,13 @@ moj.Modules.NewClaim = {
     this.$ariaLiveRegion = this.$element.next();
   },
 
-  showHideExpenseFields : function(elem){
+  showHideExpenseFields: function(elem) {
     var self = this;
 
     self.getCurrentExpenseSection(elem);
 
     //hide all the fields by default
-    if(self.$element.find('option:selected').is(':first-child')){
+    if (self.$element.find('option:selected').is(':first-child')) {
       self.$location
         .add(self.$amount)
         .add(self.$vat_amount)
@@ -122,7 +126,7 @@ moj.Modules.NewClaim = {
         .add(self.$reasonText)
         .add(self.$date)
         .hide();
-    }else{
+    } else {
       self.showExpenseFields(elem);
     }
 
@@ -130,7 +134,7 @@ moj.Modules.NewClaim = {
     self.clearUnusedFields(self.$currentExpense);
   },
 
-  showExpenseFields : function (elem){
+  showExpenseFields: function(elem) {
     var self = this;
 
     self.$date.show();
@@ -149,6 +153,8 @@ moj.Modules.NewClaim = {
     //show/Hide mileage
     self.$mileage.toggle(self.dataAttribute.mileage);
 
+    self.toggleMileageRateFields();
+
     //show/Hide hours
     self.$hours.toggle(self.dataAttribute.hours);
 
@@ -162,11 +168,23 @@ moj.Modules.NewClaim = {
 
     self.$ariaLiveRegion.children().hide().end();
   },
-
-  attachToExpenseReason : function() {
+  toggleMileageRateFields: function () {
+    var self = this;
+    // toggle between bike / car mileage
+    if (self.dataAttribute.mileageType === 'bike') {
+      self.$mileage_car.toggle(false);
+      self.$mileage_bike.toggle(true);
+      $(self.$mileage_bike).find('input').prop('disabled', false);
+    } else {
+      self.$mileage_car.toggle(true);
+      self.$mileage_bike.toggle(false);
+      $(self.$mileage_bike).find('input').prop('disabled', true);
+    }
+  },
+  attachToExpenseReason: function() {
     var self = this;
 
-    self.$expenses.on('change', '.js-expense-reason select', function(){
+    self.$expenses.on('change', '.js-expense-reason select', function() {
       self.showHideExpenseReasonsText(this);
     });
   },
@@ -177,7 +195,7 @@ moj.Modules.NewClaim = {
     expenseGroup.find('input:hidden[type="radio"]').prop("checked", false);
   },
 
-  buildReasonSelectOptions : function(expenseType) {
+  buildReasonSelectOptions: function(expenseType) {
     var newReason = [];
     var expenseReason = {};
     var self = this;
@@ -187,12 +205,12 @@ moj.Modules.NewClaim = {
 
     expenseReason = MOJ.ExpenseReasons[self.dataAttribute.reasonSet];
 
-    for(var opt in expenseReason){
-      if(expenseReason.hasOwnProperty(opt)){
+    for (var opt in expenseReason) {
+      if (expenseReason.hasOwnProperty(opt)) {
         var currentOption = new Option(expenseReason[opt].reason, expenseReason[opt].id);
 
         currentOption.setAttribute('data-reason-text', expenseReason[opt].reason_text);
-        if(expenseReason[opt].id === selectedVAL){
+        if (expenseReason[opt].id === selectedVAL) {
           currentOption.setAttribute('selected', 'selected');
         }
 
@@ -202,7 +220,7 @@ moj.Modules.NewClaim = {
     self.$reason.find('select').children().remove().end().append(newReason);
   },
 
-  showHideExpenseReasonsText : function(elem){
+  showHideExpenseReasonsText: function(elem) {
     var $reason = $(elem);
     var $currentExpense = $reason.closest('.expense-group');
     var visible = $reason.find('option:selected').data('reason-text');
@@ -214,11 +232,11 @@ moj.Modules.NewClaim = {
 
   },
 
-  setNumberOfExpenses : function() {
+  setNumberOfExpenses: function() {
     var self = this;
 
-    self.$expenses.on('cocoon:after-insert cocoon:after-remove', function(e, insertedItem){
-      $(this).find('.js-expense-count').each(function(i){
+    self.$expenses.on('cocoon:after-insert cocoon:after-remove', function(e, insertedItem) {
+      $(this).find('.js-expense-count').each(function(i) {
         var $element = $(this);
         var $currentExpense = $element.closest('.expense-group');
 
@@ -228,7 +246,7 @@ moj.Modules.NewClaim = {
       });
 
       //if inserting show/hide the new expense fields and set focus
-      if (e.type === 'cocoon:after-insert'){
+      if (e.type === 'cocoon:after-insert') {
         self.showHideExpenseFields($(insertedItem).find('.js-expense-type'));
 
         $(insertedItem).find('input:first').focus();

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -24,10 +24,14 @@
 
 class Expense < ActiveRecord::Base
 
-  MILEAGE_RATES = {
-    1 => Struct.new(:id, :name, :description).new(1, '25p', '25p per mile'),
-    2 => Struct.new(:id, :name, :description).new(2, '45p', '45p per mile')
+  CAR_MILEAGE_RATES = {
+    1 => Struct.new(:id, :mileage_type, :name, :description).new(1, :car, '25p', '25p per mile'),
+    2 => Struct.new(:id, :mileage_type, :name, :description).new(2, :car, '45p', '45p per mile')
   }
+  BIKE_MILEAGE_RATES = {
+    3 => Struct.new(:id, :mileage_type, :name, :description).new(3, :bike, '20p', '20p per mile')
+  }
+  MILEAGE_RATES = CAR_MILEAGE_RATES.merge(BIKE_MILEAGE_RATES)
 
   auto_strip_attributes :location, squish: true, nullify: true
 
@@ -48,6 +52,7 @@ class Expense < ActiveRecord::Base
   accepts_nested_attributes_for :dates_attended, reject_if: :all_blank, allow_destroy: true
 
   delegate :car_travel?,
+           :bike_travel?,
            :parking?,
            :hotel_accommodation?,
            :train?,

--- a/app/models/expense_type.rb
+++ b/app/models/expense_type.rb
@@ -57,6 +57,10 @@ class ExpenseType < ActiveRecord::Base
     name == 'Car travel'
   end
 
+  def bike_travel?
+    name == 'Bike travel'
+  end
+
   def parking?
     name == 'Parking'
   end

--- a/app/presenters/expense_type_presenter.rb
+++ b/app/presenters/expense_type_presenter.rb
@@ -7,6 +7,7 @@ class ExpenseTypePresenter < BasePresenter
       location_label: location_label,
       distance: distance_field?,
       mileage: mileage_field?,
+      mileage_type: mileage_type,
       hours: hours_field?,
       reason_set: reason_set
     }
@@ -20,7 +21,7 @@ class ExpenseTypePresenter < BasePresenter
   end
 
   def location_label
-    if car_travel? || train? || travel_time? || road_tolls? || cab_fares?
+    if car_travel? || bike_travel? || train? || travel_time? || road_tolls? || cab_fares?
       'Destination'
     elsif hotel_accommodation? || subsistence?
       'Location'
@@ -30,11 +31,19 @@ class ExpenseTypePresenter < BasePresenter
   end
 
   def distance_field?
-    car_travel?
+    car_travel? || bike_travel?
   end
 
   def mileage_field?
-    car_travel?
+    car_travel? || bike_travel?
+  end
+
+  def mileage_type
+    if car_travel?
+      :car
+    elsif bike_travel?
+      :bike
+    end
   end
 
   def hours_field?

--- a/app/validators/expense_v2_validator.rb
+++ b/app/validators/expense_v2_validator.rb
@@ -66,7 +66,7 @@ class ExpenseV2Validator < BaseValidator
   end
 
   def validate_distance
-    if @record.car_travel?
+    if @record.car_travel? || @record.bike_travel?
       validate_presence_and_numericality(:distance, minimum: 0.1)
     else
       validate_absence(:distance, 'invalid')
@@ -74,10 +74,11 @@ class ExpenseV2Validator < BaseValidator
   end
 
   def validate_mileage_rate_id
-    if @record.car_travel?
+    if @record.car_travel? || @record.bike_travel?
       validate_presence(:mileage_rate_id, 'blank')
       unless @record.mileage_rate_id.nil?
-        add_error(:mileage_rate_id, 'invalid') unless @record.mileage_rate_id.in?(Expense::MILEAGE_RATES.keys)
+        add_error(:mileage_rate_id, 'invalid') if @record.car_travel? && !@record.mileage_rate_id.in?(Expense::CAR_MILEAGE_RATES.keys)
+        add_error(:mileage_rate_id, 'invalid') if @record.bike_travel? && !@record.mileage_rate_id.in?(Expense::BIKE_MILEAGE_RATES.keys)
       end
     else
       validate_absence(:mileage_rate_id, 'invalid')

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -72,10 +72,16 @@
             %legend
               ='Cost'
             -#  (only visible for Car Travel):
-            = f.hidden_field :mileage_rate_id, value: ''
-            = f.collection_radio_buttons(:mileage_rate_id, Expense::MILEAGE_RATES.values, :id, :description) do |b|
-              - b.label(class: "block-label") { b.radio_button + b.object.description }
-            = validation_error_message(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")
+            %div.js-expense-type-car
+              = f.hidden_field :mileage_rate_id, value: ''
+              = f.collection_radio_buttons(:mileage_rate_id, Expense::CAR_MILEAGE_RATES.values, :id, :description) do |b|
+                - b.label(class: "block-label") { b.radio_button + b.object.description }
+              = validation_error_message(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")
+
+            %div.js-expense-type-bike
+              = "#{Expense::BIKE_MILEAGE_RATES[3].description}"
+              = f.hidden_field :mileage_rate_id, value: Expense::BIKE_MILEAGE_RATES[3].id
+
 
       .column-one-third.condensed
         - if @claim.lgfs?

--- a/db/seeds/expense_types.rb
+++ b/db/seeds/expense_types.rb
@@ -9,6 +9,7 @@ expense_types = [
   [16, 'Road or tunnel tolls',    ['agfs', 'lgfs'], 'A', 'ROAD'],
   [17, 'Cab fares',               ['agfs', 'lgfs'], 'A', 'CABF'],
   [18, 'Subsistence',             ['agfs', 'lgfs'], 'A', 'SUBS'],
+  [19, 'Bike travel',             ['agfs', 'lgfs'], 'A', 'BIKE']
 ]
 
 max_id = 0

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -51,10 +51,15 @@ namespace :data do
       puts "#{i} claims examined"
     end
 
+    desc 'Reseed expense types'
+    task :reseed_expense_types => :environment do
+      load File.join(Rails.root, 'db', 'seeds', 'expense_types.rb')
+    end
+
     desc 'Run all outstanding data migrations'
     task :all => :environment do
       {
-        'value_bands' => 'Recacalculate value bands where wrong',
+        'reseed_expense_types' => 'Reseed the expense types as there are some new.'
       }.each do |task, comment|
         puts comment
         Rake::Task["data:migrate:#{task}"].invoke

--- a/spec/factories/expense_types.rb
+++ b/spec/factories/expense_types.rb
@@ -36,6 +36,11 @@ FactoryGirl.define do
       unique_code 'CAR'
     end
 
+    trait :bike_travel do
+      name 'Bike travel'
+      unique_code 'BIKE'
+    end
+
     trait :parking do
       name 'Parking'
       unique_code 'PARK'

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -37,6 +37,12 @@ FactoryGirl.define do
       mileage_rate_id 2
     end
 
+    trait :bike_travel do
+      expense_type  { build :expense_type, :bike_travel }
+      distance 27
+      mileage_rate_id 3
+    end
+
     trait :parking do
       expense_type { build :expense_type, :parking }
       location nil

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Expense, type: :model do
 
     subject { build :expense, :car_travel }
 
-    [:car_travel?, :parking?, :hotel_accommodation?, :train?, :travel_time?, :road_tolls?, :cab_fares?, :subsistence?].each do |method|
+    [:car_travel?, :bike_travel?, :parking?, :hotel_accommodation?, :train?, :travel_time?, :road_tolls?, :cab_fares?, :subsistence?].each do |method|
       it "delegates #{method} to expense_type" do
         expect(expense_type).to receive(method)
         subject.send(method)

--- a/spec/models/expense_type_spec.rb
+++ b/spec/models/expense_type_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe ExpenseType, type: :model do
 
   context 'expense types helper methods' do
     let(:car_travel_expense)          { build(:expense_type, :car_travel) }
+    let(:bike_travel_expense)         { build(:expense_type, :bike_travel) }
     let(:parking_expense)             { build(:expense_type, :parking) }
     let(:hotel_accommodation_expense) { build(:expense_type, :hotel_accommodation) }
     let(:train_expense)               { build(:expense_type, :train) }
@@ -40,6 +41,9 @@ RSpec.describe ExpenseType, type: :model do
     it 'returns true for the type of expense it is' do
       expect(car_travel_expense.car_travel?).to be true
       expect(car_travel_expense.train?).to be false
+
+      expect(bike_travel_expense.bike_travel?).to be true
+      expect(bike_travel_expense.car_travel?).to be false
 
       expect(parking_expense.parking?).to be true
       expect(parking_expense.car_travel?).to be false

--- a/spec/presenters/expense_type_presenter_spec.rb
+++ b/spec/presenters/expense_type_presenter_spec.rb
@@ -11,7 +11,16 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Destination', distance: true, mileage: true, hours: false, reason_set: 'A' })
+          eq({ location: true, location_label: 'Destination', distance: true, mileage: true, mileage_type: :car, hours: false, reason_set: 'A' })
+      end
+    end
+
+    context 'Bike Travel' do
+      let(:expense_type) { :bike_travel }
+
+      it 'returns the right data attributes' do
+        expect(presenter.data_attributes).to \
+          eq({ location: true, location_label: 'Destination', distance: true, mileage: true, mileage_type: :bike, hours: false, reason_set: 'A' })
       end
     end
 
@@ -20,7 +29,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, hours: false, reason_set: 'A' })
+          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, mileage_type: nil, hours: false, reason_set: 'A' })
       end
     end
 
@@ -29,7 +38,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: false, location_label: '', distance: false, mileage: false, hours: false, reason_set: 'A' })
+          eq({ location: false, location_label: '', distance: false, mileage: false, mileage_type: nil, hours: false, reason_set: 'A' })
       end
     end
 
@@ -38,7 +47,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Location', distance: false, mileage: false, hours: false, reason_set: 'A' })
+          eq({ location: true, location_label: 'Location', distance: false, mileage: false, mileage_type: nil, hours: false, reason_set: 'A' })
       end
     end
 
@@ -47,7 +56,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, hours: true, reason_set: 'B' })
+          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, mileage_type: nil, hours: true, reason_set: 'B' })
       end
     end
 
@@ -56,7 +65,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, hours: false, reason_set: 'A' })
+          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, mileage_type: nil, hours: false, reason_set: 'A' })
       end
     end
 
@@ -65,7 +74,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, hours: false, reason_set: 'A' })
+          eq({ location: true, location_label: 'Destination', distance: false, mileage: false, mileage_type: nil, hours: false, reason_set: 'A' })
       end
     end
 
@@ -74,7 +83,7 @@ RSpec.describe ExpenseTypePresenter do
 
       it 'returns the right data attributes' do
         expect(presenter.data_attributes).to \
-          eq({ location: true, location_label: 'Location', distance: false, mileage: false, hours: false, reason_set: 'A' })
+          eq({ location: true, location_label: 'Location', distance: false, mileage: false, mileage_type: nil, hours: false, reason_set: 'A' })
       end
     end
   end

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -10,6 +10,7 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
     let(:claim)                       { build :claim, force_validation: true }
     let(:expense)                     { build :expense, :train, claim: claim }
     let(:car_travel_expense)          { build(:expense, :car_travel, claim: claim ) }
+    let(:bike_travel_expense)         { build(:expense, :bike_travel, claim: claim ) }
     let(:parking_expense)             { build(:expense, :parking, claim: claim ) }
     let(:hotel_accommodation_expense) { build(:expense, :hotel_accommodation, claim: claim) }
     let(:train_expense)               { build(:expense, :train, claim: claim) }
@@ -134,7 +135,7 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
       end
 
       context 'not travel time' do
-        let(:expenses_to_test) { [car_travel_expense, parking_expense, hotel_accommodation_expense, train_expense, road_tolls_expense, cab_fares_expense, subsistence_expense] }
+        let(:expenses_to_test) { [car_travel_expense, bike_travel_expense, parking_expense, hotel_accommodation_expense, train_expense, road_tolls_expense, cab_fares_expense, subsistence_expense] }
 
         it 'is invalid if present' do
           expenses_to_test.each do |ex|
@@ -177,7 +178,7 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
     end
 
     describe '#validate_location' do
-      let(:expenses_to_test) { [car_travel_expense, hotel_accommodation_expense, train_expense, road_tolls_expense, cab_fares_expense, subsistence_expense] }
+      let(:expenses_to_test) { [car_travel_expense, bike_travel_expense, hotel_accommodation_expense, train_expense, road_tolls_expense, cab_fares_expense, subsistence_expense] }
 
       it 'should be mandatory for everything except parking and travel time ' do
         expenses_to_test.each do |ex|
@@ -304,6 +305,11 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
           expect(car_travel_expense).to be_valid
         end
 
+        it 'is valid when present for bike travel' do
+          bike_travel_expense.distance = 33
+          expect(bike_travel_expense).to be_valid
+        end
+
         it 'is valid when distance is decimal' do
           car_travel_expense.distance = 30.52
           expect(car_travel_expense).to be_valid
@@ -371,7 +377,7 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
     end
 
     describe 'validate_mileage_rate_id' do
-      context 'not car travel' do
+      context 'not car or bike travel' do
         let(:expenses_to_test) { [parking_expense, travel_time_expense, hotel_accommodation_expense, train_expense, road_tolls_expense, cab_fares_expense, subsistence_expense] }
 
         it 'is invalid if present' do
@@ -392,6 +398,12 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
 
       context 'car travel' do
         it 'is invalid if not a value in the settings' do
+          car_travel_expense.mileage_rate_id = 4
+          expect(car_travel_expense).not_to be_valid
+          expect(car_travel_expense.errors[:mileage_rate_id]).to include('invalid')
+        end
+
+        it 'is invalid if bike travel rate' do
           car_travel_expense.mileage_rate_id = 3
           expect(car_travel_expense).not_to be_valid
           expect(car_travel_expense.errors[:mileage_rate_id]).to include('invalid')
@@ -411,6 +423,31 @@ describe 'ExpenseV1Validator and ExpenseV2Validator' do
         end
       end
 
+      context 'bike travel' do
+        it 'is invalid if not a value in the settings' do
+          bike_travel_expense.mileage_rate_id = 4
+          expect(bike_travel_expense).not_to be_valid
+          expect(bike_travel_expense.errors[:mileage_rate_id]).to include('invalid')
+        end
+
+        it 'is invalid if car travel rate' do
+          [1, 2].each do |i|
+            bike_travel_expense.mileage_rate_id = i
+            expect(bike_travel_expense).not_to be_valid
+          end
+        end
+
+        it 'is valid if the correct rate for bike travel' do
+          bike_travel_expense.mileage_rate_id = 3
+          expect(bike_travel_expense).to be_valid
+        end
+
+        it 'is invalid if absent' do
+          bike_travel_expense.mileage_rate_id = nil
+          expect(bike_travel_expense).not_to be_valid
+          expect(bike_travel_expense.errors[:mileage_rate_id]).to include('blank')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Adds "Bike travel" as an additional expense type, with separate mileage
rates.

Requires re-seeding of expense types: `rake data:migrate:all`