### PR TITLE
Remove unnecessary exposures from adapted advocate fee entity

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_advocate_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_advocate_fee.rb
@@ -3,12 +3,6 @@ module API
     module CCR
       class AdaptedAdvocateFee < API::Entities::CCR::AdaptedBaseFee
         with_options(format_with: :string) do
-          # irrelevant exposures for this consolidated "fee-of-fees"
-          # but required by CCR (quantity) or to overide superclass
-          expose :quantity
-          expose :rate
-          expose :amount
-
           # derived/transformed data exposures
           expose :ppe
           expose :number_of_witnesses
@@ -22,18 +16,6 @@ module API
         # expose :calculated_fee, as: :calculatedFee
 
         private
-
-        def quantity
-          1.0
-        end
-
-        def rate
-          0.0
-        end
-
-        def amount
-          0.0
-        end
 
         def fee_for(fee_type_unique_code)
           object.fees.find_by(fee_type_id: ::Fee::BaseFeeType.find_by_id_or_unique_code(fee_type_unique_code))

--- a/app/interfaces/api/entities/ccr/adapted_base_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_base_fee.rb
@@ -7,9 +7,6 @@ module API
       class AdaptedBaseFee < API::Entities::CCR::BaseEntity
         expose :bill_type
         expose :bill_subtype
-        expose :quantity
-        expose :rate
-        expose :amount
         expose :case_numbers
       end
     end

--- a/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
@@ -2,7 +2,12 @@ module API
   module Entities
     module CCR
       class AdaptedMiscFee < API::Entities::CCR::AdaptedBaseFee
-        # May be needed, although currently not made available, for BACAV --> a CCR AGFS_MISC_FEES
+        expose :quantity
+        expose :rate
+        expose :amount
+        # TODO: dates attended not available to add to BACAV fee in CCCD interface at the
+        # moment but in CCR it is the only misc fee that requires an occured_at date
+        # BACAV --> a CCR AGFS_MISC_FEES, AGFS_CONFERENCE
         expose :dates_attended, using: API::Entities::CCR::DateAttended
       end
     end

--- a/spec/api/entities/ccr/adapted_advocate_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_advocate_fee_spec.rb
@@ -12,18 +12,19 @@ describe API::Entities::CCR::AdaptedAdvocateFee do
     allow(claim).to receive(:case_type).and_return case_type
   end
 
-  it 'has expected json key-value pairs' do
+  it 'exposes expected json key-value pairs' do
     expect(response).to include(
       bill_type: 'AGFS_FEE',
       bill_subtype: 'AGFS_FEE',
-      quantity: '1.0',
-      rate: '0.0',
-      amount: '0.0',
       ppe: '0',
       number_of_witnesses: '0',
       number_of_cases: '1',
       daily_attendances: '0',
       case_numbers: nil
     )
+  end
+
+  it 'does not expose unneccesary fee attributes' do
+    expect(response.keys).not_to include(:quantity, :rate, :amount)
   end
 end

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -14,7 +14,7 @@ describe API::Entities::CCR::AdaptedMiscFee do
   end
   let(:adapted_misc_fee) { ::CCR::Fee::MiscFeeAdapter.new.call(misc_fee) }
 
-  it 'has expected json key-value pairs' do
+  it 'exposes expected json key-value pairs' do
     expect(response).to include(
       bill_type: 'AGFS_MISC_FEES',
       bill_subtype: 'AGFS_SPCL_PREP',
@@ -25,7 +25,7 @@ describe API::Entities::CCR::AdaptedMiscFee do
     )
   end
 
-  it 'returns dates attended' do
+  it 'exposes dates attended in JSON compatible format' do
     from = misc_fee.dates_attended.first.date&.iso8601
     to = misc_fee.dates_attended.first.date_to&.iso8601
     expect(response[:dates_attended].first).to include(from: from, to: to)


### PR DESCRIPTION
The CCR adapted advocate fee entity does not need to expose the quantity, rate and amount as they 
are irrelevant for injection of an advocate fee of type advocate fee into CCR.