### PR TITLE
Validate defendant uplift fees against number of defendants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Metrics/LineLength:
 Metrics/BlockLength:
   ExcludedMethods:
     - included
+    - class_methods
     - namespace
     - expose
     - helpers

--- a/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
@@ -23,14 +23,6 @@ module API
 
         private
 
-        CASE_UPLIFT_MAPPINGS = {
-          FXACV: 'FXACU',
-          FXASE: 'FXASU',
-          FXCBR: 'FXCBU',
-          FXCSE: 'FXCSU',
-          FXENP: 'FXENU'
-        }.with_indifferent_access.freeze
-
         def fees_for(fee_type_unique_code)
           claim.fees.where(fee_type_id: ::Fee::BaseFeeType.where(unique_code: fee_type_unique_code))
         end
@@ -66,7 +58,7 @@ module API
         end
 
         def case_uplift_fee_code
-          CASE_UPLIFT_MAPPINGS[fee_code]
+          ::Fee::FixedFeeType::CASE_UPLIFT_MAPPINGS[fee_code]
         end
 
         def defendant_uplift_fees

--- a/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
@@ -16,30 +16,6 @@ module API
 
         private
 
-        DEFENDANT_UPLIFT_MAPPINGS = {
-          BASAF: 'MISAU', # Standard appearance fee uplift
-          MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
-          MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
-          MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
-          MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
-          MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
-          MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
-          MIDSE: 'MIDSU', # Deferred sentence hearings uplift
-          MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
-          MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
-          MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
-          MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
-          MIPPC: 'MIPCU', # Paper plea & case management uplift
-          MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
-          MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
-          MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
-          MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
-          MISHR: 'MISHU', # Sentence hearings uplift
-          MITNP: 'MITNU', # Trial not proceed uplift
-          MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
-          MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
-        }.with_indifferent_access.freeze
-
         def claim
           object.object.claim
         end
@@ -53,7 +29,7 @@ module API
         end
 
         def defendant_uplift_fee_code
-          DEFENDANT_UPLIFT_MAPPINGS[fee_code]
+          ::Fee::MiscFeeType::DEFENDANT_UPLIFT_MAPPINGS[fee_code]
         end
 
         def matching_defendant_uplift_fees

--- a/app/models/concerns/case_upliftable.rb
+++ b/app/models/concerns/case_upliftable.rb
@@ -1,0 +1,28 @@
+# Certain basic and fixed fee types (and one LGFS only miscellaneous fee)
+# relate to additional cases and therefore require those additional
+# case numbers to be supplied
+
+# In addition, of those fixed fees that are case uplifts
+# there is a relationship between the uplift and its "parent"
+# fee that is important when it comes to consolidating data for
+# injection into CCR.
+#
+module CaseUpliftable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    CASE_UPLIFT_MAPPINGS = {
+      FXACV: 'FXACU',
+      FXASE: 'FXASU',
+      FXCBR: 'FXCBU',
+      FXCSE: 'FXCSU',
+      FXENP: 'FXENU'
+    }.with_indifferent_access.freeze
+  end
+
+  included do
+    def case_uplift?
+      unique_code.in?(%w[BANOC FXNOC FXACU FXASU FXCBU FXCSU FXCDU FXENU MIUPL])
+    end
+  end
+end

--- a/app/models/concerns/case_upliftable.rb
+++ b/app/models/concerns/case_upliftable.rb
@@ -1,11 +1,11 @@
-# Certain basic and fixed fee types (and one LGFS only miscellaneous fee)
-# relate to additional cases and therefore require those additional
-# case numbers to be supplied
-
-# In addition, of those fixed fees that are case uplifts
-# there is a relationship between the uplift and its "parent"
-# fee that is important when it comes to consolidating data for
-# injection into CCR.
+# Extends fee type, adding a mapping of certain fixed
+# fees to their case uplift equivalent - which is
+# important for consolidating records for injection
+# into CCR.
+#
+# In addition, specific basic and fixed fee types (and one LGFS only
+# miscellaneous fee) that require additional cases are flagged
+# here for use in validation and presentation layers
 #
 module CaseUpliftable
   extend ActiveSupport::Concern

--- a/app/models/concerns/defendant_upliftable.rb
+++ b/app/models/concerns/defendant_upliftable.rb
@@ -1,6 +1,6 @@
 #
 # extends fee types by adding methods providing
-# information and data on those that are considered
+# information and data on those fees types are considered
 # to be "defendant uplifts"
 #
 # "defendant uplifts" are fees of a type

--- a/app/models/concerns/defendant_upliftable.rb
+++ b/app/models/concerns/defendant_upliftable.rb
@@ -35,14 +35,20 @@ module DefendantUpliftable
       MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
     }.with_indifferent_access.freeze
 
+    ORPHAN_DEFENDANT_UPLIFTS = %w[BANDR FXNDR].freeze
+
     def defendant_uplifts
-      where(unique_code: DEFENDANT_UPLIFT_MAPPINGS.values)
+      where(unique_code: defendant_uplift_unique_codes)
+    end
+
+    def defendant_uplift_unique_codes
+      DEFENDANT_UPLIFT_MAPPINGS.values + ORPHAN_DEFENDANT_UPLIFTS
     end
   end
 
   included do
     def defendant_uplift?
