### PR TITLE
Allocation pagination css

### DIFF
--- a/app/assets/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/assets/javascripts/modules/Modules.AllocationDataTable.js
@@ -57,7 +57,7 @@ moj.Modules.AllocationDataTable = {
 
     // dom template with custom wrappers and structure
     // =>/options/dom
-    dom: '<"form-row"<"column-one-half"f><"column-one-half"i>>rt<"grid-row"<"column-one-half"l><"column-one-half"p>>',
+    dom: '<"form-row"<"column-one-half"f><"column-one-half"i>>rt<"grid-row"<"column-one-third"l><"column-two-thirds"p>>',
 
     // rowId can be sourced from the row data
     rowId: 'id',

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -65,7 +65,7 @@ describe("Modules.AllocationDataTable.js", function() {
     });
 
     it('...should have `dom`', function() {
-      expect(options.dom).toEqual('<"form-row"<"column-one-half"f><"column-one-half"i>>rt<"grid-row"<"column-one-half"l><"column-one-half"p>>');
+      expect(options.dom).toEqual('<"form-row"<"column-one-half"f><"column-one-half"i>>rt<"grid-row"<"column-one-third"l><"column-two-thirds"p>>');
     });
 
     it('...should have `rowId`', function() {


### PR DESCRIPTION
The pagination of the new allocation table footer meant that it always wrapped on to two lines.

This corrects the split