### PR TITLE
Working errors on refuse reject

### DIFF
--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -72,6 +72,7 @@ moj.Modules.AmountAssessedBlock = function(selector) {
 
     this.$actions.on('change', function(e) {
       var state = $(e.target).val();
+      console.log('status change to ' + state);
       $.publish('claim.status.change', {
         state: state
       })

--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -58,6 +58,7 @@ moj.Modules.AmountAssessedBlock = function(selector) {
     this.$otherCheckbox = $(this.config.otherCheckbox);
     this.$otherRefuseCheckbox = $(this.config.otherRefuseCheckbox);
     this.bindEvents();
+    this.setInitState();
   };
 
   this.slider = function(state, el) {
@@ -114,8 +115,13 @@ moj.Modules.AmountAssessedBlock = function(selector) {
         self.slider(state.refuseReasons, el)
       });
     });
-
   };
+
+  this.setInitState = function(){
+    this.$actions.find('input:checked').trigger('change');
+    this.$reasons.find('input:checked').trigger('change');
+    this.$refuseReasons.find('input:checked').trigger('change');
+  }
 
   this.init();
   return this;

--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -73,7 +73,6 @@ moj.Modules.AmountAssessedBlock = function(selector) {
 
     this.$actions.on('change', function(e) {
       var state = $(e.target).val();
-      console.log('status change to ' + state);
       $.publish('claim.status.change', {
         state: state
       })

--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -65,7 +65,7 @@ moj.Modules.AmountAssessedBlock = function(selector) {
     // open and close slider
     // true: open
     // false: close
-    return state ? $(el).slideDown() : $(el).slideUp();
+    return state ? $(el).slideDown(0) : $(el).slideUp(0);
   };
 
   this.bindEvents = function() {

--- a/app/assets/javascripts/modules/Modules.HideErrorOnChange.js
+++ b/app/assets/javascripts/modules/Modules.HideErrorOnChange.js
@@ -1,5 +1,7 @@
 moj.Modules.HideErrorOnChange = {
+
   railsErrorClassName: 'field_with_errors',
+
   config: [{
     delegate: '.form-group.field_with_errors',
     wrapperClassName: 'field_with_errors',
@@ -22,22 +24,27 @@ moj.Modules.HideErrorOnChange = {
   init: function() {
     this.bindListeners();
   },
+
   removeNestedErrorWrappers: function($el) {
     var wrappers = $el.find('.' + this.railsErrorClassName);
     if (wrappers.length) {
       wrappers.removeClass(this.railsErrorClassName);
     }
   },
+
   removeClassName: function($el, className) {
     this.removeNestedErrorWrappers($el);
     return $el.removeClass(className);
   },
+
   removeBySelector: function($el, selector) {
     return $el.find(selector).remove();
   },
+
   bindListeners: function() {
     var self = this;
     var context;
+
     this.config.forEach(function(opt) {
 
       context = opt.eventSelector || 'input';
@@ -46,6 +53,8 @@ moj.Modules.HideErrorOnChange = {
         var $el = $(e.delegateTarget);
         self.removeClassName($el, opt.wrapperClassName);
         self.removeBySelector($el, opt.messageSelector);
+
+        return false;
       });
 
       // mainly for FF

--- a/app/assets/stylesheets/moj/_forms.scss
+++ b/app/assets/stylesheets/moj/_forms.scss
@@ -534,6 +534,10 @@ label.form-date-spacing {
   input, select, textarea{
     border: 2px solid $error-colour;
   }
+
+  fieldset.indent-fieldset {
+    border-left: 5px solid $error-colour;
+  }
 }
 
 .form-row .cssfix.field_with_errors{

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -50,7 +50,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
     if updater.result == :ok
       redirect_to case_workers_claim_path(params.slice(:messages))
     else
-      @claim.errors
+      @error_presenter = ErrorPresenter.new(@claim)
       prepare_show_action
       render :show
     end

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -41,6 +41,8 @@ module Claims
     def validate_params
       if @assessment_params_present || @redetermination_params_present
         validate_state_when_value_params_present
+      elsif @state.blank?
+        add_error 'You should select a status'
       else
         validate_state_when_no_value_params
         validate_reason_presence

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -32,7 +32,7 @@ module Claims
         rejected: @params.delete('reject_reason_text'),
         refused: @params.delete('refuse_reason_text')
       }
-      reasons[@state.to_sym]
+      reasons[@state.to_sym] if @state.present?
     end
 
     def extract_assessment_params

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -67,7 +67,7 @@ module Claims
     def validate_reason_presence
       return unless %w[rejected refused].include?(@state)
       add_error("requires a reason when #{state_verb}", state_symbol(false)) if @transition_reason&.empty?
-      add_error("requires details when #{state_verb} with other", state_symbol) if transition_reason_text_missing?
+      add_error('needs a description', state_symbol) if transition_reason_text_missing?
     end
 
     def state_verb
@@ -75,7 +75,6 @@ module Claims
     end
 
     def state_symbol(other_suffix = true)
-      # binding.pry
       @state_noun ||= "#{@state}_reason#{'_other' if other_suffix}".to_sym
     end
 

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -65,11 +65,15 @@ module Claims
     def validate_reason_presence
       return unless %w[rejected refused].include?(@state)
       add_error "requires a reason when #{state_verb}" if @transition_reason&.empty?
-      add_error "requires details when #{state_verb} with other" if transition_reason_text_missing?
+      add_error("requires details when #{state_verb} with other", state_symbol) if transition_reason_text_missing?
     end
 
     def state_verb
       @state_verb ||= @state.eql?('refused') ? 'refusing' : 'rejecting'
+    end
+
+    def state_symbol
+      @state_noun ||= "#{@state}_reason_other".to_sym
     end
 
     def transition_reason_text_missing?
@@ -125,8 +129,8 @@ module Claims
       @claim.redeterminations << Redetermination.new(params_with_defaults)
     end
 
-    def add_error(message)
-      @claim.errors[:determinations] << message
+    def add_error(message, attribute = :determinations)
+      @claim.errors[attribute] << message
       @result = :error
     end
 

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -66,7 +66,7 @@ module Claims
 
     def validate_reason_presence
       return unless %w[rejected refused].include?(@state)
-      add_error "requires a reason when #{state_verb}" if @transition_reason&.empty?
+      add_error("requires a reason when #{state_verb}", state_symbol(false)) if @transition_reason&.empty?
       add_error("requires details when #{state_verb} with other", state_symbol) if transition_reason_text_missing?
     end
 
@@ -74,8 +74,9 @@ module Claims
       @state_verb ||= @state.eql?('refused') ? 'refusing' : 'rejecting'
     end
 
-    def state_symbol
-      @state_noun ||= "#{@state}_reason_other".to_sym
+    def state_symbol(other_suffix = true)
+      # binding.pry
+      @state_noun ||= "#{@state}_reason#{'_other' if other_suffix}".to_sym
     end
 
     def transition_reason_text_missing?

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -81,7 +81,7 @@
             - b.label(class: "block-label") { b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value)) + b.text }
           %fieldset.form-group.nested-fields.fieldset.spacer.js-refuse-reason-text{style: 'display:none', class: error_class?(@error_presenter, :refused_reason_other)}
             %div
-              %a#expense_refuse_reason_text
+              %a#refused_reason_other
               = f.label :refuse_reason_text, 'Reason text'
               .form-hint.xsmall These reasons will be displayed to providers
               = f.text_field :refuse_reason_text, {class: 'form-control'}

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -50,26 +50,28 @@
             = "Update the claim status"
           = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
             - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.text.downcase.eql?(params[:claim][:state])) + b.text }
-        = validation_error_message(@error_presenter, :determinations)
+          = validation_error_message(@error_presenter, :determinations)
 
       .js-cw-claim-rejection-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
             = "Choose reason for rejection"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
-            - b.label(class: "block-label") { b.check_box(checked: b.text.downcase.eql?(params[:claim].present? && params[:claim][:state_reason])) + b.text }
+            - b.label(class: "block-label") { b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value)) + b.text }
           %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none'}
             %div
-              %a#expense_reject_reason_text
+              %a#rejected_reason_other
               = f.label :reason_text, 'Reason text'
               .form-hint.xsmall These reasons will be displayed to providers
               = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_reject_reason_text'}
+              %div
+                = validation_error_message(@error_presenter, :rejected_reason_other)
       .js-cw-claim-refuse-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
             = "Choose reason for refusal"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
-            - b.label(class: "block-label") { b.check_box + b.text }
+            - b.label(class: "block-label") { b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value)) + b.text }
           %fieldset.form-group.nested-fields.fieldset.spacer.js-refuse-reason-text{style: 'display:none'}
             %div
               %a#expense_refuse_reason_text

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -4,10 +4,6 @@
     #claim-status.js-cw-claim-assessment
       %h3.heading-medium
         = 'Assessment summary'
-      ='*****'
-      =params
-      ='*****'
-
       %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
         %thead
           %tr{:style => "vertical-align: top;"}

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -37,10 +37,6 @@
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
       .js-cw-claim-action
-        -if params[:claim].present? && params[:claim][:state].eql?('rejected')
-          ='hi, developer here'
-          =" the param for state is currently set to: #{params[:claim][:state]}"
-          =' is it pre-ticked? I bet it isn`t!'
         %fieldset.form-group.inline.spacer
           %legend.bold-normal.form-label
             = "Update the claim status"

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -60,7 +60,9 @@
             = "Choose reason for rejection"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
             - b.label(class: "block-label") { b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value)) + b.text }
