### PR TITLE
Apply agreed handling of VAT for CCLF

### DIFF
--- a/app/interfaces/api/entities/cclf/adapted_disbursement.rb
+++ b/app/interfaces/api/entities/cclf/adapted_disbursement.rb
@@ -2,10 +2,7 @@ module API
   module Entities
     module CCLF
       class AdaptedDisbursement < AdaptedBaseBill
-        # NOTE: CCLF only requires the net amount and calculates vat based on rep order date
-        expose :net_amount, format_with: :string
-        expose :vat_amount, format_with: :string
-        expose :total, format_with: :string
+        expose :net_amount, :vat_amount, format_with: :string
 
         private
 

--- a/app/interfaces/api/entities/cclf/adapted_expense.rb
+++ b/app/interfaces/api/entities/cclf/adapted_expense.rb
@@ -2,8 +2,10 @@ module API
   module Entities
     module CCLF
       class AdaptedExpense < AdaptedBaseBill
-        expose :amount, format_with: :string
-        expose :vat_amount, format_with: :string
+        with_options(format_with: :string) do
+          expose :amount, as: :net_amount
+          expose :vat_amount
+        end
 
         private
 

--- a/app/interfaces/api/entities/cclf/adapted_fixed_fee.rb
+++ b/app/interfaces/api/entities/cclf/adapted_fixed_fee.rb
@@ -2,7 +2,7 @@ module API
   module Entities
     module CCLF
       class AdaptedFixedFee < AdaptedBaseBill
-        expose :amount, format_with: :string
+        expose :quantity, format_with: :integer_string
 
         private
 

--- a/app/interfaces/api/entities/cclf/adapted_graduated_fee.rb
+++ b/app/interfaces/api/entities/cclf/adapted_graduated_fee.rb
@@ -2,8 +2,7 @@ module API
   module Entities
     module CCLF
       class AdaptedGraduatedFee < AdaptedBaseBill
-        expose :quantity, format_with: :string
-        expose :amount, format_with: :string
+        expose :quantity, format_with: :integer_string
 
         private
 

--- a/app/interfaces/api/entities/cclf/final_claim.rb
+++ b/app/interfaces/api/entities/cclf/final_claim.rb
@@ -7,8 +7,8 @@ module API
           data.push AdaptedFixedFee.represent(object.fixed_fee)
           data.push AdaptedGraduatedFee.represent(object.graduated_fee)
           data.push AdaptedMiscFee.represent(object.misc_fees)
-          data.push API::Entities::CCLF::AdaptedDisbursement.represent(object.disbursements)
-          data.push API::Entities::CCLF::AdaptedExpense.represent(object.expenses)
+          data.push AdaptedDisbursement.represent(object.disbursements)
+          data.push AdaptedExpense.represent(object.expenses)
           data.push AdaptedWarrantFee.represent(object.warrant_fee)
           data.as_json.flat_select { |bill| bill[:bill_type].present? }
         end

--- a/app/interfaces/api/helpers/formatters.rb
+++ b/app/interfaces/api/helpers/formatters.rb
@@ -14,6 +14,10 @@ module API::Helpers
       number.to_f.round(2)
     end
 
+    Grape::Entity.format_with :integer_string do |number|
+      number.to_i.to_s
+    end
+
     Grape::Entity.format_with :bool_char do |boolean|
       boolean.to_s.true? ? 'Y' : 'N'
     end

--- a/app/services/cclf/case_type_adapter.rb
+++ b/app/services/cclf/case_type_adapter.rb
@@ -2,7 +2,7 @@ module CCLF
   class CaseTypeAdapter
     attr_reader :case_type
 
