### PR TITLE
Fix multi-page form continue flicker

### DIFF
--- a/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
@@ -19,16 +19,13 @@ Feature: Advocate admin submits a claim for a Trial case
     And I enter a case number of 'A20161234'
 
     Then I click "Continue" in the claim form
-
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
 
     Then I click "Continue" in the claim form
-
     And I select the offence category 'Activities relating to opium'
 
     Then I click "Continue" in the claim form
-
     And I add a basic fee with dates attended
     And I add a number of cases uplift fee with additional case numbers
     And I add a miscellaneous fee 'Adjourned appeals' with dates attended

--- a/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
@@ -2,7 +2,6 @@
 Feature: Advocate admin submits a claim for a Trial case
 
   Scenario: I create a trial claim, then submit it
-
     Given I am a signed in advocate admin
     And There are other advocates in my provider
     And I am on the 'Your claims' page

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -21,6 +21,7 @@ class ClaimFormPage < SitePrism::Page
     section :first_day_of_trial, CommonDateSection, '#first_day_of_trial'
     section :trial_concluded_on, CommonDateSection, '#trial_concluded_at'
     element :actual_trial_length, "#claim_actual_trial_length"
+    element :estimated_trial_length, '#claim_estimated_trial_length'
   end
 
   section :retrial_details, RetrialSection, "#retrial-details"

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -38,17 +38,20 @@ When(/I enter trial start and end dates$/) do
   using_wait_time 3 do
     @claim_form_page.trial_details.first_day_of_trial.set_date 9.days.ago.to_s
     @claim_form_page.trial_details.trial_concluded_on.set_date 2.days.ago.to_s
+    @claim_form_page.trial_details.estimated_trial_length.set 5
     @claim_form_page.trial_details.actual_trial_length.set 8
   end
 end
 
 When(/^I enter defendant, representation order and MAAT reference$/) do
-  @claim_form_page.wait_for_defendants
-  @claim_form_page.defendants.first.first_name.set "Bob"
-  @claim_form_page.defendants.first.last_name.set "Billiards"
-  @claim_form_page.defendants.first.dob.set_date "1955-01-01"
-  @claim_form_page.defendants.last.representation_orders.first.date.set_date "2016-01-01"
-  @claim_form_page.defendants.last.representation_orders.first.maat_reference.set "1234567890"
+    using_wait_time(6) do
+      @claim_form_page.wait_for_defendants
+      @claim_form_page.defendants.first.first_name.set "Bob"
+      @claim_form_page.defendants.first.last_name.set "Billiards"
+      @claim_form_page.defendants.first.dob.set_date "1955-01-01"
+      @claim_form_page.defendants.last.representation_orders.first.date.set_date "2016-01-01"
+      @claim_form_page.defendants.last.representation_orders.first.maat_reference.set "1234567890"
+    end
 end
 
 When(/^I save as draft$/) do
@@ -138,7 +141,7 @@ end
 
 When(/^I click "Continue" in the claim form$/) do
   sleep 3
-  @claim_form_page.continue.click
+  @claim_form_page.continue_button.click
   wait_for_ajax
 end
 

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -137,6 +137,7 @@ When(/^I add some additional information$/) do
 end
 
 When(/^I click "Continue" in the claim form$/) do
+  sleep 3
   @claim_form_page.continue.click
   wait_for_ajax
 end

--- a/features/support/date_helper.rb
+++ b/features/support/date_helper.rb
@@ -10,3 +10,5 @@ module DateHelper
     self.day.set '1'
   end
 end
+
+World(DateHelper)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -53,13 +53,14 @@ end
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.
 # See the DatabaseCleaner documentation for details. Example:
 #
-#   Before('@no-txn,@selenium,@culerity,@celerity,@javascript') do
-#     # { :except => [:widgets] } may not do what you expect here
-#     # as Cucumber::Rails::Database.javascript_strategy overrides
-#     # this setting.
-#     DatabaseCleaner.strategy = :truncation
-#   end
-#
+  # Before('@no-txn,@selenium,@culerity,@celerity,@javascript') do
+  #   # { :except => [:widgets] } may not do what you expect here
+  #   # as Cucumber::Rails::Database.javascript_strategy overrides
+  #   # this setting.
+  #   DatabaseCleaner.strategy = :truncation
+  #   Cucumber::Rails::Database.javascript_strategy = :truncation
+  # end
+
 #   Before('~@no-txn', '~@selenium', '~@culerity', '~@celerity', '~@javascript') do
 #     DatabaseCleaner.strategy = :transaction
 #   end

--- a/features/support/screenshot_helper.rb
+++ b/features/support/screenshot_helper.rb
@@ -1,6 +1,9 @@
 module ScreenshotHelper
-  def save_and_open_screenhot
-    sleep 3 # give js time to render
+  # convenience override of default method of the same name to specify
+  # full path and timestamped file name and get full screenshot.
+  #
+  def save_and_open_screenshot(wait: Capybara.default_max_wait_time)
+    sleep wait # give js time to render
     file_path = Rails.root.join("tmp/capybara/capybara-screenshot-#{Time.now.utc.iso8601.gsub('-', '').gsub(':', '')}.png").to_s
     page.save_screenshot(file_path, full: true)
     Launchy.open file_path

--- a/features/support/wait_for_ajax.rb
+++ b/features/support/wait_for_ajax.rb
@@ -1,6 +1,6 @@
 module WaitForAjax
-  def wait_for_ajax
-    Timeout.timeout(Capybara.default_max_wait_time) do
+  def wait_for_ajax(wait: Capybara.default_max_wait_time)
+    Timeout.timeout(wait) do
       loop until finished_all_ajax_requests?
     end
   end

--- a/features/support/wait_for_ajax.rb
+++ b/features/support/wait_for_ajax.rb
@@ -9,3 +9,5 @@ module WaitForAjax
     page.evaluate_script('jQuery.active').zero?
   end
 end
+
+World(WaitForAjax)

--- a/old_features/support/env.rb
+++ b/old_features/support/env.rb
@@ -43,19 +43,15 @@ rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
 end
 
-
 # lets set up some VAT rates that will apply to all cukes
 Before do
   FactoryBot.create :vat_rate, effective_date: Date.new(1970, 1, 1)
   FactoryBot.create :vat_rate, effective_date: Date.new(1990, 4, 5)
 end
 
-
 After do
   VatRate.delete_all
 end
-
-
 
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.
 # See the DatabaseCleaner documentation for details. Example:


### PR DESCRIPTION
Add sleep before continue button click

Seems to be the most reliable way to ensure we move to 
the next page. Tried extending default max wait time and
using other wait methods from capybara with poor results.
