### PR TITLE
Log CCR imports

### DIFF
--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -21,7 +21,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
     @claim.build_certification(certification_params)
     if @claim.certification.save && claim_updater.submit
       begin
-        MessageQueue::AwsClient.new(MessageQueue::MessageTemplate.claim_created(@claim.type, @claim.uuid), Settings.aws.queue).send_message!
+        MessageQueue::AwsClient.new(Settings.aws.submitted_queue).send!(MessageQueue::MessageTemplate.claim_created(@claim.type, @claim.uuid))
         Rails.logger.info "Successfully sent message about submission of claim##{@claim.id}(#{@claim.uuid})"
       rescue StandardError => err
         Rails.logger.warn "Error: '#{err.message}' while sending message about submission of claim##{@claim.id}(#{@claim.uuid})"

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -134,6 +134,7 @@ module Claim
     has_many :determinations, foreign_key: :claim_id, dependent: :destroy
     has_one  :assessment, foreign_key: :claim_id
     has_many :redeterminations, foreign_key: :claim_id
+    has_many :injection_attempts, foreign_key: :claim_id
 
     has_one  :certification, foreign_key: :claim_id, dependent: :destroy
 

--- a/app/models/injection_attempt.rb
+++ b/app/models/injection_attempt.rb
@@ -1,0 +1,5 @@
+class InjectionAttempt < ActiveRecord::Base
+  belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
+
+  validates :claim, presence: true
+end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -1,0 +1,49 @@
+class InjectionResponseService
+  def initialize(json)
+    @response = json.stringify_keys
+    raise ParseError, 'Invalid JSON string' unless @response.keys.eql?(%w[errors uuid messages])
+  end
+
+  def run!
+    claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
+    if claim.nil?
+      failure_message = "Failed to inject '#{@response['uuid']}' because no claim found"
+      LogStuff.send(:info, 'InjectionResponseService::NonExistentClaim',
+                    action: 'run!',
+                    uuid: @response['uuid']) { failure_message }
+      update_slack(failure_message)
+      return false
+    end
+    ia = InjectionAttempt.create(claim: claim, succeeded: ccr_injected?, error_message: error_message)
+    update_slack(generate_message(ccr_injected?, claim))
+    ia.save
+  end
+
+  private
+
+  def generate_message(success, claim)
+    if success
+      "Claim #{claim.case_number} successfully injected"
+    else
+      "Claim #{claim.case_number} could not be injected because #{error_message}"
+    end
+  end
+
+  def update_slack(message)
+    payload = {
+      channel: Settings.slack.channel,
+      username: Settings.slack.bot_name,
+      text: message,
+      icon_emoji: Settings.slack.icon
+    }.to_json
+    RestClient.post(Settings.slack.bot_url, payload, content_type: :json)
+  end
+
+  def ccr_injected?
+    @response['errors'].empty?
+  end
+
+  def error_message
+    @response['errors'].join(' ')
+  end
+end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -7,7 +7,7 @@ class InjectionResponseService
   def run!
     claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
     if claim.nil?
-      failure_message = "Failed to inject '#{@response['uuid']}' because no claim found"
+      failure_message = 'Failed to inject because no claim found'
       LogStuff.send(:info, 'InjectionResponseService::NonExistentClaim',
                     action: 'run!',
                     uuid: @response['uuid']) { failure_message }
@@ -33,7 +33,7 @@ class InjectionResponseService
     payload = {
       channel: Settings.slack.channel,
       username: Settings.slack.bot_name,
-      text: message,
+      text: "#{message} {#{@response['uuid']}}",
       icon_emoji: Settings.slack.icon
     }.to_json
     RestClient.post(Settings.slack.bot_url, payload, content_type: :json)

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -6,70 +6,24 @@ class InjectionResponseService
   end
 
   def run!
