### PR TITLE
Mock misc fee defendant uplifts

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
@@ -3,7 +3,6 @@ module API
     module CCR
       class AdaptedBasicFee < API::Entities::CCR::AdaptedBaseFee
         with_options(format_with: :string) do
-          # derived/transformed data exposures
           expose :ppe
           expose :number_of_witnesses
           expose :number_of_cases

--- a/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
@@ -2,13 +2,24 @@ module API
   module Entities
     module CCR
       class AdaptedMiscFee < API::Entities::CCR::AdaptedBaseFee
-        expose :quantity
-        expose :rate
-        expose :amount
+        with_options(format_with: :string) do
+          expose :quantity
+          expose :rate
+          expose :amount
+          expose :number_of_defendants
+        end
+
         # TODO: dates attended not available to add to BACAV fee in CCCD interface at the
         # moment but in CCR it is the only misc fee that requires an occured_at date
         # BACAV --> a CCR AGFS_MISC_FEES, AGFS_CONFERENCE
         expose :dates_attended, using: API::Entities::CCR::DateAttended
+
+        private
+
+        # TODO: replace with sum of quantities from misc fee defendant uplifts
+        def number_of_defendants
+          1
+        end
       end
     end
   end


### PR DESCRIPTION
So CCR can implement use of number of
defendants attribute for all bills (
advocate-fee/fixed-fee/misc-fee).