-    # TODO: these are for final claim bill scenarios. Interim and tranfer claims have others
+    # TODO: final claims only, other scenarios exist for transfer claims
     BILL_SCENARIOS = {
       FXACV: 'ST1TS0T5', # Appeal against conviction
       FXASE: 'ST1TS0T6', # Appeal against sentence

--- a/app/services/cclf/simple_bill_adapter.rb
+++ b/app/services/cclf/simple_bill_adapter.rb
@@ -3,15 +3,5 @@ require_relative 'simple_bill_typeable'
 module CCLF
   class SimpleBillAdapter < SimpleDelegator
     include SimpleBillTypeable
-
-    def bill_scenario
-      case_type_adapter.bill_scenario
-    end
-
-    private
-
-    def case_type_adapter
-      @adapter ||= ::CCLF::CaseTypeAdapter.new(claim.case_type)
-    end
   end
 end

--- a/config/schemas/cclf_claim_schema.json
+++ b/config/schemas/cclf_claim_schema.json
@@ -100,20 +100,16 @@
             "id": "/properties/bills/items/properties/quantity",
             "type": "string"
           },
+          "amount": {
+            "id": "/properties/bills/items/properties/amount",
+            "type": "string"
+          },
           "net_amount": {
             "id": "/properties/bills/items/properties/net_amount",
             "type": "string"
           },
           "vat_amount": {
             "id": "/properties/bills/items/properties/vat_amount",
-            "type": "string"
-          },
-          "total": {
-            "id": "/properties/bills/items/properties/total",
-            "type": "string"
-          },
-          "amount": {
-            "id": "/properties/bills/items/properties/amount",
             "type": "string"
           },
           "warrant_issued_date": {

--- a/spec/api/entities/cclf/adapted_disbursement_spec.rb
+++ b/spec/api/entities/cclf/adapted_disbursement_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe API::Entities::CCLF::AdaptedDisbursement, type: :adapter do
   let(:disbursement_type) { instance_double(::DisbursementType, unique_code: 'FOR') }
   let(:case_type) { instance_double(::CaseType, fee_type_code: 'FXACV') }
   let(:claim) { instance_double(::Claim::BaseClaim, case_type: case_type) }
-  let(:disbursement) { instance_double(::Disbursement, claim: claim, disbursement_type: disbursement_type, net_amount: 9.99, vat_amount: 1.99, total: 11.98) }
+  let(:disbursement) { instance_double(::Disbursement, claim: claim, disbursement_type: disbursement_type, net_amount: 9.99, vat_amount: 1.99) }
 
   it 'exposes the required keys' do
-    expect(response.keys).to match_array(%i[bill_type bill_subtype net_amount vat_amount total])
+    expect(response.keys).to match_array(%i[bill_type bill_subtype net_amount vat_amount])
   end
 
   it 'exposes expected json key-value pairs' do
@@ -18,12 +18,11 @@ RSpec.describe API::Entities::CCLF::AdaptedDisbursement, type: :adapter do
       bill_type: 'DISBURSEMENT',
       bill_subtype: 'FORENSICS',
       net_amount: '9.99',
-      vat_amount: '1.99',
-      total: '11.98'
+      vat_amount: '1.99'
     )
   end
 
-  it 'delegates bill mappings to DisbursementAdapter' do
+  it 'delegates bill type attributes to DisbursementAdapter' do
     adapter = instance_double(::CCLF::DisbursementAdapter)
     expect(::CCLF::DisbursementAdapter).to receive(:new).with(disbursement).and_return(adapter)
     expect(adapter).to receive(:bill_type)

--- a/spec/api/entities/cclf/adapted_expense_spec.rb
+++ b/spec/api/entities/cclf/adapted_expense_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe API::Entities::CCLF::AdaptedExpense, type: :adapter do
   let(:expense) { instance_double(::Expense, claim: claim, expense_type: expense_type, amount: 9.99, vat_amount: 1.99) }
 
   it 'exposes the required keys' do
-    expect(response.keys).to match_array(%i[bill_type bill_subtype amount vat_amount])
+    expect(response.keys).to match_array(%i[bill_type bill_subtype net_amount vat_amount])
   end
 
   it 'exposes expected json key-value pairs' do
     expect(response).to include(
       bill_type: 'DISBURSEMENT',
       bill_subtype: 'TRAVEL COSTS',
-      amount: '9.99',
+      net_amount: '9.99',
       vat_amount: '1.99'
     )
   end
 
