### PR TITLE
Sign up email copy change

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -2,13 +2,13 @@
   = "Dear #{@resource.first_name} #{@resource.last_name},".titleize
 
 - if @resource.sign_in_count == 0
+
   %p
-    You have been registered as a new user on the "Claim for crown court defence" digital service.
+    You have been registered as a new user on the "Claim for Crown court Defence" digital service by #{current_user.first_name} #{current_user.last_name}. Please check with them if you are unsure why you have received this email.
   %p
     Please follow the link below to reset your password.
   %p
     = link_to 'Reset your password', edit_password_url(@resource, reset_password_token: @token)
-
   %p
     - if @resource.persona.admin?
       Please note: you have been given admin privileges, so you will also need to add to the system as a user each advocate for whom you wish to submit claims.  You can do this under "Manage users".


### PR DESCRIPTION
## Blocked
- [ ] has @colinbruce done his bit

PT:
https://www.pivotaltracker.com/story/show/151091894

Why are we doing this:
Provide more clarity around account creation

What this PR does:
Update copy on the welcome email