### PR TITLE
CCR claim API endpoint JSON key renaming

### DIFF
--- a/app/interfaces/api/entities/ccr/case_type.rb
+++ b/app/interfaces/api/entities/ccr/case_type.rb
@@ -1,0 +1,14 @@
+module API
+  module Entities
+    module CCR
+      class CaseType < API::Entities::CCR::BaseEntity
+        # INJECTION: bill scenario is a CCCD mapping to CCR data based on case type description
+        # which should, ideally, be replaced by a uuid which is mapped CCR-side
+        expose :bill_scenario
+
+        # INJECTION: the case type UUID should, ideally, be used CCR-side to map to a bill scenario
+        expose :uuid
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/ccr/offence.rb
+++ b/app/interfaces/api/entities/ccr/offence.rb
@@ -1,0 +1,19 @@
+module API
+  module Entities
+    module CCR
+      class Offence < API::Entities::CCR::BaseEntity
+        expose :faked_legacy_id, as: :id
+        expose :offence_class, using: API::Entities::CCR::OffenceClass
+
+        private
+
+        # INJECTION: Using CCR Legacy Offence codes 501-511 for now (which map 1-to-1 onto offence classes)
+        # but this will eventually need to provide an ID, UUID or some key that maps
+        # CCCD offence records to CCR Offence records.
+        def faked_legacy_id
+          ('A'..'K').zip(501..511).to_h[object&.offence_class&.class_letter]
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/ccr/offence_class.rb
+++ b/app/interfaces/api/entities/ccr/offence_class.rb
@@ -1,0 +1,10 @@
+module API
+  module Entities
+    module CCR
+      class OffenceClass < API::Entities::CCR::BaseEntity
+        # CCR class letters map accurately one-to-one with CCCD class letters
+        expose :class_letter
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -18,52 +18,37 @@ module API
         expose :uuid
       end
 
-      expose :supplier do
-        expose :supplier_number, as: :accountNumber
-      end
+      expose :supplier_number
+      expose :case_number
+      expose :court_id
+      expose  :first_day_of_trial,
+              :trial_fixed_notice_at,
+              :trial_fixed_at,
+              :trial_cracked_at,
+              :last_submitted_at,
+              format_with: :utc
+      expose :trial_cracked_at_third
 
-      expose :case_number, as: :caseNumber
-      expose :court do
-        expose :court_code, as: :code
-      end
-
-      # INJECTION: should be replaced API::Entities::Export::Defendant via the full claim endpoint
+      expose :case_type, using: API::Entities::CCR::CaseType
+      expose :offence, using: API::Entities::CCR::Offence
       expose :defendants, using: API::Entities::CCR::Defendant
 
-      # INJECTION: to be removed once CCR can iterate over defendants representation orders JSON provided by API::Entities::CCR::Defendant
-      expose :first_defendant_maat_number, as: :representationOrderNumber
-      expose :first_defendant_rep_order_date, as: :representationOrderDate, format_with: :utc
+      # CCR fields with no equivalent in CCCD
+      # INJECTION: to be removed once CCR can derive this from earliest repo order date
+      expose :fee_structure_id
+      # ----------------------------------------------
 
-      expose :wrapped_bill, as: :bills
+      # CCR fields that can be derived from CCCD data
+      expose :estimated_trial_length_or_one, as: :estimated_trial_length
+      expose :actual_trial_length_or_one, as: :actual_trial_Length
+      # ----------------------------------------------
 
-      expose :empty, as: :associatedCases
+      # CCR fields whose values can, and are, mapped to a CCCD field's values
+      expose :adapted_advocate_category, as: :advocate_category
+      # ----------------------------------------------
 