+    slack = SlackNotifier.new
+    slack.build_injection_payload(@response)
     if @claim.nil?
       LogStuff.send(:info, 'InjectionResponseService::NonExistentClaim',
                     action: 'run!',
-                    uuid: @response['uuid']) { generate_message }
-      update_slack
+                    uuid: @response['uuid']) { 'Failed to inject because no claim found' }
+      slack.send_message!
       return false
     end
     ia = InjectionAttempt.create(claim: @claim, succeeded: ccr_injected?, error_message: error_message)
-    update_slack
+    slack.send_message!
     ia.save
   end
 
   private
 
-  def generate_message
-    if @claim.nil?
-      'Failed to inject because no claim found'
-    elsif ccr_injected?
-      "Claim #{@claim.case_number} successfully injected"
-    else
-      "Claim #{@claim.case_number} could not be injected"
-    end
-  end
-
-  def update_slack
-    payload = {
-      channel: Settings.slack.channel,
-      username: Settings.slack.bot_name,
-      icon_emoji: ccr_injected? ? Settings.slack.success_icon : Settings.slack.fail_icon,
-      attachments: [
-        {
-          'fallback': "#{generate_message} {#{@response['uuid']}}",
-          'color': ccr_injected? ? '#36a64f' : '#c41f1f',
-          'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}",
-          'text': @response['uuid'],
-          'fields': fields
-        }
-      ]
-    }.to_json
-    RestClient.post(Settings.slack.bot_url, payload, content_type: :json)
-  end
-
-  def fields
-    fields = [
-      { 'title': 'Claim number', 'value': @claim&.case_number, 'short': true },
-      { 'title': 'environment', 'value': ENV['ENV'], 'short': true }
-    ]
-    errors = has_no_errors? ? [] : error_fields
-    fields + errors
-  end
-
-  def error_fields
-    errors = @response['errors'].map { |x| x['error'] }.join('\n')
-    [
-      { 'title': 'Errors', 'value': errors }
-    ]
-  end
-
-  def has_no_errors?
-    @response['errors'].empty?
-  end
-
   def ccr_injected?
-    has_no_errors? && @claim.present?
+    @response['errors'].empty? && @claim.present?
   end
 
   def error_message

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -1,7 +1,7 @@
 class InjectionResponseService
   def initialize(json)
     @response = json.stringify_keys
-    raise ParseError, 'Invalid JSON string' unless @response.keys.eql?(%w[errors uuid messages])
+    raise ParseError, 'Invalid JSON string' unless @response.keys.sort.eql?(%w[errors messages uuid])
   end
 
   def run!

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -5,8 +5,8 @@ class InjectionResponseService
   end
 
   def run!
