### PR TITLE
Replace hotfix with transition based validation disabling

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -349,7 +349,7 @@ module Claim
       force_validation? || validation_required?
     end
 
-    # we must validate
+    # validation required when
     # being created from api (as draft)
     # or is in state of archived_pending_delete or draft (not from api)
     # or is in a state deleted (old statement????)
@@ -360,13 +360,10 @@ module Claim
       return false if draft? || archived_pending_delete?
       return false if disabled_for_transition?
       true
-
-      # from_api? ||
-      # !(draft? || archived_pending_delete?)
     end
 
     def disabled_for_transition?
-      disable_for_state_transition.eql?(:all)
+      disable_for_state_transition.present?
     end
 
     def step?(num)

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -349,9 +349,24 @@ module Claim
       force_validation? || validation_required?
     end
 
-    # we must validate unless it is being created as draft from any source except API or is in state of archive_pending_delete or deleted
+    # we must validate
+    # being created from api (as draft)
+    # or is in state of archived_pending_delete or draft (not from api)
+    # or is in a state deleted (old statement????)
+    # or is transitioning via certain events
+    #
     def validation_required?
-      from_api? || !(draft? || archived_pending_delete?)
+      return true if from_api?
+      return false if draft? || archived_pending_delete?
+      return false if disabled_for_transition?
+      true
+
+      # from_api? ||
+      # !(draft? || archived_pending_delete?)
+    end
+
+    def disabled_for_transition?
+      disable_for_state_transition.eql?(:all)
     end
 
     def step?(num)

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -357,8 +357,7 @@ module Claim
     #
     def validation_required?
       return true if from_api?
-      return false if draft? || archived_pending_delete?
-      return false if disabled_for_transition?
+      return false if draft? || archived_pending_delete? || disabled_for_transition?
       true
     end
 

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -79,7 +79,7 @@ module Claims
         before_transition on: %i[reject refuse], do: :set_amount_assessed_zero!
 
         around_transition any => NON_VALIDATION_STATES.map(&:to_sym) do |claim, transition, block|
-          validation_state = %i[authorise part_authorise].include?(transition.event) ? :only_amount_assessed : :all
+          validation_state = %i[authorise authorise_part].include?(transition.event) ? :only_amount_assessed : :all
           claim.disable_for_state_transition = validation_state
           block.call
           claim.disable_for_state_transition = nil

--- a/app/models/date_attended.rb
+++ b/app/models/date_attended.rb
@@ -26,7 +26,7 @@ class DateAttended < ActiveRecord::Base
   end
 
   def perform_validation?
-    claim.try(:perform_validation?)
+    claim&.perform_validation?
   end
 
   def earliest_date_before_reporder

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -112,7 +112,7 @@ module Fee
     # because once created they cannot be amended on the web UI.
     #
     def perform_validation?
-      claim && (claim.perform_validation? || claim.from_json_import?)
+      claim&.perform_validation? || claim&.from_json_import?
     end
 
     def calculated?

--- a/app/models/representation_order.rb
+++ b/app/models/representation_order.rb
@@ -43,7 +43,7 @@ class RepresentationOrder < ActiveRecord::Base
   end
 
   def perform_validation?
-    claim.try(:perform_validation?)
+    claim&.perform_validation?
   end
 
   def reporders_for_same_defendant

--- a/app/validators/defendant_validator.rb
+++ b/app/validators/defendant_validator.rb
@@ -14,18 +14,11 @@ class DefendantValidator < BaseValidator
 
   private
 
-  delegate :claim, to: :@record
-
   def validate_claim
     validate_presence(:claim, 'blank')
   end
 
   def validate_date_of_birth
-    # FIXME: hotfix to prevent breach claims with no dob from being allocated etc
-    # rubocop:disable Layout/MultilineOperationIndentation
-    return if !claim&.case_type&.requires_maat_reference? &&
-      (claim.created_at.present? ? claim.created_at <= Date.parse('03-11-2017') : false)
-    # rubocop:enable Layout/MultilineOperationIndentation
     validate_presence(:date_of_birth, 'blank')
     validate_on_or_before(10.years.ago, :date_of_birth, 'check')
     validate_on_or_after(120.years.ago, :date_of_birth, 'check')

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'custom_matchers'
 
 RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, focus: true do
 

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'custom_matchers'
 
 RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus: true do
   let(:certification_type) { create(:certification_type) }

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'custom_matchers'
 
 RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true do
 

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'custom_matchers'
 
 RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, focus: true do
 

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'custom_matchers'
 
 RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :controller, focus: true do
 

