### PR TITLE
Refuse reasons update

### DIFF
--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -70,21 +70,21 @@ moj.Modules.AmountAssessedBlock = function(selector) {
   this.bindEvents = function() {
     var self = this;
 
-    this.$actions.on('change load', function(e) {
+    this.$actions.on('change', function(e) {
       var state = $(e.target).val();
       $.publish('claim.status.change', {
         state: state
       })
     });
 
-    this.$reasons.on('change load', function(e) {
+    this.$reasons.on('change', function(e) {
       var reason = self.$otherCheckbox.is(':checked');
       $.publish('claim.reasons.change', {
         reason: reason
       });
     });
 
-    this.$refuseReasons.on('change load', function(e) {
+    this.$refuseReasons.on('change', function(e) {
       var reason = self.$otherRefuseCheckbox.is(':checked');
       $.publish('claim.refuseReasons.change', {
         reason: reason

--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -14,27 +14,34 @@ moj.Modules.AmountAssessedBlock = function(selector) {
     form: '.js-cw-claim-assessment',
     actions: '.js-cw-claim-action',
     reasons: '.js-cw-claim-rejection-reasons',
+    refuseReasons: '.js-cw-claim-refuse-reasons',
     otherinput: '.js-reject-reason-text',
+    otherRefuseInput: '.js-refuse-reason-text',
     otherCheckbox: '#_state_reason_other',
+    otherRefuseCheckbox: '#_state_reason_other_refuse',
     action: 'toggle'
   };
 
   this.states = {
     rejected: {
       form: false,
-      reasons: true
+      reasons: true,
+      refuseReasons: false
     },
     refused: {
       form: false,
-      reasons: false
+      reasons: false,
+      refuseReasons: true
     },
     authorised: {
       form: true,
-      reasons: false
+      reasons: false,
+      refuseReasons: false
     },
     part_authorised: {
       form: true,
-      reasons: false
+      reasons: false,
+      refuseReasons: false
     }
   };
 
@@ -45,8 +52,11 @@ moj.Modules.AmountAssessedBlock = function(selector) {
     this.$form = $(this.config.form);
     this.$actions = $(this.config.actions);
     this.$reasons = $(this.config.reasons);
+    this.$refuseReasons = $(this.config.refuseReasons);
     this.$otherinput = $(this.config.otherinput);
+    this.$otherRefuseInput = $(this.config.otherRefuseInput);
     this.$otherCheckbox = $(this.config.otherCheckbox);
+    this.$otherRefuseCheckbox = $(this.config.otherRefuseCheckbox);
     this.bindEvents();
   };
 
@@ -60,16 +70,23 @@ moj.Modules.AmountAssessedBlock = function(selector) {
   this.bindEvents = function() {
     var self = this;
 
-    this.$actions.on('change', function(e) {
+    this.$actions.on('change load', function(e) {
       var state = $(e.target).val();
       $.publish('claim.status.change', {
         state: state
       })
     });
 
-    this.$reasons.on('change', function(e) {
+    this.$reasons.on('change load', function(e) {
       var reason = self.$otherCheckbox.is(':checked');
       $.publish('claim.reasons.change', {
+        reason: reason
+      });
+    });
+
+    this.$refuseReasons.on('change load', function(e) {
+      var reason = self.$otherRefuseCheckbox.is(':checked');
+      $.publish('claim.refuseReasons.change', {
         reason: reason
       })
     });
@@ -78,15 +95,22 @@ moj.Modules.AmountAssessedBlock = function(selector) {
       data.reason ? self.slider(true, self.$otherinput) : self.slider(false, self.$otherinput)
     });
 
+    $.subscribe('claim.refuseReasons.change', function(e, data) {
+      data.reason ? self.slider(true, self.$otherRefuseInput) : self.slider(false, self.$otherRefuseInput)
+    });
+
     $.subscribe('claim.status.change', function(e, data) {
       var state = self.states[data.state]
-
       self.$form.is(function(idx, el) {
         self.slider(state.form, el)
       });
 
       self.$reasons.is(function(idx, el) {
         self.slider(state.reasons, el)
+      });
+
+      self.$refuseReasons.is(function(idx, el) {
+        self.slider(state.refuseReasons, el)
       });
     });
 

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -18,6 +18,10 @@ class ClaimStateTransitionReason
       no_prior_authority: 'No prior authority provided',
       no_invoice: 'No invoice provided'
     },
+    refused: {
+        wrong_ia: 'Wrong IA',
+        other: 'Other'
+    },
     global: {
       timed_transition: 'TimedTransition::Transitioner'
     }

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -21,21 +21,21 @@ class ClaimStateTransitionReason
     refused_advocate_claims: {
       wrong_ia: 'Wrong Instructed Advocate',
       duplicate_claim: 'Duplicate claim',
-      other: 'Other'
+      other_refuse: 'Other'
     },
     refused_final_claims: {
       duplicate_claim: 'Duplicate claim',
-      other: 'Other'
+      other_refuse: 'Other'
     },
     refused_transfer_claims: {
       duplicate_claim: 'Duplicate claim',
-      other: 'Other'
+      other_refuse: 'Other'
     },
     refused_interim_claims: {
       duplicate_claim: 'Duplicate claim',
       no_effective: 'No effective PCMH/start of trial has taken place',
       short_trial: 'The trial estimate was less than 10 days',
-      other: 'Other'
+      other_refuse: 'Other'
     },
     global: {
       timed_transition: 'TimedTransition::Transitioner'

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -18,9 +18,24 @@ class ClaimStateTransitionReason
       no_prior_authority: 'No prior authority provided',
       no_invoice: 'No invoice provided'
     },
-    refused: {
-        wrong_ia: 'Wrong IA',
-        other: 'Other'
+    refused_advocate_claims: {
+      wrong_ia: 'Wrong Instructed Advocate',
+      duplicate_claim: 'Duplicate claim',
+      other: 'Other'
+    },
+    refused_final_claims: {
+      duplicate_claim: 'Duplicate claim',
+      other: 'Other'
+    },
+    refused_transfer_claims: {
+      duplicate_claim: 'Duplicate claim',
+      other: 'Other'
+    },
+    refused_interim_claims: {
+      duplicate_claim: 'Duplicate claim',
+      no_effective: 'No effective PCMH/start of trial has taken place',
+      short_trial: 'The trial estimate was less than 10 days',
+      other: 'Other'
     },
     global: {
       timed_transition: 'TimedTransition::Transitioner'
@@ -49,6 +64,10 @@ class ClaimStateTransitionReason
       reasons = reasons_for('rejected')
       reasons.insert(6, reasons_for(:disbursement)) if claim.fees.first.fee_type.code.eql?('IDISO')
       reasons.flatten
+    end
+
+    def refuse_reasons_for(claim)
+      reasons_for("refused_#{claim.class.to_s.demodulize.tableize}")
     end
 
     private

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -64,9 +64,12 @@ module Claims
 
     def validate_reason_presence
       return unless %w[rejected refused].include?(@state)
-      verb = @state.eql?('refused') ? 'refusing' : 'rejecting'
-      add_error "requires a reason when #{verb}" if @transition_reason&.empty?
-      add_error "requires details when #{verb} with other" if transition_reason_text_missing?
+      add_error "requires a reason when #{state_verb}" if @transition_reason&.empty?
+      add_error "requires details when #{state_verb} with other" if transition_reason_text_missing?
+    end
+
+    def state_verb
+      @state_verb ||= @state.eql?('refused') ? 'refusing' : 'rejecting'
     end
 
     def transition_reason_text_missing?

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -63,9 +63,10 @@ module Claims
     end
 
     def validate_reason_presence
-      return unless @state == 'rejected'
-      add_error 'requires a reason when rejecting' if @transition_reason&.empty?
-      add_error 'requires details when rejecting with other' if transition_reason_text_missing?
+      return unless %w[rejected refused].include?(@state)
+      verb = @state.eql?('refused') ? 'refusing' : 'rejecting'
+      add_error "requires a reason when #{verb}" if @transition_reason&.empty?
+      add_error "requires details when #{verb} with other" if transition_reason_text_missing?
     end
 
     def transition_reason_text_missing?

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -54,6 +54,12 @@
               %a#expense_reject_reason_text
               = f.label :reason_text, 'Reason text'
               = f.text_field :reason_text, {class: 'form-control'}
+      .js-cw-claim-refuse-reasons{style: 'display:none'}
+        %fieldset.form-group.nested-fields.indent-fieldset.spacer
+          %legend.bold-normal.form-label
+            = "Choose reason for refusal"
+          = collection_radio_buttons(nil, :state_reason, ClaimStateTransitionReason.reasons(:refused), :code, :description) do |b|
+            - b.label(class: "block-label") { b.radio_button + b.text }
 
       %p
         = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -58,7 +58,7 @@
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
             = "Choose reason for refusal"
-          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reasons(:refused), :code, :description) do |b|
+          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
             - b.label(class: "block-label") { b.check_box + b.text }
 
       %p

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -58,8 +58,8 @@
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
             = "Choose reason for refusal"
-          = collection_radio_buttons(nil, :state_reason, ClaimStateTransitionReason.reasons(:refused), :code, :description) do |b|
-            - b.label(class: "block-label") { b.radio_button + b.text }
+          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reasons(:refused), :code, :description) do |b|
+            - b.label(class: "block-label") { b.check_box + b.text }
 
       %p
         = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -53,13 +53,20 @@
             %div
               %a#expense_reject_reason_text
               = f.label :reason_text, 'Reason text'
-              = f.text_field :reason_text, {class: 'form-control'}
+              .form-hint.xsmall These reasons will be displayed to providers
+              = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_reject_reason_text'}
       .js-cw-claim-refuse-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
             = "Choose reason for refusal"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
             - b.label(class: "block-label") { b.check_box + b.text }
+          %fieldset.form-group.nested-fields.fieldset.spacer.js-refuse-reason-text{style: 'display:none'}
+            %div
+              %a#expense_refuse_reason_text
+              = f.label :reason_text, 'Reason text'
+              .form-hint.xsmall These reasons will be displayed to providers
+              = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_refuse_reason_text'}
 
       %p
         = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -40,8 +40,8 @@
         %fieldset.form-group.inline.spacer
           %legend.bold-normal.form-label
             = "Update the claim status"
-          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last) do |b|
-            - b.label(class: "block-label") { b.radio_button + b.text }
+          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last, { checked: 'claim_state_rejected' } ) do |b|
+            - b.label(class: "block-label") { b.radio_button(checked: b.text.eql?(params[:state])) + b.text }
 
       .js-cw-claim-rejection-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer

--- a/features/page_objects/claim_show_page.rb
+++ b/features/page_objects/claim_show_page.rb
@@ -11,11 +11,16 @@ class ClaimShowPage < SitePrism::Page
   element :expenses, "#claim_assessment_attributes_expenses"
   element :authorised, "#claim_state_authorised"
   element :update, "input#button.button"
+  element :refused, "#claim_state_refused"
   element :rejected, "#claim_state_rejected"
 
   section :rejection_reasons, 'div.js-cw-claim-rejection-reasons' do
-      element :first_reason, 'label:nth-of-type(1) input:nth-of-type(1)'
-    end
+    element :first_reason, 'label:nth-of-type(1) input:nth-of-type(1)'
+  end
+
+  section :refusal_reasons, 'div.js-cw-claim-refuse-reasons' do
+    element :first_reason, 'label:nth-of-type(1) input:nth-of-type(1)'
+  end
 
   section :messages_panel, "#claim-accordion .messages-container" do
     element :enter_your_message, "textarea#message_body"

--- a/features/refuse_claim.feature
+++ b/features/refuse_claim.feature
@@ -1,0 +1,22 @@
+@javascript
+Feature: Case worker rejects a claim, providing a reason
+
+  Scenario: I refuse a claim providing a reason
+
+    Given a "case worker" user account exists
+    And an "advocate" user account exists
+    And there is a claim allocated to the case worker with case number 'A20161234'
+
+    And I insert the VCR cassette 'features/case_workers/claims/reject'
+
+    When I am signed in as the case worker
+    And I select the claim
+    And expand the messages section
+    And I click the refused radio button
+    And I select the first refusal reason
+    And I click update
+    Then the status at top of page should be Refused
+    And I should see 'Reason provided:'
+
+    When I click your claims
+    Then the claim I've just updated is no longer in the list

--- a/features/step_definitions/authorise_claim_steps.rb
+++ b/features/step_definitions/authorise_claim_steps.rb
@@ -31,6 +31,14 @@ And(/^I select the first rejection reason$/) do
   @case_worker_claim_show_page.rejection_reasons.first_reason.click
 end
 
+When(/^I click the refused radio button$/) do
+  @case_worker_claim_show_page.refused.click
+end
+
+And(/^I select the first refusal reason$/) do
+  @case_worker_claim_show_page.refusal_reasons.first_reason.click
+end
+
 When(/^I click update$/) do
   @case_worker_claim_show_page.update.click
 end

--- a/spec/javascripts/modules-amountAssessed_spec.js
+++ b/spec/javascripts/modules-amountAssessed_spec.js
@@ -47,8 +47,11 @@ describe("Modules.AmountAssessedBlock.js", function() {
         form: '.js-cw-claim-assessment',
         actions: '.js-cw-claim-action',
         reasons: '.js-cw-claim-rejection-reasons',
+        refuseReasons: '.js-cw-claim-refuse-reasons',
         otherinput: '.js-reject-reason-text',
+        otherRefuseInput: '.js-refuse-reason-text',
         otherCheckbox: '#_state_reason_other',
+        otherRefuseCheckbox: '#_state_reason_other_refuse',
         action: 'toggle'
       });
     });
@@ -58,19 +61,23 @@ describe("Modules.AmountAssessedBlock.js", function() {
       expect(block.states).toEqual({
         rejected: {
           form: false,
-          reasons: true
+          reasons: true,
+          refuseReasons: false
         },
         refused: {
           form: false,
-          reasons: false
+          reasons: false,
+          refuseReasons: true
         },
         authorised: {
           form: true,
-          reasons: false
+          reasons: false,
+          refuseReasons: false
         },
         part_authorised: {
           form: true,
-          reasons: false
+          reasons: false,
+          refuseReasons: false
         }
       })
     });

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -55,6 +55,28 @@ RSpec.describe ClaimStateTransitionReason, type: :model do
     end
   end
 
+  describe '.refuse_reasons_for' do
+    subject(:refuse_reasons_for) { described_class.refuse_reasons_for(claim) }
+
+    context 'for a Litigator claim' do
+      let(:claim) { create(:transfer_claim, state: 'refused') }
+
+      it { expect(subject.count).to eq 2 }
+    end
+
+    context 'for a Litigator interim claim' do
+      let(:claim) { create(:interim_claim, state: 'refused') }
+
+      it { expect(subject.count).to eq 4 }
+    end
+
+    context 'for an advocate claim' do
+      let(:claim) { create(:advocate_claim, state: 'refused') }
+
+      it { expect(subject.count).to eq 3 }
+    end
+  end
+
   describe '.get' do
     let(:code) { 'code' }
     let(:reason) { described_class.get(code) }

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe ClaimCsvPresenter do
           end
         end
 
-        context 'refused with a multiple reasons' do
+        context 'refused with multiple reasons' do
           before do
             claim.refuse!(reason_code: ['no_rep_order', 'wrong_case_no'])
           end

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -223,6 +223,56 @@ RSpec.describe ClaimCsvPresenter do
             end
           end
         end
+
+        context 'refused with a single reason as a string ' do
+          before do
+            claim.refuse!(reason_code: ['no_rep_order'])
+          end
+
+          it 'the refusal reason code should be reflected in the MI' do
+            allow_any_instance_of(ClaimStateTransition).to receive(:reason_code).and_return('no_rep_order')
+            ClaimCsvPresenter.new(claim, view).present! do |csv|
+              expect(csv[0][11]).to eq('no_rep_order')
+            end
+          end
+        end
+
+        context 'refused with a single reason' do
+          before do
+            claim.refuse!(reason_code: ['no_rep_order'])
+          end
+
+          it 'the refusal reason code should be reflected in the MI' do
+            ClaimCsvPresenter.new(claim, view).present! do |csv|
+              expect(csv[0][11]).to eq('no_rep_order')
+            end
+          end
+        end
+
+        context 'refused with a multiple reasons' do
+          before do
+            claim.refuse!(reason_code: ['no_rep_order', 'wrong_case_no'])
+          end
+
+          it 'the refusal reason code should be reflected in the MI' do
+            ClaimCsvPresenter.new(claim, view).present! do |csv|
+              expect(csv[0][11]).to eq('no_rep_order, wrong_case_no')
+            end
+          end
+        end
+
+        context 'rejected with other' do
+          before do
+            claim.reject!(reason_code: ['other'], reason_text: 'Rejection reason')
+          end
+
+          it 'the rejection reason code should be reflected in the MI' do
+            ClaimCsvPresenter.new(claim, view).present! do |csv|
+              expect(csv[0][11]).to eq('other')
+              expect(csv[0][12]).to eq('Rejection reason')
+            end
+          end
+        end
       end
     end
   end

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -1,8 +1,60 @@
 require 'rails_helper'
 
-
 module Claims
   describe CaseWorkerClaimUpdater do
+
+    RSpec.shared_examples 'a successful non-authorised claim with a single reason' do |state|
+      it_behaves_like 'base_test', state, ['no_indictment']
+    end
+
+    RSpec.shared_examples 'a successful non-authorised claim with other as reason' do |state|
+      it_behaves_like 'base_test', state, ['other'], 'a reason'
+    end
+
+    RSpec.shared_examples 'base_test' do |state, state_reason, reason_text=nil|
+      subject(:updater) { CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update! }
+      let(:claim) { create :allocated_claim }
+      let(:current_user) { double(User, id: 12345) }
+      let(:params) { {'state' => state, 'state_reason' => state_reason, 'reason_text' => reason_text, 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
+
+      it 'updates the state to `other` and returns OK' do
+        expect(updater.result).to eq :ok
+        expect(updater.claim.state).to eq state
+        expect(updater.claim.last_state_transition.reason_code).to eq state_reason
+        expect(updater.claim.last_state_transition.reason_text).to eq reason_text
+        expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
+      end
+    end
+
+    RSpec.shared_examples 'a successful assessment' do |state, fees='128.33', expenses='42.40'|
+      subject(:updater) { CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update! }
+      let(:claim) { create :allocated_claim }
+      let(:current_user) { double(User, id: 12345) }
+      let(:params) { {'state' => state, 'assessment_attributes' => {'fees' => fees, 'expenses' => expenses}} }
+
+      it 'sets the result to error' do
+        expect(updater.result).to eq :ok
+        expect(updater.claim.state).to eq state
+        expect(updater.claim.assessment.fees).to eq fees
+        expect(updater.claim.assessment.expenses).to eq expenses
+        expect(updater.claim.assessment.disbursements).to eq 0.0
+        expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
+      end
+    end
+
+    RSpec.shared_examples 'a failing assessment' do |state, expected_error, update_type='redeterminations', state_reason=nil, fees='128.33', expenses='42.40'|
+      subject(:updater) { CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update! }
+      let(:claim) { create :allocated_claim }
+      let(:current_user) { double(User, id: 12345) }
+      let(:params) { {'state' => state, 'state_reason' => state_reason, "#{update_type}_attributes" => {'0' => {'fees' => fees, 'expenses' => expenses}}} }
+
+      it 'sets the result to error' do
+        expect(updater.result).to eq :error
+        expect(updater.claim.errors[:determinations]).to eq(expected_error)
+        expect(updater.claim.state).to eq 'allocated'
+        expect(updater.claim.redeterminations).to be_empty
+      end
+    end
 
     context 'assessments' do
 
@@ -11,92 +63,25 @@ module Claims
       let(:current_user) { double(User, id: 12345) }
 
       context 'successful transitions' do
-        it 'advances the claim to part authorised' do
-          params = {'state' => 'part_authorised', 'assessment_attributes' => {'fees' => '45', 'expenses' => '0.00'}}
-          updater = CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update!
-          expect(updater.result).to eq :ok
-          expect(updater.claim.state).to eq 'part_authorised'
-          expect(updater.claim.assessment.fees).to eq 45.0
-          expect(updater.claim.assessment.expenses).to eq 0.0
-          expect(updater.claim.assessment.disbursements).to eq 0.0
-          expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
+        context 'advances the claim to part authorised' do
+          it_behaves_like 'a successful assessment', 'part_authorised', 45.0, 0
         end
 
-        it 'advances the claim to authorised' do
-          params = {'state' => 'authorised', 'assessment_attributes' => {'fees' => '128.33', 'expenses' => '42.88'}}
-          updater = CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update!
-          expect(updater.result).to eq :ok
-          expect(updater.claim.state).to eq 'authorised'
-          expect(updater.claim.assessment.fees.to_f).to eq 128.33
-          expect(updater.claim.assessment.expenses).to eq 42.88
-          expect(updater.claim.assessment.disbursements).to eq 0.0
-          expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
+        context 'advances the claim to authorised' do
+          it_behaves_like 'a successful assessment', 'authorised', 128.33, 42.88
         end
 
         context 'rejections' do
           let(:params) { {'state' => 'rejected', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
-
-          it 'advances the claim to rejected with reason supplied' do
-            updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-            expect(updater.result).to eq :ok
-            expect(updater.claim.state).to eq 'rejected'
-            expect(updater.claim.last_state_transition.reason_code).to eq ['no_indictment']
-          end
-
-          it 'saves audit attributes' do
-            updater = CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update!
-            expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
-          end
-
-          context 'other rejection with reason' do
-            let(:params) { {'state' => 'rejected', 'state_reason' => ['other'], 'reason_text' => 'a reason', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
-
-            it 'advances the claim to rejected with reason supplied' do
-              updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-              expect(updater.result).to eq :ok
-              expect(updater.claim.state).to eq 'rejected'
-              expect(updater.claim.last_state_transition.reason_code).to eq ['other']
-              expect(updater.claim.last_state_transition.reason_text).to eq 'a reason'
-            end
-
-            it 'saves audit attributes' do
-              updater = CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update!
-              expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
-            end
-          end
+          it_behaves_like 'a successful non-authorised claim with a single reason', 'rejected'
+          it_behaves_like 'a successful non-authorised claim with other as reason', 'rejected'
         end
 
         context 'refusals' do
           let(:params) { {'state' => 'refused', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
 
-          it 'advances the claim to rejected with reason supplied' do
-            updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-            expect(updater.result).to eq :ok
-            expect(updater.claim.state).to eq 'refused'
-            expect(updater.claim.last_state_transition.reason_code).to eq ['no_indictment']
-          end
-
-          it 'saves audit attributes' do
-            updater = CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update!
-            expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
-          end
-
-          context 'other rejection with reason' do
-            let(:params) { {'state' => 'refused', 'state_reason' => ['other'], 'reason_text' => 'a reason', 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
-
-            it 'advances the claim to rejected with reason supplied' do
-              updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-              expect(updater.result).to eq :ok
-              expect(updater.claim.state).to eq 'refused'
-              expect(updater.claim.last_state_transition.reason_code).to eq ['other']
-              expect(updater.claim.last_state_transition.reason_text).to eq 'a reason'
-            end
-
-            it 'saves audit attributes' do
-              updater = CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update!
-              expect(updater.claim.last_state_transition.author_id).to eq(current_user.id)
-            end
-          end
+          it_behaves_like 'a successful non-authorised claim with a single reason', 'refused'
+          it_behaves_like 'a successful non-authorised claim with other as reason', 'refused'
         end
 
         it 'advances the claim to refused when no values are supplied' do
@@ -254,40 +239,20 @@ module Claims
           expect(updater.claim.errors[:determinations]).to eq(['You must specify authorised or part authorised if you supply values'])
         end
 
-        it 'errors if values are supplied with refused' do
-          params = {'state' => 'refused', 'redeterminations_attributes' => {'0' => {'fees' => '128.33', 'expenses' => '42.40'}}}
-          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-          expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['You cannot specify values when refusing a claim'])
-          expect(updater.claim.state).to eq 'allocated'
-          expect(updater.claim.redeterminations).to be_empty
+        context 'if values are supplied with refused' do
+          it_behaves_like 'a failing assessment', 'refused', ['You cannot specify values when refusing a claim']
         end
 
-        it 'errors if values are supplied with rejected' do
-          params = {'state' => 'rejected', 'redeterminations_attributes' => {'0' => {'fees' => '128.33', 'expenses' => '42.40'}}}
-          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-          expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['You cannot specify values when rejecting a claim'])
-          expect(updater.claim.state).to eq 'allocated'
-          expect(updater.claim.redeterminations).to be_empty
+        context 'if values are supplied with rejected' do
+          it_behaves_like 'a failing assessment', 'rejected', ['You cannot specify values when rejecting a claim']
         end
 
-        it 'if no state_reason are supplied' do
-          params = {'state' => 'rejected', 'state_reason' => [''], 'redeterminations_attributes' => {'0' => {'fees' => '', 'expenses' => '0'}}}
-          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-          expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['requires a reason when rejecting'])
-          expect(updater.claim.state).to eq 'allocated'
-          expect(updater.claim.redeterminations).to be_empty
+        context 'if no state_reason are supplied' do
+          it_behaves_like 'a failing assessment', 'rejected', ['requires a reason when rejecting'], 'redeterminations', [''], '', 0
         end
 
-        it 'if state_reason is other, but no text is supplied' do
-          params = {'state' => 'rejected', 'state_reason' => ['other'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
-          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
-          expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['requires details when rejecting with other'])
-          expect(updater.claim.state).to eq 'allocated'
-          expect(updater.claim.redeterminations).to be_empty
+        context 'if state_reason is other, but no text is supplied' do
+          it_behaves_like 'a failing assessment', 'rejected', ['requires details when rejecting with other'], 'assessment', ['other'], 0, 0
         end
       end
     end

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -135,6 +135,28 @@ module Claims
           expect(updater.claim.assessment.disbursements).to eq 0.0
         end
 
+        it 'if refused and no state_reason are supplied' do
+          params = {'state' => 'refused', 'state_reason' => [''], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['requires a reason when refusing'])
+          expect(updater.claim.state).to eq 'allocated'
+          expect(updater.claim.assessment.fees.to_f).to eq 0.0
+          expect(updater.claim.assessment.expenses).to eq 0.0
+          expect(updater.claim.assessment.disbursements).to eq 0.0
+        end
+
+        it 'if refused, state_reason is other and no text is supplied' do
+          params = {'state' => 'refused', 'state_reason' => ['other'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.errors[:determinations]).to eq(['requires details when refusing with other'])
+          expect(updater.claim.state).to eq 'allocated'
+          expect(updater.claim.assessment.fees.to_f).to eq 0.0
+          expect(updater.claim.assessment.expenses).to eq 0.0
+          expect(updater.claim.assessment.disbursements).to eq 0.0
+        end
+
         it 'rollbacks the transaction if transition fails' do
           expect(submitted_claim.assessment.fees.to_f).to eq 0.0
 

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -113,7 +113,7 @@ module Claims
           expect(updater.claim.assessment.disbursements).to eq 0.0
         end
 
-        it 'if no state_reason are supplied' do
+        it 'if rejected and no state_reason are supplied' do
           params = {'state' => 'rejected', 'state_reason' => [''], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
@@ -124,7 +124,7 @@ module Claims
           expect(updater.claim.assessment.disbursements).to eq 0.0
         end
 
-        it 'if state_reason is other, but no text is supplied' do
+        it 'if rejected, state_reason is other and no text is supplied' do
           params = {'state' => 'rejected', 'state_reason' => ['other'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error


### PR DESCRIPTION
## What?
Add reasons to the refuse option for case_workers

## Acceptance criteria
- [x] Introduce a checklist of options when a caseworker has selected 'refused'
- [x] error messaging/handling for when nothing is entered in to the 'other' text field when 'other' is selected

## Next steps
* There will be a subsequent spike to assess the handling of this process and break it out into a view model (potentially) to better handle the error messages
* Work is underway to test merging the Refuse/Reject lists, therefore the technical debt of duplicating the JS code can be removed when the design is ready and the User research is complete.
