### PR TITLE
Display retrial reduction

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -272,6 +272,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
       :retrial_estimated_length,
       :retrial_actual_length,
       date_attributes_for(:retrial_concluded_at),
+      :retrial_reduction,
       date_attributes_for(:trial_fixed_notice_at),
       date_attributes_for(:trial_fixed_at),
       date_attributes_for(:trial_cracked_at),

--- a/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
@@ -4,30 +4,32 @@ module API::V1::ExternalUsers
       helpers API::V1::ClaimParamsHelper
 
       params do
+        LOCAL_I18N_SCOPE = %i[api v1 external_users claims advocate_claim params].freeze
+
+        def local_t(attribute)
+          I18n.t(attribute.to_s, scope: LOCAL_I18N_SCOPE)
+        end
+
         use :common_params
-        optional :advocate_email, type: String, desc: 'DEPRECATED: Use instead user_email.'
-        optional :user_email,
-                 type: String,
-                 desc: I18n.t('api.v1.external_users.claims.advocate_claim.params.user_email')
+        optional :advocate_email, type: String, desc: local_t(:advocate_email)
+        optional :user_email, type: String, desc: local_t(:user_email)
         optional :advocate_category,
                  type: String,
-                 desc: 'REQUIRED: The category of the advocate',
+                 desc: local_t(:advocate_category),
                  values: Settings.advocate_categories
 
         use :common_trial_params
-        optional :actual_trial_length, type: Integer, desc: 'REQUIRED/UNREQUIRED: The actual trial length in days'
-        optional :retrial_actual_length, type: Integer, desc: 'REQUIRED for retrials: The actual retrial length in days'
-        optional :retrial_concluded_at,
-                 type: String,
-                 desc: 'REQUIRED for retrials: YYYY-MM-DD',
-                 standard_json_format: true
+        optional :actual_trial_length, type: Integer, desc: local_t(:actual_trial_length)
+        optional :retrial_actual_length, type: Integer, desc: local_t(:retrial_actual_length)
+        optional :retrial_concluded_at, type: String, desc: local_t(:retrial_concluded_at), standard_json_format: true
+        optional :retrial_reduction, type: Boolean, desc: local_t(:retrial_reduction), documentation: { default: false }
 
-        optional :trial_fixed_notice_at, type: String, desc: 'OPTIONAL: YYYY-MM-DD', standard_json_format: true
-        optional :trial_fixed_at, type: String, desc: 'OPTIONAL: YYYY-MM-DD', standard_json_format: true
-        optional :trial_cracked_at, type: String, desc: 'OPTIONAL: YYYY-MM-DD', standard_json_format: true
+        optional :trial_fixed_notice_at, type: String, desc: local_t(:trial_fixed_notice_at), standard_json_format: true
+        optional :trial_fixed_at, type: String, desc: local_t(:trial_fixed_at), standard_json_format: true
+        optional :trial_cracked_at, type: String, desc: local_t(:trial_cracked_at), standard_json_format: true
         optional :trial_cracked_at_third,
                  type: String,
-                 desc: 'OPTIONAL: The third in which this case was cracked.',
+                 desc: local_t(:trial_cracked_at_third),
                  values: Settings.trial_cracked_at_third
       end
 

--- a/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
@@ -13,29 +13,31 @@
     .form-col
       %fieldset
         %legend.govuk-legend |
-          = t('.estimated_retrial_length')
+          = t('.retrial_estimated_length')
         .form-date
           %p.form-hint |
-            = t('.estimated_retrial_length_hint')
+            = t('.retrial_estimated_length_hint')
 
         .form-group.form-group-day
           = f.adp_text_field :retrial_estimated_length, label: t('.days'), input_classes:'short-input', input_type: 'number', errors: @error_presenter
 
   .form-row
-
     .form-col.form-col-one-half
       = f.gov_uk_date_field(:retrial_concluded_at, legend_text: t('.retrial_concluded_at'), legend_class: 'govuk-legend', id: "retrial_concluded_at", error_messages: gov_uk_date_field_error_messages(@error_presenter, :retrial_concluded_at))
 
     .form-col
       %fieldset
         %legend.govuk-legend |
