### PR TITLE
add rb-readline to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development, :devunicorn, :test do
   gem 'guard-rspec'
   gem 'net-ssh'
   gem 'net-scp'
+  gem 'rb-readline'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,6 +429,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    rb-readline (0.5.4)
     rdoc (4.2.2)
       json (~> 1.4)
     redis (3.3.1)
@@ -665,6 +666,7 @@ DEPENDENCIES
   rack-livereload (~> 0.3.16)
   rails (~> 4.2.8)
   rails_12factor (= 0.0.3)
+  rb-readline
   redis (~> 3.3.1)
   remotipart (~> 1.2)
   rest-client (~> 1.8)


### PR DESCRIPTION
byebug has a OS library dependency that is, nonentheless, not a
gem dependency. This results in rails server or console start raising
an error
```
Sorry, you can't use byebug without Readline. To solve this, you need to
rebuild Ruby with Readline support. If using Ubuntu, try `sudo apt-get
install libreadline-dev` and then reinstall your Ruby.
```

Easiest fix to prevent the error is to add rb-readline as dev/test
dependency in the Gemfile. See [byebug issue](https://github.com/deivid-rodriguez/byebug/issues/289) 

