### PR TITLE
Improve POSTing to root handling

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,6 +3,7 @@ class ErrorsController < ApplicationController
   protect_from_forgery except: [:not_endpoint, :not_found, :internal_server_error]
 
   def not_endpoint
+    logger.debug("Data POSTed to root with API key: #{not_endpoint_params[:api_key]}") if params.present?
     render status: 422, text: 'Not a valid api endpoint'
   end
 
@@ -22,5 +23,11 @@ class ErrorsController < ApplicationController
 
   def dummy_exception
     raise ArgumentError, "This exception has been raised as a test by going to the 'dummy_exception' endpoint."
+  end
+
+  private
+
+  def not_endpoint_params
+    params.permit(:api_key)
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,10 @@
 class ErrorsController < ApplicationController
-  skip_load_and_authorize_resource only: [:not_found, :internal_server_error, :dummy_exception]
-  protect_from_forgery except: [:not_found, :internal_server_error]
+  skip_load_and_authorize_resource only: [:not_endpoint, :not_found, :internal_server_error, :dummy_exception]
+  protect_from_forgery except: [:not_endpoint, :not_found, :internal_server_error]
+
+  def not_endpoint
+    render status: 422, text: 'Not a valid api endpoint'
+  end
 
   def not_found
     respond_to do |format|

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,7 +4,7 @@ class ErrorsController < ApplicationController
 
   def not_endpoint
     logger.debug("Data POSTed to root with API key: #{not_endpoint_params[:api_key]}") if params.present?
-    render status: 422, text: 'Not a valid api endpoint'
+    render status: 403, text: 'Not a valid api endpoint'
   end
 
   def not_found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Rails.application.routes.draw do
 
   get 'statistics', to: 'geckoboard_api/statistics#index'
 
-
+  post '/', to: 'errors#not_endpoint'
   # catch-all route
   unless Rails.env.development? || Rails.env.devunicorn?
     match '*path', to: 'errors#not_found', via: :all

--- a/spec/api/posting_to_root_spec.rb
+++ b/spec/api/posting_to_root_spec.rb
@@ -8,6 +8,6 @@ describe 'POSTING to root' do
   before { post '/', payload, format: :json }
 
   it 'returns an error' do
-    expect(response.status).to eq(422)
+    expect(response.status).to eq(403)
   end
 end

--- a/spec/api/posting_to_root_spec.rb
+++ b/spec/api/posting_to_root_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe 'POSTING to root' do
+  let!(:provider) { create(:provider) }
+  let!(:claim)    { create(:claim, source: 'api').reload }
+  let(:payload)   { {  api_key: provider.api_key, claim_id: claim.uuid, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "1980-05-10"} }
+
+  before { post '/', payload, format: :json }
+
+  it 'returns an error' do
+    expect(response.status).to eq(422)
+  end
+end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ErrorsController, type: :controller do
   describe "GET #not_endpoint" do
     before { get :not_endpoint }
 
-    it 'has a status of 422' do
-      expect(response.status).to eq(422)
+    it 'has a status of 403' do
+      expect(response.status).to eq(403)
     end
 
-    it 'renders the 404/not_found template' do
+    it 'renders the appropriate json' do
       json = 'Not a valid api endpoint'
       expect(response.body).to eq json
     end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe ErrorsController, type: :controller do
+  describe "GET #not_endpoint" do
+    before { get :not_endpoint }
+
+    it 'has a status of 422' do
+      expect(response.status).to eq(422)
+    end
+
+    it 'renders the 404/not_found template' do
+      json = 'Not a valid api endpoint'
+      expect(response.body).to eq json
+    end
+  end
+
   describe "GET #not_found" do
     before { get :not_found }
 


### PR DESCRIPTION
**Why** 
Currently a user is randomly POSTing to the root url
**What** 
Add a specific route to prevent the server throwing 500 errors.
This will prevent the platforms team being alerted to multi 500 errors out of hours.
It also includes logging of the api_key used so that we can identify the user and discuss how to prevent them posting to the wrong endpoint.