### PR TITLE
Make offence seeding of unique codes idempotent

### DIFF
--- a/db/offence_code_seeder.rb
+++ b/db/offence_code_seeder.rb
@@ -23,6 +23,8 @@
     end
 
     def exists?(code)
-      Offence.find_by(unique_code: code).present?
+      Offence.where(unique_code: code).
+        where.not(description: description).
+        present?
     end
   end


### PR DESCRIPTION
Previous version included the existing record in its
checks for whether the offence code was unique or not.
This prevents taking the current record into account
when determining whether the code is unique. The
seed files find_or_create_by will then not need to
update the record for existing valid unique codes.