-      unique_code.in?(DEFENDANT_UPLIFT_MAPPINGS.values)
+      unique_code.in?(self.class.defendant_uplift_unique_codes)
     end
   end
 end

--- a/app/models/concerns/defendant_upliftable.rb
+++ b/app/models/concerns/defendant_upliftable.rb
@@ -1,0 +1,49 @@
+#
+# extends fee types by adding methods providing
+# information and data on those that are considered
+# to be "defendant uplifts"
+#
+# "defendant uplifts" are fees of a type
+# that are applicable when claiming remuneration
+# for work done in relation to additional defendants
+# on a case
+#
+module DefendantUpliftable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    DEFENDANT_UPLIFT_MAPPINGS = {
+      BASAF: 'MISAU', # Standard appearance fee uplift
+      MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
+      MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
+      MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
+      MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
+      MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
+      MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
+      MIDSE: 'MIDSU', # Deferred sentence hearings uplift
+      MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
+      MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
+      MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
+      MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
+      MIPPC: 'MIPCU', # Paper plea & case management uplift
+      MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
+      MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
+      MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
+      MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
+      MISHR: 'MISHU', # Sentence hearings uplift
+      MITNP: 'MITNU', # Trial not proceed uplift
+      MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
+      MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
+    }.with_indifferent_access.freeze
+
+    def defendant_uplifts
+      where(unique_code: DEFENDANT_UPLIFT_MAPPINGS.values)
+    end
+  end
+
+  included do
+    def defendant_uplift?
+      unique_code.in?(DEFENDANT_UPLIFT_MAPPINGS.values)
+    end
+  end
+end

--- a/app/models/concerns/defendant_upliftable.rb
+++ b/app/models/concerns/defendant_upliftable.rb
@@ -1,5 +1,4 @@
-#
-# extends fee types by adding methods providing
+# Extends fee types by adding methods providing
 # information and data on those fees types are considered
 # to be "defendant uplifts"
 #

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -39,7 +39,7 @@ module Fee
     belongs_to :fee_type, class_name: Fee::BaseFeeType
     belongs_to :sub_type, class_name: Fee::BaseFeeType
 
-    delegate :description, :case_uplift?, to: :fee_type
+    delegate :description, :case_uplift?, :defendant_uplift?, to: :fee_type
 
     has_many :dates_attended, as: :attended_item, dependent: :destroy, inverse_of: :attended_item
 

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -45,6 +45,14 @@ module Fee
 
     default_scope { includes(:fee_type) }
 
+    scope :defendant_uplift_sums, lambda {
+      joins(:fee_type)
+        .merge(Fee::BaseFeeType.defendant_uplifts)
+        .unscope(:order)
+        .group('fee_types.unique_code')
+        .sum('quantity')
+    }
+
     validates_with FeeSubModelValidator
 
     accepts_nested_attributes_for :dates_attended, reject_if: :all_blank, allow_destroy: true

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -29,6 +29,7 @@ module Fee
     include ActionView::Helpers::NumberHelper
     include Comparable
     include Roles
+    include DefendantUpliftable
 
     self.table_name = 'fee_types'
 

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -29,6 +29,7 @@ module Fee
     include ActionView::Helpers::NumberHelper
     include Comparable
     include Roles
+    include CaseUpliftable
     include DefendantUpliftable
 
     self.table_name = 'fee_types'
@@ -60,13 +61,6 @@ module Fee
 
     def fee_class_name
       type.sub(/Type$/, '')
-    end
-
-    def case_uplift?
-      # Certain basic and fixed fee types (and one lgfs only miscellaneous fee)
-      # relate to additional cases and therefore require those additional
-      # case numbers to be supplied
-      unique_code.in?(%w[BANOC FXNOC FXACU FXASU FXCBU FXCSU FXCDU FXENU FXNOC MIUPL])
     end
 
     # utility methods for providing access to subclasses

--- a/app/models/fee/fixed_fee_type.rb
+++ b/app/models/fee/fixed_fee_type.rb
@@ -17,14 +17,6 @@
 #
 
 class Fee::FixedFeeType < Fee::BaseFeeType
-  CASE_UPLIFT_MAPPINGS = {
-    FXACV: 'FXACU',
-    FXASE: 'FXASU',
-    FXCBR: 'FXCBU',
-    FXCSE: 'FXCSU',
-    FXENP: 'FXENU'
-  }.with_indifferent_access.freeze
-
   has_many :children, class_name: Fee::FixedFeeType, foreign_key: :parent_id
   belongs_to :parent, class_name: Fee::FixedFeeType, foreign_key: :parent_id
 

--- a/app/models/fee/fixed_fee_type.rb
+++ b/app/models/fee/fixed_fee_type.rb
@@ -17,11 +17,18 @@
 #
 
 class Fee::FixedFeeType < Fee::BaseFeeType
+  CASE_UPLIFT_MAPPINGS = {
+    FXACV: 'FXACU',
+    FXASE: 'FXASU',
+    FXCBR: 'FXCBU',
+    FXCSE: 'FXCSU',
+    FXENP: 'FXENU'
+  }.with_indifferent_access.freeze
+
   has_many :children, class_name: Fee::FixedFeeType, foreign_key: :parent_id
   belongs_to :parent, class_name: Fee::FixedFeeType, foreign_key: :parent_id
 
   default_scope -> { order(parent_id: :desc, description: :asc) }
-
   scope :top_levels, -> { where(parent_id: nil) }
 
   def fee_category_name

