### PR TITLE
remove rb-readline gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ group :development, :devunicorn, :test do
   gem 'guard-rspec'
   gem 'net-ssh'
   gem 'net-scp'
-  gem 'rb-readline'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,7 +429,6 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    rb-readline (0.5.4)
     rdoc (4.2.2)
       json (~> 1.4)
     redis (3.3.1)
@@ -666,7 +665,6 @@ DEPENDENCIES
   rack-livereload (~> 0.3.16)
   rails (~> 4.2.8)
   rails_12factor (= 0.0.3)
-  rb-readline
   redis (~> 3.3.1)
   remotipart (~> 1.2)
   rest-client (~> 1.8)


### PR DESCRIPTION
The rb-readline gem fixes a library dependency on OSX but introduces
a key mapping bug when using the rails console on ubuntu (i.e. on the servers).

Instead local OSX development can be fixed using one of the
options here:

https://github.com/guard/guard/wiki/Add-Readline-support-to-Ruby-on-Mac-OS-X