### PR TITLE
Add misc fee defendant uplift specs

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
@@ -58,7 +58,7 @@ module API
         end
 
         def claim
-          object.instance_variable_get :@object
+          object.object
         end
 
         def fee_code

--- a/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
@@ -16,10 +16,34 @@ module API
 
         private
 
-        # TODO: replace with sum of quantities from misc fee defendant uplifts
-        def number_of_defendants
-          1
+        DEFENDANT_UPLIFT_MAPPINGS = {
+          MIAPH: 'MIAHU',
+        }.with_indifferent_access.freeze
+
+        def claim
+          object.object.claim
         end
+
+        def fees_for(fee_type_unique_code)
+          claim.fees.where(fee_type_id: ::Fee::BaseFeeType.where(unique_code: fee_type_unique_code))
+        end
+
+        def fee_code
+          object.fee_type.unique_code
+        end
+
+        def defendant_uplift_fee_code
+          DEFENDANT_UPLIFT_MAPPINGS[fee_code]
+        end
+
+        def matching_defendant_uplift_fees
+          fees_for(defendant_uplift_fee_code)
+        end
+
+        def number_of_defendants
+          matching_defendant_uplift_fees.map(&:quantity).inject(:+).to_i + 1
+        end
+
       end
     end
   end

--- a/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
@@ -17,7 +17,27 @@ module API
         private
 
         DEFENDANT_UPLIFT_MAPPINGS = {
-          MIAPH: 'MIAHU',
+          BASAF: 'MISAU', # Standard appearance fee uplift
+          MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
+          MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
+          MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
+          MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
+          MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
+          MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
+          MIDSE: 'MIDSU', # Deferred sentence hearings uplift
+          MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
+          MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
+          MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
+          MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
+          MIPPC: 'MIPCU', # Paper plea & case management uplift
+          MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
+          MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
+          MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
+          MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
+          MISHR: 'MISHU', # Sentence hearings uplift
+          MITNP: 'MITNU', # Trial not proceed uplift
+          MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
+          MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
         }.with_indifferent_access.freeze
 
         def claim
@@ -43,7 +63,6 @@ module API
         def number_of_defendants
           matching_defendant_uplift_fees.map(&:quantity).inject(:+).to_i + 1
         end
-
       end
     end
   end

--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -7,56 +7,35 @@ module CCR
         BACAV: zip(%w[AGFS_MISC_FEES AGFS_CONFERENCE]), # Conferences and views (basic fee)
         FXCON: zip(%w[AGFS_MISC_FEES AGFS_CONTEMPT]), # Contempt (fixed fee)
         FXSAF: zip(%w[AGFS_MISC_FEES AGFS_STD_APPRNC]), # Standard Appearance fee (fixed fee)
-        MIAHU: zip(%w[AGFS_MISC_FEES TBC]), # Abuse of process hearings (half day uplift)
         MIAPH: zip(%w[AGFS_MISC_FEES AGFS_ABS_PRC_HF]), # Abuse of process hearings (half day)
-        MIAWU: zip(%w[AGFS_MISC_FEES TBC]), # Abuse of process hearings (whole day uplift)
         MIAPW: zip(%w[AGFS_MISC_FEES AGFS_ABS_PRC_WL]), # Abuse of process hearings (whole day)
         MISAF: zip(%w[AGFS_MISC_FEES AGFS_ADJOURNED]), # Adjourned appeals
-        MIADC3: zip(%w[AGFS_MISC_FEES TBC]), # Application to dismiss a charge (half day uplift)
         MIADC1: zip(%w[AGFS_MISC_FEES AGFS_DMS_DY2_HF]), # Application to dismiss a charge (half day)
-        MIADC4: zip(%w[AGFS_MISC_FEES TBC]), # Application to dismiss a charge (whole day uplift)
         MIADC2: zip(%w[AGFS_MISC_FEES AGFS_DMS_DY2_WL]), # Application to dismiss a charge (whole day)
         MIUPL: zip(%w[TBC TBC]), # Case uplift ***CCLF-applicable-only***
-        MIDHU: zip(%w[AGFS_MISC_FEES TBC]), # Confiscation hearings (half day uplift)
         MIDTH: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_HF]), # Confiscation hearings (half day)