-      expose :fee_structure_id, as: :feeStructureId
-
-      expose :estimated_trial_length_or_one, as: :estimatedTrialLength
-      expose :actual_trial_length_or_one, as: :actualTrialLength
-      expose :first_day_of_trial, as: :trialStartDate
-
-      expose :number_of_witnesses, as: :noOfWitnesses
-
-      expose :personType do
-        expose :advocate_category, as: :personType
-      end
-
-      expose :case_number, as: :origCaseNumber
-
-      expose :offenceCode do
-        expose :offence_code_id, as: :id
-      end
-
-      expose :offenceClass do
-        expose :offence_class_code, as: :code
-      end
-
-      expose :scenario do
-        expose :fee_structure_id, as: :feeStructureId
-        expose :scenario
-      end
+      # wrapper for the mapping of CCCD fees to CCR bills
+      expose :bills
 
       private
 
@@ -72,75 +57,37 @@ module API
       WITNESSES = 10
       PPE = 11
 
-      def empty
-        []
-      end
-
-      def zero
-        0
-      end
-
-      def fee_quantity_for(fee_type_id)
-        object.fees.find_by(fee_type_id: fee_type_id)&.quantity&.to_i || 0
-      end
-
-      def court_code
-        object.court&.code
-      end
-
-      def first_defendant_maat_number
-        object.defendants.first.representation_orders.first.maat_reference
-      end
-
-      def first_defendant_rep_order_date
-        object.defendants.first.representation_orders.first.representation_order_date
-      end
-
+      # INJECTION: fee_structure_id this eventually needs to be determined on
+      # the CCR side. CCR stores fee schemes against start and end dates. CCR should
+      # use the earliest rep order date of the main defendant to determine which
+      # fee scheme version(0 to 9, 1 to 10) to apply. CCCD should send the rep
+      # orders in asc date order to assist.
       def fee_structure_id
         AGFS_FEE_SCHEME_9_CCR_FEE_STRUCTURE_ID
       end
 
-      def scenario
-        object.case_type.bill_scenario
-      end
-
       def estimated_trial_length_or_one
-        return 1 if object.estimated_trial_length.zero? || object.estimated_trial_length.nil?
-        object.estimated_trial_length
+        [object.estimated_trial_length, 1].compact.max
       end
 
       def actual_trial_length_or_one
-        return 1 if object.actual_trial_length.zero? || object.actual_trial_length.nil?
-        object.actual_trial_length
+        [object.actual_trial_length, 1].compact.max
       end
 
-      def advocate_category
+      def adapted_advocate_category
         AdvocateCategoryAdapter.code_for(object.advocate_category) if object.advocate_category.present?
       end
 
-      def offence_class_code
-        object.offence&.offence_class&.class_letter
+      def fee_quantity_for(fee_type_id)
+        object.fees.find_by(fee_type_id: fee_type_id)&.quantity.to_i
       end
 
-      def offence_code_id
-        # Using CCR Legacy Offence codes 501-511 for now (which map 1-to-1 onto offence classes)
-        ('A'..'K').zip(501..511).to_h[offence_class_code]
+      def pages_of_prosecution_evidence
+        fee_quantity_for(PPE)
       end
 
       def number_of_witnesses
         fee_quantity_for(WITNESSES)
-      end
-
-      # CCR bill type maps to the class/type of a BaseFeeType
-      # e.g. AGFS_FEE bill_type is the BasicFeeType
-      def bill_type
-        'AGFS_FEE'
-      end
-
-      # CCR bill sub types map to individual/unique fee types
-      # e.g. AGFS_FEE subtype is the BasicFeeType's Basic fee (i.e. BAF)
-      def bill_subtype
-        'AGFS_FEE'
       end
 
       # every claim is based on one case (i.e. see case number) but may involve others
@@ -148,31 +95,38 @@ module API
         fee_quantity_for(CASES_UPLIFT) + 1
       end
 
-      def pages_of_prosecution_evidence
-        fee_quantity_for(PPE)
+      def daily_attendance_fee_types
+        ::Fee::BasicFeeType.where(unique_code: %w[BADAF BADAH BADAJ])
       end
 