--- a/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'custom_matchers'
 
 RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :controller, focus: true do
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -62,7 +62,6 @@
 #
 
 require 'rails_helper'
-require 'custom_matchers'
 
 RSpec.describe Claim::AdvocateClaim, type: :model do
 

--- a/spec/models/claim/interim_claim_spec.rb
+++ b/spec/models/claim/interim_claim_spec.rb
@@ -61,7 +61,6 @@
 #
 
 require 'rails_helper'
-require 'custom_matchers'
 require_relative 'shared_examples_for_lgfs_claim'
 
 RSpec.describe Claim::InterimClaim, type: :model do

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -61,7 +61,6 @@
 #
 
 require 'rails_helper'
-require 'custom_matchers'
 require_relative 'shared_examples_for_lgfs_claim'
 
 RSpec.describe Claim::LitigatorClaim, type: :model do

--- a/spec/models/claim/transfer_claim_spec.rb
+++ b/spec/models/claim/transfer_claim_spec.rb
@@ -61,7 +61,6 @@
 #
 
 require "rails_helper"
-require "custom_matchers"
 require_relative 'shared_examples_for_lgfs_claim'
 
 describe Claim::TransferClaim, type: :model do

--- a/spec/support/matchers/custom_matchers.rb
+++ b/spec/support/matchers/custom_matchers.rb
@@ -13,9 +13,7 @@ RSpec::Matchers.define :contain_claims do |*expected|
   failure_message do |actual|
     "expected that records:\n\t #{actual.inspect} \n\nwould be equal to records\n\t #{expected.inspect}"
   end
-
 end
-
 
 RSpec::Matchers.define :be_within_seconds_of do |expected_date, leeway|
   match do |actual|

--- a/spec/support/matchers/general_matchers.rb
+++ b/spec/support/matchers/general_matchers.rb
@@ -1,5 +1,4 @@
 require 'rspec/expectations'
-require 'byebug'
 
 RSpec::Matchers.define :have_constant do |expected|
   expected.assert_valid_keys :name, :value

--- a/spec/support/matchers/raise_error_matchers.rb
+++ b/spec/support/matchers/raise_error_matchers.rb
@@ -1,0 +1,25 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :raise_only_amount_assessed_error do
+  match do |actual|
+    begin
+      actual.call
+      false
+    rescue StateMachines::InvalidTransition => err
+      @error_message = err.message
+      err.message.match?(/\(Reason\(s\)\: Amount assessed Amount assessed cannot be zero for claims in state .*\)/)
+    end
+  end
+
+  def supports_block_expectations?
+    true
+  end
+
+  failure_message do |actual|
+    "expected calling state transition to only raise an amount assessed error but got #{@error_message.nil? ? 'no error!' : "\"#{@error_message}\""}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected calling state transition to only raise an amount assessed error but got #{@error_message.nil? ? 'no error!' : "\"#{@error_message}\""}"
+  end
+end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -44,19 +44,12 @@ describe Claim::BaseClaimValidator do
           expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*court/i
         end
 
-        it 'validation is performed on sub models' do
+        it 'validation is performed on defendants sub model' do
           expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*defendant.*first name.*/i
         end
 
-        it 'validation is performed on sub-sub-models' do
+        it 'validation is performed on representation_orders sub-sub-model' do
           expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*representation order.*maat reference.*/i
-        end
-
-        # TODO: not working
-        xit 'validation is performed on aggregated values' do
-          # allow(invalid_claim).to receive(:total).and_return(0.0)
-          invalid_claim.update_attribute(:total, 0.0)
-          expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*total.*/i
         end
       end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -25,69 +25,196 @@ describe Claim::BaseClaimValidator do
     expect(claim.valid?).to be true
   end
 
-  context '#perform_validation?' do
-    let(:claim_with_nil_values) do
-      nulify_fields_on_record(claim,:case_type, :court, :case_number, :advocate_category, :offence, :estimated_trial_length, :actual_trial_length)
-      claim.defendants.destroy_all
+  context 'transition state dependant validation' do
+    let(:invalid_claim) do
+      nulify_fields_on_record(claim, :court)
       claim.fees.destroy_all
       claim.expenses.destroy_all
       claim
     end
 
