### PR TITLE
add uuid to case types with consistent values across environments

### DIFF
--- a/db/migrate/20170727130618_add_uuid_to_case_types.rb
+++ b/db/migrate/20170727130618_add_uuid_to_case_types.rb
@@ -1,0 +1,31 @@
+class AddUuidToCaseTypes < ActiveRecord::Migration
+
+  UUIDS = %w(
+    a05f6ee1-c9fb-4069-9789-1f68aea85fb8
+    2c4bc4a3-9246-4841-9813-a1e03b8d3a05
+    4e996aed-2dc9-424c-9862-b52b02fe48b3
+    7c27f365-9cd3-4993-b78d-2065ecb97fd9
+    b6d8bc8e-7238-458e-a645-c0e382a5afd1
+    60e835cf-911f-49ef-9376-8b2a55494aa6
+    5db5134a-afac-4f32-bc88-e9a6a54b4df9
+    5d646fd1-b50b-4aba-9435-de5b9377bd8a
+    03cb932c-d700-415b-a328-15839d88dc36
+    b342a476-887d-46b3-b2dc-32da2dd138ec
+    c6197718-08c5-4943-a2e1-2c5bf71bcfa8
+    f96b265a-f972-4872-a598-e78de4fcab83
+  ).freeze
+
+  def up
+    add_column :case_types, :uuid, :uuid, default: 'uuid_generate_v4()', index: true
+
+    # ensure all environment DBs have the same UUIDs because they will be required by CCR
+    puts "-- updating case_types UUIDs to consistent values"
+    CaseType.all.each do |ct|
+      ct.update!(uuid: UUIDS[ct.id-1])
+    end
+  end
+
+  def down
+    remove_column :case_types, :uuid, :uuid, default: 'uuid_generate_v4()', index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623152835) do
+ActiveRecord::Schema.define(version: 20170727130618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20170623152835) do
     t.boolean  "requires_retrial_dates",  default: false
     t.string   "roles"
     t.string   "fee_type_code"
+    t.uuid     "uuid",                    default: "uuid_generate_v4()"
   end
 
   create_table "case_worker_claims", force: :cascade do |t|

--- a/db/seeds/case_types.rb
+++ b/db/seeds/case_types.rb
@@ -19,6 +19,7 @@ create_or_update_by_name(name:                       'Appeal against conviction'
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'FXACV',
+                            uuid: 'a05f6ee1-c9fb-4069-9789-1f68aea85fb8'
                             )
 create_or_update_by_name(name:                      'Appeal against sentence',
                             is_fixed_fee:           true,
@@ -28,6 +29,7 @@ create_or_update_by_name(name:                      'Appeal against sentence',
                             allow_pcmh_fee_type:    false,
                             roles:                  %w(agfs lgfs),
                             fee_type_code:          'FXASE',
+                            uuid: '2c4bc4a3-9246-4841-9813-a1e03b8d3a05'
                             )
 create_or_update_by_name(name:                       'Breach of Crown Court order',
                             is_fixed_fee:            true,
@@ -38,6 +40,7 @@ create_or_update_by_name(name:                       'Breach of Crown Court orde
                             requires_maat_reference: false,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'FXCBR',
+                            uuid: '4e996aed-2dc9-424c-9862-b52b02fe48b3'
                             )
 create_or_update_by_name(name:                       'Committal for Sentence',
                             is_fixed_fee:            true,
@@ -48,6 +51,7 @@ create_or_update_by_name(name:                       'Committal for Sentence',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'FXCSE',
+                            uuid: '7c27f365-9cd3-4993-b78d-2065ecb97fd9'
                             )
 create_or_update_by_name(name:                       'Contempt',
                             is_fixed_fee:            true,
@@ -58,6 +62,7 @@ create_or_update_by_name(name:                       'Contempt',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'FXCON',
+                            uuid: 'b6d8bc8e-7238-458e-a645-c0e382a5afd1'
                             )
 create_or_update_by_name(name:                       'Cracked Trial',
                             is_fixed_fee:            false,
@@ -68,6 +73,7 @@ create_or_update_by_name(name:                       'Cracked Trial',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'GRRAK',
+                            uuid: '60e835cf-911f-49ef-9376-8b2a55494aa6'
                             )
 create_or_update_by_name(name:                       'Cracked before retrial',
                             is_fixed_fee:            false,
@@ -78,6 +84,7 @@ create_or_update_by_name(name:                       'Cracked before retrial',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'GRCBR',
+                            uuid: '5db5134a-afac-4f32-bc88-e9a6a54b4df9'
                             )
 create_or_update_by_name(name:                       'Discontinuance',
                             is_fixed_fee:            false,
@@ -88,6 +95,7 @@ create_or_update_by_name(name:                       'Discontinuance',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'GRDIS',
+                            uuid: '5d646fd1-b50b-4aba-9435-de5b9377bd8a'
                             )
 create_or_update_by_name(name:                       'Elected cases not proceeded',
                             is_fixed_fee:            true,
@@ -98,6 +106,7 @@ create_or_update_by_name(name:                       'Elected cases not proceede
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'FXENP',
+                            uuid: '03cb932c-d700-415b-a328-15839d88dc36'
                             )
 create_or_update_by_name(name:                       'Guilty plea',
                             is_fixed_fee:            false,
@@ -108,6 +117,7 @@ create_or_update_by_name(name:                       'Guilty plea',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs),
                             fee_type_code:           'GRGLT',
+                            uuid: 'b342a476-887d-46b3-b2dc-32da2dd138ec'
                             )
 create_or_update_by_name(name:                       'Retrial',
                             is_fixed_fee:            false,
@@ -118,6 +128,7 @@ create_or_update_by_name(name:                       'Retrial',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs interim),
                             fee_type_code:           'GRRTR',
+                            uuid: 'c6197718-08c5-4943-a2e1-2c5bf71bcfa8'
                             )
 create_or_update_by_name(name:                       'Trial',
                             is_fixed_fee:            false,
@@ -128,6 +139,7 @@ create_or_update_by_name(name:                       'Trial',
                             requires_maat_reference: true,
                             roles:                   %w(agfs lgfs interim),
                             fee_type_code:           'GRTRL',
+                            uuid: 'f96b265a-f972-4872-a598-e78de4fcab83'
                             )
 
 create_or_update_by_name(name: 'Hearing subsequent to sentence',
@@ -139,6 +151,7 @@ create_or_update_by_name(name: 'Hearing subsequent to sentence',
                             requires_maat_reference:  true,
                             roles:                    ['lgfs'],
                             fee_type_code:            'FXH2S',
+                            uuid: '5e1d62c4-b119-4b48-9811-3c92c93dee9e'
                             )
 
 # create_or_update_by_name(name: 'Transfer',


### PR DESCRIPTION
In order for CCR to validate CCCD claims it 
must determine what "billing scenario"  applies
to it. Case types and billing scenarios are virtually
synonymous!

The intention is that CCR will store a translation/mapping
between the case type's uuid and the billing scenario.

The full claim api endpoint will now need to return the UUID
for consumption by CCR.