### PR TITLE
State machine validation

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -119,13 +119,7 @@ class Allocation
 
   def allocate_claim!(claim)
     claim.deallocate!(audit_attributes) if claim.allocated?
-    claim.disable_for_state_transition = allocating?
-    # Disable the validation of the claim while allocating
-    # this allows caseworkers to allocate cases regardless
-    # of the state of linked objects, previously it would
-    # fail if the creator had changed their own status
     claim.allocate!(audit_attributes)
-    claim.disable_for_state_transition = nil
 
     claim.case_workers << case_worker
     successful_claims << claim

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -70,7 +70,7 @@ module Claim
     accepts_nested_attributes_for :basic_fees, reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees, reject_if: all_blank_or_zero, allow_destroy: true
 
-    validates_with ::Claim::AdvocateClaimValidator, unless: :disable_for_state_transition
+    validates_with ::Claim::AdvocateClaimValidator, unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
     validates_with ::Claim::AdvocateClaimSubModelValidator
 
     delegate :requires_cracked_dates?, to: :case_type

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -70,7 +70,11 @@ module Claim
 
     has_one :fixed_fee, foreign_key: :claim_id, class_name: 'Fee::FixedFee', dependent: :destroy, inverse_of: :claim
     has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
-    has_one :graduated_fee, foreign_key: :claim_id, class_name: 'Fee::GraduatedFee', dependent: :destroy, inverse_of: :claim
+    has_one :graduated_fee,
+            foreign_key: :claim_id,
+            class_name: 'Fee::GraduatedFee',
+            dependent: :destroy,
+            inverse_of: :claim
 
     accepts_nested_attributes_for :fixed_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -64,7 +64,7 @@ module Claim
   class LitigatorClaim < BaseClaim
     set_singular_route_key 'litigators_claim'
 
-    validates_with ::Claim::LitigatorClaimValidator, unless: :disable_for_state_transition
+    validates_with ::Claim::LitigatorClaimValidator, unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
     validates_with ::Claim::LitigatorSupplierNumberValidator, on: :create
     validates_with ::Claim::LitigatorClaimSubModelValidator
 

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -65,7 +65,7 @@ module Claims::StateMachine
       after_transition on: :redetermine,              do: [:remove_case_workers!, :set_last_submission_date!]
       after_transition on: :await_written_reasons,    do: [:remove_case_workers!, :set_last_submission_date!]
       after_transition on: :archive_pending_delete,   do: :set_valid_until!
-      after_transition  on: :deallocate,              do: [:remove_case_workers!, :reset_state]
+      after_transition on: :deallocate,               do: [:remove_case_workers!, :reset_state]
       before_transition on: :submit,                  do: :set_allocation_type
       before_transition on: [:reject, :refuse],       do: :set_amount_assessed_zero!
 

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -61,13 +61,7 @@ module TimedTransitions
                     dummy_run: @dummy) do
                       'Archiving claim'
                     end
-      @claim.disable_for_state_transition = true
-      # Disable the validation of the claim while archiving, this
-      # allows the timed_transitioner to archive cases regardless
-      # of the state of linked objects, previously it would fail
-      # if linked tables had changed in the months since creation
       @claim.archive_pending_delete!(reason_code: 'timed_transition') unless is_dummy?
-      @claim.disable_for_state_transition = nil
       self.success = true
     end
 

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -21,6 +21,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def validate_external_user_id
+    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
     validate_presence(:external_user, "blank_#{@record.external_user_type}")
     validate_external_user_has_required_role unless @record.external_user.nil?
     return if @record.errors.key?(:external_user)
@@ -45,6 +46,7 @@ class Claim::BaseClaimValidator < BaseValidator
 
   # ALWAYS required/mandatory
   def validate_creator
+    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
     validate_presence(:creator, 'blank') unless @record.errors.key?(:creator)
   end
 
@@ -114,6 +116,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def validate_evidence_checklist_ids
+    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
     raise ActiveRecord::SerializationTypeMismatch, "Attribute was supposed to be a Array, but was a #{@record.evidence_checklist_ids.class}." unless @record.evidence_checklist_ids.is_a?(Array)
 
     # prevent non-numeric array elements

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
     case_concluded_at   { 5.days.ago }
     supplier_number     { provider.lgfs_supplier_numbers.first.supplier_number }
     providers_ref       { random_providers_ref }
-
+    disable_for_state_transition nil
     after(:create) do |claim|
       defendant = create(:defendant, claim: claim)
       create(:representation_order, defendant: defendant, representation_order_date: 380.days.ago)

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -113,7 +113,6 @@ module TimedTransitions
             context 'when the claim has been invalidated' do
               let(:litigator) { create(:external_user, :litigator) }
               before do
-                Timecop.freeze(17.weeks.ago) { @claim = create :authorised_claim, case_number: 'A20164444' }
                 @claim.creator = litigator
                 Transitioner.new(@claim).run
               end


### PR DESCRIPTION
This PR (hopefully) addresses the issues that users (mainly case-workers) have been having with transitioning state when validations failed.

This leaves validation in place while external users are creating the claim `state: nil > draft > submitted`

It allows state_machine to set two values for a `claims.disable_for_state_transition`; `:all` and `:leave_amount`

When set to 
`:all` it completely disables the validation of a claim;
`:leave_amount` it leaves validation in place for a claims assessment account.