### PR TITLE
Add switch to docker run.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,4 +39,4 @@ EXPOSE 80
 #SECRET_TOKEN set here because otherwise devise blows up during the precompile.
 RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here
 
-CMD "$APP_HOME/run.sh"
+ENTRYPOINT ["$APPHOME/run.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,4 +40,4 @@ EXPOSE 80
 #SECRET_TOKEN set here because otherwise devise blows up during the precompile.
 RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here
 
-CMD "$APP_HOME/run.sh"
+ENTRYPOINT "$APP_HOME/run.sh"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,4 +40,4 @@ EXPOSE 80
 #SECRET_TOKEN set here because otherwise devise blows up during the precompile.
 RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here
 
-ENTRYPOINT ["$APP_HOME/run.sh"]
+CMD "$APP_HOME/run.sh"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,9 +22,10 @@ WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 
-# Hack to install private gems
+# Hack to install private gem
 #RUN socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork TCP4:$(ip route|awk '/default/ {print $3}'):$SSH_AUTH_PROXY_PORT & bundle install
 RUN bundle install
+ENV APP_HOME ./
 
 COPY . /usr/src/app
 RUN mkdir -p /usr/src/app/public/assets
@@ -32,11 +33,11 @@ RUN mkdir -p /usr/src/app/public/assets
 COPY ./docker/run.sh $APP_HOME/run.sh
 RUN chmod 777 $APP_HOME/run.sh
 
-WORKDIR $APPHOME
+WORKDIR $APP_HOME
 
 EXPOSE 80
 
 #SECRET_TOKEN set here because otherwise devise blows up during the precompile.
 RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here
 
-ENTRYPOINT ["$APPHOME/run.sh"]
+ENTRYPOINT ["$APP_HOME/run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -91,5 +91,14 @@ bundle exec scheduler_daemon start
 echo "starting sidekiq daemon"
 bundle exec sidekiq -d
 
-echo "launching unicorn"
-bundle exec unicorn -p 80 -c config/unicorn.rb
+ROLE="${1:-app}"
+case ${ROLE} in
+api)
+    echo "launching unicorn for API"
+    bundle exec unicorn -p 3001 -c config/unicorn.rb
+    ;;
+*)
+    echo "launching unicorn for app"
+    bundle exec unicorn -p 80 -c config/unicorn.rb
+    ;;
+esac


### PR DESCRIPTION
This is a test PR, the aim is to allow a docker container to be started in `api` mode

If the deploy repo sets a `startup_arg` of api, it will run a container in on a different port, this should allow the webserver container to use the api container...

By default the container will run in `normal`, web server mode
