### PR TITLE
Fix reject other

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -79,7 +79,8 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   def claim_params
     params.require(:claim).permit(
       :state,
-      :reason_text,
+      :refuse_reason_text,
+      :reject_reason_text,
       :additional_information,
       assessment_attributes: %i[
         id

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -19,6 +19,14 @@ class Claim::BaseClaimPresenter < BasePresenter
     claim.claim_state_transitions.last.reason_text
   end
 
+  def reject_reason_text
+    claim.claim_state_transitions.last.reason_text
+  end
+
+  def refuse_reason_text
+    claim.claim_state_transitions.last.reason_text
+  end
+
   def claim_state
     if claim.opened_for_redetermination?
       'Redetermination'

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -23,8 +23,16 @@ module Claims
     def extract_transition_params
       @state = @params.delete('state')
       @transition_reason = @params.delete('state_reason')&.reject(&:empty?)
-      @transition_reason_text = @params.delete('reason_text')
+      @transition_reason_text = extract_reason_text
       @current_user = @params.delete(:current_user)
+    end
+
+    def extract_reason_text
+      reasons = {
+        rejected: @params.delete('reject_reason_text'),
+        refused: @params.delete('refuse_reason_text')
+      }
+      reasons[@state.to_sym]
     end
 
     def extract_assessment_params

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -52,9 +52,9 @@
           %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none'}
             %div
               %a#expense_reject_reason_text
-              = f.label :reason_text, 'Reason text'
+              = f.label :reject_reason_text, 'Reason text'
               .form-hint.xsmall These reasons will be displayed to providers
-              = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_reject_reason_text'}
+              = f.text_field :reject_reason_text, {class: 'form-control'}
       .js-cw-claim-refuse-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
@@ -64,9 +64,9 @@
           %fieldset.form-group.nested-fields.fieldset.spacer.js-refuse-reason-text{style: 'display:none'}
             %div
               %a#expense_refuse_reason_text
-              = f.label :reason_text, 'Reason text'
+              = f.label :refuse_reason_text, 'Reason text'
               .form-hint.xsmall These reasons will be displayed to providers
-              = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_refuse_reason_text'}
+              = f.text_field :refuse_reason_text, {class: 'form-control'}
 
       %p
         = f.submit 'Update', class: 'button', id: 'button'

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -15,7 +15,7 @@ module Claims
       subject(:updater) { CaseWorkerClaimUpdater.new(claim.id, params.merge(current_user: current_user)).update! }
       let(:claim) { create :allocated_claim }
       let(:current_user) { double(User, id: 12345) }
-      let(:params) { {'state' => state, 'state_reason' => state_reason, 'reason_text' => reason_text, 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
+      let(:params) { {'state' => state, 'state_reason' => state_reason, "#{state.eql?('rejected') ? 'reject' : 'refuse'}_reason_text" => reason_text, 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
 
       it 'updates the state to `other` and returns OK' do
         expect(updater.result).to eq :ok


### PR DESCRIPTION
The second, `refuse` text field was blanking the initial, `reject` text input field

This PR ensures they have unique ID and names on the page and then processes them into a single field for validation and storage