### PR TITLE
Replace use of Webrick with puma as local development server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :development, :devunicorn, :test do
   gem 'rack-livereload',    '~> 0.3.16'
   gem 'rspec-rails',        '~> 3.4'
   gem 'rspec-collection_matchers'
-  gem 'webrick',            '~> 1.3'
+  gem 'puma'
   gem 'parallel_tests'
   gem 'site_prism'
   gem 'guard-jasmine',      '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,6 +425,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
+    puma (3.11.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.8)
@@ -633,7 +634,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    webrick (1.3.1)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -715,6 +715,7 @@ DEPENDENCIES
   posix-spawn (~> 0.3.13)
   pry-byebug
   pry-rails
+  puma
   quiet_assets
   rack-livereload (~> 0.3.16)
   rails (~> 4.2)
@@ -755,7 +756,6 @@ DEPENDENCIES
   utf8-cleaner (~> 0.2)
   vcr (~> 3.0.3)
   webmock (~> 3.0)
-  webrick (~> 1.3)
   zendesk_api (= 1.12.1)
 
 RUBY VERSION


### PR DESCRIPTION
See [CVE-2009-4492](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-4492)