### PR TITLE
Litigant supplier number validation on create only

### DIFF
--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -65,6 +65,7 @@ module Claim
     set_singular_route_key 'litigators_interim_claim'
 
     validates_with ::Claim::InterimClaimValidator
+    validates_with ::Claim::LitigatorSupplierNumberValidator
     validates_with ::Claim::InterimClaimSubModelValidator
 
     has_one :interim_fee, foreign_key: :claim_id, class_name: 'Fee::InterimFee', dependent: :destroy, inverse_of: :claim

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -65,6 +65,7 @@ module Claim
     set_singular_route_key 'litigators_claim'
 
     validates_with ::Claim::LitigatorClaimValidator
+    validates_with ::Claim::LitigatorSupplierNumberValidator, on: :create
     validates_with ::Claim::LitigatorClaimSubModelValidator
 
     has_one :fixed_fee, foreign_key: :claim_id, class_name: 'Fee::FixedFee', dependent: :destroy, inverse_of: :claim

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -21,7 +21,8 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         :trial_concluded_at,
         :retrial_started_at,
         :retrial_concluded_at,
-        :case_concluded_at
+        :case_concluded_at,
+        :supplier_number
       ],
       [
         :total

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -3,7 +3,6 @@ class Claim::BaseClaimValidator < BaseValidator
     [
       :external_user_id,
       :creator,
-      :supplier_number,
       :amount_assessed,
       :evidence_checklist_ids
     ]

--- a/app/validators/claim/litigator_supplier_number_validations.rb
+++ b/app/validators/claim/litigator_supplier_number_validations.rb
@@ -1,0 +1,38 @@
+module Claim
+  module LitigatorSupplierNumberValidations
+
+    def self.included(base)
+      base.class_eval do
+        def self.first_step_common_validations
+          [
+            :supplier_number
+          ]
+        end
+      end
+    end
+
+    private
+
+    def validate_supplier_number
+      validate_presence(:supplier_number, 'blank')
+
+      return unless @record.supplier_number.present?
+
+      validate_pattern(:supplier_number, supplier_number_regex, 'invalid')
+      validate_inclusion(:supplier_number, provider_supplier_numbers, 'unknown') unless @record.errors.key?(:supplier_number)
+    end
+
+
+    # local helpers
+    # ---------------------------
+
+
+    def supplier_number_regex
+      SupplierNumber::SUPPLIER_NUMBER_REGEX
+    end
+
+    def provider_supplier_numbers
+      @record.provider.lgfs_supplier_numbers.pluck(:supplier_number) rescue []
+    end
+  end
+end

--- a/app/validators/claim/litigator_supplier_number_validations.rb
+++ b/app/validators/claim/litigator_supplier_number_validations.rb
@@ -22,11 +22,6 @@ module Claim
       validate_inclusion(:supplier_number, provider_supplier_numbers, 'unknown') unless @record.errors.key?(:supplier_number)
     end
 
-
-    # local helpers
-    # ---------------------------
-
-
     def supplier_number_regex
       SupplierNumber::SUPPLIER_NUMBER_REGEX
     end

--- a/app/validators/claim/litigator_supplier_number_validator.rb
+++ b/app/validators/claim/litigator_supplier_number_validator.rb
@@ -1,0 +1,9 @@
+class Claim::LitigatorSupplierNumberValidator < Claim::BaseClaimValidator
+  include Claim::LitigatorSupplierNumberValidations
+
+  def self.fields_for_steps
+    [
+        [].unshift(first_step_common_validations)
+    ]
+  end
+end

--- a/app/validators/claim/litigator_supplier_number_validator.rb
+++ b/app/validators/claim/litigator_supplier_number_validator.rb
@@ -3,7 +3,7 @@ class Claim::LitigatorSupplierNumberValidator < Claim::BaseClaimValidator
 
   def self.fields_for_steps
     [
-        [].unshift(first_step_common_validations)
+        [first_step_common_validations]
     ]
   end
 end

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -46,6 +46,9 @@ FactoryGirl.define do
       end
     end
 
+    trait :forced_validation do |claim|
+      claim.force_validation true
+    end
   end
 end
 

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -147,6 +147,28 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
     end
   end
 
+  describe 'when supplier number has been invalidated' do
+    subject { claim.valid? }
+
+    before { SupplierNumber.find_by(supplier_number: claim.supplier_number).delete }
+
+    describe 'on create' do
+      describe 'the claim is invalid' do
+        let(:claim) { build :litigator_claim, :fixed_fee, :forced_validation }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe 'on edit' do
+      describe 'the claim is valid' do
+        let(:claim) { create :litigator_claim, :fixed_fee, :forced_validation }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+
   include_examples "common litigator claim attributes"
 
 end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -159,6 +159,14 @@ RSpec.describe Claims::StateMachine, type: :model do
         end
       end
     end
+
+    describe 'when supplier number has been invalidated' do
+      let(:claim) { create :litigator_claim, :fixed_fee, force_validation: true }
+
+      before { SupplierNumber.find_by(supplier_number: claim.supplier_number).delete }
+
+      it { expect{ claim.submit! }.not_to raise_error }
+    end
   end # describe 'valid transitions'
 
   describe 'set triggers' do

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -119,7 +119,8 @@ describe Claim::AdvocateClaimValidator do
           :trial_concluded_at,
           :retrial_started_at,
           :retrial_concluded_at,
-          :case_concluded_at
+          :case_concluded_at,
+          :supplier_number
       ],
       [
           :total

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -142,18 +142,6 @@ shared_examples "common litigator validations" do
     end
   end
 
-  context 'supplier_number' do
-    it 'should error when the supplier number is not valid for litigators' do
-      claim.supplier_number = 'XP312'
-      should_error_with(claim, :supplier_number, 'invalid')
-    end
-
-    it 'should error when the supplier number doesn\'t belong to the provider' do
-      claim.supplier_number = '2A267M'
-      should_error_with(claim, :supplier_number, 'unknown')
-    end
-  end
-
   context 'advocate_category' do
     it 'should be absent' do
       claim.advocate_category = 'QC'


### PR DESCRIPTION
Why are we doing this:
> Allocation of cases was being blocked in certain circumstances (i.e. a supplier had been removed from a provider) because `supplier_number` was validated on update

What have we done: 
> Apply a separate validator ruleset and apply it on create of litigator_claims.  For other claim types, added `supplier_number` to the validation rulesets

Bonus
> This also fixes the deletion of records that are `archive_pending_delete`  this has been blocked for a number of months, testing on a local, anonymised, copy of the DB, this is no longer the case