### PR TITLE
Add error logging on redraft fails

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -79,7 +79,8 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def clone_rejected
     draft = claim_updater.clone_rejected
     redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
-  rescue StandardError
+  rescue StandardError => error
+    LogStuff.send(:error, 'Cloning failed', claim_id: @claim.id, error: error.message) { 'Failed to clone' }
     redirect_to external_users_claims_url, alert: 'Can only clone rejected claims'
   end
 

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -556,16 +556,28 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
     context 'from non-rejected claim' do
       subject { create(:submitted_claim, external_user: advocate) }
 
-      before do
+      it 'logs the actual error message' do
+        expect(LogStuff).to receive(:error).once
         patch :clone_rejected, id: subject
       end
 
-      it 'redirects to advocates dashboard' do
-        expect(response).to redirect_to(external_users_claims_url)
-      end
+      describe 'the response' do
+        before do
+          # allow(log_stuff).to receive(:error)
+          patch :clone_rejected, id: subject
+        end
 
-      it 'does not create a draft claim' do
-        expect(Claim::BaseClaim.active.last).to_not be_draft
+        it 'redirects to advocates dashboard' do
+          expect(response).to redirect_to(external_users_claims_url)
+        end
+
+        it 'does not create a draft claim' do
+          expect(Claim::BaseClaim.active.last).to_not be_draft
+        end
+
+        it'displays a flash error' do
+          expect(flash[:alert]).to eq 'Can only clone rejected claims'
+        end
       end
     end
   end


### PR DESCRIPTION
### What?

Add Clone failing output to the logs

### Why?

We are getting lots of error reports on redraft from users, but because
the errors seem to be duplication related, anonymising and duplicating
the database to local doesn't replicate the S3 doc storage.

This step is designed to log better errors for us, so that we can handle
actual failures better in future and give users better feedback