-  it 'delegates bill mappings to DisbursementAdapter' do
+  it 'delegates bill type attributes to ExpenseAdapter' do
     adapter = instance_double(::CCLF::ExpenseAdapter)
     expect(::CCLF::ExpenseAdapter).to receive(:new).with(expense).and_return(adapter)
     expect(adapter).to receive(:bill_type)

--- a/spec/api/entities/cclf/adapted_fixed_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_fixed_fee_spec.rb
@@ -7,22 +7,22 @@ RSpec.describe API::Entities::CCLF::AdaptedFixedFee, type: :adapter do
   let(:fee_type) { instance_double('fee_type', unique_code: 'FXCBR') }
   let(:case_type) { instance_double('case_type', fee_type_code: 'FXCBR') }
   let(:claim) { instance_double('claim', case_type: case_type) }
-  let(:fixed_fee) { instance_double('fixed_fee', claim: claim, fee_type: fee_type, quantity: 0, amount: 225.50) }
+  let(:fixed_fee) { instance_double('fixed_fee', claim: claim, fee_type: fee_type, quantity: 0.0) }
+  let(:adapter) { instance_double(::CCLF::Fee::FixedFeeAdapter) }
 
   it 'exposes the required keys' do
-    expect(response.keys).to match_array(%i[bill_type bill_subtype amount])
+    expect(response.keys).to match_array(%i[bill_type bill_subtype quantity])
   end
 
   it 'exposes expected json key-value pairs' do
     expect(response).to include(
       bill_type: 'LIT_FEE',
       bill_subtype: 'LIT_FEE',
-      amount: '225.5',
+      quantity: "0"
     )
   end
 
   it 'delegates bill mappings to FixedFeeAdapter' do
-    adapter = instance_double(::CCLF::Fee::FixedFeeAdapter)
     expect(::CCLF::Fee::FixedFeeAdapter).to receive(:new).with(fixed_fee).and_return(adapter)
     expect(adapter).to receive(:bill_type)
     expect(adapter).to receive(:bill_subtype)

--- a/spec/api/entities/cclf/adapted_graduated_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_graduated_fee_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe API::Entities::CCLF::AdaptedGraduatedFee, type: :adapter do
   let(:fee_type) { instance_double('fee_type', unique_code: 'GRTRL') }
   let(:case_type) { instance_double('case_type', fee_type_code: 'GRTRL') }
   let(:claim) { instance_double('claim', case_type: case_type) }
-  let(:graduated_fee) { instance_double('graduated_fee', claim: claim, fee_type: fee_type, quantity: 999, amount: 1001.50) }
+  let(:graduated_fee) { instance_double('graduated_fee', claim: claim, fee_type: fee_type, quantity: 999.0) }
+  let(:adapter) { instance_double(::CCLF::Fee::GraduatedFeeAdapter) }
 
   it 'exposes the required keys' do
-    expect(response.keys).to match_array(%i[bill_type bill_subtype quantity amount])
+    expect(response.keys).to match_array(%i[bill_type bill_subtype quantity])
   end
 
   it 'exposes expected json key-value pairs' do
@@ -18,12 +19,10 @@ RSpec.describe API::Entities::CCLF::AdaptedGraduatedFee, type: :adapter do
       bill_type: 'LIT_FEE',
       bill_subtype: 'LIT_FEE',
       quantity: '999',
-      amount: '1001.5'
     )
   end
 
   it 'delegates bill mappings to GraduatedFeeAdapter' do
-    adapter = instance_double(::CCLF::Fee::GraduatedFeeAdapter)
     expect(::CCLF::Fee::GraduatedFeeAdapter).to receive(:new).with(graduated_fee).and_return(adapter)
     expect(adapter).to receive(:bill_type)
     expect(adapter).to receive(:bill_subtype)

