### PR TITLE
Fix message_added_email

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -50,6 +50,7 @@ class MessagesController < ApplicationController
   def send_email_if_required
     return unless current_user.persona.is_a?(CaseWorker)
     return unless @message.claim.creator.send_email_notification_of_message?
+    return if @message.claim.creator.softly_deleted?
     NotifyMailer.message_added_email(@message.claim).deliver_later
   end
 

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -135,6 +135,19 @@ RSpec.describe MessagesController, type: :controller do
           expect(mock_mail).to receive(:deliver_later)
           post :create, message: message_params
         end
+
+        context 'but has been deleted' do
+          before do
+            claim.creator.email_notification_of_message = 'true'
+            claim.creator.soft_delete
+            sign_in sender.user
+          end
+
+          it 'does not send an email' do
+            expect(NotifyMailer).not_to receive(:message_added_email)
+            post :create, message: message_params
+          end
+        end
       end
       context 'external_user_is_not_setup_to_recieve_emails' do
         it 'does not send an email' do


### PR DESCRIPTION
# Why?
The mailer was attempting to send emails to a softly-deleted user
As this suffixes `.deleted.{id}` to the users email, this would fail.

# What?
Add tests to replicate the situation and then handle the situation by
not attempting to send messages to softly-deleted external users