### PR TITLE
Update AWS-SDK gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby '2.4.0'
 gem 'dotenv-rails', groups: [:development, :test]
 gem 'amoeba',                 '~> 3.0.0'
 gem 'auto_strip_attributes',  '~> 2.0'
-gem 'aws-sdk',                '~> 2'
+gem 'aws-sdk-sqs',            '~> 1'
 gem 'awesome_print'
 gem 'cancancan',              '~> 1.15'
 gem 'cocoon',                 '~> 1.2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,14 +57,15 @@ GEM
     auto_strip_attributes (2.1.0)
       activerecord (>= 3.0)
     awesome_print (1.8.0)
-    aws-sdk (2.10.29)
-      aws-sdk-resources (= 2.10.29)
-    aws-sdk-core (2.10.29)
+    aws-partitions (1.20.0)
+    aws-sdk-core (3.3.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.29)
-      aws-sdk-core (= 2.10.29)
-    aws-sigv4 (1.0.1)
+    aws-sdk-sqs (1.0.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -621,7 +622,7 @@ DEPENDENCIES
   annotate
   auto_strip_attributes (~> 2.0)
   awesome_print
-  aws-sdk (~> 2)
+  aws-sdk-sqs (~> 1)
   better_errors
   binding_of_caller
   byebug


### PR DESCRIPTION
Aamazon updated the SDK so that individual requirements could be loaded.
This reduces the overhead of loading the entire SDK when only SQS is needed