-          %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none'}
+
+
+          %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none', class: error_class?(@error_presenter, :rejected_reason_other)}
             %div
               %a#rejected_reason_other
               = f.label :reason_text, 'Reason text'
@@ -68,6 +70,7 @@
               = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_reject_reason_text'}
               %div
                 = validation_error_message(@error_presenter, :rejected_reason_other)
+
       .js-cw-claim-refuse-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %div
@@ -76,7 +79,7 @@
             = "Choose reason for refusal"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
             - b.label(class: "block-label") { b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value)) + b.text }
-          %fieldset.form-group.nested-fields.fieldset.spacer.js-refuse-reason-text{style: 'display:none'}
+          %fieldset.form-group.nested-fields.fieldset.spacer.js-refuse-reason-text{style: 'display:none', class: error_class?(@error_presenter, :refused_reason_other)}
             %div
               %a#expense_refuse_reason_text
               = f.label :reason_text, 'Reason text'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -1,10 +1,21 @@
 = form_for(claim, url: case_workers_claim_path(claim), as: :claim) do |f|
   = hidden_field_tag :messages, 'true'
   .fx-assesment-hook
-    #claim-status.js-cw-claim-assessment
+    #claim-status
       %h3.heading-medium
         = 'Assessment summary'
-      %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
+
+      - if current_user_is_caseworker?
+        .js-cw-claim-action
+          %fieldset.form-group.inline.spacer{class: error_class?(@error_presenter, :determinations)}
+            %legend.bold-normal.form-label
+              = "Update the claim status"
+            = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
+              - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state]&.to_sym)) + b.text }
+            %div
+              = validation_error_message(@error_presenter, :determinations)
+
+      %table#determinations.js-cw-claim-assessment{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
         %thead
           %tr{:style => "vertical-align: top;"}
             %th &nbsp;