-          = t('.actual_retrial_length')
+          = t('.retrial_actual_length')
         .form-date
           %p.form-hint |
-            = t('.actual_retrial_length_hint')
+            = t('.retrial_actual_length_hint')
 
         .form-group.form-group-day
           = f.adp_text_field :retrial_actual_length, label: t('.days'), input_classes:'short-input', input_type: 'number', errors: @error_presenter
 
-
-
+  .form-row
+    %fieldset
+      = f.anchored_label t('.retrial_reduction'), 'retrial_reduction'
+      = f.collection_radio_buttons(:retrial_reduction, [['Yes','true'],['No','false']], :last, :first ) do |b|
+        = b.label(class: "block-label") { b.radio_button + b.text }

--- a/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
@@ -37,7 +37,18 @@
           = f.adp_text_field :retrial_actual_length, label: t('.days'), input_classes:'short-input', input_type: 'number', errors: @error_presenter
 
   .form-row
-    %fieldset
-      = f.anchored_label t('.retrial_reduction'), 'retrial_reduction'
-      = f.collection_radio_buttons(:retrial_reduction, [['Yes','true'],['No','false']], :last, :first ) do |b|
-        = b.label(class: "block-label") { b.radio_button + b.text }
+    .form-col.form-col-two-thirds
+      %fieldset
+        %legend.govuk-legend
+          = t('.retrial_reduction')
+
+        .form-group.inline
+          = f.collection_radio_buttons(:retrial_reduction, [['Yes','true'],['No','false']], :last, :first ) do |b|
+            - b.label(class: "block-label") { b.radio_button + b.text }
+        %details
+          %summary
+            %span.summary
+              = t('.retrial_reduction_help_link')
+          .panel-indent.panel-border-narrow
+            %p
+              = t('.retrial_reduction_help_html')

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -1,7 +1,7 @@
-- locale_path = "external_users.claims.case_details.fields"
-- cracked_trial_detail_translations = 'external_users.claims.case_details.cracked_trial_fields'
-- trial_detail_translations = 'external_users.claims.case_details.trial_detail_fields'
-- retrial_detail_translations = 'external_users.claims.case_details.retrial_detail_fields'
+- claim_fields = %i[external_users claims case_details fields]
+- cracked_trial_fields = %i[external_users claims case_details cracked_trial_fields]
+- trial_detail_fields = %i[external_users claims case_details trial_detail_fields]
+- retrial_detail_fields = %i[external_users claims case_details retrial_detail_fields]
 
 %table{class:'table-summary', summary: t('.summary')}
   %caption
@@ -42,7 +42,7 @@
 
     %tr
       %th{scope: 'row'}
-        = t("#{locale_path}.case_number")
+        = t("case_number", scope: claim_fields)
       %td
         = claim.case_number
 
@@ -63,20 +63,20 @@
     - if claim.case_type.try(:name)
       %tr
         %th{scope: 'row'}
-          = t("#{locale_path}.case_type")
+          = t("case_type", scope: claim_fields)
         %td
           = claim.case_type.try(:name)
 
     - if claim.agfs?
       %tr
         %th{scope: 'row'}
-          = t("#{locale_path}.offence_category")
+          = t("offence_category", scope: claim_fields)
         %td
           = claim.offence ? claim.offence.description : t("general.not_provided")
 
     %tr
       %th{scope: 'row'}
-        = t("#{locale_path}.offence_class")
+        = t("offence_class", scope: claim_fields)
       %td
         = claim.offence ? claim.offence.offence_class : t("general.not_provided")
 
@@ -87,69 +87,74 @@
         %td
           = claim.case_concluded_at
 
-    - if claim.case_type && claim.requires_cracked_dates?
+    - if claim&.case_type && claim.requires_cracked_dates?
       %tr
         %th{scope: 'row'}
-          = t("#{cracked_trial_detail_translations}.trial_fixed_notice_at")
+          = t("trial_fixed_notice_at", scope: cracked_trial_fields)
         %td
-          = claim.trial_fixed_notice_at.strftime(Settings.date_format) rescue ''
+          = claim&.trial_fixed_notice_at&.strftime(Settings.date_format)
       %tr
         %th{scope: 'row'}
-          = t("#{cracked_trial_detail_translations}.trial_fixed_at")
+          = t("trial_fixed_at", scope: cracked_trial_fields)
         %td
