### PR TITLE
Update rejection handling

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,10 @@
-engines:
+version: "2"
+checks:
+  method-lines:
+    enabled: true
+    config:
+      threshold: 100
+plugins:
   rubocop:
     enabled: true
     channel: rubocop-0-50
@@ -17,11 +23,7 @@ engines:
     enabled: true
   bundler-audit:
     enabled: true
-ratings: # customize
-  paths:
-  - app/**/*
-  - lib/**/*
-exclude_paths: # customize
+exclude_patterns: # customize
 - .bundle/
 - app/assets/fonts/
 - app/assets/images/

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,7 +103,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 193
+  Max: 196
 
 # Offense count: 7
 Metrics/PerceivedComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -100,10 +100,13 @@ Metrics/MethodLength:
     - 'scheduled_tasks/daily_stats_generator.rb'
     - 'spikes/supplier_import/migrate/20161020133346_laa_imported_suppliers.rb'
 
-# Offense count: 2
+# Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 196
+  Exclude:
+    - 'app/helpers/application_helper.rb'
+    - 'app/models/claims/cloner.rb'
+    - 'app/models/claims/state_machine.rb'
 
 # Offense count: 7
 Metrics/PerceivedComplexity:

--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -1,30 +1,97 @@
 moj.Modules.AmountAssessed = {
-    $assessmentSection: $('#claim-status.js-cw-claim-assessment'),
-    $actionSection: $('div.js-cw-claim-action'),
-    $rejectionReasons: $('div.js-cw-claim-rejection-reasons'),
+  blocks: [],
+  init: function() {
+    this.blocks.push(new moj.Modules.AmountAssessedBlock());
+  }
+};
 
-    init: function () {
-        this.$rejectionReasons.hide();
-        this.$actionSection.find('input:radio').on('change', function () {
-            moj.Modules.AmountAssessed.state();
-        });
+
+moj.Modules.AmountAssessedBlock = function(selector) {
+  var self = this;
+
+  this.config = {
+    hook: selector || '.fx-assesment-hook',
+    form: '.js-cw-claim-assessment',
+    actions: '.js-cw-claim-action',
+    reasons: '.js-cw-claim-rejection-reasons',
+    otherinput: '.js-reject-reason-text',
+    otherCheckbox: '#_state_reason_other',
+    action: 'toggle'
+  };
+
+  this.states = {
+    rejected: {
+      form: false,
+      reasons: true
     },
-    state: function () {
-        var action = this.$actionSection.find('input:radio:checked').val();
-
-        if (action === 'part_authorised' || action === 'authorised') {
-            this.$assessmentSection.slideDown('slow');
-        } else {
-            this.$assessmentSection.slideUp('slow');
-        }
-
-        if (action === 'rejected') {
-            this.$rejectionReasons.show();
-        } else {
-            this.$rejectionReasons.hide();
-            this.$rejectionReasons
-                .find('input:radio:checked').prop('checked', false)
-                .closest('label').removeClass('selected');
-        }
+    refused: {
+      form: false,
+      reasons: false
+    },
+    authorised: {
+      form: true,
+      reasons: false
+    },
+    part_authorised: {
+      form: true,
+      reasons: false
     }
+  };
+
+  this.el = this.config.hook;
+
+  this.init = function() {
+    this.$el = $(this.el);
+    this.$form = $(this.config.form);
+    this.$actions = $(this.config.actions);
+    this.$reasons = $(this.config.reasons);
+    this.$otherinput = $(this.config.otherinput);
+    this.$otherCheckbox = $(this.config.otherCheckbox);
+    this.bindEvents();
+  };
+
+  this.slider = function(state, el) {
+    // open and close slider
+    // true: open
+    // false: close
+    return state ? $(el).slideDown() : $(el).slideUp();
+  };
+
+  this.bindEvents = function() {
+    var self = this;
+
+    this.$actions.on('change', function(e) {
+      var state = $(e.target).val();
+      $.publish('claim.status.change', {
+        state: state
+      })
+    });
+
+    this.$reasons.on('change', function(e) {
+      var reason = self.$otherCheckbox.is(':checked');
+      $.publish('claim.reasons.change', {
+        reason: reason
+      })
+    });
+
+    $.subscribe('claim.reasons.change', function(e, data) {
+      data.reason ? self.slider(true, self.$otherinput) : self.slider(false, self.$otherinput)
+    });
+
+    $.subscribe('claim.status.change', function(e, data) {
+      var state = self.states[data.state]
+
+      self.$form.is(function(idx, el) {
+        self.slider(state.form, el)
+      });
+
+      self.$reasons.is(function(idx, el) {
+        self.slider(state.reasons, el)
+      });
+    });
+
+  };
+
+  this.init();
+  return this;
 };

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -79,6 +79,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   def claim_params
     params.require(:claim).permit(
       :state,
+      :reason_text,
       :additional_information,
       assessment_attributes: %i[
         id
@@ -94,7 +95,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         disbursements
         vat_amount
       ]
-    ).merge(params.permit(:state_reason, :reason_text))
+    ).merge(params.permit(:state_reason))
   end
 
   def set_claims

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -96,6 +96,10 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         vat_amount
       ]
     ).merge(params.permit(state_reason: []))
