### PR TITLE
Add additional case numbers to all summary pages

### DIFF
--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -23,7 +23,7 @@
             = t('shared.summary.fee_subtype')
           %td
             = fee.sub_type.description
-      - if fee.case_numbers.present?
+      - if fee.case_uplift?
         %tr
           %th{scope: 'row'}
             = t('shared.summary.case_numbers')

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -23,6 +23,12 @@
             = t('shared.summary.fee_subtype')
           %td
             = fee.sub_type.description
+      - if fee.case_numbers.present?
+        %tr
+          %th{scope: 'row'}
+            = t('shared.summary.case_numbers')
+          %td
+            = fee.case_numbers
 
       - if fee.claim.agfs? || fee.is_graduated? || fee.is_transfer?
         %tr

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -6,7 +6,7 @@
       %p
         = t('shared.summary.no_values.fees')
     - else
-      / table does noe require summary
+      / table does not require summary
       %table.figures
         %caption.visually-hidden
           = t('.fees.caption')
@@ -42,7 +42,9 @@
                 - if fee.sub_type.present?
                   %p
                     = "#{t('.fee_subtype')}: #{fee.sub_type.description}"
-
+                - if fee.case_numbers.present?
+                  %br
+                  = "#{t('.case_numbers')}: #{fee.case_numbers}"
               - unless claim.interim?
                 %td.numeric
                   = fee.quantity

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -42,7 +42,7 @@
                 - if fee.sub_type.present?
                   %p
                     = "#{t('.fee_subtype')}: #{fee.sub_type.description}"
-                - if fee.case_numbers.present?
+                - if fee.case_uplift?
                   %br
                   = "#{t('.case_numbers')}: #{fee.case_numbers}"
               - unless claim.interim?

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -38,6 +38,9 @@
                 - if fee.sub_type.present?
                   %p
                     = "#{t('.fee_subtype')}: #{fee.sub_type.description}"
+                - if fee.case_numbers.present?
+                  %br
+                  = "(#{t('.case_numbers')}: #{fee.case_numbers})"
               %td.numeric
                 = fee.quantity
               %td.numeric

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -38,7 +38,7 @@
                 - if fee.sub_type.present?
                   %p
                     = "#{t('.fee_subtype')}: #{fee.sub_type.description}"
-                - if fee.case_numbers.present?
+                - if fee.case_uplift?
                   %br
                   = "(#{t('.case_numbers')}: #{fee.case_numbers})"
               %td.numeric

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -890,6 +890,7 @@ en:
       fee_category: Fee category
       fee_type: Fee type
       fee_subtype: Fee subtype
+      case_numbers: *case_numbers
       quantity: Quantity
       dates_attended: Dates attended
       fees_total: 'Fees total:'
@@ -937,6 +938,7 @@ en:
       fee_category: Fee category
       fee_type: Fee type
       fee_subtype: Fee subtype
+      case_numbers: *case_numbers
       quantity: Quantity
       dates_attended: Dates attended
       fees_total: 'Fees total:'
@@ -985,6 +987,7 @@ en:
       fee_category: Fee category
       fee_type: Fee type
       fee_subtype: Fee subtype
+      case_numbers: *case_numbers
       quantity: Quantity
       dates_attended: Dates attended
       fees_total: 'Fees total:'


### PR DESCRIPTION
**What**
displays additional case numbers added to fees in summary pages

**Why**
The case workers need this information for entry into CCR. The 
external users draft claim summary and pre submission check
list/summary page should also display this for consistency.


