### PR TITLE
Enable Ajax data injection error dismissing

### DIFF
--- a/app/controllers/injection_attempts_controller.rb
+++ b/app/controllers/injection_attempts_controller.rb
@@ -1,0 +1,13 @@
+class InjectionAttemptsController < ApplicationController
+  def dismiss
+    @injection_attempt = InjectionAttempt.find(injection_attempt_params[:id])
+    @dismissed = @injection_attempt.soft_delete
+    respond_to :js
+  end
+
+  private
+
+  def injection_attempt_params
+    params.permit(:id)
+  end
+end

--- a/app/interfaces/api/entities/injection_attempt.rb
+++ b/app/interfaces/api/entities/injection_attempt.rb
@@ -3,6 +3,7 @@ module API
     class InjectionAttempt < BaseEntity
       expose :succeeded
       expose :error_messages
+      expose :deleted_at
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -47,6 +47,7 @@ class Ability
     can %i[show show_message_controls edit change_password update_password update destroy], CaseWorker
     can %i[new create], Allocation
     can :view, :management_information
+    can %i[dismiss], InjectionAttempt
   end
 
   def case_worker(persona)
@@ -56,6 +57,7 @@ class Ability
     end
     can %i[show download], Document
     can_manage_own_password(persona)
+    can %i[dismiss], InjectionAttempt
   end
 
   def persona_type(persona)

--- a/app/models/concerns/softly_deletable.rb
+++ b/app/models/concerns/softly_deletable.rb
@@ -13,8 +13,9 @@ module SoftlyDeletable
     def soft_delete
       transaction do
         before_soft_delete if respond_to?(:before_soft_delete)
-        update(deleted_at: Time.zone.now)
+        result = update(deleted_at: Time.zone.now)
         after_soft_delete if respond_to?(:after_soft_delete)
+        result
       end
     end
 

--- a/app/presenters/concerns/injection_attempt_errorable.rb
+++ b/app/presenters/concerns/injection_attempt_errorable.rb
@@ -2,6 +2,14 @@ module InjectionAttemptErrorable
   extend ActiveSupport::Concern
 
   included do
+    def last_injection_attempt
+      claim.injection_attempts&.last
+    end
+
+    def injection_errors
+      last_injection_attempt.error_messages if last_injection_attempt&.active?
+    end
+
     def injection_error
       messages = injection_errors
       return unless messages.present?
@@ -10,11 +18,6 @@ module InjectionAttemptErrorable
       message
     end
     alias_method :injection_error_summary, :injection_error
-
-    def injection_errors
-      last_attempt = claim.injection_attempts&.last
-      last_attempt&.error_messages if last_attempt&.active?
-    end
 
     def injection_error_header(messages)
       suffix = I18n.t(:error, scope: %i[shared injection_errors])

--- a/app/views/errors/_injection_error_summary.html.haml
+++ b/app/views/errors/_injection_error_summary.html.haml
@@ -1,13 +1,16 @@
 - if ep.injection_error
-  .error-summary{role: "group", 'aria-labelledby': "error-summary-heading", tabindex:'-1'}
-    %h1.heading-medium.error-summary-heading{id: 'error-summary-heading'}
-      = ep.injection_error_summary
+  .js-callout-injection-error
+    .error-summary{role: "group", 'aria-labelledby': "error-summary-heading", tabindex:'-1'}
+      %h1.heading-medium.error-summary-heading{id: 'error-summary-heading'}
+        = ep.injection_error_summary
 
-    %span.form-hint
-      = t('shared.injection_errors.form_error_hint')
+      %span.form-hint
+        = t('shared.injection_errors.form_error_hint')
 
-    %ul.error-summary-list
-      - ep.injection_errors.each do |message|
-        %li
-          = link_to '#injection_error' do
-            = message
+      %ul.error-summary-list
+        - ep.injection_errors.each do |message|
+          %li
+            = link_to '#injection_error' do
+              = message
+      .hide-link
+        = link_to 'Do not show this message again', dismiss_injection_attempt_path(ep.last_injection_attempt), method: :patch, remote: true, class: 'cb-dismiss-link'

--- a/app/views/injection_attempts/dismiss.js.haml
+++ b/app/views/injection_attempts/dismiss.js.haml
@@ -1,0 +1,6 @@
+- error_summary = "div.js-callout-injection-error"
+
+- if @dismissed
+  $("#{error_summary}").slideUp(300);
+- else
+  $("#{error_summary} .hide-link").html('There was a problem. Try again later.');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,4 +193,10 @@ Rails.application.routes.draw do
   unless Rails.env.development? || Rails.env.devunicorn?
     match '*path', to: 'errors#not_found', via: :all
   end
