### PR TITLE
Improve user satisfaction reporting

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,3 +1,5 @@
+require 'google_analytics/api'
+
 class FeedbackController < ApplicationController
   skip_load_and_authorize_resource only: [:new, :create]
   before_action :suppress_hotline_link
@@ -10,6 +12,7 @@ class FeedbackController < ApplicationController
   def create
     @feedback = Feedback.new(merged_feedback_params)
     if @feedback.save
+      GoogleAnalytics::Api.delay.event('satisfaction', merged_feedback_params[:rating], params[:ga_client_id])
       redirect_to after_create_url, notice: 'Feedback submitted'
     else
       render "feedback/#{@feedback.type}"

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -12,6 +12,7 @@
   = form_for @feedback, url: feedback_index_path(email: params[:email]), html: { novalidate: 'novalidate', class: 'normal'} do |f|
     = f.hidden_field :type
     = f.hidden_field :referrer
+    = hidden_field_tag 'ga_client_id', '', class:'ga-client-id'
     - if params[:user_id].present?
       = hidden_field_tag :user_id, params[:user_id]
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,15 +6,13 @@
 - content_for :head do
   %meta{:name =>"format-detection", :content => "telephone=no"}
   = stylesheet_link_tag "application", media: "all"
-
-- content_for :body_classes do
-  = "controller-" + controller.controller_name
-
-- content_for :body_start do
   - if GoogleAnalytics::DataTracking.enabled?
     = render partial: 'layouts/analytics', :formats => [:js], locals: { adapter: GoogleAnalytics::DataTracking.adapter_name }
     %script
       != ga_outlet
+
+- content_for :body_classes do
+  = "controller-" + controller.controller_name
 
 - content_for :header_class do
   = "with-proposition"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -51,5 +51,12 @@
 
 - content_for :body_end do
   = javascript_include_tag Rails.env.test? ? 'application.test' : 'application'
+  - if GoogleAnalytics::DataTracking.enabled?
+    :javascript
+      ga(function(tracker) {
+        var clientId = tracker.get('clientId');
+        $('.ga-client-id').val(clientId);
+      });
+
 
 = render template: 'layouts/govuk_template'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,7 @@ google_analytics:
   endpoint: "http://www.google-analytics.com/collect"
   version: 1
   tracker_id: <%= ENV['GA_TRACKER_ID'] %>
+  fallback_client_id: <%= ENV['FALLBACK_CLIENT_ID'] || '555' %>
 
 # This value is not used - the max value of 20.megabytes is hard coded into models/document.rb:36
 max_document_upload_size_mb: 400

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,10 @@ earliest_permitted_date_in_words: 10 years ago
 
 interim_earliest_permitted_repo_date: <%= Date.new(2014,10,2) %>
 
+google_analytics:
+  endpoint: "http://www.google-analytics.com/collect"
+  version: 1
+  tracker_id: <%= ENV['GA_TRACKER_ID'] %>
 
 # This value is not used - the max value of 20.megabytes is hard coded into models/document.rb:36
 max_document_upload_size_mb: 400

--- a/lib/google_analytics/api.rb
+++ b/lib/google_analytics/api.rb
@@ -1,0 +1,28 @@
+require 'rest_client'
+
+module GoogleAnalytics
+  class Api
+    def self.event(category, action, client_id = '555')
+      return unless tracker_id.present?
+      params = { v: version, tid: tracker_id, cid: client_id, t: 'event', ec: category, ea: action }
+      begin
+        RestClient.get(endpoint, params: params, timeout: 4, open_timeout: 4)
+        return true
+      rescue RestClient::Exception
+        return false
+      end
+    end
+
+    def self.tracker_id
+      Settings.google_analytics.tracker_id
+    end
+
+    def self.version
+      Settings.google_analytics.version
+    end
+
+    def self.endpoint
+      Settings.google_analytics.endpoint
+    end
+  end
+end

--- a/lib/google_analytics/api.rb
+++ b/lib/google_analytics/api.rb
@@ -2,7 +2,7 @@ require 'rest_client'
 
 module GoogleAnalytics
   class Api