--- a/app/models/fee/misc_fee.rb
+++ b/app/models/fee/misc_fee.rb
@@ -23,14 +23,6 @@ class Fee::MiscFee < Fee::BaseFee
 
   validates_with Fee::MiscFeeValidator
 
-  scope :defendant_uplift_sums, lambda {
-    joins(:fee_type)
-      .merge(Fee::BaseFeeType.defendant_uplifts)
-      .unscope(:order)
-      .group('fee_types.unique_code')
-      .sum('quantity')
-  }
-
   def is_misc?
     true
   end

--- a/app/models/fee/misc_fee.rb
+++ b/app/models/fee/misc_fee.rb
@@ -18,7 +18,6 @@
 #  case_numbers          :string
 #  date                  :date
 #
-
 class Fee::MiscFee < Fee::BaseFee
   belongs_to :fee_type, class_name: Fee::MiscFeeType
 

--- a/app/models/fee/misc_fee.rb
+++ b/app/models/fee/misc_fee.rb
@@ -23,6 +23,15 @@ class Fee::MiscFee < Fee::BaseFee
 
   validates_with Fee::MiscFeeValidator
 
+  scope :defendant_uplift_sums, lambda {
+    joins(:fee_type)
+      .merge(Fee::BaseFeeType.defendant_uplifts)
+      .unscope(:order)
+      .where.not(id: select(&:marked_for_destruction?).map(&:id))
+      .group('fee_types.unique_code')
+      .sum('quantity')
+  }
+
   def is_misc?
     true
   end

--- a/app/models/fee/misc_fee.rb
+++ b/app/models/fee/misc_fee.rb
@@ -27,7 +27,6 @@ class Fee::MiscFee < Fee::BaseFee
     joins(:fee_type)
       .merge(Fee::BaseFeeType.defendant_uplifts)
       .unscope(:order)
-      .where.not(id: select(&:marked_for_destruction?).map(&:id))
       .group('fee_types.unique_code')
       .sum('quantity')
   }

--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -12,7 +12,7 @@ module CCR
         MISAF: zip(%w[AGFS_MISC_FEES AGFS_ADJOURNED]), # Adjourned appeals
         MIADC1: zip(%w[AGFS_MISC_FEES AGFS_DMS_DY2_HF]), # Application to dismiss a charge (half day)
         MIADC2: zip(%w[AGFS_MISC_FEES AGFS_DMS_DY2_WL]), # Application to dismiss a charge (whole day)
-        MIUPL: zip(%w[TBC TBC]), # Case uplift ***CCLF-applicable-only***
+        MIUPL: zip(%w[TBC TBC]), # TODO: Case uplift ***CCLF-applicable-only***
         MIDTH: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_HF]), # Confiscation hearings (half day)
         MIDTW: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_WL]), # Confiscation hearings (whole day)
         MICJA: zip(%w[OTHER COST_JUDGE_FEE]), # Costs judge application ***CCLF-applicable-only***

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -24,8 +24,9 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         case_concluded_at
         supplier_number
       ],
-      [
-        :total
+      %i[
+        total
+        defendant_uplifts
       ]
     ]
   end
@@ -60,5 +61,9 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
 
   def validate_supplier_number
     validate_pattern(:supplier_number, supplier_number_regex, 'invalid')
+  end
+
+  def validate_defendant_uplifts
+    return if @record.source == 'api'
   end
 end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -72,8 +72,8 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
   # we add one because uplift quantities reflect the number of "additional" defendants
   def defendant_uplifts_greater_than?(no_of_defendants)
     @record
-      .misc_fees
-      .where(id: @record.misc_fees.reject(&:marked_for_destruction?).map(&:id))
+      .fees
+      .where.not(id: @record.misc_fees.select(&:marked_for_destruction?).map(&:id))
       .defendant_uplift_sums
       .values
       .map(&:to_i).any? { |sum| sum + 1 > no_of_defendants }

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -71,18 +71,10 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
 
   # we add one because uplift quantities reflect the number of "additional" defendants
   def defendant_uplifts_greater_than?(no_of_defendants)
-    defendant_uplifts.values.map(&:to_i).any? { |sum| sum + 1 > no_of_defendants }
-  end
-
-  def defendant_uplifts
-    # TODO: move to scope on MiscFee OR BaseFee
     @record
       .misc_fees
-      .joins(:fee_type)
-      .merge(Fee::MiscFeeType.defendant_uplifts)
-      .unscope(:order)
-      .where.not(id: @record.misc_fees.select(&:marked_for_destruction?).map(&:id))
-      .group('fee_types.unique_code')
-      .sum('quantity')
+      .defendant_uplift_sums
+      .values
+      .map(&:to_i).any? { |sum| sum + 1 > no_of_defendants }
   end
 end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -66,13 +66,14 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
   def validate_defendant_uplifts
     return if @record.from_api?
     no_of_defendants = @record.defendants.reject(&:marked_for_destruction?).size
-    add_error(:base, 'Too many defendant uplifts claimed') if defendant_uplifts_greater_than?(no_of_defendants)
+    add_error(:base, 'defendant_uplifts_mismatch') if defendant_uplifts_greater_than?(no_of_defendants)
   end
 
   # we add one because uplift quantities reflect the number of "additional" defendants
   def defendant_uplifts_greater_than?(no_of_defendants)
     @record
       .misc_fees
