### PR TITLE
Fix AGFS_COMMITTAL bill types and conditionally pass "Advocate Fee"

### DIFF
--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -111,9 +111,9 @@ module API
       end
 
       def bills
-        [
-          (advocate_fee if fee_adaptor.bill_type)
-        ]
+        @bills ||= [].tap do |arr|
+          arr << advocate_fee if fee_adaptor.bill_type
+        end
       end
 
       def fee_adaptor

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -84,7 +84,6 @@ module API
       # BABAF,BACAV,BADAF,BADAH,BADAJ,BANOC,BANDR,BANPW,BAPPE
       # fee types, but not BASAF or BAPCM
       def advocate_fee
-        fee_adaptor = ::CCR::FeeAdapter.new(object)
         {
           bill_type: fee_adaptor.bill_type,
           bill_subtype: fee_adaptor.bill_subtype,
@@ -113,8 +112,12 @@ module API
 
       def bills
         [
-          advocate_fee
+          (advocate_fee if fee_adaptor.bill_type)
         ]
+      end
+
+      def fee_adaptor
+        @fee_adaptor ||= ::CCR::FeeAdapter.new(object)
       end
     end
   end

--- a/app/services/ccr/case_type_adapter.rb
+++ b/app/services/ccr/case_type_adapter.rb
@@ -13,7 +13,7 @@ module CCR
       GRDIS: 'AS000001', # Discontinuance
       FXENP: 'AS000014', # Elected cases not proceeded
       GRGLT: 'AS000002', # Guilty plea
-      FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
+      FXH2S: nil, # Hearing subsequent to sentence??? LGFS only
       GRRTR: 'AS000011', # Retrial
       GRTRL: 'AS000004', # Trial
     }.freeze

--- a/app/services/ccr/fee_adapter.rb
+++ b/app/services/ccr/fee_adapter.rb
@@ -34,14 +34,14 @@ module CCR
       FXACV: zip(%w[AGFS_FEE AGFS_APPEAL_CON]), # Appeal against conviction
       FXASE: zip(%w[AGFS_FEE AGFS_APPEAL_SEN]), # Appeal against sentence
       FXCBR: zip(%w[AGFS_FEE AGFS_ORDER_BRCH]), # Breach of Crown Court order
-      FXCSE: zip(%w[AGFS_FEE AGFS_COMMITAL]), # Committal for Sentence
-      FXCON: zip(%w[NOT_ALLOWED NOT_ALLOWED]), # Contempt
+      FXCSE: zip(%w[AGFS_FEE AGFS_COMMITTAL]), # Committal for Sentence
+      FXCON: zip([nil, nil]), # Contempt
       GRRAK: zip(%w[AGFS_FEE AGFS_FEE]), # Cracked Trial
       GRCBR: zip(%w[AGFS_FEE AGFS_FEE]), # Cracked before retrial
-      GRDIS: zip(%w[NOT_ALLOWED NOT_ALLOWED]), # Discontinuance
-      FXENP: zip(%w[NOT_ALLOWED NOT_ALLOWED]), # Elected cases not proceeded
+      GRDIS: zip([nil, nil]), # Discontinuance
+      FXENP: zip([nil, nil]), # Elected cases not proceeded
       GRGLT: zip(%w[AGFS_FEE AGFS_FEE]), # Guilty plea
-      FXH2S: zip(%w[NOT_APPLICABLE NOT_APPLICABLE NOT_APPLICABLE]), # Hearing subsequent to sentence??? LGFS only
+      FXH2S: zip([nil, nil]), # Hearing subsequent to sentence??? LGFS only
       GRRTR: zip(%w[AGFS_FEE AGFS_FEE]), # Retrial
       GRTRL: zip(%w[AGFS_FEE AGFS_FEE]) # Trial
     }.freeze

--- a/app/services/ccr/fee_adapter.rb
+++ b/app/services/ccr/fee_adapter.rb
@@ -23,7 +23,7 @@ module CCR
 
     # The CCR "Advocate fee" bill can have different sub types
     # based on the type of case, which map as follows.
