### PR TITLE
Add rubocop to travis test suite

### DIFF
--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -18,6 +18,7 @@ begin
       t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'default'
+      t.cucumber_opts = '--format progress --color'
     end
 
     Cucumber::Rake::Task.new({:wip => 'test:prepare'}, 'Run features that are being worked on') do |t|

--- a/runtests.sh
+++ b/runtests.sh
@@ -6,6 +6,7 @@ if [ "$TRAVIS" = "true" ]; then
   printf '\e[32mInfo: Loading Schema\e[0m'
   bundle exec rake db:schema:load
   bundle exec rake jasmine:ci
+  bundle exec rubocop
   bundle exec rake spec
   printf "\e[33mInfo: Sleeping for two seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren't populated fast enough\e[0m"
   sleep 2


### PR DESCRIPTION
**What**
 - [X] Add rubocop to travis run
 - [X] Change cuke tests to show progress only

**Why**
- Prevent additional rubocop violations on a PR.
- keep travis logs short.