### PR TITLE
Add injection errors search filter value spec

### DIFF
--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -108,7 +108,7 @@ module API
       end
 
       def injection_errored
-        object.injection_errors.blank? ? 0 : 1
+        object.injection_errors.present?.to_i
       end
     end
   end

--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -18,6 +18,7 @@ module API
       expose :last_submitted_at_display
       expose :defendants
       expose :maat_references
+
       expose :filter do
         expose :disk_evidence
         expose :redetermination
@@ -31,9 +32,19 @@ module API
         expose :warrants
         expose :interim_disbursements
         expose :risk_based_bills
+        expose :injection_errors
       end
 
       private
+
+      def injection_error
+        I18n.t(:error, scope: %i[shared injection_errors]) if object.injection_attempts&.last&.active?
+      end
+
+      def injection_errors
+        puts 'INJECTION ERROR' if object&.injection_attempts&.last&.active?
+        object&.injection_attempts&.last&.active?.to_i
+      end
 
       def state_display
         object.state.humanize

--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -18,7 +18,7 @@ module API
       expose :last_submitted_at_display
       expose :defendants
       expose :maat_references
-      expose :injection_error
+      expose :injection_errors
 
       expose :filter do
         expose :disk_evidence
@@ -38,14 +38,6 @@ module API
 
       private
 
-      def injection_error
-        I18n.t(:error, scope: %i[shared injection_errors]) if object.injection_error.present?
-      end
-
-      def injection_errored
-        object.injection_error.blank? ? 0 : 1
-      end
-
       def state_display
         object.state.humanize
       end
@@ -60,6 +52,11 @@ module API
 
       def last_submitted_at_display
         object.last_submitted_at.strftime('%d/%m/%Y')
+      end
+
+      # for display purposes we only want to use the injection error header
+      def injection_errors
+        I18n.t(:error, scope: %i[shared injection_errors]) if object.injection_errors.present?
       end
 
       def disk_evidence
@@ -108,6 +105,10 @@ module API
 
       def risk_based_bills
         ((risk_based_class_letter && contains_risk_based_fee).eql?(true) && is_submitted?).to_i
+      end
+
+      def injection_errored
+        object.injection_errors.blank? ? 0 : 1
       end
     end
   end

--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -18,6 +18,7 @@ module API
       expose :last_submitted_at_display
       expose :defendants
       expose :maat_references
+      expose :injection_error
 
       expose :filter do
         expose :disk_evidence
@@ -32,18 +33,17 @@ module API
         expose :warrants
         expose :interim_disbursements
         expose :risk_based_bills
-        expose :injection_errors
+        expose :injection_errored
       end
 
       private
 
       def injection_error
-        I18n.t(:error, scope: %i[shared injection_errors]) if object.injection_attempts&.last&.active?
+        I18n.t(:error, scope: %i[shared injection_errors]) if object.injection_error.present?
       end
 
-      def injection_errors
-        puts 'INJECTION ERROR' if object&.injection_attempts&.last&.active?
-        object&.injection_attempts&.last&.active?.to_i
+      def injection_errored
+        object.injection_error.blank? ? 0 : 1
       end
 
       def state_display

--- a/app/interfaces/api/v2/query_helper.rb
+++ b/app/interfaces/api/v2/query_helper.rb
@@ -37,7 +37,7 @@ module API::V2
           ) AS graduated_fee_types,
           c.allocation_type,
           (
-            SELECT 'Claim not injection'
+            SELECT error_messages
             FROM
             (
               SELECT *
@@ -47,7 +47,7 @@ module API::V2
               LIMIT 1
             ) AS last_injection_attempt
             WHERE last_injection_attempt.deleted_at is NULL
-          ) AS injection_error
+          ) AS injection_errors
         FROM claims AS c
           LEFT OUTER JOIN defendants AS d
             ON c.id = d.claim_id

--- a/app/interfaces/api/v2/query_helper.rb
+++ b/app/interfaces/api/v2/query_helper.rb
@@ -35,7 +35,19 @@ module API::V2
             FROM fee_types
             WHERE type IN ('Fee::GraduatedFeeType')
           ) AS graduated_fee_types,
-          c.allocation_type
+          c.allocation_type,
+          (
+            SELECT 'Claim not injection'
+            FROM
+            (
+              SELECT *
+              FROM injection_attempts last_ia
+              WHERE last_ia.claim_id = c.id
+              ORDER BY last_ia.created_at
+              LIMIT 1
+            ) AS last_injection_attempt
+            WHERE last_injection_attempt.deleted_at is NULL
+          ) AS injection_error
         FROM claims AS c
           LEFT OUTER JOIN defendants AS d
             ON c.id = d.claim_id

--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -5,6 +5,10 @@ class Array
   include RemoteExtension
 end
 
+class Hash
+  include HashExtension
+end
+
 class String
   include StringExtension
 end

--- a/lib/extensions/hash_extension.rb
+++ b/lib/extensions/hash_extension.rb
@@ -1,0 +1,8 @@
+module HashExtension
+  def all_keys
+    each_with_object([]) do |(k, v), keys|
+      keys << k
+      keys.concat(v.all_keys) if v.is_a? Hash
+    end
+  end
+end

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -4,69 +4,98 @@ require 'spec_helper'
 describe API::Entities::SearchResult do
   subject(:search_result) { described_class.represent(claim) }
 
-  describe 'filters' do
-    subject(:filter) { JSON.parse(search_result.to_json)['filter'] }
+  context 'exposures' do
+    describe 'filters' do
+      subject(:filter) { JSON.parse(search_result.to_json, symbolize_names: true)[:filter] }
+      let(:result) do
+       {
+          disk_evidence: 0,
+          redetermination: 0,
+          fixed_fee: 0,
+          awaiting_written_reasons: 0,
+          cracked: 0,
+          trial: 0,
+          guilty_plea: 0,
+          graduated_fees: 0,
+          interim_fees: 0,
+          warrants: 0,
+          interim_disbursements: 0,
+          risk_based_bills: 0,
+          injection_errors: 0
+        }
+      end
 
-    context 'when passed a submitted case with a graduated fee ' do
-      let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
+      shared_examples 'returns expected JSON filter values' do
+        it 'returns expected JSON filterable values' do
+          is_expected.to eql result
+        end
+      end
 
