### PR TITLE
Feat: Allocation bands agfs / lgfs specific

### DIFF
--- a/app/services/claims/value_bands.rb
+++ b/app/services/claims/value_bands.rb
@@ -4,10 +4,12 @@ module Claims
     Struct.new('ValueBandDefinition', :id, :name, :min, :max)
 
     VALUE_BANDS = {
-      10 => Struct::ValueBandDefinition.new(10, 'less than £20,000', 0.0, 20_000.0),
-      20 => Struct::ValueBandDefinition.new(20, '£20,001 - £100,000', 20_000.01, 100_000.0),
+      10 => Struct::ValueBandDefinition.new(10, '(AGFS) less than £20,000', 0.0, 20_000.0),
+      15 => Struct::ValueBandDefinition.new(15, '(AGFS) £20,001 - £100,000', 20_000.01, 100_000.0),
+      20 => Struct::ValueBandDefinition.new(20, '(LGFS) less than £25,000', 0.0, 25_000.0),
+      25 => Struct::ValueBandDefinition.new(25, '(LGFS) £25,001 - £100,000', 25_000.01, 100_000.0),
       30 => Struct::ValueBandDefinition.new(30, '£100,001 - £150,000', 100_000.01, 150_000.0),
-      40 => Struct::ValueBandDefinition.new(40, 'more than £150,000', 150_000.01, 99_999_999.99),
+      40 => Struct::ValueBandDefinition.new(40, 'more than £150,000', 150_000.01, 99_999_999.99)
     }
 
     def self.band_id_for_claim(claim)

--- a/spec/models/claims/totals_spec.rb
+++ b/spec/models/claims/totals_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Claim, type: :model do
         claim.reload
         expect(claim.total).to eq 25_025.0
         expect(claim.vat_amount).to eq 5_000.0
-        expect(claim.value_band_id).to eq 20
+        expect(claim.value_band_id).to eq 15
       end
 
       it 'updates the value band id when added expenses takes it to the next band' do
@@ -240,7 +240,7 @@ RSpec.describe Claim, type: :model do
         claim.reload
         expect(claim.total).to eq 25_027.2
         expect(claim.vat_amount).to eq 5_000.20
-        expect(claim.value_band_id).to eq 20
+        expect(claim.value_band_id).to eq 15
       end
 
       it 'updates the value band id when added fees takes it to the next band' do
@@ -253,7 +253,7 @@ RSpec.describe Claim, type: :model do
         claim.reload
         expect(claim.total).to eq 25_027.2
         expect(claim.vat_amount).to eq 0.0
-        expect(claim.value_band_id).to eq 20
+        expect(claim.value_band_id).to eq 15
       end
     end
 

--- a/spec/services/claims/value_bands_spec.rb
+++ b/spec/services/claims/value_bands_spec.rb
@@ -13,7 +13,7 @@ module Claims
 
         it 'returns band 20' do
           claim = double(Claim, total: 18_000.77, vat_amount: 6_999.24)
-          expect(ValueBands.band_id_for_claim(claim)).to eq 20
+          expect(ValueBands.band_id_for_claim(claim)).to eq 15
         end
 
         it 'returns band 30' do
@@ -42,7 +42,7 @@ module Claims
 
         it 'returns band 20' do
           claim = double(Claim, total: 25_000.01, vat_amount: 0.0)
-          expect(ValueBands.band_id_for_claim(claim)).to eq 20
+          expect(ValueBands.band_id_for_claim(claim)).to eq 15
         end
 
         it 'returns band 30' do
@@ -60,31 +60,31 @@ module Claims
     describe '.band_by_id' do
       it 'returns the ValueBandDefinition struct for the given id' do
         band = ValueBands.band_by_id(20)
-        expect(band.name).to eq '£20,001 - £100,000'
-        expect(band.min).to eq 20_000.01
-        expect(band.max).to eq 100_000.0
+        expect(band.name).to eq '(LGFS) less than £25,000'
+        expect(band.min).to eq 0.0
+        expect(band.max).to eq 25_000.0
       end
     end
 
     describe '.bands' do
       it 'returns an array of bands in ascending order' do
         bands = ValueBands.bands
-        expect(bands.size).to eq 4
-        expect(bands.map(&:id)).to eq( [ 10, 20, 30, 40 ])
+        expect(bands.size).to eq 6
+        expect(bands.map(&:id)).to eq( [10, 15, 20, 25, 30, 40])
       end
     end
 
     describe '.band_ids' do
       it 'returns a list of band ids' do
-        expect(ValueBands.band_ids).to eq( [ 10, 20, 30, 40 ] )
+        expect(ValueBands.band_ids).to eq( [10, 15, 20, 25, 30, 40] )
       end
     end
 
     describe '.collection_select' do
       it 'returns an array of Bands including a dummy on for all bands' do
         bands = ValueBands.collection_select
-        expect(bands.size).to eq 5
-        expect(bands.map(&:id)).to eq( [ 0, 10, 20, 30, 40 ] )
+        expect(bands.size).to eq 7
+        expect(bands.map(&:id)).to eq( [ 0, 10, 15, 20, 25, 30, 40 ] )
         expect(bands.first.name).to eq 'All Claims'
       end
     end


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/145430905

Why are we doing this:
Changes in CCR and CCLF are cuasing workarounds in CCCD Allocation.

What does this PR do:
Adding in AGFS and LGFS specific band filters to allow for easier allocation