### PR TITLE
add uuid for hearing subsequent to sentence

### DIFF
--- a/db/migrate/20170727130618_add_uuid_to_case_types.rb
+++ b/db/migrate/20170727130618_add_uuid_to_case_types.rb
@@ -13,6 +13,7 @@ class AddUuidToCaseTypes < ActiveRecord::Migration
     b342a476-887d-46b3-b2dc-32da2dd138ec
     c6197718-08c5-4943-a2e1-2c5bf71bcfa8
     f96b265a-f972-4872-a598-e78de4fcab83
+    5e1d62c4-b119-4b48-9811-3c92c93dee9e
   ).freeze
 
   def up


### PR DESCRIPTION
another uuid is needed for case type migration.  hearing subsequent to sentence will not otherwise get one.