### PR TITLE
Messaging extend allowed statuses

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -3,7 +3,8 @@ module ClaimsHelper
     submitted
     allocated
     part_authorised
-    rejected refused
+    rejected
+    refused
     authorised
     redetermination
     awaiting_written_reasons

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -16,7 +16,8 @@ module ClaimsHelper
 
   def claim_allocation_checkbox_helper(claim, case_worker)
     checked = claim.is_allocated_to_case_worker?(case_worker) ? 'checked="checked"' : nil
-    %(<input #{checked} id="case_worker_claim_ids_#{claim.id}" name="case_worker[claim_ids][]" type="checkbox" value="#{claim.id}">).html_safe
+    element_id = "id=\"case_worker_claim_ids_#{claim.id}\""
+    %(<input #{checked} #{element_id} name="case_worker[claim_ids][]" type="checkbox" value="#{claim.id}">).html_safe
   end
 
   def to_slug(string)

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -1,4 +1,14 @@
 module ClaimsHelper
+  EXTERNAL_USER_MESSAGING_ALLOWED = %w[
+    submitted
+    allocated
+    part_authorised
+    rejected refused
+    authorised
+    redetermination
+    awaiting_written_reasons
+  ].freeze
+
   def includes_state?(claims, states)
     states.gsub(/\s+/, '').split(',').to_a unless states.is_a?(Array)
     claims.map(&:state).uniq.any? { |s| states.include?(s) }
@@ -22,7 +32,7 @@ module ClaimsHelper
   end
 
   def show_message_controls?(claim)
-    return %w[submitted allocated part_authorised rejected refused].include?(claim.state) if current_user_is_external_user?
+    return EXTERNAL_USER_MESSAGING_ALLOWED.include?(claim.state) if current_user_is_external_user?
     return claim.state != 'draft' if current_user_is_caseworker?
     false
   end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -125,7 +125,7 @@ describe ClaimsHelper do
     context 'for external_user' do
       let(:persona) { create :external_user }
 
-      %w[submitted allocated part_authorised refused rejected].each do |state|
+      %w[submitted allocated part_authorised refused rejected authorised redetermination awaiting_written_reasons].each do |state|
         context "when claim state is #{state}" do
           let(:state) { state }
 
@@ -133,7 +133,7 @@ describe ClaimsHelper do
         end
       end
 
-      %w[draft authorised redetermination awaiting_written_reasons].each do |state|
+      %w[draft archived_pending_delete].each do |state|
         context "when claim state is #{state}" do
           let(:state) { state }
 


### PR DESCRIPTION
As a provider, I want to be able to send a message after I have requested a redetermination/written reasons so that if i have forgotten something or if I need to attach more than one document I can.

As a provider, I want to be able to request for redetermination/written reasons and send a message if my claim has been authorised, so that if a caseworker accidentally clicked authorised instead of part-authorised, I can still apply for redetermination.