### PR TITLE
Splitting litigator claim pages

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -82,6 +82,7 @@ Metrics/MethodLength:
     - 'app/validators/claim/advocate_claim_validator.rb'
     - 'app/validators/claim/interim_claim_sub_model_validator.rb'
     - 'app/validators/claim/interim_claim_validator.rb'
+    - 'app/validators/claim/litigator_claim_validator.rb'
     - 'app/validators/claim/litigator_claim_sub_model_validator.rb'
     - 'app/validators/claim/litigator_common_validations.rb'
     - 'app/validators/claim/transfer_claim_sub_model_validator.rb'

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 brew "postgresql", restart_service: true
 brew "redis", restart_service: true
 brew "phantomjs"
+brew "chromedriver"
 cask "libreoffice"

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -131,7 +131,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def new
     load_offences_and_case_types
     build_nested_resources
-    track_visit({ url: 'external_user/%{type}/claim/new/page1', title: 'New %{type} claim page 1' },
+    track_visit({ url: 'external_user/%{type}/claim/new/%{step}', title: 'New %{type} claim %{step}' },
                 claim_tracking_substitutions)
   end
 
@@ -147,7 +147,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
     @claim.touch(:last_edited_at)
 
-    track_visit({ url: 'external_user/%{type}/claim/edit/page1', title: 'Edit %{type} claim page 1' },
+    track_visit({ url: 'external_user/%{type}/claim/edit/%{step}', title: 'Edit %{type} claim %{step}' },
                 claim_tracking_substitutions)
   end
 
@@ -413,7 +413,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
     load_offences_and_case_types
 
     track_visit({
-                  url: 'external_user/%{type}/claim/%{action}/page%{step}',
+                  url: 'external_user/%{type}/claim/%{action}/%{step}',
                   title: '%{action_t} %{type} claim page %{step}'
                 }, claim_tracking_substitutions)
 

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -117,13 +117,6 @@ module Claim
       documents.each { |d| d.update_column(:external_user_id, external_user_id) }
     end
 
-    def current_step_required?
-      # NOTE: offence details step is only required when the
-      # case type does not have a fixed fee
-      return super unless current_step == 3
-      !fixed_fee_case?
-    end
-
     private
 
     def provider_delegator

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -100,13 +100,6 @@ module Claim
       :litigator
     end
 
-    def current_step_required?
-      # NOTE: offence details step is only required when the
-      # case type does not have a fixed fee
-      return super unless current_step == 3
-      !fixed_fee_case?
-    end
-
     private
 
     def provider_delegator

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -76,6 +76,10 @@ module Claim
     accepts_nested_attributes_for :interim_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
 
+    def submission_stages
+      %i[case_details defendants offence_details fees]
+    end
+
     def lgfs?
       self.class.lgfs?
     end
@@ -94,6 +98,13 @@ module Claim
 
     def external_user_type
       :litigator
+    end
+
+    def current_step_required?
+      # NOTE: offence details step is only required when the
+      # case type does not have a fixed fee
+      return super unless current_step == 3
+      !fixed_fee_case?
     end
 
     private

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -82,6 +82,10 @@ module Claim
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :graduated_fee, reject_if: :all_blank, allow_destroy: false
 
+    def submission_stages
+      %i[case_details defendants offence_details fees]
+    end
+
     def lgfs?
       self.class.lgfs?
     end
@@ -117,6 +121,13 @@ module Claim
 
     def requires_case_concluded_date?
       true
+    end
+
+    def current_step_required?
+      # NOTE: offence details step is only required when the
+      # case type does not have a fixed fee
+      return super unless current_step == 3
+      !fixed_fee_case?
     end
 
     private

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -123,13 +123,6 @@ module Claim
       true
     end
 
-    def current_step_required?
-      # NOTE: offence details step is only required when the
-      # case type does not have a fixed fee
-      return super unless current_step == 3
-      !fixed_fee_case?
-    end
-
     private
 
     def provider_delegator

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -137,13 +137,6 @@ module Claim
       false
     end
 
-    def current_step_required?
-      # NOTE: offence details step is only required when the
-      # case type does not have a fixed fee
-      return super unless current_step == 4
-      !fixed_fee_case?
-    end
-
     private
 
     # called from state_machine before_submit

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -93,6 +93,10 @@ module Claim
       end
     end
 
+    def submission_stages
+      %i[transfer_fee_details case_details defendants offence_details fees]
+    end
+
     def lgfs?
       self.class.lgfs?
     end
@@ -131,6 +135,13 @@ module Claim
 
     def requires_case_type?
       false
+    end
+
+    def current_step_required?
+      # NOTE: offence details step is only required when the
+      # case type does not have a fixed fee
+      return super unless current_step == 4
+      !fixed_fee_case?
     end
 
     private

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -6,8 +6,4 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
   def can_have_disbursements?
     false
   end
-
-  def current_step
-    submission_stages[super - 1]
-  end
 end

--- a/app/presenters/claim/interim_claim_presenter.rb
+++ b/app/presenters/claim/interim_claim_presenter.rb
@@ -18,8 +18,4 @@ class Claim::InterimClaimPresenter < Claim::BaseClaimPresenter
   def pretty_type
     'LGFS Interim'
   end
-
-  def current_step
-    submission_stages[super - 1]
-  end
 end

--- a/app/presenters/claim/interim_claim_presenter.rb
+++ b/app/presenters/claim/interim_claim_presenter.rb
@@ -18,4 +18,8 @@ class Claim::InterimClaimPresenter < Claim::BaseClaimPresenter
   def pretty_type
     'LGFS Interim'
   end
+
+  def current_step
+    submission_stages[super - 1]
+  end
 end

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -8,4 +8,8 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
   def pretty_type
     'LGFS Final'
   end
+
+  def current_step
+    submission_stages[super - 1]
+  end
 end

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -8,8 +8,4 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
   def pretty_type
     'LGFS Final'
   end
-
-  def current_step
-    submission_stages[super - 1]
-  end
 end

--- a/app/presenters/claim/transfer_claim_presenter.rb
+++ b/app/presenters/claim/transfer_claim_presenter.rb
@@ -38,4 +38,8 @@ class Claim::TransferClaimPresenter < Claim::BaseClaimPresenter
   rescue StandardError
     ''
   end
+
+  def current_step
+    submission_stages[super - 1]
+  end
 end

--- a/app/presenters/claim/transfer_claim_presenter.rb
+++ b/app/presenters/claim/transfer_claim_presenter.rb
@@ -38,8 +38,4 @@ class Claim::TransferClaimPresenter < Claim::BaseClaimPresenter
   rescue StandardError
     ''
   end
-
-  def current_step
-    submission_stages[super - 1]
-  end
 end

--- a/app/validators/claim/advocate_claim_sub_model_validator.rb
+++ b/app/validators/claim/advocate_claim_sub_model_validator.rb
@@ -1,24 +1,24 @@
 class Claim::AdvocateClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_one_association_names_for_steps
-    [
-      [],
-      [],
-      [],
-      %i[
+    {
+      case_details: [],
+      defendants: [],
+      offence_details: [],
+      fees: %i[
         assessment
         certification
       ]
-    ]
+    }
   end
 
   def has_many_association_names_for_steps
-    [
-      [],
-      [
+    {
+      case_details: [],
+      defendants: [
         :defendants
       ],
-      [],
-      %i[
+      offence_details: [],
+      fees: %i[
         basic_fees
         misc_fees
         fixed_fees
@@ -27,6 +27,6 @@ class Claim::AdvocateClaimSubModelValidator < Claim::BaseClaimSubModelValidator
         redeterminations
         documents
       ]
-    ]
+    }
   end
 end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -1,7 +1,7 @@
 class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
   def self.fields_for_steps
-    [
-      %i[
+    {
+      case_details: %i[
         case_type
         court
         case_number
@@ -23,13 +23,13 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         case_concluded_at
         supplier_number
       ],
-      [],
-      %i[offence],
-      %i[
+      defendants: [],
+      offence_details: %i[offence],
+      fees: %i[
         total
         defendant_uplifts
       ]
-    ]
+    }
   end
 
   private

--- a/app/validators/claim/base_claim_sub_model_validator.rb
+++ b/app/validators/claim/base_claim_sub_model_validator.rb
@@ -1,12 +1,12 @@
 class Claim::BaseClaimSubModelValidator < BaseSubModelValidator
   # Override this method in the derived class
   def has_many_association_names_for_steps
-    []
+    {}
   end
 
   # Override this method in the derived class
   def has_one_association_names_for_steps
-    []
+    {}
   end
 
   def validate(record)
@@ -19,19 +19,31 @@ class Claim::BaseClaimSubModelValidator < BaseSubModelValidator
 
   private
 
+  def associations_for_has_many_validations(record)
+    has_many_association_names_for_steps.select do |k, _v|
+      record.submission_stages[steps_range(record)].include?(k)
+    end.values.flatten
+  end
+
   def validate_has_many_associations_step_fields(record)
-    has_many_association_names_for_steps[steps_range(record)].flatten.each do |association_name|
+    associations_for_has_many_validations(record).each do |association_name|
       validate_collection_for(record, association_name)
     end
   end
 
+  def associations_for_has_one_validations(record)
+    has_one_association_names_for_steps.select do |k, _v|
+      record.submission_stages[steps_range(record)].include?(k)
+    end.values.flatten
+  end
+
   def validate_has_one_association_step_fields(record)
-    has_one_association_names_for_steps[steps_range(record)].flatten.each do |association_name|
+    associations_for_has_one_validations(record).each do |association_name|
       validate_association_for(record, association_name)
     end
   end
 
   def has_many_association_names_for_errors
-    has_many_association_names_for_steps.flatten
+    has_many_association_names_for_steps.values.flatten
   end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -1,17 +1,18 @@
 class Claim::BaseClaimValidator < BaseValidator
   def self.mandatory_fields
-    %i[
-      external_user_id
-      creator
-      amount_assessed
-      evidence_checklist_ids
-    ]
+    %i[external_user_id creator amount_assessed evidence_checklist_ids]
   end
 
   private
 
+  def step_fields_for_validation
+    self.class.fields_for_steps.select do |k, _v|
+      @record.submission_stages[steps_range(@record)].include?(k)
+    end.values.flatten
+  end
+
   def validate_step_fields
-    self.class.fields_for_steps[steps_range(@record)].flatten.each do |field|
+    step_fields_for_validation.each do |field|
       validate_field(field)
     end
   end

--- a/app/validators/claim/interim_claim_sub_model_validator.rb
+++ b/app/validators/claim/interim_claim_sub_model_validator.rb
@@ -1,30 +1,28 @@
 class Claim::InterimClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_one_association_names_for_steps
-    [
-      [],
-      [],
-      [],
-      %i[
+    {
+      case_details: [],
+      defendants: [],
+      offence_details: [],
+      fees: %i[
         interim_fee
         assessment
         certification
       ]
-    ]
+    }
   end
 
   def has_many_association_names_for_steps
-    [
-      [],
-      [
-        :defendants
-      ],
-      [],
-      %i[
+    {
+      case_details: [],
+      defendants: %i[defendants],
+      offence_details: [],
+      fees: %i[
         disbursements
         messages
         redeterminations
         documents
       ]
-    ]
+    }
   end
 end

--- a/app/validators/claim/interim_claim_sub_model_validator.rb
+++ b/app/validators/claim/interim_claim_sub_model_validator.rb
@@ -2,6 +2,8 @@ class Claim::InterimClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_one_association_names_for_steps
     [
       [],
+      [],
+      [],
       %i[
         interim_fee
         assessment
@@ -12,9 +14,11 @@ class Claim::InterimClaimSubModelValidator < Claim::BaseClaimSubModelValidator
 
   def has_many_association_names_for_steps
     [
+      [],
       [
         :defendants
       ],
+      [],
       %i[
         disbursements
         messages

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -2,8 +2,8 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
   include Claim::LitigatorCommonValidations
 
   def self.fields_for_steps
-    [
-      %i[
+    {
+      case_details: %i[
         case_type
         court
         case_number
@@ -12,9 +12,9 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
         advocate_category
         case_concluded_at
       ],
-      [],
-      %i[offence],
-      %i[
+      defendants: [],
+      offence_details: %i[offence],
+      fees: %i[
         first_day_of_trial
         estimated_trial_length
         trial_concluded_at
@@ -24,7 +24,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
         legal_aid_transfer_date
         total
       ]
-    ]
+    }
   end
 
   private

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -3,7 +3,17 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
 
   def self.fields_for_steps
     [
-      [].unshift(first_step_common_validations),
+      %i[
+        case_type
+        court
+        case_number
+        transfer_court
+        transfer_case_number
+        advocate_category
+        case_concluded_at
+      ],
+      [],
+      %i[offence],
       %i[
         first_day_of_trial
         estimated_trial_length

--- a/app/validators/claim/litigator_claim_sub_model_validator.rb
+++ b/app/validators/claim/litigator_claim_sub_model_validator.rb
@@ -2,6 +2,8 @@ class Claim::LitigatorClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_one_association_names_for_steps
     [
       [],
+      [],
+      [],
       %i[
         graduated_fee
         fixed_fee
@@ -14,9 +16,11 @@ class Claim::LitigatorClaimSubModelValidator < Claim::BaseClaimSubModelValidator
 
   def has_many_association_names_for_steps
     [
+      [],
       [
         :defendants
       ],
+      [],
       %i[
         misc_fees
         disbursements

--- a/app/validators/claim/litigator_claim_sub_model_validator.rb
+++ b/app/validators/claim/litigator_claim_sub_model_validator.rb
@@ -1,27 +1,25 @@
 class Claim::LitigatorClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_one_association_names_for_steps
-    [
-      [],
-      [],
-      [],
-      %i[
+    {
+      case_details: [],
+      defendants: [],
+      offence_details: [],
+      fees: %i[
         graduated_fee
         fixed_fee
         warrant_fee
         assessment
         certification
       ]
-    ]
+    }
   end
 
   def has_many_association_names_for_steps
-    [
-      [],
-      [
-        :defendants
-      ],
-      [],
-      %i[
+    {
+      case_details: [],
+      defendants: %i[defendants],
+      offence_details: [],
+      fees: %i[
         misc_fees
         disbursements
         expenses
@@ -29,6 +27,6 @@ class Claim::LitigatorClaimSubModelValidator < Claim::BaseClaimSubModelValidator
         redeterminations
         documents
       ]
-    ]
+    }
   end
 end

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -2,8 +2,8 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
   include Claim::LitigatorCommonValidations
 
   def self.fields_for_steps
-    [
-      %i[
+    {
+      case_details: %i[
         case_type
         court
         case_number
@@ -12,12 +12,12 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
         advocate_category
         case_concluded_at
       ],
-      [],
-      %i[offence],
-      %i[
+      defendants: [],
+      offence_details: %i[offence],
+      fees: %i[
         actual_trial_length
         total
       ]
-    ]
+    }
   end
 end

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -3,7 +3,17 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
 
   def self.fields_for_steps
     [
-      [].unshift(first_step_common_validations),
+      %i[
+        case_type
+        court
+        case_number
+        transfer_court
+        transfer_case_number
+        advocate_category
+        case_concluded_at
+      ],
+      [],
+      %i[offence],
       %i[
         actual_trial_length
         total

--- a/app/validators/claim/litigator_common_validations.rb
+++ b/app/validators/claim/litigator_common_validations.rb
@@ -34,7 +34,7 @@ module Claim
     end
 
     def validate_offence
-      validate_presence(:offence, 'blank_class')
+      validate_presence(:offence, 'blank_class') unless fixed_fee_case?
     end
 
     def validate_case_concluded_at

--- a/app/validators/claim/litigator_supplier_number_validator.rb
+++ b/app/validators/claim/litigator_supplier_number_validator.rb
@@ -2,8 +2,8 @@ class Claim::LitigatorSupplierNumberValidator < Claim::BaseClaimValidator
   include Claim::LitigatorSupplierNumberValidations
 
   def self.fields_for_steps
-    [
-      [first_step_common_validations]
-    ]
+    {
+      case_details: first_step_common_validations
+    }
   end
 end

--- a/app/validators/claim/transfer_claim_sub_model_validator.rb
+++ b/app/validators/claim/transfer_claim_sub_model_validator.rb
@@ -2,6 +2,9 @@ class Claim::TransferClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_one_association_names_for_steps
     [
       [],
+      [],
+      [],
+      [],
       %i[
         transfer_fee
         assessment
@@ -13,9 +16,11 @@ class Claim::TransferClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_many_association_names_for_steps
     [
       [],
+      [],
       [
         :defendants
       ],
+      [],
       %i[
         misc_fees
         disbursements

--- a/app/validators/claim/transfer_claim_sub_model_validator.rb
+++ b/app/validators/claim/transfer_claim_sub_model_validator.rb
@@ -1,27 +1,25 @@
 class Claim::TransferClaimSubModelValidator < Claim::BaseClaimSubModelValidator
   def has_one_association_names_for_steps
-    [
-      [],
-      [],
-      [],
-      [],
-      %i[
+    {
+      transfer_fee_details: [],
+      case_details: [],
+      defendants: [],
+      offence_details: [],
+      fees: %i[
         transfer_fee
         assessment
         certification
       ]
-    ]
+    }
   end
 
   def has_many_association_names_for_steps
-    [
-      [],
-      [],
-      [
-        :defendants
-      ],
-      [],
-      %i[
+    {
+      transfer_fee_details: [],
+      case_details: [],
+      defendants: %i[defendants],
+      offence_details: [],
+      fees: %i[
         misc_fees
         disbursements
         expenses
@@ -29,6 +27,6 @@ class Claim::TransferClaimSubModelValidator < Claim::BaseClaimSubModelValidator
         redeterminations
         documents
       ]
-    ]
+    }
   end
 end

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -25,15 +25,14 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
         transfer_court
         transfer_case_number
         advocate_category
-        offence
         case_concluded_at
         supplier_number
         amount_assessed
         evidence_checklist_ids
       ],
-      [
-        :total
-      ]
+      [],
+      %i[offence],
+      %i[total]
     ]
   end
 

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -10,8 +10,8 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
   end
 
   def self.fields_for_steps
-    [
-      %i[
+    {
+      transfer_fee_details: %i[
         litigator_type
         elected_case
         transfer_stage_id
@@ -19,7 +19,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
         case_conclusion_id
         transfer_detail_combo
       ],
-      %i[
+      case_details: %i[
         court
         case_number
         transfer_court
@@ -30,10 +30,10 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
         amount_assessed
         evidence_checklist_ids
       ],
-      [],
-      %i[offence],
-      %i[total]
-    ]
+      defendants: [],
+      offence_details: %i[offence],
+      fees: %i[total]
+    }
   end
 
   def validate(record)

--- a/app/views/external_users/litigators/claims/_case_details_form_step.html.haml
+++ b/app/views/external_users/litigators/claims/_case_details_form_step.html.haml
@@ -1,0 +1,7 @@
+= render partial: 'external_users/claims/api_promo_banner', locals: { claim: @claim }
+
+= render partial: 'external_users/claims/supplier_number/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/case_details/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/claims/_defendants_form_step.html.haml
+++ b/app/views/external_users/litigators/claims/_defendants_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/defendants/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/claims/_fees_form_step.html.haml
+++ b/app/views/external_users/litigators/claims/_fees_form_step.html.haml
@@ -1,0 +1,21 @@
+= render partial: 'external_users/claims/fees_shared_header'
+
+= render partial: 'external_users/claims/fixed_fees/litigators/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/graduated_fees/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/misc_fees/litigators/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/disbursements/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/expenses/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/warrant_fee/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/supporting_documents/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/supporting_evidence_checklist/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/additional_information/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_submit_claim' }

--- a/app/views/external_users/litigators/claims/_form.html.haml
+++ b/app/views/external_users/litigators/claims/_form.html.haml
@@ -4,41 +4,4 @@
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step
 
-    - if @claim.step?(1)
-
-      = render partial: 'external_users/claims/api_promo_banner', locals: { claim: @claim }
-
-      = render partial: 'external_users/claims/supplier_number/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/case_details/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/offence_details/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/defendants/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }
-
-
-    - if @claim.step?(2)
-
-      = render partial: 'external_users/claims/fees_shared_header'
-
-      = render partial: 'external_users/claims/fixed_fees/litigators/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/graduated_fees/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/misc_fees/litigators/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/expenses/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/warrant_fee/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/supporting_documents/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/supporting_evidence_checklist/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/additional_information/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_submit_claim' }
+    = render partial: "#{claim.current_step}_form_step", locals: { claim: claim, f: f }

--- a/app/views/external_users/litigators/claims/_offence_details_form_step.html.haml
+++ b/app/views/external_users/litigators/claims/_offence_details_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/offence_details/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/claims/edit.html.haml
+++ b/app/views/external_users/litigators/claims/edit.html.haml
@@ -5,7 +5,7 @@
 - present(@claim) do |claim|
   .grid-row.grid-sidebar
     .column-two-thirds.first
-      = render 'form'
+      = render partial: 'form', locals: { claim: claim }
 
     .column-one-third.first
       = render partial: 'external_users/claims/summary_claims_sidebar', locals: { claim: claim, display_buttons: false }

--- a/app/views/external_users/litigators/claims/new.html.haml
+++ b/app/views/external_users/litigators/claims/new.html.haml
@@ -5,7 +5,7 @@
 - present(@claim) do |claim|
   .grid-row.grid-sidebar
     .column-two-thirds.first
-      = render 'form'
+      = render partial: 'form', locals: { claim: claim }
 
     .column-one-third.first
       = render partial: 'external_users/claims/summary_claims_sidebar', locals: { claim: claim, display_buttons: false }

--- a/app/views/external_users/litigators/interim_claims/_case_details_form_step.html.haml
+++ b/app/views/external_users/litigators/interim_claims/_case_details_form_step.html.haml
@@ -1,0 +1,7 @@
+= render partial: 'external_users/claims/api_promo_banner', locals: { claim: @claim }
+
+= render partial: 'external_users/claims/supplier_number/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/case_details/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/interim_claims/_defendants_form_step.html.haml
+++ b/app/views/external_users/litigators/interim_claims/_defendants_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/defendants/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/interim_claims/_fees_form_step.html.haml
+++ b/app/views/external_users/litigators/interim_claims/_fees_form_step.html.haml
@@ -1,0 +1,11 @@
+= render partial: 'external_users/claims/fees_shared_header'
+
+= render partial: 'external_users/claims/interim_fee/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/supporting_documents/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/supporting_evidence_checklist/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/additional_information/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_submit_claim' }

--- a/app/views/external_users/litigators/interim_claims/_form.html.haml
+++ b/app/views/external_users/litigators/interim_claims/_form.html.haml
@@ -4,31 +4,4 @@
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step
 
-    - if @claim.step?(1)
-
-      = render partial: 'external_users/claims/api_promo_banner', locals: { claim: @claim }
-
-      = render partial: 'external_users/claims/supplier_number/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/case_details/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/offence_details/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/defendants/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }
-
-
-    - if @claim.step?(2)
-
-      = render partial: 'external_users/claims/fees_shared_header'
-
-      = render partial: 'external_users/claims/interim_fee/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/supporting_documents/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/supporting_evidence_checklist/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/additional_information/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_submit_claim' }
+    = render partial: "#{claim.current_step}_form_step", locals: { claim: claim, f: f }

--- a/app/views/external_users/litigators/interim_claims/_offence_details_form_step.html.haml
+++ b/app/views/external_users/litigators/interim_claims/_offence_details_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/offence_details/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/interim_claims/edit.html.haml
+++ b/app/views/external_users/litigators/interim_claims/edit.html.haml
@@ -5,7 +5,7 @@
 - present(@claim) do |claim|
   .grid-row.grid-sidebar
     .column-two-thirds.first
-      = render 'form'
+      = render partial: 'form', locals: { claim: claim }
 
     .column-one-third.first
       = render partial: 'external_users/claims/summary_claims_sidebar', locals: { claim: claim, display_buttons: false }

--- a/app/views/external_users/litigators/interim_claims/new.html.haml
+++ b/app/views/external_users/litigators/interim_claims/new.html.haml
@@ -5,7 +5,7 @@
 - present(@claim) do |claim|
   .grid-row.grid-sidebar
     .column-two-thirds.first
-      = render 'form'
+      = render partial: 'form', locals: { claim: claim }
 
     .column-one-third.first
       = render partial: 'external_users/claims/summary_claims_sidebar', locals: { claim: claim, display_buttons: false }

--- a/app/views/external_users/litigators/transfer_claims/_case_details_form_step.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_case_details_form_step.html.haml
@@ -1,0 +1,5 @@
+= render partial: 'external_users/claims/supplier_number/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/case_details/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/transfer_claims/_defendants_form_step.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_defendants_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/defendants/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/transfer_claims/_fees_form_step.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_fees_form_step.html.haml
@@ -1,0 +1,17 @@
+= render partial: 'external_users/claims/fees_shared_header'
+
+= render partial: 'external_users/claims/transfer_fee/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/misc_fees/litigators/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/disbursements/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/expenses/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/supporting_documents/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/supporting_evidence_checklist/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/additional_information/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_submit_claim' }

--- a/app/views/external_users/litigators/transfer_claims/_form.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_form.html.haml
@@ -4,43 +4,4 @@
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step
 
-    - if @claim.step?(1)
-
-      = render partial: 'external_users/claims/api_promo_banner', locals: { claim: @claim }
-
-      = render partial: 'external_users/claims/transfer_fee/detail_fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_stage_1' }
-
-    - if @claim.step?(2)
-
-      = render partial: 'external_users/claims/supplier_number/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/case_details/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/offence_details/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/defendants/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }
-
-
-    - if @claim.step?(3)
-
-      = render partial: 'external_users/claims/fees_shared_header'
-
-      = render partial: 'external_users/claims/transfer_fee/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/misc_fees/litigators/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/expenses/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/supporting_documents/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/supporting_evidence_checklist/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/additional_information/fields', locals: { f: f }
-
-      = render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_submit_claim' }
+    = render partial: "#{claim.current_step}_form_step", locals: { claim: claim, f: f }

--- a/app/views/external_users/litigators/transfer_claims/_offence_details_form_step.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_offence_details_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/offence_details/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/litigators/transfer_claims/_transfer_fee_details_form_step.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_transfer_fee_details_form_step.html.haml
@@ -1,0 +1,5 @@
+= render partial: 'external_users/claims/api_promo_banner', locals: { claim: @claim }
+
+= render partial: 'external_users/claims/transfer_fee/detail_fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_stage_1' }

--- a/app/views/external_users/litigators/transfer_claims/edit.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/edit.html.haml
@@ -5,7 +5,7 @@
 - present(@claim) do |claim|
   .grid-row.grid-sidebar
     .column-two-thirds.first
-      = render 'form'
+      = render partial: 'form', locals: { claim: claim }
 
     .column-one-third.first
       = render partial: 'external_users/claims/summary_claims_sidebar', locals: { claim: claim, display_buttons: false }

--- a/app/views/external_users/litigators/transfer_claims/new.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/new.html.haml
@@ -5,7 +5,7 @@
 - present(@claim) do |claim|
   .grid-row.grid-sidebar
     .column-two-thirds.first
-      = render 'form'
+      = render partial: 'form', locals: { claim: claim }
 
     .column-one-third.first
       = render partial: 'external_users/claims/summary_claims_sidebar', locals: { claim: claim, display_buttons: false }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,8 @@ en:
         supplier_number: 'Supplier number'
       case_worker:
         roles: *roles
+      certification:
+        certified_by: 'Name of person certifying'
       user:
         email: *email
         password: *password

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -25,8 +25,13 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     When I click the claim 'A20161234'
     And I edit this claim
 
+    Then I click "Continue" in the claim form
+
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
+
+    Then I click "Continue" in the claim form
+
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -25,10 +25,11 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I edit this claim
 
     And I enter the case concluded date
+
+    Then I click "Continue" in the claim form
+
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the offence category 'Handling stolen goods'
-    And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -15,10 +15,12 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     And I select a case type of 'Contempt'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date
+
+    Then I click "Continue" in the claim form
+
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    And I select the offence category 'Activities relating to opium'
-    And I sleep for '1' second
+
     Then I click "Continue" in the claim form
 
     And I fill '100.75' as the fixed fee total

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -19,7 +19,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     And I click "Continue" in the claim form
 
-
     When I select the supplier number '1A222Z'
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
@@ -35,8 +34,14 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I click "Continue" in the claim form
 
     And I enter the case concluded date
+
+    And I click "Continue" in the claim form
+
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
+
+    And I click "Continue" in the claim form
+
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,6 +20,14 @@ Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, js_errors: true)
 end
 
+if ENV['BROWSER'] == 'chrome'
+  Capybara.register_driver :chrome do |app|
+    Capybara::Selenium::Driver.new(app, browser: :chrome)
+  end
+
+  Capybara.javascript_driver = :chrome
+end
+
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
 # selectors in your step definitions to use the XPath syntax.

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -198,12 +198,12 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
 
           let(:claim_params_step2) do
             {
-                form_step: 2,
-                additional_information: 'foo',
-                expenses_attributes:
-                    [
-                        expense_params
-                    ]
+              form_step: 'defendants',
+              additional_information: 'foo',
+              expenses_attributes:
+              [
+                expense_params
+              ]
             }
           end
 
@@ -213,7 +213,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
             post :create, commit_continue: 'Continue', claim: claim_params_step1
             expect(subject_claim.draft?).to be_truthy
             expect(subject_claim.valid?).to be_truthy
-            expect(assigns(:claim).current_step).to eq(2)
+            expect(assigns(:claim).current_step).to eq(:defendants)
             expect(response).to render_template('external_users/advocates/claims/new')
 
             put :update, id: subject_claim, commit_submit_claim: 'Submit to LAA', claim: claim_params_step2

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -192,12 +192,12 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
 
           let(:claim_params_step2) do
             {
-                form_step: 2,
-                additional_information: 'foo',
-                expenses_attributes:
-                    [
-                        expense_params
-                    ]
+              form_step: :defendants,
+              additional_information: 'foo',
+              expenses_attributes:
+              [
+                expense_params
+              ]
             }
           end
 
@@ -207,7 +207,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
             post :create, commit_continue: 'Continue', claim: claim_params_step1
             expect(subject_claim.draft?).to be_truthy
             expect(subject_claim.valid?).to be_truthy
-            expect(assigns(:claim).current_step).to eq(2)
+            expect(assigns(:claim).current_step).to eq(:defendants)
             expect(response).to render_template('external_users/litigators/claims/new')
 
             put :update, id: subject_claim, commit_submit_claim: 'Submit to LAA', claim: claim_params_step2

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -151,8 +151,8 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
 
           let(:claim_params_step2) do
             {
-                form_step: 2,
-                additional_information: 'foo'
+              form_step: 'defendants',
+              additional_information: 'foo'
             }.merge(interim_fee_params)
           end
 
@@ -163,9 +163,15 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
             before do
               post :create, commit_continue: 'Continue', claim: claim_params_step1
             end
-            
-            it 'should leave claim in draft state'  do expect(subject_claim.draft?).to be_truthy end
-            it 'should assign current_step to 2'    do expect(assigns(:claim).current_step).to eq(2) end
+
+            it 'should leave claim in draft state' do
+              expect(subject_claim.draft?).to be_truthy
+            end
+
+            it 'should assign current_step to 2' do
+              expect(assigns(:claim).current_step).to eq(:defendants)
+            end
+
             it { expect(response).to render_template('external_users/litigators/interim_claims/new') }
           end
 
@@ -178,7 +184,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
             it 'saves as draft' do
               expect(subject_claim.draft?).to be_truthy
             end
-            
+
             it 'redirects to summary page' do
               expect(response).to redirect_to(summary_external_users_claim_path(subject_claim))
             end

--- a/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
     let(:params) do
       {
         'claim' => {
-          'form_step' => '1',
+          'form_step' => 'transfer_fee_details',
           'form_id' => SecureRandom.uuid,
           'litigator_type' => 'original',
           'elected_case' => 'true',
@@ -186,7 +186,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
         {
           'claim' => {
             'form_id' => SecureRandom.uuid,
-            'form_step' => '1',
+            'form_step' => 'transfer_fee_details',
             'litigator_type' => 'original',
             'elected_case' => 'true',
             'transfer_stage_id' => '10',
@@ -230,7 +230,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
         {
           'claim' => {
             'form_id' => claim.form_id,
-            'form_step' => '2',
+            'form_step' => 'case_details',
             'supplier_number' => claim.provider.lgfs_supplier_numbers.first.supplier_number,
             'providers_ref' => 'PSR004',
             'court_id' => court.id.to_s,

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -508,7 +508,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
     end
 
-
     context 'find by advocate and defendant' do
 
       let!(:current_external_user) { create(:external_user) }
@@ -784,7 +783,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
   end
 
-
   describe 'allocate claim when assigning to case worker' do
     subject { create(:submitted_claim) }
     let(:case_worker) { create(:case_worker) }
@@ -905,7 +903,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
   end
 
-
   describe '.total_greater_than_or_equal_to' do
     let(:not_greater_than_400) do
       claims = []
@@ -974,7 +971,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   end
 
   describe 'sets the source field before saving a claim' do
-    let(:claim)       { FactoryBot.build :claim }
+    let(:claim) { FactoryBot.build :claim }
 
     it 'sets the source to web by default if unset' do
       expect(claim.save).to eq(true)
@@ -1239,7 +1236,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
         end
       end
 
-
       context 'latest redetermination created after transition to redetermination' do
         it 'should be false' do
           Timecop.freeze(Time.now + 10.minutes) do
@@ -1385,35 +1381,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       result = claim.valid?
       expect(claim.expenses).to have(1).member
       expect(claim.expenses_total).to eq 40.0
-    end
-  end
-
-  describe '#current_step_required?' do
-    let(:claim) { build(:advocate_claim) }
-    subject { claim.current_step_required? }
-
-    specify { is_expected.to eq(true) }
-
-    context 'when current step is offence details (3)' do
-      before do
-        claim.form_step = 3
-      end
-
-      context 'and the case type does not have a fixed fee' do
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(false)
-        end
-
-        specify { is_expected.to eq(true) }
-      end
-
-      context 'and the case type has a fixed fee' do
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(true)
-        end
-
-        specify { is_expected.to eq(false) }
-      end
     end
   end
 

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -30,8 +30,6 @@ module TestHelpers
   def set_value(record, attribute, value)
     setter_method = "#{attribute}=".to_sym
     record.__send__(setter_method, value)
-    record.form_step = 2
-    record.force_validation = true
   end
 
   def no_error_for(record, attribute)

--- a/spec/validators/claim/base_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/base_claim_sub_model_validator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Claim::BaseClaimSubModelValidator, type: :validator do
 
   before(:each) do
     claim.force_validation = true
-    claim.form_step = 2
+    claim.form_step = :defendants
   end
 
   it 'should call the validators on all the defendants' do
@@ -27,7 +27,7 @@ RSpec.describe Claim::BaseClaimSubModelValidator, type: :validator do
       @misc_fee = FactoryBot.create :misc_fee,:with_date_attended, claim: claim
       FactoryBot.create :date_attended, attended_item: @misc_fee
       claim.fees.map(&:dates_attended).flatten      # iterate through the fees and dates attended so that the examples below know they have been created
-      claim.form_step = 4
+      claim.form_step = :fees
     end
 
     it 'should call the validator on all the attended dates for all the fees' do
@@ -43,7 +43,7 @@ RSpec.describe Claim::BaseClaimSubModelValidator, type: :validator do
       FactoryBot.create :date_attended, attended_item: @expense
       claim.expenses.map(&:dates_attended).flatten       # iterate through the expenses and dates attended so that the examples below know they have been created
       claim.force_validation = true
-      claim.form_step = 3
+      claim.form_step = :offence_details
     end
 
   end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         before do
           invalid_claim.defendants.first.update_attribute(:first_name, nil)
           invalid_claim.defendants.first.representation_orders.first.update_attribute(:maat_reference, nil)
-          invalid_claim.form_step = 2
+          invalid_claim.form_step = :defendants
         end
 
         it 'validation is performed on claim' do
@@ -186,7 +186,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
   context 'total' do
     before do
       allow(claim).to receive(:total).and_return(total)
-      claim.form_step = 4
+      claim.form_step = :fees
     end
 
     context 'when total is not greater than 0' do

--- a/spec/validators/claim/interim_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_sub_model_validator_spec.rb
@@ -7,10 +7,14 @@ RSpec.describe Claim::InterimClaimSubModelValidator, type: :validator do
   include_examples 'common partial association validations', {
       has_one: [
           [],
+          [],
+          [],
           [:interim_fee, :assessment, :certification]
       ],
       has_many: [
+          [],
           [:defendants],
+          [],
           [:disbursements, :messages, :redeterminations, :documents]
       ]
   }

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
     before do
       allow(claim).to receive(:interim_fee).and_return(interim_fee)
       claim.source = 'web'
-      claim.form_step = 4
+      claim.form_step = :fees
     end
 
     context 'estimated_trial_length' do

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
       :transfer_court,
       :transfer_case_number,
       :advocate_category,
-      :offence,
       :case_concluded_at
     ],
+    [],
+    [ :offence ],
     [
       :first_day_of_trial,
       :estimated_trial_length,
@@ -38,7 +39,7 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
     before do
       allow(claim).to receive(:interim_fee).and_return(interim_fee)
       claim.source = 'web'
-      claim.form_step = 2
+      claim.form_step = 4
     end
 
     context 'estimated_trial_length' do

--- a/spec/validators/claim/litigator_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_sub_model_validator_spec.rb
@@ -5,13 +5,17 @@ RSpec.describe Claim::LitigatorClaimSubModelValidator, type: :validator do
   let(:claim) { FactoryBot.create :litigator_claim }
 
   include_examples 'common partial association validations', {
-      has_one: [
-          [],
-          [:graduated_fee, :fixed_fee, :warrant_fee, :assessment, :certification]
-      ],
-      has_many: [
-          [:defendants],
-          [:misc_fees, :disbursements, :expenses, :messages, :redeterminations, :documents]
-      ]
+    has_one: [
+      [],
+      [],
+      [],
+      [:graduated_fee, :fixed_fee, :warrant_fee, :assessment, :certification]
+    ],
+    has_many: [
+      [],
+      [:defendants],
+      [],
+      [:misc_fees, :disbursements, :expenses, :messages, :redeterminations, :documents]
+    ]
   }
 end

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -12,19 +12,20 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
   include_examples "common litigator validations"
 
   include_examples 'common partial validations', [
-      [
-          :case_type,
-          :court,
-          :case_number,
-          :transfer_court,
-          :transfer_case_number,
-          :advocate_category,
-          :offence,
-          :case_concluded_at
-      ],
-      [
-          :actual_trial_length,
-          :total
-      ]
+    [
+      :case_type,
+      :court,
+      :case_number,
+      :transfer_court,
+      :transfer_case_number,
+      :advocate_category,
+      :case_concluded_at
+    ],
+    [],
+    %i[offence],
+    [
+      :actual_trial_length,
+      :total
+    ]
   ]
 end

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -1,4 +1,4 @@
-shared_examples "common advocate litigator validations" do |external_user_type|
+RSpec.shared_examples "common advocate litigator validations" do |external_user_type|
 
   context 'external_user' do
     it 'should error if not present, regardless' do
@@ -62,8 +62,7 @@ shared_examples "common advocate litigator validations" do |external_user_type|
   end
 end
 
-
-shared_examples "common litigator validations" do
+RSpec.shared_examples "common litigator validations" do
 
   let(:advocate)      { build(:external_user, :advocate) }
   let(:offence)       { build(:offence) }
@@ -152,13 +151,16 @@ shared_examples "common litigator validations" do
   end
 
   context 'offence' do
-    before { claim.offence = nil }
+    before do
+      claim.form_step = 3
+      claim.offence = nil
+    end
 
-    it 'should error if NOT present for any case type' do
+    it 'should error if NOT present for case type without fixed fees' do
       claim.case_type.is_fixed_fee = false
       should_error_with(claim, :offence, 'blank_class')
       claim.case_type.is_fixed_fee = true
-      should_error_with(claim, :offence, 'blank_class')
+      should_not_error(claim, :offence)
     end
 
     it 'should NOT error if a Miscellaneous/other offence' do

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -152,7 +152,7 @@ RSpec.shared_examples "common litigator validations" do
 
   context 'offence' do
     before do
-      claim.form_step = 3
+      claim.form_step = :offence_details
       claim.offence = nil
     end
 

--- a/spec/validators/claim/shared_examples_for_step_validators.rb
+++ b/spec/validators/claim/shared_examples_for_step_validators.rb
@@ -146,7 +146,7 @@ shared_examples 'common partial association validations' do |steps|
       end
 
       it 'should validate all the has_many associations for all the steps' do
-        (step1_has_many + step2_has_many + step3_has_many).each do |association|
+        steps[:has_many].flatten.each do |association|
           expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association)
         end
 

--- a/spec/validators/claim/shared_examples_for_step_validators.rb
+++ b/spec/validators/claim/shared_examples_for_step_validators.rb
@@ -1,4 +1,4 @@
-shared_examples 'common partial validations' do |steps|
+RSpec.shared_examples 'common partial validations' do |steps|
 
   context 'partial validation' do
     let(:step1_attributes) { steps[0] }
@@ -10,9 +10,9 @@ shared_examples 'common partial validations' do |steps|
         claim.source = 'web'
       end
 
-      context 'step 1' do
+      context 'first step' do
         before do
-          claim.form_step = 1
+          claim.form_step = claim.submission_stages.first
         end
 
         it 'should validate only attributes for this step' do
@@ -28,9 +28,9 @@ shared_examples 'common partial validations' do |steps|
         end
       end
 
-      context 'step 2' do
+      context 'second step' do
         before do
-          claim.form_step = 2
+          claim.form_step = claim.submission_stages.second
         end
 
         it 'should validate attributes for this step and previous steps' do
@@ -59,7 +59,7 @@ shared_examples 'common partial validations' do |steps|
   end
 end
 
-shared_examples 'common partial association validations' do |steps|
+RSpec.shared_examples 'common partial association validations' do |steps|
 
   context 'partial validation' do
     let(:step1_has_one) { steps[:has_one][0] }
@@ -79,9 +79,9 @@ shared_examples 'common partial association validations' do |steps|
         claim.source = 'web'
       end
 
-      context 'step 1' do
+      context 'first step' do
         before do
-          claim.form_step = 1
+          claim.form_step = claim.submission_stages.first
         end
 
         it 'should validate has_one associations for this step' do
@@ -109,9 +109,9 @@ shared_examples 'common partial association validations' do |steps|
         end
       end
 
-      context 'step 2' do
+      context 'second step' do
         before do
-          claim.form_step = 2
+          claim.form_step = claim.submission_stages.second
         end
 
         it 'should validate has_one associations for this step and previous steps' do

--- a/spec/validators/claim/transfer_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_sub_model_validator_spec.rb
@@ -5,28 +5,31 @@ RSpec.describe Claim::TransferClaimSubModelValidator, type: :validator do
   let(:claim) { FactoryBot.create :transfer_claim }
 
   include_examples 'common partial association validations', {
-      has_one: [
-                  [ ],
-                  [
-                    :transfer_fee,
-                    :assessment,
-                    :certification
-                  ]
-               ],
-      has_many: [
-                  [],
-                  [
-                    :defendants,
-                  ],
-                  [
-                    :misc_fees,
-                    :disbursements,
-                    :expenses,
-                    :messages,
-                    :redeterminations,
-                    :documents
-                  ]
-                ]
-
+    has_one: [
+      [],
+      [],
+      [],
+      [
+        :transfer_fee,
+        :assessment,
+        :certification
+      ]
+    ],
+    has_many: [
+      [],
+      [],
+      [
+        :defendants,
+      ],
+      [],
+      [
+        :misc_fees,
+        :disbursements,
+        :expenses,
+        :messages,
+        :redeterminations,
+        :documents
+      ]
+    ]
   }
 end

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
     ]
   ]
 
+  before do
+    claim.form_step = :case_details
+    claim.force_validation = true
+  end
+
   context 'litigator type' do
     it 'errors if not new or original' do
       expect_invalid_attribute_with_message(claim, :litigator_type, 'xxx', 'invalid')
@@ -112,12 +117,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
 
   context 'case_conclusion' do
 
-    let(:claim) do
-      claim = Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id:30, case_conclusion_id: 10)
-      claim.form_step = 2
-      claim.force_validation = true
-      claim
-    end
+    let(:claim) { Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id:30, case_conclusion_id: 10) }
 
     it 'is valid if a valid case conclusion id' do
       expect_valid_attribute claim, :case_conclusion_id, 20
@@ -128,12 +128,8 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
     end
 
     context 'presence and absence' do
-      let(:claim) do
-        claim = Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10)
-        claim.form_step = 2
-        claim.force_validation = true
-        claim
-      end
+      let(:claim) { Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10) }
+
       it 'should error if absent but required' do
         claim.transfer_stage_id = 30
         expect_invalid_attribute_with_message(claim, :case_conclusion_id, nil, 'blank')
@@ -147,12 +143,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
 
   context 'transfer_details combination' do
 
-    let(:claim) do
-      claim = Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10)
-      claim.form_step = 2
-      claim.force_validation = true
-      claim
-    end
+    let(:claim) { Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10) }
 
     it 'adds a transfer detail combination error for invalid combinations' do
       expect(claim).not_to be_valid

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -23,12 +23,13 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
       :transfer_court,
       :transfer_case_number,
       :advocate_category,
-      :offence,
       :case_concluded_at,
       :supplier_number,
       :amount_assessed,
       :evidence_checklist_ids,
     ],
+    [],
+    [ :offence ],
     [
       :total,
     ]


### PR DESCRIPTION
💎  [Page splitting for Litigator final fee](https://www.pivotaltracker.com/story/show/154799214)
💎  [Page splitting for Litigator Interim Fee](https://www.pivotaltracker.com/story/show/154799221)
💎  [Page splitting for Litigator Transfer Fee](https://www.pivotaltracker.com/story/show/154799228)

Also:

* Change from *numbered steps* to **named steps**. Numbered steps at a given time can represent any sort of step, which makes it quite hard to understand what step was taken by a user in the past.