### PR TITLE
PPE field for LGFS transfer fee

### DIFF
--- a/app/views/external_users/claims/transfer_fee/_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_fields.html.haml
@@ -9,12 +9,21 @@
     .transfer-fee-group.nested-fields.mod-fees.js-block{data:{"type":"fees", autovat: @claim.apply_vat? ? "true" : "false"}}
       %fieldset
         .form-row
-          .column-three-quarters
+          .column-one-third
             = tf.label :fee_type, t('.fee_type')
             = tf.anchored_attribute 'fee_type'
             = @claim.transfer_fee.description
 
-          .column-quarter.fee-amount
+          .column-one-third.condensed.js-expense-location.fee-amount
+            .form-group.location_wrapper
+              = tf.adp_text_field :quantity,
+                        label: t('.ppe_total'),
+                        input_classes:'quantity',
+                        value: tf.object.quantity,
+                        error_key:'transfer_fee.quantity',
+                        errors: @error_presenter
+
+          .column-one-third.condensed.fee-total
             = tf.adp_text_field :amount,
                                 label: t('.total'),
                                 input_classes:'total',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -636,6 +636,7 @@ en:
           summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows.'
       transfer_fee:
         fields:
+          ppe_total: "PPE total"
           transfer_fee_section_header: Transfer fee
           transfer_fee_prompt_text_html: You must enter a total amount for the transfer fee. Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a>
           fee_type: Fee type


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/144704837

Why are we doing this:
On litigator transfer claims there is no input for PPE

What does this PR do:
Refactor to the view to expose the input for the model

## before
![screen shot 2017-05-11 at 11 51 26](https://cloud.githubusercontent.com/assets/3668907/25945825/3d9cf8dc-3640-11e7-93c6-d39a2b9189e7.png)


## after
![screen shot 2017-05-11 at 11 51 06](https://cloud.githubusercontent.com/assets/3668907/25945826/3d9f0a32-3640-11e7-93f7-b711339895f3.png)
