### PR TITLE
Change 25k in claim value filter to 20k

### DIFF
--- a/app/services/claims/value_bands.rb
+++ b/app/services/claims/value_bands.rb
@@ -4,9 +4,9 @@ module Claims
     Struct.new('ValueBandDefinition', :id, :name, :min, :max)
 
     VALUE_BANDS = {
-      10 => Struct::ValueBandDefinition.new(10, 'less than £25,000', 0.0, 25_000.0),
-      20 => Struct::ValueBandDefinition.new(20, '£25,000 - £100,000', 25_000.01, 100_000.0),
-      30 => Struct::ValueBandDefinition.new(30, '£100,000 - £150,000', 100_000.01, 150_000.0),
+      10 => Struct::ValueBandDefinition.new(10, 'less than £20,000', 0.0, 20_000.0),
+      20 => Struct::ValueBandDefinition.new(20, '£20,001 - £100,000', 20_000.01, 100_000.0),
+      30 => Struct::ValueBandDefinition.new(30, '£100,001 - £150,000', 100_000.01, 150_000.0),
       40 => Struct::ValueBandDefinition.new(40, 'more than £150,000', 150_000.01, 99_999_999.99),
     }
 

--- a/spec/services/claims/value_bands_spec.rb
+++ b/spec/services/claims/value_bands_spec.rb
@@ -7,7 +7,7 @@ module Claims
     describe '.band_id_for_claim' do
       context 'with VAT' do
         it 'returns band 10' do
-          claim = double(Claim, total: 18_000.77, vat_amount: 6_999.23)
+          claim = double(Claim, total: 13_000.77, vat_amount: 6_999.23)
           expect(ValueBands.band_id_for_claim(claim)).to eq 10
         end
 
@@ -36,7 +36,7 @@ module Claims
 
       context 'without VAT' do
         it 'returns band 10' do
-          claim = double(Claim, total: 25_000.00, vat_amount: 0.0)
+          claim = double(Claim, total: 20_000.00, vat_amount: 0.0)
           expect(ValueBands.band_id_for_claim(claim)).to eq 10
         end
 
@@ -60,8 +60,8 @@ module Claims
     describe '.band_by_id' do
       it 'returns the ValueBandDefinition struct for the given id' do
         band = ValueBands.band_by_id(20)
-        expect(band.name).to eq '£25,000 - £100,000'
-        expect(band.min).to eq 25_000.01
+        expect(band.name).to eq '£20,001 - £100,000'
+        expect(band.min).to eq 20_000.01
         expect(band.max).to eq 100_000.0
       end
     end


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/145430905

Why are we doing this:
CCR has not yet been updated to reflect this change. Reverting back until we sync with CCR

What this PR does:
Update the value bands used for allocation filters