-        MIDWU: zip(%w[AGFS_MISC_FEES TBC]), # Confiscation hearings (whole day uplift)
         MIDTW: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_WL]), # Confiscation hearings (whole day)
         MICJA: zip(%w[OTHER COST_JUDGE_FEE]), # Costs judge application ***CCLF-applicable-only***
         MICJP: zip(%w[OTHER COST_JUD_EXP]), # Costs judge preparation ***CCLF-applicable-only***
         MIDSE: zip(%w[AGFS_MISC_FEES AGFS_DEF_SEN_HR]), # Deferred sentence hearings
-        MIDSU: zip(%w[AGFS_MISC_FEES TBC]), # Deferred sentence hearings uplift
         MIEVI: zip(%w[EVID_PROV_FEE EVID_PROV_FEE]), # Evidence provision fee ***CCLF-applicable-only***
-        MIEHU: zip(%w[AGFS_MISC_FEES TBC]), # Hearings relating to admissibility of evidence (half day uplift)
         MIAEH: zip(%w[AGFS_MISC_FEES AGFS_ADM_EVD_HF]), # Hearings relating to admissibility of evidence (half day)
-        MIEWU: zip(%w[AGFS_MISC_FEES TBC]), # Hearings relating to admissibility of evidence (whole day uplift)
         MIAEW: zip(%w[AGFS_MISC_FEES AGFS_ADM_EVD_WL]), # Hearings relating to admissibility of evidence (whole day)
-        MIHHU: zip(%w[AGFS_MISC_FEES TBC]), # Hearings relating to disclosure (half day uplift)
         MIHDH: zip(%w[AGFS_MISC_FEES AGFS_DISC_HALF]), # Hearings relating to disclosure (half day)
-        MIHWU: zip(%w[AGFS_MISC_FEES TBC]), # Hearings relating to disclosure (whole day uplift)
         MIHDW: zip(%w[AGFS_MISC_FEES AGFS_DISC_FULL]), # Hearings relating to disclosure (whole day)
         MINBR: zip(%w[AGFS_MISC_FEES AGFS_NOTING_BRF]), # Noting brief fee
         MIPPC: zip(%w[AGFS_MISC_FEES AGFS_PAPER_PLEA]), # Paper plea & case management
-        MIPCU: zip(%w[AGFS_MISC_FEES TBC]), # Paper plea & case management uplift
-        MICHU: zip(%w[AGFS_MISC_FEES TBC]), # Proceeds of crime hearings (half day uplift)
         MIPCH: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_HF]), # Proceeds of crime hearings (half day) **** DUPLICATE - sames as confiscation hearings above****
-        MICHW: zip(%w[AGFS_MISC_FEES TBC]), # Proceeds of crime hearings (whole day uplift)
         MIPCW: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_WL]), # Proceeds of crime hearings (whole day) **** DUPLICATE - sames as confiscation hearings above****
-        MIPIU3: zip(%w[AGFS_MISC_FEES TBC]), # Public interest immunity hearings (half day uplift)
         MIPIH1: zip(%w[AGFS_MISC_FEES AGFS_PI_IMMN_HF]), # Public interest immunity hearings (half day)
-        MIPIH4: zip(%w[AGFS_MISC_FEES TBC]), # Public interest immunity hearings (whole day uplift)
         MIPIH2: zip(%w[AGFS_MISC_FEES AGFS_PI_IMMN_WL]), # Public interest immunity hearings (whole day)
         MIRNF: zip(%w[AGFS_MISC_FEES AGFS_NOVELISSUE]), # Research of very unusual or novel factual issue
         MIRNL: zip(%w[AGFS_MISC_FEES AGFS_NOVEL_LAW]), # Research of very unusual or novel point of law
         MISHR: zip(%w[AGFS_MISC_FEES AGFS_SENTENCE]), # Sentence hearings
-        MISHU: zip(%w[AGFS_MISC_FEES TBC]), # Sentence hearings uplift
         MISPF: zip(%w[AGFS_MISC_FEES AGFS_SPCL_PREP]), # Special preparation fee - AGFS only version
         # MISPF: zip(%w[FEE_SUPPLEMENT SPECIAL_PREP]), # TODO: Special preparation fee - LGFS only version - need to apply fee type role logic
-        MISAU: zip(%w[AGFS_MISC_FEES TBC]), # Standard appearance fee uplift
         MITNP: zip(%w[AGFS_MISC_FEES AGFS_NOT_PRCD]), # Trial not proceed