-      it { is_expected.to eql result }
-    end
+      context 'when passed a submitted case with a graduated fee ' do
+        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(graduated_fees: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a redetermination case with a graduated fee ' do
-      let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'redetermination', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>1, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>0, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
+      context 'when passed a redetermination case with a graduated fee ' do
+        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'redetermination', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(redetermination: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator case with a risk based bill' do
+        let(:claim) {OpenStruct.new('id'=>'113336', 'uuid'=>'446fd8db-4441-4726-857c-3e80e440f5a2', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'T20170329', 'state'=>'submitted', 'court_name'=>'Chester', 'case_type'=>'Guilty plea', 'total'=>'556.11', 'disk_evidence'=>'f', 'external_user'=>'Ozella Adams', 'maat_references'=>'5782148', 'defendants'=>'Vallie King', 'fees'=>'30.0~Guilty plea~Fee::GraduatedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'H', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRGLT', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(guilty_plea: 1, graduated_fees: 1, risk_based_bills: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator case with a risk based bill' do
-      let(:claim) {OpenStruct.new('id'=>'113336', 'uuid'=>'446fd8db-4441-4726-857c-3e80e440f5a2', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'T20170329', 'state'=>'submitted', 'court_name'=>'Chester', 'case_type'=>'Guilty plea', 'total'=>'556.11', 'disk_evidence'=>'f', 'external_user'=>'Ozella Adams', 'maat_references'=>'5782148', 'defendants'=>'Vallie King', 'fees'=>'30.0~Guilty plea~Fee::GraduatedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'H', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRGLT', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>1, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>1} }
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator case with a final fee' do
+        let(:claim) {OpenStruct.new('id'=>'132506', 'uuid'=>'1344fb35-2337-4d22-b45a-5389315d06c5', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'S20170495', 'state'=>'redetermination', 'court_name'=>'Newcastle', 'case_type'=>'Committal for Sentence', 'total'=>'309.82', 'disk_evidence'=>'f', 'external_user'=>'Ole Hermann', 'maat_references'=>'5782148', 'defendants'=>'Zetta Rau', 'fees'=>'0.0~Committal for sentence hearings~Fee::FixedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'E', 'is_fixed_fee'=>'t', 'fee_type_code'=>'FXCSE', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(redetermination: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator case with a final fee' do
-      let(:claim) {OpenStruct.new('id'=>'132506', 'uuid'=>'1344fb35-2337-4d22-b45a-5389315d06c5', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'S20170495', 'state'=>'redetermination', 'court_name'=>'Newcastle', 'case_type'=>'Committal for Sentence', 'total'=>'309.82', 'disk_evidence'=>'f', 'external_user'=>'Ole Hermann', 'maat_references'=>'5782148', 'defendants'=>'Zetta Rau', 'fees'=>'0.0~Committal for sentence hearings~Fee::FixedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'E', 'is_fixed_fee'=>'t', 'fee_type_code'=>'FXCSE', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>1, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>0, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator case with Final fee' do
+        let(:claim) {OpenStruct.new('id' => '180772', 'uuid' => 'ef682b0b-82ef-4908-9b3f-3cee19acc148', 'scheme' => 'lgfs', 'scheme_type' => 'Final', 'case_number' => 'T20170981', 'state' => 'submitted', 'court_name' => 'Newcastle', 'case_type' => 'Elected cases not proceeded', 'total' => '396.4', 'disk_evidence' => 'f', 'external_user' => 'Name Padberg', 'maat_references' => '5924967', 'defendants' => 'Maybell Bahringer', 'fees' => '0.0~Elected case not proceeded~Fee::FixedFeeType', 'last_submitted_at' => '2017-12-08 14:55:58.416695', 'class_letter' => 'H', 'is_fixed_fee' => 't', 'fee_type_code' => 'FXENP', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(fixed_fee: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator case with Final fee' do
-      let(:claim) {OpenStruct.new('id' => '180772',	'uuid' => 'ef682b0b-82ef-4908-9b3f-3cee19acc148',	'scheme' => 'lgfs',	'scheme_type' => 'Final',	'case_number' => 'T20170981',	'state' => 'submitted',	'court_name' => 'Newcastle',	'case_type' => 'Elected cases not proceeded',	'total' => '396.4',	'disk_evidence' => 'f',	'external_user' => 'Name Padberg',	'maat_references' => '5924967',	'defendants' => 'Maybell Bahringer',	'fees' => '0.0~Elected case not proceeded~Fee::FixedFeeType',	'last_submitted_at' => '2017-12-08 14:55:58.416695',	'class_letter' => 'H',	'is_fixed_fee' => 't',	'fee_type_code' => 'FXENP',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>1, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>0, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator Disbursement only Interim fee' do
+        let(:claim) {OpenStruct.new('id' => '179473', 'uuid' => '7bca9dd7-0a32-442c-b399-85a2379609ad', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20170276', 'state' => 'submitted', 'court_name' => 'Worcester', 'case_type' => 'Trial', 'total' => '4652.64', 'disk_evidence' => 'f', 'external_user' => 'Stacey Bosco', 'maat_references' => '5853600', 'defendants' => 'Jordyn Marquardt', 'fees' => '0.0~Disbursement only~Fee::InterimFeeType', 'last_submitted_at' => '07/12/2017  10:30:54', 'class_letter' => 'D', 'is_fixed_fee' => 'f', 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(trial: 1, graduated_fees: 1, interim_disbursements: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator Disbursement only Interim fee' do
-      let(:claim) {OpenStruct.new('id' => '179473',	'uuid' => '7bca9dd7-0a32-442c-b399-85a2379609ad',	'scheme' => 'lgfs',	'scheme_type' => 'Interim',	'case_number' => 'T20170276',	'state' => 'submitted',	'court_name' => 'Worcester',	'case_type' => 'Trial',	'total' => '4652.64',	'disk_evidence' => 'f',	'external_user' => 'Stacey Bosco',	'maat_references' => '5853600',	'defendants' => 'Jordyn Marquardt',	'fees' => '0.0~Disbursement only~Fee::InterimFeeType',	'last_submitted_at' => '07/12/2017  10:30:54',	'class_letter' => 'D',	'is_fixed_fee' => 'f',	'fee_type_code' => 'GRTRL',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>1, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>1, 'risk_based_bills'=>0} }
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator warrant Interim fee' do
+        let(:claim) {OpenStruct.new('id' => '179818', 'uuid' => '887cbd94-3f48-4955-8646-918de4db3617', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20170081', 'state' => 'submitted', 'court_name' => 'Cambridge', 'case_type' => 'Trial', 'total' => '667.33', 'disk_evidence' => 'f', 'external_user' => 'Fernando Zboncak', 'maat_references' => '5663494', 'defendants' => 'Reta Stark', 'fees' => '0.0~Warrant~Fee::InterimFeeType', 'last_submitted_at' => '07/12/2017  12:58:29', 'class_letter' => 'B', 'is_fixed_fee' => 'f', 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(trial: 1, graduated_fees: 1, warrants: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator warrant Interim fee' do
-      let(:claim) {OpenStruct.new('id' => '179818',	'uuid' => '887cbd94-3f48-4955-8646-918de4db3617',	'scheme' => 'lgfs',	'scheme_type' => 'Interim',	'case_number' => 'T20170081',	'state' => 'submitted',	'court_name' => 'Cambridge',	'case_type' => 'Trial',	'total' => '667.33',	'disk_evidence' => 'f',	'external_user' => 'Fernando Zboncak',	'maat_references' => '5663494',	'defendants' => 'Reta Stark',	'fees' => '0.0~Warrant~Fee::InterimFeeType',	'last_submitted_at' => '07/12/2017  12:58:29',	'class_letter' => 'B',	'is_fixed_fee' => 'f',	'fee_type_code' => 'GRTRL',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>1, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>1, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator Interim fee' do
+        let(:claim) {OpenStruct.new('id' => '180773', 'uuid' => 'c4a9bf51-ffe1-40eb-8399-f9ae2510b417', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20171115', 'state' => 'submitted', 'court_name' => 'Liverpool', 'case_type' => 'Trial', 'total' => '213.3', 'disk_evidence' => 'f', 'external_user' => 'Eldridge Muller', 'maat_references' => '5841779', 'defendants' => 'Destini Thiel', 'fees' => '19.0~Effective PCMH~Fee::InterimFeeType', 'last_submitted_at' => '11/12/2017  10:37:06', 'class_letter' => 'H', 'is_fixed_fee' => 'f', 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        before { result.merge!(trial: 1, graduated_fees: 1, interim_fees: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator Interim fee' do
-      let(:claim) {OpenStruct.new('id' => '180773',	'uuid' => 'c4a9bf51-ffe1-40eb-8399-f9ae2510b417',	'scheme' => 'lgfs',	'scheme_type' => 'Interim',	'case_number' => 'T20171115',	'state' => 'submitted',	'court_name' => 'Liverpool',	'case_type' => 'Trial',	'total' => '213.3',	'disk_evidence' => 'f',	'external_user' => 'Eldridge Muller',	'maat_references' => '5841779',	'defendants' => 'Destini Thiel',	'fees' => '19.0~Effective PCMH~Fee::InterimFeeType',	'last_submitted_at' => '11/12/2017  10:37:06',	'class_letter' => 'H',	'is_fixed_fee' => 'f',	'fee_type_code' => 'GRTRL',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>1, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>1, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator Transfer fixed fee' do
+        let(:claim) {OpenStruct.new('id' => '179658', 'uuid' => '7464a789-16a2-482b-a37e-4ffb957be5a4', 'scheme' => 'lgfs', 'scheme_type' => 'Transfer', 'case_number' => 'T20170186', 'state' => 'submitted', 'court_name' => 'Bristol', 'case_type' => 'Transfer', 'total' => '257.81', 'disk_evidence' => 'f', 'external_user' => 'Stacey Bosco', 'maat_references' => '5696689', 'defendants' => 'Liam Huels', 'fees' => '44.0~Transfer~Fee::TransferFeeType', 'last_submitted_at' => '11/12/2017  10:37:06', 'class_letter' => 'D', 'is_fixed_fee' => 'f', 'fee_type_code' => '', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'allocation_type' => 'Fixed') }
+        before { result.merge!(fixed_fee: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator Transfer fixed fee' do
-      let(:claim) {OpenStruct.new('id' => '179658',	'uuid' => '7464a789-16a2-482b-a37e-4ffb957be5a4',	'scheme' => 'lgfs',	'scheme_type' => 'Transfer',	'case_number' => 'T20170186',	'state' => 'submitted',	'court_name' => 'Bristol',	'case_type' => 'Transfer',	'total' => '257.81',	'disk_evidence' => 'f',	'external_user' => 'Stacey Bosco',	'maat_references' => '5696689',	'defendants' => 'Liam Huels',	'fees' => '44.0~Transfer~Fee::TransferFeeType',	'last_submitted_at' => '11/12/2017  10:37:06',	'class_letter' => 'D',	'is_fixed_fee' => 'f',	'fee_type_code' => '',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR',	'allocation_type' => 'Fixed') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>1, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>0, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
-      it { is_expected.to eql result }
-    end
+      context 'when passed a litigator Transfer grad fee' do
+        let(:claim) {OpenStruct.new('id' => '179730', 'uuid' => '43016337-ca7a-4ac5-82a2-e32bd8174305', 'scheme' => 'lgfs', 'scheme_type' => 'Transfer', 'case_number' => 'T20177304', 'state' => 'submitted', 'court_name' => 'Croydon', 'case_type' => 'Transfer', 'total' => '333.67', 'disk_evidence' => 'f', 'external_user' => 'Emmanuelle Olson', 'maat_references' => '5864761', 'defendants' => 'Sadie Keeling', 'fees' => '0.0~Transfer~Fee::TransferFeeType', 'last_submitted_at' => '11/12/2017 10:37:06', 'class_letter' => 'B', 'is_fixed_fee' => 'f', 'fee_type_code' => '', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'allocation_type' => 'Grad') }
+        before { result.merge!(graduated_fees: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
 
-    context 'when passed a litigator Transfer grad fee' do
-      let(:claim) {OpenStruct.new('id' => '179730',	'uuid' => '43016337-ca7a-4ac5-82a2-e32bd8174305',	'scheme' => 'lgfs',	'scheme_type' => 'Transfer',	'case_number' => 'T20177304',	'state' => 'submitted',	'court_name' => 'Croydon',	'case_type' => 'Transfer',	'total' => '333.67',	'disk_evidence' => 'f',	'external_user' => 'Emmanuelle Olson',	'maat_references' => '5864761',	'defendants' => 'Sadie Keeling',	'fees' => '0.0~Transfer~Fee::TransferFeeType',	'last_submitted_at' => '11/12/2017 10:37:06',	'class_letter' => 'B',	'is_fixed_fee' => 'f',	'fee_type_code' => '',	'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR',	'allocation_type' => 'Grad') }
-      let(:result) { {'disk_evidence'=>0, 'redetermination'=>0, 'fixed_fee'=>0, 'awaiting_written_reasons'=>0, 'cracked'=>0, 'trial'=>0, 'guilty_plea'=>0, 'graduated_fees'=>1, 'interim_fees'=>0, 'warrants'=>0, 'interim_disbursements'=>0, 'risk_based_bills'=>0} }
-      it { is_expected.to eql result }
+      context 'when passed an advocate claims with an injection attempt error' do
+        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_errors'=>'') }
+        before { result.merge!(graduated_fees: 1, injection_errors: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
     end
   end
 end

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -38,7 +38,7 @@ describe API::Entities::SearchResult do
     it { is_expected.to expose :last_submitted_at_display }
     it { is_expected.to expose :defendants }
     it { is_expected.to expose :maat_references }
-    it { is_expected.to expose :injection_error }
+    it { is_expected.to expose :injection_errors }
 
     describe 'filters' do
       subject(:filter) { JSON.parse(search_result.to_json, symbolize_names: true)[:filter] }
@@ -141,7 +141,7 @@ describe API::Entities::SearchResult do
       end
 
       context 'when passed an advocate claims with an injection attempt error' do
-        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_error'=>'Claim not injected') }
+        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_errors'=>'Claim not injected') }
         before { result.merge!(graduated_fees: 1, injection_errored: 1) }
         include_examples 'returns expected JSON filter values'
       end

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -1,10 +1,45 @@
 require 'rails_helper'
 require 'spec_helper'
 
+RSpec::Matchers.define :expose do |expected|
+  match do |actual|
+    @hashed = JSON.parse(actual.to_json, symbolize_names: true).with_indifferent_access
+    @hashed.key?(expected)
+  end
+
+  description do
+    "expose the \"#{expected}\" attribute"
+  end
+
+  failure_message do |actual|
+    "expected JSON attributes #{@hashed.keys} to include \"#{expected}\""
+  end
+end
+
 describe API::Entities::SearchResult do
   subject(:search_result) { described_class.represent(claim) }
 
   context 'exposures' do
+    let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_error'=>'') }
+
+    it { is_expected.to expose :id }
+    it { is_expected.to expose :uuid }
+    it { is_expected.to expose :scheme }
+    it { is_expected.to expose :scheme_type }
+    it { is_expected.to expose :case_number }
+    it { is_expected.to expose :state }
+    it { is_expected.to expose :state_display }
+    it { is_expected.to expose :court_name }
+    it { is_expected.to expose :case_type }
+    it { is_expected.to expose :total }
+    it { is_expected.to expose :total_display }
+    it { is_expected.to expose :external_user }
+    it { is_expected.to expose :last_submitted_at }
+    it { is_expected.to expose :last_submitted_at_display }
+    it { is_expected.to expose :defendants }
+    it { is_expected.to expose :maat_references }
+    it { is_expected.to expose :injection_error }
+
     describe 'filters' do
       subject(:filter) { JSON.parse(search_result.to_json, symbolize_names: true)[:filter] }
       let(:result) do
@@ -21,9 +56,23 @@ describe API::Entities::SearchResult do
           warrants: 0,
           interim_disbursements: 0,
           risk_based_bills: 0,
-          injection_errors: 0
+          injection_errored: 0
         }
       end
+
+      # it { is_expected.to expose :disk_evidence }
+      # it { is_expected.to expose :redetermination }
+      # it { is_expected.to expose :fixed_fee }
+      # it { is_expected.to expose :awaiting_written_reasons }
+      # it { is_expected.to expose :cracked }
+      # it { is_expected.to expose :trial }
+      # it { is_expected.to expose :guilty_plea }
+      # it { is_expected.to expose :graduated_fees }
+      # it { is_expected.to expose :interim_fees }
+      # it { is_expected.to expose :warrants }
+      # it { is_expected.to expose :interim_disbursements }
+      # it { is_expected.to expose :risk_based_bills }
+      # it { is_expected.to expose :injection_errored }
 
       shared_examples 'returns expected JSON filter values' do
         it 'returns expected JSON filterable values' do
@@ -92,8 +141,8 @@ describe API::Entities::SearchResult do
       end
 
       context 'when passed an advocate claims with an injection attempt error' do
-        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_errors'=>'') }
-        before { result.merge!(graduated_fees: 1, injection_errors: 1) }
+        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>'f', 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>'f', 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_error'=>'Claim not injected') }
+        before { result.merge!(graduated_fees: 1, injection_errored: 1) }
         include_examples 'returns expected JSON filter values'
       end
     end

--- a/spec/api/v2/search_spec.rb
+++ b/spec/api/v2/search_spec.rb
@@ -18,12 +18,43 @@ describe API::V2::Search do
   let(:case_worker_admin) { create(:case_worker, :admin) }
   let(:l33t_h4xx0r) { create(:external_user) }
   let(:api_key) { case_worker_admin.user.api_key }
-  let(:params) do
-    {
-        api_key: api_key,
-        scheme: 'agfs'
-    }
-  end
+  let(:params) { { api_key: api_key, scheme: 'agfs' } }
+  let(:search_keys) {
+                      %i[
+                          id
+                          uuid
+                          scheme
+                          scheme_type
+                          case_number
+                          state
+                          state_display
+                          court_name
+                          case_type
+                          total
+                          total_display
+                          external_user
+                          last_submitted_at
+                          last_submitted_at_display
+                          defendants
+                          maat_references
+                          injection_error
+                          filter
+                          disk_evidence
+                          redetermination
+                          fixed_fee
+                          awaiting_written_reasons
+                          cracked
+                          trial
+                          guilty_plea
+                          graduated_fees
+                          interim_fees
+                          warrants
+                          interim_disbursements
+                          risk_based_bills
+                          injection_errored
+                      ]
+                    }
+
 
   def do_request
     get get_claims_endpoint, params, format: :json
@@ -47,22 +78,24 @@ describe API::V2::Search do
     end
 
     context 'when accessed by a CaseWorker' do
-      it 'should return a JSON with the required information' do
-        response = do_request
-        expect(response.status).to eq 200
+      before { do_request }
 
-        body = JSON.parse(response.body, symbolize_names: true)
-        cw = body.first
+      it 'returns success' do
+        expect(last_response).to be_ok
+      end
 
-        expect(cw.keys).to eq([:id, :uuid, :scheme, :scheme_type, :case_number, :state, :state_display, :court_name, :case_type, :total, :total_display, :external_user, :last_submitted_at, :last_submitted_at_display, :defendants, :maat_references, :filter])
+      it 'returns JSON with the required search result keys' do
+        search_result_keys = JSON.parse(last_response.body, symbolize_names: true).first.all_keys
+        expect(search_result_keys).to eq(search_keys)
       end
     end
+
     context 'when accessed by a ExternalUser' do
+      before { do_request }
       let(:api_key) { l33t_h4xx0r.user.api_key }
 
       it 'returns unauthorised' do
-        do_request
-        expect(last_response.status).to eq 401
+        expect(last_response).to be_unauthorized
         expect(last_response.body).to include('Unauthorised')
       end
     end

--- a/spec/api/v2/search_spec.rb
+++ b/spec/api/v2/search_spec.rb
@@ -9,7 +9,9 @@ describe API::V2::Search do
   include DatabaseHousekeeping
 
   before(:all) do
-    create(:deterministic_claim, :redetermination)
+    create(:deterministic_claim, :redetermination) do |claim|
+      create(:injection_attempt, :with_errors, claim: claim)
+    end
   end
 
   after(:all) { clean_database }
@@ -37,7 +39,7 @@ describe API::V2::Search do
                           last_submitted_at_display
                           defendants
                           maat_references
-                          injection_error
+                          injection_errors
                           filter
                           disk_evidence
                           redetermination
@@ -87,6 +89,11 @@ describe API::V2::Search do
       it 'returns JSON with the required search result keys' do
         search_result_keys = JSON.parse(last_response.body, symbolize_names: true).first.all_keys
         expect(search_result_keys).to eq(search_keys)
+      end
+
+      it 'returns JSON expected values' do
+        search_result = JSON.parse(last_response.body, symbolize_names: true).first
+        expect(search_result[:injection_errors]).to eql 'Claim not injected'
       end
     end
 

--- a/spec/api/v2/search_spec.rb
+++ b/spec/api/v2/search_spec.rb
@@ -91,7 +91,7 @@ describe API::V2::Search do
         expect(search_result_keys).to eq(search_keys)
       end
 
-      it 'returns JSON expected values' do
+      it 'returns JSON with expected injection error message' do
         search_result = JSON.parse(last_response.body, symbolize_names: true).first
         expect(search_result[:injection_errors]).to eql 'Claim not injected'
       end

--- a/vcr/cassettes/features/case_workers/admin/allocation.yml
+++ b/vcr/cassettes/features/case_workers/admin/allocation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers?api_key=a5b81bcc-82e3-41c8-b807-8b2c6477974f
+    uri: http://localhost:3001/api/case_workers?api_key=2e6db5de-2270-4456-853f-81e18d1f57e8
     body:
       encoding: US-ASCII
       string: ''
@@ -27,24 +27,24 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"165775bd42afa37023d94d67da46a11f"
+      - W/"6821528eda95aa84b97860b2682236ef"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b1588f36-de97-42d7-99cd-54725fa13aa9
+      - 35541b59-57c4-4ac3-b191-7c14bd7e50a9
       X-Runtime:
-      - '0.176078'
+      - '0.176830'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJ4yXVoAA1yOuQ7CMBBE/8V1bNnJxompKKgQHSVCaOODGJxEykGD+HcckDjS7T7N6M3hTrwhK5GQaZoPgiqVmdaKYqoUBQBHleCOmlLkuYLcSpQkIc73w3hqsbGxs+3qNrKAX7Rv/FhHZhv0If6XGGHDDNcBkZ27G5uu5JG89elHry2oVEBGDceCglOalpW2lEuBzkCBnFdL/Qb7bunfWdPa/meAmUMsvPDfhOMTAAD//wMAMRa1CwMBAAA=
+        H4sIAKzqYVoAA1yOyw7CIBBF/4V1ISBQwZVrY9y4NMYMBSqWtkkfboz/Lq2Jj+5mTu7NuacHChZtWIbGcTrQWhnGKPdYU0Gx4FRjxaXHXgGw3FClNUcZ8qHrh0sDtUudXXttEovwRcc6DNfEXA0hpv+WIqSf4DYCkLK9k7FCz+ytX330EpywDCguLGNYWO1xMuZYFo5qy4y0uVnqD6EKAywG7F3Ztf3PgmZOkTjzvxHnFwAAAP//AwDeRRm9BQEAAA==
     http_version: 
-  recorded_at: Mon, 15 Jan 2018 23:00:46 GMT
+  recorded_at: Fri, 19 Jan 2018 12:55:08 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=a5b81bcc-82e3-41c8-b807-8b2c6477974f&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
+    uri: http://localhost:3001/api/case_workers/claims?api_key=2e6db5de-2270-4456-853f-81e18d1f57e8&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
     body:
       encoding: US-ASCII
       string: ''
@@ -69,24 +69,24 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"f763942b6c22e350f1e38d51a2214137"
+      - W/"9b6b6cee2af9f765021c0961940bdacb"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 4d3f7913-5c73-4c21-ba84-2a288ec124c1
+      - b9fc79f8-62b1-40af-ba16-3ba2f374aa5e
       X-Runtime:
-      - '0.318446'
+      - '0.276747'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJ8yXVoAA+yXWW/kxhHHv8qCz2qh70NPShTHOZTYyS6S2MZiUH3t0OIhN8mVtYv97inOjobyiBrAWPjBgJ5m2E12Vdfx639/rG7hXd3BWPdddfGxClMpqRs3OJqqC3ZWjf0Ize5xePQc+qkbqwt1VjV1W4+b99BM+D5Xn86qekwtvvvDx6qOu0+maf5TsRycTdESCFYTmUMm3kkgjudAlZI5Bl+dVQGGtOmm1qeCH73hlGlKKcOZYYQRjVTD5NHmmCKOjfe389BVA3V7cfGH+L4P+NLuEWcbGMbN4fUNoMsVLmgJZYSpN1xcUHoh5ffVfl/zDs7pWfUexg20+z3OA/1t6nCB3JdNSTGNqbSHoGVohnRW3ZXZSIfzMPTdsOmnER3uYt29O7wT6+Fmk97XMXUhHUbbNAxzfB+iivamDpeJm5WZ9DMa7zAF0zAH6DjISXrIiQExSmGQg2DEhygJ5zFxYTy1QuBuc10wMh20c/D+lLquHh7CtR98PaZtwbHUQo1xqXKB7qZO50PY1k2TyqUHzBGELQ6UHmNSzrs0Vpj/mHLqInTjWhFwy12ULhAvRCbSWiwHgU6mKKnwoJW2+ti/b4Y7aGJ/5OCfp+4GhyKme9Pnja/LuJ2rzNl9enGypNuSBqznXao2fUE317wSUhswjBMRuSEy6kBstliannkZNBeKz1FrAeui4PbK5/xVwlHmGOeO7T35XF+a4FKMYTA+G+IHQw4k9YlykgMTuH0uCHCsR60DY9pHw6xZMyQp45oyIelTQwINvf30dt85nxtiv0FqzFm1j9cVzr56g7OvZmfrYZPrn+eSTkshlvTTVJe53AqEG5ycLQ1Pp8dSYwH+chKapr/b3IZ2Oy+5d+P4w+N9jWV6PF3S2sqlb+anHyp4l3dVOv/gdh/MYHNEXKubmmamT/djCrtsA7Zje7urwjk4/VTGh8Aop+08NH9X/ef6iswh2cfpq7ZNpQ5bclX6DnYzu2/3W6pC6e+66tPT3FJrZKBBz0WEuRUK+UYhE4F5A5mF0MY+yzf+wrcTfHvUQBY89hsCzduInYr/rMieKGqEt54HFdUxP/4GLW79l/S4TtB1uLsFcDMpmnR/2d/0HRZc2J6Hvn2GZ4s/EgIHqSjhNFhMekjEBjCEzyXGjNee0mN//pLGsU5HDn09jTf93XBTfxnTxMEzi6QVTkYSYkbSSukRNTQT5pSBiBQK66jhxkjEoZTqJNPkYkga4/18xiSr8MhxlFgKiSjvMAbgbRZuzZBVzGLklNC/kml2hWn8hWlOuwPTrq7/R/jCtD/C+OHVX7uwGztFs6V8IjYSU1ITJbHHJE+aOOoEsVgfXmgGWNrP0kz8hjRTv3uaLUF2KfqcBBBrgBGJ+EI1TA2xzDsVUREzy47p8dUwpgxdDUcA+W+qhwF3+RhpONPA5q5vcr5Eok3N+OFBtp3X/TNwW9xL1DlrMP0hUoSty4GAsgxPNB641VpzCk/F5I+wPXLtCiNcY2jTl7FNHRxTNIKetaNNfKauwH9aClS5UqQktdR2Xa8ZZjiKNmVOsk0vctWkgIoUoW48YAQsRU2IWRIKjJCJssDTqiFsHUWppivC8CTb3ArbxAvbnKEHtv3zu2+IWNj2pr8nr7G223Y3eopu8lHjBRUi83hOI1+k8igjsNoJRBNYwgxHAc/STb7Q7QTdliDnLKxMCYjKkeMRghdSCykiPhQAKmXJ4pO73lXf1N0RPv49jdtUcL/xEdtSue8uwzSLdRjhhFZb/FHJMZtlIArwgiyzZ9jWFEh2weYYgEr7VKvdt3Dsz3XKGW/AXwYzszDG+eh1CMRIg7UYKdImOizNbIVUmWuj9BpjjMVLodVMnBZqdhFqDHGOdxGivccLig5Y9JAjWksM1bMA5/26UNMM9SxfU4SnYGbpCszkC8ycYQeYXf/reyIfwaykaUzNK+zVV6+xc3dzp5C2nIk20MSVNCRZijKcI9w8xzsonocZtZozsJNl60hTvyHS9O8eaUuQhZI2OB0JyIBBNjHhpQp71RgGGGwegg/HCLlOXV+O1do/oPw0QYmP5Vrsuw4um9TepHNff3iGZ4szBnzWGRwRACjR8YwkPrtMqDcZ21w48ZSv12jjyd3zCsr4pTxzB7c85ZmpjFeFnFHUMoWFmPDiqYEmhbIW6W9XMSO4VkxSI0/yjNHlFFeeGY162YWAV1zOOfHWBuIjFZ5TbimHNUvaOMMNV+pXqjPLVoCmXoCG0TwA7bvXXxO1AO3v0+0WGvLtVOL9bnwVZm8//V8AAAAA//8DACpQGRCIGAAA
+        H4sIAKzqYVoAA+yYWW/bSBKA/4rBZ7fR9+Enz8zuZJADm8wGecggEPqothhRpLdJ2pME/u9blBXRkWUBQZCHAWxAMNXV7Kqu4+tqfamu/GXd+qHu2ur8SxXHUqAdFjgK1Tk7rYZu8M3ma3/ve+zGdqjO1WnV1Ot6WFz7ZsT5XN2eVvUAa5z715eqTptXxnF6qIJKLooARMSkiQwgidXMEKWT1ImKJH2qTqvoe1i04zpAwZfecso0pZShpB/8gEqqfgyoc4Bp9vDpahr6rfH1+vz8l3TdRZy0+YrSxvfDYjd94dHkChe0hDLC3FvGz5U6p+p9td3XtIMzelpd+2Hh19s9TgPdFbS4QO7KokCCAcp657Tsmx5Oq5syKWlR7vuu7RfdOKDBbarby92cVPerBVzXCdoIu9E19P3k369eRX1ji8ukxQEJ/I3KWwzB2E8O2neyAnDoMEW4i47IqCVxKUXijZcyRW+dnFyZ64Keaf16ct7vTffVV9uRVz7Cx1V3XUcUwNrX6Jmqa2AxNk2p4/IigF/69qyFocKIJ8jQJt8Oh8LuBZXWW0Om+BIpjSBBaEtA2uw1foRT+xb9u/ns90z6Y4Smx7GE4V10eRHqMixxnDm7DScKC1wV6DF/N6FZdCVBOWQTgGc80kCy95iKjkZiTeCEK2mcM8CCtLjc2mMeFNxcuYtXJYxTFqdrvrXkLp80YZwwha64U8R3ioTwLmmHu81cESl8JkEDKhJUWGkU40IfUmQUOk1Ibu03isy0Uyqr2w+3H7aVclcA2w1yd1pt/fUbCk/eovBkinfdL3L995TBMOddgf+NdZmyq/i4QuGkqH8oHkqN+fat0DdNd7O4iuvltOTWiv0X97c1lPG+uMChlQvm2RSzyl/mKeDN9A93+1UN1kLCtVpMxQk27UeIm2B7rL711SYFJ990Yxm++oVrMY1Mr1Vv/nxPJo9s3fRiXLanJy8h9OiCEyxXfO7jcjNls8Z2a1Us3U1b3T4MsdGcOqB2CqzFirOY31oCiYoaCDwyjPejWOM/EWv6H4+12ckUC4YqPDuMnApWYOk6mbCY0LssWO9CeIC1d1DSPkWe4/M9pGEG+sXlOKy6m35VX3xEqR+hHOHabJKNhipDJSJtMgkUxj1ZjLtm1iTKOdAHJv3RFfRlD3tW/dLg6A1MQPshwImdcQ4McCcMsSJiUlLFiY8B16GJahlioOkg4DhiSWlHrTsKODkroi5yISXJUSPdVQaCBw8jmkcjpDbg3EHASS0o4xxL57sAJ+gBwPEnwGm5A9zL128InwH3CobP5EXTxVW3GT4GtXv5o3TIVkbCoohEGszrAECJ8xK4zIpRGx6FmniC2hGozU7GzUVrnCQpeU8kZx4Jgq2ISdgqZY7dEbf7BHkGXbmsfbsPtl+nCN8jW9ONde/P+mUNTeovQtfHbo010H6u4WzzzmG+zdZpniVjCmOeGKaAxDBYxiXBuuYJDPfe6n3rXnn0Gvr5W9v+09yN/QDZ1M6snHI2PmZsJxk2uDonvEVAJlowifYprSEcAo611uAfM+Yo2fR8ricVoxKaKIfgxNbNItmSISFAVMAkyMOKsG+zzmrOxfeRjR0gm3gim1Y7sj1/95qImWyvfVlBIb8DlvunjeAY2+YjSzjOlIhINOkMBpYbghcAPLew9w9ZWOo8PMo2+RPZZv7xbJudHCOPwJUn2dk4OTkQn/ESyLSOJltHlX3Atn/58oAdrzBXcP0ZbJ+6BjfjF6HAagUX2Kt73MVZ7B4B2mySztisZI2XL0ORHNick0ClItQYmowJGUTYN+m5r8v+5fi/Q+nW/geBZnZmSSc5CEmJSmiM9Cajp/DGGFT2igbNeEqHOOO4MEI4ZN5RoNmZnJBocMhLJzV2rRSPG4vdGTEh5ASacpXMIUXKOG7wKBDfdxcV/ADQ5BPQtN4B7dn7F0Teu4tilWGynzwr3Xi1ERwD2nwkSoXdvneZiIAYwx5c4iHFMbAUlHR4ybQ+Pwo09QS0I0CbnWyNVy4bge0AxYsONkfEmyQIE8oGSJxbC/v0eOvb+sHvWLjDDTzmTu0GmuZiNQ5xeVa3+TGQzaYoZbW2IIgBRomMyRKMsCLaJaMRrhHbyQds7dbQ1psW8WfcPN1M2eSylABEKI6UzcYQT/nU2YLKyWubhDpMGWycBOarPoozRuc7SvQOHMUGLcvpNwGL4JQM8UYZk1mA55vr/8MGjWunlbOcfh/PxAGeqSeeaTNfPd+8I2rm2UtYtlOD5pfYn6nHcPbh9v8CAAAA//8DABfBybqEGAAA
     http_version: 
-  recorded_at: Mon, 15 Jan 2018 23:00:47 GMT
+  recorded_at: Fri, 19 Jan 2018 12:55:08 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers?api_key=a5b81bcc-82e3-41c8-b807-8b2c6477974f
+    uri: http://localhost:3001/api/case_workers?api_key=2e6db5de-2270-4456-853f-81e18d1f57e8
     body:
       encoding: US-ASCII
       string: ''
@@ -111,24 +111,24 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"d52fc3e85a9e8fc8a007be640a072cd8"
+      - W/"e56d30385066553498483fe77d06a09e"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 471f32a3-af2b-47ce-9a44-61c5fc8a1f75
+      - 6b79afc5-301f-4ab0-bf03-2359f8bea75e
       X-Runtime:
-      - '0.010372'
+      - '0.007523'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJ8yXVoAA1yOuQ7CMBBE/8V1bNnJxompKKgQHSVCaOODGJxEykGD+HcckDjS7T7N6M3hTrwhK5GQaZoPgiqVmdaKYqoUBQBHleCOmlLkuYLcSpQkIc73w3hqsbGxs+3qNrKAX7Rv/FhHZhv0If6XGGHDDNcBkZ27G5uu5JG89elHry2oVEBGDceCglOalpW2lEuBzkCBnFdL/Qb7bunfWdPa/meAmUMsvPDfhOMTAAD//wMAMRa1CwMBAAA=
+        H4sIAK3qYVoAA1yOyw7CIBBF/4V1ISBQwZVrY9y4NMYMBSqWtkkfboz/Lq2Jj+5mTu7NuacHChZtWIbGcTrQWhnGKPdYU0Gx4FRjxaXHXgGw3FClNUcZ8qHrh0sDtUudXXttEovwRcc6DNfEXA0hpv+WIqSf4DYCkLK9k7FCz+ytX330EpywDCguLGNYWO1xMuZYFo5qy4y0uVnqD6EKAywG7F3Ztf3PgmZOkTjzvxHnFwAAAP//AwDeRRm9BQEAAA==
     http_version: 
-  recorded_at: Mon, 15 Jan 2018 23:00:47 GMT
+  recorded_at: Fri, 19 Jan 2018 12:55:09 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=a5b81bcc-82e3-41c8-b807-8b2c6477974f&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
+    uri: http://localhost:3001/api/case_workers/claims?api_key=2e6db5de-2270-4456-853f-81e18d1f57e8&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
     body:
       encoding: US-ASCII
       string: ''
@@ -153,24 +153,24 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"f763942b6c22e350f1e38d51a2214137"
+      - W/"19abd5bf831fed63b21315d98a3f0e95"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 814e1252-5e66-455c-b982-002c6a17d4d6
+      - 41e8978a-df1b-41bd-bc94-6604d109ae92
       X-Runtime:
-      - '0.167497'
+      - '0.159651'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAJ8yXVoAA+yXWW/kxhHHv8qCz2qh70NPShTHOZTYyS6S2MZiUH3t0OIhN8mVtYv97inOjobyiBrAWPjBgJ5m2E12Vdfx639/rG7hXd3BWPdddfGxClMpqRs3OJqqC3ZWjf0Ize5xePQc+qkbqwt1VjV1W4+b99BM+D5Xn86qekwtvvvDx6qOu0+maf5TsRycTdESCFYTmUMm3kkgjudAlZI5Bl+dVQGGtOmm1qeCH73hlGlKKcOZYYQRjVTD5NHmmCKOjfe389BVA3V7cfGH+L4P+NLuEWcbGMbN4fUNoMsVLmgJZYSpN1xcUHoh5ffVfl/zDs7pWfUexg20+z3OA/1t6nCB3JdNSTGNqbSHoGVohnRW3ZXZSIfzMPTdsOmnER3uYt29O7wT6+Fmk97XMXUhHUbbNAxzfB+iivamDpeJm5WZ9DMa7zAF0zAH6DjISXrIiQExSmGQg2DEhygJ5zFxYTy1QuBuc10wMh20c/D+lLquHh7CtR98PaZtwbHUQo1xqXKB7qZO50PY1k2TyqUHzBGELQ6UHmNSzrs0Vpj/mHLqInTjWhFwy12ULhAvRCbSWiwHgU6mKKnwoJW2+ti/b4Y7aGJ/5OCfp+4GhyKme9Pnja/LuJ2rzNl9enGypNuSBqznXao2fUE317wSUhswjBMRuSEy6kBstliannkZNBeKz1FrAeui4PbK5/xVwlHmGOeO7T35XF+a4FKMYTA+G+IHQw4k9YlykgMTuH0uCHCsR60DY9pHw6xZMyQp45oyIelTQwINvf30dt85nxtiv0FqzFm1j9cVzr56g7OvZmfrYZPrn+eSTkshlvTTVJe53AqEG5ycLQ1Pp8dSYwH+chKapr/b3IZ2Oy+5d+P4w+N9jWV6PF3S2sqlb+anHyp4l3dVOv/gdh/MYHNEXKubmmamT/djCrtsA7Zje7urwjk4/VTGh8Aop+08NH9X/ef6iswh2cfpq7ZNpQ5bclX6DnYzu2/3W6pC6e+66tPT3FJrZKBBz0WEuRUK+UYhE4F5A5mF0MY+yzf+wrcTfHvUQBY89hsCzduInYr/rMieKGqEt54HFdUxP/4GLW79l/S4TtB1uLsFcDMpmnR/2d/0HRZc2J6Hvn2GZ4s/EgIHqSjhNFhMekjEBjCEzyXGjNee0mN//pLGsU5HDn09jTf93XBTfxnTxMEzi6QVTkYSYkbSSukRNTQT5pSBiBQK66jhxkjEoZTqJNPkYkga4/18xiSr8MhxlFgKiSjvMAbgbRZuzZBVzGLklNC/kml2hWn8hWlOuwPTrq7/R/jCtD/C+OHVX7uwGztFs6V8IjYSU1ITJbHHJE+aOOoEsVgfXmgGWNrP0kz8hjRTv3uaLUF2KfqcBBBrgBGJ+EI1TA2xzDsVUREzy47p8dUwpgxdDUcA+W+qhwF3+RhpONPA5q5vcr5Eok3N+OFBtp3X/TNwW9xL1DlrMP0hUoSty4GAsgxPNB641VpzCk/F5I+wPXLtCiNcY2jTl7FNHRxTNIKetaNNfKauwH9aClS5UqQktdR2Xa8ZZjiKNmVOsk0vctWkgIoUoW48YAQsRU2IWRIKjJCJssDTqiFsHUWppivC8CTb3ArbxAvbnKEHtv3zu2+IWNj2pr8nr7G223Y3eopu8lHjBRUi83hOI1+k8igjsNoJRBNYwgxHAc/STb7Q7QTdliDnLKxMCYjKkeMRghdSCykiPhQAKmXJ4pO73lXf1N0RPv49jdtUcL/xEdtSue8uwzSLdRjhhFZb/FHJMZtlIArwgiyzZ9jWFEh2weYYgEr7VKvdt3Dsz3XKGW/AXwYzszDG+eh1CMRIg7UYKdImOizNbIVUmWuj9BpjjMVLodVMnBZqdhFqDHGOdxGivccLig5Y9JAjWksM1bMA5/26UNMM9SxfU4SnYGbpCszkC8ycYQeYXf/reyIfwaykaUzNK+zVV6+xc3dzp5C2nIk20MSVNCRZijKcI9w8xzsonocZtZozsJNl60hTvyHS9O8eaUuQhZI2OB0JyIBBNjHhpQp71RgGGGwegg/HCLlOXV+O1do/oPw0QYmP5Vrsuw4um9TepHNff3iGZ4szBnzWGRwRACjR8YwkPrtMqDcZ21w48ZSv12jjyd3zCsr4pTxzB7c85ZmpjFeFnFHUMoWFmPDiqYEmhbIW6W9XMSO4VkxSI0/yjNHlFFeeGY162YWAV1zOOfHWBuIjFZ5TbimHNUvaOMMNV+pXqjPLVoCmXoCG0TwA7bvXXxO1AO3v0+0WGvLtVOL9bnwVZm8//V8AAAAA//8DACpQGRCIGAAA
+        H4sIAK3qYVoAA+yYWW/bSBKA/4rBZ7fR9+Enz8zuZJADm8wGecggEPqothhRpLdJ2pME/u9blBXRkWUBQZCHAWxAMNXV7Kqu4+tqfamu/GXd+qHu2ur8SxXHUqAdFjgK1Tk7rYZu8M3ma3/ve+zGdqjO1WnV1Ot6WFz7ZsT5XN2eVvUAa5z715eqTptXxnF6qIJKLooARMSkiQwgidXMEKWT1ImKJH2qTqvoe1i04zpAwZfecso0pZShpB/8gEqqfgyoc4Bp9vDpahr6rfH1+vz8l3TdRZy0+YrSxvfDYjd94dHkChe0hDLC3FvGz5U6p+p9td3XtIMzelpd+2Hh19s9TgPdFbS4QO7KokCCAcp657Tsmx5Oq5syKWlR7vuu7RfdOKDBbarby92cVPerBVzXCdoIu9E19P3k369eRX1ji8ukxQEJ/I3KWwzB2E8O2neyAnDoMEW4i47IqCVxKUXijZcyRW+dnFyZ64Keaf16ct7vTffVV9uRVz7Cx1V3XUcUwNrX6Jmqa2AxNk2p4/IigF/69qyFocKIJ8jQJt8Oh8LuBZXWW0Om+BIpjSBBaEtA2uw1foRT+xb9u/ns90z6Y4Smx7GE4V10eRHqMixxnDm7DScKC1wV6DF/N6FZdCVBOWQTgGc80kCy95iKjkZiTeCEK2mcM8CCtLjc2mMeFNxcuYtXJYxTFqdrvrXkLp80YZwwha64U8R3ioTwLmmHu81cESl8JkEDKhJUWGkU40IfUmQUOk1Ibu03isy0Uyqr2w+3H7aVclcA2w1yd1pt/fUbCk/eovBkinfdL3L995TBMOddgf+NdZmyq/i4QuGkqH8oHkqN+fat0DdNd7O4iuvltOTWiv0X97c1lPG+uMChlQvm2RSzyl/mKeDN9A93+1UN1kLCtVpMxQk27UeIm2B7rL711SYFJ990Yxm++oVrMY1Mr1Vv/nxPJo9s3fRiXLanJy8h9OiCEyxXfO7jcjNls8Z2a1Us3U1b3T4MsdGcOqB2CqzFirOY31oCiYoaCDwyjPejWOM/EWv6H4+12ckUC4YqPDuMnApWYOk6mbCY0LssWO9CeIC1d1DSPkWe4/M9pGEG+sXlOKy6m35VX3xEqR+hHOHabJKNhipDJSJtMgkUxj1ZjLtm1iTKOdAHJv3RFfRlD3tW/dLg6A1MQPshwImdcQ4McCcMsSJiUlLFiY8B16GJahlioOkg4DhiSWlHrTsKODkroi5yISXJUSPdVQaCBw8jmkcjpDbg3EHASS0o4xxL57sAJ+gBwPEnwGm5A9zL128InwH3CobP5EXTxVW3GT4GtXv5o3TIVkbCoohEGszrAECJ8xK4zIpRGx6FmniC2hGozU7GzUVrnCQpeU8kZx4Jgq2ISdgqZY7dEbf7BHkGXbmsfbsPtl+nCN8jW9ONde/P+mUNTeovQtfHbo010H6u4WzzzmG+zdZpniVjCmOeGKaAxDBYxiXBuuYJDPfe6n3rXnn0Gvr5W9v+09yN/QDZ1M6snHI2PmZsJxk2uDonvEVAJlowifYprSEcAo611uAfM+Yo2fR8ricVoxKaKIfgxNbNItmSISFAVMAkyMOKsG+zzmrOxfeRjR0gm3gim1Y7sj1/95qImWyvfVlBIb8DlvunjeAY2+YjSzjOlIhINOkMBpYbghcAPLew9w9ZWOo8PMo2+RPZZv7xbJudHCOPwJUn2dk4OTkQn/ESyLSOJltHlX3Atn/58oAdrzBXcP0ZbJ+6BjfjF6HAagUX2Kt73MVZ7B4B2mySztisZI2XL0ORHNick0ClItQYmowJGUTYN+m5r8v+5fi/Q+nW/geBZnZmSSc5CEmJSmiM9Cajp/DGGFT2igbNeEqHOOO4MEI4ZN5RoNmZnJBocMhLJzV2rRSPG4vdGTEh5ASacpXMIUXKOG7wKBDfdxcV/ADQ5BPQtN4B7dn7F0Teu4tilWGynzwr3Xi1ERwD2nwkSoXdvneZiIAYwx5c4iHFMbAUlHR4ybQ+Pwo09QS0I0CbnWyNVy4bge0AxYsONkfEmyQIE8oGSJxbC/v0eOvb+sHvWLjDDTzmTu0GmuZiNQ5xeVa3+TGQzaYoZbW2IIgBRomMyRKMsCLaJaMRrhHbyQds7dbQ1psW8WfcPN1M2eSylABEKI6UzcYQT/nU2YLKyWubhDpMGWycBOarPoozRuc7SvQOHMUGLcvpNwGL4JQM8UYZk1mA55vr/8MGjWunlbOcfh/PxAGeqSeeaTNfPd+8I2rm2UtYtlOD5pfYn6nHcPbh9v8CAAAA//8DABfBybqEGAAA
     http_version: 
-  recorded_at: Mon, 15 Jan 2018 23:00:47 GMT
+  recorded_at: Fri, 19 Jan 2018 12:55:09 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=7476bfdd-919d-4674-8eb0-047d7b9ed090&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=6f654dec-7d39-4530-9820-f74a5ffb998d&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -195,19 +195,19 @@ http_interactions:
       Content-Encoding:
       - gzip
       Etag:
-      - W/"ed1f404126ee97131744f47cde9c142d"
+      - W/"f839575e929583b4843beca9d8f9ad37"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 996ba54e-acb4-4e2b-b714-167e4b8926a2
+      - c7bef7a3-801c-4a6d-b9a9-17c2ab40b7eb
       X-Runtime:
-      - '0.098271'
+      - '0.171954'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAKAyXVoAA+xVyY7cNhD9FYPnZoObJKpPTiY7DOQQIwhiGEJxm5ZboiYUNWPHmH9PUdOzuKdtIMglB59arCJrefXq9UdyBZd9hNxPkew+Eruk5GPu0OrJjm9InjIM63F+crbTEjPZiQ0Z+rHP3TUMS7nPbjekz37Eu28+kt6tT5alfBAebKu90xSsrqkKNlDTKqCtCJZVlQrOGrIhFmbfxWU0PuGj14LxmjHG0TNnyJiEwDBMFj8d2vKHq2K6GKAfd7tv3PXqWY/oHWDO3bwYLBGvd4AlEwyoKeOUV6+F3DG2U+pPcuwLO6q2bEOuIXcw3vW4GqYrHzFAmFKXvPPZp/EBtADD7DfkJpUkEf0wT3HupiVjwdH18fLhjuvnQ+eve+ej9Q/W0c9zwfceVcy3RAzjujMe/x6TRxzBMheATkH2ykDwHGhTVQiylZwa6xQVwnkhG8O0lNht6BMiE2Es4H3nY+zne7iOxt+y3ye0+RF6xIWEBPHQ++1s9/0w+PTSAM4I7B4NaUJM0jb6THD+zgcfHcR8jgRCi9ap1lIjZaBKa6SDxCK9U0waqKta16f1/TrfwOCmkwJ/WOIBTQ7H3U2hM33K+8KyVh/Hi87kr5Kfkc/rqLopYZnnqpKqbqDhgkonGqpcbakOGqlpuFG2FrISBbURkBcJ20t38yOyZbzlQrT8WMkdv2qKoThHMO4SiYdELShmPBM0WC6xfSEpCORjXVvOa+MarptziRTjomZcKvY8kcREb2/fHjfnbiGODbKm2ZAjXhfoffEavS9Ksf3chf59obR/JGLyfy19KnRLYA/oLJnm5+6ceiTgp86ylDfdlR33JeSxjNOHp33ltDx1J38ucpqGcnpD4DKsLC0/2O59GlwOh7HiMgxFfeI7b9dpA67jeLWy8B6cmykdzjMAWlFLa1scR9tSpVSgLWeBOs2rqlWVr+EZL3+Z9vF0a1Bp9k+25h1e2c7F+HIA2F5O19vlQNZhTUvK94Oq2loXU+mD/P7qgpYRHUN+P44+9XZPL9IUYfWsb48QE5umm0hun3ON6UZZZutCauSarFBvGQQqkUeggpR1oz+rt+Kr3n5Bb58stAaD+48Ca7RD5cAvLYOhFWuk0UbYylXPeAMjtv4pcV55iHGKT6hTlGvwH15OhyniAtj91k7jZ/T1sR4FVoCqGBXMahy69VRbaKgoFOONqQ1jp/X85HPu/UlBPy75MN3Mh/6/aax8qEyj8stWOWpdCGXDDO4abhhvqwYcqqI9L32iaRTKs1LVFzVWPSZSTWNM+c/zusK/wJZRzcDTyrSIARgdZHsuka64RuQqWf9LjdVnNFZ81dj/n8a2Dxp78eoPKh419lvIf7/4OdrVdlZd397+IwAAAAD//wMA3jmE2yoLAAA=
+        H4sIAK7qYVoAA+xV227jNhD9lYDPZkCRFEX6KYtFi8VegG4b9GGLQKDIUaxYolxKsrcb+N93qDhO1nEXKIoCLdAHw9QMNZczZ47uycbeNsGOTR/I8p64KUYIY4lWIMtsQcZ+tO38ODx7dv0URrLkC9I2XTOWW9tO6T7bL0gzQod3f7snjZ9fmaZ0IFXujRMVUOG8orICSbXKCporL5VnwkvryYI4O0AZpq6CiC9dc5YpxliGnmG0IyYhtm17h8d0e/xjk0yvW9t0y+Urv5098yN6WzuM5TBVWCJeLy2WTDCgpiyjmbnO+DLPlyz/RA59YUf5JVuQrR1L2z30OBv6DQQMUPexjOBhhNgdQattO8CC7GJKEtBvhz4MZT+NWHDwTbg93vHNsC5h23gIDo7WDoYh4fuIKuabAobx5RkPfMbkAUcwDQmgU5BzAIOA5ZQbZ6h0SlLjvaO2sFJ6Z7WRCcq6iYhMsF0C78e2f8TqYPlgHdyt+23j0AGdbRAZ0rdQTm0bG7e6qsCubLgMMBKcuIcagrdhPDd2K5jUVhc0zZdKWQhaCaUpSF1bhT9h8tOKfmi/2JOS3kzQDmjzON6yr8uqieMK7ZnRh3GiM8ImwoD8nUdT9tFDPFcTgM24YxWtrUUqGuaoLipOeS4LYwrIKqkxXGeRBxGbiw/zIqIwucbrih8qeeCTohmnWY5QPCTix0RCWOOVwW5rnlMpbE0rBZhIMKFlkWdcqHOJihxBE5Jr/U2iInXKJNnf7G8Om/KwAIcGuVmQA16v0Xlxjc6LNO9mKOvmc2IwPPEuwu9TExO7onVrdKZEw0v3GBvk27fOtIO7cuO6VQp5qOL0xdO2xjg9d0c4Fzkiz9LMiL2t08Db9IfdPqbBXfAYKyAVk9iEO3DzsC1uX7eZKfiIza6P6/MEKHSVZUzU1DDJcC7MUC3ymtba2kxVTBsjTkn5tl+FE1L+gsKyerYid3jlckjGq9bay9t+ezmtyTyrforj45y4EsmS2iAff/5E04QOEd9Nq7C4eA/VgCO5QPnA8+BW85U5xgFq4mK/C2T/knKF4swA04loGhVA474pCdTlrICKuwz596cyy/9BmVX/eZl9ApnhArMcv2WFTAIiUEqM9LjciG5WaWuq6oXM/grRn6raWzw/4w9uhC1vp3Hd74Z1c3WHXjtB/I7OPpWkXcHygkmU2FQS5Dh3r3HuKtOFZ5wDe1HSmz4ilgOcVPWqResO4sztvyG44licgQK4EQVumUNSspxT6yqMwzxTsnIV82cFl6NM5srgPn5XcOVTImYcF1LS2in82uQ1UPwQZlRxVwipCjDmrOBKJVjGOa7OXxJcwc4ILv9fcP91giuPgvv+p4+UPwnuBxi/0HeodOt+Np8V2Zv9VwEAAAD//wMAtrUGlygLAAA=
     http_version: 
-  recorded_at: Mon, 15 Jan 2018 23:00:48 GMT
+  recorded_at: Fri, 19 Jan 2018 12:55:10 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
**What**
Expose active injection errors to case worker allocation page

**Why**
So the datatables jQuery plugin can use this data
to visually display to case workers which claims
did not inject into CCR/CCLF success fully and
enable (in a later PR) filtering by those claims.