+      .where(id: @record.misc_fees.reject(&:marked_for_destruction?).map(&:id))
       .defendant_uplift_sums
       .values
       .map(&:to_i).any? { |sum| sum + 1 > no_of_defendants }

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -42,7 +42,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def validate_total
-    return if @record.source == 'api'
+    return if @record.from_api?
 
     validate_numericality(:total, 'numericality', 0.1, nil)
     validate_amount_less_than_claim_max(:total)

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -41,6 +41,19 @@ defendant:
 
 #################################################################################
 #                                                                               #
+#   CLAIM BASE AGGREGATE ERRORS                                                 #
+#                                                                               #
+#################################################################################
+
+base:
+  _seq: 5
+  defendant_uplifts_mismatch:
+    long: The quantity of defendant uplifts exceeds the number of defendants
+    short: Too many defendant uplifts
+    api: Defendant uplift sums must match number of defendants
+
+#################################################################################
+#                                                                               #
 #   CLAIM                                                                       #
 #                                                                               #
 #################################################################################

--- a/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
@@ -115,29 +115,5 @@ describe API::Entities::CCR::AdaptedFixedFee do
         end
       end
     end
-
-    describe '::CASE_UPLIFT_MAPPINGS' do
-      subject { described_class::CASE_UPLIFT_MAPPINGS[code] }
-
-      EXPECTED_MAPPINGS = {
-        FXACV: 'FXACU',
-        FXASE: 'FXASU',
-        FXCBR: 'FXCBU',
-        FXCSE: 'FXCSU',
-        FXENP: 'FXENU'
-      }.with_indifferent_access.freeze
-
-      context 'mappings' do
-        EXPECTED_MAPPINGS.each do |code, uplift_code|
-          context "code #{code}" do
-            let(:code) { code }
-
-            it "returns #{uplift_code}" do
-              is_expected.to eql uplift_code
-            end
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -41,10 +41,10 @@ describe API::Entities::CCR::AdaptedMiscFee do
     let(:adapted_misc_fee) { ::CCR::Fee::MiscFeeAdapter.new.call(misc_fee) }
 
     before do
-      create(:misc_fee, :with_date_attended, fee_type: miaph, claim: claim, quantity: 1.1, rate: 25)
+      create(:misc_fee, :with_date_attended, fee_type: miaph, claim: claim, quantity: 1, rate: 25)
     end
 
-    context 'when matching misc fee uplift NOT claimed' do
+    context 'when matching misc fee (defendant) uplift NOT claimed' do
       it 'returns 1 for the main defendant' do
         is_expected.to eq "1"
       end
@@ -70,44 +70,44 @@ describe API::Entities::CCR::AdaptedMiscFee do
       end
     end
 
-    describe '::DEFENDANT_UPLIFT_MAPPINGS' do
-      subject { described_class::DEFENDANT_UPLIFT_MAPPINGS[code] }
+    # describe '::DEFENDANT_UPLIFT_MAPPINGS' do
+    #   subject { described_class::DEFENDANT_UPLIFT_MAPPINGS[code] }
 
-      EXPECTED_MAPPINGS = {
-          BASAF: 'MISAU', # Standard appearance fee uplift
-          MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
-          MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
-          MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
-          MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
-          MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
-          MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
-          MIDSE: 'MIDSU', # Deferred sentence hearings uplift
-          MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
-          MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
-          MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
-          MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
-          MIPPC: 'MIPCU', # Paper plea & case management uplift
-          MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
-          MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
-          MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
-          MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
-          MISHR: 'MISHU', # Sentence hearings uplift
-          MITNP: 'MITNU', # Trial not proceed uplift
-          MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
-          MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
-      }.freeze
+    #   EXPECTED_MAPPINGS = {
+    #       BASAF: 'MISAU', # Standard appearance fee uplift
+    #       MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
+    #       MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
+    #       MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
+    #       MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
+    #       MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
+    #       MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
+    #       MIDSE: 'MIDSU', # Deferred sentence hearings uplift
+    #       MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
+    #       MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
+    #       MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
+    #       MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
+    #       MIPPC: 'MIPCU', # Paper plea & case management uplift
+    #       MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
+    #       MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
+    #       MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
+    #       MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
+    #       MISHR: 'MISHU', # Sentence hearings uplift
+    #       MITNP: 'MITNU', # Trial not proceed uplift
+    #       MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
+    #       MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
+    #   }.freeze
 
-      context 'mappings' do
-        EXPECTED_MAPPINGS.each do |code, uplift_code|
-          context "code #{code}" do
-            let(:code) { code }
+    #   context 'mappings' do
+    #     EXPECTED_MAPPINGS.each do |code, uplift_code|
+    #       context "code #{code}" do
+    #         let(:code) { code }
 
-            it "returns #{uplift_code}" do
-              is_expected.to eql uplift_code
-            end
-          end
-        end
-      end
-    end
+    #         it "returns #{uplift_code}" do
+    #           is_expected.to eql uplift_code
+    #         end
+    #       end
+    #     end
+    #   end
+    # end
   end
 end

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -69,45 +69,5 @@ describe API::Entities::CCR::AdaptedMiscFee do
         is_expected.to eq "5"
       end
     end
