### PR TITLE
Allow "from" attribute in injection response

### DIFF
--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -1,7 +1,7 @@
 class InjectionResponseService
   def initialize(json)
     @response = json.stringify_keys
-    raise ParseError, 'Invalid JSON string' unless @response.keys.sort.eql?(%w[errors messages uuid])
+    raise ParseError, 'Invalid JSON string' unless @response.keys.sort.eql?(%w[errors from messages uuid])
     @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
   end
 

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -62,8 +62,7 @@ class SlackNotifier
   end
 
   def app_name
-    return 'indeterminable system' if @claim.nil?
-    @claim.agfs? ? 'CCR' : 'CCLF'
+    @response['from'] || 'indeterminable system'
   end
 
   def has_no_errors?

--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe InjectionResponseService, slack_bot: true do
   let(:injection_attempt) { claim.injection_attempts.last }
 
   let(:invalid_json) { { "errors": [], 'claim_id': '1234567', "messages":[] } }
-  let(:valid_json_with_invalid_uuid) { { "errors":[], "uuid":'b08cfd61-9999-8888-7777-651477183efb', "messages":[{'message':'Claim injected successfully.'}]} }
-  let(:valid_json_on_success) { { "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
-  let(:valid_json_on_failure) { { "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."}, {'error':"Another injection error."} ],"uuid":claim.uuid,"messages":[] } }
+  let(:valid_json_with_invalid_uuid) { { "from":"external application", "errors":[], "uuid":'b08cfd61-9999-8888-7777-651477183efb', "messages":[{'message':'Claim injected successfully.'}]} }
+  let(:valid_json_on_success) { { "from":"external application", "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
+  let(:valid_json_on_failure) { { "from":"external application", "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."}, {'error':"Another injection error."} ],"uuid":claim.uuid,"messages":[] } }
 
 shared_examples "creates injection attempts" do
   it 'returns true' do

--- a/spec/services/message_queue/aws_client_spec.rb
+++ b/spec/services/message_queue/aws_client_spec.rb
@@ -22,12 +22,20 @@ module MessageQueue
     let(:stub_queue_response) { stub_queue_response_success }
     let(:stub_send_response) {}
     let(:stub_poll_response) {}
-    let(:stub_queue_response_success)  { { queue_url: 'http://aws_url' } }
-    let(:stub_queue_response_failure)  do
+    let(:stub_queue_response_success) { { queue_url: 'http://aws_url' } }
+    let(:stub_queue_response_failure) do
       Aws::SQS::Errors::NonExistentQueue.new(
         double('request'),
         double('response', :status => 400, :body => '<foo/>')
       )
+    end
+    let(:body) do
+      {
+        from: "external application",
+        uuid: "3d34c071-c19a-4248-93ea-6f0e91002561",
+        errors: [ { error: "PPE is a mandatory field for Claim Element of type Advocate Fee." } ],
+        messages: []
+      }.to_json
     end
 
     let(:stub_poll_response_success) { Aws::SQS::Types::ReceiveMessageResult.new(
@@ -37,7 +45,7 @@ module MessageQueue
             message_id: "a1dc5042-e8bf-4417-a443-ed9a2c9558e6",
             receipt_handle: "AQEB4y8lIzE9G2HiEVen7vRjcmv0xFQML6VcyZYDbnOUzOHFO00yLwaZFE0flYhEv2XMTVyURrK3pRNgaHUH4KK7kFd6cGay35L58UljtEHCJNbBEHSJpuWiV98G56fz04DtTDZN5IKG4tBthDjeDlAheUBkMiiBBLESHSOlUsgGj0vu++x9IlcdjO8+pszXH8356DM3/eayvgoOq9i2yCKkSy4piO6tNX9/VHFVH0fyjIwW3knpbWJHNg2ROKs3RloXKIaBmD4boqc8DSPDx4Mx77zh/T0z3UBG/1CXzmtcXt9NfJJzSqzHus11s4l7bY6qEqIheTaQVl1rl6XF5RBN46M+qIR2i4ggV50TINn+629dP7H2J1yPDPWKJmkV/BzNuCF4fXWlsxiuleoM8v1pbQ==",
             md5_of_body: "06ca6b264e9878e64c76b3b6858a1676",
-            body: "{\"errors\":[{\"error\":\"PPE is a mandatory field for Claim Element of type Advocate Fee.\"}],\"uuid\":\"3d34c071-c19a-4248-93ea-6f0e91002561\",\"messages\":[]}",
+            body: body,
             attributes: {},
             md5_of_message_attributes: nil,
             message_attributes: {}

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe SlackNotifier, slack_bot: true do
   subject(:slack_notifier) { described_class.new() }
 
   let(:claim) { create :claim }
-  let(:valid_json_on_success) { { "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
-  let(:valid_json_on_failure) { { "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."} ],"uuid":claim.uuid,"messages":[] } }
+  let(:valid_json_on_success) { { "from":"external application", "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
+  let(:valid_json_on_failure) { { "from":"external application", "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."} ],"uuid":claim.uuid,"messages":[] } }
 
   it { is_expected.to be_a described_class }
 


### PR DESCRIPTION
CCR and CCLF will identify themselves using this
attribute in the injection attempt responses. CCCD
will use this to output the responders name to 
slack. Eventually may add attribute to injection attempt 
to persist this data.