### PR TITLE
Remove unnecessary blanking of MAAT reference

### DIFF
--- a/app/models/representation_order.rb
+++ b/app/models/representation_order.rb
@@ -18,11 +18,6 @@ class RepresentationOrder < ActiveRecord::Base
 
   before_save :upcase_maat_ref
 
-  before_validation do
-    case_type = defendant&.claim&.case_type
-    self.maat_reference = nil if case_type&.requires_maat_reference?.eql?(false)
-  end
-
   acts_as_gov_uk_date :representation_order_date, validate_if: :perform_validation?, error_clash_behaviour: :override_with_gov_uk_date_field_error
 
   default_scope { order('id ASC') }

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -28,9 +28,8 @@ class RepresentationOrderValidator < BaseValidator
   # must be exactly 7 - 10 numeric digits
   def validate_maat_reference
     case_type = claim.try(:case_type)
-    return unless case_type&.requires_maat_reference?
-    validate_presence(:maat_reference, 'invalid')
-    validate_pattern(:maat_reference, /^[0-9]{7,10}$/, 'invalid')
+    validate_presence(:maat_reference, 'invalid') if case_type&.requires_maat_reference?
+    validate_pattern(:maat_reference, /^[0-9]{7,10}$/, 'invalid') if @record.maat_reference.present?
   end
 
   # helper methods

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -80,6 +80,7 @@ describe API::V1::ExternalUsers::RepresentationOrder do
           before { claim.case_type.update_column(:requires_maat_reference, false) }
 
           it 'creates a new representation_order record with all provided attributes' do
+            valid_params.delete(:maat_reference)
             post_to_create_endpoint
             new_representation_order = RepresentationOrder.last
             expect(new_representation_order.defendant_id).to eq defendant.id


### PR DESCRIPTION
Breach of crown courts orders do not require
a MAAT ref. because they are quickly heard cases
that may/will not have received one. However,
unless we are enforcing the absence it seems
pointless to get rid of any provided MAAT
ref.