-        MITNU: zip(%w[AGFS_MISC_FEES TBC]), # Trial not proceed uplift
-        MIUAV3: zip(%w[AGFS_MISC_FEES TBC]), # Unsuccessful application to vacate a guilty plea (half day uplift)
         MIUAV1: zip(%w[AGFS_MISC_FEES AGFS_UN_VAC_HF]), # Unsuccessful application to vacate a guilty plea (half day)
-        MIUAV4: zip(%w[AGFS_MISC_FEES TBC]), # Unsuccessful application to vacate a guilty plea (whole day uplift)
         MIUAV2: zip(%w[AGFS_MISC_FEES AGFS_UN_VAC_WL]), # Unsuccessful application to vacate a guilty plea (whole day)
         MIWPF: zip(%w[AGFS_MISC_FEES AGFS_WSTD_PREP]), # Wasted preparation fee
         MIWOA: zip(%w[AGFS_MISC_FEES AGFS_WRTN_ORAL]) # Written / oral advice

--- a/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
@@ -115,5 +115,29 @@ describe API::Entities::CCR::AdaptedFixedFee do
         end
       end
     end
+
+    describe '::CASE_UPLIFT_MAPPINGS' do
+      subject { described_class::CASE_UPLIFT_MAPPINGS[code] }
+
+      EXPECTED_MAPPINGS = {
+        FXACV: 'FXACU',
+        FXASE: 'FXASU',
+        FXCBR: 'FXCBU',
+        FXCSE: 'FXCSU',
+        FXENP: 'FXENU'
+      }.with_indifferent_access.freeze
+
+      context 'mappings' do
+        EXPECTED_MAPPINGS.each do |code, uplift_code|
+          context "code #{code}" do
+            let(:code) { code }
+
+            it "returns #{uplift_code}" do
+              is_expected.to eql uplift_code
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -50,13 +50,23 @@ describe API::Entities::CCR::AdaptedMiscFee do
       end
     end
 
-    context 'when matching misc fee uplift claimed' do
+    context 'when 1 matching misc fee (defendant) uplift claimed' do
       before do
         create(:misc_fee, fee_type: miahu, claim: claim, quantity: 2, amount: 21.01)
       end
 
-      it 'returns sum of all Number of defendants uplift quantities plus one for the main defendant' do
+      it 'returns sum of (defendant) uplift quantity plus one for the main defendant' do
         is_expected.to eq "3"
+      end
+    end
+
+    context 'when more than 1 matching misc fee (defendant) uplift claimed' do
+      before do
+        create_list(:misc_fee, 2, fee_type: miahu, claim: claim, quantity: 2, amount: 21.01)
+      end
+
+      it 'returns sum of all (defendant) uplift quantities plus one for the main defendant' do
+        is_expected.to eq "5"
       end
     end
   end

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -109,6 +109,5 @@ describe API::Entities::CCR::AdaptedMiscFee do
         end
       end
     end
-
   end
 end

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -69,5 +69,46 @@ describe API::Entities::CCR::AdaptedMiscFee do
         is_expected.to eq "5"
       end
     end
+
+    describe '::DEFENDANT_UPLIFT_MAPPINGS' do
+      subject { described_class::DEFENDANT_UPLIFT_MAPPINGS[code] }
+
+      EXPECTED_MAPPINGS = {
+          BASAF: 'MISAU', # Standard appearance fee uplift
+          MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
+          MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
+          MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
+          MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
+          MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
+          MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
+          MIDSE: 'MIDSU', # Deferred sentence hearings uplift
+          MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
+          MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
+          MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
+          MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
+          MIPPC: 'MIPCU', # Paper plea & case management uplift
+          MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
+          MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
+          MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
+          MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
+          MISHR: 'MISHU', # Sentence hearings uplift
+          MITNP: 'MITNU', # Trial not proceed uplift
+          MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
+          MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
+      }.freeze
+
+      context 'mappings' do
+        EXPECTED_MAPPINGS.each do |code, uplift_code|
+          context "code #{code}" do
+            let(:code) { code }
+
+            it "returns #{uplift_code}" do
+              is_expected.to eql uplift_code
+            end
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -89,6 +89,22 @@ FactoryBot.define do
         quantity_is_decimal false
       end
 
+      trait :miaph do
+        description 'Abuse of process hearings (half day)'
+        code 'APH'
+        unique_code 'MIAPH'
+        calculated false
+        quantity_is_decimal false
+      end
+
+      trait :miahu do
+        description 'Abuse of process hearings (half day uplift)'
+        code 'AHU'
+        unique_code 'MIAHU'
+        calculated true
+        quantity_is_decimal false
+      end
+
       trait :miupl do
         lgfs
         description 'Case uplift'