-
-    # describe '::DEFENDANT_UPLIFT_MAPPINGS' do
-    #   subject { described_class::DEFENDANT_UPLIFT_MAPPINGS[code] }
-
-    #   EXPECTED_MAPPINGS = {
-    #       BASAF: 'MISAU', # Standard appearance fee uplift
-    #       MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
-    #       MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
-    #       MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
-    #       MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
-    #       MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
-    #       MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
-    #       MIDSE: 'MIDSU', # Deferred sentence hearings uplift
-    #       MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
-    #       MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
-    #       MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
-    #       MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
-    #       MIPPC: 'MIPCU', # Paper plea & case management uplift
-    #       MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
-    #       MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
-    #       MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
-    #       MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
-    #       MISHR: 'MISHU', # Sentence hearings uplift
-    #       MITNP: 'MITNU', # Trial not proceed uplift
-    #       MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
-    #       MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
-    #   }.freeze
-
-    #   context 'mappings' do
-    #     EXPECTED_MAPPINGS.each do |code, uplift_code|
-    #       context "code #{code}" do
-    #         let(:code) { code }
-
-    #         it "returns #{uplift_code}" do
-    #           is_expected.to eql uplift_code
-    #         end
-    #       end
-    #     end
-    #   end
-    # end
   end
 end

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -86,14 +86,15 @@ FactoryBot.define do
         description 'Special preparation fee'
         code 'SPF'
         unique_code 'MISPF'
-        quantity_is_decimal false
+        calculated true
+        quantity_is_decimal true
       end
 
       trait :miaph do
         description 'Abuse of process hearings (half day)'
         code 'APH'
         unique_code 'MIAPH'
-        calculated false
+        calculated true
         quantity_is_decimal false
       end
 
@@ -105,6 +106,22 @@ FactoryBot.define do
         quantity_is_decimal false
       end
 
+      trait :midtw do
+        description 'Confiscation hearings (whole day)'
+        code 'DTW'
+        unique_code 'MIDTW'
+        calculated true
+        quantity_is_decimal false
+      end
+
+      trait :midwu do
+        description 'Confiscation hearings (whole day uplift)'
+        code 'DWU'
+        unique_code 'MIDWU'
+        calculated true
+        quantity_is_decimal false
+      end
+
       trait :miupl do
         lgfs
         description 'Case uplift'
@@ -112,7 +129,6 @@ FactoryBot.define do
         unique_code 'MIUPL'
         quantity_is_decimal true
       end
-
     end
 
     factory :fixed_fee_type, class: Fee::FixedFeeType do

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -145,6 +145,10 @@ FactoryBot.define do
       fee_type { build :basic_fee_type, description: 'Pages of prosecution evidence', code: 'PPE', unique_code: 'BAPPE', calculated: false }
     end
 
+    trait :ndr_fee do
+      fee_type { build :basic_fee_type, description: 'Number of defendants uplift', code: 'NDR', unique_code: 'BANDR', calculated: true }
+    end
+
     trait :noc_fee do
       fee_type { build :basic_fee_type, description: 'Number of cases uplift', code: 'NOC', unique_code: 'BANOC', calculated: true }
     end

--- a/spec/models/fee/base_fee_spec.rb
+++ b/spec/models/fee/base_fee_spec.rb
@@ -21,9 +21,7 @@
 
 require 'rails_helper'
 
-
 module Fee
-
   class FeeDouble < Fee::BaseFee
   end
 
@@ -162,7 +160,6 @@ module Fee
   end
 
   RSpec.describe Fee::BaseFee, type: :model do
-
     context '#new' do
       it 'should raise BaseFeeAbstractClassError' do
         expect { BaseFee.new }.to raise_error(Fee::BaseFeeAbstractClassError)

--- a/spec/models/fee/base_fee_type_spec.rb
+++ b/spec/models/fee/base_fee_type_spec.rb
@@ -19,7 +19,6 @@
 require 'rails_helper'
 
 module Fee
-
   RSpec.describe BaseFeeType, type: :model do
     include DatabaseHousekeeping
 
@@ -40,7 +39,6 @@ module Fee
   end
 
   RSpec.describe FeeTypeDouble, type: :model do
-    
     it { should have_many(:fees) }
 
     it { should validate_presence_of(:description).with_message('Fee type description cannot be blank') }
@@ -76,7 +74,7 @@ module Fee
       end
     end
 
-    describe  '#fee_category_name' do
+    describe '#fee_category_name' do
       it 'returns the humanised name' do
         expect(build(:transfer_fee_type).fee_category_name).to eq 'Transfer Fee'
         expect(build(:basic_fee_type).fee_category_name).to eq 'Basic Fees'
@@ -89,17 +87,15 @@ module Fee
 
   end
 
-  context 'fee category name' do
-    describe '#fee_category_name' do
-      it 'returns the correct category name' do
-        expect(BasicFeeType.new.fee_category_name).to eq 'Basic Fees'
-        expect(MiscFeeType.new.fee_category_name).to eq 'Miscellaneous Fees'
-        expect(FixedFeeType.new.fee_category_name).to eq 'Fixed Fees'
-        expect(InterimFeeType.new.fee_category_name).to eq 'Interim Fees'
-        expect(TransferFeeType.new.fee_category_name).to eq 'Transfer Fee'
-        expect(GraduatedFeeType.new.fee_category_name).to eq 'Graduated Fees'
-        expect(WarrantFeeType.new.fee_category_name).to eq 'Warrant Fee'
-      end
+  describe '#fee_category_name' do
+    it 'returns the correct category name' do
+      expect(BasicFeeType.new.fee_category_name).to eq 'Basic Fees'
+      expect(MiscFeeType.new.fee_category_name).to eq 'Miscellaneous Fees'
+      expect(FixedFeeType.new.fee_category_name).to eq 'Fixed Fees'
+      expect(InterimFeeType.new.fee_category_name).to eq 'Interim Fees'
+      expect(TransferFeeType.new.fee_category_name).to eq 'Transfer Fee'
+      expect(GraduatedFeeType.new.fee_category_name).to eq 'Graduated Fees'
+      expect(WarrantFeeType.new.fee_category_name).to eq 'Warrant Fee'
     end
   end
 