-    claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
-    if claim.nil?
+    @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
+    if @claim.nil?
       failure_message = 'Failed to inject because no claim found'
       LogStuff.send(:info, 'InjectionResponseService::NonExistentClaim',
                     action: 'run!',
@@ -14,18 +14,18 @@ class InjectionResponseService
       update_slack(failure_message)
       return false
     end
-    ia = InjectionAttempt.create(claim: claim, succeeded: ccr_injected?, error_message: error_message)
-    update_slack(generate_message(ccr_injected?, claim))
+    ia = InjectionAttempt.create(claim: @claim, succeeded: ccr_injected?, error_message: error_message)
+    update_slack(generate_message)
     ia.save
   end
 
   private
 
-  def generate_message(success, claim)
-    if success
-      "Claim #{claim.case_number} successfully injected"
+  def generate_message
+    if ccr_injected?
+      "Claim #{@claim.case_number} successfully injected"
     else
-      "Claim #{claim.case_number} could not be injected because #{error_message}"
+      "Claim #{@claim.case_number} could not be injected"
     end
   end
 
@@ -33,14 +33,42 @@ class InjectionResponseService
     payload = {
       channel: Settings.slack.channel,
       username: Settings.slack.bot_name,
-      text: "#{message} {#{@response['uuid']}}",
-      icon_emoji: Settings.slack.icon
+      icon_emoji: Settings.slack.icon,
+      attachments: [
+        {
+          'fallback': "#{message} {#{@response['uuid']}}",
+          'color': ccr_injected? ? '#36a64f' : '#c41f1f',
+          'title': 'UUID',
+          'text': @response['uuid'],
+          'fields': fields(message)
+        }
+      ]
     }.to_json
     RestClient.post(Settings.slack.bot_url, payload, content_type: :json)
   end
 
-  def ccr_injected?
+  def fields(message)
+    fields = [
+      { 'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}", 'value': message, 'short': true },
+      { 'title': 'environment', 'value': ENV['ENV'], 'short': true }
+    ]
+    errors = has_no_errors? ? [] : error_fields
+    fields + errors
+  end
+
+  def error_fields
+    errors = @response['errors'].map { |x| x['error'] }.join('\n')
+    [
+      { 'title': 'Errors', 'value': errors }
+    ]
+  end
+
+  def has_no_errors?
     @response['errors'].empty?
+  end
+
+  def ccr_injected?
+    has_no_errors? && @claim.present?
   end
 
   def error_message

--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -1,43 +1,35 @@
 module MessageQueue
   class AwsClient
-    def initialize(message, to_queue)
+    def initialize(queue)
       @sqs = Aws::SQS::Client.new(access_key_id: Settings.aws.access, secret_access_key: Settings.aws.secret)
-      @message = message
       begin
-        @queue_url = @sqs.get_queue_url(queue_name: to_queue).queue_url
+        @queue_url = @sqs.get_queue_url(queue_name: queue).queue_url
       rescue Aws::SQS::Errors::NonExistentQueue
-        raise StandardError.new, "Non existing queue: #{to_queue}."
+        raise StandardError.new, "Non existing queue: #{queue}."
       end
     end
 
-    def send_message!
+    def send!(message)
       @sqs.send_message(
         queue_url: @queue_url,
-        message_body: @message[:body],
-        message_attributes: @message[:attributes]
+        message_body: message[:body],
+        message_attributes: message[:attributes]
       )
       true
     end
-  end
 
-  class MessageTemplate
-    def self.claim_created(type, uuid)
-      {
-        body: 'Claim submitted',
-        attributes:
-          {
-            'type':
-              {
-                data_type: 'String',
-                string_value: type
-              },
-            'uuid':
-              {
-                data_type: 'String',
-                string_value: uuid
-              }
-          }
-      }
+    def poll!
+      resp = @sqs.receive_message(
+        queue_url: @queue_url,
+        max_number_of_messages: Settings.aws.poll_message_count,
+        wait_time_seconds: Settings.aws.poll_message_wait_time
+      )
+      resp.messages.each do |m|
+        irs = InjectionResponseService.new(JSON.parse(m.body))
+        if irs.run! && %w[demo production].include?(ENV['ENV'])
+          @sqs.delete_message(queue_url: @queue_url, receipt_handle: m.receipt_handle)
+        end
+      end
     end
   end
 end

--- a/app/services/message_queue/message_template.rb
+++ b/app/services/message_queue/message_template.rb
@@ -1,0 +1,22 @@
+module MessageQueue
+  class MessageTemplate
+    def self.claim_created(type, uuid)
+      {
+        body: 'Claim submitted',
+        attributes:
+        {
+          'type':
+        {
+          data_type: 'String',
+          string_value: type
+        },
+          'uuid':
+          {
+            data_type: 'String',
+            string_value: uuid
+          }
+        }
+      }
+    end
+  end
+end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -18,11 +18,11 @@ class SlackNotifier
     @response = response.stringify_keys
     @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
     @payload.merge(
-      icon_emoji: ccr_injected? ? Settings.slack.success_icon : Settings.slack.fail_icon,
+      icon_emoji: message_icon,
       attachments: [
         {
           'fallback': "#{generate_message} {#{@response['uuid']}}",
-          'color': ccr_injected? ? '#36a64f' : '#c41f1f',
+          'color': message_colour,
           'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}",
           'text': @response['uuid'],
           'fields': fields
@@ -46,6 +46,14 @@ class SlackNotifier
 
   def error_message
     @response['errors'].join(' ')
+  end
+
+  def message_colour
+    ccr_injected? ? '#36a64f' : '#c41f1f'
+  end
+
+  def message_icon
+    ccr_injected? ? Settings.slack.success_icon : Settings.slack.fail_icon
   end
 
   def fields

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,0 +1,30 @@
+class SlackNotifier
+  def initialize
+    @slack_url = Settings.slack.bot_url
+    @ready_to_send = false
+  end
+
+  def send_message!
+    raise 'Unable to send without payload' unless @ready_to_send
+
+    RestClient.post(@slack_url, {})
+  end
+
+  def build_injection
+    # {
+    #   channel: Settings.slack.channel,
+    #   username: Settings.slack.bot_name,
+    #   icon_emoji: ccr_injected? ? Settings.slack.success_icon : Settings.slack.fail_icon,
+    #   attachments: [
+    #     {
+    #       'fallback': "#{generate_message} {#{@response['uuid']}}",
+    #       'color': ccr_injected? ? '#36a64f' : '#c41f1f',
+    #       'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}",
+    #       'text': @response['uuid'],
+    #       'fields': fields
+    #     }
+    #   ]
+    # }.to_json
+    @ready_to_send = true
+  end
+end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -2,29 +2,75 @@ class SlackNotifier
   def initialize
     @slack_url = Settings.slack.bot_url
     @ready_to_send = false
+    @payload = {
+      channel: Settings.slack.channel,
+      username: Settings.slack.bot_name
+    }
   end
 
   def send_message!
     raise 'Unable to send without payload' unless @ready_to_send
 
-    RestClient.post(@slack_url, {})
+    RestClient.post(@slack_url, @payload.to_json, content_type: :json)
   end
 
-  def build_injection
-    # {
-    #   channel: Settings.slack.channel,
-    #   username: Settings.slack.bot_name,
-    #   icon_emoji: ccr_injected? ? Settings.slack.success_icon : Settings.slack.fail_icon,
-    #   attachments: [
-    #     {
-    #       'fallback': "#{generate_message} {#{@response['uuid']}}",
-    #       'color': ccr_injected? ? '#36a64f' : '#c41f1f',
-    #       'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}",
-    #       'text': @response['uuid'],
-    #       'fields': fields
-    #     }
-    #   ]
-    # }.to_json
+  def build_injection_payload(response)
+    @response = response.stringify_keys
+    @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
+    @payload.merge(
+      icon_emoji: ccr_injected? ? Settings.slack.success_icon : Settings.slack.fail_icon,
+      attachments: [
+        {
+          'fallback': "#{generate_message} {#{@response['uuid']}}",
+          'color': ccr_injected? ? '#36a64f' : '#c41f1f',
+          'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}",
+          'text': @response['uuid'],
+          'fields': fields
+        }
+      ]
+    )
     @ready_to_send = true
+  rescue StandardError
+    @ready_to_send = false
+  end
+
+  private
+
+  def ccr_injected?
+    has_no_errors? && @claim.present?
+  end
+
+  def has_no_errors?
+    @response['errors'].empty?
+  end
+
+  def error_message
+    @response['errors'].join(' ')
+  end
+
+  def fields
+    fields = [
+      { 'title': 'Claim number', 'value': @claim&.case_number, 'short': true },
+      { 'title': 'environment', 'value': ENV['ENV'], 'short': true }
+    ]
+    errors = has_no_errors? ? [] : error_fields
+    fields + errors
+  end
+
+  def error_fields
+    errors = @response['errors'].map { |x| x['error'] }.join('\n')
+    [
+      { 'title': 'Errors', 'value': errors }
+    ]
+  end
+
+  def generate_message
+    if @claim.nil?
+      'Failed to inject because no claim found'
+    elsif ccr_injected?
+      "Claim #{@claim.case_number} successfully injected"
+    else
+      "Claim #{@claim.case_number} could not be injected"
+    end
   end
 end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -17,7 +17,7 @@ class SlackNotifier
   def build_injection_payload(response)
     @response = response.stringify_keys
     @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
-    @payload.merge(
+    specific_payload = {
       icon_emoji: message_icon,
       attachments: [
         {
@@ -28,7 +28,8 @@ class SlackNotifier
           'fields': fields
         }
       ]
-    )
+    }
+    @payload.merge!(specific_payload)
     @ready_to_send = true
   rescue StandardError
     @ready_to_send = false

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -17,19 +17,16 @@ class SlackNotifier
   def build_injection_payload(response)
     @response = response.stringify_keys
     @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
-    specific_payload = {
-      icon_emoji: message_icon,
-      attachments: [
-        {
-          'fallback': "#{generate_message} {#{@response['uuid']}}",
-          'color': message_colour,
-          'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}",
-          'text': @response['uuid'],
-          'fields': fields
-        }
-      ]
-    }
-    @payload.merge!(specific_payload)
+    @payload[:icon_emoji] = message_icon
+    @payload[:attachments] = [
+      {
+        'fallback': "#{generate_message} {#{@response['uuid']}}",
+        'color': message_colour,
+        'title': "Injection #{ccr_injected? ? 'succeeded' : 'failed'}",
+        'text': @response['uuid'],
+        'fields': fields
+      }
+    ]
     @ready_to_send = true
   rescue StandardError
     @ready_to_send = false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,7 +102,8 @@ slack:
   bot_url: 'slack_bot_url'
   channel: '#channel_name'
   bot_name: 'bot_name'
-  icon: ':icon:'
+  success_icon: ':icon:'
+  fail_icon: ':icon:'
 
 govuk_notify:
   api_key: 'never-put-real-api-key-here-use-env-vars'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -98,6 +98,12 @@ aws:
   submitted_queue: <%= ENV['AWS_QUEUE_NAME'] %>
   response_queue: <%= ENV['AWS_RESPONSE_QUEUE_NAME'] %>
 
+slack:
+  bot_url: 'slack_bot_url'
+  channel: '#channel_name'
+  bot_name: 'bot_name'
+  icon: ':icon:'
+
 govuk_notify:
   api_key: 'never-put-real-api-key-here-use-env-vars'
   templates:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,7 +95,8 @@ laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
 aws:
   access: <%= ENV['AWS_ACCESS_KEY'] %>
   secret: <%= ENV['SECRET_ACCESS_KEY'] %>
-  queue: <%= ENV['AWS_QUEUE_NAME'] %>
+  submitted_queue: <%= ENV['AWS_QUEUE_NAME'] %>
+  response_queue: <%= ENV['AWS_RESPONSE_QUEUE_NAME'] %>
 
 govuk_notify:
   api_key: 'never-put-real-api-key-here-use-env-vars'

--- a/db/migrate/20171111113526_create_injection_attempts.rb
+++ b/db/migrate/20171111113526_create_injection_attempts.rb
@@ -1,0 +1,10 @@
+class CreateInjectionAttempts < ActiveRecord::Migration
+  def change
+    create_table :injection_attempts do |t|
+      t.references :claim, index: true, foreign_key: true
+      t.boolean :succeeded
+      t.string :error_message
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170921105947) do
+ActiveRecord::Schema.define(version: 20171111113526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -352,6 +352,16 @@ ActiveRecord::Schema.define(version: 20170921105947) do
   add_index "fees", ["claim_id"], name: "index_fees_on_claim_id", using: :btree
   add_index "fees", ["fee_type_id"], name: "index_fees_on_fee_type_id", using: :btree
 
+  create_table "injection_attempts", force: :cascade do |t|
+    t.integer  "claim_id"
+    t.boolean  "succeeded"
+    t.string   "error_message"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "injection_attempts", ["claim_id"], name: "index_injection_attempts_on_claim_id", using: :btree
+
   create_table "locations", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"
@@ -518,4 +528,5 @@ ActiveRecord::Schema.define(version: 20170921105947) do
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
+  add_foreign_key "injection_attempts", "claims"
 end

--- a/scheduled_tasks/poll_injection_responses_task.rb
+++ b/scheduled_tasks/poll_injection_responses_task.rb
@@ -1,0 +1,18 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon
+class PollInjectionResponsesTask < Scheduler::SchedulerTask
+  environments :production, :demo
+  every '1m'
+
+  def run
+    queue = Settings.aws.response_queue
+    return unless queue
+    log("Checking for messages on #{queue}")
+    MessageQueue::AwsClient.new(queue).poll!
+  rescue StandardError => ex
+    log('There was an error: ' + ex.message)
+  ensure
+    log('Injection import complete')
+  end
+end

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
       end
 
       it 'logs a successful message on the queue' do
-        allow(Settings.aws).to receive(:queue).and_return('valid_queue_name')
+        allow(Settings.aws).to receive(:submitted_queue).and_return('valid_queue_name')
         expect(Rails.logger).to receive(:info).with(/Successfully sent message about submission of claim#/)
         post :create, valid_certification_params(claim, certification_type)
       end

--- a/spec/factories/injection_attempts.rb
+++ b/spec/factories/injection_attempts.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :injection_attempt do
+    claim
+    succeeded true
+    error_message nil
+  end
+end
+

--- a/spec/models/injection_attempt_spec.rb
+++ b/spec/models/injection_attempt_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe InjectionAttempt, type: :model do
+  subject(:injection_attempt) { build(:injection_attempt, params) }
+
+  let(:params) { { succeeded: true, error_message: nil } }
+
+  describe 'validations' do
+    subject { injection_attempt.valid? }
+
+    it { is_expected.to be true }
+
+    context 'when claim is missing' do
+      let(:params) { { claim: nil } }
+
+      it { is_expected.to be false }
+    end
+  end
+end
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -105,7 +105,8 @@ RSpec.configure do |config|
     allow(Settings.slack).to receive(:bot_url).and_return('https://hooks.slack.com/services/fake/endpoint')
     allow(Settings.slack).to receive(:channel).and_return('#monitoring')
     allow(Settings.slack).to receive(:bot_name).and_return('monitor_bot')
-    allow(Settings.slack).to receive(:icon).and_return(':robot')
+    allow(Settings.slack).to receive(:success_icon).and_return(':good_icon:')
+    allow(Settings.slack).to receive(:fail_icon).and_return(':bad_icon:')
     stub_request(:post, 'https://hooks.slack.com/services/fake/endpoint').to_return(status: 200, body: '', headers: {})
   end
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,6 +101,13 @@ RSpec.configure do |config|
         to_return(status: 200, body: "", headers: {})
   end
 
+  config.before :each, slack_bot: true do
+    allow(Settings.slack).to receive(:bot_url).and_return('https://hooks.slack.com/services/fake/endpoint')
+    allow(Settings.slack).to receive(:channel).and_return('#monitoring')
+    allow(Settings.slack).to receive(:bot_name).and_return('monitor_bot')
+    allow(Settings.slack).to receive(:icon).and_return(':robot')
+    stub_request(:post, 'https://hooks.slack.com/services/fake/endpoint').to_return(status: 200, body: '', headers: {})
+  end
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe InjectionResponseService, slack_bot: true do
+  subject(:irs) { described_class.new(json) }
+
+  let(:claim) { create :claim }
+  let(:invalid_json) { { "errors": [], 'claim_id': '1234567', "messages":[] } }
+  let(:valid_json_with_invalid_uuid) { { "errors":[], "uuid":'b08cfd61-9999-8888-7777-651477183efb', "messages":[{'message':'Claim injected successfully.'}]} }
+  let(:valid_json_on_success) { { "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
+  let(:valid_json_on_failure) { { "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."} ],"uuid":claim.uuid,"messages":[] } }
+
+  context 'when initialized with' do
+    describe 'valid json' do
+      let(:json) { valid_json_on_success }
+
+      it { is_expected.to be_a_kind_of(described_class) }
+    end
+
+    describe 'invalid json' do
+      let(:json) { invalid_json }
+
+      it { expect { subject }.to raise_error ParseError, 'Invalid JSON string' }
+    end
+  end
+
+  describe '#run!' do
+    subject(:irs_run!) { irs.run! }
+
+    context 'when injection succeeded' do
+      let(:json) { valid_json_on_success }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when injection failed' do
+      let(:json) { valid_json_on_failure }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when claim uuid cannot be matched' do
+      let(:json) { valid_json_with_invalid_uuid }
+
+      it { is_expected.to be false }
+      it 'logs an error' do
+        expect(LogStuff).to receive(:info).with('InjectionResponseService::NonExistentClaim',
+                                                action: 'run!',
+                                                uuid: 'b08cfd61-9999-8888-7777-651477183efb')
+        irs_run!
+      end
+    end
+  end
+end

--- a/spec/services/message_queue/aws_client_spec.rb
+++ b/spec/services/message_queue/aws_client_spec.rb
@@ -1,39 +1,58 @@
 require 'rails_helper'
 
 module MessageQueue
-  describe AwsClient do
-    subject(:aws_client) { described_class.new(message, aws_queue_name) }
+  describe AwsClient, slack_bot: true do
+    subject(:aws_client) { described_class.new(aws_queue_name) }
 
     let(:client) do
       Aws::SQS::Client.new(
         region: 'eu_west_1',
         stub_responses:
-        {
-          list_queues: { queue_urls:['valid_queue_name'] },
-          get_queue_url: stub_queue_response,
-          send_message: stub_send_response
-        }
+          {
+            list_queues: { queue_urls:['valid_queue_name'] },
+            get_queue_url: stub_queue_response,
+            send_message: stub_send_response,
+            receive_message: stub_poll_response,
+            delete_message: true
+          }
+      )
+    end
+    let(:claim) { create(:claim) }
+    let(:aws_queue_name) { 'valid_queue_name' }
+    let(:stub_queue_response) { stub_queue_response_success }
+    let(:stub_send_response) {}
+    let(:stub_poll_response) {}
+    let(:stub_queue_response_success)  { { queue_url: 'http://aws_url' } }
+    let(:stub_queue_response_failure)  do
+      Aws::SQS::Errors::NonExistentQueue.new(
+        double('request'),
+        double('response', :status => 400, :body => '<foo/>')
       )
     end
 
-    let(:aws_queue_name) { 'valid_queue_name' }
-    let(:stub_queue_response) { stub_response_success }
-    let(:stub_send_response) {}
-    let(:stub_response_success)  { { queue_url: 'http://aws_url' } }
-    let(:stub_response_failure)  { Aws::SQS::Errors::NonExistentQueue.new(
-                                     double('request'),
-                                     double('response', :status => 400, :body => '<foo/>')
-                                    )
-                                 }
-    let(:message) { { body: 'Claim added', attributes: { 'uuid': { data_type: 'String', string_value: SecureRandom.uuid } } } }
+    let(:stub_poll_response_success) { Aws::SQS::Types::ReceiveMessageResult.new(
+      messages: [
+        Aws::SQS::Types::Message.new(
+          {
+            message_id: "a1dc5042-e8bf-4417-a443-ed9a2c9558e6",
+            receipt_handle: "AQEB4y8lIzE9G2HiEVen7vRjcmv0xFQML6VcyZYDbnOUzOHFO00yLwaZFE0flYhEv2XMTVyURrK3pRNgaHUH4KK7kFd6cGay35L58UljtEHCJNbBEHSJpuWiV98G56fz04DtTDZN5IKG4tBthDjeDlAheUBkMiiBBLESHSOlUsgGj0vu++x9IlcdjO8+pszXH8356DM3/eayvgoOq9i2yCKkSy4piO6tNX9/VHFVH0fyjIwW3knpbWJHNg2ROKs3RloXKIaBmD4boqc8DSPDx4Mx77zh/T0z3UBG/1CXzmtcXt9NfJJzSqzHus11s4l7bY6qEqIheTaQVl1rl6XF5RBN46M+qIR2i4ggV50TINn+629dP7H2J1yPDPWKJmkV/BzNuCF4fXWlsxiuleoM8v1pbQ==",
+            md5_of_body: "06ca6b264e9878e64c76b3b6858a1676",
+            body: "{\"errors\":[{\"error\":\"PPE is a mandatory field for Claim Element of type Advocate Fee.\"}],\"uuid\":\"3d34c071-c19a-4248-93ea-6f0e91002561\",\"messages\":[]}",
+            attributes: {},
+            md5_of_message_attributes: nil,
+            message_attributes: {}
+          })
+      ]
+    )}
 
     before do
       allow(Aws::SQS::Client).to receive(:new).and_return client
+      allow(Claim::BaseClaim).to receive(:find_by) { claim }
     end
 
     context 'when passed a non-existant queue' do
       let(:aws_queue_name) { 'no_such_queue' }
-      let(:stub_queue_response) { stub_response_failure }
+      let(:stub_queue_response) { stub_queue_response_failure }
 
       it 'raises an appropriate error' do
         expect{aws_client}.to raise_error(StandardError, 'Non existing queue: no_such_queue.')
@@ -41,7 +60,9 @@ module MessageQueue
     end
 
     describe '#send_message!' do
-      subject(:send_message!) { aws_client.send_message! }
+      subject(:send!) { aws_client.send!(message) }
+
+      let(:message) { { body: 'Claim added', attributes: { 'uuid': { data_type: 'String', string_value: SecureRandom.uuid } } } }
 
       context 'when values are good' do
         it { is_expected.to eql true }
@@ -54,9 +75,19 @@ module MessageQueue
       end
 
       context 'when an error occurs (simulate someone deleting the queue mid-submission?!)' do
-        let(:stub_send_response) { stub_response_failure }
+        let(:stub_send_response) { stub_queue_response_failure }
 
-        it { expect{ send_message! }.to raise_error(stub_response_failure) }
+        it { expect{ send! }.to raise_error(stub_queue_response_failure) }
+      end
+    end
+
+    describe '.poll!' do
+      subject(:poll!) { aws_client.poll! }
+
+      context 'when there are messages on the queue' do
+        let(:stub_poll_response) { stub_poll_response_success }
+
+        it { expect{ poll! }.to change { InjectionAttempt.count }.by(1) }
       end
     end
   end

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 RSpec.describe SlackNotifier, slack_bot: true do
   subject(:slack_notifier) { described_class.new() }
 
+  let(:claim) { create :claim }
+  let(:valid_json_on_success) { { "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
+  let(:valid_json_on_failure) { { "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."} ],"uuid":claim.uuid,"messages":[] } }
+
   it { is_expected.to be_a described_class }
 
-  it { is_expected.to respond_to :build_injection }
+  it { is_expected.to respond_to :build_injection_payload }
   it { is_expected.to respond_to :send_message! }
 
   describe '#send_message!' do
@@ -18,7 +22,7 @@ RSpec.describe SlackNotifier, slack_bot: true do
     end
 
     context 'after payload set' do
-      before { slack_notifier.build_injection }
+      before { slack_notifier.build_injection_payload(valid_json_on_success) }
       it 'calls the slack api' do
         subject
         expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made.times(1)

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotifier, slack_bot: true do
+  subject(:slack_notifier) { described_class.new() }
+
+  it { is_expected.to be_a described_class }
+
+  it { is_expected.to respond_to :build_injection }
+  it { is_expected.to respond_to :send_message! }
+
+  describe '#send_message!' do
+    subject(:send_message!) { slack_notifier.send_message! }
+
+    context 'before message payload is set' do
+      it 'raises an error' do
+        expect{ subject }.to raise_error(RuntimeError, 'Unable to send without payload')
+      end
+    end
+
+    context 'after payload set' do
+      before { slack_notifier.build_injection }
+      it 'calls the slack api' do
+        subject
+        expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made.times(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why?

To monitor the CCR data injection, this is designed to monitor the response queues in SNS and store the results in CCCD

Still to do:
- [x] move the slack notifier into it's own class