--- a/spec/api/entities/cclf/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_misc_fee_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe API::Entities::CCLF::AdaptedMiscFee, type: :adapter do
   let(:case_type) { instance_double('case_type', fee_type_code: 'GRTRL') }
   let(:claim) { instance_double('claim', case_type: case_type) }
   let(:misc_fee) { instance_double('misc_fee', claim: claim, fee_type: fee_type, amount: 199.50) }
+  let(:adapter) { instance_double(::CCLF::Fee::MiscFeeAdapter) }
 
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype amount])
@@ -21,8 +22,7 @@ RSpec.describe API::Entities::CCLF::AdaptedMiscFee, type: :adapter do
     )
   end
 
-  it 'delegates bill mappings to GraduatedFeeAdapter' do
-    adapter = instance_double(::CCLF::Fee::MiscFeeAdapter)
+  it 'delegates bill type attributes to MiscFeeAdapter' do
     expect(::CCLF::Fee::MiscFeeAdapter).to receive(:new).with(misc_fee).and_return(adapter)
     expect(adapter).to receive(:bill_type)
     expect(adapter).to receive(:bill_subtype)

--- a/spec/api/entities/cclf/adapted_warrant_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_warrant_fee_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe API::Entities::CCLF::AdaptedWarrantFee, type: :adapter do
   let(:case_type) { instance_double('case_type', fee_type_code: 'FXCBR') }
   let(:claim) { instance_double('claim', case_type: case_type) }
   let(:warrant_fee) { instance_double('warrant_fee', claim: claim, fee_type: fee_type, amount: 111.01, warrant_issued_date: '01-Jun-2017'.to_date, warrant_executed_date: '01-Aug-2017'.to_date) }
+  let(:adapter) { instance_double(::CCLF::Fee::WarrantFeeAdapter) }
 
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype amount warrant_issued_date warrant_executed_date])
@@ -23,8 +24,7 @@ RSpec.describe API::Entities::CCLF::AdaptedWarrantFee, type: :adapter do
     )
   end
 
-  it 'delegates bill mappings to FixedFeeAdapter' do
-    adapter = instance_double(::CCLF::Fee::WarrantFeeAdapter)
+  it 'delegates bill types to FixedFeeAdapter' do
     expect(::CCLF::Fee::WarrantFeeAdapter).to receive(:new).with(warrant_fee).and_return(adapter)
     expect(adapter).to receive(:bill_type)
     expect(adapter).to receive(:bill_subtype)

--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -32,6 +32,17 @@ RSpec.shared_examples 'returns LGFS claim type' do |type|
   end
 end
 
+RSpec.shared_examples 'CCLF disbursement' do |type|
+  it 'returns a disbursement bill type' do
+    expect(response).to be_json_eql('DISBURSEMENT'.to_json).at_path("bills/0/bill_type")
+  end
+
+  it 'exposes a net and vat amount' do
+    expect(response).to have_json_path("bills/0/net_amount")
+    expect(response).to have_json_path("bills/0/vat_amount")
+  end
+end
+
 RSpec.describe API::V2::CCLFClaim do
   include Rack::Test::Methods
   include ApiSpecHelper
@@ -196,7 +207,7 @@ RSpec.describe API::V2::CCLFClaim do
             let(:claim) do
               create(:litigator_claim, :without_fees, :submitted).tap do |claim|
                 claim.update!(case_type: case_type_grtrl)
-                create(:graduated_fee, fee_type: grtrl, claim: claim)
+                create(:graduated_fee, fee_type: grtrl, claim: claim, quantity: 1000)
               end
             end
 
@@ -215,6 +226,10 @@ RSpec.describe API::V2::CCLFClaim do
               allow_any_instance_of(::Fee::GraduatedFeeType).to receive(:unique_code).and_return 'XXXXX'
               expect(response).to be_json_eql('LIT_FEE'.to_json).at_path("bills/0/bill_type")
               expect(response).to be_json_eql('LIT_FEE'.to_json).at_path("bills/0/bill_subtype")
