### PR TITLE
remove cracked trial validation

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -162,7 +162,6 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be before earliest rep order
   # cannot be more than 5 years old
   def validate_trial_fixed_notice_at
-    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
     return unless @record.case_type && @record.requires_cracked_dates?
     validate_presence(:trial_fixed_notice_at, 'blank')
     validate_on_or_before(Date.today, :trial_fixed_notice_at, 'check_not_in_future')
@@ -177,13 +176,11 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be more than 5 years old
   # cannot be before trial_fixed_notice_at
   def validate_trial_fixed_at
-    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
-    if @record.case_type && @record.requires_cracked_dates?
-      validate_presence(:trial_fixed_at, 'blank')
-      validate_too_far_in_past(:trial_fixed_at)
-      validate_on_or_after(@record.trial_fixed_notice_at, :trial_fixed_at,
-                           'check_not_earlier_than_trial_fixed_notice_at')
-    end
+    return unless @record.case_type && @record.requires_cracked_dates?
+    validate_presence(:trial_fixed_at, 'blank')
+    validate_too_far_in_past(:trial_fixed_at)
+    validate_on_or_after(@record.trial_fixed_notice_at, :trial_fixed_at,
+                         'check_not_earlier_than_trial_fixed_notice_at')
   end
 
   # required when case type is cracked, cracked before retrial
@@ -192,15 +189,12 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be more than 5 years in the past
   # cannot be before the trial fixed/warned issued
   def validate_trial_cracked_at
-    return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
-    if @record.case_type && @record.requires_cracked_dates?
-      validate_presence(:trial_cracked_at, 'blank')
-      validate_on_or_before(Date.today, :trial_cracked_at, 'check_not_in_future')
-      validate_too_far_in_past(:trial_cracked_at)
-      validate_on_or_after(@record.trial_fixed_notice_at, :trial_cracked_at,
-                           'check_not_earlier_than_trial_fixed_notice_at')
-      validate_on_or_before(@record.trial_fixed_at, :trial_cracked_at, 'check_before_trial_fixed_at')
-    end
+    return unless @record.case_type && @record.requires_cracked_dates?
+    validate_presence(:trial_cracked_at, 'blank')
+    validate_on_or_before(Date.today, :trial_cracked_at, 'check_not_in_future')
+    validate_too_far_in_past(:trial_cracked_at)
+    validate_on_or_after(@record.trial_fixed_notice_at, :trial_cracked_at,
+                         'check_not_earlier_than_trial_fixed_notice_at')
   end
 
   # must be less than or equal to last day of trial
@@ -212,7 +206,7 @@ class Claim::BaseClaimValidator < BaseValidator
 
   # cannot be before the first day of trial
   # cannot be before the first rep order was granted
-  # cannot be more than 5 years in sthe past
+  # cannot be more than 5 years in the past
   def validate_trial_concluded_at
     validate_trial_start_and_end(:first_day_of_trial, :trial_concluded_at, true)
   end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -494,7 +494,6 @@ describe Claim::BaseClaimValidator do
         it { should_error_if_in_future(cracked_trial_claim, :trial_cracked_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_trial_claim, :trial_cracked_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
         it { should_error_if_earlier_than_other_date(cracked_trial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
-        it { should_error_if_after_specified_field(cracked_trial_claim, :trial_cracked_at, :trial_fixed_at, 'check_before_trial_fixed_at') }
       end
 
       context 'cracked before retrial' do
@@ -502,25 +501,8 @@ describe Claim::BaseClaimValidator do
         it { should_error_if_in_future(cracked_before_retrial_claim, :trial_cracked_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_before_retrial_claim, :trial_cracked_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
         it { should_error_if_earlier_than_other_date(cracked_before_retrial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
-        it { should_error_if_after_specified_field(cracked_trial_claim, :trial_cracked_at, :trial_fixed_at, 'check_before_trial_fixed_at') }
       end
     end
-
-    # after validation changes had been implemented, there where claims to be assessed that violated the new validation records
-    context 'and validation has been overridden only for amount_assessed' do
-      let(:claim) do
-        create :claim, case_type: cracked_trial,
-                       trial_fixed_notice_at: 2.weeks.ago,
-                       trial_fixed_at: 1.week.ago,
-                       trial_cracked_at: 2.days.ago,
-                       disable_for_state_transition: :only_amount_assessed
-      end
-      
-      before { claim.valid? }
-
-      it { expect(claim.errors['trial_cracked_at']).to be_empty }
-    end
-
   end
 
   context 'for claims requiring trial details' do

--- a/spec/validators/cracked_trial_validation_spec.rb
+++ b/spec/validators/cracked_trial_validation_spec.rb
@@ -72,7 +72,6 @@ describe 'new validation rules around cracked trials' do
 
     describe 'validate trial_cracked_at' do
       # trial_cracked_at > trial_fixed_notice_at
-      # trial_cracked_at < trial_fixed_at
 
       context '> trial_fixed_notice_at' do
         it { is_expected.to be true }
@@ -81,23 +80,6 @@ describe 'new validation rules around cracked trials' do
       context '< trial_fixed_notice_at' do
         let(:trial_cracked_at) { 91.days.ago }
 
-        it { is_expected.to be false }
-      end
-
-      context '< trial_fixed_at' do
-        let(:trial_cracked_at) { 29.days.ago }
-
-        it { is_expected.to be true }
-      end
-
-      context '= trial_fixed_at' do
-        let(:trial_cracked_at) { 28.days.ago }
-
-        it { is_expected.to be true }
-      end
-
-      context '> trial_fixed_at' do
-        let(:trial_cracked_at) { 27.days.ago }
         it { is_expected.to be false }
       end
     end


### PR DESCRIPTION
This reverts the validation change that was implemented due to an inconsistency in CCR and CCCD validations...

it turns out that *we* were right.