### PR TITLE
Correct email recipient

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -4,7 +4,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
   # This is just an example:
   #
   def message_added_email(claim)
-    user = claim.external_user.user
+    user = claim.creator.user
 
     set_template(Settings.govuk_notify.templates.message_added_email)
     set_personalisation(

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe NotifyMailer, type: :mailer do
     let(:template) { '4240bf0e-0000-444e-9c30-0d1bb64a2fb4' }
 
     let(:user) { instance_double(User, name: 'Test Name', email: 'test@example.com') }
+    let(:creator) { instance_double(User, name: 'Creator Name', email: 'creator@example.com') }
     let(:external_user) { instance_double(ExternalUser, user: user) }
-    let(:claim) { instance_double(Claim::BaseClaim, external_user: external_user, case_number: 'T201600001') }
+    let(:creator_user) { instance_double(ExternalUser, user: creator) }
+    let(:claim) { instance_double(Claim::BaseClaim, external_user: external_user, creator: creator_user, case_number: 'T201600001') }
 
     let(:mail) { described_class.message_added_email(claim) }
 
@@ -18,7 +20,11 @@ RSpec.describe NotifyMailer, type: :mailer do
     end
 
     it 'sets the recipient' do
-      expect(mail.to).to eq(['test@example.com'])
+      expect(mail.to).to eq(['creator@example.com'])
+    end
+
+    it 'ignores the external user' do
+      expect(mail.to).to_not eq(['test@example.com'])
     end
 
     it 'sets the body' do


### PR DESCRIPTION
The message notifictaions should go to the creator, not the user.

In the factory they were both the same person, so when I duplicated that it was harder to test the required need.