### PR TITLE
Advocate fee defendant uplift calc

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
@@ -40,7 +40,7 @@ module API
         end
 
         def number_of_defendants
-          fee_quantity_for('BANDR') +1
+          fee_quantity_for('BANDR') + 1
         end
 
         def case_numbers

--- a/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
@@ -7,6 +7,7 @@ module API
           expose :ppe
           expose :number_of_witnesses
           expose :number_of_cases
+          expose :number_of_defendants
           expose :daily_attendances
         end
 
@@ -38,27 +39,16 @@ module API
           fee_quantity_for('BANOC') + 1
         end
 
+        def number_of_defendants
+          fee_quantity_for('BANDR') +1
+        end
+
         def case_numbers
           fee_for('BANOC')&.case_numbers
         end
 
         def daily_attendances
           ::CCR::DailyAttendanceAdapter.attendances_for(object)
-        end
-
-        def calculated_fee
-          {
-            basicCaseFee: 0.0,
-            date: object.last_submitted_at&.strftime('%Y-%m-%d %H:%M:%S'),
-            defendantUplift: 0.0,
-            exVat: 0.0,
-            incVat: 0.0,
-            ppeUplift: 0.0,
-            trialLengthUplift: 0.0,
-            vat: 0.0,
-            vatIncluded: true,
-            vatRate: 20.0
-          }
         end
       end
     end

--- a/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
@@ -14,9 +14,9 @@ module API
     module CCR
       class AdaptedFixedFee < API::Entities::CCR::AdaptedBaseFee
         with_options(format_with: :string) do
-          expose :daily_attendances_or_one, as: :daily_attendances
-          expose :number_of_defendants_plus_one, as: :number_of_defendants
-          expose :number_of_cases_plus_one, as: :number_of_cases
+          expose :daily_attendances
+          expose :number_of_defendants
+          expose :number_of_cases
         end
 
         expose :case_numbers
@@ -36,7 +36,7 @@ module API
         end
 
         # CCR requires total number of cases (claim's + additional's for the fee)
-        def number_of_cases_plus_one
+        def number_of_cases
           case_numbers.split(',').size + 1
         end
 
@@ -49,11 +49,11 @@ module API
           @case_numbers = @case_numbers.map(&:strip).uniq.join(',')
         end
 
-        def daily_attendances_or_one
+        def daily_attendances
           [matching_fixed_fees.map(&:quantity).inject(:+).to_i, 1].max
         end
 
-        def number_of_defendants_plus_one
+        def number_of_defendants
           defendant_uplift_fees.map(&:quantity).inject(:+).to_i + 1
         end
 

--- a/app/services/ccr/fee/basic_fee_adapter.rb
+++ b/app/services/ccr/fee/basic_fee_adapter.rb
@@ -19,11 +19,6 @@
 #   * This fee can be derived from CCCD fees of the following types:
 #     BABAF BADAF BADAH BADAJ BANOC BANDR BANPW BAPPE
 #
-# TODO: map defendants based on BANDR fee
-#  * In addition the BANDR (defendant uplifts) is
-#    being mapped based on the actual number of defendants
-#    at time of writing (and ignoring the quantity of this fee??!)
-#
 #  * The BASAF, BAPCM and BACAV fees are handled
 #    as miscellaneous fees in CCR (i.e. AGFS_MISC_FEES).
 #

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -29,17 +29,26 @@ FactoryBot.define do
       description 'Pages of prosecution evidence'
       code 'PPE'
       calculated false
+      unique_code 'BAPPE'
     end
 
     trait :npw do
       description 'Number of prosecution witnesses'
       code 'NPW'
       calculated false
+      unique_code 'BANPW'
     end
 
     trait :noc do
       description 'Number of cases uplift'
       code 'NOC'
+      unique_code 'BANOC'
+    end
+
+    trait :ndr do
+      description 'Number of cases uplift'
+      code 'NOC'
+      unique_code 'BANDR'
     end
 
     trait :lgfs do


### PR DESCRIPTION
**What**
Send number of defendants for advocate fee 

**Why**
Previously this was determined by CCR from
the actual of number of defendants on the claim
but this means CCR could end paying a fee when
one was not claimed. Now this number is determined
from the defendant uplift quantity plus one for the
main defendant.

**TODO**
CCR will need to implement this change