@@ -36,15 +47,6 @@
 
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
-      .js-cw-claim-action
-        %fieldset.form-group.inline.spacer{class: error_class?(@error_presenter, :determinations)}
-          %legend.bold-normal.form-label
-            = "Update the claim status"
-          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
-            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state]&.to_sym)) + b.text }
-          %div
-            = validation_error_message(@error_presenter, :determinations)
-
       .js-cw-claim-rejection-reasons{style: 'display:none', class: error_class?(@error_presenter, :rejected_reason)}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %div

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -4,10 +4,6 @@
     #claim-status.js-cw-claim-assessment
       %h3.heading-medium
         = 'Assessment summary'
-      ='*****'
-      =params
-      ='*****'
-
       %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
         %thead
           %tr{:style => "vertical-align: top;"}
@@ -41,10 +37,6 @@
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
       .js-cw-claim-action
-        -if params[:claim].present? && params[:claim][:state].eql?('rejected')
-          ='hi, developer here'
-          =" the param for state is currently set to: #{params[:claim][:state]}"
-          =' is it pre-ticked? I bet it isn`t!'
         %fieldset.form-group.inline.spacer
           %legend.bold-normal.form-label
             = "Update the claim status"

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -41,19 +41,21 @@
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
       .js-cw-claim-action
