### PR TITLE
Modify fixed fee number of defendants calculation

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
@@ -15,7 +15,7 @@ module API
       class AdaptedFixedFee < API::Entities::CCR::AdaptedBaseFee
         with_options(format_with: :string) do
           expose :daily_attendances_or_one, as: :daily_attendances
-          expose :number_of_defendants_or_one, as: :number_of_defendants
+          expose :number_of_defendants_plus_one, as: :number_of_defendants
           expose :number_of_cases_plus_one, as: :number_of_cases
         end
 
@@ -49,14 +49,12 @@ module API
           @case_numbers = @case_numbers.map(&:strip).uniq.join(',')
         end
 
-        # Assume one is claimed regardless
-        # TODO: eventually app should add default matching fixed fee for the case type
         def daily_attendances_or_one
           [matching_fixed_fees.map(&:quantity).inject(:+).to_i, 1].max
         end
 
-        def number_of_defendants_or_one
-          [defendant_uplift_fees.map(&:quantity).inject(:+).to_i, 1].max
+        def number_of_defendants_plus_one
+          defendant_uplift_fees.map(&:quantity).inject(:+).to_i + 1
         end
 
         def claim

--- a/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
@@ -100,7 +100,7 @@ describe API::Entities::CCR::AdaptedFixedFee do
       subject { response[:number_of_defendants] }
 
       context 'when "Number of defendant uplifts" NOT claimed' do
-        it 'returns 1' do
+        it 'returns 1 for the main defendant' do
           is_expected.to eq "1"
         end
       end
@@ -110,8 +110,8 @@ describe API::Entities::CCR::AdaptedFixedFee do
           create_list(:fixed_fee, 2, fee_type: fxndr, claim: claim, quantity: 2)
         end
 
-        it 'returns sum of all Number of defendants uplift quanitities' do
-          is_expected.to eq "4"
+        it 'returns sum of all Number of defendants uplift quantities plus one for the main defendant' do
+          is_expected.to eq "5"
         end
       end
     end

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -405,7 +405,7 @@ describe API::V2::CCRClaim do
         context 'number_of_defendants' do
           before do |example|
             create(:fixed_fee, fee_type: fxcbr, claim: claim, quantity: 1)
-            create(:fixed_fee, fee_type: fxndr, claim: claim, quantity: 2) unless example.metadata[:skip_uplifts]
+            create(:fixed_fee, fee_type: fxndr, claim: claim, quantity: 1) unless example.metadata[:skip_uplifts]
           end
 
           it 'includes property', :skip_uplifts do
@@ -413,7 +413,7 @@ describe API::V2::CCRClaim do
             expect(response).to have_json_type(String).at_path "bills/0/number_of_defendants"
           end
 
-          it 'calculated, FOR NOW, from count of defendants on claim' do
+          it 'calculated from sum of "number of defendants uplift" fee quanitities on claim plus one' do
             expect(response).to be_json_eql("2".to_json).at_path "bills/0/number_of_defendants"
           end
         end


### PR DESCRIPTION
**What**
Modify calculation for number of defendants on a fixed fee

**Why**
CCR expects the total number of defendants and any above
one is treated as an uplift. In CCCD this equates to
the sum of all quantities for Number of defendants uplift fees 
FXNDR plus one for the main defendant.