### PR TITLE
Rubocop refactoring - Remove long modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,4 +36,8 @@ Metrics/BlockLength:
     - group
     - state_machine
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'app/models/claims/state_machine.rb'
+
 inherit_from: .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -90,14 +90,6 @@ Metrics/MethodLength:
     - 'scheduled_tasks/daily_stats_generator.rb'
     - 'spikes/supplier_import/migrate/20161020133346_laa_imported_suppliers.rb'
 
-# Offense count: 3
-# Configuration parameters: CountComments.
-Metrics/ModuleLength:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/claims/cloner.rb'
-    - 'app/models/claims/state_machine.rb'
-
 # Offense count: 7
 Metrics/PerceivedComplexity:
   Max: 13

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,11 +115,7 @@ module ApplicationHelper
   end
 
   def your_claims_header
-    if current_user.persona.admin?
-      t('external_users.all_claims')
-    else
-      t('external_users.your_claims')
-    end
+    current_user.persona.admin? ? t('external_users.all_claims') : t('external_users.your_claims')
   end
 
   def user_requires_scheme_column?

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -118,10 +118,7 @@ module Claims::Cloner
   def clone_details_to_draft(other_claim)
     raise ArgumentError, 'Can only clone details to claims in state "draft"' unless other_claim.draft?
 
-    other_claim.attributes = {
-      court_id: court_id,
-      defendants: defendants.map(&:duplicate)
-    }
+    other_claim.attributes = { court_id: court_id, defendants: defendants.map(&:duplicate) }
 
     other_claim.save(validate: false)
     other_claim


### PR DESCRIPTION
* Reduce module length of application_helper
* Reduce module length of Claims::Cloner
* Update rubocop-todo
  > remove todo exclusion for ModuleLength and explicitly ignore state_machine in rubocop a sthis will need a significant amount of work to refactor/reduce module length