+    # the state_reason needs to be merged because the collection_check_boxes control on the view requires
+    # a claim object to render.  Because state_reason does not belong to claim, it refuses to render and
+    # therefore nil is passed to the object.  This then comes back outside of the claim namespace and has
+    # to be manually merged.
   end
 
   def set_claims

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -95,7 +95,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         disbursements
         vat_amount
       ]
-    ).merge(params.permit(:state_reason))
+    ).merge(params.permit(state_reason: []))
   end
 
   def set_claims

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -94,7 +94,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         disbursements
         vat_amount
       ]
-    ).merge(params.permit(:state_reason))
+    ).merge(params.permit(:state_reason, :reason_text))
   end
 
   def set_claims

--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -19,8 +19,23 @@ class ClaimStateTransition < ActiveRecord::Base
   belongs_to :author, class_name: User, foreign_key: :author_id
   belongs_to :subject, class_name: User, foreign_key: :subject_id
 
+  serialize :reason_code, Array
+
   def reason
-    ClaimStateTransitionReason.get(reason_code)
+    if reason_code.is_a?(Array)
+      reasons
+    else
+      [] << ClaimStateTransitionReason.get(reason_code)
+    end
+  end
+
+  def reasons
+    reasons = reason_code.reject(&:empty?)
+    result = []
+    reasons.each do |reason_code|
+      result << ClaimStateTransitionReason.get(reason_code)
+    end
+    result
   end
 
   def self.decided_this_month(state)

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -7,8 +7,11 @@ class ClaimStateTransitionReason
   TRANSITION_REASONS = HashWithIndifferentAccess.new(
     rejected: {
       no_indictment: 'No indictment attached',
-      no_rep_order: 'No rep order attached (granted before 1/8/2015)',
-      time_elapsed: 'More than 3 months has elapsed since case completion',
+      no_rep_order: 'No magistrates’ representation order attached (granted before 1/8/2015)',
+      time_elapsed: 'Claim significantly out of time with no explanation.',
+      no_amend_rep_order: 'No amending representation order',
+      case_still_live: 'Case still live',
+      wrong_case_no: 'Incorrect case number',
       other: 'Other'
     },
     global: {

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -7,7 +7,7 @@ class ClaimStateTransitionReason
   TRANSITION_REASONS = HashWithIndifferentAccess.new(
     rejected: {
       no_indictment: 'No indictment attached',
-      no_rep_order: 'No magistrates’ representation order attached (granted before 1/8/2015)',
+      no_rep_order: 'No Magistrates’ representation order attached (granted before 1/8/2015)',
       time_elapsed: 'Claim significantly out of time with no explanation.',
       no_amend_rep_order: 'No amending representation order',
       case_still_live: 'Case still live',

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -14,6 +14,10 @@ class ClaimStateTransitionReason
       wrong_case_no: 'Incorrect case number',
       other: 'Other'
     },
+    disbursement: {
+      no_prior_authority: 'No prior authority provided',
+      no_invoice: 'No invoice provided'
+    },
     global: {
       timed_transition: 'TimedTransition::Transitioner'
     }
@@ -35,6 +39,12 @@ class ClaimStateTransitionReason
 
     def reasons(state)
       reasons_for(state)
+    end
+
+    def reject_reasons_for(claim)
+      reasons = reasons_for('rejected')
+      reasons.insert(6, reasons_for(:disbursement)) if claim.fees.first.fee_type.code.eql?('IDISO')
+      reasons.flatten
     end
 
     private

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -53,7 +53,7 @@ module Claims
 
     def self.included(klass)
       klass.state_machine :state, initial: :draft do
-        audit_trail class: ClaimStateTransition, context: %i[reason_code author_id subject_id]
+        audit_trail class: ClaimStateTransition, context: %i[reason_code reason_text author_id subject_id]
 
         state :allocated,
               :archived_pending_delete,
@@ -190,6 +190,10 @@ module Claims
 
     def reason_code(transition)
       extract_transition_option!(transition, :reason_code)
+    end
+
+    def reason_text(transition)
+      extract_transition_option!(transition, :reason_text)
     end
 
     def author_id(transition)

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -64,7 +64,7 @@ module TimedTransitions
                     dummy_run: @dummy) do
                       'Archiving claim'
                     end
-      @claim.archive_pending_delete!(reason_code: 'timed_transition') unless is_dummy?
+      @claim.archive_pending_delete!(reason_code: ['timed_transition']) unless is_dummy?
       self.success = true
     end
 

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -13,6 +13,10 @@ class Claim::BaseClaimPresenter < BasePresenter
     valid_transitions(include_submitted: false) if claim.state == 'allocated'
   end
 
+  def reason_text
+    claim.claim_state_transitions.last.reason_text
+  end
+
   def claim_state
     if claim.opened_for_redetermination?
       'Redetermination'

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -96,7 +96,11 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def state_reason_code
-    @journey.last.reason_code
+    @journey.last.reason_code.flatten.join(', ')
+  end
+
+  def rejection_reason
+    @journey.last.reason_text
   end
 
   def submitted_states

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -22,7 +22,7 @@ module Claims
 
     def extract_transition_params
       @state = @params.delete('state')
-      @transition_reason = @params.delete('state_reason')
+      @transition_reason = @params.delete('state_reason')&.reject(&:empty?)
       @transition_reason_text = @params.delete('reason_text')
       @current_user = @params.delete(:current_user)
     end
@@ -64,7 +64,7 @@ module Claims
 
     def validate_reason_presence
       return unless @state == 'rejected'
-      add_error 'requires a reason when rejecting' if @transition_reason&.reject(&:empty?)&.empty?
+      add_error 'requires a reason when rejecting' if @transition_reason&.empty?
       add_error 'requires details when rejecting with other' if transition_reason_text_missing?
     end
 

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -42,6 +42,7 @@ module Claims
         validate_state_when_value_params_present
       else
         validate_state_when_no_value_params
+        validate_reason_presence
       end
     end
 
@@ -58,6 +59,10 @@ module Claims
     def validate_state_when_no_value_params
       return unless @state.in?(%w[authorised part_authorised])
       add_error 'You must specify positive values if authorising or part authorising a claim'
+    end
+
+    def validate_reason_presence
+      add_error 'You must specify a reason when rejecting' if @state == 'rejected' && @transition_reason.nil?
     end
 
     def nil_or_empty_zero_or_negative?(determination_params)

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -62,7 +62,7 @@ module Claims
     end
 
     def validate_reason_presence
-      add_error 'You must specify a reason when rejecting' if @state == 'rejected' && @transition_reason.nil?
+      add_error 'requires a reason when rejecting' if @state == 'rejected' && @transition_reason.nil?
     end
 
     def nil_or_empty_zero_or_negative?(determination_params)

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -64,12 +64,12 @@ module Claims
 
     def validate_reason_presence
       return unless @state == 'rejected'
-      add_error 'requires a reason when rejecting' if @transition_reason.nil?
+      add_error 'requires a reason when rejecting' if @transition_reason&.reject(&:empty?)&.empty?
       add_error 'requires details when rejecting with other' if transition_reason_text_missing?
     end
 
     def transition_reason_text_missing?
-      @transition_reason == 'other' && @transition_reason_text.nil?
+      @transition_reason&.include?('other') && @transition_reason_text.blank?
     end
 
     def nil_or_empty_zero_or_negative?(determination_params)

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -49,6 +49,11 @@
           = "Choose reason for rejection"
         = collection_radio_buttons(nil, :state_reason, ClaimStateTransitionReason.reasons(:rejected), :code, :description) do |b|
           - b.label(class: "block-label") { b.radio_button + b.text }
+        %fieldset.form-group.nested-fields.fieldset.spacer
+          %div.js-reject-reason-text
+            %a#expense_reject_reason_text
+            = f.label :reason_text, 'Reason text'
+            = f.text_field :reason_text, {class: 'form-control'}
 
     %p
       = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -47,8 +47,8 @@
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
             = "Choose reason for rejection"
-          = collection_radio_buttons(nil, :state_reason, ClaimStateTransitionReason.reasons(:rejected), :code, :description) do |b|
-            - b.label(class: "block-label") { b.radio_button + b.text }
+          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
+            - b.label(class: "block-label") { b.check_box + b.text }
           %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none'}
             %div
               %a#expense_reject_reason_text

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -1,59 +1,59 @@
 = form_for(claim, url: case_workers_claim_path(claim), as: :claim) do |f|
   = hidden_field_tag :messages, 'true'
+  .fx-assesment-hook
+    #claim-status.js-cw-claim-assessment
+      %h3.heading-medium
+        = 'Assessment summary'
+      %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
+        %thead
+          %tr{:style => "vertical-align: top;"}
+            %th &nbsp;
+            %th
+              = t('shared.assessment.claimed_by', type: claim.external_user_description)
+            %th
+              Total authorised by LAA
+              - if claim.opened_for_redetermination?
+                .form-hint.xsmall include any amount already authorised
+        %tbody
+          // CASEWORKER
+          -if current_user_is_caseworker? && @claim.enable_assessment_input?
+            // ASSESSMENT INPUT
+            = f.fields_for :assessment do |af|
+              = render partial: 'case_workers/claims/determination_fields', locals: { f: af, claim: claim}
 
-  #claim-status.js-cw-claim-assessment
-    %h3.heading-medium
-      = 'Assessment summary'
-    %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
-      %thead
-        %tr{:style => "vertical-align: top;"}
-          %th &nbsp;
-          %th
-            = t('shared.assessment.claimed_by', type: claim.external_user_description)
-          %th
-            Total authorised by LAA
-            - if claim.opened_for_redetermination?
-              .form-hint.xsmall include any amount already authorised
-      %tbody
-        // CASEWORKER
-        -if current_user_is_caseworker? && @claim.enable_assessment_input?
-          // ASSESSMENT INPUT
-          = f.fields_for :assessment do |af|
-            = render partial: 'case_workers/claims/determination_fields', locals: { f: af, claim: claim}
+          -elsif current_user_is_caseworker? && @claim.enable_determination_input?
+            // DETERMINATION INPUT
+            = f.fields_for :redeterminations, claim.redeterminations.build do |rf|
+              = render partial: 'case_workers/claims/determination_fields', locals: { f: rf, claim: claim}
 
-        -elsif current_user_is_caseworker? && @claim.enable_determination_input?
-          // DETERMINATION INPUT
-          = f.fields_for :redeterminations, claim.redeterminations.build do |rf|
-            = render partial: 'case_workers/claims/determination_fields', locals: { f: rf, claim: claim}
+          - elsif claim.redeterminations.any?
+            // REDETERMINATION
+            = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.redeterminations.last }
 
-        - elsif claim.redeterminations.any?
-          // REDETERMINATION
-          = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.redeterminations.last }
+          - else
+            // ELSE
+            = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.assessment }
 