-        -if params[:state].present?
+        -if params[:claim].present? && params[:claim][:state].eql?('rejected')
           ='hi, developer here'
-          =" the param for state is currently set to: #{params[:state]}"
+          =" the param for state is currently set to: #{params[:claim][:state]}"
           =' is it pre-ticked? I bet it isn`t!'
         %fieldset.form-group.inline.spacer
           %legend.bold-normal.form-label
             = "Update the claim status"
-          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
-            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.text.downcase.eql?(params[:claim][:state])) + b.text }
           = validation_error_message(@error_presenter, :determinations)
+          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
+            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state].to_sym)) + b.text }
 
       .js-cw-claim-rejection-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
+          %div
+            = validation_error_message(@error_presenter, :rejected_reason)
           %legend.bold-normal.form-label
             = "Choose reason for rejection"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
@@ -68,6 +70,8 @@
                 = validation_error_message(@error_presenter, :rejected_reason_other)
       .js-cw-claim-refuse-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
+          %div
+            = validation_error_message(@error_presenter, :refused_reason)
           %legend.bold-normal.form-label
             = "Choose reason for refusal"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
@@ -78,7 +82,8 @@
               = f.label :reason_text, 'Reason text'
               .form-hint.xsmall These reasons will be displayed to providers
               = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_refuse_reason_text'}
-              = validation_error_message(@error_presenter, :determinations)
+              %div
+                = validation_error_message(@error_presenter, :refused_reason_other)
 
       %p
         = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -50,7 +50,7 @@
             = "Update the claim status"
           = validation_error_message(@error_presenter, :determinations)
           = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
-            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state].to_sym)) + b.text }
+            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && params[:claim][:state].present? && b.value.eql?(params[:claim][:state].to_sym)) + b.text }
 
       .js-cw-claim-rejection-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -4,6 +4,10 @@
     #claim-status.js-cw-claim-assessment
       %h3.heading-medium
         = 'Assessment summary'
+      ='*****'
+      =params
+      ='*****'
+
       %table#determinations{data:{apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }}
         %thead
           %tr{:style => "vertical-align: top;"}
@@ -37,18 +41,23 @@
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
       .js-cw-claim-action
+        -if params[:state].present?
+          ='hi, developer here'
+          =" the param for state is currently set to: #{params[:state]}"
+          =' is it pre-ticked? I bet it isn`t!'
         %fieldset.form-group.inline.spacer
           %legend.bold-normal.form-label
             = "Update the claim status"
-          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last, { checked: 'claim_state_rejected' } ) do |b|
-            - b.label(class: "block-label") { b.radio_button(checked: b.text.eql?(params[:state])) + b.text }
+          = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
+            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.text.downcase.eql?(params[:claim][:state])) + b.text }
+        = validation_error_message(@error_presenter, :determinations)
 
       .js-cw-claim-rejection-reasons{style: 'display:none'}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %legend.bold-normal.form-label
             = "Choose reason for rejection"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
-            - b.label(class: "block-label") { b.check_box + b.text }
+            - b.label(class: "block-label") { b.check_box(checked: b.text.downcase.eql?(params[:claim].present? && params[:claim][:state_reason])) + b.text }
           %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none'}
             %div
               %a#expense_reject_reason_text
@@ -67,6 +76,7 @@
               = f.label :reason_text, 'Reason text'
               .form-hint.xsmall These reasons will be displayed to providers
               = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_refuse_reason_text'}
+              = validation_error_message(@error_presenter, :determinations)
 
       %p
         = f.submit 'Update', class: 'button', id: 'button'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -37,12 +37,13 @@
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
       .js-cw-claim-action
-        %fieldset.form-group.inline.spacer
+        %fieldset.form-group.inline.spacer{class: error_class?(@error_presenter, :determinations)}
           %legend.bold-normal.form-label
             = "Update the claim status"
-          = validation_error_message(@error_presenter, :determinations)
           = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
-            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state].to_sym)) + b.text }
+            - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state]&.to_sym)) + b.text }
+          %div
+            = validation_error_message(@error_presenter, :determinations)
 
       .js-cw-claim-rejection-reasons{style: 'display:none', class: error_class?(@error_presenter, :rejected_reason)}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
