### PR TITLE
Reverse the RAG status generation sequence

### DIFF
--- a/app/services/stats/claim_percentage_authorised_generator.rb
+++ b/app/services/stats/claim_percentage_authorised_generator.rb
@@ -19,7 +19,7 @@ module Stats
       calculate_claims_decided_this_month
       total_claims = @decided_claims_by_state.values.sum
       percentages = {}
-      @decided_claims_by_state.keys.each do |state|
+      @decided_claims_by_state.keys.sort_by {|k,v| k.to_s}.reverse.each do |state|
         percentages[state] = @decided_claims_by_state[state].to_f / total_claims.to_f * 100
       end
       percentages

--- a/spec/services/stats/claim_percentage_authorised_generator_spec.rb
+++ b/spec/services/stats/claim_percentage_authorised_generator_spec.rb
@@ -18,9 +18,9 @@ module Stats
       {
         item:
           [
-            { value: 71.20418848167539, text: 'Authorised' },
+            { value: 7.853403141361256, text: 'Rejected/refused'},
             { value: 20.94240837696335, text: 'Part authorised' },
-            { value: 7.853403141361256, text: 'Rejected/refused'}
+            { value: 71.20418848167539, text: 'Authorised' }
           ]
         }
     end


### PR DESCRIPTION
# What
The geckoboard RAG output was displayed incorrectly
![image](https://cloud.githubusercontent.com/assets/6757677/26450669/9190784a-4150-11e7-8cc2-8d79d1de2dc5.png) 
This was due to the ordering of the generated data, successful was returned first so was displayed as Red, rather than green.

# How
This PR reverses (and tests) the sequence returns Rejected, partial and Authorised; so Red-Amber-Green