### PR TITLE
disallow external_users messaging on a rejected claim

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -3,7 +3,6 @@ module ClaimsHelper
     submitted
     allocated
     part_authorised
-    rejected
     refused
     authorised
     redetermination

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -125,7 +125,7 @@ describe ClaimsHelper do
     context 'for external_user' do
       let(:persona) { create :external_user }
 
-      %w[submitted allocated part_authorised refused rejected authorised redetermination awaiting_written_reasons].each do |state|
+      %w[submitted allocated part_authorised refused authorised redetermination awaiting_written_reasons].each do |state|
         context "when claim state is #{state}" do
           let(:state) { state }
 
@@ -133,7 +133,7 @@ describe ClaimsHelper do
         end
       end
 
-      %w[draft archived_pending_delete].each do |state|
+      %w[draft rejected archived_pending_delete].each do |state|
         context "when claim state is #{state}" do
           let(:state) { state }
 


### PR DESCRIPTION
Why?
As per ticket #152604192, do not allow external_users to send messages
or apply for redetermination