### PR TITLE
Prevent attempted duplication of injection_attempts

### DIFF
--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -24,6 +24,7 @@ module Claims::Cloner
       exclude_association :assessment
       exclude_association :redeterminations
       exclude_association :certification
+      exclude_association :injection_attempts
 
       EXCLUDED_FEE_ASSOCIATIONS.each { |assoc| exclude_association assoc }
 

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -165,6 +165,11 @@ RSpec.describe Claims::Cloner, type: :model do
         expect(@cloned_claim.certification).to be_nil
       end
 
+      it 'does not clone the injection attempts' do
+        expect(@original_claim.injection_attempts.count).to eq(1)
+        expect(@cloned_claim.injection_attempts.count).to eq(0)
+      end
+
       it 'creates the first state transition for the cloned claim' do
         expect(@cloned_claim.claim_state_transitions.count).to eq(1)
 
@@ -219,6 +224,7 @@ RSpec.describe Claims::Cloner, type: :model do
     create(:disbursement, claim: claim)
     create(:redetermination, claim: claim)
 
+    claim.injection_attempts << create(:injection_attempt)
     claim.documents << create(:document, :verified)
 
     claim.allocate!

--- a/spec/support/database_housekeeping.rb
+++ b/spec/support/database_housekeeping.rb
@@ -4,6 +4,7 @@ module DatabaseHousekeeping
       CaseType,
       Expense,
       ClaimStateTransition,
+      InjectionAttempt,
       Claim::BaseClaim,
       DateAttended,
       Defendant,


### PR DESCRIPTION
This should prevent redrafts attempting to duplicate the source claims Injection attempts for the new clone claim