### PR TITLE
Expose retrial details

### DIFF
--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -23,8 +23,7 @@ module API
       expose :offence, using: API::Entities::CCR::Offence
       expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants
 
-      # TODO: need a new field for retrial reductions
-      expose :dummy_retrial_reduction, as: :retrial_reduction
+      expose :retrial_reduction
 
       with_options(format_with: :string) do
         expose :actual_trial_length_or_one, as: :actual_trial_Length
@@ -42,10 +41,6 @@ module API
 
       def defendants_with_main_first
         object.defendants.order(created_at: :asc)
-      end
-
-      def dummy_retrial_reduction
-        true
       end
 
       def estimated_trial_length_or_one

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -12,10 +12,12 @@ module API
               :trial_fixed_notice_at,
               :trial_fixed_at,
               :trial_cracked_at,
+              :retrial_started_at,
               :last_submitted_at,
               format_with: :utc
       expose :trial_cracked_at_third
 
+      expose :adapted_advocate_category, as: :advocate_category
       expose :case_type, using: API::Entities::CCR::CaseType
       expose :court, using: API::Entities::CCR::Court
       expose :offence, using: API::Entities::CCR::Offence
@@ -23,27 +25,17 @@ module API
 
       # TODO: need a new field for retrial reductions
       expose :dummy_retrial_reduction, as: :retrial_reduction
-      expose :retrial_started_at, :retrial_concluded_at, format_with: :utc
+
       with_options(format_with: :string) do
+        expose :actual_trial_length_or_one, as: :actual_trial_Length
+        expose :estimated_trial_length_or_one, as: :estimated_trial_length
         expose :retrial_actual_length_or_one, as: :retrial_actual_length
         expose :retrial_estimated_length_or_one, as: :retrial_estimated_length
       end
 
-      # TODO: Retrial, original trial details
-      # NOTE: CCR requires original trial case number but defaults this
-      # to the retrials case number as they are usually the same. Similarly
-      # with court. Ideally CCR should infer this information until such time
-      # as new fields are added to CCCD.
-      #
-      # expose :case_number, as: :retrial_original_case_number
-      # expose :court, using: API::Entities::CCR::Court, as: :retrial_original_court
-
-      expose :estimated_trial_length_or_one, as: :estimated_trial_length, format_with: :string
-      expose :actual_trial_length_or_one, as: :actual_trial_Length, format_with: :string
-      expose :adapted_advocate_category, as: :advocate_category
       expose :additional_information
 
-      # CCR fee to bill mappings
+      # CCR fees and expenses to bill mappings
       expose :bills
 
       private
@@ -53,7 +45,7 @@ module API
       end
 
       def dummy_retrial_reduction
-        'true'
+        true
       end
 
       def estimated_trial_length_or_one

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -52,28 +52,24 @@ module API
         object.defendants.order(created_at: :asc)
       end
 
-      def length_or_one(length)
-        [length, 1].compact.max
-      end
-
-      def estimated_trial_length_or_one
-        length_or_one(object.estimated_trial_length)
-      end
-
-      def actual_trial_length_or_one
-        length_or_one(object.actual_trial_length)
-      end
-
       def dummy_retrial_reduction
         'true'
       end
 
+      def estimated_trial_length_or_one
+        object.estimated_trial_length.or_one
+      end
+
+      def actual_trial_length_or_one
+        object.actual_trial_length.or_one
+      end
+
       def retrial_actual_length_or_one
-        length_or_one(object.retrial_actual_length)
+        object.retrial_actual_length.or_one
       end
 
       def retrial_estimated_length_or_one
-        length_or_one(object.retrial_actual_length)
+        object.retrial_actual_length.or_one
       end
 
       def bills

--- a/app/interfaces/api/entities/ccr_claim.rb
+++ b/app/interfaces/api/entities/ccr_claim.rb
@@ -21,6 +21,23 @@ module API
       expose :offence, using: API::Entities::CCR::Offence
       expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants
 