+
+  # match 'injection_attempts/dismiss/:id', to: 'injection_attempts#dismiss', via: [:patch, :put], format: :js
+  resources :injection_attempts, only: [:dismiss] do
+    patch 'dismiss', format: :js, on: :member
+    put 'dismiss', format: :js, on: :member
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,18 +185,19 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :injection_attempts, only: [:dismiss] do
+    patch 'dismiss', format: :js, on: :member
+    put 'dismiss', format: :js, on: :member
+  end
 
   get 'statistics', to: 'geckoboard_api/statistics#index'
 
   post '/', to: 'errors#not_endpoint'
+
   # catch-all route
+  # -------------------------------------------------
+  # WARNING: do not put routes below this point
   unless Rails.env.development? || Rails.env.devunicorn?
     match '*path', to: 'errors#not_found', via: :all
-  end
-
-  # match 'injection_attempts/dismiss/:id', to: 'injection_attempts#dismiss', via: [:patch, :put], format: :js
-  resources :injection_attempts, only: [:dismiss] do
-    patch 'dismiss', format: :js, on: :member
-    put 'dismiss', format: :js, on: :member
   end
 end

--- a/features/injection_errors.feature
+++ b/features/injection_errors.feature
@@ -11,13 +11,17 @@ Feature: Case worker viewing and dismissing a data injection error
     And I insert the VCR cassette 'features/case_workers/claims/injection_error'
 
     When I am signed in as the case worker
-    And I select the claim
-    Then the injection error summary is visible
-    # When I click the dismiss injection error button
-    # When I click the link 'Do not show this message again'
-    # Then the injection error disappears
+    And I click your claims
+    Then claim "A20161234" does have an injection error visible
 
-    # When I click your claims
-    # Then claim "A200161234" does not have an injection error visible
+    And I select claim "A20161234"
+    Then the injection error summary is visible
+    And there are "2" injection error messages
+
+    When I dismiss the injection error
+    Then the injection error summary is not visible
+
+    When I click your claims
+    Then claim "A20161234" does not have an injection error visible
 
     And I eject the VCR cassette

--- a/features/injection_errors.feature
+++ b/features/injection_errors.feature
@@ -12,11 +12,12 @@ Feature: Case worker viewing and dismissing a data injection error
 
     When I am signed in as the case worker
     And I select the claim
-    Then The injection error summary is visible
-    # And I click the dismiss injection error button
+    Then the injection error summary is visible
+    # When I click the dismiss injection error button
+    # When I click the link 'Do not show this message again'
     # Then the injection error disappears
 
     # When I click your claims
-    # Then the claim I've just updated no longer has an error in the list
+    # Then claim "A200161234" does not have an injection error visible
 
     And I eject the VCR cassette

--- a/features/page_objects/case_worker_claim_show_page.rb
+++ b/features/page_objects/case_worker_claim_show_page.rb
@@ -4,5 +4,5 @@ require_relative "sections/injection_error_summary_section"
 class CaseWorkerClaimShowPage < ClaimShowPage
   set_url "/case_workers/claims{/claim_id}"
 
-  section :injection_error_summary, InjectionErrorSummarySection, 'div.error-summary'
+  section :injection_error_summary, InjectionErrorSummarySection, '.js-callout-injection-error'
 end

--- a/features/page_objects/sections/injection_error_summary_section.rb
+++ b/features/page_objects/sections/injection_error_summary_section.rb
@@ -1,6 +1,6 @@
 class InjectionErrorSummarySection < SitePrism::Section
   element :header, '#error-summary-heading'
-  element :dimiss_button, 'button.button-secondary'
+  element :dismiss_link, '.cb-dismiss-link'
   sections :injection_errors, '.error-summary-list > li' do
     element :link, 'a'
   end

--- a/features/page_objects/user_home_page.rb
+++ b/features/page_objects/user_home_page.rb
@@ -7,6 +7,7 @@ class UserHomePage < SitePrism::Page
     element :state, "span.state"
     element :claimed, "td.claimed-amount"
     element :view_messages, "td.messages > a"
+    element :error_message, '.error-message'
   end
 
   def claim_for(case_number)
@@ -17,7 +18,6 @@ class UserHomePage < SitePrism::Page
     list_to_array(comma_list).each do |case_number|
       return false unless case_numbers.include?(case_number)
     end
-
     true
   end
 
@@ -27,5 +27,9 @@ class UserHomePage < SitePrism::Page
 
   def list_to_array(comma_separated_list)
     comma_separated_list.split(',').map(&:strip)
+  end
+
+  def error_messages
+    claims.map { |claim | claim.error_message.text }
   end
 end

