### PR TITLE
Change court CCR claim api JSON to be the code of the court

### DIFF
--- a/app/interfaces/api/entities/ccr/court.rb
+++ b/app/interfaces/api/entities/ccr/court.rb
@@ -1,0 +1,9 @@
+module API
+  module Entities
+    module CCR
+      class Court < API::Entities::CCR::BaseEntity
+        expose :code
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -20,7 +20,6 @@ module API
 
       expose :supplier_number
       expose :case_number
-      expose :court_id
       expose  :first_day_of_trial,
               :trial_fixed_notice_at,
               :trial_fixed_at,
@@ -30,6 +29,7 @@ module API
       expose :trial_cracked_at_third
 
       expose :case_type, using: API::Entities::CCR::CaseType
+      expose :court, using: API::Entities::CCR::Court
       expose :offence, using: API::Entities::CCR::Offence
       expose :defendants, using: API::Entities::CCR::Defendant
 

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -145,9 +145,16 @@
       "id": "/properties/case_number",
       "type": "string"
     },
-    "court_id": {
-      "id": "/properties/court_id",
-      "type": "integer"
+    "court": {
+      "id": "/properties/court",
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "id": "/properties/court/properties/code",
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "defendants": {
       "id": "/properties/defendants",

--- a/spec/api/entities/ccr/court_spec.rb
+++ b/spec/api/entities/ccr/court_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe API::Entities::CCR::Court do
+  subject(:response) { JSON.parse(described_class.represent(court).to_json).deep_symbolize_keys }
+
+  let(:court) { build(:court, code: '999') }
+
+  it 'has expected json key-value pairs' do
+    expect(response).to include(code: '999')
+  end
+end


### PR DESCRIPTION
Was previously sending the CCCD court id, which has
no mapping in CCR.

Changes to JSON response:
* court_id --> court { code }