### PR TITLE
amend full claim endpoint to return case type uuid

### DIFF
--- a/app/interfaces/api/entities/full_claim.rb
+++ b/app/interfaces/api/entities/full_claim.rb
@@ -18,7 +18,8 @@ module API
       end
 
       expose :case_details do
-        expose :case_type
+        expose :case_type_name, as: :case_type
+        expose :case_type_uuid
         expose :case_number
         expose :cms_number
         expose :providers_ref, as: :providers_reference
@@ -73,10 +74,13 @@ module API
 
       private
 
-      def case_type
+      def case_type_name
         object.case_type.name
       end
 
+      def case_type_uuid
+        object.case_type.uuid
+      end
       def court_code
         object.court&.code
       end

--- a/spec/api/v2/claim_spec.rb
+++ b/spec/api/v2/claim_spec.rb
@@ -64,6 +64,7 @@ describe API::V2::Claim do
       end
     end
 
+
     # TODO: to be updated and enabled once the claim export structure is finalised.
     xit 'should return a JSON with the required information' do
       claim = get_full_claim
@@ -71,57 +72,60 @@ describe API::V2::Claim do
     end
 
     # TODO: to be updated and enabled once the claim export structure is finalised.
-    # context 'should return the expected details' do
-    #   it 'claim details' do
-    #     details = get_full_claim[:claim_details]
-    #     expect(details.to_json).to eq '{"uuid":"uuid","type":"Claim::AdvocateClaim","provider_code":"XY666","advocate_category":"QC","additional_information":"This is some important additional information.","apply_vat":true,"state":"redetermination","submitted_at":"2016-03-10T11:44:55Z","originally_submitted_at":"2016-03-10T11:44:55Z","authorised_at":"2016-03-10T11:44:55Z","created_by":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"},"external_user":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"}}'
-    #   end
-    #
-    #   it 'case details' do
-    #     details = get_full_claim[:case_details]
-    #     expect(details.to_json).to eq '{"case_type":"Fixed fee","case_number":"T20161234","source":"web","cms_number":"CMS-12345","providers_reference":"reference-123","court":{"id":1,"code":"ABC","name":"Acme Court","court_type":"crown"},"transfer_court":{"court":{"id":1,"code":"ZZZ","name":"Northern Court","court_type":"crown"},"case_number":"A20161234"},"offence":{"category":"Miscellaneous/other","class":"Lesser offences involving violence or damage and less serious drug offences"},"trial_dates":{"date_started":null,"date_concluded":null,"estimated_length":0,"actual_length":0},"retrial_dates":{"date_started":null,"date_concluded":null,"estimated_length":0,"actual_length":0},"cracked_dates":{"date_fixed_notice":null,"date_fixed":null,"date_cracked":null,"date_cracked_at_third":null},"effective_pcmh_date":null,"legal_aid_transfer_date":null,"totals":{"fees":25.0,"expenses":9.99,"disbursements":0.0,"vat_amount":6.13,"total":34.99},"evidence_documents":["LAC1 - memo of conviction","Representation order"]}'
-    #   end
-    #
-    #   it 'defendants details' do
-    #     details = get_full_claim[:defendants]
-    #     expect(details.to_json).to eq '[{"id":1,"uuid":"uuid","first_name":"Kaia","last_name":"Casper","date_of_birth":"1995-06-20T00:00:00Z","representation_orders":[{"id":1,"uuid":"uuid","maat_reference":"1234567890","date":"2016-01-10T00:00:00Z"}]}]'
-    #   end
-    #
-    #   it 'fees details' do
-    #     details = get_full_claim[:fees]
-    #     expect(details.to_json).to eq '[{"type":"Pages of prosecution evidence","code":"PPE","date":null,"quantity":1.0,"amount":25.0,"rate":0.0,"dates_attended":[]}]'
-    #   end
-    #
-    #   it 'expenses details' do
-    #     details = get_full_claim[:expenses]
-    #     expect(details.to_json).to eq '[{"date":"2016-01-10T00:00:00Z","type":"Car travel","location":"Brighton","mileage_rate":"45p","reason":"Pre-trial conference expert witnesses","distance":27.0,"hours":0.0,"quantity":0.0,"rate":0.0,"net_amount":9.99,"vat_amount":0.0}]'
-    #   end
-    #
-    #   # Advocate claims do not have disbursements, tested separated in /spec/api/entities/disbursement_spec.rb
-    #   it 'disbursements details' do
-    #     details = get_full_claim[:disbursements]
-    #     expect(details.to_json).to eq '[]'
-    #   end
-    #
-    #   it 'documents details' do
-    #     details = get_full_claim[:documents]
-    #     expect(details.to_json).to eq '[{"uuid":"uuid","url":"assets/test/images/longer_lorem.pdf","file_name":"longer_lorem.pdf","size":49993}]'
-    #   end
-    #
-    #   it 'messages details' do
-    #     details = get_full_claim[:messages]
-    #     expect(details.to_json).to eq '[{"created_at":"2016-03-10T11:44:55Z","sender_uuid":"uuid","body":"This is the message body.","document":{"url":"assets/test/images/shorter_lorem.docx","file_name":"shorter_lorem.docx","size":14713}}]'
-    #   end
-    #
-    #   it 'assessment details' do
-    #     details = get_full_claim[:assessment]
-    #     expect(details.to_json).to eq '{"created_at":"2016-03-10T11:44:55Z","totals":{"fees":24.2,"expenses":8.5,"disbursements":0.0,"vat_amount":5.72,"total":32.7}}'
-    #   end
-    #
-    #   it 'redeterminations details' do
-    #     details = get_full_claim[:redeterminations]
-    #     expect(details.to_json).to eq '[{"created_at":"2016-03-10T11:44:55Z","totals":{"fees":25.0,"expenses":9.2,"disbursements":0.0,"vat_amount":5.99,"total":34.2}}]'
-    #   end
-    # end
+    context 'should return the expected details' do
+      # it 'claim details' do
+      #   details = get_full_claim[:claim_details]
+      #   expect(details.to_json).to eq '{"uuid":"uuid","type":"Claim::AdvocateClaim","provider_code":"XY666","advocate_category":"QC","additional_information":"This is some important additional information.","apply_vat":true,"state":"redetermination","submitted_at":"2016-03-10T11:44:55Z","originally_submitted_at":"2016-03-10T11:44:55Z","authorised_at":"2016-03-10T11:44:55Z","created_by":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"},"external_user":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"}}'
+      # end
+
+      context 'case details' do
+        subject { get_full_claim[:case_details] }
+        it 'contains name and uuid' do
+          is_expected.to include(case_type: 'Fixed fee', case_type_uuid: @claim.case_type.uuid)
+        end
+      end
+
+      #
+      #   it 'defendants details' do
+      #     details = get_full_claim[:defendants]
+      #     expect(details.to_json).to eq '[{"id":1,"uuid":"uuid","first_name":"Kaia","last_name":"Casper","date_of_birth":"1995-06-20T00:00:00Z","representation_orders":[{"id":1,"uuid":"uuid","maat_reference":"1234567890","date":"2016-01-10T00:00:00Z"}]}]'
+      #   end
+      #
+      #   it 'fees details' do
+      #     details = get_full_claim[:fees]
+      #     expect(details.to_json).to eq '[{"type":"Pages of prosecution evidence","code":"PPE","date":null,"quantity":1.0,"amount":25.0,"rate":0.0,"dates_attended":[]}]'
+      #   end
+      #
+      #   it 'expenses details' do
+      #     details = get_full_claim[:expenses]
+      #     expect(details.to_json).to eq '[{"date":"2016-01-10T00:00:00Z","type":"Car travel","location":"Brighton","mileage_rate":"45p","reason":"Pre-trial conference expert witnesses","distance":27.0,"hours":0.0,"quantity":0.0,"rate":0.0,"net_amount":9.99,"vat_amount":0.0}]'
+      #   end
+      #
+      #   # Advocate claims do not have disbursements, tested separated in /spec/api/entities/disbursement_spec.rb
+      #   it 'disbursements details' do
+      #     details = get_full_claim[:disbursements]
+      #     expect(details.to_json).to eq '[]'
+      #   end
+      #
+      #   it 'documents details' do
+      #     details = get_full_claim[:documents]
+      #     expect(details.to_json).to eq '[{"uuid":"uuid","url":"assets/test/images/longer_lorem.pdf","file_name":"longer_lorem.pdf","size":49993}]'
+      #   end
+      #
+      #   it 'messages details' do
+      #     details = get_full_claim[:messages]
+      #     expect(details.to_json).to eq '[{"created_at":"2016-03-10T11:44:55Z","sender_uuid":"uuid","body":"This is the message body.","document":{"url":"assets/test/images/shorter_lorem.docx","file_name":"shorter_lorem.docx","size":14713}}]'
+      #   end
+      #
+      #   it 'assessment details' do
+      #     details = get_full_claim[:assessment]
+      #     expect(details.to_json).to eq '{"created_at":"2016-03-10T11:44:55Z","totals":{"fees":24.2,"expenses":8.5,"disbursements":0.0,"vat_amount":5.72,"total":32.7}}'
+      #   end
+      #
+      #   it 'redeterminations details' do
+      #     details = get_full_claim[:redeterminations]
+      #     expect(details.to_json).to eq '[{"created_at":"2016-03-10T11:44:55Z","totals":{"fees":25.0,"expenses":9.2,"disbursements":0.0,"vat_amount":5.99,"total":34.2}}]'
+      #   end
+    end
   end
 end

--- a/spec/factories/case_types.rb
+++ b/spec/factories/case_types.rb
@@ -24,6 +24,7 @@ FactoryGirl.define do
     requires_trial_dates        false
     requires_maat_reference     true
     roles                       %w{ agfs lgfs }
+    uuid SecureRandom.uuid
 
     trait :fixed_fee do
       name            'Fixed fee'


### PR DESCRIPTION
**What**
 returns case type uuid in full claim json 

**Why**
Rather than storing bill scenario logic in CCCD  it 
is expected that CCR will store a mapping/translation
of CCCD case type UUIDs against CCR bill scenario keys/ids.