### PR TITLE
Ensure CCR JSON returns empty array when no fees/bills exist

### DIFF
--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -24,17 +24,12 @@ module API
       # CCR fields that can be derived from CCCD data
       expose :estimated_trial_length_or_one, as: :estimated_trial_length, format_with: :string
       expose :actual_trial_length_or_one, as: :actual_trial_Length, format_with: :string
-      # ----------------------------------------------
 
       # CCR fields whose values can, and are, mapped to a CCCD field's values
       expose :adapted_advocate_category, as: :advocate_category
-      # ----------------------------------------------
 
-      # wrapper for the mapping of CCCD fees to CCR bills
-      expose :bills do
-        expose :advocate_fees, merge: true, using: API::Entities::CCR::AdaptedAdvocateFee
-        expose :miscellaneous_fees, merge: true, using: API::Entities::CCR::AdaptedMiscFee
-      end
+      # CCR fee to bill mappings
+      expose :bills
 
       private
 
@@ -48,6 +43,13 @@ module API
 
       def actual_trial_length_or_one
         [object.actual_trial_length, 1].compact.max
+      end
+
+      def bills
+        data = []
+        data.push API::Entities::CCR::AdaptedAdvocateFee.represent(advocate_fees)
+        data.push API::Entities::CCR::AdaptedMiscFee.represent(miscellaneous_fees)
+        data.flatten.as_json
       end
 
       def adapted_advocate_category

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -109,12 +109,17 @@ describe API::V2::CCRClaim do
     end
 
     context 'bills' do
-      subject(:response) do
-        do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-      end
+      subject(:response) { do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body }
+      subject(:bills) { JSON.parse(response)['bills'] }
 
       let(:claim) do
         create(:authorised_claim, :without_fees)
+      end
+
+      it 'returns empty array if no bills found' do
+        expect(response).to have_json_size(0).at_path("bills")
+        expect(bills).to be_an Array
+        expect(bills).to be_empty
       end
 
       context 'advocate fee' do


### PR DESCRIPTION
**What**
Ensure that the bills in the JSON output always return an array 
even if it is empty, and never nil or {}.

**Why**
CCR assumes it receives an array, not nil. Returning
an empty array instead of nil, or JSON {}, is more
predictable for consumers generally.