### PR TITLE
Soft delete Cost judge type disbursements

### DIFF
--- a/app/services/cclf/disbursement_adapter.rb
+++ b/app/services/cclf/disbursement_adapter.rb
@@ -1,12 +1,13 @@
 module CCLF
   class DisbursementAdapter < MappingBillAdapter
+    # NOTE: TRV, CJA, CJP disabled/softly-deleted as handled as
+    # expenses (TRV) and Misc Fees (CJA/CJP)
+    #
     DISBURSEMENT_BILL_MAPPINGS = {
       ARP: zip(%w[DISBURSEMENT ACCIDENT]), # Accident reconstruction report
       ACC: zip(%w[DISBURSEMENT ACCOUNTANTS]), # Accounts
       SWX: zip(%w[DISBURSEMENT COMPUTER_EXPERT]), # Computer experts
       CMR: zip(%w[DISBURSEMENT CONSULTANT_REP]), # Consultant medical reports
-      CJA: zip(%w[DISBURSEMENT TBC]), # TODO: "Costs judge application fee" - this is a miscelleneous fee too
-      CJP: zip(%w[DISBURSEMENT TBC]), # TODO: "Costs judge preparation award" - this is a miscelleneous fee too
       DNA: zip(%w[DISBURSEMENT DNA_TESTING]), # DNA testing
       ENG: zip(%w[DISBURSEMENT ENGINEER]), # Engineer
       ENQ: zip(%w[DISBURSEMENT ENQUIRY_AGENTS]), # Enquiry agents
@@ -30,12 +31,9 @@ module CCLF
       ARC: zip(%w[DISBURSEMENT SURVEYOR]), # Surveyor/architect
       SCR: zip(%w[DISBURSEMENT TRANSCRIPTS]), # Transcripts
       TRA: zip(%w[DISBURSEMENT TRANSLATOR]), # Translator
-      # TRV: zip(['DISBURSEMENT', 'TRAVEL COSTS']), # Travel costs **
       VET: zip(%w[DISBURSEMENT VET_REPORT]), # Vet report
       VOI: zip(%w[DISBURSEMENT VOICE_RECOG]) # Voice recognition
     }.freeze
-
-    # TODO: ** disabled for Litigator Claims, could be removed from app
 
     private
 