@@ -110,7 +106,7 @@ module Fee
     end
   end
 
-  describe  'Specialized fee type methods' do
+  describe 'Specialized fee type methods' do
     before(:all) do
       @bf1 = create :basic_fee_type, description: 'basic fee type 1'
       @bf2 = create :basic_fee_type, description: 'basic fee type 2'
@@ -169,8 +165,5 @@ module Fee
     it 'returns all transfer fee types' do
       expect(Fee::BaseFeeType.transfer).to match_array( [ @tf1, @tf2 ] )
     end
-
-
   end
-
 end

--- a/spec/models/fee/fixed_fee_type_spec.rb
+++ b/spec/models/fee/fixed_fee_type_spec.rb
@@ -84,5 +84,29 @@ module Fee
         expect(Fee::FixedFeeType.all.pluck(:description)).to eq ['Ppppp','Sssss','Xxxxx']
       end
     end
+
+    describe '::CASE_UPLIFT_MAPPINGS' do
+      subject { described_class::CASE_UPLIFT_MAPPINGS[code] }
+
+      EXPECTED_MAPPINGS = {
+        FXACV: 'FXACU',
+        FXASE: 'FXASU',
+        FXCBR: 'FXCBU',
+        FXCSE: 'FXCSU',
+        FXENP: 'FXENU'
+      }.with_indifferent_access.freeze
+
+      context 'mappings' do
+        EXPECTED_MAPPINGS.each do |code, uplift_code|
+          context "code #{code}" do
+            let(:code) { code }
+
+            it "returns #{uplift_code}" do
+              is_expected.to eql uplift_code
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/fee/misc_fee_spec.rb
+++ b/spec/models/fee/misc_fee_spec.rb
@@ -31,6 +31,7 @@ module Fee
     let(:fee_type) { instance_double('fee_type') }
 
     include_examples '#defendant_uplift?'
+    include_examples '.defendant_uplift_sums'
 
     describe '#is_misc?' do
       it 'returns true' do

--- a/spec/models/fee/misc_fee_spec.rb
+++ b/spec/models/fee/misc_fee_spec.rb
@@ -20,19 +20,22 @@
 #
 
 require 'rails_helper'
+require_relative 'shared_examples_for_defendant_uplifts'
 
 module Fee
   describe MiscFee do
     it { should belong_to(:fee_type) }
-
     it { should validate_presence_of(:claim).with_message('blank') }
-    
     it { should validate_presence_of(:fee_type).with_message('blank') }
-  end
 
-  describe '#is_misc?' do
-    it 'returns true' do
-      expect(build(:misc_fee).is_misc?).to be true
+    let(:fee_type) { instance_double('fee_type') }
+
+    include_examples '#defendant_uplift?'
+
+    describe '#is_misc?' do
+      it 'returns true' do
+        expect(build(:misc_fee).is_misc?).to be true
+      end
     end
   end
 end

--- a/spec/models/fee/misc_fee_type_spec.rb
+++ b/spec/models/fee/misc_fee_type_spec.rb
@@ -15,13 +15,13 @@
 #  quantity_is_decimal :boolean          default(FALSE)
 #  unique_code         :string
 #
-
 require 'rails_helper'
+require_relative 'shared_examples_for_defendant_uplifts'
 
 module Fee
   describe MiscFeeType do
-
     let(:fee_type) { build :misc_fee_type }
+    include_examples 'defendant uplifts'
 
     describe '#fee_category_name' do
       it 'returns the category name' do
@@ -42,14 +42,16 @@ module Fee
     end
 
     describe '#case_uplift?' do
+      subject { fee_type.case_uplift? }
+
       it 'returns true when fee_type is Case Uplift' do
         fee_type.unique_code = 'MIUPL'
-        expect(fee_type.case_uplift?).to be_truthy
+        is_expected.to be_truthy
       end
 
       it 'returns false when fee_type is not Case Uplift' do
         fee_type.code = 'XXX'
-        expect(fee_type.case_uplift?).to be_falsey
+        is_expected.to be_falsey
       end
     end
   end

--- a/spec/models/fee/misc_fee_type_spec.rb
+++ b/spec/models/fee/misc_fee_type_spec.rb
@@ -21,7 +21,7 @@ require_relative 'shared_examples_for_defendant_uplifts'
 module Fee
   describe MiscFeeType do
     let(:fee_type) { build :misc_fee_type }
-    include_examples 'defendant uplifts'
+    it_behaves_like 'defendant upliftable'
 
     describe '#fee_category_name' do
       it 'returns the category name' do

