### PR TITLE
GA Tracking housekeeping

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,7 +71,11 @@ module ApplicationHelper
   end
 
   def ga_outlet
-    (flash[:ga] || []).join("\n")
+    if flash[:ga].present?
+      flash[:ga].join("\n")
+    else
+      "ga('send', 'pageview');"
+    end
   end
 
   def sortable(column, title = nil)

--- a/app/models/google_analytics/data_tracking.rb
+++ b/app/models/google_analytics/data_tracking.rb
@@ -4,7 +4,7 @@ module GoogleAnalytics
 
     class << self
       def enabled?
-        adapter.present? && Rails.env.production? && (Rails.host.staging? || Rails.host.gamma?)
+        adapter.present? && Rails.env.production?
       end
 
       def track(*args)

--- a/app/views/layouts/_analytics.js.haml
+++ b/app/views/layouts/_analytics.js.haml
@@ -14,4 +14,3 @@
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
     ga('create', "#{ENV['GA_TRACKER_ID']}", 'auto');
     ga('set', 'anonymizeIp', true);
-    ga('send', 'pageview');

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -3,4 +3,4 @@
 #   :ga  -> Google Analytics
 #   :gtm -> Google Tag Manager
 #
-GoogleAnalytics::DataTracking.adapter = Rails.host.gamma? ? :ga : :gtm
+GoogleAnalytics::DataTracking.adapter = :ga

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -19,11 +19,6 @@ module GoogleAnalytics
             expect(described_class.enabled?).to be_truthy
           end
         end
-
-        it 'returns false when host is demo' do
-          allow(RailsHost).to receive(:env).and_return('demo')
-          expect(described_class.enabled?).to be_falsey
-        end
       end
 
       context 'with no adapter set' do


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/145853977

Why are we doing this?
GA is implemented differently in pre-production environments. It uses Google Tag Manager. In order to review the analytics strategy and test it we want a consistent implementation on ALL pre-prod env's

What this PR does?
- [x] Remove the GTM implementation
- [x] Enable GA on all pre-prod env's
- [x] Fix the double page view call