### PR TITLE
Add find user

### DIFF
--- a/app/controllers/super_admins/external_users_controller.rb
+++ b/app/controllers/super_admins/external_users_controller.rb
@@ -1,8 +1,9 @@
 class SuperAdmins::ExternalUsersController < ApplicationController
   include PasswordHelpers
 
-  before_action :set_provider
+  before_action :set_provider, except: %i[find search]
   before_action :set_external_user, only: %i[show edit update change_password update_password]
+  before_action :external_user_by_email, only: %i[search]
 
   def show; end
 
@@ -29,6 +30,16 @@ class SuperAdmins::ExternalUsersController < ApplicationController
   end
 
   def edit; end
+
+  def find; end
+
+  def search
+    if @external_user&.is_a?(ExternalUser)
+      redirect_to super_admins_provider_external_user_path(@external_user.provider, @external_user)
+    else
+      redirect_to super_admins_external_users_find_path, alert: 'No provider found with that email'
+    end
+  end
 
   def update
     if @external_user.update(external_user_params)
@@ -66,6 +77,10 @@ class SuperAdmins::ExternalUsersController < ApplicationController
 
   def set_external_user
     @external_user = ExternalUser.active.find(params[:id])
+  end
+
+  def external_user_by_email
+    @external_user = User.active.find_by(email: params[:external_user][:email])&.persona
   end
 
   def set_provider

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,7 @@ class Ability
 
     if persona.is_a? SuperAdmin
       can %i[show index new create edit update], Provider
-      can %i[show index new create edit update change_password update_password], ExternalUser
+      can %i[show index new create edit update change_password update_password find search], ExternalUser
       can %i[show edit update change_password update_password], SuperAdmin, id: persona.id
       can [:update_settings], User, id: user.id
       return

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -7,6 +7,8 @@
         %li
           = link_to 'Add a provider', new_super_admins_provider_path, class: cp(new_super_admins_provider_path)
         %li
+          = link_to 'Manage user by email', super_admins_external_users_find_path, class: cp(new_super_admins_provider_path)
+        %li
           = link_to 'Sidekiq console', sidekiq_web_path
       - elsif current_user.persona.is_a?(ExternalUser)
         %li

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -7,7 +7,7 @@
         %li
           = link_to 'Add a provider', new_super_admins_provider_path, class: cp(new_super_admins_provider_path)
         %li
-          = link_to 'Manage user by email', super_admins_external_users_find_path, class: cp(new_super_admins_provider_path)
+          = link_to 'Find provider by email', super_admins_external_users_find_path, class: cp(new_super_admins_provider_path)
         %li
           = link_to 'Sidekiq console', sidekiq_web_path
       - elsif current_user.persona.is_a?(ExternalUser)

--- a/app/views/super_admins/external_users/find.html.haml
+++ b/app/views/super_admins/external_users/find.html.haml
@@ -1,0 +1,8 @@
+= render partial: 'layouts/header', locals: {page_heading:  'Search for user by email'}
+
+= form_for(:external_user, url: super_admins_external_users_find_path) do |f|
+  .form-group
+    = f.label t(".email"), class: "form-label"
+    = f.email_field :email, class: "form-control"
+
+  = f.submit t('.submit'), class: "button"

--- a/app/views/super_admins/external_users/find.html.haml
+++ b/app/views/super_admins/external_users/find.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'layouts/header', locals: {page_heading:  'Search for user by email'}
+= render partial: 'layouts/header', locals: {page_heading:  'Find provider by email'}
 
 = form_for(:external_user, url: super_admins_external_users_find_path) do |f|
   .form-group

--- a/app/views/super_admins/external_users/show.html.haml
+++ b/app/views/super_admins/external_users/show.html.haml
@@ -4,6 +4,10 @@
   = @external_user.email
 
 %p
+  Provider:
+  = link_to @external_user.provider.name, super_admins_provider_path(@provider)
+
+%p
   Name:
   = @external_user.name
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,6 +343,9 @@ en:
         apply_vat: "VAT registered"
         roles: *roles
         submit: 'Create user'
+      find:
+        email: *email
+        submit: 'Search'
       change_password:
         error: 'error'
         prohibited_save: 'This user password change has'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,8 @@ Rails.application.routes.draw do
 
   namespace :super_admins do
     root to: 'providers#index'
+    get 'external_users/find', to: 'external_users#find'
+    post 'external_users/find', to: 'external_users#search'
 
     resources :providers, except: [:destroy] do
       resources :external_users, except: [:destroy] do

--- a/spec/controllers/super_admins/external_users_controller_spec.rb
+++ b/spec/controllers/super_admins/external_users_controller_spec.rb
@@ -42,7 +42,38 @@ RSpec.describe SuperAdmins::ExternalUsersController, type: :controller do
     it 'assigns @external_users' do
       expect(assigns(:external_users)).to include(external_user)
     end
+  end
 
+  describe 'GET #find' do
+    before { get :find }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'POST #search' do
+    subject { response }
+
+    before { post :search, external_user: { email: email } }
+
+    context 'when the email is for a provider' do
+      let(:email) { external_user.email }
+
+      it { is_expected.to redirect_to(super_admins_provider_external_user_path(external_user.provider, external_user)) }
+    end
+
+    context 'when the email is for a non-provider' do
+      let(:email) { super_admin.email }
+
+      it { is_expected.to redirect_to(super_admins_external_users_find_path) }
+    end
+
+    context 'when the email does not exist' do
+      let(:email) { 'vail.email@does.not.exist.com' }
+
+      it { is_expected.to redirect_to(super_admins_external_users_find_path) }
+    end
   end
 
   describe "GET #new" do


### PR DESCRIPTION
### Why?
As a caseworking superuser, I'd like to be able to find an existing user by email.
Sometimes when adding a new user, I am told that the email address is already in use but I can't find it without manually searching through the providers.