### PR TITLE
Update allocation to pass correct number

### DIFF
--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -139,6 +139,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   end
 
   def criteria_params
-    { sorting: sort_column, direction: sort_direction, scheme: scheme, filter: filter, page: current_page, limit: page_size, search: search_terms, value_band_id: value_band_id }
+    limit = quantity_allocation? ? quantity_to_allocate : page_size
+    { sorting: sort_column, direction: sort_direction, scheme: scheme, filter: filter, page: current_page, limit: limit, search: search_terms, value_band_id: value_band_id }
   end
 end


### PR DESCRIPTION
Previously it always passed the page_size limit, regardless of the quantity to allocate

Personally, there is far to much logic in this controller and it should be extracted to an `allocation_service` it would allow for much clearer execution and testing... but, for now, so that case workers can actually use it...