### PR TITLE
Hide download all link when no documents

### DIFF
--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -4,8 +4,9 @@
   %div.grid-row
     %h3.heading-medium
       = t('.existing_evidence')
-      - if current_user_persona_is?(CaseWorker)
+      - if current_user_persona_is?(CaseWorker) && @claim.documents.any?
         = link_to 'Download all', download_zip_case_workers_claim_path(@claim), class: 'font-small', style: 'float:right'
+
     - if @claim.documents.none?
       = t('.no_documents_uploaded')
 


### PR DESCRIPTION
Why are we doing this:
- the download all link should only be visible if there are downloads

What this PR does:
- hides the link when no docs