### PR TITLE
Remove SQS for AGFS

### DIFF
--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -146,7 +146,7 @@ When(/^I click "Continue" in the claim form$/) do
 end
 
 When(/^I click Submit to LAA$/) do
-  allow(Aws::SQS::Client).to receive(:new).and_return Aws::SQS::Client.new(region: 'eu_west_1', stub_responses: true)
+  allow(Aws::SNS::Client).to receive(:new).and_return Aws::SNS::Client.new(region: 'eu_west_1', stub_responses: true)
   @claim_form_page.submit_to_laa.trigger "click"
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -74,7 +74,7 @@ When(/^I check “I attended the main hearing”$/) do
 end
 
 When(/^I click Certify and submit claim$/) do
-  allow(Aws::SQS::Client).to receive(:new).and_return Aws::SQS::Client.new(region: 'eu_west_1', stub_responses: true)
+  allow(Aws::SNS::Client).to receive(:new).and_return Aws::SNS::Client.new(region: 'eu_west_1', stub_responses: true)
   @certification_page.certify_and_submit_claim.trigger "click"
 end
 


### PR DESCRIPTION
We were temporarily sending both SQS and SNS notifications on completion of an AGFS claim
This is no longer needed