@@ -56,9 +57,9 @@
           %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none', class: error_class?(@error_presenter, :rejected_reason_other)}
             %div
               %a#rejected_reason_other
-              = f.label :reason_text, 'Reason text'
+              = f.label :reject_reason_text, 'Reason text'
               .form-hint.xsmall These reasons will be displayed to providers
-              = f.text_field :reason_text, {class: 'form-control', name:'claim[reason_text]', id: 'claim_reject_reason_text'}
+              = f.text_field :reject_reason_text, {class: 'form-control'}
               %div
                 = validation_error_message(@error_presenter, :rejected_reason_other)
 

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -52,10 +52,11 @@
           = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
             - b.label(class: "block-label") { b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state].to_sym)) + b.text }
 
-      .js-cw-claim-rejection-reasons{style: 'display:none'}
+      .js-cw-claim-rejection-reasons{style: 'display:none', class: error_class?(@error_presenter, :rejected_reason)}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %div
             = validation_error_message(@error_presenter, :rejected_reason)
+          %a#rejected_reason
           %legend.bold-normal.form-label
             = "Choose reason for rejection"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
@@ -69,10 +70,11 @@
               %div
                 = validation_error_message(@error_presenter, :rejected_reason_other)
 
-      .js-cw-claim-refuse-reasons{style: 'display:none'}
+      .js-cw-claim-refuse-reasons{style: 'display:none', class: error_class?(@error_presenter, :refused_reason)}
         %fieldset.form-group.nested-fields.indent-fieldset.spacer
           %div
             = validation_error_message(@error_presenter, :refused_reason)
