### PR TITLE
Feedback email if anonymous

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -44,7 +44,7 @@ class FeedbackController < ApplicationController
     if current_user
       current_user.email
     else
-      email_from_user_id || 'anonymous'
+      email_from_user_id || params[:feedback][:email] || 'anonymous'
     end
   end
 
@@ -70,7 +70,8 @@ class FeedbackController < ApplicationController
       :event,
       :outcome,
       :case_number,
-      :referrer
+      :referrer,
+      :email
     )
   end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -2,4 +2,8 @@ module FeedbackHelper
   def referrer_is_claim?(referrer)
     referrer =~ /claims/
   end
+
+  def cannot_identify_user?
+    params[:user_id].blank? && current_user.blank?
+  end
 end

--- a/app/views/feedback/_anonymous_email_prompt.html.haml
+++ b/app/views/feedback/_anonymous_email_prompt.html.haml
@@ -1,0 +1,8 @@
+.form-group
+  %fieldset.inline
+    %legend
+      = f.label :email, 'What is your email address? (Optional)'
+    %p.form-hint
+      = 'We will need your email address to be able to respond to your message.'
+
+    = f.text_field :email, class: 'form-control'

--- a/app/views/feedback/_anonymous_email_prompt.html.haml
+++ b/app/views/feedback/_anonymous_email_prompt.html.haml
@@ -1,8 +1,8 @@
 .form-group
   %fieldset.inline
     %legend
-      = f.label :email, 'What is your email address? (Optional)'
+      = f.label :email
     %p.form-hint
-      = 'We will need your email address to be able to respond to your message.'
+      = t('activemodel.attributes.feedback.email_hint')
 
     = f.text_field :email, class: 'form-control'

--- a/app/views/feedback/bug_report.html.haml
+++ b/app/views/feedback/bug_report.html.haml
@@ -14,19 +14,28 @@
     = f.hidden_field :referrer
 
     .form-group
-      = f.anchored_label 'Case number / Unique ID', :case_number
-      .form-hint.xsmall.zero-vert-margin
-        = 'If your issue is related to a particular claim, provide the case number along with the unique ID you will find next to it (starts with #)'
-      = f.text_field :case_number, class: 'form-control'
+      %fieldset.inline
+        %legend
+          = f.anchored_label 'Case number / Unique ID', :case_number
+        .form-hint.xsmall.zero-vert-margin
+          = 'If your issue is related to a particular claim, provide the case number along with the unique ID you will find next to it (starts with #)'
+        = f.text_field :case_number, class: 'form-control'
     .form-group
-      = f.anchored_label 'What you were doing', :event
-      .form-hint.xsmall.zero-vert-margin
-        = 'Include as much information as possible, including the fee scheme (Advocate, Litigator final, Litigator interim or Litigator transfer) and case type'
-      = f.text_area :event, rows: 6, class: 'form-control'
+      %fieldset.inline
+        %legend
+          = f.anchored_label 'What you were doing when the fault occurred?', :event
+        .form-hint.xsmall.zero-vert-margin
+          = 'Include as much information as possible, including the fee scheme (Advocate, Litigator final, Litigator interim or Litigator transfer) and case type'
+        = f.text_area :event, rows: 6, class: 'form-control'
     .form-group
-      = f.anchored_label 'What went wrong', :outcome
-      .form-hint.xsmall.zero-vert-margin
-        = ''
-      = f.text_area :outcome, rows: 6, class: 'form-control'
+      %fieldset.inline
+        %legend
+          = f.anchored_label 'What went wrong?', :outcome
+        .form-hint.xsmall.zero-vert-margin
+          = ''
+        = f.text_area :outcome, rows: 6, class: 'form-control'
+
+    = render partial: 'feedback/anonymous_email_prompt', locals: { f: f } if cannot_identify_user?
+
     .button-holder
       = f.submit 'Send', class: 'button button-primary', id: 'submit-button'

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -1,12 +1,12 @@
 - title 'Feedback'
 
 = render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: 'This feedback has '}
-= render partial: 'layouts/header', locals: {page_heading: 'Help us improve this service'}
+= render partial: 'layouts/header', locals: {page_heading: t('activemodel.attributes.feedback.heading')}
 
 .body-content
   .panel.panel-border-wide
     %p
