### PR TITLE
Cracked trial validation transition

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -162,6 +162,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be before earliest rep order
   # cannot be more than 5 years old
   def validate_trial_fixed_notice_at
+    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
     return unless @record.case_type && @record.requires_cracked_dates?
     validate_presence(:trial_fixed_notice_at, 'blank')
     validate_on_or_before(Date.today, :trial_fixed_notice_at, 'check_not_in_future')
@@ -176,6 +177,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be more than 5 years old
   # cannot be before trial_fixed_notice_at
   def validate_trial_fixed_at
+    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
     if @record.case_type && @record.requires_cracked_dates?
       validate_presence(:trial_fixed_at, 'blank')
       validate_too_far_in_past(:trial_fixed_at)
@@ -190,6 +192,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be more than 5 years in the past
   # cannot be before the trial fixed/warned issued
   def validate_trial_cracked_at
+    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
     if @record.case_type && @record.requires_cracked_dates?
       validate_presence(:trial_cracked_at, 'blank')
       validate_on_or_before(Date.today, :trial_cracked_at, 'check_not_in_future')

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -505,6 +505,22 @@ describe Claim::BaseClaimValidator do
         it { should_error_if_after_specified_field(cracked_trial_claim, :trial_cracked_at, :trial_fixed_at, 'check_before_trial_fixed_at') }
       end
     end
+
+    # after validation changes had been implemented, there where claims to be assessed that violated the new validation records
+    context 'and validation has been overridden only for amount_assessed' do
+      let(:claim) do
+        create :claim, case_type: cracked_trial,
+                       trial_fixed_notice_at: 2.weeks.ago,
+                       trial_fixed_at: 1.week.ago,
+                       trial_cracked_at: 2.days.ago,
+                       disable_for_state_transition: :only_amount_assessed
+      end
+      
+      before { claim.valid? }
+
+      it { expect(claim.errors['trial_cracked_at']).to be_empty }
+    end
+
   end
 
   context 'for claims requiring trial details' do


### PR DESCRIPTION
Users cannot allocate claims that were created before the new cracked trial validation rules were implemented.

This re-uses the `only_amount_assessed` validation flag on trial_fixed_notice_at, trial_fixed_at and trial_cracked_at while allocating claims to ensure that the fields are not re-validated on authorisation