### PR TITLE
Change new claim page title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,8 +418,8 @@ en:
           form_error_hint: 'Check below for more detail'
     all_claims: All claims
     your_claims: Your claims
-    start_agfs_claim_heading: Claim for advocate graduated fees
-    start_lgfs_final_claim_heading: Claim for litigator graduated fees
+    start_agfs_claim_heading: Claim for advocate fees
+    start_lgfs_final_claim_heading: Claim for litigator fees
     start_lgfs_interim_claim_heading: Claim for litigator interim fees
     start_lgfs_transfer_claim_heading: Claim for litigator transfer fees
     certifications:

--- a/old_features/step_definitions/advocate_new_claim_steps.rb
+++ b/old_features/step_definitions/advocate_new_claim_steps.rb
@@ -246,7 +246,7 @@ Then(/^I should be redirected to the claim certification page$/) do
 end
 
 Then(/^I should be redirected back to the claim form with error$/) do
-  expect(page).to have_content('Claim for advocate graduated fees')
+  expect(page).to have_content('Claim for advocate fees')
   expect(page).to have_content(/This claim has \d+ errors?/)
   expect(page).to have_content("Choose an advocate")
 end

--- a/old_features/step_definitions/sign_in_steps.rb
+++ b/old_features/step_definitions/sign_in_steps.rb
@@ -88,7 +88,7 @@ end
 
 Then(/^I should see the advocates Start a claim link and it should work$/) do
   find('.primary-nav-bar').click_link('Start a claim')
-  expect(find('h1')).to have_content('Claim for advocate graduated fees')
+  expect(find('h1')).to have_content('Claim for advocate fees')
 end
 
 Then(/^I should see the admin advocates Manage advocates link and it should work$/) do


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/149840901

Why are we doing this:
The word “gradutated” is not always the correct context for a claim

What this PR does:
Removes the “graduated” from the main title