--- a/db/migrate/20180207085503_softly_delete_cost_judge_disbursement_types.rb
+++ b/db/migrate/20180207085503_softly_delete_cost_judge_disbursement_types.rb
@@ -1,0 +1,9 @@
+class SoftlyDeleteCostJudgeDisbursementTypes < ActiveRecord::Migration
+  def up
+    DisbursementType.where(unique_code: %i[CJP CJA]).each {|d| d.soft_delete }
+  end
+
+  def down
+    DisbursementType.where(unique_code: %i[CJP CJA]).each {|d| d.update(deleted_at: nil) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180115161809) do
+ActiveRecord::Schema.define(version: 20180207085503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds/disbursement_types.rb
+++ b/db/seeds/disbursement_types.rb
@@ -5,8 +5,8 @@ disbursement_types = [
   [2, 'ACC', 'Accounts'],
   [3, 'SWX', 'Computer experts'],
   [4, 'CMR', 'Consultant medical reports'],
-  [5, 'CJA', 'Costs judge application fee'],
-  [6, 'CJP', 'Costs judge preparation award'],
+  [5, 'CJA', 'Costs judge application fee'], # softly deleted as handled by misc fees
+  [6, 'CJP', 'Costs judge preparation award'], # softly deleted as handled misc fees
   [7, 'DNA', 'DNA testing'],
   [8, 'ENG', 'Engineer'],
   [9, 'ENQ', 'Enquiry agents'],
@@ -30,7 +30,7 @@ disbursement_types = [
   [27, 'ARC', 'Surveyor/architect'],
   [28, 'SCR', 'Transcripts'],
   [29, 'TRA', 'Translator'],
-  [30, 'TRV', 'Travel costs'],
+  [30, 'TRV', 'Travel costs'], # softly deleted as handled by travel expenses
   [31, 'VET', 'Vet report'],
   [32, 'VOI', 'Voice recognition'],
 ]

--- a/spec/services/cclf/disbursement_adapter_spec.rb
+++ b/spec/services/cclf/disbursement_adapter_spec.rb
@@ -8,14 +8,13 @@ RSpec.describe CCLF::Fee::DisbursementAdapter, type: :adapter do
   # however the bill scenario and "formula"* depend on the
   # case type and litigator claim type.
   # *nb: formula is used CCLF-side only and maps to whether to use quantity or amount???
+  # NOTE: Costs judge prep, Cost judge application and travel costs have been softly deleted
   #
   DISBURSEMENT_BILL_TYPES = {
     ARP: ['DISBURSEMENT', 'ACCIDENT'], # Accident reconstruction report
     ACC: ['DISBURSEMENT', 'ACCOUNTANTS'], # Accounts
     SWX: ['DISBURSEMENT', 'COMPUTER_EXPERT'], # Computer experts
     CMR: ['DISBURSEMENT', 'CONSULTANT_REP'], # Consultant medical reports
-    CJA: ['DISBURSEMENT', 'TBC'], # TODO: "Costs judge application fee" - this is a miscelleneous fee too
-    CJP: ['DISBURSEMENT', 'TBC'], # TODO: "Costs judge preparation award" - this is a miscelleneous fee too
     DNA: ['DISBURSEMENT', 'DNA_TESTING'], # DNA testing
     ENG: ['DISBURSEMENT', 'ENGINEER'], # Engineer
     ENQ: ['DISBURSEMENT', 'ENQUIRY_AGENTS'], # Enquiry agents
@@ -39,7 +38,6 @@ RSpec.describe CCLF::Fee::DisbursementAdapter, type: :adapter do
     ARC: ['DISBURSEMENT', 'SURVEYOR'], # Surveyor/architect
     SCR: ['DISBURSEMENT', 'TRANSCRIPTS'], # Transcripts
     TRA: ['DISBURSEMENT', 'TRANSLATOR'], # Translator
-  # TRV: ['DISBURSEMENT', 'TRAVEL COSTS'], # Travel costs - # TODO: disable for Litigator Claims, could be removed from app
     VET: ['DISBURSEMENT', 'VET_REPORT'], # Vet report
     VOI: ['DISBURSEMENT', 'VOICE_RECOG'], # Voice recognition
   }.freeze

--- a/spikes/adapters/laa_disbursement_adapter.rb
+++ b/spikes/adapters/laa_disbursement_adapter.rb
@@ -4,8 +4,8 @@ class LaaDisbursementAdapter
     'ACC' => 'ACCOUNTANTS',
     'SWX' => 'COMPUTER_EXPERT',
     'CMR' => 'CONSULTANT_REP',
-    'CJA' => nil,
-    'CJP' => nil,
+    # 'CJA' => nil, **
+    # 'CJP' => nil, **
     'DNA' => 'DNA_TESTING',
     'ENG' => 'ENGINEER',
     'ENQ' => 'ENQUIRY_AGENTS',
@@ -29,10 +29,12 @@ class LaaDisbursementAdapter
     'ARC' => 'SURVEYOR',
     'SCR' => 'TRANSCRIPTS',
     'TRA' => 'TRANSLATOR',
-    'TRV' => 'TRAVEL COSTS',
+    # 'TRV' => 'TRAVEL COSTS', *
     'VET' => 'VET_REPORT',
     'VOI' => 'VOICE_RECOG'
   }.freeze
+
+  # softley deleted as not needed, handled by expenses (*) or misc fees (**)
 
   LAA_BILL_TYPE = 'DISBURSEMENT'.freeze
 


### PR DESCRIPTION
These disbursement types have been softly deleted on all environments
already as they are handled as LGFS miscellaneous fees in the app
and are handled as "OTHER" type bills in CCLF. They are not applicable
to LGFS Interim claims either.