### PR TITLE
Fix rescue error violations

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -47,3 +47,4 @@ exclude_paths: # customize
 - features/support/*
 - script/*
 - Gemfile*
+- scheduled_tasks/*_task.rb

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,45 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 45
-Lint/RescueWithoutErrorClass:
-  Exclude:
-    - 'scheduled_tasks/management_information_generation_task.rb'
-    - 'scheduled_tasks/geckoboard_provider_task.rb'
-    - 'scheduled_tasks/document_cleaner_task.rb'
-    - 'scheduled_tasks/daily_stats_generator.rb'
-    - 'app/validators/fee/base_fee_validator.rb'
-    - 'app/validators/disbursement_validator.rb'
-    - 'app/validators/claim/litigator_supplier_number_validations.rb'
-    - 'app/validators/claim/litigator_common_validations.rb'
-    - 'app/validators/claim/base_claim_validator.rb'
-    - 'app/validators/claim/base_claim_validator.rb'
-    - 'app/services/claims/case_worker_claim_updater.rb'
-    - 'app/rake_helpers/document_recloner.rb'
-    - 'app/presenters/fee/misc_fee_presenter.rb'
-    - 'app/presenters/fee/fixed_fee_presenter.rb'
-    - 'app/presenters/error_presenter.rb'
-    - 'app/presenters/claim/transfer_claim_presenter.rb'
-    - 'app/presenters/claim/base_claim_presenter.rb'
-    - 'app/presenters/base_presenter.rb'
-    - 'app/models/user.rb'
-    - 'app/models/stats/management_information_generator.rb'
-    - 'app/models/stats/collector/completion_rate_collector.rb'
-    - 'app/models/representation_order.rb'
-    - 'app/models/json_document_importer.rb'
-    - 'app/models/fee/base_fee.rb'
-    - 'app/models/document.rb'
-    - 'app/models/claim/transfer_brain_data_item.rb'
-    - 'app/models/allocation.rb'
-    - 'app/interfaces/api/helpers/api_helper.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/form_builders/adp_date_fields.rb'
-    - 'app/controllers/heartbeat_controller.rb'
-    - 'app/controllers/feedback_controller.rb'
-    - 'app/controllers/external_users/claims_controller.rb'
-    - 'app/controllers/external_users/certifications_controller.rb'
-    - 'app/controllers/concerns/password_helpers.rb'
-
 # Offense count: 38
 Metrics/AbcSize:
   Max: 87

--- a/app/controllers/concerns/password_helpers.rb
+++ b/app/controllers/concerns/password_helpers.rb
@@ -25,8 +25,8 @@ module PasswordHelpers
     user.save(validate: false)
     message = DeviseMailer.reset_password_instructions(user, token, current_user.name)
     message.deliver_later
-  rescue => e
-    Rails.logger.error("DEVISE MAILER ERROR: '#{e.message}' while sending reset password mail")
+  rescue StandardError => err
+    Rails.logger.error("DEVISE MAILER ERROR: '#{err.message}' while sending reset password mail")
   end
 
   private

--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -23,7 +23,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
       begin
         MessageQueue::AwsClient.new(MessageQueue::MessageTemplate.claim_created(@claim.type, @claim.uuid), Settings.aws.queue).send_message!
         Rails.logger.info "Successfully sent message about submission of claim##{@claim.id}(#{@claim.uuid})"
-      rescue => err
+      rescue StandardError => err
         Rails.logger.warn "Error: '#{err.message}' while sending message about submission of claim##{@claim.id}(#{@claim.uuid})"
       end
       redirect_to confirmation_external_users_claim_path(@claim)

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -79,7 +79,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def clone_rejected
     draft = claim_updater.clone_rejected
     redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
-  rescue
+  rescue StandardError
     redirect_to external_users_claims_url, alert: 'Can only clone rejected claims'
   end
 

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -36,17 +36,21 @@ class FeedbackController < ApplicationController
   end
 
   def merged_feedback_params
-    feedback_params.merge(email: (begin
-                current_user.email
-              rescue
-                (email_from_user_id || 'anonymous')
-              end),
+    feedback_params.merge(email: user_email_or_anonymous,
                           user_agent: request.user_agent)
   end
 
+  def user_email_or_anonymous
+    if current_user
+      current_user.email
+    else
+      email_from_user_id || 'anonymous'
+    end
+  end
+
   def email_from_user_id
-    User.active.find(params[:user_id]).try(:email)
-  rescue
+    User.active.find(params[:user_id])&.email
+  rescue ActiveRecord::RecordNotFound
     nil
   end
 

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -36,14 +36,14 @@ class HeartbeatController < ApplicationController
   def redis_alive?
     Sidekiq.redis(&:info)
     true
-  rescue
+  rescue StandardError
     false
   end
 
   def sidekiq_alive?
     ps = Sidekiq::ProcessSet.new
     !ps.size.zero?
-  rescue
+  rescue StandardError
     false
   end
 
@@ -51,7 +51,7 @@ class HeartbeatController < ApplicationController
     dead = Sidekiq::DeadSet.new
     retries = Sidekiq::RetrySet.new
     dead.size.zero? && retries.size.zero?
-  rescue
+  rescue StandardError
     false
   end
 

--- a/app/form_builders/adp_date_fields.rb
+++ b/app/form_builders/adp_date_fields.rb
@@ -13,21 +13,9 @@ class AdpDateFields
   end
 
   def output
-    day_value = begin
-                  @object.send(@attribute).strftime('%d')
-                rescue
-                  nil
-                end
-    month_value = begin
-                    @object.send(@attribute).strftime('%m')
-                  rescue
-                    nil
-                  end
-    year_value = begin
-                   @object.send(@attribute).strftime('%Y')
-                 rescue
-                   nil
-                 end
+    day_value = @object.send(@attribute)&.strftime('%d')
+    month_value = @object.send(@attribute)&.strftime('%m')
+    year_value = @object.send(@attribute)&.strftime('%Y')
 
     %(
       #{@form.text_field(@attribute, field_options(day_value, html_id(:day), html_name(:day), 'DD', 2))}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -104,13 +104,13 @@ module ApplicationHelper
 
   def extract_uri_param(path, param)
     CGI.parse(URI.parse(path).query)[param][0]
-  rescue
+  rescue NoMethodError
     nil
   end
 
   def strip_params(path)
     URI.parse(path).path
-  rescue
+  rescue URI::Error
     nil
   end
 

--- a/app/interfaces/api/helpers/api_helper.rb
+++ b/app/interfaces/api/helpers/api_helper.rb
@@ -72,7 +72,7 @@ module API
         def test_editability(model_instance)
           return unless (Fee::BaseFee.subclasses + [Expense, Disbursement, Defendant, RepresentationOrder, DateAttended]).include?(model_instance.class)
           model_instance.errors.add(:base, 'uneditable_state') unless model_instance.claim.editable?
-        rescue
+        rescue StandardError
           true
         end
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -63,7 +63,7 @@ class Allocation
 
   def case_worker
     CaseWorker.active.find(@case_worker_id)
-  rescue
+  rescue ActiveRecord::ActiveRecordError
     nil
     # deallocation will have a nil case worker id
   end
@@ -98,8 +98,8 @@ class Allocation
     else
       allocate_claim! claim
     end
-  rescue => ex
-    errors.add(:base, "Claim #{claim.case_number} has errors: #{ex.message}")
+  rescue StandardError => err
+    errors.add(:base, "Claim #{claim.case_number} has errors: #{err.message}")
   end
 
   def rollback_all_allocations!

--- a/app/models/claim/transfer_brain_data_item.rb
+++ b/app/models/claim/transfer_brain_data_item.rb
@@ -4,20 +4,13 @@ module Claim
                 :allocation_type, :validity, :transfer_fee_full_name
 
     def initialize(arry)
-      copy_array = arry
-      begin
-        @litigator_type           = arry.shift.downcase
-        @elected_case             = arry.shift.to_bool
-        @transfer_stage_id        = TransferBrain.transfer_stage_id(arry.shift)
-        @case_conclusion_id       = get_case_conclusion_id(arry.shift)
-        @validity                 = arry.shift.to_bool
-        @transfer_fee_full_name   = arry.shift
-        @allocation_type          = arry.shift
-      rescue => err
-        puts "#{err.class}: #{err.message}"
-        ap copy_array
-        raise 'Boom'
-      end
+      @litigator_type           = arry.shift.downcase
+      @elected_case             = arry.shift.to_bool
+      @transfer_stage_id        = TransferBrain.transfer_stage_id(arry.shift)
+      @case_conclusion_id       = get_case_conclusion_id(arry.shift)
+      @validity                 = arry.shift.to_bool
+      @transfer_fee_full_name   = arry.shift
+      @allocation_type          = arry.shift
     end
 
     def match_detail?(detail)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -98,7 +98,7 @@ class Document < ActiveRecord::Base
       self.file_path = document.path
       self.verified = verified_file_size.positive?
       save!
-    rescue => err
+    rescue StandardError => err
       errors[:document] << err.message
       self.verified = false
     end

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -116,9 +116,7 @@ module Fee
     end
 
     def calculated?
-      fee_type.calculated?
-    rescue
-      true
+      fee_type&.calculated?.nil? ? true : fee_type&.calculated?
     end
 
     def calculation_required?

--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -60,7 +60,7 @@ class JsonDocumentImporter
   def json_data
     @json_data ||= begin
                      JSON.parse(File.read(@file.tempfile))
-                   rescue
+                   rescue StandardError
                      nil
                    end
   end

--- a/app/models/representation_order.rb
+++ b/app/models/representation_order.rb
@@ -19,12 +19,7 @@ class RepresentationOrder < ActiveRecord::Base
   before_save :upcase_maat_ref
 
   before_validation do
-    case_type = begin
-                  defendant.claim.case_type
-                rescue
-                  nil
-                end
-
+    case_type = defendant&.claim&.case_type
     self.maat_reference = nil if case_type&.requires_maat_reference?.eql?(false)
   end
 

--- a/app/models/stats/collector/completion_rate_collector.rb
+++ b/app/models/stats/collector/completion_rate_collector.rb
@@ -14,7 +14,7 @@ module Stats
         num_completed = Claim::BaseClaim.active.where(form_id: form_ids_created_at_period_start).where.not(last_submitted_at: nil).count
         percentage_completed_e2 = num_started.zero? ? 1000 : ((num_completed.to_f / num_started) * 10_000).to_i # 0.2546, i.e. 25.46% is stored as 2546
         Statistic.create_or_update(@date, 'completion_percentage', 'Claim::BaseClaim', percentage_completed_e2, num_completed)
-      rescue => err
+      rescue StandardError => err
         puts "Error processing for date #{@date}"
         puts err.class
         puts err.message

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -11,7 +11,7 @@ module Stats
         report_contents = generate_new_report
         report_record.write_report(report_contents)
       end
-    rescue => err
+    rescue StandardError => err
       report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
       report_record.write_error(report_contents)
       raise err

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ActiveRecord::Base
 
   def settings
     HashWithIndifferentAccess.new(JSON.parse(read_attribute(:settings)))
-  rescue
+  rescue StandardError
     {}
   end
 

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -16,9 +16,7 @@ class BasePresenter < SimpleDelegator
   private_class_method :presents
 
   def format_date(date)
-    date.strftime(Settings.date_format)
-  rescue
-    nil
+    date&.strftime(Settings.date_format)
   end
 
   def date_format(options = {})

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -55,7 +55,7 @@ class Claim::BaseClaimPresenter < BasePresenter
 
   def retrial
     claim.case_type.name.match?(/retrial/i) ? 'Yes' : 'No'
-  rescue
+  rescue NoMethodError
     ''
   end
 

--- a/app/presenters/claim/transfer_claim_presenter.rb
+++ b/app/presenters/claim/transfer_claim_presenter.rb
@@ -13,7 +13,7 @@ class Claim::TransferClaimPresenter < Claim::BaseClaimPresenter
 
   def transfer_detail_summary
     Claim::TransferBrain.transfer_detail_summary(claim.transfer_detail)
-  rescue
+  rescue StandardError
     ''
   end
 
@@ -35,7 +35,7 @@ class Claim::TransferClaimPresenter < Claim::BaseClaimPresenter
 
   def case_conclusion_description
     case_conclusions[claim.case_conclusion_id.to_s]
-  rescue
+  rescue StandardError
     ''
   end
 end

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -62,12 +62,8 @@ class ErrorPresenter
     parent_sequence = 0
     if is_submodel_key?(key)
       parent_model, attribute = last_parent_attribute(@translations, key)
-      parent_sequence = begin
-                          @translations[parent_model]['_seq']
-                        rescue
-                          0
-                        end
-      translations_subset = @translations[parent_model][attribute]
+      parent_sequence = @translations.dig(parent_model, '_seq') || 0
+      translations_subset = @translations.dig(parent_model, attribute)
     else
       translations_subset = @translations[key]
     end
@@ -82,7 +78,7 @@ class ErrorPresenter
     translations_subset, parent_sequence = translations_sub_set_and_parent_sequence(key)
     begin
       translations_subset['_seq'].present? ? translations_subset['_seq'] + parent_sequence : parent_sequence || 99_999
-    rescue
+    rescue StandardError
       99_999
     end
   end

--- a/app/presenters/fee/fixed_fee_presenter.rb
+++ b/app/presenters/fee/fixed_fee_presenter.rb
@@ -14,8 +14,6 @@ class Fee::FixedFeePresenter < Fee::BaseFeePresenter
   private
 
   def agfs?
-    fee.claim.agfs? ? true : false
-  rescue
-    true
+    fee&.claim&.agfs? ? true : false
   end
 end

--- a/app/presenters/fee/misc_fee_presenter.rb
+++ b/app/presenters/fee/misc_fee_presenter.rb
@@ -10,8 +10,6 @@ class Fee::MiscFeePresenter < Fee::BaseFeePresenter
   private
 
   def agfs?
-    fee.claim.agfs? ? true : false
-  rescue
-    true
+    fee&.claim&.agfs? ? true : false
   end
 end

--- a/app/rake_helpers/document_recloner.rb
+++ b/app/rake_helpers/document_recloner.rb
@@ -55,7 +55,7 @@ class DocumentRecloner
   def is_corrupted?(doc)
     begin
       downloaded_file = Paperclip.io_adapters.for(doc.document).path
-    rescue
+    rescue StandardError
       return true
     end
     File.stat(downloaded_file).size.zero?

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -80,8 +80,8 @@ module Claims
           update_assessment if @assessment_params_present
           add_redetermination if @redetermination_params_present
           @claim.send(event, audit_attributes.merge(reason_code: @transition_reason)) unless @state.blank? || @state == @claim.state
-        rescue => ex
-          add_error ex.message
+        rescue StandardError => err
+          add_error err.message
           raise ActiveRecord::Rollback
         end
       end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -235,7 +235,7 @@ class Claim::BaseClaimValidator < BaseValidator
     if method.to_s.match?(/^requires_(re){0,1}trial_dates\?/)
       begin
         @record.case_type.__send__(method)
-      rescue
+      rescue NoMethodError
         false
       end
     else
@@ -280,9 +280,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def cracked_case?
-    @record.case_type.name.match(/[Cc]racked/)
-  rescue
-    false
+    @record&.case_type&.name&.match?(/[Cc]racked/)
   end
 
   def has_fees_or_expenses_attributes?
@@ -291,9 +289,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def fixed_fee_case?
-    @record.case_type.is_fixed_fee?
-  rescue
-    false
+    @record&.case_type&.is_fixed_fee?
   end
 
   def snake_case_type

--- a/app/validators/claim/litigator_common_validations.rb
+++ b/app/validators/claim/litigator_common_validations.rb
@@ -56,7 +56,7 @@ module Claim
 
     def provider_supplier_numbers
       @record.provider.lgfs_supplier_numbers.pluck(:supplier_number)
-    rescue
+    rescue StandardError
       []
     end
   end

--- a/app/validators/claim/litigator_supplier_number_validations.rb
+++ b/app/validators/claim/litigator_supplier_number_validations.rb
@@ -27,7 +27,7 @@ module Claim
 
     def provider_supplier_numbers
       @record.provider.lgfs_supplier_numbers.pluck(:supplier_number)
-    rescue
+    rescue StandardError
       []
     end
   end

--- a/app/validators/disbursement_validator.rb
+++ b/app/validators/disbursement_validator.rb
@@ -15,11 +15,7 @@ class DisbursementValidator < BaseValidator
 
   def validate_claim
     validate_presence(:claim, 'blank')
-    add_error(:claim, 'invalid_fee_scheme') if begin
-                                                  @record.claim.agfs?
-                                                rescue
-                                                  false
-                                                end
+    add_error(:claim, 'invalid_fee_scheme') if @record&.claim&.agfs?
   end
 
   def validate_disbursement_type

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -179,7 +179,7 @@ module Fee
     # This is required for retrial claims created prior to retrial fields being added.
     def daf_retrial_combo_ignorable
       @record.claim.case_type.requires_retrial_dates? && !@record.claim.editable?
-    rescue
+    rescue StandardError
       false
     end
   end

--- a/scheduled_tasks/daily_stats_generator.rb
+++ b/scheduled_tasks/daily_stats_generator.rb
@@ -11,7 +11,7 @@ class DailyStatsGenerator < Scheduler::SchedulerTask
       log("Starting #{klass}")
       begin
         klass.new(date).collect
-      rescue => err
+      rescue StandardError => err
         log("ERROR: #{err.class} #{err.message}")
       end
     end

--- a/scheduled_tasks/document_cleaner_task.rb
+++ b/scheduled_tasks/document_cleaner_task.rb
@@ -7,7 +7,7 @@ class DocumentCleanerTask < Scheduler::SchedulerTask
   def run
     log('Document Cleaner started')
     DocumentCleaner.new.clean!
-  rescue => ex
+  rescue StandardError => ex
     log('There was an error: ' + ex.message)
   ensure
     log('Document Cleaner finished')

--- a/scheduled_tasks/geckoboard_provider_task.rb
+++ b/scheduled_tasks/geckoboard_provider_task.rb
@@ -7,7 +7,7 @@ class GeckoboardProviderTask < Scheduler::SchedulerTask
   def run
     log('Geckoboard Provider data generated')
     GeckoboardPublisher::ProvidersReport.new.publish!
-  rescue => ex
+  rescue StandardError => ex
     log('There was an error: ' + ex.message)
   ensure
     log('Geckoboard Provider task finished')

--- a/scheduled_tasks/management_information_generation_task.rb
+++ b/scheduled_tasks/management_information_generation_task.rb
@@ -7,8 +7,8 @@ class ManagementInformationGenerationTask < Scheduler::SchedulerTask
   def run
     log('Management Information Generation started')
     Stats::ManagementInformationGenerator.new.run
-  rescue => ex
-    log('There was an error: ' + ex.message)
+  rescue StandardError => err
+    log('There was an error: ' + err.message)
   ensure
     log('Management Information Generation finished')
   end

--- a/spec/models/claim/transfer_brain_data_item_spec.rb
+++ b/spec/models/claim/transfer_brain_data_item_spec.rb
@@ -37,10 +37,9 @@ module Claim
 
     context 'invalid initialization array' do
       it 'raises' do
-        expect_any_instance_of(IO).to receive(:puts).at_least(1)
         expect {
           TransferBrainDataItem.new(['xxx', 'xxx'])
-        }.to raise_error RuntimeError, 'Boom'
+        }.to raise_error ArgumentError
       end
     end
 


### PR DESCRIPTION
Replace unspecific rescues with either a more specific error to rescue or alternative to a rescue, such as using a safe operator `&.`

***Note:*** where StandardError is rescued this is an explicit rescue of what is actually the default (when no named error class is rescued) so **just** fixes the violation. Where replacements
of the rescue have been written with a safe operator or specific error we may end up getting sentry errors which we can then iterate on.