--- a/spec/services/ccr/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/misc_fee_adapter_spec.rb
@@ -22,56 +22,35 @@ module CCR
         BASAF:  %w[AGFS_MISC_FEES AGFS_STD_APPRNC], # Standard appearance fee (basic fee) - *** CCR/Regulations apply same fee to any SAF***
         FXSAF:  %w[AGFS_MISC_FEES AGFS_STD_APPRNC], # Standard Appearance fee (fixed fee) - *** CCR/Regulations apply same fee to any SAF***
         FXCON:  %w[AGFS_MISC_FEES AGFS_CONTEMPT], # Contempt (fixed fee)
-        MIAHU:  %w[AGFS_MISC_FEES TBC], # Abuse of process hearings (half day uplift)
         MIAPH:  %w[AGFS_MISC_FEES AGFS_ABS_PRC_HF], # Abuse of process hearings (half day)
-        MIAWU:  %w[AGFS_MISC_FEES TBC], # Abuse of process hearings (whole day uplift)
         MIAPW:  %w[AGFS_MISC_FEES AGFS_ABS_PRC_WL], # Abuse of process hearings (whole day)
         MISAF:  %w[AGFS_MISC_FEES AGFS_ADJOURNED], # Adjourned appeals
-        MIADC3: %w[AGFS_MISC_FEES TBC], # Application to dismiss a charge (half day uplift)
         MIADC1: %w[AGFS_MISC_FEES AGFS_DMS_DY2_HF], # Application to dismiss a charge (half day)
-        MIADC4: %w[AGFS_MISC_FEES TBC], # Application to dismiss a charge (whole day uplift)
         MIADC2: %w[AGFS_MISC_FEES AGFS_DMS_DY2_WL], # Application to dismiss a charge (whole day)
         MIUPL:  %w[TBC TBC], # Case uplift
-        MIDHU:  %w[AGFS_MISC_FEES TBC], # Confiscation hearings (half day uplift)
         MIDTH:  %w[AGFS_MISC_FEES AGFS_CONFISC_HF], # Confiscation hearings (half day)
-        MIDWU:  %w[AGFS_MISC_FEES TBC], # Confiscation hearings (whole day uplift)
         MIDTW:  %w[AGFS_MISC_FEES AGFS_CONFISC_WL], # Confiscation hearings (whole day)
         MICJA:  %w[OTHER COST_JUDGE_FEE], # Costs judge application
         MICJP:  %w[OTHER COST_JUD_EXP], # Costs judge preparation
         MIDSE:  %w[AGFS_MISC_FEES AGFS_DEF_SEN_HR], # Deferred sentence hearings
-        MIDSU:  %w[AGFS_MISC_FEES TBC], # Deferred sentence hearings uplift
         MIEVI:  %w[EVID_PROV_FEE EVID_PROV_FEE], # Evidence provision fee
-        MIEHU:  %w[AGFS_MISC_FEES TBC], # Hearings relating to admissibility of evidence (half day uplift)
         MIAEH:  %w[AGFS_MISC_FEES AGFS_ADM_EVD_HF], # Hearings relating to admissibility of evidence (half day)
-        MIEWU:  %w[AGFS_MISC_FEES TBC], # Hearings relating to admissibility of evidence (whole day uplift)
         MIAEW:  %w[AGFS_MISC_FEES AGFS_ADM_EVD_WL], # Hearings relating to admissibility of evidence (whole day)
-        MIHHU:  %w[AGFS_MISC_FEES TBC], # Hearings relating to disclosure (half day uplift)
         MIHDH:  %w[AGFS_MISC_FEES AGFS_DISC_HALF], # Hearings relating to disclosure (half day)
-        MIHWU:  %w[AGFS_MISC_FEES TBC], # Hearings relating to disclosure (whole day uplift)
         MIHDW:  %w[AGFS_MISC_FEES AGFS_DISC_FULL], # Hearings relating to disclosure (whole day)
         MINBR:  %w[AGFS_MISC_FEES AGFS_NOTING_BRF], # Noting brief fee
         MIPPC:  %w[AGFS_MISC_FEES AGFS_PAPER_PLEA], # Paper plea & case management
