### PR TITLE
Add posix-spawn gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'colorize'
 gem 'shell-spinner', '~> 1.0', '>= 1.0.4'
 gem 'ruby-progressbar'
 gem 'geckoboard-ruby'
+gem 'posix-spawn', '~> 0.3.13'
 
 group :production, :devunicorn do
   gem 'rails_12factor', '0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,6 +410,7 @@ GEM
       websocket-driver (>= 0.2.0)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
+    posix-spawn (0.3.13)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -702,6 +703,7 @@ DEPENDENCIES
   parallel_tests
   pg (~> 0.18.2)
   poltergeist (~> 1.9.0)
+  posix-spawn (~> 0.3.13)
   pry-byebug
   pry-rails
   quiet_assets


### PR DESCRIPTION
Getting alot of errors during document upload:

`Errno::ENOMEM: Cannot allocate memory - file -b --mime '/tmp/*`

posix-spawn works with paperclips dependency cocaine:
see http://blog.sundaycoding.com/blog/2014/02/05/fighting-paperclip-errno-enomem-error/
