### PR TITLE
Litigator message queuing

### DIFF
--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -20,7 +20,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
   def create
     @claim.build_certification(certification_params)
     if @claim.certification.save && claim_updater.submit
-      sqs_enqueue(queue: Settings.aws.submitted_queue)
+      notify_legacy_importers
       redirect_to confirmation_external_users_claim_path(@claim)
     else
       @certification = @claim.certification
@@ -38,12 +38,24 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
     redirect_to external_users_claim_path(@claim), alert: t('shared.certification.alert') if @claim.submitted?
   end
 
-  def sqs_enqueue(queue:)
-    message = MessageQueue::MessageTemplate.claim_created(@claim.type, @claim.uuid)
-    MessageQueue::AwsClient.new(queue).send!(message)
+  def notify_legacy_importers
+    if @claim.agfs?
+      sqs_enqueue(queue: Settings.aws.submitted_queue)
+    else
+      publish_via_sns
+    end
     Rails.logger.info "Successfully sent #{log_suffix}"
   rescue StandardError => err
     Rails.logger.warn "Error: '#{err.message}' while sending #{log_suffix}"
+  end
+
+  def publish_via_sns
+    NotificationQueue::AwsClient.new.send!(@claim)
+  end
+
+  def sqs_enqueue(queue:)
+    message = MessageQueue::MessageTemplate.claim_created(@claim.type, @claim.uuid)
+    MessageQueue::AwsClient.new(queue).send!(message)
   end
 
   def log_suffix

--- a/app/services/notification_queue/aws_client.rb
+++ b/app/services/notification_queue/aws_client.rb
@@ -1,0 +1,11 @@
+module NotificationQueue
+  class AwsClient
+    def send!(claim)
+      client = Aws::SNS::Client.new(access_key_id: Settings.aws.access, secret_access_key: Settings.aws.secret)
+      arn = Settings.aws.submitted_topic_arn
+      message = NotificationQueue::MessageTemplate.for_claim(arn, claim)
+      client.publish(message)
+      true
+    end
+  end
+end

--- a/app/services/notification_queue/message_template.rb
+++ b/app/services/notification_queue/message_template.rb
@@ -6,7 +6,7 @@ module NotificationQueue
         message: 'Claim created',
         message_structure: 'messageStructure',
         message_attributes: {
-          'Type' => { data_type: 'String', string_value: claim.type },
+          'claim_type' => { data_type: 'String', string_value: claim.type },
           'uuid' => { data_type: 'String', string_value: claim.uuid }
         }
       }

--- a/app/services/notification_queue/message_template.rb
+++ b/app/services/notification_queue/message_template.rb
@@ -1,0 +1,15 @@
+module NotificationQueue
+  class MessageTemplate
+    def self.for_claim(arn, claim)
+      {
+        topic_arn: arn,
+        message: 'Claim created',
+        message_structure: 'messageStructure',
+        message_attributes: {
+          'Type' => { data_type: 'String', string_value: claim.type },
+          'uuid' => { data_type: 'String', string_value: claim.uuid }
+        }
+      }
+    end
+  end
+end

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -52,63 +52,87 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
   end
 
   describe 'POST create' do
