### PR TITLE
Allocation fix

### DIFF
--- a/app/interfaces/api/helpers/search_result_helpers.rb
+++ b/app/interfaces/api/helpers/search_result_helpers.rb
@@ -10,12 +10,12 @@ module SearchResultHelpers
   end
 
   def fee_is_interim_type
-    fees.map do |fee|
+    fees&.map do |fee|
       [
         fee[2].eql?('Fee::InterimFeeType'),
         fee[1].downcase.in?(['effective pcmh', 'trial start', 'retrial new solicitor', 'retrial start'])
       ].all?
-    end.any?
+    end&.any?
   end
 
   def contains_risk_based_fee
@@ -34,7 +34,7 @@ module SearchResultHelpers
         fee[2].eql?('Fee::InterimFeeType'),
         fee[1].eql?(fee_type_description)
       ].all?
-    end.any?
+    end&.any?
   end
 
   def risk_based_class_letter

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -26,5 +26,35 @@ describe API::Entities::SearchResult do
       let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>1, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>1} }
       it { is_expected.to eql result }
     end
+
+    context 'when passed a litigator case with a final fee' do
+      let(:claim) {OpenStruct.new('id'=>'132506', 'uuid'=>'1344fb35-2337-4d22-b45a-5389315d06c5', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'S20170495', 'state'=>'redetermination', 'court_name'=>'Newcastle', 'case_type'=>'Committal for Sentence', 'total'=>'309.82', 'disk_evidence'=>'f', 'external_user'=>'Ole Hermann', 'maat_references'=>'5782148', 'defendants'=>'Zetta Rau', 'fees'=>'0.0~Committal for sentence hearings~Fee::FixedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'E', 'is_fixed_fee'=>'t', 'fee_type_code'=>'FXCSE', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+      let(:result) { {'disk_evidence'=>0, 'redetermination'=>1, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>0, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
+      it { is_expected.to eql result }
+    end
+
+    context 'when passed a litigator case with Final fee' do
+      let(:claim) {OpenStruct.new('id' => '180772',	'uuid' => 'ef682b0b-82ef-4908-9b3f-3cee19acc148',	'scheme' => 'lgfs',	'scheme_type' => 'Final',	'case_number' => 'T20170981',	'state' => 'submitted',	'court_name' => 'Newcastle',	'case_type' => 'Elected cases not proceeded',	'total' => '396.4',	'disk_evidence' => 'f',	'external_user' => 'Name Padberg',	'maat_references' => '5924967',	'defendants' => 'Maybell Bahringer',	'fees' => '0.0~Elected case not proceeded~Fee::FixedFeeType',	'last_submitted_at' => '2017-12-08 14:55:58.416695',	'class_letter' => 'H',	'is_fixed_fee' => 't',	'fee_type_code' => 'FXENP',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>1, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>0, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
+      it { is_expected.to eql result }
+    end
+
+    context 'when passed a litigator Disbursement only Interim fee' do
+      let(:claim) {OpenStruct.new('id' => '179473',	'uuid' => '7bca9dd7-0a32-442c-b399-85a2379609ad',	'scheme' => 'lgfs',	'scheme_type' => 'Interim',	'case_number' => 'T20170276',	'state' => 'submitted',	'court_name' => 'Worcester',	'case_type' => 'Trial',	'total' => '4652.64',	'disk_evidence' => 'f',	'external_user' => 'Stacey Bosco',	'maat_references' => '5853600',	'defendants' => 'Jordyn Marquardt',	'fees' => '0.0~Disbursement only~Fee::InterimFeeType',	'last_submitted_at' => '07/12/2017  10:30:54',	'class_letter' => 'D',	'is_fixed_fee' => 'f',	'fee_type_code' => 'GRTRL',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>1, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>1, 'risk_based_bills'=>0} }
+      it { is_expected.to eql result }
+    end
+
+    context 'when passed a litigator warrant Interim fee' do
+      let(:claim) {OpenStruct.new('id' => '179818',	'uuid' => '887cbd94-3f48-4955-8646-918de4db3617',	'scheme' => 'lgfs',	'scheme_type' => 'Interim',	'case_number' => 'T20170081',	'state' => 'submitted',	'court_name' => 'Cambridge',	'case_type' => 'Trial',	'total' => '667.33',	'disk_evidence' => 'f',	'external_user' => 'Fernando Zboncak',	'maat_references' => '5663494',	'defendants' => 'Reta Stark',	'fees' => '0.0~Warrant~Fee::InterimFeeType',	'last_submitted_at' => '07/12/2017  12:58:29',	'class_letter' => 'B',	'is_fixed_fee' => 'f',	'fee_type_code' => 'GRTRL',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>1, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>1, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
+      it { is_expected.to eql result }
+    end
+
+    context 'when passed a litigator Interim fee' do
+      let(:claim) {OpenStruct.new('id' => '180773',	'uuid' => 'c4a9bf51-ffe1-40eb-8399-f9ae2510b417',	'scheme' => 'lgfs',	'scheme_type' => 'Interim',	'case_number' => 'T20171115',	'state' => 'submitted',	'court_name' => 'Liverpool',	'case_type' => 'Trial',	'total' => '213.3',	'disk_evidence' => 'f',	'external_user' => 'Eldridge Muller',	'maat_references' => '5841779',	'defendants' => 'Destini Thiel',	'fees' => '19.0~Effective PCMH~Fee::InterimFeeType',	'last_submitted_at' => '11/12/2017  10:37:06',	'class_letter' => 'H',	'is_fixed_fee' => 'f',	'fee_type_code' => 'GRTRL',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>1, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>1, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
+      it { is_expected.to eql result }
+    end
   end
 end


### PR DESCRIPTION
Although this should not occur in live it is a fix for allocation where fees are missing

On a local, dev machine an ajax error was raised when trying to filter claims with null fee types

Uses `&.` to check, and exclude, null fees in all fee types