### PR TITLE
Trap redraft timeout error explicitly

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -87,6 +87,8 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
     LogStuff.send(:error, 'ExternalUsers::ClaimsController',
                   action: 'clone',
                   claim_id: @claim.id,
+                  documents: @claim.documents.count,
+                  total_size: @claim.documents.sum(:document_file_size),
                   error: error.message) do
       'Failed to clone'
     end

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -82,6 +82,14 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
     Timeout.timeout(15) do
       draft = claim_updater.clone_rejected
     end
+    LogStuff.send(:info, 'ExternalUsers::ClaimsController',
+                  action: 'clone',
+                  claim_id: @claim.id,
+                  documents: @claim.documents.count,
+                  total_size: @claim.documents.sum(:document_file_size)) do
+      'Redraft succeeded'
+    end
+
     redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
   rescue StandardError => error
     LogStuff.send(:error, 'ExternalUsers::ClaimsController',
@@ -90,7 +98,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
                   documents: @claim.documents.count,
                   total_size: @claim.documents.sum(:document_file_size),
                   error: error.message) do
-      'Failed to clone'
+      'Redraft failed'
     end
     redirect_to external_users_claims_url, alert: t('external_users.claims.redraft.error_html').html_safe
   end

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -78,7 +78,10 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def clone_rejected
-    draft = claim_updater.clone_rejected
+    draft = nil
+    Timeout.timeout(15) do
+      draft = claim_updater.clone_rejected
+    end
     redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
   rescue StandardError => error
     LogStuff.send(:error, 'ExternalUsers::ClaimsController',

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -574,6 +574,8 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
         expect(LogStuff).to receive(:error).with('ExternalUsers::ClaimsController',
                                                  action: 'clone',
                                                  claim_id: subject.id,
+                                                 documents: 0,
+                                                 total_size: 0,
                                                  error: 'Claims::Cloner.clone_rejected_to_new_draft failed with error \'Can only clone claims in state "rejected"\'')
         patch :clone_rejected, id: subject
       end


### PR DESCRIPTION
Add an explicit timeout error trap for when cloning takes too long