-        - else
-          // ELSE
-          = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.assessment }
+    // CASE WORKER ACTIONS
+    - if current_user_is_caseworker?
+      .js-cw-claim-action
+        %fieldset.form-group.inline.spacer
+          %legend.bold-normal.form-label
+            = "Update the claim status"
+          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last) do |b|
+            - b.label(class: "block-label") { b.radio_button + b.text }
 
-  // CASE WORKER ACTIONS
-  - if current_user_is_caseworker?
-    .js-cw-claim-action
-      %fieldset.form-group.inline.spacer
-        %legend.bold-normal.form-label
-          = "Update the claim status"
-        = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last) do |b|
-          - b.label(class: "block-label") { b.radio_button + b.text }
+      .js-cw-claim-rejection-reasons{style: 'display:none'}
+        %fieldset.form-group.nested-fields.indent-fieldset.spacer
+          %legend.bold-normal.form-label
+            = "Choose reason for rejection"
+          = collection_radio_buttons(nil, :state_reason, ClaimStateTransitionReason.reasons(:rejected), :code, :description) do |b|
+            - b.label(class: "block-label") { b.radio_button + b.text }
+          %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none'}
+            %div
+              %a#expense_reject_reason_text
+              = f.label :reason_text, 'Reason text'
+              = f.text_field :reason_text, {class: 'form-control'}
 
