### PR TITLE
Reset Sequence Ids to max id for table

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,4 +26,13 @@ Style/FormatStringToken:
 Metrics/LineLength:
   Max: 120
 
+Metrics/BlockLength:
+  ExcludedMethods:
+    - included
+    - namespace
+    - expose
+    - helpers
+    - group
+    - state_machine
+
 inherit_from: .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,16 +15,6 @@ Naming/FileName:
 Metrics/AbcSize:
   Max: 87
 
-# Offense count: 9
-# Configuration parameters: CountComments, ExcludedMethods.
-Metrics/BlockLength:
-  Max: 30
-  Exclude:
-    - app/interfaces/api/v2/case_workers/claim.rb
-    - app/models/claims/cloner.rb
-    - app/interfaces/api/v1/dropdown_data.rb
-    - app/models/claims/state_machine.rb
-
 # Offense count: 14
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/lib/id_sequence_resettable.rb
+++ b/lib/id_sequence_resettable.rb
@@ -1,0 +1,46 @@
+module IdSequenceResettable
+  extend ActiveSupport::Concern
+
+  included do
+    def sequence_resets
+      tables.each_with_object([]) do |table_name, memo|
+        memo << reset_sql(table_name)
+        yield memo.last if block_given?
+      end
+    end
+
+    def append_sequence_resets(file_name)
+      sequence_resets do |sql|
+        open(file_name, 'a') do |file|
+          file.puts sql
+        end
+      end
+    end
+
+    private
+
+    def tables_sql
+      <<~SQL
+        SELECT table_name
+        FROM information_schema.columns
+        WHERE column_default LIKE 'nextval(''' || table_name || '_id_seq''%';
+      SQL
+    end
+
+    def tables
+      ActiveRecord::Base
+        .connection
+        .execute(tables_sql)
+        .each_with_object([]) do |rec, memo|
+          memo << rec['table_name']
+          yield memo.last if block_given?
+        end
+    end
+
+    def reset_sql(table_name)
+      <<~SQL
+        SELECT pg_catalog.setval(pg_get_serial_sequence('#{table_name}', 'id'), (SELECT MAX(id) FROM #{table_name}));
+      SQL
+    end
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -101,6 +101,7 @@ namespace :db do
   desc 'Restores the database from a backup'
   task :restore, [:file] => :environment do |_task, args|
     production_protected
+    include IdSequenceResettable
 
     dump_file = args.file
 
@@ -120,6 +121,8 @@ namespace :db do
       dump_file = dump_file[0..-4]
     end
 
+    append_sequence_resets(dump_file)
+
     shell_working 'recreating schema' do
       system (with_config do |_db_name, connection_opts|
           "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -c \"drop schema public cascade\""
@@ -134,7 +137,6 @@ namespace :db do
         "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -f #{dump_file} > /dev/null"
       end)
     end
-
   end
 
   namespace :dump do
@@ -303,5 +305,4 @@ namespace :db do
   def fake_paragraphs max_paragraph_count=4
     Faker::Lorem.paragraphs(max_paragraph_count).pop(rand(1..max_paragraph_count)).join("\n")
   end
-
 end


### PR DESCRIPTION
**What**
Synchronise all sequences for tables with id sequence

**Why**
Restoring a full dump of a database
can result in db sequence IDs being thrown
out of sink. This addition to the restore
task ensures that all tables that rely on
nextval to give them an ID will not break
after restore.