--- a/features/step_definitions/authorise_claim_steps.rb
+++ b/features/step_definitions/authorise_claim_steps.rb
@@ -47,10 +47,6 @@ Then(/^the status at top of page should be (.*)$/) do |text|
   expect(@case_worker_claim_show_page.status.text).to eq(text)
 end
 
-When(/^I click your claims$/) do
-  @case_worker_claim_show_page.nav.your_claims.click
-end
-
 Then(/^the claim I've just updated is no longer in the list$/) do
   expect(@case_worker_home_page).not_to have_content(@claim.case_number)
 end

--- a/features/step_definitions/common_case_worker_steps.rb
+++ b/features/step_definitions/common_case_worker_steps.rb
@@ -1,0 +1,3 @@
+When(/^I click your claims$/) do
+  @case_worker_claim_show_page.nav.your_claims.click
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -113,6 +113,7 @@ And(/^I should see in the sidebar total '(.*?)'$/) do |total|
   end
 end
 
+
 And(/^I should see in the sidebar vat total '(.*?)'$/) do |total|
   within('div.totals-summary') do
     expect(page.find('span.total-vat')).to have_content(total)
@@ -122,7 +123,8 @@ end
 # Record modes can be: all, none, new_episodes or once. Default is 'none'.
 # When creating new tests that calls new endpoints, you will need to record the cassette.
 # NOTE: see the README section 'Recording new VCR cassettes' for assistance
-# NOTE: Never commit code with VCR in record mode.
+# NOTE: Never commit code that would result in VCR attempting to record a cassette
+#       i.e. either cassette must exist, or you explicitly call "and record 'none'"
 #
 And(/^I insert the VCR cassette '(.*?)'(?: and record '(.*?)')?$/) do |name, record|
   # Caching.clear if record

--- a/features/step_definitions/injection_error_steps.rb
+++ b/features/step_definitions/injection_error_steps.rb
@@ -7,20 +7,16 @@ Given(/^the claim "([^"]*)" has an injection error$/) do |case_number|
   create(:injection_attempt, :with_errors, claim: claim)
 end
 
-Then(/^The injection error summary is visible$/) do
+Then(/^the injection error summary is visible$/) do
   expect(case_worker_claims_show_page.injection_error_summary).to be_visible
 end
 
+# TODO: this step does not work
 Then(/^I click the dismiss injection error button$/) do
-  pending
-  case_worker_claims_show_page.dimiss_button.click
+  case_worker_claims_show_page.injection_error_summary.dismiss_link.click
+  wait_for_ajax
 end
 
 Then(/^the injection error disappears$/) do
-  pending
-  expect(case_worker_claims_show_page.injection_error_summary).not_to be_visible
-end
-
-Then(/^the claim I've just updated no longer has an error in the list$/) do
-  pending 'need your claims page object'
+  expect(case_worker_claims_show_page.injection_error_summary).not_to be_displayed
 end

--- a/features/step_definitions/injection_error_steps.rb
+++ b/features/step_definitions/injection_error_steps.rb
@@ -2,21 +2,41 @@ def case_worker_claims_show_page
   @case_worker_claims_show_page ||= CaseWorkerClaimShowPage.new
 end
 
+def case_worker_your_claims_page
+  @case_worker_your_claims_page ||= CaseWorkerYourClaimsPage.new
+end
+
+When(/^I select claim "([^"]*)"$/) do |case_number|
+  case_worker_your_claims_page.claim_for(case_number).case_number.click
+end
+
 Given(/^the claim "([^"]*)" has an injection error$/) do |case_number|
   claim = Claim::BaseClaim.find_by(case_number: case_number)
   create(:injection_attempt, :with_errors, claim: claim)
+  expect(claim.injection_attempts.last).to be_active
 end
 
-Then(/^the injection error summary is visible$/) do
-  expect(case_worker_claims_show_page.injection_error_summary).to be_visible
+Then(/^the injection error summary is (not )?visible$/) do |negate|
+  if negate
+    expect(case_worker_claims_show_page).to_not have_injection_error_summary
+  else
+    expect(case_worker_claims_show_page).to have_injection_error_summary
+  end
 end
 
-# TODO: this step does not work
-Then(/^I click the dismiss injection error button$/) do
+Then(/^there are "([^"]*)" injection error messages$/) do |num|
+  expect(case_worker_claims_show_page.injection_error_summary).to have_injection_errors(count: num.to_i)
+end
+
+And(/^I dismiss the injection error$/) do
   case_worker_claims_show_page.injection_error_summary.dismiss_link.click
-  wait_for_ajax
+  case_worker_claims_show_page.injection_error_summary.wait_until_header_invisible(10) # uses jQuery slide effect, so takes time
 end
 