+      # TODO: need a new field for retrial reductions
+      expose :dummy_retrial_reduction, as: :retrial_reduction
+      expose :retrial_started_at, :retrial_concluded_at, format_with: :utc
+      with_options(format_with: :string) do
+        expose :retrial_actual_length_or_one, as: :retrial_actual_length
+        expose :retrial_estimated_length_or_one, as: :retrial_estimated_length
+      end
+
+      # TODO: Retrial, original trial details
+      # NOTE: CCR requires original trial case number but defaults this
+      # to the retrials case number as they are usually the same. Similarly
+      # with court. Ideally CCR should infer this information until such time
+      # as new fields are added to CCCD.
+      #
+      # expose :case_number, as: :retrial_original_case_number
+      # expose :court, using: API::Entities::CCR::Court, as: :retrial_original_court
+
       expose :estimated_trial_length_or_one, as: :estimated_trial_length, format_with: :string
       expose :actual_trial_length_or_one, as: :actual_trial_Length, format_with: :string
       expose :adapted_advocate_category, as: :advocate_category
@@ -35,12 +52,28 @@ module API
         object.defendants.order(created_at: :asc)
       end
 
+      def length_or_one(length)
+        [length, 1].compact.max
+      end
+
       def estimated_trial_length_or_one
-        [object.estimated_trial_length, 1].compact.max
+        length_or_one(object.estimated_trial_length)
       end
 
       def actual_trial_length_or_one
-        [object.actual_trial_length, 1].compact.max
+        length_or_one(object.actual_trial_length)
+      end
+
+      def dummy_retrial_reduction
+        'true'
+      end
+
+      def retrial_actual_length_or_one
+        length_or_one(object.retrial_actual_length)
+      end
+
+      def retrial_estimated_length_or_one
+        length_or_one(object.retrial_actual_length)
       end
 
       def bills

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -14,6 +14,7 @@
 #  requires_retrial_dates  :boolean          default(FALSE)
 #  roles                   :string
 #  fee_type_code           :string
+#  uuid                    :uuid
 #
 
 class CaseType < ActiveRecord::Base

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 module Claim

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 module Claim

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 module Claim

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 module Claim

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 module Claim

--- a/app/models/injection_attempt.rb
+++ b/app/models/injection_attempt.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: injection_attempts
+#
+#  id            :integer          not null, primary key
+#  claim_id      :integer
+#  succeeded     :boolean
+#  error_message :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#
+
 class InjectionAttempt < ActiveRecord::Base
   belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
 

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -7,6 +7,7 @@
 #  offence_class_id :integer
 #  created_at       :datetime
 #  updated_at       :datetime
+#  unique_code      :string           default("anyoldrubbish"), not null
 #
 
 class Offence < ActiveRecord::Base

--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -37,3 +37,7 @@ end
 class FalseClass
   include BooleanExtension::False
 end
+
+class Integer
+  include IntegerExtension
+end

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -30,18 +30,10 @@
     },
     "retrial_reduction": {
       "id": "/properties/retrial_reduction",
-      "type": ["string","null"]
+      "type": "boolean"
     },
     "retrial_started_at": {
       "id": "/properties/retrial_started_at",
-      "type": ["string","null"]
-    },
-    "retrial_concluded_at": {
-      "id": "/properties/retrial_concluded_at",
-      "type": ["string","null"]
-    },
-    "retrial_actual_length": {
-      "id": "/properties/retrial_actual_length",
       "type": ["string","null"]
     },
     "retrial_actual_length": {

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -28,6 +28,30 @@
       "id": "/properties/trial_cracked_at_third",
       "type": ["string","null"]
     },
+    "retrial_reduction": {
+      "id": "/properties/retrial_reduction",
+      "type": ["string","null"]
+    },
+    "retrial_started_at": {
+      "id": "/properties/retrial_started_at",
+      "type": ["string","null"]
+    },
+    "retrial_concluded_at": {
+      "id": "/properties/retrial_concluded_at",
+      "type": ["string","null"]
+    },
+    "retrial_actual_length": {
+      "id": "/properties/retrial_actual_length",
+      "type": ["string","null"]
+    },
+    "retrial_actual_length": {
+      "id": "/properties/retrial_actual_length",
+      "type": ["string","null"]
+    },
+    "retrial_estimated_length": {
+      "id": "/properties/retrial_estimated_length",
+      "type": ["string","null"]
+    },
     "last_submitted_at": {
       "id": "/properties/last_submitted_at",
       "type": ["string","null"]

--- a/db/migrate/20171211120149_add_retrial_reduction_to_claim.rb
+++ b/db/migrate/20171211120149_add_retrial_reduction_to_claim.rb
@@ -1,0 +1,5 @@
+class AddRetrialReductionToClaim < ActiveRecord::Migration
+  def change
+    add_column :claims, :retrial_reduction, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171111113526) do
+ActiveRecord::Schema.define(version: 20171211120149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 20171111113526) do
     t.decimal  "expenses_vat",             default: 0.0
     t.decimal  "disbursements_vat",        default: 0.0
     t.integer  "value_band_id"
