### PR TITLE
Force redetermination before AWR

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -365,6 +365,10 @@ module Claim
       VALID_STATES_FOR_REDETERMINATION.include?(state) && !interim?
     end
 
+    def applicable_for_written_reasons?
+      redeterminations.count.positive?
+    end
+
     def perform_validation?
       force_validation? || validation_required?
     end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -366,7 +366,7 @@ module Claim
     end
 
     def applicable_for_written_reasons?
-      redeterminations.count.positive?
+      claim_state_transitions.any? { |x| x.to == 'redetermination' }
     end
 
     def perform_validation?

--- a/app/services/claims/external_user_actions.rb
+++ b/app/services/claims/external_user_actions.rb
@@ -3,5 +3,9 @@ module Claims
     def self.all
       Settings.claim_actions
     end
+
+    def self.available_for(claim)
+      [] << Settings.claim_actions[claim.applicable_for_written_reasons? ? 1 : 0]
+    end
   end
 end

--- a/app/services/claims/external_user_actions.rb
+++ b/app/services/claims/external_user_actions.rb
@@ -8,7 +8,7 @@ module Claims
       if claim.applicable_for_written_reasons?
         Settings.claim_actions
       else
-        [] << Settings.claim_actions[1]
+        [] << Settings.claim_actions[0]
       end
     end
   end

--- a/app/services/claims/external_user_actions.rb
+++ b/app/services/claims/external_user_actions.rb
@@ -8,7 +8,7 @@ module Claims
       if claim.applicable_for_written_reasons?
         Settings.claim_actions
       else
-        [] << Settings.claim_actions[0]
+        Settings.claim_actions.reject { |option| option.eql?('Request written reasons') }
       end
     end
   end

--- a/app/services/claims/external_user_actions.rb
+++ b/app/services/claims/external_user_actions.rb
@@ -1,0 +1,7 @@
+module Claims
+  class ExternalUserActions
+    def self.all
+      Settings.claim_actions
+    end
+  end
+end

--- a/app/services/claims/external_user_actions.rb
+++ b/app/services/claims/external_user_actions.rb
@@ -5,7 +5,11 @@ module Claims
     end
 
     def self.available_for(claim)
-      [] << Settings.claim_actions[claim.applicable_for_written_reasons? ? 1 : 0]
+      if claim.applicable_for_written_reasons?
+        Settings.claim_actions
+      else
+        [] << Settings.claim_actions[1]
+      end
     end
   end
 end

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -5,7 +5,7 @@
     .js-hide-status
       = f.label t('.update_claim_status'), class: "form-label bold-normal"
       .form-group.inline.js-test-claim-action
-        = f.collection_radio_buttons(:claim_action, Claims::ExternalUserActions.all, :to_s, :to_s) do |b|
+        = f.collection_radio_buttons(:claim_action, Claims::ExternalUserActions.available_for(@claim), :to_s, :to_s) do |b|
           - b.label(class: "block-label") { b.radio_button + b.value.humanize }
 
   - if messaging_permitted?(message) || current_user_is_caseworker?

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -5,7 +5,7 @@
     .js-hide-status
       = f.label t('.update_claim_status'), class: "form-label bold-normal"
       .form-group.inline.js-test-claim-action
-        = f.collection_radio_buttons(:claim_action, Settings.claim_actions, :to_s, :to_s) do |b|
+        = f.collection_radio_buttons(:claim_action, Claims::ExternalUserActions.all, :to_s, :to_s) do |b|
           - b.label(class: "block-label") { b.radio_button + b.value.humanize }
 
   - if messaging_permitted?(message) || current_user_is_caseworker?

--- a/spec/services/claims/external_user_actions_spec.rb
+++ b/spec/services/claims/external_user_actions_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Claims::ExternalUserActions do
     context 'when the claim has not been redetermined yet' do
       let(:claim) { create :advocate_claim }
 
-      it { is_expected.to eq ['Apply for redetermination'] }
+      it { is_expected.to eq ['Request written reasons'] }
     end
 
     context 'when the claim has already been redetermined' do
       let(:claim) { create :deterministic_claim, :redetermination }
 
-      it { is_expected.to eq ['Request written reasons'] }
+      it { is_expected.to eq ['Apply for redetermination', 'Request written reasons'] }
     end
   end
 end

--- a/spec/services/claims/external_user_actions_spec.rb
+++ b/spec/services/claims/external_user_actions_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Claims::ExternalUserActions do
+  describe '.available' do
+    subject { described_class.all }
+
+    it { is_expected.to eq ['Apply for redetermination', 'Request written reasons'] }
+  end
+end

--- a/spec/services/claims/external_user_actions_spec.rb
+++ b/spec/services/claims/external_user_actions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Claims::ExternalUserActions do
     context 'when the claim has not been redetermined yet' do
       let(:claim) { create :advocate_claim }
 
-      it { is_expected.to eq ['Request written reasons'] }
+      it { is_expected.to eq ['Apply for redetermination'] }
     end
 
     context 'when the claim has already been redetermined' do

--- a/spec/services/claims/external_user_actions_spec.rb
+++ b/spec/services/claims/external_user_actions_spec.rb
@@ -1,9 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Claims::ExternalUserActions do
-  describe '.available' do
+  describe '.all' do
     subject { described_class.all }
 
     it { is_expected.to eq ['Apply for redetermination', 'Request written reasons'] }
+  end
+
+  describe '#available_for' do
+    subject { described_class.available_for(claim) }
+
+    context 'when the claim has not been redetermined yet' do
+      let(:claim) { create :advocate_claim }
+
+      it { is_expected.to eq ['Apply for redetermination'] }
+    end
+
+    context 'when the claim has already been redetermined' do
+      let(:claim) { create :deterministic_claim, :redetermination }
+
+      it { is_expected.to eq ['Request written reasons'] }
+    end
   end
 end


### PR DESCRIPTION
[Pivotal Ticket](https://www.pivotaltracker.com/story/show/154280789)

**AS A** senior caseworker
**I WANT** written reasons claims to have first been through the redetermination process
**SO THAT** I don't have to spend lots of time rejecting these claims.

### acceptance criteria
only display the 'awaiting written reasons' radio button when the claim has already had the state 'redetermination'

![redetermination-written-reasons-flow](https://user-images.githubusercontent.com/6757677/35980498-bebf1944-0ce2-11e8-8df1-37d12db42d86.png)
