### PR TITLE
Map CCCD claim case types to CCR bill sub types

### DIFF
--- a/app/interfaces/api/entities/ccr/case_type.rb
+++ b/app/interfaces/api/entities/ccr/case_type.rb
@@ -4,10 +4,16 @@ module API
       class CaseType < API::Entities::CCR::BaseEntity
         # INJECTION: bill scenario is a CCCD mapping to CCR data based on case type description
         # which should, ideally, be replaced by a uuid which is mapped CCR-side
-        expose :bill_scenario
+        expose :adapted_case_type, as: :bill_scenario
 
         # INJECTION: the case type UUID should, ideally, be used CCR-side to map to a bill scenario
         expose :uuid
+
+        private
+
+        def adapted_case_type
+          ::CCR::CaseTypeAdapter.new(object).bill_scenario
+        end
       end
     end
   end

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -84,9 +84,10 @@ module API
       # BABAF,BACAV,BADAF,BADAH,BADAJ,BANOC,BANDR,BANPW,BAPPE
       # fee types, but not BASAF or BAPCM
       def advocate_fee
+        fee_adaptor = ::CCR::FeeAdapter.new(object)
         {
-          bill_type: 'AGFS_FEE',
-          bill_subtype: 'AGFS_FEE',
+          bill_type: fee_adaptor.bill_type,
+          bill_subtype: fee_adaptor.bill_subtype,
           quantity: 1.0,
           rate: 0.0,
           ppe: pages_of_prosecution_evidence,

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -57,14 +57,4 @@ class CaseType < ActiveRecord::Base
   def requires_defendant_dob?
     fee_type_code != 'FXCBR'
   end
-
-  # CCR stores billing scenarios that map to
-  # to CCCD case types, except "Hearing subsequent to sentence".
-  # Passed to CCR via API for calculation of fees.
-  #
-  def bill_scenario
-    @bill_scenario ||= Settings.ccr_bill_scenario_mappings.to_h.select do |_k, v|
-      v.casecmp(name) == 0
-    end.keys.first
-  end
 end

--- a/app/services/ccr/case_type_adapter.rb
+++ b/app/services/ccr/case_type_adapter.rb
@@ -1,0 +1,36 @@
+module CCR
+  class CaseTypeAdapter
+    attr_reader :case_type
+
+    SCENARIO_MAPPINGS = {
+      FXACV: 'AS000005', # Appeal against conviction
+      FXASE: 'AS000006', # Appeal against sentence
+      FXCBR: 'AS000009', # Breach of Crown Court order
+      FXCSE: 'AS000007', # Committal for Sentence
+      FXCON: 'AS000008', # Contempt
+      GRRAK: 'AS000003', # Cracked Trial
+      GRCBR: 'AS000010', # Cracked before retrial
+      GRDIS: 'AS000001', # Discontinuance
+      FXENP: 'AS000014', # Elected cases not proceeded
+      GRGLT: 'AS000002', # Guilty plea
+      FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
+      GRRTR: 'AS000011', # Retrial
+      GRTRL: 'AS000004', # Trial
+    }.freeze
+
+    def initialize(case_type)
+      @case_type = case_type
+    end
+
+    class << self
+      def bill_scenario(case_type)
+        adapter = new(case_type)
+        adapter.bill_scenario
+      end
+    end
+
+    def bill_scenario
+      SCENARIO_MAPPINGS[case_type.fee_type_code.to_sym]
+    end
+  end
+end

--- a/app/services/ccr/fee_adapter.rb
+++ b/app/services/ccr/fee_adapter.rb
@@ -1,0 +1,65 @@
+# CCR bill types are logically similar to CCCD fee types,
+# however the "advocate fee" is a combination
+# of some of the basic fee types' values.
+#
+# * Its bill type "key" is AGFS_FEE
+# * Its bill sub type "key" is derived from the case type
+# * some case types are not allowed to claim an "advocate fee" at all
+#
+module CCR
+  class FeeAdapter
+    attr_reader :claim
+
+   # The CCR "Advocate fee" bill can have different sub types
+    # based on the type of case, which map as follows.
+    # Those case types marked as not allowed cannot claim an "Advocate fee" at all
+    #
+    ADVOCATE_FEE_BILL_SUBTYPE_MAPPINGS = {
+      FXACV: 'AGFS_APPEAL_CON', # Appeal against conviction
+      FXASE: 'AGFS_APPEAL_SEN', # Appeal against sentence
+      FXCBR: 'AGFS_ORDER_BRCH', # Breach of Crown Court order
+      FXCSE: 'AGFS_COMMITAL', # Committal for Sentence
+      FXCON: 'NOT_ALLOWED', # Contempt
+      GRRAK: 'AGFS_FEE', # Cracked Trial
+      GRCBR: 'AGFS_FEE', # Cracked before retrial
+      GRDIS: 'NOT_ALLOWED', # Discontinuance
+      FXENP: 'NOT_ALLOWED', # Elected cases not proceeded
+      GRGLT: 'AGFS_FEE', # Guilty plea
+      FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
+      GRRTR: 'AGFS_FEE', # Retrial
+      GRTRL: 'AGFS_FEE', # Trial
+    }.freeze
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    # Convienience class methods for single calls.
+    # Multiple adaptor calls should instantiate an
+    # instance and call the instance methods instead
+    #
+    class << self
+      def bill_type(claim)
+        adapter = new(claim)
+        adapter.bill_type
+      end
+
+      def bill_subtype(claim)
+        adapter = new(claim)
+        adapter.bill_type
+      end
+    end
+
+    # INJECTION: this will need to be derived once mapping logic for misc
+    # fees and other fee types in CCCD are understood.
+    # Currently this is hardcoded to the "advocate fee" bill of CCR
+    def bill_type
+      'AGFS_FEE'
+    end
+
+    def bill_subtype
+      ADVOCATE_FEE_BILL_SUBTYPE_MAPPINGS[claim.case_type.fee_type_code.to_sym]
+    end
+
+  end
+end

--- a/app/services/ccr/fee_adapter.rb
+++ b/app/services/ccr/fee_adapter.rb
@@ -6,32 +6,51 @@
 # * Its bill sub type "key" is derived from the case type
 # * some case types are not allowed to claim an "advocate fee" at all
 #
+# INJECTION: eventually the bill type and sub type (for advocate fee)
+# should be derivable by CCR from the bill scenario alone, since this
+# maps the case type in any event.
+# i.e.
+# case type -> bill scenario
+# case type -> bill type/subtype
+# =
+# bill scenario -> bill type/subtype
+# AND eventually no mappings will be necessary on CCCD side as..
+# case type uuid -> bill scenario/type/subtype
+#
 module CCR
   class FeeAdapter
     attr_reader :claim
 
-   # The CCR "Advocate fee" bill can have different sub types
+    # The CCR "Advocate fee" bill can have different sub types
     # based on the type of case, which map as follows.
     # Those case types marked as not allowed cannot claim an "Advocate fee" at all
     #
-    ADVOCATE_FEE_BILL_SUBTYPE_MAPPINGS = {
-      FXACV: 'AGFS_APPEAL_CON', # Appeal against conviction
-      FXASE: 'AGFS_APPEAL_SEN', # Appeal against sentence
-      FXCBR: 'AGFS_ORDER_BRCH', # Breach of Crown Court order
-      FXCSE: 'AGFS_COMMITAL', # Committal for Sentence
-      FXCON: 'NOT_ALLOWED', # Contempt
-      GRRAK: 'AGFS_FEE', # Cracked Trial
-      GRCBR: 'AGFS_FEE', # Cracked before retrial
-      GRDIS: 'NOT_ALLOWED', # Discontinuance
-      FXENP: 'NOT_ALLOWED', # Elected cases not proceeded
-      GRGLT: 'AGFS_FEE', # Guilty plea
-      FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
-      GRRTR: 'AGFS_FEE', # Retrial
-      GRTRL: 'AGFS_FEE', # Trial
+    KEYS = %i[bill_type bill_subtype].freeze
+    def self.zip(bill_types = [])
+      Hash[KEYS.zip(bill_types)]
+    end
+
+    ADVOCATE_FEE_BILL_MAPPINGS = {
+      FXACV: zip(%w[AGFS_FEE AGFS_APPEAL_CON]), # Appeal against conviction
+      FXASE: zip(%w[AGFS_FEE AGFS_APPEAL_SEN]), # Appeal against sentence
+      FXCBR: zip(%w[AGFS_FEE AGFS_ORDER_BRCH]), # Breach of Crown Court order
+      FXCSE: zip(%w[AGFS_FEE AGFS_COMMITAL]), # Committal for Sentence
+      FXCON: zip(%w[NOT_ALLOWED NOT_ALLOWED]), # Contempt
+      GRRAK: zip(%w[AGFS_FEE AGFS_FEE]), # Cracked Trial
+      GRCBR: zip(%w[AGFS_FEE AGFS_FEE]), # Cracked before retrial
+      GRDIS: zip(%w[NOT_ALLOWED NOT_ALLOWED]), # Discontinuance
+      FXENP: zip(%w[NOT_ALLOWED NOT_ALLOWED]), # Elected cases not proceeded
+      GRGLT: zip(%w[AGFS_FEE AGFS_FEE]), # Guilty plea
+      FXH2S: zip(%w[NOT_APPLICABLE NOT_APPLICABLE NOT_APPLICABLE]), # Hearing subsequent to sentence??? LGFS only
+      GRRTR: zip(%w[AGFS_FEE AGFS_FEE]), # Retrial
+      GRTRL: zip(%w[AGFS_FEE AGFS_FEE]) # Trial
     }.freeze
+
+    delegate :bill_type, :bill_subtype, to: :@bill_types
 
     def initialize(claim)
       @claim = claim
+      @bill_types = OpenStruct.new(ADVOCATE_FEE_BILL_MAPPINGS[bill_key])
     end
 
     # Convienience class methods for single calls.
@@ -46,20 +65,14 @@ module CCR
 
       def bill_subtype(claim)
         adapter = new(claim)
-        adapter.bill_type
+        adapter.bill_subtype
       end
     end
 
-    # INJECTION: this will need to be derived once mapping logic for misc
-    # fees and other fee types in CCCD are understood.
-    # Currently this is hardcoded to the "advocate fee" bill of CCR
-    def bill_type
-      'AGFS_FEE'
-    end
+    private
 
-    def bill_subtype
-      ADVOCATE_FEE_BILL_SUBTYPE_MAPPINGS[claim.case_type.fee_type_code.to_sym]
+    def bill_key
+      claim.case_type.fee_type_code.to_sym
     end
-
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,20 +91,3 @@ remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') +
 
 # contact email address
 laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
-
-# mappings of case types to CCR Bill scenario keys/ids
-# INJECTION: may be replaced CCR-side by case-type-uuid mappings to bill scenarios
-# TODO: may be removed
-ccr_bill_scenario_mappings:
-  AS000005: Appeal against Conviction
-  AS000006: Appeal against Sentence
-  AS000009: Breach of Crown Court Order
-  AS000007: Committal for Sentence
-  AS000008: Contempt
-  AS000003: Cracked Trial
-  AS000010: Cracked before retrial
-  AS000001: Discontinuance
-  AS000014: Elected cases not proceeded
-  AS000002: Guilty Plea
-  AS000011: Retrial
-  AS000004: Trial

--- a/spec/api/entities/ccr/case_type_spec.rb
+++ b/spec/api/entities/ccr/case_type_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe API::Entities::CCR::CaseType do
   subject(:response) { JSON.parse(described_class.represent(case_type).to_json).deep_symbolize_keys }
 
-  let(:case_type) { build(:case_type, :trial, uuid: 'd6af0535-eee4-4a24-9d20-054f5f48fcec') }
+  let(:case_type) { build(:case_type, :trial, fee_type_code: 'GRTRL', uuid: 'd6af0535-eee4-4a24-9d20-054f5f48fcec') }
 
   it 'has expected json key-value pairs' do
     expect(response).to include(uuid: 'd6af0535-eee4-4a24-9d20-054f5f48fcec', bill_scenario: 'AS000004')

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -67,10 +67,6 @@ describe API::V2::CCRClaim do
     context 'should return CCR compatible JSON' do
       subject(:response) { do_request }
 
-      before do
-        allow_any_instance_of(CaseType).to receive(:bill_scenario).and_return 'AS000004'
-      end
-
       it 'should be valid against CCR claim JSON schema' do
         expect(response).to be_valid_ccr_claim_json
       end

--- a/spec/services/ccr/case_type_adapter_spec.rb
+++ b/spec/services/ccr/case_type_adapter_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+module CCR
+  describe CaseTypeAdapter do
+    let(:case_type) { instance_double('case_type') }
+
+    describe '#bill_scenario' do
+      subject { described_class.new(case_type).bill_scenario }
+
+      SCENARIO_MAPPINGS = {
+        FXACV: 'AS000005', # Appeal against conviction
+        FXASE: 'AS000006', # Appeal against sentence
+        FXCBR: 'AS000009', # Breach of Crown Court order
+        FXCSE: 'AS000007', # Committal for Sentence
+        FXCON: 'AS000008', # Contempt
+        GRRAK: 'AS000003', # Cracked Trial
+        GRCBR: 'AS000010', # Cracked before retrial
+        GRDIS: 'AS000001', # Discontinuance
+        FXENP: 'AS000014', # Elected cases not proceeded
+        GRGLT: 'AS000002', # Guilty plea
+        FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
+        GRRTR: 'AS000011', # Retrial
+        GRTRL: 'AS000004', # Trial
+      }.freeze
+
+      context 'mappings' do
+        SCENARIO_MAPPINGS.each do |code, scenario|
+          context "maps #{code} to #{scenario}" do
+            before do
+              allow(case_type).to receive(:fee_type_code).and_return code
+            end
+
+            it "returns #{scenario}" do
+              is_expected.to eql scenario
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/ccr/fee_adapter_spec.rb
+++ b/spec/services/ccr/fee_adapter_spec.rb
@@ -1,12 +1,21 @@
 require 'rails_helper'
+require 'spec_helper'
 
 module CCR
   describe FeeAdapter do
-    subject { described_class.new(claim) }
-    let(:claim) { create(:authorised_claim) }
+    let(:claim) { instance_double('claim') }
+    let(:case_type) { instance_double('case_type') }
+
+    before do
+      allow(claim).to receive(:case_type).and_return case_type
+    end
 
     describe '#bill_type' do
       subject { described_class.new(claim).bill_type }
+
+      before do
+        allow(case_type).to receive(:fee_type_code).and_return 'GRTRL'
+      end
 
       it 'returns CCR Advocate Fee bill type' do
         is_expected.to eql 'AGFS_FEE'
@@ -16,7 +25,7 @@ module CCR
     describe '#bill_subtype' do
       subject { described_class.new(claim).bill_subtype }
 
-      MAPPINGS = {
+      SUBTYPE_MAPPINGS = {
         FXACV: 'AGFS_APPEAL_CON', # Appeal against conviction
         FXASE: 'AGFS_APPEAL_SEN', # Appeal against sentence
         FXCBR: 'AGFS_ORDER_BRCH', # Breach of Crown Court order
@@ -33,10 +42,10 @@ module CCR
       }.freeze
 
       context 'mappings' do
-        MAPPINGS.each do |code, bill_subtype|
+        SUBTYPE_MAPPINGS.each do |code, bill_subtype|
           context "maps #{code} to #{bill_subtype}" do
             before do
-              allow_any_instance_of(CaseType).to receive(:fee_type_code).and_return code
+              allow(case_type).to receive(:fee_type_code).and_return code
             end
 
             it "returns #{bill_subtype}" do

--- a/spec/services/ccr/fee_adapter_spec.rb
+++ b/spec/services/ccr/fee_adapter_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+module CCR
+  describe FeeAdapter do
+    subject { described_class.new(claim) }
+    let(:claim) { create(:authorised_claim) }
+
+    describe '#bill_type' do
+      subject { described_class.new(claim).bill_type }
+
+      it 'returns CCR Advocate Fee bill type' do
+        is_expected.to eql 'AGFS_FEE'
+      end
+    end
+
+    describe '#bill_subtype' do
+      subject { described_class.new(claim).bill_subtype }
+
+      MAPPINGS = {
+        FXACV: 'AGFS_APPEAL_CON', # Appeal against conviction
+        FXASE: 'AGFS_APPEAL_SEN', # Appeal against sentence
+        FXCBR: 'AGFS_ORDER_BRCH', # Breach of Crown Court order
+        FXCSE: 'AGFS_COMMITAL', # Committal for Sentence
+        FXCON: 'NOT_ALLOWED', # Contempt
+        GRRAK: 'AGFS_FEE', # Cracked Trial
+        GRCBR: 'AGFS_FEE', # Cracked before retrial
+        GRDIS: 'NOT_ALLOWED', # Discontinuance
+        FXENP: 'NOT_ALLOWED', # Elected cases not proceeded
+        GRGLT: 'AGFS_FEE', # Guilty plea
+        FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
+        GRRTR: 'AGFS_FEE', # Retrial
+        GRTRL: 'AGFS_FEE', # Trial
+      }.freeze
+
+      context 'mappings' do
+        MAPPINGS.each do |code, bill_subtype|
+          context "maps #{code} to #{bill_subtype}" do
+            before do
+              allow_any_instance_of(CaseType).to receive(:fee_type_code).and_return code
+            end
+
+            it "returns #{bill_subtype}" do
+              is_expected.to eql bill_subtype
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What**
Send relevant bill subtype to CCR for the Advocate fee

**Why**
Successful injection of certain claim case types requires
that the appropriate bill sub type for the advocate fee
is mapped. This is a CCCD side mapping which may eventually
be replaced by a CCR side mapping.