-    let(:claim) { create(:claim) }
-    let(:aws_client) do
-      Aws::SQS::Client.new(
-        region: 'eu_west_1',
-        stub_responses:
-          {
-            list_queues: { queue_urls:['valid_queue_name'] },
-            get_queue_url: { queue_url: 'http://aws_url' },
-            send_message: stub_send_response
-          }
-      )
+    context 'AGFS' do
+      let(:claim) { create(:claim) }
+      let(:sqs_client) do
+        Aws::SQS::Client.new(
+          region: 'eu_west_1',
+          stub_responses:
+            {
+              list_queues: { queue_urls:['valid_queue_name'] },
+              get_queue_url: { queue_url: 'http://aws_url' },
+              send_message: stub_send_response
+            }
+        )
+      end
+      let(:stub_send_response) { stub_response_success }
+      let(:stub_response_success) { }
+      let(:stub_response_failure)  { Aws::SQS::Errors::NonExistentQueue.new(
+                                       double('request'),
+                                       double('response', :status => 400, :body => '<foo/>')
+                                     )
+      }
+
+      context 'valid certification params for submission' do
+        let(:frozen_time) { Time.new(2015, 8, 20, 13, 54, 22) }
+        before { allow(Aws::SQS::Client).to receive(:new).and_return sqs_client }
+
+        it 'should be a redirect to confirmation' do
+          post :create, valid_certification_params(claim, certification_type)
+          expect(response).to redirect_to(confirmation_external_users_claim_path(claim))
+        end
+
+        it 'should change the state to submitted' do
+          post :create, valid_certification_params(claim, certification_type)
+          expect(claim.reload).to be_submitted
+        end
+
+        it 'should set the submitted at date' do
+          Timecop.freeze(frozen_time) do
+            post :create, valid_certification_params(claim, certification_type)
+          end
+
+          expect(claim.reload.last_submitted_at).to eq(frozen_time)
+        end
+
+        it 'logs a successful message on the queue' do
+          allow(Settings.aws).to receive(:submitted_queue).and_return('valid_queue_name')
+          expect(Rails.logger).to receive(:info).with(/Successfully sent message about submission of claim#/)
+          post :create, valid_certification_params(claim, certification_type)
+        end
+
+        context 'when SQS fails' do
+          let(:stub_send_response) { stub_response_failure }
+
+          it 'logs an error message' do
+            expect(Rails.logger).to receive(:warn).with(/Error: .* while sending message about submission of claim#/)
+            post :create, valid_certification_params(claim, certification_type)
+          end
+        end
+      end
     end
-    let(:stub_send_response) { stub_response_success }
-    let(:stub_response_success) { }
-    let(:stub_response_failure)  { Aws::SQS::Errors::NonExistentQueue.new(
-                                     double('request'),
-                                     double('response', :status => 400, :body => '<foo/>')
-                                   )
-    }
+    context 'LGFS' do
+      let(:claim) { create(:litigator_claim) }
 
-    context 'valid certification params for submission' do
-      let(:frozen_time) { Time.new(2015, 8, 20, 13, 54, 22) }
-      before { allow(Aws::SQS::Client).to receive(:new).and_return aws_client }
+      let(:sns_client) do
+        Aws::SNS::Client.new(
+          region: 'eu_west_1',
+          stub_responses:
+            {
+              publish: {}
+            }
+        )
+      end
 
-      it 'should be a redirect to confirmation' do
+      before do
+        allow(Aws::SNS::Client).to receive(:new).and_return sns_client
+        allow(sns_client).to receive(:publish)
+      end
+
+      it 'calls the SNS notification path' do
         post :create, valid_certification_params(claim, certification_type)
-        expect(response).to redirect_to(confirmation_external_users_claim_path(claim))
+        expect(sns_client).to have_received(:publish).once
       end
-
-      it 'should change the state to submitted' do
-        post :create, valid_certification_params(claim, certification_type)
-        expect(claim.reload).to be_submitted
-      end
-
-      it 'should set the submitted at date' do
-        Timecop.freeze(frozen_time) do
-          post :create, valid_certification_params(claim, certification_type)
-        end
-
-        expect(claim.reload.last_submitted_at).to eq(frozen_time)
-      end
-
-      it 'logs a successful message on the queue' do
-        allow(Settings.aws).to receive(:submitted_queue).and_return('valid_queue_name')
-        expect(Rails.logger).to receive(:info).with(/Successfully sent message about submission of claim#/)
-        post :create, valid_certification_params(claim, certification_type)
-      end
-
-      context 'when SQS fails' do
-        let(:stub_send_response) { stub_response_failure }
-
-        it 'logs an error message' do
-          expect(Rails.logger).to receive(:warn).with(/Error: .* while sending message about submission of claim#/)
-          post :create, valid_certification_params(claim, certification_type)
-        end
-      end
-
     end
 
     context 'invalid certification' do

--- a/spec/services/message_queue/aws_client_spec.rb
+++ b/spec/services/message_queue/aws_client_spec.rb
@@ -59,7 +59,7 @@ module MessageQueue
       end
     end
 
-    describe '#send_message!' do
+    describe '#send!' do
       subject(:send!) { aws_client.send!(message) }
 
       let(:message) { { body: 'Claim added', attributes: { 'uuid': { data_type: 'String', string_value: SecureRandom.uuid } } } }

--- a/spec/services/notification_queue/aws_client_spec.rb
+++ b/spec/services/notification_queue/aws_client_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+module NotificationQueue
+  describe AwsClient, slack_bot: true do
+    subject(:aws_client) { described_class.new }
+
+    let(:client) do
+      Aws::SNS::Client.new(
+        region: 'eu_west_1',
+        stub_responses:
+          {
+            publish: stub_publish_response
+          }
+      )
+    end
+    let(:stub_publish_response) {}
+
+    before { allow(Aws::SNS::Client).to receive(:new).and_return client }
+
+    describe '#send!' do
+      subject(:send!) { aws_client.send!(claim) }
+
+      let(:claim) { create(:claim) }
+
+      it { is_expected.to eql true}
+    end
+  end
+end


### PR DESCRIPTION
Implement a separate queue (using SNS rather than SQS) for Litigator claims

This allows the two separate backends to poll separate queues and not block each other.

Long term goal:  Use a single SNS point for both AGFS and LGFS and use a lambda query to update to SQS queues, this will give a single endpoint for users interested in stats around claims issued, while allowing individual end points for the back end importers