-      # The "Advocate Fee" is the CCR equivalent of all the
-      # BasicFeeType fees in CCCD.
-      # The Advocate Fee is of type AGFS_FEE and subtype AGFS_FEE
+      # The first 2 daily attendances are included in the Basic Fee (BAF)
+      def daily_attendances
+        object.fees.where(fee_type_id: daily_attendance_fee_types).sum(:quantity).to_i + 2
+      end
+
+      # The "Advocate Fee" is the CCR equivalent of all most but not
+      # all the BasicFeeType fees in CCCD. The Advocate Fee is of type
+      # AGFS_FEE and subtype AGFS_FEE
+      #
+      # CCR bill type maps to the class/type of a BaseFeeType
+      # e.g. AGFS_FEE bill_type is, almost, equivalent to the BasicFeeType
+      #
+      # CCR bill sub types map to individual/unique fee types
+      # e.g. AGFS_FEE subtype represents the BasicFeeType's
+      # BABAF,BACAV,BADAF,BADAH,BADAJ,BANOC,BANDR,BANPW,BAPPE
+      # fee types, but not BASAF or BAPCM
       def advocate_fee
         {
-          billType: {
-            billType: bill_type
-          },
-          billSubType: {
-            billSubType: bill_subtype
-          },
-          userCreatedRole: 'CCRGradeB1',
-          ppe: pages_of_prosecution_evidence,
+          bill_type: 'AGFS_FEE',
+          bill_subtype: 'AGFS_FEE',
           quantity: 1.0,
           rate: 0.0,
-          dateNotice1stFixedWarn: nil,
-          firstFixedWarnedDate: nil,
-          dateOfCrack: nil,
-          thirdCracked: nil,
-          dateIncurred: object.last_submitted_at.strftime('%Y-%m-%d %H:%M:%S'),
-          noOfCases: number_of_cases,
+          ppe: pages_of_prosecution_evidence,
+          number_of_cases: number_of_cases,
+          number_of_witnesses: number_of_witnesses,
+          daily_attendances: daily_attendances,
+          conferences_and_views_refno: 0, # CCR required only - CAV record/instance number/occurence - could be removed if CCR defaults to 0
+          conferences_and_views_at: nil, # CCR required only - CAV record/instance date, not available in CCCD. could be removed if CCR can default
           calculatedFee: {
             basicCaseFee: 0.0,
             date: object.last_submitted_at.strftime('%Y-%m-%d %H:%M:%S'),
@@ -184,16 +138,11 @@ module API
             vat: 0.0,
             vatIncluded: true,
             vatRate: 20.0
-          },
-          refno: 0,
-          occurDate: nil,
-          firstFixedWarnedDateOrig: nil,
-          caseUpliftAmount: 0.0,
-          defendantUpliftAmount: 0.0
+          }
         }
       end
 
