### PR TITLE
Improve handling of provider LGFS supplier numbers

### DIFF
--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -119,6 +119,7 @@ module Claims::StateMachine
       klass.scope s, -> { klass.where(state: s) }
     end
 
+    klass.scope :non_archived_pending_delete, -> { klass.where.not(state: :archived_pending_delete) }
     klass.scope :non_draft, -> { klass.where(state: NON_DRAFT_STATES) }
 
     klass.scope :submitted_or_redetermination_or_awaiting_written_reasons, -> { klass.where(state: CASEWORKER_DASHBOARD_UNALLOCATED_STATES) }

--- a/app/models/supplier_number.rb
+++ b/app/models/supplier_number.rb
@@ -21,4 +21,13 @@ class SupplierNumber < ActiveRecord::Base
   def to_s
     supplier_number
   end
+
+  def has_non_archived_claims?
+    # FIXME: For whatever reason claims don't actually have a relationship to SupplierNumber,
+    #   instead storing the literal string supplier number in a string column. This needs to
+    #   be fixed, but opens up a whole other can of worms. So for now we'll have this ugly
+    #   hack.
+
+    Claim::BaseClaim.non_archived_pending_delete.where(supplier_number: supplier_number).any?
+  end
 end

--- a/app/views/shared/_supplier_number_fields.html.haml
+++ b/app/views/shared/_supplier_number_fields.html.haml
@@ -1,5 +1,15 @@
 .form-group.supplier-number-group
   = f.label :supplier_number, class: 'form-label'
-  = f.text_field :supplier_number, class: 'form-control'
 
-  = link_to_remove_association t('.remove'), f, { wrapper_class: 'supplier-number-group' }
+  - if f.object.supplier_number.blank? || !f.object.valid?
+    = f.text_field :supplier_number, class: 'form-control'
+    = link_to_remove_association t('.remove'), f, { wrapper_class: 'supplier-number-group' }
+  - else
+    = f.text_field :supplier_number, class: 'form-control', disabled: true
+    - if f.object.has_non_archived_claims?
+      %span.form-hint
+        Cannot remove supplier number while claims are still in progress
+    - else
+      = link_to_remove_association t('.remove'), f, { wrapper_class: 'supplier-number-group' }
+
+

--- a/spec/models/claims/state_machine_scopes_spec.rb
+++ b/spec/models/claims/state_machine_scopes_spec.rb
@@ -33,5 +33,11 @@ RSpec.describe Claims::StateMachine, type: :model do
         expect(Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons).to match_array([submitted_claim, redetermination_claim, awaiting_written_reasons_claim])
       end
     end
+
+    describe '.non_archived_pending_delete' do
+      it 'returns everything but archived_pending_delete cases' do
+        expect(Claim::BaseClaim.active.non_archived_pending_delete).to match_array([draft_claim, submitted_claim, allocated_claim, redetermination_claim, awaiting_written_reasons_claim])
+      end
+    end
   end
 end

--- a/spec/models/supplier_number_spec.rb
+++ b/spec/models/supplier_number_spec.rb
@@ -49,4 +49,30 @@ RSpec.describe SupplierNumber, type: :model do
       expect(subject).to be_valid
     end
   end
+
+  describe '#has_non_archived_claims?' do
+    let(:relation) { double(ActiveRecord::Relation) }
+    subject { described_class.new(supplier_number: '6X666X') }
+
+    before do
+      expect(Claim::BaseClaim).to receive(:non_archived_pending_delete).and_return(relation)
+      expect(relation).to receive(:where).with(supplier_number: '6X666X').and_return(claims)
+    end
+
+    context 'when there are claims' do
+      let(:claims) { [double('Claim')] }
+
+      it 'returns true' do
+        expect(subject.has_non_archived_claims?).to be true
+      end
+    end
+
+    context 'when there are no claims' do
+      let(:claims) { [] }
+
+      it 'returns false' do
+        expect(subject.has_non_archived_claims?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
At the moment, providers can delete any of their LGFS supplier numbers
which breaks the claim state machine if they still have claims that
haven't been archived pending delete.

- Supplier numbers should not be editable once added
- Supplier numbers should not be deletable if they still have claims
  ongoing