-Then(/^the injection error disappears$/) do
-  expect(case_worker_claims_show_page.injection_error_summary).not_to be_displayed
+Then(/^claim "([^"]*)" does (not )?have an injection error visible$/) do |case_number, negate|
+  if negate
+    expect(case_worker_your_claims_page.claim_for(case_number)).to_not have_error_message
+  else
+    expect(case_worker_your_claims_page.claim_for(case_number)).to have_error_message
+  end
 end

--- a/spec/api/entities/injection_attempt_spec.rb
+++ b/spec/api/entities/injection_attempt_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe API::Entities::InjectionAttempt do
+  let(:injection_attempt) { build(:injection_attempt, :with_errors) }
+
+  it 'represents the injection_attempt entity' do
+    result = described_class.represent(injection_attempt)
+    expect(result.to_json).to eq '{"succeeded":false,"error_messages":["injection error 1","injection error 2"],"deleted_at":null}'
+  end
+end

--- a/spec/controllers/injection_attempts_controller_spec.rb
+++ b/spec/controllers/injection_attempts_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe InjectionAttemptsController, type: :controller do
+  describe "PATCH #dismiss" do
+    let(:case_worker) { create(:case_worker) }
+    let(:claim) { create(:submitted_claim) }
+    let(:injection_attempt) { create(:injection_attempt, :with_errors, claim: claim) }
+
+    def do_put
+      put :dismiss, id: injection_attempt.id, format: :js
+      injection_attempt.reload
+    end
+
+    before do
+      sign_in case_worker.user
+      expect(injection_attempt).to be_active
+      do_put
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'assigns injection attempt to @injection_attempt' do
+      expect(assigns(:injection_attempt)).to eql injection_attempt
+    end
+
+    it 'assigns result to @dismissed' do
+      expect(assigns(:dismissed)).to be_truthy
+    end
+
+    it "softley deletes the injection attempt" do
+      expect(injection_attempt).to_not be_active
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -405,6 +405,10 @@ describe Ability do
         it { should_not be_able_to(action, Allocation.new) }
       end
     end
+
+    context 'can dismiss injection attempt errors' do
+      it { should be_able_to(:dismiss, InjectionAttempt.new) }
+    end
   end
 
   context 'case worker admin' do
@@ -437,6 +441,10 @@ describe Ability do
       [:view].each do |action|
         it { should be_able_to(action, :management_information) }
       end
+    end
+
+    context 'can dismiss injection attempt errors' do
+      it { should be_able_to(:dismiss, InjectionAttempt.new) }
     end
   end
 

--- a/spec/presenters/base_claim_presenter_spec.rb
+++ b/spec/presenters/base_claim_presenter_spec.rb
@@ -355,6 +355,7 @@ RSpec.describe Claim::BaseClaimPresenter do
   it { is_expected.to respond_to :injection_error }
   it { is_expected.to respond_to :injection_error_summary }
   it { is_expected.to respond_to :injection_errors }
+  it { is_expected.to respond_to :last_injection_attempt }
 
   describe '#injection_error' do
     subject { presenter.injection_error }
@@ -384,10 +385,10 @@ RSpec.describe Claim::BaseClaimPresenter do
     it 'calls last error messages attribute of model' do
       injection_attempts = instance_double('injection_attempts')
       injection_attempt = instance_double('injection_attempt')
-      expect(claim).to receive(:injection_attempts).and_return(injection_attempts)
-      expect(injection_attempts).to receive(:last).and_return(injection_attempt)
-      expect(injection_attempt).to receive(:active?).and_return true
-      expect(injection_attempt).to receive(:error_messages)
+      expect(claim).to receive(:injection_attempts).at_least(:once).and_return(injection_attempts)
+      expect(injection_attempts).to receive(:last).at_least(:once).and_return(injection_attempt)
+      expect(injection_attempt).to receive(:active?).at_least(:once).and_return true
+      expect(injection_attempt).to receive(:error_messages).at_least(:once)
       subject
     end
 

--- a/vcr/cassettes/features/case_workers/claims/injection_error.yml
+++ b/vcr/cassettes/features/case_workers/claims/injection_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=b7efa83c-687d-4c26-b8d6-fe1c714ca857&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=e68914c5-51d5-4219-9e14-a2ef8d62ba2c&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -27,19 +27,19 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"94e6cd1167b130f30871792875a40753"
+      - W/"3bbdb7d0da6b75054dfc54edb408c9b5"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7dc11ba9-fa7e-4893-ba22-48ed67e6104c
+      - b0478a03-771c-4d86-84f3-40ebddc48aec
       X-Runtime:
