### PR TITLE
Sort CCR API defendants and rep orders JSON output to have earliest created first

### DIFF
--- a/app/interfaces/api/entities/ccr/defendant.rb
+++ b/app/interfaces/api/entities/ccr/defendant.rb
@@ -3,12 +3,16 @@ module API
     module CCR
       class Defendant < API::Entities::CCR::BaseEntity
         expose :main_defendant
-        expose :representation_orders, using: API::Entities::CCR::RepresentationOrder
+        expose :representation_orders_with_earliest_first, using: API::Entities::CCR::RepresentationOrder, as: :representation_orders
 
         private
 
         def main_defendant
-          object.claim&.defendants&.order(created_at: :asc)&.first == object || false
+          object.claim&.defendants&.unscope(:order).order(created_at: :asc)&.first == object || false
+        end
+
+        def representation_orders_with_earliest_first
+          object.representation_orders.unscope(:order).order(representation_order_date: :asc)
         end
       end
     end

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -31,7 +31,7 @@ module API
       expose :case_type, using: API::Entities::CCR::CaseType
       expose :court, using: API::Entities::CCR::Court
       expose :offence, using: API::Entities::CCR::Offence
-      expose :defendants, using: API::Entities::CCR::Defendant
+      expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants
 
       # CCR fields with no equivalent in CCCD
       # INJECTION: to be removed once CCR can derive this from earliest repo order date
@@ -59,6 +59,10 @@ module API
       # orders in asc date order to assist.
       def fee_structure_id
         AGFS_FEE_SCHEME_9_CCR_FEE_STRUCTURE_ID
+      end
+
+      def defendants_with_main_first
+        object.defendants.order(created_at: :asc)
       end
 
       def estimated_trial_length_or_one

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -11,7 +11,6 @@
 module API
   module Entities
     class CCRClaim < BaseEntity
-      AGFS_FEE_SCHEME_9_CCR_FEE_STRUCTURE_ID = 10
 
       expose :_cccd do
         expose :id
@@ -33,11 +32,6 @@ module API
       expose :offence, using: API::Entities::CCR::Offence
       expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants
 
-      # CCR fields with no equivalent in CCCD
-      # INJECTION: to be removed once CCR can derive this from earliest repo order date
-      expose :fee_structure_id
-      # ----------------------------------------------
-
       # CCR fields that can be derived from CCCD data
       expose :estimated_trial_length_or_one, as: :estimated_trial_length
       expose :actual_trial_length_or_one, as: :actual_trial_Length
@@ -51,15 +45,6 @@ module API
       expose :bills
 
       private
-
-      # INJECTION: fee_structure_id this eventually needs to be determined on
-      # the CCR side. CCR stores fee schemes against start and end dates. CCR should
-      # use the earliest rep order date of the main defendant to determine which
-      # fee scheme version(0 to 9, 1 to 10) to apply. CCCD should send the rep
-      # orders in asc date order to assist.
-      def fee_structure_id
-        AGFS_FEE_SCHEME_9_CCR_FEE_STRUCTURE_ID
-      end
 
       def defendants_with_main_first
         object.defendants.order(created_at: :asc)

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -209,10 +209,6 @@
       "id": "/properties/estimated_trial_length",
       "type": "integer"
     },
-    "feeStructureId": {
-      "id": "/properties/feeStructureId",
-      "type": "integer"
-    },
     "offence": {
       "additionalProperties": false,
       "id": "/properties/offence",
@@ -238,10 +234,6 @@
     "advocate_category": {
       "id": "/properties/advocate_category",
       "type": "string"
-    },
-    "fee_structure_id": {
-      "id": "/properties/scenario/properties/fee_structure_id",
-      "type": "integer"
     },
     "supplier_number": {
       "id": "/properties/supplier_number",

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -22,7 +22,6 @@ end
 
 describe API::V2::CCRClaim do
   include Rack::Test::Methods
-  include ActiveSupport::Testing::TimeHelpers
   include ApiSpecHelper
 
   after(:all) { clean_database }

--- a/spec/factories/claim/claim_factory_helpers.rb
+++ b/spec/factories/claim/claim_factory_helpers.rb
@@ -6,8 +6,6 @@ module ClaimFactoryHelpers
     claim.reload
   end
 
-
-
   def allocate_claim(claim)
     publicise_errors(claim) { claim.submit! }
     case_worker = create :case_worker

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,6 +74,7 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :view
   config.include KaminariRspec::TestHelpers, type: :controller
   config.include ActionView::TestCase::Behavior, file_path: %r{spec/presenters}
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include JsonSpec::Helpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
**What**
Sorts the JSON output from the CCR API endpoint such that
the defendant created first is returned first and the earliest
representation order (per defendant) is returned first.

**Why**
CCR needs to know who the "main" defendant is as 
the main defendants earliest representation order is used order to determine
what fee scheme to apply in calculations. The main defendant is considered
to be the one entered first onto the old paper form. This therefore maps to the 
defendant first created in the CCCD form. The earliest rep order is determined 
by the rep order date attribute.
