### PR TITLE
Message queue update

### DIFF
--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -20,6 +20,12 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
   def create
     @claim.build_certification(certification_params)
     if @claim.certification.save && claim_updater.submit
+      begin
+        MessageQueue::AwsClient.new(MessageQueue::MessageTemplate.claim_created(@claim.type, @claim.uuid), Settings.aws.queue).send_message!
+        Rails.logger.warn "Successfully sent message about submission of claim##{@claim.id}(#{@claim.uuid})"
+      rescue => err
+        Rails.logger.warn "Error: '#{err.message}' while sending message about submission of claim##{@claim.id}(#{@claim.uuid})"
+      end
       redirect_to confirmation_external_users_claim_path(@claim)
     else
       @certification = @claim.certification

--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -22,7 +22,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
     if @claim.certification.save && claim_updater.submit
       begin
         MessageQueue::AwsClient.new(MessageQueue::MessageTemplate.claim_created(@claim.type, @claim.uuid), Settings.aws.queue).send_message!
-        Rails.logger.warn "Successfully sent message about submission of claim##{@claim.id}(#{@claim.uuid})"
+        Rails.logger.info "Successfully sent message about submission of claim##{@claim.id}(#{@claim.uuid})"
       rescue => err
         Rails.logger.warn "Error: '#{err.message}' while sending message about submission of claim##{@claim.id}(#{@claim.uuid})"
       end

--- a/app/services/claims/create_claim.rb
+++ b/app/services/claims/create_claim.rb
@@ -13,12 +13,6 @@ module Claims
 
       save_claim!(validate?)
 
-      begin
-        MessageQueue::AwsClient.new(MessageQueue::MessageTemplate.claim_created(claim.type, claim.uuid), Settings.aws.queue).send_message!
-      rescue => err
-        Rails.logger.warn "Error: '#{err.message}' while sending message about claim##{claim.id}(#{claim.uuid})"
-      end
-
       result
     end
 

--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -23,7 +23,7 @@ module MessageQueue
   class MessageTemplate
     def self.claim_created(type, uuid)
       {
-        body: 'Claim added',
+        body: 'Claim submitted',
         attributes:
           {
             'type':

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -124,6 +124,7 @@ When(/^I click "Continue" in the claim form$/) do
 end
 
 When(/^I click Submit to LAA$/) do
+  allow(Aws::SQS::Client).to receive(:new).and_return Aws::SQS::Client.new(region: 'eu_west_1', stub_responses: true)
   @claim_form_page.submit_to_laa.trigger "click"
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -70,6 +70,7 @@ When(/^I check “I attended the main hearing”$/) do
 end
 
 When(/^I click Certify and submit claim$/) do
+  allow(Aws::SQS::Client).to receive(:new).and_return Aws::SQS::Client.new(region: 'eu_west_1', stub_responses: true)
   @certification_page.certify_and_submit_claim.trigger "click"
 end
 

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
           }
       )
     end
-    let(:stub_send_response) {}
+    let(:stub_send_response) { stub_response_success }
+    let(:stub_response_success) { }
     let(:stub_response_failure)  { Aws::SQS::Errors::NonExistentQueue.new(
                                      double('request'),
                                      double('response', :status => 400, :body => '<foo/>')
@@ -95,6 +96,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
       end
 
       it 'logs a successful message on the queue' do
+        allow(Settings.aws).to receive(:queue).and_return('valid_queue_name')
         expect(Rails.logger).to receive(:info).with(/Successfully sent message about submission of claim#/)
         post :create, valid_certification_params(claim, certification_type)
       end

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -83,6 +83,10 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
         expect(claim.reload.last_submitted_at).to eq(frozen_time)
       end
 
+      it 'logs a successful message on the queue' do
+        expect(Rails.logger).to receive(:info).with(/Successfully sent message about submission of claim#/)
+      end
+
       context 'when SQS fails' do
         it 'logs an error message' do
           expect(Rails.logger).to receive(:warn).with(/Error: .* while sending message about submission of claim#/)

--- a/spec/services/claims/create_claim_spec.rb
+++ b/spec/services/claims/create_claim_spec.rb
@@ -21,16 +21,8 @@ describe Claims::CreateClaim do
   end
 
   describe '#call' do
-    let(:aws_client) do
-      Aws::SQS::Client.new(
-          region: 'eu_west_1',
-          stub_responses: true
-      )
-    end
-    before do
-      expect(subject.claim.persisted?).to be_falsey
-      allow(Aws::SQS::Client).to receive(:new).and_return aws_client
-    end
+
+    before { expect(subject.claim.persisted?).to be_falsey }
 
     context 'with a valid Claim' do
       before { expect(subject.claim).to receive(:update_claim_document_owners) }
@@ -64,13 +56,6 @@ describe Claims::CreateClaim do
       end
 
       after { expect(subject.claim.persisted?).to be_falsey }
-    end
-
-    context 'when SQS fails' do
-      it 'logs an error message' do
-        expect(Rails.logger).to receive(:warn).with(/Error: .* while sending message about claim#/)
-        subject.call
-      end
     end
 
     context 'with an already submitted Claim' do


### PR DESCRIPTION
### Why?
The message send was originally placed in what seemed like a good place... the create_claim service class.
Apparently this is never hit and so no messages were sent.

### What?
Moved it into the certification controller. This will be hit by manual claim creation as well as API submitted confirmations.

Then updated the RSpec and Cukes to use the appropriate stubs