### PR TITLE
Modify CCR api JSON response to return null instead of empty string

### DIFF
--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -167,10 +167,10 @@ module API
           ppe: pages_of_prosecution_evidence,
           quantity: 1.0,
           rate: 0.0,
-          dateNotice1stFixedWarn: '',
-          firstFixedWarnedDate: '',
-          dateOfCrack: '',
-          thirdCracked: '',
+          dateNotice1stFixedWarn: nil,
+          firstFixedWarnedDate: nil,
+          dateOfCrack: nil,
+          thirdCracked: nil,
           dateIncurred: object.last_submitted_at.strftime('%Y-%m-%d %H:%M:%S'),
           noOfCases: number_of_cases,
           calculatedFee: {
@@ -186,8 +186,8 @@ module API
             vatRate: 20.0
           },
           refno: 0,
-          occurDate: '',
-          firstFixedWarnedDateOrig: '',
+          occurDate: nil,
+          firstFixedWarnedDateOrig: nil,
           caseUpliftAmount: 0.0,
           defendantUpliftAmount: 0.0
         }

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -103,15 +103,15 @@
           },
           "dateIncurred": {
             "id": "/properties/bills/items/properties/dateIncurred",
-            "type": "string"
+            "type": ["string","null"]
           },
           "dateNotice1stFixedWarn": {
             "id": "/properties/bills/items/properties/dateNotice1stFixedWarn",
-            "type": "string"
+            "type": ["string","null"]
           },
           "dateOfCrack": {
             "id": "/properties/bills/items/properties/dateOfCrack",
-            "type": "string"
+            "type": ["string","null"]
           },
           "defendantUpliftAmount": {
             "id": "/properties/bills/items/properties/defendantUpliftAmount",
@@ -119,11 +119,11 @@
           },
           "firstFixedWarnedDate": {
             "id": "/properties/bills/items/properties/firstFixedWarnedDate",
-            "type": "string"
+            "type": ["string","null"]
           },
           "firstFixedWarnedDateOrig": {
             "id": "/properties/bills/items/properties/firstFixedWarnedDateOrig",
-            "type": "string"
+            "type": ["string","null"]
           },
           "noOfCases": {
             "id": "/properties/bills/items/properties/noOfCases",
@@ -131,7 +131,7 @@
           },
           "occurDate": {
             "id": "/properties/bills/items/properties/occurDate",
-            "type": "string"
+            "type": ["string","null"]
           },
           "ppe": {
             "id": "/properties/bills/items/properties/ppe",
@@ -151,7 +151,7 @@
           },
           "thirdCracked": {
             "id": "/properties/bills/items/properties/thirdCracked",
-            "type": "string"
+            "type": ["string","null"]
           },
           "userCreatedRole": {
             "id": "/properties/bills/items/properties/userCreatedRole",
@@ -288,7 +288,7 @@
     },
     "trialStartDate": {
       "id": "/properties/trialStartDate",
-      "type": "null"
+      "type": ["string","null"]
     }
   },
   "type": "object"


### PR DESCRIPTION
Nulls are easier to handle on the CCR side and is preferred
in JSON in any event. Also, modify schema to allow string
or null for fields that could be either.