+          %a#refused_reason
           %legend.bold-normal.form-label
             = "Choose reason for refusal"
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -151,7 +151,7 @@ module Claims
           params = {'state' => 'rejected', 'state_reason' => ['other'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
-          expect(updater.claim.errors[:rejected_reason_other]).to eq(['requires details when rejecting with other'])
+          expect(updater.claim.errors[:rejected_reason_other]).to eq(['needs a description'])
           expect(updater.claim.state).to eq 'allocated'
           expect(updater.claim.assessment.fees.to_f).to eq 0.0
           expect(updater.claim.assessment.expenses).to eq 0.0
@@ -173,7 +173,7 @@ module Claims
           params = {'state' => 'refused', 'state_reason' => ['other'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
-          expect(updater.claim.errors[:refused_reason_other]).to eq(['requires details when refusing with other'])
+          expect(updater.claim.errors[:refused_reason_other]).to eq(['needs a description'])
           expect(updater.claim.state).to eq 'allocated'
           expect(updater.claim.assessment.fees.to_f).to eq 0.0
           expect(updater.claim.assessment.expenses).to eq 0.0
@@ -257,7 +257,7 @@ module Claims
         end
 
         context 'if state_reason is other, but no text is supplied' do
-          it_behaves_like 'a failing assessment', 'rejected', ['requires details when rejecting with other'], 'redeterminations', ['other'], 0, 0, :rejected_reason_other
+          it_behaves_like 'a failing assessment', 'rejected', ['needs a description'], 'redeterminations', ['other'], 0, 0, :rejected_reason_other
         end
       end
     end

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -91,7 +91,7 @@ module Claims
       end
 
       context 'errors' do
-        it 'errors if no and and no values submitted' do
+        it 'errors if no state and and no values submitted' do
           params = {'assessment_attributes'=>{'fees'=>'0.00', 'expenses'=>'0.00', 'id'=>'3'}, 'state'=>''}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
@@ -140,7 +140,7 @@ module Claims
           params = {'state' => 'rejected', 'state_reason' => [''], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['requires a reason when rejecting'])
+          expect(updater.claim.errors[:rejected_reason]).to eq(['requires a reason when rejecting'])
           expect(updater.claim.state).to eq 'allocated'
           expect(updater.claim.assessment.fees.to_f).to eq 0.0
           expect(updater.claim.assessment.expenses).to eq 0.0
@@ -162,7 +162,7 @@ module Claims
           params = {'state' => 'refused', 'state_reason' => [''], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
           expect(updater.result).to eq :error
-          expect(updater.claim.errors[:determinations]).to eq(['requires a reason when refusing'])
+          expect(updater.claim.errors[:refused_reason]).to eq(['requires a reason when refusing'])
           expect(updater.claim.state).to eq 'allocated'
           expect(updater.claim.assessment.fees.to_f).to eq 0.0
           expect(updater.claim.assessment.expenses).to eq 0.0
@@ -253,11 +253,11 @@ module Claims
         end
 
         context 'if no state_reason are supplied' do
-          it_behaves_like 'a failing assessment', 'rejected', ['requires a reason when rejecting'], 'redeterminations', [''], '', 0
+          it_behaves_like 'a failing assessment', 'rejected', ['requires a reason when rejecting'], 'redeterminations', [''], '', 0, :rejected_reason
         end
 
         context 'if state_reason is other, but no text is supplied' do
-          it_behaves_like 'a failing assessment', 'rejected', ['requires details when rejecting with other'], 'assessment', ['other'], 0, 0, :rejected_reason_other
+          it_behaves_like 'a failing assessment', 'rejected', ['requires details when rejecting with other'], 'redeterminations', ['other'], 0, 0, :rejected_reason_other
         end
       end
     end

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -72,14 +72,11 @@ module Claims
         end
 
         context 'rejections' do
-          let(:params) { {'state' => 'rejected', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
           it_behaves_like 'a successful non-authorised claim with a single reason', 'rejected'
           it_behaves_like 'a successful non-authorised claim with other as reason', 'rejected'
         end
 
         context 'refusals' do
-          let(:params) { {'state' => 'refused', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
-
           it_behaves_like 'a successful non-authorised claim with a single reason', 'refused'
           it_behaves_like 'a successful non-authorised claim with other as reason', 'refused', ['other_refuse']
         end
@@ -94,6 +91,14 @@ module Claims
       end
 
       context 'errors' do
+        it 'errors if no and and no values submitted' do
+          params = {'assessment_attributes'=>{'fees'=>'0.00', 'expenses'=>'0.00', 'id'=>'3'}, 'state'=>''}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.assessment).to be_zero
+          expect(updater.claim.errors[:determinations]).to eq(['You should select a status'])
+        end
+
         it 'errors if part auth selected and no values' do
           params = {'assessment_attributes'=>{'fees'=>'0.00', 'expenses'=>'0.00', 'id'=>'3'}, 'state'=>'part_authorised'}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -72,14 +72,11 @@ module Claims
         end
 
         context 'rejections' do
-          let(:params) { {'state' => 'rejected', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
           it_behaves_like 'a successful non-authorised claim with a single reason', 'rejected'
           it_behaves_like 'a successful non-authorised claim with other as reason', 'rejected'
         end
 
         context 'refusals' do
-          let(:params) { {'state' => 'refused', 'state_reason' => ['no_indictment'], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}} }
-
           it_behaves_like 'a successful non-authorised claim with a single reason', 'refused'
           it_behaves_like 'a successful non-authorised claim with other as reason', 'refused'
         end
@@ -94,6 +91,14 @@ module Claims
       end
 
       context 'errors' do
+        it 'errors if no and and no values submitted' do
+          params = {'assessment_attributes'=>{'fees'=>'0.00', 'expenses'=>'0.00', 'id'=>'3'}, 'state'=>''}
+          updater = CaseWorkerClaimUpdater.new(claim.id, params).update!
+          expect(updater.result).to eq :error
+          expect(updater.claim.assessment).to be_zero
+          expect(updater.claim.errors[:determinations]).to eq(['You should select a status'])
+        end
+
         it 'errors if part auth selected and no values' do
           params = {'assessment_attributes'=>{'fees'=>'0.00', 'expenses'=>'0.00', 'id'=>'3'}, 'state'=>'part_authorised'}
           updater = CaseWorkerClaimUpdater.new(claim.id, params).update!


### PR DESCRIPTION
### What?
Display better errors to users when refusing or rejecting claims

### Why?
Case workers can reject or refuse claims, validation ensures this is completed, but currently the form does not re-render properly, selections are not completed and context errors are not displayed

### How? 
Extend the CaseWorkerClaimUpdater, add better granularity of error naming and descriptions
Update the view to display the users' choices and display context errors next to incorrect fields
