### PR TITLE
MI fix

### DIFF
--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -24,10 +24,8 @@ module Stats
         csv << Settings.claim_csv_headers.map { |header| header.to_s.humanize }
         Claim::BaseClaim.active.non_draft.find_each do |claim|
           ClaimCsvPresenter.new(claim, 'view').present! do |claim_journeys|
-            if claim_journeys.any?
-              claim_journeys.each do |claim_journey|
-                csv << claim_journey
-              end
+            claim_journeys.each do |claim_journey|
+              csv << claim_journey
             end
           end
         end

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -24,8 +24,10 @@ module Stats
         csv << Settings.claim_csv_headers.map { |header| header.to_s.humanize }
         Claim::BaseClaim.active.non_draft.find_each do |claim|
           ClaimCsvPresenter.new(claim, 'view').present! do |claim_journeys|
-            claim_journeys.each do |claim_journey|
-              csv << claim_journey
+            if claim_journeys.any?
+              claim_journeys.each do |claim_journey|
+                csv << claim_journey
+              end
             end
           end
         end

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -5,7 +5,7 @@ class ClaimCsvPresenter < BasePresenter
   SUBMITTED_STATES = %w[submitted redetermination awaiting_written_reasons].freeze
 
   def present!
-    yield parsed_journeys
+    yield parsed_journeys if block_given?
   end
 
   def journeys
@@ -22,7 +22,7 @@ class ClaimCsvPresenter < BasePresenter
   def parsed_journeys
     journeys.map do |journey|
       @journey = clean_deallocations(journey)
-      Settings.claim_csv_headers.map { |method_call| send(method_call) }
+      Settings.claim_csv_headers.map { |method_call| send(method_call) } if @journey.any?
     end
   end
 


### PR DESCRIPTION
An edge case has occurred where all claim_state_transitions are ineligible, this meant that MI failed

This allows the `parsed_journey` method to return nothing and handle that in `present!` and then skip that row in `management_information_generator`