-      def wrapped_bill
+      def bills
         [
           advocate_fee
         ]

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -1,10 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {},
-  "id": "https://claim-crown-court-defence.service.gov.uk/schemas/ccr_claim",
+  "id": "https://claim-crown-court-defence.service.gov.uk/json_schemas/ccr_schema",
+  "additionalProperties": false,
   "properties": {
     "_cccd": {
       "id": "/properties/_cccd",
+      "additionalProperties": false,
       "properties": {
         "id": {
           "id": "/properties/_cccd/properties/id",
@@ -17,42 +19,47 @@
       },
       "type": "object"
     },
-    "actualTrialLength": {
-      "id": "/properties/actualTrialLength",
+    "actual_trial_Length": {
+      "id": "/properties/actual_trial_length",
       "type": "integer"
     },
-    "associatedCases": {
-      "id": "/properties/associatedCases",
-      "items": {},
-      "type": "array"
+    "trial_fixed_notice_at": {
+      "id": "/properties/trial_fixed_notice_at",
+      "type": ["string","null"]
+    },
+    "trial_fixed_at": {
+      "id": "/properties/trial_fixed_at",
+      "type": ["string","null"]
+    },
+    "trial_cracked_at": {
+      "id": "/properties/trial_cracked_at",
+      "type": ["string","null"]
+    },
+    "trial_cracked_at_third": {
+      "id": "/properties/trial_cracked_at_third",
+      "type": ["string","null"]
+    },
+    "last_submitted_at": {
+      "id": "/properties/last_submitted_at",
+      "type": ["string","null"]
     },
     "bills": {
       "id": "/properties/bills",
       "items": {
         "id": "/properties/bills/items",
+        "additionalProperties": false,
         "properties": {
-          "billSubType": {
-            "id": "/properties/bills/items/properties/billSubType",
-            "properties": {
-              "billSubType": {
-                "id": "/properties/bills/items/properties/billSubType/properties/billSubType",
-                "type": "string"
-              }
-            },
-            "type": "object"
+          "bill_type": {
+            "id": "/properties/bills/items/properties/bill_type",
+            "type": "string"
           },
-          "billType": {
-            "id": "/properties/bills/items/properties/billType",
-            "properties": {
-              "billType": {
-                "id": "/properties/bills/items/properties/billType/properties/billType",
-                "type": "string"
-              }
-            },
-            "type": "object"
+          "bill_subtype": {
+            "id": "/properties/bills/items/properties/bill_subtype",
+            "type": "string"
           },
           "calculatedFee": {
             "id": "/properties/bills/items/properties/calculatedFee",
+            "additionalProperties": false,
             "properties": {
               "basicCaseFee": {
                 "id": "/properties/bills/items/properties/calculatedFee/properties/basicCaseFee",
@@ -97,40 +104,24 @@
             },
             "type": "object"
           },
-          "caseUpliftAmount": {
-            "id": "/properties/bills/items/properties/caseUpliftAmount",
-            "type": "number"
-          },
-          "dateIncurred": {
-            "id": "/properties/bills/items/properties/dateIncurred",
-            "type": ["string","null"]
-          },
-          "dateNotice1stFixedWarn": {
-            "id": "/properties/bills/items/properties/dateNotice1stFixedWarn",
-            "type": ["string","null"]
-          },
-          "dateOfCrack": {
-            "id": "/properties/bills/items/properties/dateOfCrack",
-            "type": ["string","null"]
-          },
-          "defendantUpliftAmount": {
-            "id": "/properties/bills/items/properties/defendantUpliftAmount",
-            "type": "number"
-          },
-          "firstFixedWarnedDate": {
-            "id": "/properties/bills/items/properties/firstFixedWarnedDate",
-            "type": ["string","null"]
-          },
-          "firstFixedWarnedDateOrig": {
-            "id": "/properties/bills/items/properties/firstFixedWarnedDateOrig",
-            "type": ["string","null"]
-          },
-          "noOfCases": {
-            "id": "/properties/bills/items/properties/noOfCases",
+          "number_of_cases": {
+            "id": "/properties/bills/items/properties/number_of_cases",
             "type": "integer"
           },
-          "occurDate": {
-            "id": "/properties/bills/items/properties/occurDate",
+          "number_of_witnesses": {
+            "id": "/properties/bills/items/properties/number_of_witnesses",
+            "type": "integer"
+          },
+          "daily_attendances": {
+            "id": "/properties/bills/items/properties/daily_attendances",
+            "type": "integer"
+          },
+          "conferences_and_views_refno": {
+            "id": "/properties/bills/items/properties/conferences_and_views_refno",
+            "type": "integer"
+          },
+          "conferences_and_views_at": {
+            "id": "/properties/bills/items/properties/conferences_and_views_at",
             "type": ["string","null"]
           },
           "ppe": {
@@ -139,47 +130,30 @@
           },
           "quantity": {
             "id": "/properties/bills/items/properties/quantity",
-            "type": "intgeger"
+            "type": "number"
           },
           "rate": {
             "id": "/properties/bills/items/properties/rate",
             "type": "number"
-          },
-          "refno": {
-            "id": "/properties/bills/items/properties/refno",
-            "type": "integer"
-          },
-          "thirdCracked": {
-            "id": "/properties/bills/items/properties/thirdCracked",
-            "type": ["string","null"]
-          },
-          "userCreatedRole": {
-            "id": "/properties/bills/items/properties/userCreatedRole",
-            "type": "string"
           }
         },
         "type": "object"
       },
       "type": "array"
     },
-    "caseNumber": {
-      "id": "/properties/caseNumber",
+    "case_number": {
+      "id": "/properties/case_number",
       "type": "string"
     },
-    "court": {
-      "id": "/properties/court",
-      "properties": {
-        "code": {
-          "id": "/properties/court/properties/code",
-          "type": "string"
-        }
-      },
-      "type": "object"
+    "court_id": {
+      "id": "/properties/court_id",
+      "type": "integer"
     },
     "defendants": {
       "id": "/properties/defendants",
       "items": {
         "id": "/properties/defendants/items",
+        "additionalProperties": false,
         "properties": {
           "main_defendant": {
             "id": "/properties/defendants/items/properties/main_defendant",
@@ -189,6 +163,7 @@
             "id": "/properties/defendants/items/properties/representation_orders",
             "items": {
               "id": "/properties/defendants/items/properties/representation_orders/items",
+              "additionalProperties": false,
               "properties": {
                 "maat_reference": {
                   "id": "/properties/defendants/items/properties/representation_orders/items/properties/maat_reference",
@@ -208,86 +183,65 @@
       },
       "type": "array"
     },
-    "estimatedTrialLength": {
-      "id": "/properties/estimatedTrialLength",
+    "case_type": {
+      "id": "/properties/case_type",
+      "additionalProperties": false,
+      "properties": {
+        "uuid": {
+          "id": "/properties/case_type/properties/uuid",
+          "type": "string"
+        },
+        "bill_scenario": {
+          "id": "/properties/case_type/properties/bill_scenario",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "estimated_trial_length": {
+      "id": "/properties/estimated_trial_length",
       "type": "integer"
     },
     "feeStructureId": {
       "id": "/properties/feeStructureId",
       "type": "integer"
     },
-    "noOfWitnesses": {
-      "id": "/properties/noOfWitnesses",
-      "type": "integer"
-    },
-    "offenceClass": {
-      "id": "/properties/offenceClass",
-      "properties": {
-        "code": {
-          "id": "/properties/offenceClass/properties/code",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "offenceCode": {
-      "id": "/properties/offenceCode",
+    "offence": {
+      "additionalProperties": false,
+      "id": "/properties/offence",
       "properties": {
         "id": {
-          "id": "/properties/offenceCode/properties/id",
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
-    "origCaseNumber": {
-      "id": "/properties/origCaseNumber",
-      "type": "string"
-    },
-    "personType": {
-      "id": "/properties/personType",
-      "properties": {
-        "personType": {
-          "id": "/properties/personType/properties/personType",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "representationOrderDate": {
-      "id": "/properties/representationOrderDate",
-      "type": "string"
-    },
-    "representationOrderNumber": {
-      "id": "/properties/representationOrderNumber",
-      "type": "string"
-    },
-    "scenario": {
-      "id": "/properties/scenario",
-      "properties": {
-        "feeStructureId": {
-          "id": "/properties/scenario/properties/feeStructureId",
+          "id": "/properties/offence/properties/id",
           "type": "integer"
         },
-        "scenario": {
-          "id": "/properties/scenario/properties/scenario",
-          "type": "string"
+        "offence_class": {
+          "additionalProperties": false,
+          "id": "/properties/offence/properties/offence_class",
+          "properties": {
+            "class_letter": {
+              "id": "/properties/offence/properties/offence_class/properties/class_letter",
+              "type": "string"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"
     },
-    "supplier": {
-      "id": "/properties/supplier",
-      "properties": {
-        "accountNumber": {
-          "id": "/properties/supplier/properties/accountNumber",
-          "type": "string"
-        }
-      },
-      "type": "object"
+    "advocate_category": {
+      "id": "/properties/advocate_category",
+      "type": "string"
     },
-    "trialStartDate": {
-      "id": "/properties/trialStartDate",
+    "fee_structure_id": {
+      "id": "/properties/scenario/properties/fee_structure_id",
+      "type": "integer"
+    },
+    "supplier_number": {
+      "id": "/properties/supplier_number",
+      "type": "string"
+    },
+    "first_day_of_trial": {
+      "id": "/properties/first_day_of_trial",
       "type": ["string","null"]
     }
   },

--- a/spec/api/entities/ccr/case_type_spec.rb
+++ b/spec/api/entities/ccr/case_type_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe API::Entities::CCR::CaseType do
+  subject(:response) { JSON.parse(described_class.represent(case_type).to_json).deep_symbolize_keys }
+
+  let(:case_type) { build(:case_type, :trial, uuid: 'd6af0535-eee4-4a24-9d20-054f5f48fcec') }
+
+  it 'has expected json key-value pairs' do
+    expect(response).to include(uuid: 'd6af0535-eee4-4a24-9d20-054f5f48fcec', bill_scenario: 'AS000004')
+  end
+end

--- a/spec/api/entities/ccr/offence_class_spec.rb
+++ b/spec/api/entities/ccr/offence_class_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe API::Entities::CCR::OffenceClass do
+  subject(:response) { JSON.parse(described_class.represent(offence_class).to_json).deep_symbolize_keys }
+
+  let(:offence_class) { build(:offence_class, class_letter: 'E') }
+
+  it 'has expected json key-value pairs' do
+    expect(response).to include(class_letter: 'E')
+  end
+end

--- a/spec/api/entities/ccr/offence_spec.rb
+++ b/spec/api/entities/ccr/offence_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe API::Entities::CCR::Offence do
+  subject(:response) { JSON.parse(described_class.represent(offence).to_json).deep_symbolize_keys }
+
+  let(:offence_class) { create(:offence_class, class_letter: 'A') }
+  let(:offence) { build(:offence, offence_class_id: offence_class.id) }
+
+  it 'has expected json key-value pairs' do
+    expect(response).to include(id: 501, offence_class: { class_letter: 'A' })
+  end
+end

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -58,7 +58,7 @@ describe API::V2::CCRClaim do
       end
     end
 
-    context 'should return the expected details' do
+    context 'should return CCR compatible JSON' do
       subject(:response) { do_request }
 
       before do


### PR DESCRIPTION
Rename CCR API json response keys to CCCD naming conventions
 - [X] rename keys to snake case CCCD attributes where possible
 - [X] extract claim fields from bill
 - [X] move number of witnesses to bill
 - [X] add daily attendance and calculation to bill
 - [X] use offence, offence class and case type entities

**Field change breakdown for mapping in CCR**

    FAO @cibuanokpe, The new JSON schema can be viewed at:
    <domain>/json_schemas/ccr_schema

 - [X] scenario { feeStructureId } --> fee_structure_id
 - [X] scenario { scenario } --> case_type { bill_scenario }
 - [X] caseNumber --> case_number
 - [X] accountNumber --> supplier_number
 - [X] offenceCode { id } --> offence { id }
 - [X] offenceClass { code } --> offence { offence_class { class_letter }}
 - [X] bills [{ dateNotice1stFixedWarn }] --> trial_fixed_notice_at
 - [X] bills [{ firstFixedWarnedDate }] --> trial_fixed_at
 - [X] bills [{ dateOfCrack }] --> trial_cracked_at
 - [X] bills [{ thirdCracked }] --> trial_cracked_at_third
 - [X] bills [{ dateIncurred }] --> last_submitted_at
 - [X] actualTrialLength --> actual_trial_length
 - [X] estimatedTrialLength --> estimated_trial_length
 - [X] trialStartDate --> first_day_of_trial
 - [X] personType { personType } --> advocate_category
 - [X] court { court_code } --> court_id
 - [X] bills [{ billType { billType } }]--> bills [{ bill_type }]
 - [X] bills [{ billSubType { billSubType } }]--> bills [{ bill_subtype }]
 - [X] associatedCases - removed
 - [X] origCaseNumber - removed
 - [X] noOfWitnesses --> bills { number_of witnesses }
 - [X] bills [{ daily_attendances}] --> new field
 - [X] bill scenarios --> case_type { bill_scenario }
 - [X] bills { refno } --> bills [{ conferences_and_views_refno }]
 - [X] bills { occurDate } --> bills [{ conferences_and_views_at }]