### PR TITLE
Improve Redraft logging

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -86,7 +86,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
                   error: error.message) do
       'Failed to clone'
     end
-    redirect_to external_users_claims_url, alert: 'Can only clone rejected claims'
+    redirect_to external_users_claims_url, alert: t('external_users.claims.redraft.error_html').html_safe
   end
 
   def destroy

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -81,7 +81,11 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
     draft = claim_updater.clone_rejected
     redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
   rescue StandardError => error
-    LogStuff.send(:error, 'Cloning failed', claim_id: @claim.id, error: error.message) { 'Failed to clone' }
+    LogStuff.send(:error, 'ExternalUsers::ClaimsController',
+                  claim_id: @claim.id,
+                  error: error.message) do
+      'Failed to clone'
+    end
     redirect_to external_users_claims_url, alert: 'Can only clone rejected claims'
   end
 

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -107,6 +107,8 @@ module Claims::Cloner
     draft = duplicate
     draft.transition_clone_to_draft!(author_id: author_id)
     draft
+  rescue StandardError => error
+    raise("Claims::Cloner.clone_rejected_to_new_draft failed with error '#{error.message}'")
   end
 
   # `other_claim` can be a draft instance of any kind of claim scheme (agfs or lgfs).

--- a/app/services/claims/external_user_claim_updater.rb
+++ b/app/services/claims/external_user_claim_updater.rb
@@ -17,6 +17,8 @@ module Claims
 
     def clone_rejected
       claim.clone_rejected_to_new_draft(audit_attributes)
+    rescue StandardError => error
+      raise "Claims::ExternalUserClaimUpdater.clone_rejected with #{error.message}"
     end
 
     def request_redetermination

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,7 +442,8 @@ en:
         lgfs_interim_rb: Litigator interim fee
         lgfs_transfer_rb: Litigator transfer fee
     claims:
-
+      redraft:
+        error_html: 'An error is preventing this claim from being redrafted.  The problem has been logged and is being investigated. To continue please start a new claim.'
       additional_information:
         fields:
           additional_information: 'Additional information'

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -577,7 +577,6 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
 
       describe 'the response' do
         before do
-          # allow(log_stuff).to receive(:error)
           patch :clone_rejected, id: subject
         end
 

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -589,7 +589,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
         end
 
         it'displays a flash error' do
-          expect(flash[:alert]).to eq 'Can only clone rejected claims'
+          expect(flash[:alert]).to eq 'An error is preventing this claim from being redrafted.  The problem has been logged and is being investigated. To continue please start a new claim.'
         end
       end
     end

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -180,6 +180,16 @@ RSpec.describe Claims::Cloner, type: :model do
         expect(transition.event).to eq('transition_clone_to_draft')
         expect(transition.author_id).to eq(@current_user.id)
       end
+
+      context 'when an error occurs during cloning' do
+        subject(:clone_fail) { @original_claim.clone_rejected_to_new_draft(author_id: @current_user.id) }
+
+        before { allow_any_instance_of(Claim::BaseClaim).to receive(:transition_clone_to_draft!).and_raise(RuntimeError) }
+
+        it 'raises the correct error' do
+          expect { clone_fail }.to raise_error("Claims::Cloner.clone_rejected_to_new_draft failed with error 'RuntimeError'")
+        end
+      end
     end
   end
 

--- a/spec/services/claims/external_user_claim_updater_spec.rb
+++ b/spec/services/claims/external_user_claim_updater_spec.rb
@@ -78,6 +78,22 @@ module Claims
         draft = subject.clone_rejected
         expect(draft.last_state_transition.author_id).to eq(current_user.id)
       end
+
+      context 'when the claim is not rejected' do
+        let(:claim) { create :submitted_claim }
+
+        it 'raises an appropriate error' do
+          expect { subject.clone_rejected }.to raise_error('Claims::ExternalUserClaimUpdater.clone_rejected with Claims::Cloner.clone_rejected_to_new_draft failed with error \'Can only clone claims in state "rejected"\'')
+        end
+      end
+
+      context 'when another error is raised' do
+        before { allow(claim).to receive(:clone_rejected_to_new_draft).and_raise(ArgumentError.new('unknowable error')) }
+
+        it 'is passed upwards' do
+          expect { subject.clone_rejected }.to raise_error('Claims::ExternalUserClaimUpdater.clone_rejected with unknowable error')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Why?  We have some logging info stored, but insufficient to identify the issue

How?  Add error traps at all levels of the clone path and consistently pass them up the chain