-      - '0.369166'
+      - '0.388430'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAA8pXVoAA2xUTY/bOAz9KwOdo8CS5a+cWrSHBbpAF7M9bVEYtEQnbmwpleykg8H896UcJ53J5GSLj+LH46Oe2QG2nYWxc5ZtnpmevEc71mRFthErNroR+vkYXp21m+w4n/tu6Mb6CP0U/ZOXFetGHMj3+zPrzOwyTfGHARgtVV5wCabkSqSaQ0VHjUonAFnT6oatmIaAtZ2GBj1d+igTkQuZKkLCCCPGQH3vNP0aso1Ph2j61EM3bDYfzXFG5iOhPYSxDlNDJZJ7DVQyo4AlTwQX2TcpN6LaZOV/bOmLbWS2TlbsCGMNw7nH2eAOaClA63zt0eCIfriS1kIfcMVOPiaxhENwNtRuGqlgazq7vfqYLuxrPHYGrcardcAQIr8XVinfZCmMqe8g+JuSWxrBFCJBtyRLnRZVVRRc5brhSqLmZQIl16kpq6wRIkegbtvOEzMWhkje41OP3XZ34Wux/jUZ6oOMOEBHzLAd+MHZeoDttnMfwuhd6OyeRrF3a+e3jEZvsEVrwI735t+YtsSiRC5SyLnSSvBS5oqnSVJqlRohhbkt7TMc8aauL1NUiaEp166tm86PO7KKqlymSqDHg8dAMp4nVDtv0N9VZGlUVaQVT9PEcFWanIMAxbXIIBNaYJmVFG4AkoOn1vx5bCyThZRpkVXFUslZVjkXkgtBRJwTyWuiPEtEVmSKK2g0tS6p9VK1vFVJXqg2KaqmuJeoKBKZilzJ6n2ilBL9ePmxLMx5D855S1Ws2MLWJwIfvhH4IChEF+q2+x2FjH/k5/HX1PkoMg96T2BMFN7Do+9Idm/BuIqn+qCHXQy5VHF78bat0U+vYY/3InvXx9N3Bts2RAnED3V7SUMrYSiWnfo+vjn2J+p52EBLOBwWAYZJa6R9Ndew6D3t8GWvYvzr1YcZO/N0Y5PsD9Mn5/f35VSINjWVkryVuuIqy5BXOkk4ZnmRgZEyK/Jbgf9DDPT4dKPxR7eD16t3OHutfbR/6AHWW3dcT/s7UsNMVEZXOW8SQa9Amyje5AlV0lYkuwra1lTvtgxP8GRvF+1fygVv6zBnx3VYoDelRILc5MeLDFWZF9EUx8T+fvzMI7NL7K/e8i/z0zFb53uLepj27mTZC4n7fwAAAP//AwB7pLepnQYAAA==
+        H4sIAG8kX1oAA2xUy5LbNhD8lS2cBRUJgiCpkx0nqeSSHOxTXC4WHsNdRCSo4KF1amv/PQOKkncZnSRMg9MzPT14ISf5aJ2Mdnbk8EJ08h5c7DEK5FDuSJyjHJdjeHPWc3JxOY92srE/yzHl+8XrjtgIE979+kKsWa6klP8Q00k+iFrQpuoqyoe2plIxQ2uuWVeXle4YkB3RMkDv0qTA40cfWVGKklUckRBlRBIix3HW+NdgLP57yqFPo7TT4fDRnBdkOSI6yhD7kBSWiNd7iSUTTNjSoqRl86UsDowfeP0XWfsiB1bvix05y9jL6dLjEphP4DDBMPveg4EIfrqJNsgxwI48+0ziEJdhdqGfU8SCnbHu8XbH2HDs4WwNOA236AQhZH2vqiJfcpjG9HcQ+I7kDkeQQhZoK3JbFVrrUlAJoqXcqIEq0dRUyxrUYAbDeYndDtajMk5OWbzP8iydk1e91ujP2HGwR4zCJC1KQ87Wo1UsfAjRz5N0e+uGmeDEDQzgjHTx3thrbVQLhtNKNA3lHDiVJde002XHK6MRr7YV/eKRZlPPZ/1kxxF7Rj4ccT8PvbI+PiFUdu06UgQ9nDwE9PAynn72BvzdumrUikusBguhvANUSrecsrZtSiULwUSWZJLoBY8N+svMSF21Fbq4qZq1kounBC0ZLSuU40LEbkRDA6ozyNGxCokK0VHZqBbNr6AptFJsMPeIyrZjouB1J94RNbnTgpHXb6/f1m25LMGFl1diR1bJPiH48AXBhzxzG/rBfs8uhh/e8/BPsj47zEt9RDAThf/D0Vv03Hsw7+Fzf9LTU065VrH9cNtW9Okt7OFeZj+P+fSVyMchZB/kH+z2SoP7YDCXS+OYHxz3N+hl2BI3cDqtNgxJa8BlNbe04D0u8HWpcv7bpw8LdtFpE2OZ2cAI1ydkob1q/zz7432DCcZlq6CiRd3ge1fW6IC6KGijZVGoVjSsEVvj/5TM1vaXXXuzhiqZ/bqBH0Yp94/zeZ+Od4xXlKY1DJfOmI5TjpamLWsUhYpXSggFplbbAv6Y/fYh+C0ZfNDeFODwzv5pib4rIEsyJx+vVmRlI3LILIl//5NmdX9scxptiPRXidIuyPLt6iKi/fzsyCua/D8AAAD//wMAVVXyeKIGAAA=
     http_version: 
