### PR TITLE
Improve test suite run organization

### DIFF
--- a/lib/tasks/_jasmine.rake
+++ b/lib/tasks/_jasmine.rake
@@ -1,0 +1,3 @@
+if %w(development test).include? Rails.env
+  task(:default).prerequisites.unshift('jasmine:ci') if Gem.loaded_specs.key?('jasmine')
+end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,0 +1,14 @@
+namespace :ci do
+  desc 'Run all tests in application-defined order, intended for CI test suite run'
+  task :test_suite => :environment do
+    raise 'The test suite should only be run in development and test environments!' unless Rails.env.in? %w(development test)
+    puts 'Info: Running Test Suite'.green
+    Rake::Task['rubocop'].invoke
+    Rake::Task['jasmine:ci'].invoke
+    Rake::Task['spec'].invoke
+    puts 'Info: Sleeping for five seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren''t populated fast enough.'.green
+    sleep 5
+    Rake::Task['cucumber'].invoke
+  end
+end
+

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,5 @@
+if %w(development test).include?(Rails.env) && Gem.loaded_specs.key?('rubocop')
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new()
+  task(:default).prerequisites.unshift(task(:rubocop))
+end

--- a/runtests.sh
+++ b/runtests.sh
@@ -3,18 +3,12 @@ set -ex
 # set variables. It's presumed the absence of these is causing
 # TRAVIS to fail
 if [ "$TRAVIS" = "true" ]; then
-  printf '\e[32mInfo: Loading Schema\e[0m'
+  printf '\e[32mInfo: Loading Schema\e[0m\n'
   bundle exec rake db:schema:load
-  bundle exec rake jasmine:ci
-  bundle exec rubocop
-  bundle exec rake spec
-  printf "\e[33mInfo: Sleeping for two seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren't populated fast enough\e[0m"
-  sleep 2
-  bundle exec rake cucumber
-
+  bundle exec rake ci:test_suite
   exit 0
 else
-  printf "\e[33mInfo: Executing smoke test\e[0m"
+  printf '\e[33mInfo: Executing smoke test\e[0m\n'
   bundle exec rake db:migrate
   bundle exec rake db:seed
   bundle exec rake api:smoke_test


### PR DESCRIPTION
**What**
- [X] Add rubocop and jasmine:ci to default rake task
- [X] define test suite run task for travis

**Why**
- Allow devs to run full test suite using by issuing `rake` command alone
- Have travis run rubocop, jasmine, rspec, cucumber in order