-          = claim.trial_fixed_at.strftime(Settings.date_format) rescue ''
+          = claim&.trial_fixed_at&.strftime(Settings.date_format)
       %tr
         %th{scope: 'row'}
-          = t("#{cracked_trial_detail_translations}.trial_cracked_at")
+          = t("trial_cracked_at", scope: cracked_trial_fields)
         %td
-          = claim.trial_cracked_at.strftime(Settings.date_format) rescue ''
+          = claim&.trial_cracked_at&.strftime(Settings.date_format)
       %tr
         %th{scope: 'row'}
-          = t("#{cracked_trial_detail_translations}.trial_cracked_at_third")
+          = t("trial_cracked_at_third", scope: cracked_trial_fields)
         %td
-          = claim.trial_cracked_at_third.humanize rescue ''
+          = claim&.trial_cracked_at_third&.humanize
 
     - unless claim.interim?
-      - if claim.case_type && claim.requires_trial_dates?
+      - if claim&.case_type && claim.requires_trial_dates?
         %tr
           %th{scope: 'row'}
-            = t("#{trial_detail_translations}.first_day_of_trial")
+            = t("first_day_of_trial", scope: trial_detail_fields)
           %td
-            = claim.first_day_of_trial.strftime(Settings.date_format) rescue ''
+            = claim&.first_day_of_trial.strftime(Settings.date_format)
         %tr
           %th{scope: 'row'}
-            = t("#{trial_detail_translations}.estimated_trial_length")
+            = t("estimated_trial_length", scope: trial_detail_fields)
           %td
-            = claim.estimated_trial_length rescue ''
+            = claim&.estimated_trial_length
         %tr
           %th{scope: 'row'}
-            = t("#{trial_detail_translations}.actual_trial_length")
+            = t("actual_trial_length", scope: trial_detail_fields)
           %td
-            = claim.actual_trial_length rescue ''
+            = claim&.actual_trial_length
         %tr
           %th{scope: 'row'}
-            = t("#{trial_detail_translations}.trial_concluded_at")
+            = t("trial_concluded_at", scope: trial_detail_fields)
           %td
-            = claim.trial_concluded_at.strftime(Settings.date_format) rescue ''
+            = claim&.trial_concluded_at&.strftime(Settings.date_format)
 
-      - if claim.case_type && claim.requires_retrial_dates?
+      - if claim&.case_type && claim.requires_retrial_dates?
         %tr
           %th{scope: 'row'}
-            = t("#{retrial_detail_translations}.retrial_started_at")
+            = t("retrial_started_at", scope: retrial_detail_fields)
           %td
-            = claim.retrial_started_at.strftime(Settings.date_format) rescue ''
+            = claim&.retrial_started_at.strftime(Settings.date_format)
         %tr
           %th{scope: 'row'}
-            = t("#{retrial_detail_translations}.retrial_estimated_length")
+            = t("retrial_estimated_length", scope: retrial_detail_fields)
           %td
-            = claim.retrial_estimated_length rescue ''
+            = claim&.retrial_estimated_length
         %tr
           %th{scope: 'row'}
-            = t("#{retrial_detail_translations}.retrial_actual_length")
+            = t("retrial_actual_length", scope: retrial_detail_fields)
           %td
-            = claim.retrial_actual_length rescue ''
+            = claim&.retrial_actual_length
         %tr
           %th{scope: 'row'}
-            = t("#{retrial_detail_translations}.retrial_concluded_at")
+            = t("retrial_concluded_at", scope: retrial_detail_fields)
           %td
-            = claim.retrial_concluded_at.strftime(Settings.date_format) rescue ''
+            = claim&.retrial_concluded_at&.strftime(Settings.date_format)
+        %tr
+          %th{scope: 'row'}
+            = t("retrial_reduction", scope: retrial_detail_fields)
+          %td
+            = claim&.retrial_reduction? ? 'Yes' : 'No'

--- a/app/views/shared/_claim_retrial_details.html.haml
+++ b/app/views/shared/_claim_retrial_details.html.haml
@@ -1,24 +1,30 @@
-- retrial_detail_translations = 'external_users.claims.case_details.retrial_detail_fields'
+- retrial_i18n_scope = %i[external_users claims case_details retrial_detail_fields]
 %tr
   %th{scope: "col"}