-        MIPCU:  %w[AGFS_MISC_FEES TBC], # Paper plea & case management uplift
-        MICHU:  %w[AGFS_MISC_FEES TBC], # Proceeds of crime hearings (half day uplift)
         MIPCH:  %w[AGFS_MISC_FEES AGFS_CONFISC_HF], # Proceeds of crime hearings (half day) **** DUPLICATE - sames as confiscation hearings above****
-        MICHW:  %w[AGFS_MISC_FEES TBC], # Proceeds of crime hearings (whole day uplift)
         MIPCW:  %w[AGFS_MISC_FEES AGFS_CONFISC_WL], # Proceeds of crime hearings (whole day) **** DUPLICATE - sames as confiscation hearings above****
-        MIPIU3: %w[AGFS_MISC_FEES TBC], # Public interest immunity hearings (half day uplift)
         MIPIH1: %w[AGFS_MISC_FEES AGFS_PI_IMMN_HF], # Public interest immunity hearings (half day)
-        MIPIH4: %w[AGFS_MISC_FEES TBC], # Public interest immunity hearings (whole day uplift)
         MIPIH2: %w[AGFS_MISC_FEES AGFS_PI_IMMN_WL], # Public interest immunity hearings (whole day)
         MIRNF:  %w[AGFS_MISC_FEES AGFS_NOVELISSUE], # Research of very unusual or novel factual issue
         MIRNL:  %w[AGFS_MISC_FEES AGFS_NOVEL_LAW], # Research of very unusual or novel point of law
         MISHR:  %w[AGFS_MISC_FEES AGFS_SENTENCE], # Sentence hearings
-        MISHU:  %w[AGFS_MISC_FEES TBC], # Sentence hearings uplift
         MISPF: %w[AGFS_MISC_FEES AGFS_SPCL_PREP], # Special preparation fee - AGFS only version
         # MISPF: %w[FEE_SUPPLEMENT SPECIAL_PREP]), # TODO: Special preparation fee - LGFS only version - need to apply fee type role logic
-        MISAU:  %w[AGFS_MISC_FEES TBC], # Standard appearance fee uplift
         MITNP:  %w[AGFS_MISC_FEES AGFS_NOT_PRCD], # Trial not proceed
-        MITNU:  %w[AGFS_MISC_FEES TBC], # Trial not proceed uplift
-        MIUAV3: %w[AGFS_MISC_FEES TBC], # Unsuccessful application to vacate a guilty plea (half day uplift)
         MIUAV1: %w[AGFS_MISC_FEES AGFS_UN_VAC_HF], # Unsuccessful application to vacate a guilty plea (half day)
-        MIUAV4: %w[AGFS_MISC_FEES TBC], # Unsuccessful application to vacate a guilty plea (whole day uplift)
         MIUAV2: %w[AGFS_MISC_FEES AGFS_UN_VAC_WL], # Unsuccessful application to vacate a guilty plea (whole day)
         MIWPF:  %w[AGFS_MISC_FEES AGFS_WSTD_PREP], # Wasted preparation fee
         MIWOA:  %w[AGFS_MISC_FEES AGFS_WRTN_ORAL], # Written / oral advice

--- a/spec/services/ccr/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/misc_fee_adapter_spec.rb
@@ -27,7 +27,7 @@ module CCR
         MISAF:  %w[AGFS_MISC_FEES AGFS_ADJOURNED], # Adjourned appeals
         MIADC1: %w[AGFS_MISC_FEES AGFS_DMS_DY2_HF], # Application to dismiss a charge (half day)
         MIADC2: %w[AGFS_MISC_FEES AGFS_DMS_DY2_WL], # Application to dismiss a charge (whole day)
-        MIUPL:  %w[TBC TBC], # Case uplift
+        MIUPL:  %w[TBC TBC], # Case uplift - **LGFS only**
         MIDTH:  %w[AGFS_MISC_FEES AGFS_CONFISC_HF], # Confiscation hearings (half day)
         MIDTW:  %w[AGFS_MISC_FEES AGFS_CONFISC_WL], # Confiscation hearings (whole day)
         MICJA:  %w[OTHER COST_JUDGE_FEE], # Costs judge application


### PR DESCRIPTION
**What**
Consolidates miscellaneous fees of the uplift variety into their "parent" misc fee 
as a defendant count, for injection into CCR.

**Why**
CCR accepts only the "parent" varieties of miscellaneous fee
with (defendant) uplifts applied via a "number of defendants" field
on the bill/fee.