-    context 'when claim is draft' do
-      context 'and validation is forced' do
+    context 'when claim is in draft state' do
+      context 'during submission' do
+        before do
+          invalid_claim.defendants.first.update_attribute(:first_name, nil)
+          invalid_claim.defendants.first.representation_orders.first.update_attribute(:maat_reference, nil)
+        end
 
-        before { claim_with_nil_values.force_validation=true }
+        it 'validation is performed on claim' do
+          expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*court/i
+        end
 
-        it 'should validate presence of case_type, court, case_number, advocate_category, offence' do
-          expect(claim_with_nil_values).to_not be_valid
+        it 'validation is performed on sub models' do
+          expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*defendant.*first name.*/i
+        end
+
+        it 'validation is performed on sub-sub-models' do
+          expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*representation order.*maat reference.*/i
+        end
+
+        # TODO: not working
+        xit 'validation is performed on aggregated values' do
+          # allow(invalid_claim).to receive(:total).and_return(0.0)
+          invalid_claim.update_attribute(:total, 0.0)
+          expect { invalid_claim.submit! }.to raise_error StateMachines::InvalidTransition, /reason.*total.*/i
         end
       end
 
-      context 'and validation is NOT forced' do
+      context 'when saving as draft' do
+        context '...and validation is forced' do
+          before { invalid_claim.force_validation = true }
 
-        before { claim_with_nil_values.force_validation=false }
-
-        context 'and it is coming from the api' do
-          before { claim_with_nil_values.source = 'api' }
-          it 'should validate presence of case_type, court, case_number, advocate_category, offence' do
-            expect(claim_with_nil_values).to_not be_valid
+          it 'validation is performed' do
+            expect(invalid_claim).to_not be_valid
           end
         end
 
-        context 'and it is coming from the web app' do
-          before { claim_with_nil_values.source = 'web' }
-          it 'should NOT validate presence of case_type, court, case_number, advocate_category, offence' do
-            expect(claim_with_nil_values).to be_valid
+        context '...and validation is NOT forced' do
+          before { invalid_claim.force_validation = false }
+
+          context '...and it is coming from the api' do
+            before { invalid_claim.source = 'api' }
+
+            it 'validation is performed' do
+              expect(invalid_claim).to_not be_valid
+            end
+          end
+
+          context '...and it is coming from the web app' do
+            before { invalid_claim.source = 'web' }
+
+            it 'validation is NOT performed' do
+              expect(invalid_claim).to be_valid
+            end
           end
         end
-
       end
     end
 
-    context 'when claim is NOT draft' do
+    context 'when claim is in archived_pending_delete state' do
+      let(:claim) { create(:archived_pending_delete_claim) }
 
-      before(:each) do
-        claim.force_validation=false
+      before do
+        nulify_fields_on_record(claim, :case_type, :court, :case_number, :advocate_category, :offence, :estimated_trial_length, :actual_trial_length)
+        claim.force_validation = false
       end
 
-      context 'a submitted claim' do
-        before { claim.submit! }
+      it 'validation is NOT performed' do
+        expect(claim).to be_valid
+      end
+    end
 
-        it 'should error on any state-conditional validations (non-exhaustive test)' do
-          nulify_fields_on_record(claim,:case_type, :court, :case_number, :advocate_category, :offence, :estimated_trial_length, :actual_trial_length)
-          expect(claim).to_not be_valid
+    context 'when claim is in submitted state' do
+      before do
+        claim.submit!
+        claim.force_validation = false
+        nulify_fields_on_record(claim, :case_type, :court, :case_number, :advocate_category, :offence, :estimated_trial_length, :actual_trial_length)
+        claim.defendants.destroy_all
+        claim.fees.destroy_all
+        claim.expenses.destroy_all
+      end
+
+      it 'validation is performed' do
+        expect(claim).to_not be_valid
+      end
+
+      context 'during allocation' do
+        it 'validation is NOT performed' do
+          expect { claim.allocate! }.to_not raise_error
         end
       end
 
-      context 'an archived_pending_delete claim' do
-        let(:claim) { create(:archived_pending_delete_claim) }
-
-        it 'should NOT validate presence of case_type, court, case_number, advocate_category, offence' do
-          nulify_fields_on_record(claim,:case_type, :court, :case_number, :advocate_category, :offence, :estimated_trial_length, :actual_trial_length)
-          expect(claim).to be_valid
+      RSpec::Matchers.define :raise_only_amount_assessed_error do
+        match do |actual|
+          begin
+            actual.call
+            false
+          rescue StateMachines::InvalidTransition => err
+            @error_message = err.message
+            err.message.match?(/\(Reason\(s\)\: Amount assessed Amount assessed cannot be zero for claims in state .*\)/)
+          end
         end
 