-    .js-cw-claim-rejection-reasons
-      %fieldset.form-group.nested-fields.indent-fieldset.spacer
-        %legend.bold-normal.form-label
-          = "Choose reason for rejection"
-        = collection_radio_buttons(nil, :state_reason, ClaimStateTransitionReason.reasons(:rejected), :code, :description) do |b|
-          - b.label(class: "block-label") { b.radio_button + b.text }
-        %fieldset.form-group.nested-fields.fieldset.spacer
-          %div.js-reject-reason-text
-            %a#expense_reject_reason_text
-            = f.label :reason_text, 'Reason text'
-            = f.text_field :reason_text, {class: 'form-control'}
-
-    %p
-      = f.submit 'Update', class: 'button', id: 'button'
+      %p
+        = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_determinations_table.html.haml
+++ b/app/views/shared/_determinations_table.html.haml
@@ -7,6 +7,8 @@
             = "Warning"
         %strong.bold-small
           = "Reason provided: #{claim.last_state_transition_reason.description}"
+          %br/
+          = "NEED: #{claim.claim_state_transitions.last.reason_text}"
 
 
   = render partial: 'shared/summary_totals', locals: {claim: claim }

--- a/app/views/shared/_determinations_table.html.haml
+++ b/app/views/shared/_determinations_table.html.haml
@@ -6,9 +6,12 @@
           %span.visuallyhidden
             = "Warning"
         %strong.bold-small
