### PR TITLE
Use retrial length for injection of retrials

### DIFF
--- a/app/services/ccr/daily_attendance_adapter.rb
+++ b/app/services/ccr/daily_attendance_adapter.rb
@@ -26,7 +26,7 @@ module CCR
       if daily_attendance_uplifts?
         daily_attendance_uplifts + DAILY_ATTENDANCES_IN_BASIC
       else
-        [claim.actual_trial_length, DAILY_ATTENDANCES_IN_BASIC].compact.min
+        [trial_length, DAILY_ATTENDANCES_IN_BASIC].compact.min
       end
     end
 
@@ -34,6 +34,10 @@ module CCR
 
     # The first 2 daily attendances are included in the Basic Fee (BABAF)
     DAILY_ATTENDANCES_IN_BASIC = 2
+
+    def trial_length
+      claim&.case_type&.requires_retrial_dates? ? claim&.retrial_actual_length : claim&.actual_trial_length
+    end
 
     def daily_attendance_fee_types
       ::Fee::BasicFeeType.where(unique_code: %w[BADAF BADAH BADAJ])

--- a/spec/api/entities/ccr/adapted_basic_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_basic_fee_spec.rb
@@ -5,7 +5,7 @@ describe API::Entities::CCR::AdaptedBasicFee do
   subject(:response) { JSON.parse(described_class.represent(adapted_basic_fees).to_json).deep_symbolize_keys }
 
   let(:claim) { create(:authorised_claim) }
-  let(:case_type) { instance_double('case_type', fee_type_code: 'GRTRL')}
+  let(:case_type) { instance_double('case_type', fee_type_code: 'GRTRL', requires_retrial_dates?: false) }
   let(:adapted_basic_fees) { ::CCR::Fee::BasicFeeAdapter.new.call(claim) }
 
   before do

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -334,12 +334,27 @@ describe API::V2::CCRClaim do
           end
 
           context 'lower bound value' do
-            before do
-              claim.update(actual_trial_length: 2)
+            context 'for trials' do
+              before do
+                claim.update(actual_trial_length: 2)
+              end
+
+              it 'calculated from acutal trial length if no daily attendance fees' do
+                expect(response).to be_json_eql("2".to_json).at_path "bills/0/daily_attendances"
+              end
             end
 
-            it 'calculated from acutal trial length if no daily attendance fees' do
-              expect(response).to be_json_eql("2".to_json).at_path "bills/0/daily_attendances"
+            context 'for retrials' do
+              let(:retrial) { instance_double('case_type', name: 'Retrial', requires_retrial_dates: true) }
+
+              before do
+                allow(claim).to receive(:case_type).and_return retrial
+                claim.update(retrial_actual_length: 4)
+              end
+
+              it 'calculated from acutal retrial length if no daily attendance fees' do
+                expect(response).to be_json_eql("4".to_json).at_path "bills/0/daily_attendances"
+              end
             end
           end
         end

--- a/spec/services/ccr/daily_attendance_adapter_spec.rb
+++ b/spec/services/ccr/daily_attendance_adapter_spec.rb
@@ -8,12 +8,33 @@ module CCR
     describe '#attendances' do
       subject { described_class.new(claim).attendances }
 
-      context 'when no daily attendance uplift fees applied' do
-        [0,1,3,nil].each do |trial_length|
-          context "and claim has an actual trial length of #{trial_length || 'nil'}" do
-            before { claim.update(actual_trial_length: trial_length) }
-            it "returns #{[trial_length,2].compact.min} - as least of actual trial length or 2 (included in basic fee)" do
-              is_expected.to eql [trial_length,2].compact.min
+      context 'for trials' do
+        context 'when no daily attendance uplift fees applied' do
+          [0,1,3,nil].each do |trial_length|
+            context "and claim has an actual trial length of #{trial_length || 'nil'}" do
+              before { claim.update(actual_trial_length: trial_length) }
+              it "returns #{[trial_length,2].compact.min} - as least of actual trial length or 2 (included in basic fee)" do
+                is_expected.to eql [trial_length,2].compact.min
+              end
+            end
+          end
+        end
+
+        context 'for retrials' do
+          let(:retrial) { create(:case_type, :retrial) }
+
+          before do
+            claim.update(case_type: retrial)
+          end
+
+          context 'when no daily attendance uplift fees applied' do
+            [0,1,3,nil].each do |trial_length|
+              context "and claim has an actual retrial length of #{trial_length || 'nil'}" do
+                before { claim.update(retrial_actual_length: trial_length) }
+                it "returns #{[trial_length,2].compact.min} - as least of actual retrial length or 2 (included in basic fee)" do
+                  is_expected.to eql [trial_length,2].compact.min
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
Retrials have separate trial length fields
against which basic fees for daily attendance
are validated. In addition, for injection, it
is the retrial length that should be used in
calculating the daily attendances sent to CCR.