+        def supports_block_expectations?
+          true
+        end
+
+        failure_message do |actual|
+          "expected calling state transition to only raise an amount assessed error but got #{@error_message.nil? ? 'no error!' : "\"#{@error_message}\""}"
+        end
+
+        failure_message_when_negated do |actual|
+          "expected calling state transition to only raise an amount assessed error but got #{@error_message.nil? ? 'no error!' : "\"#{@error_message}\""}"
+        end
+      end
+
+      context 'during authorisation' do
+        before { claim.allocate! }
+
+        context 'when assessment included' do
+          it 'raises no errors' do
+            claim.update_amount_assessed(fees: 100.00)
+            expect { claim.authorise! }.to_not raise_only_amount_assessed_error
+          end
+        end
+
+        context 'when assessment NOT included' do
+          it 'raises only amount assessed errors' do
+            expect { claim.authorise! }.to raise_only_amount_assessed_error
+          end
+        end
+      end
+
+      context 'during part authorisation' do
+        before { claim.allocate! }
+
+        context 'when assessment included' do
+          it 'raises no errors' do
+            claim.update_amount_assessed(fees: 100.00)
+            expect { claim.authorise_part! }.to_not raise_only_amount_assessed_error
+          end
+        end
+
+        context 'when assessment NOT included' do
+          it 'raises only amount assessed errors' do
+            expect { claim.authorise_part! }.to raise_only_amount_assessed_error
+          end
+        end
+      end
+
+      context 'during redetermination' do
+        before { claim.allocate!; claim.reject! }
+        it 'validation is NOT performed' do
+          expect { claim.redetermine! }.to_not raise_error
+        end
+      end
+
+      context 'during awaiting_written_reasons' do
+        before { claim.allocate!; claim.reject! }
+        it 'validation is NOT performed' do
+          expect { claim.await_written_reasons! }.to_not raise_error
+        end
+      end
+
+      context 'during refusal' do
+        before { claim.allocate! }
+        it 'validation is NOT performed' do
+          expect { claim.refuse! }.to_not raise_error
+        end
+      end
+
+      context 'during rejection' do
+        before { claim.allocate! }
+        it 'validation is NOT performed' do
+          expect { claim.reject! }.to_not raise_error
+        end
+      end
+
+      context 'during deallocation' do
+        before { claim.allocate! }
+        it 'validation is NOT performed' do
+          expect { claim.deallocate! }.to_not raise_error
+        end
       end
     end
   end
@@ -297,7 +424,7 @@ describe Claim::BaseClaimValidator do
 
     it 'should error if NO assessment present and state is transitioned to authorised or part_authorised' do
       expect{ claim.authorise! }.to raise_error(StateMachines::InvalidTransition)
-      expect{ claim.part_authorise! }.to raise_error(NoMethodError)
+      expect{ claim.authorise_part! }.to raise_error(StateMachines::InvalidTransition)
     end
 
     it 'should error if authorised claim has assessment zeroized' do

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -117,30 +117,6 @@ describe Claim::BaseClaimValidator do
         end
       end
 
-      RSpec::Matchers.define :raise_only_amount_assessed_error do
-        match do |actual|
-          begin
-            actual.call
-            false
-          rescue StateMachines::InvalidTransition => err
-            @error_message = err.message
-            err.message.match?(/\(Reason\(s\)\: Amount assessed Amount assessed cannot be zero for claims in state .*\)/)
-          end
-        end
-
-        def supports_block_expectations?
-          true
-        end
-
-        failure_message do |actual|
-          "expected calling state transition to only raise an amount assessed error but got #{@error_message.nil? ? 'no error!' : "\"#{@error_message}\""}"
-        end
-
-        failure_message_when_negated do |actual|
-          "expected calling state transition to only raise an amount assessed error but got #{@error_message.nil? ? 'no error!' : "\"#{@error_message}\""}"
-        end
-      end
-
       context 'during authorisation' do
         before { claim.allocate! }
 


### PR DESCRIPTION
**What**
Prevent validating of claim components during transitions
which should not be affected by them.

**Why**
With the implementation of new validations
existing submitted claims may suddenly become
invalid thereby preventing case workers from
processing them - and advocates/litigators
cannot amend by this stage.