-          = "Reason provided: #{claim.last_state_transition_reason.description}"
-          %br/
-          = "NEED: #{claim.claim_state_transitions.last.reason_text}"
+          = "#{"Reason".pluralize(claim.last_state_transition_reason.count)} provided:"
+          %ul.timed-retention-states
+            -claim.last_state_transition_reason.each do |reason|
+              %li
+                =reason.description
+                = "(#{claim.last_state_transition.reason_text})" if reason.description.eql?('Other') && claim.last_state_transition.reason_text.present?
 
 
   = render partial: 'shared/summary_totals', locals: {claim: claim }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,7 @@ claim_csv_headers:
   - :completed_at
   - :current_or_end_state
   - :state_reason_code
+  - :rejection_reason
   - :case_worker
 
 expense_schema_version: 2

--- a/db/migrate/20171219122957_add_reason_text_to_claim_state_transition.rb
+++ b/db/migrate/20171219122957_add_reason_text_to_claim_state_transition.rb
@@ -1,0 +1,5 @@
+class AddReasonTextToClaimStateTransition < ActiveRecord::Migration
+  def change
+    add_column :claim_state_transitions, :reason_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171211120149) do
+ActiveRecord::Schema.define(version: 20171219122957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 20171211120149) do
     t.string   "reason_code"
     t.integer  "author_id"
     t.integer  "subject_id"
+    t.string   "reason_text"
   end
 
   add_index "claim_state_transitions", ["claim_id"], name: "index_claim_state_transitions_on_claim_id", using: :btree

--- a/spec/javascripts/modules-amountAssessed_spec.js
+++ b/spec/javascripts/modules-amountAssessed_spec.js
@@ -48,6 +48,7 @@ describe("Modules.AmountAssessedBlock.js", function() {
         actions: '.js-cw-claim-action',
         reasons: '.js-cw-claim-rejection-reasons',
         otherinput: '.js-reject-reason-text',
+        otherCheckbox: '#_state_reason_other',
         action: 'toggle'
       });
     });
