### PR TITLE
Require and validate defendant DoB for all case types

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/CaseTypeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/CaseTypeFieldsDisplay.js
@@ -26,7 +26,6 @@ moj.Modules.CaseTypeFieldsDisplay = {
     } else {
       this.$trialFieldSet.hide();
       this.$retrialFieldSet.hide();
-      this.$defendantFieldSet.removeClass('hide-dob');
     }
   }
 };

--- a/app/assets/stylesheets/moj/_forms.scss
+++ b/app/assets/stylesheets/moj/_forms.scss
@@ -502,13 +502,6 @@ label.form-date-spacing {
   }
 }
 
-// This is needed for javascript in views/case_types/show.js.erb
-.defendants.hide-dob {
-  div.dob {
-    display: none;
-  }
-}
-
 // To ensure date fields are wide enough
 .form-date input[type=number] {
   width: 100%;

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -52,9 +52,4 @@ class CaseType < ActiveRecord::Base
   def is_graduated_fee?
     graduated_fee_type.nil? ? false : true
   end
-
-  # We do not need the D.O.B of the defendant to be requested for case type "Breach of Crown Court order"
-  def requires_defendant_dob?
-    fee_type_code != 'FXCBR'
-  end
 end

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -44,10 +44,6 @@ class Defendant < ActiveRecord::Base
   end
 
   def validate_date?
-    perform_validation? && case_type_requires_date?
-  end
-
-  def case_type_requires_date?
-    claim&.case_type&.requires_defendant_dob?
+    perform_validation? && claim&.case_type.present?
   end
 end

--- a/app/validators/defendant_validator.rb
+++ b/app/validators/defendant_validator.rb
@@ -19,7 +19,6 @@ class DefendantValidator < BaseValidator
   end
 
   def validate_date_of_birth
-    return unless requires_dob?
     validate_presence(:date_of_birth, 'blank')
     validate_on_or_before(10.years.ago, :date_of_birth, 'check')
     validate_on_or_after(120.years.ago, :date_of_birth, 'check')
@@ -40,11 +39,5 @@ class DefendantValidator < BaseValidator
   def validate_last_name
     validate_presence(:last_name, 'blank')
     validate_max_length(:last_name, 40, 'max_length')
-  end
-
-  # local helpers
-  #
-  def requires_dob?
-    @record.claim&.case_type&.requires_defendant_dob?
   end
 end

--- a/app/views/case_types/show.js.erb
+++ b/app/views/case_types/show.js.erb
@@ -9,9 +9,3 @@
 <% else %>
   $('#retrial-details').hide();
 <% end %>
-
-<% if @case_type.requires_defendant_dob? %>
-  $('div.defendants').removeClass('hide-dob');
-<% else %>
-  $('div.defendants').addClass('hide-dob');
-<% end %>

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe Defendant, type: :model do
       expect(defendant).to receive(:perform_validation?).and_return(true)
     end
 
-    
     it 'should return false if there is no associated claim' do
       defendant.claim = nil
       expect(defendant.validate_date?).to be_falsey
@@ -64,13 +63,7 @@ RSpec.describe Defendant, type: :model do
       expect(defendant.validate_date?).to be_falsey
     end
 
-    it 'should return false if there is a claim with a case type that does not require a date of birth' do
-      expect(defendant.claim.case_type).to receive(:requires_defendant_dob?).and_return false
-      expect(defendant.validate_date?).to be_falsey
-    end
-
-    it 'should return true if there is a claim with a case type that requires a date of birth' do
-      expect(defendant.claim.case_type).to receive(:requires_defendant_dob?).and_return true
+    it 'should return true if there is a claim with any case type' do
       expect(defendant.validate_date?).to be true
     end
   end

--- a/spec/validators/defendant_validator_spec.rb
+++ b/spec/validators/defendant_validator_spec.rb
@@ -7,7 +7,6 @@ describe DefendantValidator do
 
   let(:claim)     { FactoryGirl.build(:claim, force_validation: true) }
   let(:defendant) { FactoryGirl.build :defendant, claim: claim }
-  let(:case_type) { FactoryGirl.build(:case_type, :cbr) }
 
   describe '#validate_claim' do
     it { should_error_if_not_present(defendant, :claim, 'blank') }
@@ -24,20 +23,9 @@ describe DefendantValidator do
   end
 
   describe '#validate_date_of_birth' do
-    context 'for case type requiring DOB' do
-      it { should_error_if_not_present(defendant, :date_of_birth, 'blank') }
-      it { should_error_if_before_specified_date(defendant, :date_of_birth, 120.years.ago, 'check') }
-      it { should_error_if_after_specified_date(defendant, :date_of_birth, 10.years.ago, 'check') }
-    end
-
-    context 'for case type not requiring DOB' do
-      before do
-        allow(claim).to receive(:case_type).and_return(case_type)
-        defendant.date_of_birth = nil
-      end
-
-      it { should_not_error(defendant, :date_of_birth) }
-    end
+    it { should_error_if_not_present(defendant, :date_of_birth, 'blank') }
+    it { should_error_if_before_specified_date(defendant, :date_of_birth, 120.years.ago, 'check') }
+    it { should_error_if_after_specified_date(defendant, :date_of_birth, 10.years.ago, 'check') }
   end
 
   describe '#validate_representation_orders' do


### PR DESCRIPTION
**What**
Enforces Defendant DoB requirements for all case types.

**Why**
Previously defendant DoB was not required (and field hidden) for 
Breach of crown court order case types (Fixed fees). This is the
opposite of what CCR requires where a DoB is required for these
types of case specifically because the defendant will/may not 
have a rep order MAAT reference for such cases.