### PR TITLE
Ensure that an assessment is always returned

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -138,6 +138,11 @@ module Claim
 
     has_many :determinations, foreign_key: :claim_id, dependent: :destroy
     has_one  :assessment, foreign_key: :claim_id
+
+    def assessment
+      super || build_assessment
+    end
+
     has_many :redeterminations, foreign_key: :claim_id
     has_many :injection_attempts, foreign_key: :claim_id
 
@@ -190,7 +195,7 @@ module Claim
                      :set_force_validation_to_false
 
     before_create do
-      build_assessment if assessment.nil?
+      build_associations
     end
 
     before_save do
@@ -261,7 +266,6 @@ module Claim
     end
 
     def update_amount_assessed(options)
-      build_assessment if assessment.nil?
       assessment.update_values(options[:fees], options[:expenses], options[:disbursements])
     end
 
@@ -552,6 +556,10 @@ module Claim
 
     def last_state_transition_later_than_redetermination?(last_state_transition)
       last_redetermination.nil? ? true : last_redetermination.created_at < last_state_transition.created_at
+    end
+
+    def build_associations
+      assessment || true
     end
 
     def default_values

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -194,10 +194,45 @@ module Claim
           expect(@claim.disbursements_without_vat_net). to eq 125.0
         end
       end
+    end
 
+    describe 'assessment' do
+      subject { claim.assessment }
+
+      context 'when claim built' do
+        let(:claim) { build(:advocate_claim) }
+
+        it 'builds a zeroized assessment' do
+          expect(claim).to_not be_persisted
+          is_expected.to_not be_nil
+          is_expected.to_not be_persisted
+          is_expected.to have_attributes(fees: 0.0, expenses: 0.0, disbursements: 0.0)
+        end
+      end
+
+      context 'when claim created' do
+        let(:claim) { create(:advocate_claim) }
+
+        it 'creates an zeroized assessment' do
+          expect(claim).to be_persisted
+          is_expected.to_not be_nil
+          is_expected.to be_persisted
+          is_expected.to have_attributes(fees: 0.0, expenses: 0.0, disbursements: 0.0)
+        end
+      end
+
+      describe '#update_amount_assessed' do
+        subject { claim.assessment }
+        let(:claim) { create(:advocate_claim) }
+
+        before { claim.update_amount_assessed(fees: 100.0, expenses: 200.0) }
+
+        it 'updates the specified assessment attributes' do
+          is_expected.to have_attributes(fees: 100.0, expenses: 200.0, disbursements: 0.0)
+        end
+      end
     end
   end
-
 
   describe MockBaseClaim do
     context 'date formatting' do


### PR DESCRIPTION
[Sentry errors](https://sentry.service.dsd.io/mojds/private-beta/issues/26495/) have shown that assessments are not
always being created and can raise an error
on summary pages as a result. Rather than workaround
this in the presenter this change ensures an assessment
is always returned (being built if necessary).

  