-    # Those case types marked as not allowed cannot claim an "Advocate fee" at all
+    # Those case types with nil values cannot claim an "Advocate fee" at all
     #
     KEYS = %i[bill_type bill_subtype].freeze
     def self.zip(bill_types = [])

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -113,10 +113,10 @@ describe API::V2::CCRClaim do
 
       let(:claim) { create(:authorised_claim) }
 
-      context 'advocate fees' do
-        it 'returns nil when case type does not permit advocate fees' do
+      context 'advocate fee' do
+        it 'is not added to array when case type does not permit advocate fees' do
           allow_any_instance_of(CaseType).to receive(:fee_type_code).and_return 'FXCON' # mock a contempt case type
-          expect(response).to be_json_eql(nil.to_json).at_path("bills/0")
+          expect(response).to have_json_size(0).at_path("bills")
         end
       end
 

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -107,14 +107,20 @@ describe API::V2::CCRClaim do
     end
 
     context 'bills' do
+      subject(:response) do
+        do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
+      end
+
+      let(:claim) { create(:authorised_claim) }
+
+      context 'advocate fees' do
+        it 'returns nil when case type does not permit advocate fees' do
+          allow_any_instance_of(CaseType).to receive(:fee_type_code).and_return 'FXCON' # mock a contempt case type
+          expect(response).to be_json_eql(nil.to_json).at_path("bills/0")
+        end
+      end
 
       context 'bill type' do
-        subject(:response) do
-          do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-        end
-
-        let(:claim) { create(:authorised_claim) }
-
         it 'includes bill type' do
           expect(response).to have_json_path("bills/0/bill_type")
           expect(response).to have_json_type(String).at_path "bills/0/bill_type"
@@ -126,12 +132,6 @@ describe API::V2::CCRClaim do
       end
 
       context 'bill sub type' do
-        subject(:response) do
-          do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-        end
-
-        let(:claim) { create(:authorised_claim) }
-
         it 'includes bill subtype' do
           expect(response).to have_json_path("bills/0/bill_subtype")
           expect(response).to have_json_type(String).at_path "bills/0/bill_subtype"

--- a/spec/services/ccr/case_type_adapter_spec.rb
+++ b/spec/services/ccr/case_type_adapter_spec.rb
@@ -18,7 +18,7 @@ module CCR
         GRDIS: 'AS000001', # Discontinuance
         FXENP: 'AS000014', # Elected cases not proceeded
         GRGLT: 'AS000002', # Guilty plea
-        FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
+        FXH2S: nil, # Hearing subsequent to sentence??? LGFS only
         GRRTR: 'AS000011', # Retrial
         GRTRL: 'AS000004', # Trial
       }.freeze

--- a/spec/services/ccr/fee_adapter_spec.rb
+++ b/spec/services/ccr/fee_adapter_spec.rb
@@ -29,14 +29,14 @@ module CCR
         FXACV: 'AGFS_APPEAL_CON', # Appeal against conviction
         FXASE: 'AGFS_APPEAL_SEN', # Appeal against sentence
         FXCBR: 'AGFS_ORDER_BRCH', # Breach of Crown Court order
-        FXCSE: 'AGFS_COMMITAL', # Committal for Sentence
-        FXCON: 'NOT_ALLOWED', # Contempt
+        FXCSE: 'AGFS_COMMITTAL', # Committal for Sentence
+        FXCON: nil, # Contempt
         GRRAK: 'AGFS_FEE', # Cracked Trial
         GRCBR: 'AGFS_FEE', # Cracked before retrial
-        GRDIS: 'NOT_ALLOWED', # Discontinuance
-        FXENP: 'NOT_ALLOWED', # Elected cases not proceeded
+        GRDIS: nil, # Discontinuance
+        FXENP: nil, # Elected cases not proceeded
         GRGLT: 'AGFS_FEE', # Guilty plea
-        FXH2S: 'NOT_APPLICABLE', # Hearing subsequent to sentence??? LGFS only
+        FXH2S: nil, # Hearing subsequent to sentence??? LGFS only
         GRRTR: 'AGFS_FEE', # Retrial
         GRTRL: 'AGFS_FEE', # Trial
       }.freeze


### PR DESCRIPTION
**What**
- [X] Fix AGFS_COMMITTAL bill sub types
- [X] Only send advocate fee bill for applicable case types

**Why**
* typo in mappings for sub types
* certain claims types cannot have an Advocate Fee bill
