### PR TITLE
Allow allocation regardless of validation

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -119,7 +119,13 @@ class Allocation
 
   def allocate_claim!(claim)
     claim.deallocate!(audit_attributes) if claim.allocated?
+    claim.disable_for_state_transition = allocating?
+    # Disable the validation of the claim while allocating
+    # this allows caseworkers to allocate cases regardless
+    # of the state of linked objects, previously it would
+    # fail if the creator had changed their own status
     claim.allocate!(audit_attributes)
+    claim.disable_for_state_transition = nil
 
     claim.case_workers << case_worker
     successful_claims << claim

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -70,7 +70,7 @@ module Claim
     accepts_nested_attributes_for :basic_fees, reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees, reject_if: all_blank_or_zero, allow_destroy: true
 
-    validates_with ::Claim::AdvocateClaimValidator
+    validates_with ::Claim::AdvocateClaimValidator, unless: :disable_for_state_transition
     validates_with ::Claim::AdvocateClaimSubModelValidator
 
     delegate :requires_cracked_dates?, to: :case_type

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -77,6 +77,7 @@ module Claim
     serialize :evidence_checklist_ids, Array
 
     attr_accessor :form_step
+    attr_accessor :disable_for_state_transition
 
     include ::Claims::StateMachine
     extend ::Claims::Search

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -64,7 +64,7 @@ module Claim
   class LitigatorClaim < BaseClaim
     set_singular_route_key 'litigators_claim'
 
-    validates_with ::Claim::LitigatorClaimValidator
+    validates_with ::Claim::LitigatorClaimValidator, unless: :disable_for_state_transition
     validates_with ::Claim::LitigatorSupplierNumberValidator, on: :create
     validates_with ::Claim::LitigatorClaimSubModelValidator
 

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -61,7 +61,13 @@ module TimedTransitions
                     dummy_run: @dummy) do
                       'Archiving claim'
                     end
+      @claim.disable_for_state_transition = true
+      # Disable the validation of the claim while archiving, this
+      # allows the timed_transitioner to archive cases regardless
+      # of the state of linked objects, previously it would fail
+      # if linked tables had changed in the months since creation
       @claim.archive_pending_delete!(reason_code: 'timed_transition') unless is_dummy?
+      @claim.disable_for_state_transition = nil
       self.success = true
     end
 

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -84,6 +84,22 @@ RSpec.describe Allocation, type: :model do
         end
       end
 
+      context 'when creator is a litigator' do
+        let!(:claim) { create :submitted_claim }
+        let(:allocator)  { Allocation.new(claim_ids: [claim.id], case_worker_id: case_worker.id, allocating: true, current_user: current_user) }
+
+        describe 'and then changes role to advocate' do
+          before do
+            claim.creator.roles = ['litigator']
+            claim.creator.save!
+          end
+
+          it 'allows the allocation of the claim' do
+            expect(allocator.save).to be true
+          end
+        end
+      end
+
       context 'when invalid because no caseworker id specified' do
         let(:claims) { create_list(:submitted_claim, 3) }
         let(:allocator)  { Allocation.new(claim_ids: claims.map(&:id), allocating: true) }

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -64,26 +64,6 @@ RSpec.describe Allocation, type: :model do
         end
       end
 
-      context 'when claim contains errors that forbids transitioning' do
-        let(:claims) { create_list(:submitted_claim, 1) }
-
-        before do
-          # Introduce an error in the claim
-          claims.each { |claim| claim.update_column(:case_number, 'case_number') }
-        end
-
-        it 'returns false' do
-          expect(allocator.save).to be false
-        end
-
-        it 'details the errors' do
-          allocator.save
-          expect(allocator.errors[:base].size).to eq 2
-          expect(allocator.errors[:base]).to include('NO claims allocated because: ')
-          expect(allocator.errors[:base][1]).to match(/^Claim CASE_NUMBER has errors/)
-        end
-      end
-
       context 'when creator is a litigator' do
         let!(:claim) { create :submitted_claim }
         let(:allocator)  { Allocation.new(claim_ids: [claim.id], case_worker_id: case_worker.id, allocating: true, current_user: current_user) }

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
 
   it { should delegate_method(:requires_trial_dates?).to(:case_type) }
   it { should delegate_method(:requires_retrial_dates?).to(:case_type) }
+  it { is_expected.to respond_to :disable_for_state_transition }
 
   describe '#final?' do
     it 'should return true' do

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -108,6 +108,20 @@ module TimedTransitions
               last_transition = @claim.reload.claim_state_transitions.first
               expect(last_transition.reason_code).to eq('timed_transition')
             end
+
+
+            context 'when the claim has been invalidated' do
+              let(:litigator) { create(:external_user, :litigator) }
+              before do
+                Timecop.freeze(17.weeks.ago) { @claim = create :authorised_claim, case_number: 'A20164444' }
+                @claim.creator = litigator
+                Transitioner.new(@claim).run
+              end
+
+              it 'still transitions to archived_pending_delete' do
+                expect(@claim.reload.state).to eq 'archived_pending_delete'
+              end
+            end
           end
         end
 
@@ -371,5 +385,5 @@ module TimedTransitions
         end
       end
     end
-  end
+    end
 end


### PR DESCRIPTION
Users were unable to allocate claims where linked tables had been invalidated since creation, e.g. the creator of a claim had changed roles from `litigator` to `advocate`.

This removes validation when allocating cases.

It also removes the validation when the timed transitioner runs overnight to archive the old records