### PR TITLE
Map discontinuance claim fees to CCR Advocate fee bill

### DIFF
--- a/app/services/ccr/fee/basic_fee_adapter.rb
+++ b/app/services/ccr/fee/basic_fee_adapter.rb
@@ -25,14 +25,10 @@
 module CCR
   module Fee
     class BasicFeeAdapter < BaseFeeAdapter
-      # The CCR "Advocate fee" bill can have different sub types
-      # based on the type of case, which map to basic fees as follows.
-      # Those case types with nil values cannot claim an "Advocate fee" at all
-      #
       BASIC_FEE_BILL_MAPPINGS = {
         GRRAK: zip(%w[AGFS_FEE AGFS_FEE]), # Cracked Trial - LGFS only
         GRCBR: zip(%w[AGFS_FEE AGFS_FEE]), # Cracked before retrial - LGFS only
-        GRDIS: zip([nil, nil]), # TODO: Discontinuance
+        GRDIS: zip(%w[AGFS_FEE AGFS_FEE]), # Discontinuance
         GRGLT: zip(%w[AGFS_FEE AGFS_FEE]), # Guilty plea
         GRRTR: zip(%w[AGFS_FEE AGFS_FEE]), # Retrial
         GRTRL: zip(%w[AGFS_FEE AGFS_FEE]) # Trial

--- a/app/services/ccr/fee/fixed_fee_adapter.rb
+++ b/app/services/ccr/fee/fixed_fee_adapter.rb
@@ -21,7 +21,7 @@
 # B. For other CCCD fixed fees the bill sub type is based on the case_type/bill_scenario
 #
 #   * The fee's attributes can be derived from CCCD fees equivalent to the
-#     case_type/bill_scenario plus uplift versions and generix fixed
+#     case_type/bill_scenario plus uplift versions and generic fixed
 #     case/defendant uplift fees. see adapted fixed fee entity for specifics.
 #     e.g.  FXACV FXASE FXCBR FXCSE FXENP
 #             plus their uplifts...
@@ -37,10 +37,6 @@
 module CCR
   module Fee
     class FixedFeeAdapter < BaseFeeAdapter
-      # The CCR "Advocate fee" bill can have different sub types
-      # based on the type of case, which map as follows.
-      # Those case types with nil values cannot claim an "Advocate fee" at all
-      #
       FIXED_FEE_BILL_MAPPINGS = {
         FXACV: zip(%w[AGFS_FEE AGFS_APPEAL_CON]), # Appeal against conviction
         FXASE: zip(%w[AGFS_FEE AGFS_APPEAL_SEN]), # Appeal against sentence

--- a/spec/services/ccr/fee/basic_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/basic_fee_adapter_spec.rb
@@ -29,7 +29,7 @@ module CCR
         SUBTYPE_MAPPINGS = {
           GRRAK: 'AGFS_FEE', # Cracked Trial
           GRCBR: 'AGFS_FEE', # Cracked before retrial
-          GRDIS: nil, # Discontinuance # TODO: handle discontinuance advocate fee sub types
+          GRDIS: 'AGFS_FEE', # Discontinuance
           GRGLT: 'AGFS_FEE', # Guilty plea
           GRRTR: 'AGFS_FEE', # Retrial
           GRTRL: 'AGFS_FEE' # Trial


### PR DESCRIPTION
Discontinuance is a bill scenario in CCR that
accepts the AGFS_FEE, AGFS_FEE bill type/sub-type.

The CCR fee itself only accepts PPE, defendant uplift and
case uplift fields, which are already being passed.