-    = t("#{retrial_detail_translations}.retrial_started_at")
+    = t('retrial_started_at', scope: retrial_i18n_scope)
   %td
-    = claim.retrial_started_at.strftime(Settings.date_format) rescue ''
+    = claim&.retrial_started_at&.strftime(Settings.date_format)
 
 %tr
   %th{scope: "col"}
-    = t("#{retrial_detail_translations}.retrial_estimated_length")
+    = t('retrial_estimated_length', scope: retrial_i18n_scope)
   %td
-    = claim.retrial_estimated_length rescue ''
+    = claim&.retrial_estimated_length
 
 %tr
   %th{scope: "col"}
-    = t("#{retrial_detail_translations}.retrial_actual_length")
+    = t('retrial_actual_length', scope: retrial_i18n_scope)
   %td
-    = claim.retrial_actual_length rescue ''
+    = claim&.retrial_actual_length
 
 %tr
   %th{scope: "col"}
-    = t("#{retrial_detail_translations}.retrial_concluded_at")
+    = t('retrial_concluded_at', scope: retrial_i18n_scope)
   %td
-    = claim.retrial_concluded_at.strftime(Settings.date_format) rescue ''
+    = claim&.retrial_concluded_at&.strftime(Settings.date_format)
+
+%tr
+  %th{scope: "col"}
+    = t('retrial_reduction', scope: retrial_i18n_scope)
+  %td
+    = claim&.retrial_reduction

--- a/app/views/shared/_claim_retrial_details.html.haml
+++ b/app/views/shared/_claim_retrial_details.html.haml
@@ -27,4 +27,4 @@
   %th{scope: "col"}
     = t('retrial_reduction', scope: retrial_i18n_scope)
   %td
-    = claim&.retrial_reduction
+    = claim&.retrial_reduction? ? 'Yes' : 'No'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1184,7 +1184,18 @@ en:
         claims:
           advocate_claim:
             params:
+              advocate_email: 'DEPRECATED: Use instead user_email'
+              advocate_category: 'REQUIRED: The category of the advocate'
               user_email: 'REQUIRED: The ADP account email address that uniquely identifies the advocate to whom this claim belongs.'
+              actual_trial_length: 'REQUIRED/UNREQUIRED: The actual trial length in days'
+              retrial_actual_length: 'REQUIRED for retrials: The actual retrial length in days'
+              retrial_concluded_at: 'REQUIRED for retrials: YYYY-MM-DD'
+              trial_fixed_notice_at: 'OPTIONAL: YYYY-MM-DD'
+              trial_fixed_at: 'OPTIONAL: YYYY-MM-DD'
+              trial_cracked_at: 'OPTIONAL: YYYY-MM-DD'
+              trial_cracked_at_third: 'OPTIONAL: The third in which this case was cracked.'
+              retrial_reduction: 'OPTIONAL: Whether to request a reduced rate on the retrial'
+              actual_trial_length: 'REQUIRED/UNREQUIRED: The actual trial length in days'
           transfer_claim:
             params:
               case_conclusion_id: 'REQUIRED/UNREQUIRED: Only required for new litigators that transferred onto unelected cases at specific stages.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -527,7 +527,7 @@ en:
           retrial_estimated_length_hint: 'Number of days'
           retrial_started_at: 'First day of retrial'
           retrial_concluded_at: 'Retrial concluded on'
-          retrial_reduction: 'Are you applying for a reduction?'
+          retrial_reduction: 'Apply reduced rate to retrial?'
           days: "Days"
         offence_id_select:
           offence_class: "Offence class"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,12 +521,13 @@ en:
           trial_concluded_at: 'Trial concluded on'
           days: "Days"
         retrial_detail_fields:
-          actual_retrial_length: 'Actual retrial length'
-          actual_retrial_length_hint: 'Number of days'
-          estimated_retrial_length: 'Estimated retrial length'
-          estimated_retrial_length_hint: 'Number of days'
+          retrial_actual_length: 'Actual retrial length'
+          retrial_actual_length_hint: 'Number of days'
+          retrial_estimated_length: 'Estimated retrial length'
+          retrial_estimated_length_hint: 'Number of days'
           retrial_started_at: 'First day of retrial'
           retrial_concluded_at: 'Retrial concluded on'
