### PR TITLE
MI failure report update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ end
 
 group :test do
   gem 'capybara',                   '~> 2.6.2'
+  gem 'climate_control'
   gem 'codeclimate-test-reporter',  require: false
   gem 'cucumber-rails',             require: false
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -663,6 +663,7 @@ DEPENDENCIES
   byebug
   cancancan (~> 1.15)
   capybara (~> 2.6.2)
+  climate_control
   cocoon (~> 1.2.6)
   codeclimate-test-reporter
   colorize

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -14,14 +14,7 @@ module Stats
     rescue StandardError => err
       report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
       report_record.write_error(report_contents)
-      if ENV['ENV'].eql?('gamma')
-        slack = SlackNotifier.new('cccd_development')
-        slack.build_generic_payload(':robot_face:',
-                                    "MI Generation failed on #{ENV['ENV']}",
-                                    "#{report_contents} \n Stats::StatsReport.id: #{report_record.id}",
-                                    false)
-        slack.send_message!
-      end
+      send_slack_message(report_record) if ENV['ENV'].eql?('gamma')
       raise err
     end
 
@@ -39,6 +32,15 @@ module Stats
         end
       end
       csv_string
+    end
+
+    def send_slack_message(report_record)
+      slack = SlackNotifier.new('cccd_development')
+      slack.build_generic_payload(':robot_face:',
+                                  "MI Generation failed on #{ENV['ENV']}",
+                                  "#{report_record.report} \n Stats::StatsReport.id: #{report_record.id}",
+                                  false)
+      slack.send_message!
     end
   end
 end

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -15,7 +15,10 @@ module Stats
       report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
       report_record.write_error(report_contents)
       slack = SlackNotifier.new('cccd_development')
-      slack.build_generic_payload(':robot_face:', 'MI Generation failed', report_contents, false)
+      slack.build_generic_payload(':robot_face:',
+                                  'MI Generation failed',
+                                  "#{report_contents} \n Stats::StatsReport.id: #{report_record.id}",
+                                  false)
       slack.send_message!
       raise err
     end

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -6,11 +6,10 @@ module Stats
 
     def run
       StatsReport.clean_up(REPORT_NAME)
-      unless StatsReport.generation_in_progress?(REPORT_NAME)
-        report_record = Stats::StatsReport.record_start(REPORT_NAME)
-        report_contents = generate_new_report
-        report_record.write_report(report_contents)
-      end
+      return if StatsReport.generation_in_progress?(REPORT_NAME)
+      report_record = Stats::StatsReport.record_start(REPORT_NAME)
+      report_contents = generate_new_report
+      report_record.write_report(report_contents)
     rescue StandardError => err
       report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
       report_record.write_error(report_contents)

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -14,12 +14,14 @@ module Stats
     rescue StandardError => err
       report_contents = "#{err.class} - #{err.message} \n #{err.backtrace}"
       report_record.write_error(report_contents)
-      slack = SlackNotifier.new('cccd_development')
-      slack.build_generic_payload(':robot_face:',
-                                  'MI Generation failed',
-                                  "#{report_contents} \n Stats::StatsReport.id: #{report_record.id}",
-                                  false)
-      slack.send_message!
+      if ENV['ENV'].eql?('gamma')
+        slack = SlackNotifier.new('cccd_development')
+        slack.build_generic_payload(':robot_face:',
+                                    "MI Generation failed on #{ENV['ENV']}",
+                                    "#{report_contents} \n Stats::StatsReport.id: #{report_record.id}",
+                                    false)
+        slack.send_message!
+      end
       raise err
     end
 

--- a/spec/models/stats/management_information_generator_spec.rb
+++ b/spec/models/stats/management_information_generator_spec.rb
@@ -48,12 +48,11 @@ module Stats
           before do
             allow(Settings).to receive(:claim_csv_headers).and_raise ArgumentError.new('XXXXXXXX')
           end
-
           it 'creates an errored report' do
-            ENV['ENV'] = 'gamma'
-            expect { generator.run }.to raise_exception(ArgumentError)
-            expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made
-            ENV['ENV'] = nil
+            ClimateControl.modify ENV: 'gamma' do
+              expect { generator.run }.to raise_exception(ArgumentError)
+              expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made
+            end
           end
         end
       end


### PR DESCRIPTION
Extend the Error message to provide a link to the failing report
Also, only report when the report fails on live