### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,8 +32,6 @@ RUN mkdir -p /usr/src/app/public/assets
 COPY ./docker/run.sh $APP_HOME/run.sh
 RUN chmod 777 $APP_HOME/run.sh
 
-WORKDIR $APPHOME
-
 EXPOSE 80
 
 #SECRET_TOKEN set here because otherwise devise blows up during the precompile.


### PR DESCRIPTION
**What?** remove WORKDIR instruction
**Why?** It looks like a typo from https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/commit/b4c2012550076862fb68927a2c8857696c9e396a anyway

removing it still allows the build to proceed