### PR TITLE
Exclude features and any vendor files from codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,12 +27,15 @@ exclude_paths: # customize
 - app/assets/images/
 - app/assets/javascripts/vendor/
 - app/assets/stylesheets/vendor/
+- "**/vendor/"
 - bin/rails
 - bin/rake
 - doc/
 - files/
 - public/
 - spec/
+- features/
+- old_features/
 - tmp/
 - app/interfaces/api/entities/*
 - app/interfaces/api/v1/*


### PR DESCRIPTION
Existing .codeclimate.yml config excluded specs but not features
for no good reason. Also old_features were included unnecessarily.

Also worth noting that it is worth using local codeclimate CLI to
run the static analysis, as below:

```bash
# install docker for mac first
$ docker pull codeclimate/codeclimate
$ brew update
$ brew tap codeclimate/formulae
$ brew install codeclimate
$ cd <local_repo_root>
$ codeclimate analyze
```

see [codeclimate CLI](https://github.com/codeclimate/codeclimate) for more detail.