### PR TITLE
LAC check list option handling

### DIFF
--- a/app/assets/javascripts/modules/Modules.EvidenceChecklist.js
+++ b/app/assets/javascripts/modules/Modules.EvidenceChecklist.js
@@ -1,0 +1,10 @@
+moj.Modules.AddEditAdvocate = {
+  el: '.fx-lac-1',
+  init : function () {
+    $(this.el).is(function(idx, el){
+      if(!$('.fx-lac-1').find('input:checked').length){
+        $('.fx-lac-1').remove();
+      }
+    });
+  }
+};

--- a/app/views/external_users/claims/supporting_evidence_checklist/_evidence_checklist.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_evidence_checklist.html.haml
@@ -1,2 +1,2 @@
 = f.collection_check_boxes :evidence_checklist_ids, collection, :id, :name do |b|
-  = b.label(class: "block-label") {b.check_box + b.text}
+  = b.label(class: "block-label " + (b.value == 2 ? 'fx-lac-1' : '') ) {b.check_box + b.text}


### PR DESCRIPTION
Why are we doing this:
- This option is redundant

What this PR does:
- JS will remove the option unless it is in use by a claim
- As the option is empty we simply remove the input