### PR TITLE
Download all link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'paper_trail',            '4.0.2' # version locked, https://github.com/airbl
 gem 'pg',                     '~> 0.18.2'
 gem 'rails',                  '~> 4.2'
 gem 'redis',                  '~> 3.3.1'
+gem 'rubyzip'
 gem 'config',                 '~> 1.2' # this gem provides our Settings.xxx mechanism
 gem 'remotipart',             '~> 1.2'
 gem 'rest-client',            '~> 2.0' # needed for scheduled smoke testing plus others

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -716,6 +716,7 @@ DEPENDENCIES
   rspec-rails (~> 3.4)
   rubocop (~> 0.50)
   ruby-progressbar
+  rubyzip
   sass-rails (~> 5.0.6)
   scheduler_daemon!
   sdoc (~> 0.4.0)

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -15,7 +15,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   before_action :filter_archived_claims,  only: [:archived]
   before_action :sort_claims,             only: %i[index archived]
 
-  before_action :set_claim, only: %i[show messages publish enquire]
+  before_action :set_claim, only: %i[show messages publish enquire download_zip]
   before_action :set_doctypes, only: %i[show update]
 
   include ReadMessages
@@ -27,6 +27,18 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
 
   def show
     prepare_show_action
+  end
+
+  def download_zip
+    zipper = S3ZipDownloader.new(@claim)
+    zip_file = zipper.generate!
+
+    send_data zip_file,
+              filename: "#{@claim.case_number}_documents.zip",
+              type: 'application/zip',
+              disposition: 'inline',
+              stream: 'true',
+              buffer_size: '4096'
   end
 
   def messages

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -33,12 +33,10 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
     zipper = S3ZipDownloader.new(@claim)
     zip_file = zipper.generate!
 
-    send_data zip_file,
-              filename: "#{@claim.case_number}_documents.zip",
+    send_file zip_file,
+              filename: "#{@claim.case_number}-documents.zip",
               type: 'application/zip',
-              disposition: 'inline',
-              stream: 'true',
-              buffer_size: '4096'
+              disposition: 'attachment'
   end
 
   def messages

--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -6,21 +6,20 @@ class S3ZipDownloader
     @folder = Dir.mktmpdir("#{@claim.case_number}-", './tmp')
     move_files
     @files_to_zip = Dir.entries(@folder) - %w[. ..]
-    @zip_file = Tempfile.new([@claim.case_number, '.zip'], './tmp')
+    @zip_file = "./tmp/#{@claim.case_number}-#{SecureRandom.uuid}-documents.zip"
   end
 
   def generate!
-    return_zip = zip_files
+    zip_files
     FileUtils.rm_rf(@folder)
-    return_zip
+    @zip_file
   end
 
   private
 
   def zip_files
-    Zip::File.new(@zip_file, Zip::File::CREATE) do |zip_file|
+    Zip::File.open(@zip_file, Zip::File::CREATE) do |zip_file|
       @files_to_zip.each do |filename|
-        puts "adding '#{File.join(@folder, filename)}' to '#{@zip_file.path}'"
         zip_file.add(filename, File.join(@folder, filename))
       end
     end

--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -26,21 +26,8 @@ class S3ZipDownloader
   end
 
   def move_files
-    send("move_files_from_#{Paperclip::Attachment.default_options[:storage]}")
-  end
-
-  def move_files_from_filesystem
     @claim.documents.each do |file|
-      FileUtils.copy(file.file_path, @folder)
-    end
-  end
-
-  def move_files_from_s3
-    s3 = Aws::S3::Resource.new(region: 'eu-west-1')
-    bucket = s3.bucket(ENV['adp-bucket-name'])
-    @claim.documents.each do |file|
-      file_obj = bucket.object(file.file_path)
-      file_obj.get(response_target: "#{@folder}/#{file}")
+      FileUtils.copy(Paperclip.io_adapters.for(file.document).path, @folder)
     end
   end
 end

--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -1,0 +1,47 @@
+class S3ZipDownloader
+  require 'zip'
+
+  def initialize(claim)
+    @claim = claim
+    @folder = Dir.mktmpdir("#{@claim.case_number}-", './tmp')
+    move_files
+    @files_to_zip = Dir.entries(@folder) - %w[. ..]
+    @zip_file = Tempfile.new([@claim.case_number, '.zip'], './tmp')
+  end
+
+  def generate!
+    return_zip = zip_files
+    FileUtils.rm_rf(@folder)
+    return_zip
+  end
+
+  private
+
+  def zip_files
+    Zip::File.new(@zip_file, Zip::File::CREATE) do |zip_file|
+      @files_to_zip.each do |filename|
+        puts "adding '#{File.join(@folder, filename)}' to '#{@zip_file.path}'"
+        zip_file.add(filename, File.join(@folder, filename))
+      end
+    end
+  end
+
+  def move_files
+    send("move_files_from_#{Paperclip::Attachment.default_options[:storage]}")
+  end
+
+  def move_files_from_filesystem
+    @claim.documents.each do |file|
+      FileUtils.copy(file.file_path, @folder)
+    end
+  end
+
+  def move_files_from_s3
+    s3 = Aws::S3::Resource.new(region: 'eu-west-1')
+    bucket = s3.bucket(ENV['adp-bucket-name'])
+    @claim.documents.each do |file|
+      file_obj = bucket.object(file.file_path)
+      file_obj.get(response_target: "#{@folder}/#{file}")
+    end
+  end
+end

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -4,6 +4,8 @@
   %div.grid-row
     %h3.heading-medium
       = t('.existing_evidence')
