### PR TITLE
Add any? check to claim presenter

### DIFF
--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -24,8 +24,10 @@ module Stats
         csv << Settings.claim_csv_headers.map { |header| header.to_s.humanize }
         Claim::BaseClaim.active.non_draft.find_each do |claim|
           ClaimCsvPresenter.new(claim, 'view').present! do |claim_journeys|
-            claim_journeys.each do |claim_journey|
-              csv << claim_journey
+            if claim_journeys.any?
+              claim_journeys.each do |claim_journey|
+                csv << claim_journey
+              end
             end
           end
         end


### PR DESCRIPTION
An edge case has occurred where all claim_state_transitions are ineligible, this meant that MI failed

This allows the parsed_journey method to return nothing and handle that in present! and then skip that row in management_information_generator

This was removed from the original PR #2242 as it was not required in development... after deploying to prod, this needs re-instating