### PR TITLE
Remove offence id from CCR JSON API response

### DIFF
--- a/app/interfaces/api/entities/ccr/offence.rb
+++ b/app/interfaces/api/entities/ccr/offence.rb
@@ -2,18 +2,8 @@ module API
   module Entities
     module CCR
       class Offence < API::Entities::CCR::BaseEntity
-        expose :faked_legacy_id, as: :id
         expose :unique_code
         expose :offence_class, using: API::Entities::CCR::OffenceClass
-
-        private
-
-        # INJECTION: Using CCR Legacy Offence codes 501-511 for now (which map 1-to-1 onto offence classes)
-        # but this will eventually need to provide an ID, UUID or some key that maps
-        # CCCD offence records to CCR Offence records.
-        def faked_legacy_id
-          ('A'..'K').zip(501..511).to_h[object&.offence_class&.class_letter]
-        end
       end
     end
   end

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -218,10 +218,6 @@
       "additionalProperties": false,
       "id": "/properties/offence",
       "properties": {
-        "id": {
-          "id": "/properties/offence/properties/id",
-          "type": "integer"
-        },
         "unique_code": {
           "id": "/properties/offence/properties/unique_code",
           "type": "string"

--- a/spec/api/entities/ccr/offence_spec.rb
+++ b/spec/api/entities/ccr/offence_spec.rb
@@ -8,6 +8,6 @@ describe API::Entities::CCR::Offence do
   let(:offence) { build(:offence, unique_code: 'ABOCUT_C', offence_class_id: offence_class.id) }
 
   it 'has expected json key-value pairs' do
-    expect(response).to include(id: 503, unique_code: 'ABOCUT_C', offence_class: { class_letter: 'C' })
+    expect(response).to include(unique_code: 'ABOCUT_C', offence_class: { class_letter: 'C' })
   end
 end


### PR DESCRIPTION
No longer needed as unique_code is
exposed and will be used by consumers
including CCR.