--- a/spec/models/fee/shared_examples_for_case_uplifts.rb
+++ b/spec/models/fee/shared_examples_for_case_uplifts.rb
@@ -1,0 +1,41 @@
+shared_examples 'case upliftable' do
+  it { is_expected.to respond_to :case_uplift? }
+
+  describe '#case_uplift?' do
+    subject { fee_type.case_uplift? }
+
+    context 'for fees that require additional case numbers' do
+      %w[BANOC FXNOC FXACU FXASU FXCBU FXCSU FXCDU FXENU MIUPL].each do |unique_code|
+        before { allow(fee_type).to receive(:unique_code).and_return unique_code }
+
+        it "#{unique_code} should return true" do
+          is_expected.to be_truthy
+        end
+      end
+    end
+  end
+
+  describe '::CASE_UPLIFT_MAPPINGS' do
+    subject { described_class::CASE_UPLIFT_MAPPINGS[code] }
+
+    EXPECTED_MAPPINGS = {
+      FXACV: 'FXACU',
+      FXASE: 'FXASU',
+      FXCBR: 'FXCBU',
+      FXCSE: 'FXCSU',
+      FXENP: 'FXENU'
+    }.with_indifferent_access.freeze
+
+    context 'mappings' do
+      EXPECTED_MAPPINGS.each do |code, uplift_code|
+        context "code #{code}" do
+          let(:code) { code }
+
+          it "returns #{uplift_code}" do
+            is_expected.to eql uplift_code
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/fee/shared_examples_for_defendant_uplifts.rb
+++ b/spec/models/fee/shared_examples_for_defendant_uplifts.rb
@@ -1,0 +1,68 @@
+shared_examples '#defendant_uplift?' do
+  describe '#defendant_uplift?' do
+    before do
+      allow(subject).to receive(:fee_type).and_return fee_type
+    end
+
+    it 'delegates to fee type' do
+      expect(fee_type).to receive(:defendant_uplift?)
+      subject.defendant_uplift?
+    end
+  end
+end
+
+shared_examples 'defendant uplifts fee types' do
+ describe '#defendant_uplift?' do
+    subject { fee_type.defendant_uplift? }
+
+    it 'returns true when fee_type is a defendant uplift' do
+      fee_type.unique_code = 'MIAHU'
+      is_expected.to be_truthy
+    end
+
+    it 'returns false when fee_type is not a defendant uplift' do
+      fee_type.unique_code = 'MIUPL'
+      is_expected.to be_falsey
+    end
+  end
+
+  describe '::DEFENDANT_UPLIFT_MAPPINGS' do
+    subject { described_class::DEFENDANT_UPLIFT_MAPPINGS[code] }
+
+    EXPECTED_MAPPINGS = {
+        BASAF: 'MISAU', # Standard appearance fee uplift
+        MIAPH: 'MIAHU', # Abuse of process hearings (half day uplift)
+        MIAPW: 'MIAWU', # Abuse of process hearings (whole day uplift)
+        MIADC1: 'MIADC3', # Application to dismiss a charge (half day uplift)
+        MIADC2: 'MIADC4', # Application to dismiss a charge (whole day uplift)
+        MIDTH: 'MIDHU', # Confiscation hearings (half day uplift)
+        MIDTW: 'MIDWU', # Confiscation hearings (whole day uplift)
+        MIDSE: 'MIDSU', # Deferred sentence hearings uplift
+        MIAEH: 'MIEHU', # Hearings relating to admissibility of evidence (half day uplift)
+        MIAEW: 'MIEWU', # Hearings relating to admissibility of evidence (whole day uplift)
+        MIHDH: 'MIHHU', # Hearings relating to disclosure (half day uplift)
+        MIHDW: 'MIHWU', # Hearings relating to disclosure (whole day uplift)
+        MIPPC: 'MIPCU', # Paper plea & case management uplift
+        MIPCH: 'MICHU', # Proceeds of crime hearings (half day uplift)
+        MIPCW: 'MICHW', # Proceeds of crime hearings (whole day uplift)
+        MIPIH1: 'MIPIU3', # Public interest immunity hearings (half day uplift)
+        MIPIH2: 'MIPIH4', # Public interest immunity hearings (whole day uplift)
+        MISHR: 'MISHU', # Sentence hearings uplift
+        MITNP: 'MITNU', # Trial not proceed uplift
+        MIUAV1: 'MIUAV3', # Unsuccessful application to vacate a guilty plea (half day uplift)
+        MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
+    }.freeze
+
+    context 'mappings' do
+      EXPECTED_MAPPINGS.each do |code, uplift_code|
+        context "code #{code}" do
+          let(:code) { code }
+
+          it "returns #{uplift_code}" do
+            is_expected.to eql uplift_code
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/fee/shared_examples_for_defendant_uplifts.rb
+++ b/spec/models/fee/shared_examples_for_defendant_uplifts.rb
@@ -11,7 +11,23 @@ shared_examples '#defendant_uplift?' do
   end
 end
 
-shared_examples 'defendant uplifts fee types' do
+shared_examples '.defendant_uplift_sums' do
+  describe '.defendant_uplift_sums' do
+    subject { described_class.defendant_uplift_sums }
+    let(:claim) { create(:claim) }
+    let(:miahu) { create(:misc_fee_type, :miahu) }
+
+    before do
+      create(:misc_fee, fee_type: miahu, claim: claim, quantity: 3, amount: 21.01)
+    end
+
+    it 'returns hash of sums grouped by fee\'s unique_code' do
+      is_expected.to eql({ "MIAHU" => 3 })
+    end
+  end
+end
+
+shared_examples 'defendant upliftable' do
  describe '#defendant_uplift?' do
     subject { fee_type.defendant_uplift? }
 

