### PR TITLE
State machine validation

### DIFF
--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -79,7 +79,7 @@ module Claims
         before_transition on: [:reject, :refuse],       do: :set_amount_assessed_zero!
 
         around_transition any => NON_VALIDATION_STATES.map(&:to_sym) do |claim, transition, block|
-          validation_state = [:authorise, :part_authorise].include?(transition.event) ? :leave_amount : :all
+          validation_state = [:authorise, :part_authorise].include?(transition.event) ? :only_amount_assessed : :all
           claim.disable_for_state_transition = validation_state
           block.call
           claim.disable_for_state_transition = nil

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -48,9 +48,16 @@ describe Claim::AdvocateClaimValidator do
   end
 
   context 'creator' do
+    before { claim.creator = litigator }
+
     it 'should error when their provider does not have AGFS role' do
-      claim.creator = litigator
       should_error_with(claim, :creator, "must be from a provider with permission to submit AGFS claims")
+    end
+
+    context 'when validation has been overridden' do
+      before { claim.disable_for_state_transition = :all }
+
+      it { expect(claim.valid?).to be true }
     end
   end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -336,6 +336,28 @@ describe Claim::BaseClaimValidator do
         end
       end
     end
+
+    context 'when creator has been made invalid' do
+      before { assessed_claim.creator = create(:external_user, :litigator) }
+
+      context 'and validation has been overridden' do
+        before { assessed_claim.disable_for_state_transition = :all }
+
+        it { expect(assessed_claim.valid?).to be true }
+      end
+
+      context 'and validation has been overridden only for amount_assessed' do
+        before { assessed_claim.disable_for_state_transition = :only_amount_assessed }
+
+        it { expect(assessed_claim.valid?).to be false }
+      end
+
+      context 'and validation has not been overridden' do
+        before { assessed_claim.disable_for_state_transition = nil }
+
+        it { expect(assessed_claim.valid?).to be false }
+      end
+    end
   end
 
   context 'evidence_checklist_ids' do
@@ -380,6 +402,36 @@ describe Claim::BaseClaimValidator do
         claim.evidence_checklist_ids = '1, 45, 457'
         claim.save!
       }.to raise_error ActiveRecord::SerializationTypeMismatch, /Attribute was supposed to be a Array, but was a String. -- "1, 45, 457"/i
+    end
+
+    context 'when evidence_checklist_ids have been made invalid' do
+      before { claim.evidence_checklist_ids = [101,1001,200,32] }
+
+      context 'and validation has been overridden' do
+        before { claim.disable_for_state_transition = :all }
+
+        it { expect(claim.valid?).to be true }
+      end
+
+      describe 'and validation has been overridden for amount_assessed' do
+        context 'using the correct symbol' do
+          before { claim.disable_for_state_transition = :only_amount_assessed }
+
+          it { expect(claim.valid?).to be true }
+        end
+
+        context 'using the wrong symbol' do
+          before { claim.disable_for_state_transition = :leave_amount }
+
+          it { expect(claim.valid?).to be false }
+        end
+      end
+
+      context 'and validation has not been overridden' do
+        before { claim.disable_for_state_transition = nil }
+
+        it { expect(claim.valid?).to be false }
+      end
     end
   end
 


### PR DESCRIPTION
This PR increases the test coverage around state machine transitions and corrects the spelling of the symbol used to enable validation during authorising claims