+    t.boolean  "retrial_reduction",        default: false
   end
 
   add_index "claims", ["case_number"], name: "index_claims_on_case_number", using: :btree

--- a/lib/extensions/integer_extension.rb
+++ b/lib/extensions/integer_extension.rb
@@ -1,0 +1,5 @@
+module IntegerExtension
+  def or_one
+    [self, 1].compact.max
+  end
+end

--- a/spec/factories/case_types.rb
+++ b/spec/factories/case_types.rb
@@ -14,6 +14,7 @@
 #  requires_retrial_dates  :boolean          default(FALSE)
 #  roles                   :string
 #  fee_type_code           :string
+#  uuid                    :uuid
 #
 
 FactoryBot.define do

--- a/spec/factories/injection_attempts.rb
+++ b/spec/factories/injection_attempts.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: injection_attempts
+#
+#  id            :integer          not null, primary key
+#  claim_id      :integer
+#  succeeded     :boolean
+#  error_message :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#
+
 FactoryBot.define do
   factory :injection_attempt do
     claim

--- a/spec/factories/offences.rb
+++ b/spec/factories/offences.rb
@@ -7,6 +7,7 @@
 #  offence_class_id :integer
 #  created_at       :datetime
 #  updated_at       :datetime
+#  unique_code      :string           default("anyoldrubbish"), not null
 #
 
 FactoryBot.define do

--- a/spec/models/case_type_spec.rb
+++ b/spec/models/case_type_spec.rb
@@ -14,6 +14,7 @@
 #  requires_retrial_dates  :boolean          default(FALSE)
 #  roles                   :string
 #  fee_type_code           :string
+#  uuid                    :uuid
 #
 
 require 'rails_helper'

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -59,6 +59,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/claim/interim_claim_spec.rb
+++ b/spec/models/claim/interim_claim_spec.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/claim/transfer_claim_spec.rb
+++ b/spec/models/claim/transfer_claim_spec.rb
@@ -58,6 +58,8 @@
 #  fees_vat                 :decimal(, )      default(0.0)
 #  expenses_vat             :decimal(, )      default(0.0)
 #  disbursements_vat        :decimal(, )      default(0.0)
+#  value_band_id            :integer
+#  retrial_reduction        :boolean          default(FALSE)
 #
 
 require "rails_helper"

--- a/spec/models/fee/graduated_fee_type_spec.rb
+++ b/spec/models/fee/graduated_fee_type_spec.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: fee_types
+#
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
+#  unique_code         :string
+#
+

--- a/spec/models/fee/interim_fee_type_spec.rb
+++ b/spec/models/fee/interim_fee_type_spec.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: fee_types
+#
+#  id                  :integer          not null, primary key
+#  description         :string
+#  code                :string
+#  created_at          :datetime
+#  updated_at          :datetime
+#  max_amount          :decimal(, )
+#  calculated          :boolean          default(TRUE)
+#  type                :string
+#  roles               :string
+#  parent_id           :integer
+#  quantity_is_decimal :boolean          default(FALSE)
+#  unique_code         :string
+#
+
 require 'rails_helper'
 
 module Fee

--- a/spec/models/injection_attempt_spec.rb
+++ b/spec/models/injection_attempt_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: injection_attempts
+#
+#  id            :integer          not null, primary key
+#  claim_id      :integer
+#  succeeded     :boolean
+#  error_message :string
+#  created_at    :datetime
+#  updated_at    :datetime
+#
+
 require 'rails_helper'
 
 RSpec.describe InjectionAttempt, type: :model do

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -7,6 +7,7 @@
 #  offence_class_id :integer
 #  created_at       :datetime
 #  updated_at       :datetime
+#  unique_code      :string           default("anyoldrubbish"), not null
 #
 
 require 'rails_helper'


### PR DESCRIPTION
**What**
expose details needed for injection of retrials

**Why**
So retrials can be injected with all data required
by CCR, to avoid rekeying by case workers.