--- a/spec/models/fee/shared_examples_for_defendant_uplifts.rb
+++ b/spec/models/fee/shared_examples_for_defendant_uplifts.rb
@@ -42,6 +42,21 @@ shared_examples 'defendant upliftable' do
     end
   end
 
+  describe '.defendant_uplifts' do
+    it 'calls .defendant_uplift_unique_codes' do
+      expect(described_class).to receive(:defendant_uplift_unique_codes)
+      described_class.defendant_uplifts
+    end
+  end
+
+  describe '.defendant_uplift_unique_codes' do
+    subject { described_class.defendant_uplift_unique_codes }
+
+    it 'includes orphan defendant uplift unique codes' do
+      is_expected.to include(*%w[BANDR FXNDR])
+    end
+  end
+
   describe '::DEFENDANT_UPLIFT_MAPPINGS' do
     subject { described_class::DEFENDANT_UPLIFT_MAPPINGS[code] }
 

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -124,14 +124,8 @@ describe Claim::AdvocateClaimValidator do
       expect(claim.misc_fees.first.fee_type).to have_attributes(unique_code: 'MIAPH')
     end
 
-    context 'when defendant count matches defendant uplifts claimed' do
-      it 'should not error' do
-        should_not_error(claim, :defendant_uplifts)
-      end
-    end
-
-    context 'where defendant uplifts count does not match defendant uplifts claimed' do
-      context 'when 1 defendant and 0 uplifts' do
+    context 'with 1 defendant' do
+      context 'when there are 0 uplifts' do
         it 'test setup' do
           expect(claim.defendants.size).to eql 1
           expect(claim.misc_fees.map { |f| f.fee_type.unique_code }).to eql(%w[MIAPH])
@@ -142,7 +136,7 @@ describe Claim::AdvocateClaimValidator do
         end
       end
 
-      context 'when 1 defendant and 1 uplift' do
+      context 'when there is 1 uplift' do
         before do
           create(:misc_fee, fee_type: miahu, claim: claim, quantity: 1, amount: 21.01)
         end
@@ -158,7 +152,7 @@ describe Claim::AdvocateClaimValidator do
         end
 
         it 'should error with message' do
-          should_error_with(claim, :base, 'Too many defendant uplifts claimed')
+          should_error_with(claim, :base, 'defendant_uplifts_mismatch')
         end
 
         context 'when from api' do
@@ -172,13 +166,13 @@ describe Claim::AdvocateClaimValidator do
         end
       end
 
-      context 'when multiple defendants and uplift varieties' do
+      context 'with 2 defendants' do
         before do
           create(:defendant, claim: claim)
           create(:misc_fee, fee_type: midtw, claim: claim, quantity: 1, amount: 21.01)
         end
 
-        context 'when sums of uplift quantities per fee type do not exceed the number of defendants' do
+        context 'when there are multiple uplifts of 1 per fee type' do
           before do
             create(:misc_fee, fee_type: miahu, claim: claim, quantity: 1, amount: 21.01)
             create(:misc_fee, fee_type: midwu, claim: claim, quantity: 1, amount: 21.01)
@@ -194,7 +188,7 @@ describe Claim::AdvocateClaimValidator do
           end
         end
 
-        context 'when sums of any uplift quantities per fee type exceed the number of defendants' do
+        context 'when there are multiple uplifts of 2 (or more) per fee type' do
           before do
             create(:misc_fee, fee_type: miahu, claim: claim, quantity: 2, amount: 21.01)
             create(:misc_fee, fee_type: midwu, claim: claim, quantity: 2, amount: 21.01)

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 require_relative '../validation_helpers'
 
-
 describe Claim::BaseClaimValidator do
-
   include ValidationHelpers
 
   let(:claim)                       { FactoryBot.create :claim }
@@ -532,7 +530,6 @@ describe Claim::BaseClaimValidator do
   end
 
   context 'cracked (re)trials' do
-
     let(:cracked_trial_claim) do
       claim = FactoryBot.create :claim, case_type: cracked_trial
       nulify_fields_on_record(claim, :trial_fixed_notice_at, :trial_fixed_at, :trial_cracked_at)

--- a/spec/validators/validation_helpers.rb
+++ b/spec/validators/validation_helpers.rb
@@ -6,6 +6,12 @@ module ValidationHelpers
     end
   end
 
+  shared_context "step-index" do |step|
+    before do
+      allow(claim).to receive(:current_step_index).and_return(step || 0)
+    end
+  end
+
   # needed to work around Total validation on claim
   def create_and_submit_claim(claim)
     claim.force_validation = false


### PR DESCRIPTION
**What**
Ensure advocates cannot claim defendant uplift
miscellaneous fees that exceed the number of defendants.

**Why**
To ensure that no miscellaneous fees can be created that would
error when injected into CCR. CCR requires that the number of
defendant uplifts is less than or equal to the number of defendants 
on the claim. CCCD handles defendant uplifts via separate records
where the quantity is the number of defendants. A sum of these quantities
per uplift fee type must therefore not exceed the number of defendant
records on the claim.