### PR TITLE
Messaging update

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -22,8 +22,9 @@ module ClaimsHelper
   end
 
   def show_message_controls?(claim)
-    (current_user_is_caseworker? || current_user_is_external_user?) &&
-      %w[draft rejected archived_pending_delete].exclude?(claim.state)
+    return %w[submitted allocated part_authorised rejected].include?(claim.state) if current_user_is_external_user?
+    return claim.state != 'draft' if current_user_is_caseworker?
+    false
   end
 
   def messaging_permitted?(message)

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -22,7 +22,7 @@ module ClaimsHelper
   end
 
   def show_message_controls?(claim)
-    return %w[submitted allocated part_authorised rejected].include?(claim.state) if current_user_is_external_user?
+    return %w[submitted allocated part_authorised rejected refused].include?(claim.state) if current_user_is_external_user?
     return claim.state != 'draft' if current_user_is_caseworker?
     false
   end

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -13,7 +13,7 @@ module Claims
     CASEWORKER_DASHBOARD_UNALLOCATED_STATES         = %w[submitted redetermination awaiting_written_reasons].freeze
     CASEWORKER_DASHBOARD_ARCHIVED_STATES            = %w[ authorised part_authorised rejected
                                                           refused archived_pending_delete].freeze
-    VALID_STATES_FOR_REDETERMINATION                = %w[authorised part_authorised refused].freeze
+    VALID_STATES_FOR_REDETERMINATION                = %w[authorised part_authorised refused rejected].freeze
     VALID_STATES_FOR_ARCHIVAL                       = %w[authorised part_authorised refused rejected].freeze
     VALID_STATES_FOR_ALLOCATION                     = %w[submitted redetermination awaiting_written_reasons].freeze
     VALID_STATES_FOR_DEALLOCATION                   = %w[allocated].freeze

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -26,7 +26,7 @@ describe ClaimsHelper do
 
   end
 
-	describe "#includes_state?" do
+	describe '#includes_state?' do
 
 		let(:only_allocated_claims) { create_list(:allocated_claim, 5) }
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -125,7 +125,7 @@ describe ClaimsHelper do
     context 'for external_user' do
       let(:persona) { create :external_user }
 
-      %w[submitted allocated part_authorised rejected].each do |state|
+      %w[submitted allocated part_authorised refused rejected].each do |state|
         context "when claim state is #{state}" do
           let(:state) { state }
 
@@ -133,7 +133,7 @@ describe ClaimsHelper do
         end
       end
 
-      %w[draft authorised refused redetermination awaiting_written_reasons].each do |state|
+      %w[draft authorised redetermination awaiting_written_reasons].each do |state|
         context "when claim state is #{state}" do
           let(:state) { state }
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -86,4 +86,67 @@ describe ClaimsHelper do
       end
     end
   end
+
+  describe '#show_message_controls?' do
+    subject(:subj_show_message_controls?) { show_message_controls?(claim) }
+    require 'application_helper'
+    let(:claim) { build :claim, state: state }
+
+    RSpec.configure do |c|
+      c.include ApplicationHelper
+    end
+
+    helper do
+      def current_user
+        instance_double(User, persona: persona)
+      end
+    end
+
+    context 'for case_worker' do
+      let(:persona) { create :case_worker }
+
+      %w[submitted allocated authorised part_authorised rejected refused redetermination awaiting_written_reasons].each do |state|
+        context "when claim state is #{state}" do
+          let(:state) { state }
+
+          it { is_expected.to be_truthy }
+        end
+      end
+
+      %w[draft].each do |state|
+        context "when claim state is #{state}" do
+          let(:state) { state }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
+
+    context 'for external_user' do
+      let(:persona) { create :external_user }
+
+      %w[submitted allocated part_authorised rejected].each do |state|
+        context "when claim state is #{state}" do
+          let(:state) { state }
+
+          it { is_expected.to be_truthy }
+        end
+      end
+
+      %w[draft authorised refused redetermination awaiting_written_reasons].each do |state|
+        context "when claim state is #{state}" do
+          let(:state) { state }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
+
+    context 'for user with invalid persona' do
+      let(:persona) { nil }
+      let(:state) { 'submitted' }
+
+      it { is_expected. to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
# Why
Users needed to request redeterminations and send messages when their claims where in additional states.

# How
Extend the #show_message_controls? method to better define the rules around when to display the message partial