-    def self.event(category, action, client_id = '555')
+    def self.event(category, action, client_id = fallback_client_id)
       return unless tracker_id.present?
       params = { v: version, tid: tracker_id, cid: client_id, t: 'event', ec: category, ea: action }
       begin
@@ -23,6 +23,10 @@ module GoogleAnalytics
 
     def self.endpoint
       Settings.google_analytics.endpoint
+    end
+
+    def self.fallback_client_id
+      Settings.google_analytics.fallback_client_id.to_s
     end
   end
 end

--- a/spec/lib/google_analytics/api_spec.rb
+++ b/spec/lib/google_analytics/api_spec.rb
@@ -7,11 +7,13 @@ describe GoogleAnalytics::Api do
   let(:endpoint) { 'http://example.com' }
   let(:tracker_id) { 'GA123456' }
   let(:version) { '1' }
+  let(:fallback_client_id) { '555' }
 
   before do
     allow(Settings.google_analytics).to receive(:endpoint).and_return(endpoint)
     allow(Settings.google_analytics).to receive(:tracker_id).and_return(tracker_id)
     allow(Settings.google_analytics).to receive(:version).and_return(version)
+    allow(Settings.google_analytics).to receive(:fallback_client_id).and_return(fallback_client_id)
   end
 
   describe '.event' do
@@ -72,6 +74,20 @@ describe GoogleAnalytics::Api do
       let(:version) { nil }
 
       it { is_expected.to be nil }
+    end
+  end
+
+  describe '.fallback_client_id' do
+    subject(:api_fallback_client_id) { api.fallback_client_id }
+
+    describe 'when not set' do
+      it { is_expected.to eq '555' }
+    end
+
+    describe 'when explicitly set' do
+      let(:fallback_client_id) { '777' }
+
+      it { is_expected.to eq '777' }
     end
   end
 end

--- a/spec/lib/google_analytics/api_spec.rb
+++ b/spec/lib/google_analytics/api_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+require 'google_analytics/api'
+
+describe GoogleAnalytics::Api do
+  subject(:api) { described_class }
+
+  let(:endpoint) { 'http://example.com' }
+  let(:tracker_id) { 'GA123456' }
+  let(:version) { '1' }
+
+  before do
+    allow(Settings.google_analytics).to receive(:endpoint).and_return(endpoint)
+    allow(Settings.google_analytics).to receive(:tracker_id).and_return(tracker_id)
+    allow(Settings.google_analytics).to receive(:version).and_return(version)
+  end
+
+  describe '.event' do
+    subject(:api_event) { api.event(category, event) }
+
+    let(:event) { '5' }
+    let(:category) { 'satisfaction' }
+
+    it 'submits a get request via RestClient' do
+      params = { v: '1', tid: 'GA123456', cid: '555', t: 'event', ec: 'satisfaction', ea: '5' }
+      expect(RestClient).to receive(:get).with('http://example.com', params: params, timeout: 4, open_timeout: 4)
+      subject
+    end
+
+    describe 'when tracker_id is not set' do
+      let(:tracker_id) { nil }
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.endpoint' do
+    subject(:api_endpoint) { api.endpoint }
+
+    describe 'when set' do
+      it { is_expected.to eq endpoint }
+    end
+
+    describe 'when not set' do
+      let(:endpoint) { nil }
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.tracker_id' do
+    subject(:api_tracker_id) { api.tracker_id }
+
+    describe 'when set' do
+      it { is_expected.to eq tracker_id }
+    end
+
+    describe 'when not set' do
+      let(:tracker_id) { nil }
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe '.version' do
+    subject(:api_version) { api.version }
+
+    describe 'when set' do
+      it { is_expected.to eq version }
+    end
+
+    describe 'when not set' do
+      let(:version) { nil }
+
+      it { is_expected.to be nil }
+    end
+  end
+end


### PR DESCRIPTION
# Why?
A separate aggregation program used to run and provide an end point for the [gov.uk performance platform](https://www.gov.uk/performance/crown-court-defence-claims) to access data.  This broke in October 2016 and no-one was available to correct it.

# Fixes
This PR makes the application submit an event to google analytics that the PP team can use to aggregate the data instead.  

# Still to do
A separate event will need tobe undertaken to provide them with static data from Oct 2016 to date.