+            end
+
+            it 'returns quantity of ppe' do
+              expect(response).to be_json_eql('1000'.to_json).at_path("bills/0/quantity")
             end
           end
 
@@ -237,6 +252,10 @@ RSpec.describe API::V2::CCLFClaim do
             it 'returns a litigator fee bill' do
               expect(response).to be_json_eql('LIT_FEE'.to_json).at_path("bills/0/bill_type")
               expect(response).to be_json_eql('LIT_FEE'.to_json).at_path("bills/0/bill_subtype")
+            end
+
+            it 'returns 0 for quantity of ppe' do
+              expect(response).to be_json_eql('0'.to_json).at_path("bills/0/quantity")
             end
           end
 
@@ -304,16 +323,17 @@ RSpec.describe API::V2::CCLFClaim do
               expect(response).to have_json_size(1).at_path("bills")
             end
 
-            it 'returns array containing a special prep fee bill' do
-              expect(response).to be_json_eql('DISBURSEMENT'.to_json).at_path("bills/0/bill_type")
+            it 'returns array containing a disbursement bill subtype' do
               expect(response).to be_json_eql('FORENSICS'.to_json).at_path("bills/0/bill_subtype")
             end
+
+            it_behaves_like 'CCLF disbursement'
           end
 
           context 'when expenses exist' do
             let(:claim) do
               create(:litigator_claim, :submitted, :without_fees).tap do |claim|
-                create(:expense, :bike_travel, claim: claim)
+                create(:expense, :bike_travel, claim: claim, amount: 9.99, vat_amount: 1.99)
               end
             end
 
@@ -327,10 +347,11 @@ RSpec.describe API::V2::CCLFClaim do
               expect(response).to have_json_size(1).at_path("bills")
             end
 
-            it 'returns array containing a special prep fee bill' do
-              expect(response).to be_json_eql('DISBURSEMENT'.to_json).at_path("bills/0/bill_type")
+            it 'returns array containing a travel costs disbursement bill sub type' do
               expect(response).to be_json_eql('TRAVEL COSTS'.to_json).at_path("bills/0/bill_subtype")
             end
+
+            it_behaves_like 'CCLF disbursement'
           end
         end
       end

--- a/spec/services/cclf/disbursement_adapter_spec.rb
+++ b/spec/services/cclf/disbursement_adapter_spec.rb
@@ -57,14 +57,16 @@ context 'bill mappings' do
           end
 
           describe '#bill_type' do
+            subject { instance.bill_type }
             it "returns #{bill_types.first}" do
-              expect(instance.bill_type).to eql bill_types.first
+              is_expected.to eql bill_types.first
             end
           end
 
           describe '#bill_subtype' do
+            subject { instance.bill_subtype }
             it "returns #{bill_types.second}" do
-              expect(instance.bill_subtype).to eql bill_types.second
+              is_expected.to eql bill_types.second
             end
           end
         end

--- a/spec/services/cclf/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/cclf/fee/misc_fee_adapter_spec.rb
@@ -32,14 +32,16 @@ RSpec.describe CCLF::Fee::MiscFeeAdapter, type: :adapter do
           end
 
           describe '#bill_type' do
+            subject { instance.bill_type }
             it "returns #{bill_types.first}" do
-              expect(instance.bill_type).to eql bill_types.first
+              is_expected.to eql bill_types.first
             end
           end
 
           describe '#bill_subtype' do
+            subject { instance.bill_subtype }
             it "returns #{bill_types.second}" do
-              expect(instance.bill_subtype).to eql bill_types.second
+              is_expected.to eql bill_types.second
             end
           end
         end

--- a/spec/services/cclf/fee/shared_examples_for_cclf_fee_adapters.rb
+++ b/spec/services/cclf/fee/shared_examples_for_cclf_fee_adapters.rb
@@ -1,6 +1,6 @@
 shared_examples 'returns CCLF Litigator Fee bill (sub)type' do |code|
   before { allow(fee_type).to receive(:unique_code).and_return code }
