### PR TITLE
FIX: Add handler for vat_amount being nil

### DIFF
--- a/app/presenters/redetermination_presenter.rb
+++ b/app/presenters/redetermination_presenter.rb
@@ -22,6 +22,6 @@ class RedeterminationPresenter < BasePresenter
   end
 
   def total_inc_vat
-    h.number_to_currency(redetermination.total + redetermination.vat_amount)
+    h.number_to_currency(redetermination.total + (redetermination.vat_amount || 0))
   end
 end

--- a/spec/presenters/redetermination_presenter_spec.rb
+++ b/spec/presenters/redetermination_presenter_spec.rb
@@ -6,7 +6,6 @@ describe RedeterminationPresenter do
   let(:rd)              { FactoryGirl.create :redetermination, fees: 1452.33, expenses: 2455.77, disbursements: 2123.55, claim: claim }
   let(:presenter)       { RedeterminationPresenter.new(rd, view) }
 
-
   context 'currency fields' do
     it 'should format currency amount' do
       expect(presenter.fees_total).to eq '£1,452.33'
@@ -18,4 +17,11 @@ describe RedeterminationPresenter do
     end
   end
 
+  context 'when VAT amount is nil' do
+    before { allow(rd).to receive(:vat_amount).and_return(nil) }
+
+    it 'should still calculate' do
+      expect(presenter.total_inc_vat).to eq '£6,031.65'
+    end
+  end
 end


### PR DESCRIPTION
# Why
The front end allows caseworkers to submit a nil value for VAT amount
this causes the redetermination presenter to blow up because it
can't add nil to the total.
This prevented the display of the claim entirely.

# How
This ensures the vat amount will add zero instead of nil and allow the
display of the claim