-  recorded_at: Mon, 15 Jan 2018 22:19:59 GMT
+  recorded_at: Wed, 17 Jan 2018 10:24:47 GMT
 recorded_with: VCR 3.0.3

--- a/vcr/cassettes/features/case_workers/claims/injection_error.yml
+++ b/vcr/cassettes/features/case_workers/claims/injection_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=e68914c5-51d5-4219-9e14-a2ef8d62ba2c&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=9555a12c-3155-492e-aac5-7819f45429d1&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -27,19 +27,103 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"3bbdb7d0da6b75054dfc54edb408c9b5"
+      - W/"6ddfaa8cd50d8aa33b3649afebb6296f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b0478a03-771c-4d86-84f3-40ebddc48aec
+      - e211326e-55ad-488a-a849-8774ae11a891
       X-Runtime:
-      - '0.388430'
+      - '0.053861'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAG8kX1oAA2xUy5LbNhD8lS2cBRUJgiCpkx0nqeSSHOxTXC4WHsNdRCSo4KF1amv/PQOKkncZnSRMg9MzPT14ISf5aJ2Mdnbk8EJ08h5c7DEK5FDuSJyjHJdjeHPWc3JxOY92srE/yzHl+8XrjtgIE979+kKsWa6klP8Q00k+iFrQpuoqyoe2plIxQ2uuWVeXle4YkB3RMkDv0qTA40cfWVGKklUckRBlRBIix3HW+NdgLP57yqFPo7TT4fDRnBdkOSI6yhD7kBSWiNd7iSUTTNjSoqRl86UsDowfeP0XWfsiB1bvix05y9jL6dLjEphP4DDBMPveg4EIfrqJNsgxwI48+0ziEJdhdqGfU8SCnbHu8XbH2HDs4WwNOA236AQhZH2vqiJfcpjG9HcQ+I7kDkeQQhZoK3JbFVrrUlAJoqXcqIEq0dRUyxrUYAbDeYndDtajMk5OWbzP8iydk1e91ujP2HGwR4zCJC1KQ87Wo1UsfAjRz5N0e+uGmeDEDQzgjHTx3thrbVQLhtNKNA3lHDiVJde002XHK6MRr7YV/eKRZlPPZ/1kxxF7Rj4ccT8PvbI+PiFUdu06UgQ9nDwE9PAynn72BvzdumrUikusBguhvANUSrecsrZtSiULwUSWZJLoBY8N+svMSF21Fbq4qZq1kounBC0ZLSuU40LEbkRDA6ozyNGxCokK0VHZqBbNr6AptFJsMPeIyrZjouB1J94RNbnTgpHXb6/f1m25LMGFl1diR1bJPiH48AXBhzxzG/rBfs8uhh/e8/BPsj47zEt9RDAThf/D0Vv03Hsw7+Fzf9LTU065VrH9cNtW9Okt7OFeZj+P+fSVyMchZB/kH+z2SoP7YDCXS+OYHxz3N+hl2BI3cDqtNgxJa8BlNbe04D0u8HWpcv7bpw8LdtFpE2OZ2cAI1ydkob1q/zz7432DCcZlq6CiRd3ge1fW6IC6KGijZVGoVjSsEVvj/5TM1vaXXXuzhiqZ/bqBH0Yp94/zeZ+Od4xXlKY1DJfOmI5TjpamLWsUhYpXSggFplbbAv6Y/fYh+C0ZfNDeFODwzv5pib4rIEsyJx+vVmRlI3LILIl//5NmdX9scxptiPRXidIuyPLt6iKi/fzsyCua/D8AAAD//wMAVVXyeKIGAAA=
+        H4sIAJC9X1oAA2xUTY/bOAz9KwOdR4HlD1nOqcUctuhigQW22MMWhUFLdKLGllLJznR2MP99KceZzmRzskVSfOTjo57ZEXbWwWS9Y9tnpucQ0E0tWZFtxT2b/ATDcoxvztrPblrOgx3t1J5gmFN89nLP7IQjxX59ZtYsIfOcfline4G5LjnKruFlUygOohBcNV1R9kbndd+we6YhYuvmscNAlz7mmZAiL0ryxAkmAmEwDF7TryHb9HRMpocB7LjdfjSnxbMcyTtAnNo4d1QihbdAJTNKqHgmuKi/5GIr1DZT/7C1L7bNq012z04wtTCee1wM/oiOEvQ+tAENThjGV9J6GCLes8eQQBz5IXoXWz9PVLAz1u1eY4yNhxZP1qDT+GodMcbE74VVwpsdpTHtDQ/+JHBHI5hjIuia5KYXvQDTc9Eow0sJBW90V3KRNRJQ5p0xOXXb20DMOBhX8mYqEy+ErebfBn8iCIIcwRI1pJT4Y4YBPxws7t3GekbTNtijM+CmWyM3us9kpjLe1VnOS9U3XJV1xbtO1FL3huYqr6v5/WlAu9tfFfNpNsQqGQ2Nt/V929kw7clBfa7jJGfAY8BI+l1G0/pgMNyqS/RUikbkZZlTXVUpOOgGOFRCl1WFQkigdCOQDgI1GM7zYkUm67KQslRrJWc9SS5yLgqi4wyU/9J8ZjJocskrpTpeFn3GoatyLqUUaDqoUKtbQEoJ1ciyqOU7oDp1muXs5dvLt3VTzguwNliVBH2ZKnnvvpD3TlAOG9ve/kwSxl/CC/hjtiHJK4A+kDMhxf+7p2BJcO+daQkf26Me9ynlWsb1xeu+pjC/dQe8lTn4IZ2+Mtj1MckgfajdCwwtg6Fcbh6G9Nq476iXaQOt33hcdRhnTfM19EZc0mIItL2XjUr5X6/eLb4zT1e2PCEbHPDyfiywF/IffTjcVliRk1KkVlwbKUhhkHNV0J8yZd3UtRK1gGvl/0kgV7J/mEd6aHbx7RZS1Eav9g8DwGbnT5v5cEN9mBUgK+jpxa2Al11HCteF5KA6nZkaKyX0dRGf/ZO+ruIPnP59U8H3FLIZyfgOPpHi5zBd1KiqukqmNCz29+dPPPG7ZvxL74On8QT+4IfBurg4l+urlJgO/tGxF5L6fwAAAP//AwAjj3wSpAYAAA==
     http_version: 
