### PR TITLE
API V2 security

### DIFF
--- a/app/interfaces/api/helpers/authorisation.rb
+++ b/app/interfaces/api/helpers/authorisation.rb
@@ -16,7 +16,7 @@ module API::Helpers
     end
 
     def authenticate_user_is?(persona)
-      authorisation_error unless current_user.persona_type.eql?(persona)
+      authorisation_error unless current_user&.persona_type.eql?(persona)
     end
 
     private

--- a/app/interfaces/api/v2/case_workers/allocate.rb
+++ b/app/interfaces/api/v2/case_workers/allocate.rb
@@ -2,10 +2,6 @@ module API
   module V2
     module CaseWorkers
       class Allocate < Grape::API
-        before_validation do
-          authenticate_user_is?('CaseWorker')
-        end
-
         namespace :case_workers do
           params do
             optional :api_key, type: String, desc: I18n.t('api.v2.generic.params.api_key')

--- a/app/interfaces/api/v2/root.rb
+++ b/app/interfaces/api/v2/root.rb
@@ -7,7 +7,7 @@ module API
 
       group do
         before_validation do
-          authenticate_key!
+          authenticate_user_is?('CaseWorker')
         end
 
         namespace :api, desc: 'Retrieval, creation and validation operations' do

--- a/app/interfaces/api/v2/search.rb
+++ b/app/interfaces/api/v2/search.rb
@@ -4,10 +4,6 @@ module API
       helpers API::V2::CriteriaHelper
       helpers API::V2::QueryHelper
 
-      before_validation do
-        authenticate_user_is?('CaseWorker')
-      end
-
       resource :search, desc: 'Search for claims' do
         params do
           optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the user'

--- a/spec/api/v2/case_worker_spec.rb
+++ b/spec/api/v2/case_worker_spec.rb
@@ -8,12 +8,14 @@ describe API::V2::CaseWorker do
 
   let(:get_case_workers_endpoint) { '/api/case_workers' }
   let(:case_workers) { create_list(:case_worker, 3) }
+  let(:external_user) { create(:external_user) }
   let(:sorting) { {} }
   let(:params) do
     {
-      api_key: case_workers.first.user.api_key
+      api_key: api_key
     }.merge(sorting)
   end
+  let(:api_key) { case_workers.first.user.api_key }
 
   def do_request
     get get_case_workers_endpoint, params, format: :json
@@ -34,6 +36,16 @@ describe API::V2::CaseWorker do
       do_request
       expect(last_response.status).to eq 401
       expect(last_response.body).to include('Unauthorised')
+    end
+
+    context 'when accessed by a ExternalUser' do
+      let(:api_key) { external_user.user.api_key }
+
+      it 'returns unauthorised' do
+        do_request
+        expect(last_response.status).to eq 401
+        expect(last_response.body).to include('Unauthorised')
+      end
     end
 
     it 'should return a JSON with the required information' do

--- a/spec/api/v2/case_workers/claim_spec.rb
+++ b/spec/api/v2/case_workers/claim_spec.rb
@@ -12,6 +12,7 @@ describe API::V2::CaseWorkers::Claim do
 
   let(:get_claims_endpoint) { '/api/case_workers/claims' }
   let(:case_worker) { create(:case_worker) }
+  let(:external_user) { create(:external_user) }
   let(:pagination) { {} }
   let(:params) do
     {
@@ -46,6 +47,15 @@ describe API::V2::CaseWorkers::Claim do
       body = JSON.parse(response.body, symbolize_names: true)
       expect(body).to have_key(:pagination)
       expect(body).to have_key(:items)
+    end
+
+    context 'when accessed by a ExternalUser' do
+      before { do_request(api_key: external_user.user.api_key )}
+
+      it 'returns unauthorised' do
+        expect(last_response.status).to eq 401
+        expect(last_response.body).to include('Unauthorised')
+      end
     end
 
     context 'filtering the correct dataset' do

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -64,6 +64,15 @@ describe API::V2::CCRClaim do
       expect(last_response.body).to include('Unauthorised')
     end
 
+    context 'when accessed by a ExternalUser' do
+      before { do_request(api_key: @claim.external_user.user.api_key )}
+
+      it 'returns unauthorised' do
+        expect(last_response.status).to eq 401
+        expect(last_response.body).to include('Unauthorised')
+      end
+    end
+
     context 'claim not found' do
       it 'respond not found when claim is not found' do
         do_request(claim_uuid: '123-456-789')

--- a/spec/api/v2/claim_spec.rb
+++ b/spec/api/v2/claim_spec.rb
@@ -8,12 +8,12 @@ describe API::V2::Claim do
   include ApiSpecHelper
 
   after(:all) { clean_database }
-
+  let(:case_worker) { create :case_worker }
   before(:all) do
     @claim = create(:deterministic_claim, :redetermination)
   end
 
-  def do_request(claim_uuid: @claim.uuid, api_key: @claim.external_user.user.api_key)
+  def do_request(claim_uuid: @claim.uuid, api_key: case_worker.user.api_key)
     get "/api/claims/#{claim_uuid}", {api_key: api_key}, {format: :json}
   end
 
@@ -64,6 +64,14 @@ describe API::V2::Claim do
       end
     end
 
+    context 'when accessed by a ExternalUser' do
+      before { do_request(api_key: @claim.external_user.user.api_key )}
+
+      it 'returns unauthorised' do
+        expect(last_response.status).to eq 401
+        expect(last_response.body).to include('Unauthorised')
+      end
+    end
 
     # TODO: to be updated and enabled once the claim export structure is finalised.
     # it 'should return a JSON with the required information' do


### PR DESCRIPTION
### What?
Ensure that all API v2 endpoints are only accessible by case_worker api_keys

### Why?
At present, and until the API v2 is expanded, all end points should only be accessed by case_workers, previously any valid api_key could access them.
