### PR TITLE
Add second unicorn instance

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -93,3 +93,6 @@ bundle exec sidekiq -d
 
 echo "launching unicorn"
 bundle exec unicorn -p 80 -c config/unicorn.rb
+
+echo "launching unicorn for API"
+bundle exec unicorn -p 3001 -c config/unicorn.rb


### PR DESCRIPTION
In order to run the API in a stable fashion, a second unicorn instance should be spun up to serve *only* the api