### PR TITLE
Add initial JSON Schema for full claim

### DIFF
--- a/config/schemas/internal_full_claim_schema.json
+++ b/config/schemas/internal_full_claim_schema.json
@@ -1,0 +1,519 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "definitions": {},
+    "description": "A claim from the CCCD service",
+    "id": "https://www.gov.uk/schemas/claim-for-crown-court-defence/claim.json",
+    "properties": {
+        "claim": {
+            "additionalProperties": false,
+            "id": "/properties/claim",
+            "properties": {
+                "case_details": {
+                    "additionalProperties": false,
+                    "id": "/properties/claim/properties/case_details",
+                    "properties": {
+                        "case_number": {
+                            "id": "/properties/claim/properties/case_details/properties/case_number",
+                            "type": "string"
+                        },
+                        "case_type": {
+                            "id": "/properties/claim/properties/case_details/properties/case_type",
+                            "type": "string"
+                        },
+                        "cms_number": {
+                            "id": "/properties/claim/properties/case_details/properties/cms_number",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                        },
+                        "court_code": {
+                            "id": "/properties/claim/properties/case_details/properties/court_code",
+                            "type": "string"
+                        },
+                        "cracked_dates": {
+                            "additionalProperties": false,
+                            "id": "/properties/claim/properties/case_details/properties/cracked_dates",
+                            "properties": {
+                                "date_cracked": {
+                                    "id": "/properties/claim/properties/case_details/properties/cracked_dates/properties/date_cracked",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                },
+                                "date_cracked_at_third": {
+                                    "id": "/properties/claim/properties/case_details/properties/cracked_dates/properties/date_cracked_at_third",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                },
+                                "date_fixed": {
+                                    "id": "/properties/claim/properties/case_details/properties/cracked_dates/properties/date_fixed",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                },
+                                "date_fixed_notice": {
+                                    "id": "/properties/claim/properties/case_details/properties/cracked_dates/properties/date_fixed_notice",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                }
+                            },
+                            "required": [
+                                "date_cracked",
+                                "date_fixed_notice",
+                                "date_cracked_at_third",
+                                "date_fixed"
+                            ],
+                            "type": "object"
+                        },
+                        "offence": {
+                            "additionalProperties": false,
+                            "id": "/properties/claim/properties/case_details/properties/offence",
+                            "properties": {
+                                "category": {
+                                    "id": "/properties/claim/properties/case_details/properties/offence/properties/category",
+                                    "type": "string"
+                                },
+                                "class": {
+                                    "id": "/properties/claim/properties/case_details/properties/offence/properties/class",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "category",
+                                "class"
+                            ],
+                            "type": "object"
+                        },
+                        "providers_reference": {
+                            "id": "/properties/claim/properties/case_details/properties/providers_reference",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                        },
+                        "retrial_dates": {
+                            "additionalProperties": false,
+                            "id": "/properties/claim/properties/case_details/properties/retrial_dates",
+                            "properties": {
+                                "actual_length": {
+                                    "id": "/properties/claim/properties/case_details/properties/retrial_dates/properties/actual_length",
+                                    "type": "integer"
+                                },
+                                "date_concluded": {
+                                    "id": "/properties/claim/properties/case_details/properties/retrial_dates/properties/date_concluded",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                },
+                                "date_started": {
+                                    "id": "/properties/claim/properties/case_details/properties/retrial_dates/properties/date_started",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                },
+                                "estimated_length": {
+                                    "id": "/properties/claim/properties/case_details/properties/retrial_dates/properties/estimated_length",
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "estimated_length",
+                                "date_started",
+                                "actual_length",
+                                "date_concluded"
+                            ],
+                            "type": "object"
+                        },
+                        "trial_dates": {
+                            "additionalProperties": false,
+                            "id": "/properties/claim/properties/case_details/properties/trial_dates",
+                            "properties": {
+                                "actual_length": {
+                                    "id": "/properties/claim/properties/case_details/properties/trial_dates/properties/actual_length",
+                                    "type": "integer"
+                                },
+                                "date_concluded": {
+                                    "id": "/properties/claim/properties/case_details/properties/trial_dates/properties/date_concluded",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                },
+                                "date_started": {
+                                    "id": "/properties/claim/properties/case_details/properties/trial_dates/properties/date_started",
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "format": "date"
+                                },
+                                "estimated_length": {
+                                    "id": "/properties/claim/properties/case_details/properties/trial_dates/properties/estimated_length",
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "estimated_length",
+                                "date_started",
+                                "actual_length",
+                                "date_concluded"
+                            ],
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "court_code",
+                        "case_number",
+                        "offence",
+                        "cms_number",
+                        "cracked_dates",
+                        "case_type",
+                        "providers_reference",
+                        "retrial_dates",
+                        "trial_dates"
+                    ],
+                    "type": "object"
+                },
+                "claim_details": {
+                    "additionalProperties": false,
+                    "id": "/properties/claim/properties/claim_details",
+                    "properties": {
+                        "additional_information": {
+                            "id": "/properties/claim/properties/claim_details/properties/additional_information",
+                            "type": "string"
+                        },
+                        "advocate_category": {
+                            "id": "/properties/claim/properties/claim_details/properties/advocate_category",
+                            "type": "string"
+                        },
+                        "apply_vat": {
+                            "id": "/properties/claim/properties/claim_details/properties/apply_vat",
+                            "type": "string",
+                            "enum": [
+                              "Y",
+                              "N"
+                            ]
+                        },
+                        "authorised_at": {
+                            "id": "/properties/claim/properties/claim_details/properties/authorised_at",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                        },
+                        "claim_type": {
+                            "id": "/properties/claim/properties/claim_details/properties/claim_type",
+                            "type": "string"
+                        },
+                        "created_by": {
+                            "additionalProperties": false,
+                            "id": "/properties/claim/properties/claim_details/properties/created_by",
+                            "properties": {
+                                "email": {
+                                    "id": "/properties/claim/properties/claim_details/properties/created_by/properties/email",
+                                    "type": "string"
+                                },
+                                "first_name": {
+                                    "id": "/properties/claim/properties/claim_details/properties/created_by/properties/first_name",
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "id": "/properties/claim/properties/claim_details/properties/created_by/properties/id",
+                                    "type": "integer"
+                                },
+                                "last_name": {
+                                    "id": "/properties/claim/properties/claim_details/properties/created_by/properties/last_name",
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "id": "/properties/claim/properties/claim_details/properties/created_by/properties/uuid",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "email",
+                                "first_name",
+                                "last_name",
+                                "id",
+                                "uuid"
+                            ],
+                            "type": "object"
+                        },
+                        "external_user": {
+                            "additionalProperties": false,
+                            "id": "/properties/claim/properties/claim_details/properties/external_user",
+                            "properties": {
+                                "email": {
+                                    "id": "/properties/claim/properties/claim_details/properties/external_user/properties/email",
+                                    "type": "string"
+                                },
+                                "first_name": {
+                                    "id": "/properties/claim/properties/claim_details/properties/external_user/properties/first_name",
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "id": "/properties/claim/properties/claim_details/properties/external_user/properties/id",
+                                    "type": "integer"
+                                },
+                                "last_name": {
+                                    "id": "/properties/claim/properties/claim_details/properties/external_user/properties/last_name",
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "id": "/properties/claim/properties/claim_details/properties/external_user/properties/uuid",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "email",
+                                "first_name",
+                                "last_name",
+                                "id",
+                                "uuid"
+                            ],
+                            "type": "object"
+                        },
+                        "originally_submitted_at": {
+                            "id": "/properties/claim/properties/claim_details/properties/originally_submitted_at",
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "state": {
+                            "id": "/properties/claim/properties/claim_details/properties/state",
+                            "type": "string"
+                        },
+                        "submitted_at": {
+                            "id": "/properties/claim/properties/claim_details/properties/submitted_at",
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "supplier_account_code": {
+                            "id": "/properties/claim/properties/claim_details/properties/supplier_account_code",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "submitted_at",
+                        "apply_vat",
+                        "originally_submitted_at",
+                        "authorised_at",
+                        "supplier_account_code",
+                        "additional_information",
+                        "advocate_category",
+                        "claim_type",
+                        "state",
+                        "external_user",
+                        "created_by"
+                    ],
+                    "type": "object"
+                },
+                "claim_uuid": {
+                    "id": "/properties/claim/properties/claim_uuid",
+                    "type": "string"
+                },
+                "defendants": {
+                    "id": "/properties/claim/properties/defendants",
+                    "items": {
+                        "additionalProperties": false,
+                        "id": "/properties/claim/properties/defendants/items",
+                        "properties": {
+                            "representation_orders": {
+                                "id": "/properties/claim/properties/defendants/items/properties/representation_orders",
+                                "items": {
+                                    "additionalProperties": false,
+                                    "id": "/properties/claim/properties/defendants/items/properties/representation_orders/items",
+                                    "properties": {
+                                        "date": {
+                                            "id": "/properties/claim/properties/defendants/items/properties/representation_orders/items/properties/date",
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                                        "maat_reference": {
+                                            "id": "/properties/claim/properties/defendants/items/properties/representation_orders/items/properties/maat_reference",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "date",
+                                        "maat_reference"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array",
+                                "minItems": 1
+                            }
+                        },
+                        "required": [
+                            "representation_orders"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array",
+                    "minItems": 1
+                },
+                "expenses": {
+                    "id": "/properties/claim/properties/expenses",
+                    "items": {
+                        "additionalProperties": false,
+                        "id": "/properties/claim/properties/expenses/items",
+                        "properties": {
+                            "date": {
+                                "id": "/properties/claim/properties/expenses/items/properties/date",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "format": "date"
+                            },
+                            "distance": {
+                                "id": "/properties/claim/properties/expenses/items/properties/distance",
+                                "type": "number"
+                            },
+                            "hours": {
+                                "id": "/properties/claim/properties/expenses/items/properties/hours",
+                                "type": "number"
+                            },
+                            "location": {
+                                "id": "/properties/claim/properties/expenses/items/properties/location",
+                                "type": "string"
+                            },
+                            "mileage_rate": {
+                                "id": "/properties/claim/properties/expenses/items/properties/mileage_rate",
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                            },
+                            "net_amount": {
+                                "id": "/properties/claim/properties/expenses/items/properties/net_amount",
+                                "type": "number"
+                            },
+                            "quantity": {
+                                "id": "/properties/claim/properties/expenses/items/properties/quantity",
+                                "type": "number"
+                            },
+                            "rate": {
+                                "id": "/properties/claim/properties/expenses/items/properties/rate",
+                                "type": "number"
+                            },
+                            "reason": {
+                                "id": "/properties/claim/properties/expenses/items/properties/reason",
+                                "type": "string"
+                            },
+                            "type": {
+                                "id": "/properties/claim/properties/expenses/items/properties/type",
+                                "type": "string"
+                            },
+                            "vat_amount": {
+                                "id": "/properties/claim/properties/expenses/items/properties/vat_amount",
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "distance",
+                            "vat_amount",
+                            "rate",
+                            "hours",
+                            "reason",
+                            "location",
+                            "date",
+                            "net_amount",
+                            "quantity",
+                            "type",
+                            "mileage_rate"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "fees": {
+                    "id": "/properties/claim/properties/fees",
+                    "items": {
+                        "additionalProperties": false,
+                        "id": "/properties/claim/properties/fees/items",
+                        "properties": {
+                            "amount": {
+                                "id": "/properties/claim/properties/fees/items/properties/amount",
+                                "type": "number"
+                            },
+                            "code": {
+                                "id": "/properties/claim/properties/fees/items/properties/code",
+                                "type": "string"
+                            },
+                            "date": {
+                                "id": "/properties/claim/properties/fees/items/properties/date",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "format": "date"
+                            },
+                            "dates_attended": {
+                                "id": "/properties/claim/properties/fees/items/properties/dates_attended",
+                                "items": {
+                                  "type": "string",
+                                  "format": "date"
+                                },
+                                "type": "array"
+                            },
+                            "quantity": {
+                                "id": "/properties/claim/properties/fees/items/properties/quantity",
+                                "type": "number"
+                            },
+                            "rate": {
+                                "id": "/properties/claim/properties/fees/items/properties/rate",
+                                "type": "number"
+                            },
+                            "type": {
+                                "id": "/properties/claim/properties/fees/items/properties/type",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "code",
+                            "rate",
+                            "dates_attended",
+                            "amount",
+                            "date",
+                            "type",
+                            "quantity"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "claim_uuid",
+                "case_details",
+                "expenses",
+                "claim_details",
+                "fees",
+                "defendants"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "claim"
+    ],
+    "type": "object"
+}


### PR DESCRIPTION
This adds a basic JSON Schema for CCCD claims as exposed by the
`FullClaim` entity.

This doesn't fix any of the underlying issues with the JSON, just
specifies what already exists.