### PR TITLE
Use explicit app root path in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,9 @@ RUN mkdir -p /usr/src/app/public/assets
 COPY ./docker/run.sh $APP_HOME/run.sh
 RUN chmod 777 $APP_HOME/run.sh
 
+RUN pwd
 WORKDIR /usr/src/app
+RUN pwd
 
 EXPOSE 80
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p /usr/src/app/public/assets
 COPY ./docker/run.sh $APP_HOME/run.sh
 RUN chmod 777 $APP_HOME/run.sh
 
-WORKDIR $APPHOME
+WORKDIR /usr/src/app
 
 EXPOSE 80
 


### PR DESCRIPTION
An unknown change has cause the $APPHOME variable
to not be available in the docker file
resulting in the WORKDIR $APPHOME docker
command raise a `cannot normalise nothing`
error.

This fix simply hard codes the app root
path to be used as the current working directory.
But need to talk to ops about underlying cause
and to check for a better fix or check whether this
is appropriate.