-  recorded_at: Wed, 17 Jan 2018 10:24:47 GMT
+  recorded_at: Wed, 17 Jan 2018 21:18:08 GMT
+- request:
+    method: get
+    uri: http://localhost:3001/api/case_workers/claims?api_key=9555a12c-3155-492e-aac5-7819f45429d1&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin15.6.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:3001
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"cae4b5d0ebc2d8930bc8ef73165ae427"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6a95e266-c845-4cfa-a7b7-cc022ecfc742
+      X-Runtime:
+      - '0.048600'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJG9X1oAA2xUTY/bOAz9KwOdR4HlD1nOqcUctuhigQW22MMWhUFLdKLGllLJznR2MP99KceZzmRzskVSfOTjo57ZEXbWwWS9Y9tnpucQ0E0tWZFtxT2b/ATDcoxvztrPblrOgx3t1J5gmFN89nLP7IQjxX59ZtYsIfOcfline4G5LjnKruFlUygOohBcNV1R9kbndd+we6YhYuvmscNAlz7mmZAiL0ryxAkmAmEwDF7TryHb9HRMpocB7LjdfjSnxbMcyTtAnNo4d1QihbdAJTNKqHgmuKi/5GIr1DZT/7C1L7bNq012z04wtTCee1wM/oiOEvQ+tAENThjGV9J6GCLes8eQQBz5IXoXWz9PVLAz1u1eY4yNhxZP1qDT+GodMcbE74VVwpsdpTHtDQ/+JHBHI5hjIuia5KYXvQDTc9Eow0sJBW90V3KRNRJQ5p0xOXXb20DMOBhX8mYqEy+ErebfBn8iCIIcwRI1pJT4Y4YBPxws7t3GekbTNtijM+CmWyM3us9kpjLe1VnOS9U3XJV1xbtO1FL3huYqr6v5/WlAu9tfFfNpNsQqGQ2Nt/V929kw7clBfa7jJGfAY8BI+l1G0/pgMNyqS/RUikbkZZlTXVUpOOgGOFRCl1WFQkigdCOQDgI1GM7zYkUm67KQslRrJWc9SS5yLgqi4wyU/9J8ZjJocskrpTpeFn3GoatyLqUUaDqoUKtbQEoJ1ciyqOU7oDp1muXs5dvLt3VTzguwNliVBH2ZKnnvvpD3TlAOG9ve/kwSxl/CC/hjtiHJK4A+kDMhxf+7p2BJcO+daQkf26Me9ynlWsb1xeu+pjC/dQe8lTn4IZ2+Mtj1MckgfajdCwwtg6Fcbh6G9Nq476iXaQOt33hcdRhnTfM19EZc0mIItL2XjUr5X6/eLb4zT1e2PCEbHPDyfiywF/IffTjcVliRk1KkVlwbKUhhkHNV0J8yZd3UtRK1gGvl/0kgV7J/mEd6aHbx7RZS1Eav9g8DwGbnT5v5cEN9mBUgK+jpxa2Al11HCteF5KA6nZkaKyX0dRGf/ZO+ruIPnP59U8H3FLIZyfgOPpHi5zBd1KiqukqmNCz29+dPPPG7ZvxL74On8QT+4IfBurg4l+urlJgO/tGxF5L6fwAAAP//AwAjj3wSpAYAAA==
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 21:18:09 GMT
+- request:
+    method: get
+    uri: http://localhost:3001/api/case_workers/claims?api_key=9555a12c-3155-492e-aac5-7819f45429d1&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin15.6.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:3001
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"bf9333aa56008609f714c067037e8e65"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b846a7c3-7de6-4965-9107-37eada273ad8
+      X-Runtime:
+      - '0.049485'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJK9X1oAA3xUTY/bNhD9KwteaxqkPijKpwR7SJCgQIEGPTQIhBE5spmVKIeSvNku9r93KMvOrmr0JHHecN58vOEzO8LeeRhd79numZkpBPRjRVZkO7lhYz9COx+HV2fTT36cz63r3FidoJ2iv3jZMDdiR75fn5mzs8s0xR9Wm0ZiYjKOqi55Vqaag0wl12WdZo01SdGUbMMMDFj5qasx0KX3iZBKJmlGyDDCSCQM2rY39GvJNj4do+m+Bdftdu/taUbmI6EtDGM1TDWlSO4VUMqMAmouJJfFl0TupN4J/Tdb6mK7JN+KDTvBWEF3rnE29Ef0FKDpQxXQ4oihuzatgXbADXsMkcQTDkPvh6qfRkrYW+f3Vx/rhocKT86iN3i1djgMsb+XrhLf5CmMrW4g+JPIPY1gGmKD1k0uG9lIsA2XpbY8U5Dy0tQZl6JUgCqprU2o2sYF6oyHbmneRGnipWGL+UPbn4iCKDtw1BpSyvBjghbfPTg8+K3rGU3bYoPegh9vjdyaRiihBa8LkfBMNyXXWZHzupaFMo2luap1Np+fWnT7wyqZj5OlrpLR0nirvqlqF8YDAVTnMk4CAx4DDqTfeTRVHyyGW3nJhlIxiDzLEsorzyQHUwKHXJosz1FKBRSuA9JBoALDeV4sFarIUqUyvWRy1pPiMuEypXaciZJfmhdWQJkonmtd8yxtBIc6T7hSSqKtIUejbxFpLXWpsrRQb4iKWKlI2Mu3l2/LppwXYCkwz4j6MlVC774Qeicphhuqxv2MEsZfwgv4Y3IhyiuAeSAwMg3/hcfgSHBvwbiEj9XRdIcYckljfXFd1xim13DAW5FD38bTVwb7ZogyiB8q90JDy2Aplp/aNr42/juaedpA69cdFx0Ok6H5WnojLmExBNrey0bF+NerdzN27tPKlkRmiy3+z/tR/ibETgh2ncljHx5uCy9NSEDKaG6skiQ8SLhO6U/brCiLQstCwnoh/iDu1TbcTx29P/vh9XKS19Ys9nctwHbfn7bTww1RokhB5dDQQ5wDz+qahG9SxUHXRtgCcy3NOolP/ZNZZ/E7jv+8yuB7dNl2ZHxDH5vST2G8iFTnRR5NcYbsr08feWz7EvFPcwg9TS3w+75tnR9mcL6+KIyZ0D969kIb8C8AAAD//wMAcQK+j7sGAAA=
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 21:18:10 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
**What**
Enable case workers to dismiss/ignore individual data injection errors

**Why**
The fact an injection failed is primarily to inform
case worker decision making about work loads.
The time taken to process a claim that does not inject
is significantly longer.