-      We will use your answers to the questions below to help us build a better service.
+      = t('activemodel.attributes.feedback.callout')
       = render partial: 'feedback/claim_edit_alert' if referrer_is_claim?(@feedback.referrer)
 
   = form_for @feedback, url: feedback_index_path(email: params[:email]), html: { novalidate: 'novalidate', class: 'normal'} do |f|
@@ -19,9 +19,9 @@
     .form-group
       %fieldset.inline
         %legend
-          = f.label :comment, 'Tell us about your experience of using this service today.'
+          = f.label :comment
         %p.form-hint
-          = 'Don\'t include any personal or sensitive information.'
+          = t('activemodel.attributes.feedback.comment_hint')
         = f.text_area :comment, rows: 5, class: "form-control"
 
     = render partial: 'feedback/anonymous_email_prompt', locals: { f: f } if cannot_identify_user?
@@ -29,7 +29,7 @@
     .form-group
       %fieldset.inline
         %legend
-          = 'Overall, how satisfied were you with this service?'
+          = f.label :rating
 
         = f.collection_radio_buttons(:rating, Feedback::RATINGS.map {|k,v| [v,k]}, :last, :first) do |b|
           - b.label(class: 'block-label') { b.radio_button + b.object.first  }

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -17,17 +17,22 @@
       = hidden_field_tag :user_id, params[:user_id]
 
     .form-group
-      = f.label :comment, 'Tell us about your experience of using this service today.'
-      %p.form-hint
-        = 'Don\'t include any personal or sensitive information.'
-      = f.text_area :comment, rows: 5, class: "form-control"
+      %fieldset.inline
+        %legend
+          = f.label :comment, 'Tell us about your experience of using this service today.'
+        %p.form-hint
+          = 'Don\'t include any personal or sensitive information.'
+        = f.text_area :comment, rows: 5, class: "form-control"
 
-    %fieldset.inline
-      %legend
-        = 'Overall, how satisfied were you with this service?'
+    = render partial: 'feedback/anonymous_email_prompt', locals: { f: f } if cannot_identify_user?
 
-      = f.collection_radio_buttons(:rating, Feedback::RATINGS.map {|k,v| [v,k]}, :last, :first) do |b|
-        - b.label(class: 'block-label') { b.radio_button + b.object.first  }
+    .form-group
+      %fieldset.inline
+        %legend
+          = 'Overall, how satisfied were you with this service?'
+
+        = f.collection_radio_buttons(:rating, Feedback::RATINGS.map {|k,v| [v,k]}, :last, :first) do |b|
+          - b.label(class: 'block-label') { b.radio_button + b.object.first  }
 
     .button-holder
       = f.submit 'Send', class: 'button button-primary', id: 'submit-button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,16 @@ en:
     not_provided: *not_provided
     not_applicable: *not_applicable
 
