### PR TITLE
Add errors when allocation fails

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -134,7 +134,22 @@ class Allocation
     claim.allocate!(audit_attributes)
 
     claim.case_workers << case_worker
-    successful_claims << claim
+    if claim.case_workers.empty?
+      LogStuff.send(:error, 'Allocation',
+                    action: 'allocating',
+                    claim_id: claim.id,
+                    allocating_user_id: @current_user.id,
+                    allocating_to_user_id: @case_worker_id,
+                    claim_ids: @claim_ids,
+                    allocating: @allocating,
+                    deallocate: @deallocate) do
+        "Allocating claim #{claim.id} failed"
+      end
+
+      errors.add(:base, "Allocating Claim #{claim.case_number} to #{case_worker&.name} was unsuccessful")
+    else
+      successful_claims << claim
+    end
   end
 
   def audit_attributes

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -48,6 +48,23 @@ RSpec.describe Allocation, type: :model do
         end
       end
 
+      context 'when valid, but allocation bug occurs' do
+        subject { allocator.save }
+        let(:claims) { create_list(:submitted_claim, 1) }
+        let(:case_worker_dbl) { double(Array, empty?: true, exists?: false) }
+        before do
+          allow(case_worker_dbl).to receive(:<<)
+          allow_any_instance_of(Claim::BaseClaim).to receive(:case_workers).and_return(case_worker_dbl)
+        end
+
+        it 'logs the error' do
+          expect(LogStuff).to receive(:error).once
+          subject
+        end
+
+        it { is_expected.to be false }
+      end
+
       context 'when in an invalid state' do
         let(:claims) { create_list(:allocated_claim, 2) }
 


### PR DESCRIPTION
As part of the allocation process, the system logs the claim as allocated
and _then_ links the case worker.  Twice we have seen a situation where
part 1 happens but part 2 fails.

This PR should log errors that can be monitored in kibana to give us some
details to debug this issue.

~~No tests could be written because I cannot determine the state of the data
before the circumstances occur.~~

I spent far to long writing the tests to make code climate happy