+          retrial_reduction: 'Are you applying for a reduction?'
           days: "Days"
         offence_id_select:
           offence_class: "Offence class"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -528,6 +528,13 @@ en:
           retrial_started_at: 'First day of retrial'
           retrial_concluded_at: 'Retrial concluded on'
           retrial_reduction: 'Apply reduced rate to retrial?'
+          retrial_reduction_help_link: 'Help with claiming a reduced rate'
+          retrial_reduction_help_html: |
+              A reduced rate can be requested if: <br/>
+              <ul class="list list-bullet">
+                <li>you represented the defendant(s) at the original trial</li>
+                <li>you don’t want the reduced rate to be applied to the original trial</li>
+              </ul>
           days: "Days"
         offence_id_select:
           offence_class: "Offence class"

--- a/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
@@ -12,6 +12,8 @@ Feature: Advocate admin submits a claim for a Trial case
     When I select an advocate category of 'Junior alone'
     And I select an advocate
     And I select the court 'Blackfriars'
+    And I select a case type of 'Retrial'
+    Then I should see retrial fields
     And I select a case type of 'Trial'
     And I enter a case number of 'A20161234'
     And I select the offence category 'Activities relating to opium'

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -1,4 +1,5 @@
 require_relative 'sections/common_date_section'
+require_relative 'sections/retrial_section'
 require_relative 'sections/fee_case_numbers_section'
 require_relative 'sections/fee_dates_section'
 require_relative 'sections/fee_section'
@@ -21,6 +22,8 @@ class ClaimFormPage < SitePrism::Page
     section :trial_concluded_on, CommonDateSection, '#trial_concluded_at'
     element :actual_trial_length, "#claim_actual_trial_length"
   end
+
+  section :retrial_details, RetrialSection, "#retrial-details"
 
   sections :defendants, "div.defendants > div.js-test-defendant" do
     element :first_name, "div.first-name input"

--- a/features/page_objects/sections/retrial_section.rb
+++ b/features/page_objects/sections/retrial_section.rb
@@ -1,0 +1,10 @@
+require_relative 'common_date_section'
+
+class RetrialSection < SitePrism::Section
+  section :retrial_started_at, CommonDateSection, '#retrial_started_at'
+  section :retrial_concluded_at, CommonDateSection, '#retrial_concluded_at'
+  element :retrial_actual_length, "#claim_retrial_actual_length"
+  element :retrial_estimated_length, "#claim_retrial_estimated_length"
+  element :retrial_reduction_yes, "#claim_retrial_reduction_true"
+  element :retrial_reduction_no, "#claim_retrial_reduction_false"
+end

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -166,3 +166,9 @@ Given(/^There are other advocates in my provider$/) do
                      user: FactoryBot.create(:user, first_name: 'Joe', last_name: 'Blow'),
                      supplier_number: 'XY455')
 end
+
+Then(/^I should see retrial fields$/) do
+  expect(@claim_form_page).to have_retrial_details
+  expect(@claim_form_page.retrial_details).to be_visible
+  expect(@claim_form_page.retrial_details).to be_all_there
+end

--- a/features/support/screenshot_helper.rb
+++ b/features/support/screenshot_helper.rb
@@ -1,0 +1,10 @@
+module ScreenshotHelper
+  def save_and_open_screenhot
+    sleep 3 # give js time to render
+    file_path = Rails.root.join("tmp/capybara/capybara-screenshot-#{Time.now.utc.iso8601.gsub('-', '').gsub(':', '')}.png").to_s
+    page.save_screenshot(file_path, full: true)
+    Launchy.open file_path
+  end
+end
+
+World(ScreenshotHelper)


### PR DESCRIPTION
**What**
Enable users to specify they are opting for a 
reduced rate on a retrial claim

**What**
When a trial goes to retrial remuneration may be requested
at a reduced rate. If not reduced the original trial remuneration
may be reduced retrospectively. However, reduced rates need
not be applied if the advocate did not work on the original trial
or if they prefer to reduce the rate on the trial.