+  activemodel:
+    attributes:
+      feedback:
+        heading: 'Help us improve this service'
+        callout: 'We will use your answers to the questions below to help us build a better service.'
+        rating: 'Overall, how satisfied were you with this service?'
+        comment: 'Tell us about your experience of using this service today.'
+        comment_hint: "Don't include any personal or sensitive information."
+        email: 'What is your email address? (Optional)'
+        email_hint: 'We will need your email address to be able to respond to your message.'
   activerecord:
     models:
       super_admin: *super_admin

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -1,0 +1,32 @@
+@stub_zendesk_request
+
+Feature: A user can provide feedback and report bugs
+  Scenario: An advocate is redirected to the feedback page upon sign out and is not prompted for their email
+    Given I am a signed in advocate
+    And I sign out
+    Then I should be redirected to the feedback page
+    And I should be informed that I have signed out
+    Then I should not see 'What is your email address?'
+    When I fill in the 'feedback' form
+    Then I expect ZendeskSender to receive a description with an email
+    And I see confirmation that my 'feedback' was received
+    And I should be on the sign in page
+
+  Scenario: An advocate is unable to sign in and selects to submit feedback and is prompted for their email and ignores it
+    Given I have not signed in
+    When I click the link 'feedback'
+    Then I should see 'What is your email address?'
+    When I fill in the 'feedback' form
+    Then I expect ZendeskSender to receive a description without an email
+    And I see confirmation that my 'feedback' was received
+    And I should be on the sign in page
+
+  Scenario: An advocate is unable to sign in and selects to submit feedback and is prompted for their email and completes it
+    Given I have not signed in
+    When I click the link 'feedback'
+    Then I should see 'What is your email address?'
+    When I fill in the 'feedback' form with email of 'test@example.com'
+    Then I expect ZendeskSender to receive a description with an email
+    And I see confirmation that my 'feedback' was received
+    And I should be on the sign in page
+ 

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -1,0 +1,60 @@
+When(/^I fill in the '(.*?)' form$/) do |payload|
+  case payload
+  when 'feedback'
+    fill_in 'feedback[comment]', with: 'This is great!'
+    choose('Very satisfied')
+    click_on 'Send'
+  when 'bug report'
+    fill_in 'feedback[event]', with: 'Filling in a new claim form'
+    fill_in 'feedback[outcome]', with: 'Something went wrong'
+    click_on 'Send'
+  end
+end
+
+When(/^I fill in the '(.*?)' form with email of '(.*?)'$/) do |payload, email|
+  case payload
+    when 'feedback'
+      fill_in 'feedback[comment]', with: 'This is great!'
+      choose('Very satisfied')
+      fill_in 'feedback[email]', with: email
+      click_on 'Send'
+    when 'bug report'
+      fill_in 'feedback[event]', with: 'Filling in a new claim form'
+      fill_in 'feedback[outcome]', with: 'Something went wrong'
+      click_on 'Send'
+  end
+end
+
+When(/^I have not signed in$/) do
+  visit new_user_session_path
+end
+
+Then(/^I expect ZendeskSender to receive a description (with|without) an email$/) do |visibility|
+  if (visibility == 'with')
+    regex = /email:\s\w/
+  else
+    regex = /email:\s\"/
+  end
+  expect(@called_zendesk.with { |req| regex.match(req.body) }).to have_been_made.once
+end
+
+Then(/^I see confirmation that my '(.*?)' was received$/) do |payload|
+  case payload
+  when 'feedback'
+    expect(page).to have_content "Feedback submitted"
+  when 'bug report'
+    expect(page).to have_content "Feedback submitted"
+  end
+end
+
+Then(/^I should be informed that I have signed out$/) do
+  expect(page).to have_content('You have signed out')
+end
+
+Then(/^I should be redirected to the feedback page$/) do
+  expect(current_path).to eq(new_feedback_path)
+end
+
+Then(/^I should be on the sign in page$/) do
+  expect(current_path).to eq(new_user_session_path)
+end

--- a/features/support/stub_zendesk_requests.rb
+++ b/features/support/stub_zendesk_requests.rb
@@ -1,0 +1,5 @@
+require 'webmock/cucumber'
+
+Before('@stub_zendesk_request') do
+  @called_zendesk = stub_request(:post, %r{\Ahttps://.*ministryofjustice.zendesk.com/api/v2/tickets\z} )
+end

--- a/spec/helpers/feedback_helper_spec.rb
+++ b/spec/helpers/feedback_helper_spec.rb
@@ -14,4 +14,21 @@ describe FeedbackHelper do
     end
   end
 
+  describe '#cannot_identify_user?' do
+    subject { helper.cannot_identify_user? }
+
+    before { allow(helper).to receive(:current_user).and_return(defined_user) }
+
+    context 'when user is not logged in ' do
+      let(:defined_user) { nil }
+      let(:params) { { user_id: nil } }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when external user is logged in' do
+      let(:defined_user) { create(:external_user, :advocate) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
[Pivotal Ticket](https://www.pivotaltracker.com/story/show/153989596)
### Why?
As a provider who is struggling to log in to the service, I need to be able to provide my email address on the feedback form, so that I can be contacted with help and assistance. 

### How?
Add an optional field to the feedback, and bug report views that, if we cannot identify the user by other means, prompts the user to add an email, if they wish.  This is the incorporated into the zendesk ticket
