### PR TITLE
Fix vulnerabilities

### DIFF
--- a/app/controllers/geckoboard_api/application_controller.rb
+++ b/app/controllers/geckoboard_api/application_controller.rb
@@ -1,4 +1,5 @@
 class GeckoboardApi::ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
   before_action :authenticate_token!
 
   private

--- a/app/interfaces/api/entities/ccr/defendant.rb
+++ b/app/interfaces/api/entities/ccr/defendant.rb
@@ -8,7 +8,7 @@ module API
         private
 
         def main_defendant
-          object.claim&.defendants&.order(created_at: :asc).first == object || false
+          object.claim&.defendants&.order(created_at: :asc)&.first == object || false
         end
       end
     end

--- a/app/models/claim_json_schema_validator.rb
+++ b/app/models/claim_json_schema_validator.rb
@@ -27,5 +27,4 @@ class ClaimJsonSchemaValidator
       JSON::Validator.validate!(basic_schema, data, list: data.is_a?(Array))
     end
   end
-
 end


### PR DESCRIPTION
## Why
Brakeman warned of a severe vulnerability in the geckoboard controller
Because of the inheritance of `ActionController` and `ActionController::Base` the protect from forgery flag was not turned on

## Fix
Turning on the `protect_from_forgery` address should close that warning

Bonus - Fixed a couple of minor Rubocop warnings
