### PR TITLE
add store of and retrieval method for CCR bill scenario

### DIFF
--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -1,3 +1,13 @@
+# current endpoint: GET /api/ccr/claims{uuid}
+# target endpoint: GET api/claims{uuid}
+#
+# This API endpoint is intended to be replaced by the GET api/claims{uuid} endpoint
+# however the following fields are CCR specific:
+#
+#   - feeStructureId
+#   - scenario
+#
+
 module API
   module Entities
     class CCRClaim < BaseEntity
@@ -78,7 +88,8 @@ module API
       end
 
       def scenario
-        'AS000004' # Hardcoded for "trial" case type
+        object.case_type.bill_scenario
+        # 'AS000004' # Hardcoded for "trial" case type
       end
 
       def estimated_trial_length_or_one

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -40,7 +40,7 @@ module API
       expose :actual_trial_length_or_one, as: :actualTrialLength
       expose :first_day_of_trial, as: :trialStartDate
 
-      expose :zero, as: :noOfWitnesses
+      expose :number_of_witnesses, as: :noOfWitnesses
 
       expose :personType do
         expose :advocate_category, as: :personType
@@ -112,6 +112,10 @@ module API
       def offence_code_id
         # Using CCR Legacy Offence codes 501-511 for now (which map 1-to-1 onto offence classes)
         ('A'..'K').zip(501..511).to_h[offence_class_code]
+      end
+
+      def number_of_witnesses
+        object.fees.find_by(fee_type_id: 10)&.quantity&.to_i || 0
       end
 
       # CCR bill type maps to the class/type of a BaseFeeType

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -63,12 +63,21 @@ module API
 
       private
 
+      # fee type ids
+      CASES_UPLIFT = 9
+      WITNESSES = 10
+      PPE = 11
+
       def empty
         []
       end
 
       def zero
         0
+      end
+
+      def fee_quantity_for(fee_type_id)
+        object.fees.find_by(fee_type_id: fee_type_id)&.quantity&.to_i || 0
       end
 
       def court_code
@@ -115,7 +124,7 @@ module API
       end
 
       def number_of_witnesses
-        object.fees.find_by(fee_type_id: 10)&.quantity&.to_i || 0
+        fee_quantity_for(WITNESSES)
       end
 
       # CCR bill type maps to the class/type of a BaseFeeType
@@ -132,12 +141,11 @@ module API
 
       # every claim is based on one case (i.e. see case number) but may involve others
       def number_of_cases
-        n = object.fees.find_by(fee_type_id: 9)&.quantity&.to_i || 0
-        n + 1
+        fee_quantity_for(CASES_UPLIFT) + 1
       end
 
       def pages_of_prosecution_evidence
-        object.fees.find_by(fee_type_id: 11)&.quantity&.to_i
+        fee_quantity_for(PPE)
       end
 
       # The "Advocate Fee" is the CCR equivalent of all the
@@ -187,7 +195,6 @@ module API
           advocate_fee
         ]
       end
-
     end
   end
 end

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -114,13 +114,13 @@ module API
         ('A'..'K').zip(501..511).to_h[offence_class_code]
       end
 
-      # CCR bill type maps to the type of a BaseFeeType
+      # CCR bill type maps to the class/type of a BaseFeeType
       # e.g. AGFS_FEE bill_type is the BasicFeeType
       def bill_type
         'AGFS_FEE'
       end
 
-      # CCR bill sub types map to individual
+      # CCR bill sub types map to individual/unique fee types
       # e.g. AGFS_FEE subtype is the BasicFeeType's Basic fee (i.e. BAF)
       def bill_subtype
         'AGFS_FEE'
@@ -136,10 +136,11 @@ module API
         object.fees.find_by(fee_type_id: 11)&.quantity&.to_i
       end
 
-      # This "bill" currently represents information that is required
-      # for the BasicFeeTypes as they map to an Advocate Fee in CCR
-      def wrapped_bill
-        [{
+      # The "Advocate Fee" is the CCR equivalent of all the
+      # BasicFeeType fees in CCCD.
+      # The Advocate Fee is of type AGFS_FEE and subtype AGFS_FEE
+      def advocate_fee
+        {
           billType: {
             billType: bill_type
           },
@@ -174,8 +175,15 @@ module API
           firstFixedWarnedDateOrig: nil,
           caseUpliftAmount: 0.0,
           defendantUpliftAmount: 0.0
-        }]
+        }
       end
+
+      def wrapped_bill
+        [
+          advocate_fee
+        ]
+      end
+
     end
   end
 end

--- a/app/interfaces/api/entities/full_claim.rb
+++ b/app/interfaces/api/entities/full_claim.rb
@@ -81,6 +81,7 @@ module API
       def case_type_uuid
         object.case_type.uuid
       end
+
       def court_code
         object.court&.code
       end

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -57,4 +57,14 @@ class CaseType < ActiveRecord::Base
   def requires_defendant_dob?
     fee_type_code != 'FXCBR'
   end
+
+  # CCR stores billing scenarios that map to
+  # to CCCD case types, except "Hearing subsequent to sentence".
+  # Passed to CCR via API for calculation of fees.
+  #
+  def bill_scenario
+    @bill_scenario ||= Settings.ccr_bill_scenario_mappings.to_h.select do |k,v|
+      v.downcase == name.downcase
+    end.keys.first
+  end
 end

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -63,8 +63,8 @@ class CaseType < ActiveRecord::Base
   # Passed to CCR via API for calculation of fees.
   #
   def bill_scenario
-    @bill_scenario ||= Settings.ccr_bill_scenario_mappings.to_h.select do |k,v|
-      v.downcase == name.downcase
+    @bill_scenario ||= Settings.ccr_bill_scenario_mappings.to_h.select do |_k, v|
+      v.casecmp(name) == 0
     end.keys.first
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,3 +91,17 @@ remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') +
 
 # contact email address
 laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
+
+ccr_bill_scenario_mappings:
+  AS000005: Appeal against Conviction
+  AS000006: Appeal against Sentence
+  AS000009: Breach of Crown Court Order
+  AS000007: Committal for Sentence
+  AS000008: Contempt
+  AS000003: Cracked Trial
+  AS000010: Cracked before retrial
+  AS000001: Discontinuance
+  AS000014: Elected cases not proceeded
+  AS000002: Guilty Plea
+  AS000011: Retrial
+  AS000004: Trial

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,6 +92,9 @@ remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') +
 # contact email address
 laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
 
+# mappings of case types to CCR Bill scenario keys/ids
+# INJECTION: may be replaced CCR-side by case-type-uuid mappings to bill scenarios
+# TODO: may be removed
 ccr_bill_scenario_mappings:
   AS000005: Appeal against Conviction
   AS000006: Appeal against Sentence


### PR DESCRIPTION
**What**
adds a mapping for CCR bill scenario IDs
to CCCD case types and modifies endpoint to supply:

* bill scenario
* number of cases
* number of prosecution witnesses

**Why**
CCR needs to know what bill scenario to apply
to determine the relevant validation and calculations
to apply. The number of cases and prosecution witnesses
is additional information that is used to calculate the Advocate
Fee in CCR.
