### PR TITLE
Update the travel_time quantity

### DIFF
--- a/app/services/ccr/expenses_adapter.rb
+++ b/app/services/ccr/expenses_adapter.rb
@@ -81,7 +81,7 @@ module CCR
       when 'CAR', 'BIKE'
         expense.distance
       when 'TRAVL'
-        expense.hours
+        ((expense.hours * 4).ceil / 4.0)
       else
         1
       end

--- a/spec/fixtures/ccr_test_expenses_fixtures.rb
+++ b/spec/fixtures/ccr_test_expenses_fixtures.rb
@@ -44,9 +44,9 @@ module CCR
 
     def for_travel_time
       [
-          { source_expense: { location: 'Prison - HMP Forest Bank', quantity: nil, rate: nil, amount: 37.33, reason_id: 2, reason_text: nil, schema_version: 2, distance: nil, mileage_rate_id: nil, date: '2017-03-02', hours: 0.8, vat_amount: 7.47 }, expected_return: { "bill_type": "AGFS_EXPENSES", "bill_subtype": "AGFS_TCT_CNF_VW", "date_incurred": "2017-03-02", "description": "Prison - HMP Forest Bank", "quantity": "0.8", "rate": "0" } },
+          { source_expense: { location: 'Prison - HMP Forest Bank', quantity: nil, rate: nil, amount: 37.33, reason_id: 2, reason_text: nil, schema_version: 2, distance: nil, mileage_rate_id: nil, date: '2017-03-02', hours: 0.8, vat_amount: 7.47 }, expected_return: { "bill_type": "AGFS_EXPENSES", "bill_subtype": "AGFS_TCT_CNF_VW", "date_incurred": "2017-03-02", "description": "Prison - HMP Forest Bank", "quantity": "1", "rate": "0" } },
           { source_expense: { location: 'HMP Walton', quantity: nil, rate: nil, amount: 39, reason_id: 3, reason_text: nil, schema_version: 2, distance: nil, mileage_rate_id: nil, date: '2016-01-29', hours: 1, vat_amount: 7.8 }, expected_return: { "bill_type": "AGFS_EXPENSES", "bill_subtype": "AGFS_TCT_CNF_VW", "date_incurred": "2016-01-29", "description": "HMP Walton", "quantity": "1", "rate": "0" } },
-          { source_expense: { location: 'Site Visit, Lincoln', quantity: nil, rate: nil, amount: 195, reason_id: 4, reason_text: nil, schema_version: 2, distance: nil, mileage_rate_id: nil, date: '2016-07-29', hours: 5, vat_amount: 39 }, expected_return: { "bill_type": "AGFS_EXPENSES", "bill_subtype": "AGFS_TCT_CNF_VW", "date_incurred": "2016-07-29", "description": "Site Visit, Lincoln", "quantity": "5", "rate": "0" } },
+          { source_expense: { location: 'Site Visit, Lincoln', quantity: nil, rate: nil, amount: 195, reason_id: 4, reason_text: nil, schema_version: 2, distance: nil, mileage_rate_id: nil, date: '2016-07-29', hours: 5.3, vat_amount: 39 }, expected_return: { "bill_type": "AGFS_EXPENSES", "bill_subtype": "AGFS_TCT_CNF_VW", "date_incurred": "2016-07-29", "description": "Site Visit, Lincoln", "quantity": "5.5", "rate": "0" } },
       ]
     end
 


### PR DESCRIPTION
CCR expects travel time to be in quarter amounts e.g. 1.25, 1.5, 1.75, 2.0

Currently case-workers will round up the provider stored values, this commit
ensures that when providing data for the CCR endpoint it does this automatically
this makes the injection more robust and will reduce the re-keying needed