### PR TITLE
Fix for refusing a claim with other, but no text

### DIFF
--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -73,7 +73,7 @@ module Claims
     end
 
     def transition_reason_text_missing?
-      %w[other other_refuse].include?(@transition_reason&.first) && @transition_reason_text.blank?
+      @transition_reason&.any? { |reason| %w[other other_refuse].include?(reason) } && @transition_reason_text.blank?
     end
 
     def nil_or_empty_zero_or_negative?(determination_params)

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -73,7 +73,7 @@ module Claims
     end
 
     def transition_reason_text_missing?
-      @transition_reason&.include?('other') && @transition_reason_text.blank?
+      %w[other other_refuse].include?(@transition_reason&.first) && @transition_reason_text.blank?
     end
 
     def nil_or_empty_zero_or_negative?(determination_params)

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -7,8 +7,8 @@ module Claims
       it_behaves_like 'base_test', state, ['no_indictment']
     end
 
-    RSpec.shared_examples 'a successful non-authorised claim with other as reason' do |state|
-      it_behaves_like 'base_test', state, ['other'], 'a reason'
+    RSpec.shared_examples 'a successful non-authorised claim with other as reason' do |state, state_reason=['other']|
+      it_behaves_like 'base_test', state, state_reason, 'a reason'
     end
 
     RSpec.shared_examples 'base_test' do |state, state_reason, reason_text=nil|
@@ -81,7 +81,7 @@ module Claims
           let(:params) { {'state' => 'refused', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
 
           it_behaves_like 'a successful non-authorised claim with a single reason', 'refused'
-          it_behaves_like 'a successful non-authorised claim with other as reason', 'refused'
+          it_behaves_like 'a successful non-authorised claim with other as reason', 'refused', ['other_refuse']
         end
 
         it 'advances the claim to refused when no values are supplied' do


### PR DESCRIPTION
There was an omission in the code that meant the wrong
values where being checked.