### PR TITLE
Prevent sending advocate fee when no basic fees claimed.

### DIFF
--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -112,8 +112,13 @@ module API
 
       def bills
         @bills ||= [].tap do |arr|
-          arr << advocate_fee if fee_adaptor.bill_type
+          arr << advocate_fee if advocate_fee_claimed?
         end
+      end
+
+      def advocate_fee_claimed?
+        fee_adaptor.bill_type &&
+          object.basic_fees.any? { |f| f.amount.positive? || f.quantity.positive? || f.rate.positive? }
       end
 
       def fee_adaptor


### PR DESCRIPTION
**What**
Stop sending Advocate fee "bill" when no CCCD fee equivalents being claimed 

**Why**
Advocate Fee was being sent as a CCR "Bill" even when no CCCD fees that make it up
were part of the claim. This causes a validation error in CCR when the Advocate fee is provided with no PPE (at least) since this is mandatory in CCR. This PR prevents the CCR JSON API endpoint from adding the Advocate Fee "bill" if no "basic fees" are being claimed (i.e. if their quantity/rate/amount are all 0).