+      - if current_user_persona_is?(CaseWorker)
+        = link_to 'Download all', download_zip_case_workers_claim_path(@claim), class: 'font-small', style: 'float:right'
     - if @claim.documents.none?
       = t('.no_documents_uploaded')
 
@@ -43,6 +45,3 @@
                           download_document_path(document),
                           class: 'download',
                           'aria-label': "Evidence: Download document #{document.document_file_name}"
-
-      - if current_user_persona_is?(CaseWorker)
-        =link_to 'Download all', download_zip_case_workers_claim_path(@claim)

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -43,3 +43,6 @@
                           download_document_path(document),
                           class: 'download',
                           'aria-label': "Evidence: Download document #{document.document_file_name}"
+
+      - if current_user_persona_is?(CaseWorker)
+        =link_to 'Download all', download_zip_case_workers_claim_path(@claim)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "8738e8b7994af508882a105d873642c98a284c6139f8c6bcf53ae7e25bf14bfa",
+      "check_name": "SendFile",
+      "message": "Model attribute used in file name",
+      "file": "app/controllers/case_workers/claims_controller.rb",
+      "line": 36,
+      "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "send_file(S3ZipDownloader.new(Claim::BaseClaim.active.find(params[:id])).generate!, :filename => (\"#{Claim::BaseClaim.active.find(params[:id]).case_number}-documents.zip\"), :type => \"application/zip\", :disposition => \"attachment\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CaseWorkers::ClaimsController",
+        "method": "download_zip"
+      },
+      "user_input": "Claim::BaseClaim.active.find(params[:id])",
+      "confidence": "Weak",
+      "note": "Caseworkers need to identify the downloads correspond to the cases they are processing"
+    }
+  ],
+  "updated": "2017-10-19 11:24:18 +0100",
+  "brakeman_version": "4.0.1"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,7 @@ Rails.application.routes.draw do
       get 'show_message_controls', on: :member
       get 'messages', on: :member
       get 'archived', on: :collection
+      get 'download_zip', on: :member
     end
 
     namespace :admin do

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -50,6 +50,23 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
     end
   end
 
+  describe 'GET download_zip' do
+    let(:claim) { create :claim }
+
+    before(:each) { get :download_zip, id: claim }
+
+    it 'responds with an http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns a zip file' do
+      expect(response.headers['Content-Type']).to eq 'application/zip'
+    end
+
+    it 'returns a correctly named file' do
+      expect(response.headers['Content-Disposition']).to eq "attachment; filename=\"#{claim.case_number}-documents.zip\""
+    end
+  end
 
   describe  'GET show' do
     let(:claim) { create :claim }

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -50,7 +50,7 @@ FactoryGirl.define do
 
     trait :verified do
       verified_file_size 2663
-      file_path 'public/tmp/longer_lorem.pdf'
+      file_path Rails.root + 'features/examples/longer_lorem.pdf'
       verified true
     end
 

--- a/spec/services/s3_zip_downloader_spec.rb
+++ b/spec/services/s3_zip_downloader_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe S3ZipDownloader do
   describe 'generate!' do
     subject(:generate!) { s3_zip_downloader.generate! }
 
-    it { is_expected.to be_a Zip::File }
+    it { is_expected.to be_a String }
+
+    it { expect(File.exists?(subject)).to be true }
   end
 end

--- a/spec/services/s3_zip_downloader_spec.rb
+++ b/spec/services/s3_zip_downloader_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe S3ZipDownloader do
+  subject(:s3_zip_downloader) { described_class.new(claim) }
+
+  let!(:claim) { create :claim }
+  let!(:document) { create :document, :verified, claim: claim }
+
+  describe 'generate!' do
+    subject(:generate!) { s3_zip_downloader.generate! }
+
+    it { is_expected.to be_a Zip::File }
+  end
+end

--- a/spec/views/case_workers/claim_view_spec.rb
+++ b/spec/views/case_workers/claim_view_spec.rb
@@ -50,6 +50,20 @@ describe 'case_workers/claims/show.html.haml', type: :view do
       expect(rendered).to have_content('First day of retrial')
     end
 
+    describe 'document checklist' do
+      let!(:claim_with_doc) { create :claim }
+      let!(:document) { create :document, :verified, claim: claim_with_doc }
+
+      before do
+        allow(view).to receive(:current_user_persona_is?).with(CaseWorker).and_return(true)
+        assign(:claim, claim_with_doc)
+        render
+      end
+
+      it 'displays a `download all` link' do
+        expect(rendered).to have_link('Download all')
+      end
+    end
   end
 
 
@@ -67,8 +81,9 @@ describe 'case_workers/claims/show.html.haml', type: :view do
   end
 
   def trial_claim(trial_prefix = nil)
-    @claim = create(:submitted_claim, case_type: FactoryGirl.create(:case_type, "#{trial_prefix}trial".to_sym))
+    @claim = create(:submitted_claim, case_type: FactoryGirl.create(:case_type, "#{trial_prefix}trial".to_sym), evidence_checklist_ids: [1, 9])
     @case_worker.claims << @claim
+    @document = create(:document, claim_id: @claim.id, form_id: @claim.form_id)
     @messages = @claim.messages.most_recent_last
     @message = @claim.messages.build
   end

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -31,6 +31,10 @@ describe 'external_users/claims/show.html.haml', type: :view do
         expect(rendered).to have_selector('li', text: 'Representation order')
         expect(rendered).to have_selector('li', text: 'Justification for out of time claim')
       end
+
+      it 'does not display a `download all` link' do
+        expect(rendered).to_not have_link('Download all')
+      end
     end
 
     describe 'basic claim information' do


### PR DESCRIPTION
# What

Add a download all files link for caseworkers

# Why

To allow caseworkers quick downloads of all files, rather than downloading the files individually
