### PR TITLE
Update the code climate/rubocop interaction

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,9 @@
 engines:
   rubocop:
     enabled: true
+    channel: rubocop-0-49
+    config:
+      file: .rubocop.yml
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
We are losing 'points' on CC because it is using an older version
of Rubocop, e.g.
rubocop 46: `%i-literals should be delimited by ( and )`
rubocop 49: `%i-literals should be delimited by [ and ]`