### PR TITLE
Feat: Removal of Judicial Apportionment

### DIFF
--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -15,15 +15,6 @@
       %a{:id => "defendant_#{@defendant_count+1}_date_of_birth"}
       = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
 
-  - unless @claim.interim?
-    .form-row
-      .form-col.form-col-two-thirds
-        %label.block-label.judicial-apportionment-notice
-          = f.check_box :order_for_judicial_apportionment
-          = raw t('.order_for_judicial_apportionment')
-          = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
-
-
   .documents
     = f.fields_for :representation_orders do |repo_form|
       = render partial: 'external_users/claims/defendants/representation_order_fields', locals: { f: repo_form }

--- a/app/views/external_users/claims/defendants/_summary.html.haml
+++ b/app/views/external_users/claims/defendants/_summary.html.haml
@@ -19,15 +19,6 @@
           %td
             = defendant.date_of_birth.strftime('%d/%m/%Y') rescue ''
 
-      - unless claim.interim?
-        %tr
-          %th{scope:'row'}
-            %span.visuallyhidden
-              = "#{t('common.defendant')} #{index}"
-            = t('external_users.claims.defendants.defendant_fields.judical_apportionment')
-          %td
-            = defendant.order_for_judicial_apportionment == true ? 'Yes' : 'No'
-
       - defendant.representation_orders.each.with_index(1) do | representation_order, index|
         %tr
           %th{scope:'row'}

--- a/app/views/shared/_claim_defendant_details.html.haml
+++ b/app/views/shared/_claim_defendant_details.html.haml
@@ -16,13 +16,6 @@
           .xsmall
             = defendant.date_of_birth.strftime(Settings.date_format) rescue ''
 
-    - unless @claim.interim?
-      .judical_apportionment
-        %span.b
-          Judicial apportionment:
-        %span.xsmall
-          = defendant.order_for_judicial_apportionment == true ? 'Yes' : 'No'
-
     .rep-orders
       - if defendant.representation_orders.any?
         %table


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/144433507

Why are we doing this:
Judicial Apportionment is no longer a required metric to be collected

What does this PR do:
We are removing the view layer inputs and outputs
All BE methods / models / presenters  are unchanged