### PR TITLE
Send defendant details in JSON API for CCR consumption

### DIFF
--- a/app/interfaces/api/entities/ccr/defendant.rb
+++ b/app/interfaces/api/entities/ccr/defendant.rb
@@ -3,6 +3,9 @@ module API
     module CCR
       class Defendant < API::Entities::CCR::BaseEntity
         expose :main_defendant
+        expose :first_name
+        expose :last_name
+        expose :date_of_birth
         expose :representation_orders_with_earliest_first, using: API::Entities::CCR::RepresentationOrder, as: :representation_orders
 
         private

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -155,6 +155,18 @@
             "id": "/properties/defendants/items/properties/main_defendant",
             "type": "boolean"
           },
+          "first_name": {
+            "id": "/properties/defendants/items/properties/first_name",
+            "type": "string"
+          },
+          "last_name": {
+            "id": "/properties/defendants/items/properties/last_name",
+            "type": "string"
+          },
+          "date_of_birth": {
+            "id": "/properties/defendants/items/properties/date_of_birth",
+            "type": "string"
+          },
           "representation_orders": {
             "id": "/properties/defendants/items/properties/representation_orders",
             "items": {

--- a/spec/api/entities/ccr/defendant_spec.rb
+++ b/spec/api/entities/ccr/defendant_spec.rb
@@ -19,8 +19,8 @@ describe API::Entities::CCR::Defendant do
     )
   end
 
-  it 'has expected keys' do
-    expect(response.keys).to include(:main_defendant, :representation_orders)
+  it 'has expected json key-value pairs' do
+    expect(response).to include(main_defendant: false, first_name: 'Kaia', last_name: 'Casper', date_of_birth: '1995-06-20')
   end
 
   it 'returns main defendant true for the defendant created first' do


### PR DESCRIPTION
**What**
Adds defendant details to JSON API for CCR consumption

**Why**
CCR allows any bill type to specify that the MAAT reference is NOT required.
It then requires the user to enter the defendants first name, surname and DOB
to be supplied. In addition, and specifically, a MAAT reference is NOT required
in CCCD for "Breach of crown court order" claims. There may be others...

Pivotal Tracker Ticket: **#151434930**