@@ -61,7 +62,7 @@ describe("Modules.AmountAssessedBlock.js", function() {
         },
         refused: {
           form: false,
-          reasons: true
+          reasons: false
         },
         authorised: {
           form: true,

--- a/spec/javascripts/modules-amountAssessed_spec.js
+++ b/spec/javascripts/modules-amountAssessed_spec.js
@@ -1,0 +1,114 @@
+describe("Modules.AmountAssessedBlock.js", function() {
+  var domFixture = $('<div class="main" />');
+  var view = [
+    '<div class="fx-assesment-hook">',
+    '  <div class="js-cw-claim-assessment" id="claim-status" style="display: block;">',
+    '    <h3 class="heading-medium">',
+    '      Assessment summary',
+    '    </h3>',
+    '  </div>',
+    '  <div class="js-cw-claim-action">',
+    '      <input type="radio" value="part_authorised" name="claim[state]" id="claim_state_part_authorised" />',
+    '      <input type="radio" value="authorised" name="claim[state]" id="claim_state_authorised" />',
+    '      <input type="radio" value="refused" name="claim[state]" id="claim_state_refused" />',
+    '      <input type="radio" value="rejected" name="claim[state]" id="claim_state_rejected" />',
+    '  </div>',
+    '  <div class="js-cw-claim-rejection-reasons" style="display: none;">',
+    '    <input type="radio" value="wrong_case_no" name="[state_reason]" id="_state_reason_wrong_case_no">',
+    '    <input type="radio" value="other" name="[state_reason]" id="_state_reason_other">',
+    '    <fieldset class="js-reject-reason-text">',
+    '      <div>',
+    '        <input class="form-control" type="text" name="claim[reason_text]" id="claim_reason_text">',
+    '      </div>',
+    '    </fieldset>',
+    '  </div>',
+    '</div>'
+  ].join('');
+
+
+  beforeEach(function() {
+    domFixture.append($(view));
+    $('body').append(domFixture);
+
+
+    // reset to default state
+    moj.Modules.AmountAssessed.init();
+  });
+
+  afterEach(function() {
+    domFixture.empty();
+  });
+
+  describe('Defaults', function() {
+    it('should have `this.config` defined', function() {
+      var block = moj.Modules.AmountAssessed.blocks[0];
+      expect(block.config).toEqual({
+        hook: '.fx-assesment-hook',
+        form: '.js-cw-claim-assessment',
+        actions: '.js-cw-claim-action',
+        reasons: '.js-cw-claim-rejection-reasons',
+        otherinput: '.js-reject-reason-text',
+        action: 'toggle'
+      });
+    });
+
+    it('should have `this.states` defined', function() {
+      var block = moj.Modules.AmountAssessed.blocks[0];
+      expect(block.states).toEqual({
+        rejected: {
+          form: false,
+          reasons: true
+        },
+        refused: {
+          form: false,
+          reasons: true
+        },
+        authorised: {
+          form: true,
+          reasons: false
+        },
+        part_authorised: {
+          form: true,
+          reasons: false
+        }
+      })
+    });
+  });
+
+  describe('Methods..', function() {
+    describe('...slider', function() {
+      it('should call correct $.fn', function(){
+        var block = moj.Modules.AmountAssessed.blocks[0];
+        var x = false;
+        $.fn.slideUp = function(){
+          x = true;
+        }
+        expect(x).toEqual(false)
+        block.slider(false, $('<div />'))
+        expect(x).toEqual(true)
+
+      });
+    });
+  });
+});
+
+describe("Modules.AmountAssessed.js", function() {
+  beforeEach(function() {
+    // reset to default state
+    moj.Modules.AmountAssessed.init();
+  });
+
+  afterEach(function() {});
+
+  describe('Defaults', function() {
+    it('should have a `blocks` array defined', function() {
+      expect(moj.Modules.AmountAssessed.blocks).toEqual(jasmine.any(Array));
+    });
+
+    it('should call `moj.Modules.AmountAssessedBlock` on init', function() {
+      spyOn(moj.Modules, 'AmountAssessedBlock');
+      moj.Modules.AmountAssessed.init();
+      expect(moj.Modules.AmountAssessedBlock).toHaveBeenCalled();
+    });
+  });
+});

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe ClaimStateTransitionReason, type: :model do
     end
   end
 
+  describe '.reject_reasons_for' do
+    subject(:reject_reasons_for) { described_class.reject_reasons_for(claim) }
+
+    context 'for a Litigator interim, disbursement only claim' do
+      let(:claim) { create(:interim_claim, :disbursement_only_fee, state: 'rejected') }
+
+      it { expect(subject.count).to eq 9 }
+    end
+
+    context 'for an advocate claim' do
+      let(:claim) { create(:advocate_claim, state: 'rejected') }
+
+      it { expect(subject.count).to eq 7 }
+    end
+  end
+
   describe '.get' do
     let(:code) { 'code' }
     let(:reason) { described_class.get(code) }

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Claims::StateMachine, type: :model do
         event: 'submit',
         from: 'draft',
         to: 'submitted',
-        reason_code: nil
+        reason_code: []
       }
     end
 
@@ -360,7 +360,7 @@ RSpec.describe Claims::StateMachine, type: :model do
   describe 'reject! supports a reason code' do
     before { subject.submit!; subject.allocate!; subject.reject!(reason_code: reason_code) }
 
-    let(:reason_code) { 'reason' }
+    let(:reason_code) { ['reason'] }
 
     it 'updates the transition reason code' do
       transition = subject.claim_state_transitions.first
@@ -372,7 +372,7 @@ RSpec.describe Claims::StateMachine, type: :model do
   describe 'refuse! supports a reason code' do
     before { subject.submit!; subject.allocate!; subject.refuse!(reason_code: reason_code) }
 
-    let(:reason_code) { 'reason' }
+    let(:reason_code) { ['reason'] }
 
     it 'updates the transition reason code' do
       transition = subject.claim_state_transitions.first

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -106,7 +106,7 @@ module TimedTransitions
             it 'records the transition in claim state transitions' do
               Transitioner.new(@claim).run
               last_transition = @claim.reload.claim_state_transitions.first
-              expect(last_transition.reason_code).to eq('timed_transition')
+              expect(last_transition.reason_code).to eq(['timed_transition'])
             end
 
 

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -174,13 +174,40 @@ RSpec.describe ClaimCsvPresenter do
       context 'state transitions reasons' do
         let(:claim) { create(:allocated_claim) }
 
-        before do
-          claim.reject!(reason_code: 'no_rep_order')
+        context 'rejected with a single reason' do
+          before do
+            claim.reject!(reason_code: ['no_rep_order'])
+          end
+
+          it 'the rejection reason code should be reflected in the MI' do
+            ClaimCsvPresenter.new(claim, view).present! do |csv|
+              expect(csv[0][11]).to eq('no_rep_order')
+            end
+          end
         end
 
-        it 'the rejection reason code should be reflected in the MI' do
-          ClaimCsvPresenter.new(claim, view).present! do |csv|
-            expect(csv[0][11]).to eq('no_rep_order')
+        context 'rejected with a multiple reasons' do
+          before do
+            claim.reject!(reason_code: ['no_rep_order', 'wrong_case_no'])
+          end
+
+          it 'the rejection reason code should be reflected in the MI' do
+            ClaimCsvPresenter.new(claim, view).present! do |csv|
+              expect(csv[0][11]).to eq('no_rep_order, wrong_case_no')
+            end
+          end
+        end
+
+        context 'rejected with other' do
+          before do
+            claim.reject!(reason_code: ['other'], reason_text: 'Rejection reason')
+          end
+
+          it 'the rejection reason code should be reflected in the MI' do
+            ClaimCsvPresenter.new(claim, view).present! do |csv|
+              expect(csv[0][11]).to eq('other')
+              expect(csv[0][12]).to eq('Rejection reason')
+            end
           end
         end
       end

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -100,7 +100,7 @@ module Claims
           params = {'state' => 'rejected', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['You must specify a reason when rejecting'])
+          expect(updater.claim.errors[:determinations]).to eq(['requires a reason when rejecting'])
           expect(updater.claim.state).to eq 'allocated'
           expect(updater.claim.assessment.fees.to_f).to eq 0.0
           expect(updater.claim.assessment.expenses).to eq 0.0
@@ -193,7 +193,7 @@ module Claims
           params = {'state' => 'rejected', 'redeterminations_attributes' => {'0' => {'fees' => '', 'expenses' => '0'}}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['You must specify a reason when rejecting'])
+          expect(updater.claim.errors[:determinations]).to eq(['requires a reason when rejecting'])
           expect(updater.claim.state).to eq 'allocated'
           expect(updater.claim.redeterminations).to be_empty
         end

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -34,13 +34,13 @@ module Claims
         end
 
         context 'rejections' do
-          let(:params) { {'state' => 'rejected', 'state_reason' => 'no_indictment', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
+          let(:params) { {'state' => 'rejected', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
 
           it 'advances the claim to rejected with reason supplied' do
             updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
             expect(updater.result).to eq :ok
             expect(updater.claim.state).to eq 'rejected'
-            expect(updater.claim.last_state_transition.reason_code).to eq 'no_indictment'
+            expect(updater.claim.last_state_transition.reason_code).to eq ['no_indictment']
           end
 
           it 'saves audit attributes' do
@@ -49,13 +49,13 @@ module Claims
           end
 
           context 'other rejection with reason' do
-            let(:params) { {'state' => 'rejected', 'state_reason' => 'other', 'reason_text' => 'a reason', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
+            let(:params) { {'state' => 'rejected', 'state_reason' => ['other'], 'reason_text' => 'a reason', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
 
             it 'advances the claim to rejected with reason supplied' do
               updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
               expect(updater.result).to eq :ok
               expect(updater.claim.state).to eq 'rejected'
-              expect(updater.claim.last_state_transition.reason_code).to eq 'other'
+              expect(updater.claim.last_state_transition.reason_code).to eq ['other']
               expect(updater.claim.last_state_transition.reason_text).to eq 'a reason'
             end
 
@@ -114,7 +114,7 @@ module Claims
         end
 
         it 'if no state_reason are supplied' do
-          params = {'state' => 'rejected', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
+          params = {'state' => 'rejected', 'state_reason' => [''], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
           expect(updater.claim.errors[:determinations]).to eq(['requires a reason when rejecting'])
@@ -125,7 +125,7 @@ module Claims
         end
 
         it 'if state_reason is other, but no text is supplied' do
-          params = {'state' => 'rejected', 'state_reason' => 'other', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
+          params = {'state' => 'rejected', 'state_reason' => ['other'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
           expect(updater.claim.errors[:determinations]).to eq(['requires details when rejecting with other'])
@@ -218,7 +218,7 @@ module Claims
         end
 
         it 'if no state_reason are supplied' do
-          params = {'state' => 'rejected', 'redeterminations_attributes' => {'0' => {'fees' => '', 'expenses' => '0'}}}
+          params = {'state' => 'rejected', 'state_reason' => [''], 'redeterminations_attributes' => {'0' => {'fees' => '', 'expenses' => '0'}}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
           expect(updater.claim.errors[:determinations]).to eq(['requires a reason when rejecting'])
@@ -227,7 +227,7 @@ module Claims
         end
 
         it 'if state_reason is other, but no text is supplied' do
-          params = {'state' => 'rejected', 'state_reason' => 'other', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
+          params = {'state' => 'rejected', 'state_reason' => ['other'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
           expect(updater.claim.errors[:determinations]).to eq(['requires details when rejecting with other'])

--- a/spec/views/case_workers/claim_view_spec.rb
+++ b/spec/views/case_workers/claim_view_spec.rb
@@ -64,6 +64,53 @@ describe 'case_workers/claims/show.html.haml', type: :view do
         expect(rendered).to have_link('Download all')
       end
     end
+
+    describe 'reject reasons' do
+      let(:claim) { create(:allocated_claim) }
+      let(:reason_code) { ['no_amend_rep_order'] }
+      let(:old_style) { false }
+      before do
+        claim.reject!(reason_code: reason_code)
+        @messages = claim.messages.most_recent_last
+        @message = claim.messages.build
+        allow_any_instance_of(ClaimStateTransition).to receive(:reason_code).and_return('wrong_case_no') if old_style
+        assign(:claim, claim)
+        render
+      end
+
+      it 'has the correct status display' do
+        expect(rendered).to have_selector('span', 'state state-rejected', text: 'Rejected')
+      end
+
+      it 'renders the reason header with the correct tense' do
+        expect(rendered).to have_content('Reason provided:')
+      end
+
+      it 'renders the full text of the reason' do
+        expect(rendered).to have_selector('li', text: 'No amending representation order')
+      end
+
+      context 'with multiple reasons' do
+        let(:reason_code) { %w[no_amend_rep_order case_still_live] }
+
+        it 'renders the reason header with the correct tense' do
+          expect(rendered).to have_content('Reasons provided:')
+        end
+
+        it 'renders the full text of the reasons' do
+          expect(rendered).to have_selector('li', text: 'No amending representation order')
+          expect(rendered).to have_selector('li', text: 'Case still live')
+        end
+      end
+
+      context 'legacy cases with non-array reason codes' do
+        let(:old_style) { true }
+
+        it 'renders the full text of the reason' do
+          expect(rendered).to have_selector('li', text: 'Incorrect case number')
+        end
+      end
+    end
   end
 
 


### PR DESCRIPTION
- [x] update reject reasons list with revised list when a caseworker selects 'rejected' for AGFS .
- [x] Add validation to ensure case workers have selected a reason when submitting a `reject` response
- [x] display a mandatory a free form text box when 'other' is selected
- [x] NEW: Show other reasons on claim view 
![image](https://user-images.githubusercontent.com/6757677/34407298-88634756-ebb5-11e7-8165-c14f5092e1d9.png)

- [x] Add interim disbursement choices for LGFS and make them conditional so that they only show for interim claims.
- [x] make ALL choices checkboxes so that more than one option can be selected.
- [x]  Update MI report to add reason_text after `other`
- [ ] consider mapping to 'improved' messages for providers, giving them clear instructions on what to do next. i.e. 'no indictment attached' would map to 'please redraft your claim and attach an indictment'. This can happen in a future iteration.

## Github Todo

- [x] design review
- [x] remove un-necessary migration `reasons`
- [x] extend tests, the coverage is at 94%
- [x] rebase PR 