-  it 'returns CCLF Litigator Fee bill type' do
+  it 'returns CCLF Litigator Fee bill (sub)type - LIT_FEE' do
     is_expected.to eql 'LIT_FEE'
   end
 end
@@ -8,7 +8,7 @@ end
 shared_examples 'Litigator Fee Adapter' do |bill_scenario_mappings|
   let(:fee) { instance_double('fee') }
   let(:claim) { instance_double('claim', case_type: case_type) }
-  let(:case_type) { instance_double('case_type') }
+  let(:case_type) { instance_double(::CaseType) }
   let(:fee_type) { instance_double('fee_type') }
 
   before do

--- a/spec/services/cclf/fee/warrant_fee_adapter_spec.rb
+++ b/spec/services/cclf/fee/warrant_fee_adapter_spec.rb
@@ -2,22 +2,6 @@ require 'rails_helper'
 require 'spec_helper'
 
 RSpec.describe CCLF::Fee::WarrantFeeAdapter, type: :adapter do
-  # TODO: final claims only, other scenarios exist for transfer claims
-
-  shared_examples 'returns CCLF Warrant Fee bill type' do |code|
-    before { allow(fee_type).to receive(:unique_code).and_return code }
-    it 'returns CCLF Warrant Fee bill type - FEE_ADVANCE' do
-      is_expected.to eql 'FEE_ADVANCE'
-    end
-  end
-
-  shared_examples 'returns CCLF Warrant Fee bill subtype' do |code|
-    before { allow(fee_type).to receive(:unique_code).and_return code }
-    it 'returns CCLF Warrant Fee bill type - WARRANT' do
-      is_expected.to eql 'WARRANT'
-    end
-  end
-
   let(:fee) { instance_double('fee') }
   let(:claim) { instance_double('claim', case_type: case_type) }
   let(:case_type) { instance_double('case_type') }
@@ -29,20 +13,16 @@ RSpec.describe CCLF::Fee::WarrantFeeAdapter, type: :adapter do
   end
 
   describe '#bill_type' do
-    final_claim_bill_scenarios.keys.each do |code|
-      context "for #{code} fee type" do
-        subject { described_class.new(fee).bill_type }
-        include_examples 'returns CCLF Warrant Fee bill type', code
-      end
+    subject { described_class.new(fee).bill_type }
+    it 'returns CCLF Warrant Fee bill type - FEE_ADVANCE' do
+      is_expected.to eql 'FEE_ADVANCE'
     end
   end
 
   describe '#bill_subtype' do
-    final_claim_bill_scenarios.keys.each do |code|
-      context "for #{code} fee type" do
-        subject { described_class.new(fee).bill_subtype }
-        include_examples 'returns CCLF Warrant Fee bill subtype', code
-      end
+    subject { described_class.new(fee).bill_subtype }
+    it 'returns CCLF Warrant Fee bill subtype - WARRANT' do
+      is_expected.to eql 'WARRANT'
     end
   end
 end


### PR DESCRIPTION
What:
provide required CCCD JSON for CCLF to handle VAT

Why:
 - CCCD fees - CCCD will only supply net amounts (without VAT).
   CCLF will assume that VAT is not included and therefore apply VAT
   if the supplier number is vat registered.

- CCCD disbursements and travel expenses (i.e. CCLF disbursement
   equivalents)  - CCCD will supply the net amount and VAT amount separately.
   CCLF will use these to determine whether it needs to handle VAT as a
   separate disbursement, as below:

   If VAT amount equals the VAT rate % (20% currently) of the net amount
   then it can create one disbursement with a value of the net amount and
   mark the bill as VAT not included.

   If VAT amount is not equal the VAT rate % of the net amount then it
   needs to create 2 disbursements:
   * to represent the part on which VAT is not claimed.
   * to represent the part on which VAT is claimed.