### PR TITLE
use single ssh session and refactor dump script

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -301,7 +301,7 @@ namespace :db do
   end
 
   def fake_paragraphs max_paragraph_count=4
-    Faker::Lorem.paragraphs(max_paragraph_count).pop(rand(1..max_paragraph_count)).join('\n')
+    Faker::Lorem.paragraphs(max_paragraph_count).pop(rand(1..max_paragraph_count)).join("\n")
   end
 
 end

--- a/script/db_dump.rb
+++ b/script/db_dump.rb
@@ -3,6 +3,7 @@
 require 'net/ssh' # gem install net-ssh
 require 'net/scp' # gem install net-scp
 require 'colorize'
+require 'shell-spinner'
 
 ENVIRONMENTS = {
   'dev' => %w(dev adp_dev_new),
@@ -41,30 +42,36 @@ def install_postgres(ssh)
 end
 
 begin
-  puts 'Connecting to host %s' % ssh_address
-  ssh = Net::SSH.start ssh_address, ssh_user
+  print 'Connecting to host %s... ' % ssh_address
+  ssh = Net::SSH.start(ssh_address, ssh_user)
+  puts 'done'.green
 
-  puts 'Installing postgresql in container...'
-  install_postgres ssh
+  ShellSpinner 'Installing postgresql in container' do
+    install_postgres ssh
+  end
 
-  puts 'Running task db:dump_anonymised...'
-  puts ssh.exec!("sudo docker exec advocatedefencepayments rake db:dump_anonymised[#{dump_file_name}]")
-  puts ssh.exec!("sudo docker cp advocatedefencepayments:/usr/src/app/#{gzip_file_name} ~/")
+  ShellSpinner 'Dumping database' do
+    puts ssh.exec!("sudo docker exec advocatedefencepayments rake db:dump_anonymised[#{dump_file_name}]")
+    puts ssh.exec!("sudo docker cp advocatedefencepayments:/usr/src/app/#{gzip_file_name} ~/")
+  end
 
   puts 'Downloading dump file'
-  Net::SCP.download!(ssh_address, ssh_user, "/home/#{ssh_user}/#{gzip_file_name}", '.') do |_channel, _name, sent, total|
+  success = ssh.scp.download!("/home/#{ssh_user}/#{gzip_file_name}", '.') do |_channel, _name, sent, total|
     puts "...downloading... #{sent}/#{total}... #{'done'.green}" if sent % 512_000 == 0
   end
 
-  puts 'File %s downloaded' % gzip_file_name
+  puts 'File %{file} download... %{success}' % { file: gzip_file_name, success: success ? 'done'.green : 'fail'.red }
 
 rescue Exception => e
   puts 'Usage: ./db_dump.rb username environment [IP]'
   puts e
 ensure
   if !ssh.closed?
-    puts 'Deleting remote compressed dump file... '
-    puts ssh.exec!("sudo docker exec advocatedefencepayments rm #{gzip_file_name}")
-    ssh.close
+    ShellSpinner 'Deleting remote compressed dump file' do
+      ssh.exec!("sudo docker exec advocatedefencepayments rm #{gzip_file_name}")
+    end
+    ShellSpinner 'Closing connection' do
+      ssh.close
+    end
   end
 end

--- a/script/db_dump.rb
+++ b/script/db_dump.rb
@@ -57,7 +57,8 @@ begin
 
   puts 'Downloading dump file %s from host %s' % [gzip_file_name, ssh_address]
   success = ssh.scp.download!("/home/#{ssh_user}/#{gzip_file_name}", '.') do |_channel, _name, sent, total|
-    puts "...downloading... #{sent}/#{total}... #{'done'.green}" if sent % 512_000 == 0
+    print "...downloading... #{sent.to_s.green}/#{total} \r" if sent % 8192 == 0
+    STDOUT.flush
   end
 
   puts 'File %{file} download... %{success}' % { file: gzip_file_name, success: success ? 'done'.green : 'fail'.red }

--- a/script/db_dump.rb
+++ b/script/db_dump.rb
@@ -55,7 +55,7 @@ begin
     puts ssh.exec!("sudo docker cp advocatedefencepayments:/usr/src/app/#{gzip_file_name} ~/")
   end
 
-  puts 'Downloading dump file'
+  puts 'Downloading dump file %s from host %s' % [gzip_file_name, ssh_address]
   success = ssh.scp.download!("/home/#{ssh_user}/#{gzip_file_name}", '.') do |_channel, _name, sent, total|
     puts "...downloading... #{sent}/#{total}... #{'done'.green}" if sent % 512_000 == 0
   end

--- a/script/db_upload.rb
+++ b/script/db_upload.rb
@@ -2,6 +2,8 @@
 
 require 'net/ssh' # gem install net-ssh
 require 'net/scp' # gem install net-scp
+require 'colorize'
+require 'shell-spinner'
 
 ENVIRONMENTS = {
   'dev' => 'dev',
@@ -41,28 +43,37 @@ def install_postgres(ssh)
 end
 
 begin
+
+  print 'Connecting to host %s as %s... ' % [ssh_address, ssh_user]
+  ssh = Net::SSH.start ssh_address, ssh_user
+  puts 'done'.green
+
   puts 'Uploading dump file %s to host %s' % [dump_file_name, ssh_address]
-  Net::SCP.upload!(ssh_address, ssh_user, dump_file_name, "/home/#{ssh_user}/#{dump_file_name}.uploading") do |_channel, _name, sent, total|
-    puts "...uploading... #{sent}/#{total}" if sent % 512_000 == 0
+  ssh.scp.upload!(dump_file_name, "/home/#{ssh_user}/#{dump_file_name}") do |_channel, _name, sent, total|
+    puts "...uploading... #{sent}/#{total}... #{'done'.green}" if sent % 512_000 == 0
   end
 
-  ssh = Net::SSH.start ssh_address, ssh_user
-  puts ssh.exec!("mv /home/#{ssh_user}/#{dump_file_name}.uploading /home/#{ssh_user}/#{dump_file_name}")
-
   # Note: Docker 1.8 supports cp command to copy a file from the host to the container, but we are using a lower version
-  puts 'Copying dump file into container...'
-  puts ssh.exec!("cat #{dump_file_name} | sudo docker exec -i advocatedefencepayments sh -c 'cat > /usr/src/app/#{dump_file_name}'")
-  puts ssh.exec!("rm -f /home/#{ssh_user}/#{dump_file_name}")
+  ShellSpinner 'Copying dump file into container' do
+    puts ssh.exec!("sudo docker cp ~/#{dump_file_name} advocatedefencepayments:/usr/src/app/#{dump_file_name}")
+    puts ssh.exec!("rm -f ~/#{dump_file_name}")
+  end
 
-  puts 'Installing postgresql in container...'
-  install_postgres ssh
+  ShellSpinner 'Installing postgresql in container' do
+    install_postgres ssh
+  end
 
-  puts 'Running task db:restore (this will take several minutes)...'
-  puts ssh.exec!("sudo docker exec advocatedefencepayments rake db:restore[#{dump_file_name}]")
+  # NOTE: Errors encountered below related to COMMENTs and can be safely ignored
+  #  ERROR: must be owner of extension plpgsql
+  #  ERROR: must be owner of extension uuid-ossp
+  # see https://www.ca.com/us/services-support/ca-support/ca-support-online/knowledge-base-articles.TEC1634878.html
+  ShellSpinner "Restoring database using #{dump_file_name}" do
+    puts ssh.exec!("sudo docker exec advocatedefencepayments rake db:restore[#{dump_file_name}]")
+  end
 
-  puts 'Dump %s was successfully restored' % dump_file_name
-  ssh.close
 rescue Exception => e
   puts 'Usage: ./db_upload username environment [IP] filename'
   puts e
+ensure
+  ssh.close if !ssh.closed?
 end

--- a/script/db_upload.rb
+++ b/script/db_upload.rb
@@ -49,8 +49,9 @@ begin
   puts 'done'.green
 
   puts 'Uploading dump file %s to host %s' % [dump_file_name, ssh_address]
-  ssh.scp.upload!(dump_file_name, "/home/#{ssh_user}/#{dump_file_name}") do |_channel, _name, sent, total|
-    puts "...uploading... #{sent}/#{total}... #{'done'.green}" if sent % 512_000 == 0
+  ssh.scp.upload!(dump_file_name, "/home/#{ssh_user}/#{dump_file_name}" ) do |_channel, _name, sent, total|
+    print "...uploading... #{sent.to_s.green}/#{total} \r" if sent % 8192 == 0
+    STDOUT.flush
   end
 
   # Note: Docker 1.8 supports cp command to copy a file from the host to the container, but we are using a lower version


### PR DESCRIPTION
Two SSH sessions (one for running dump and another for scp'ing)
is unnecessary overhead and causes problems if you try to
use first session after second has started.