### PR TITLE
Error messages: new style radios

### DIFF
--- a/app/assets/stylesheets/moj/_forms.scss
+++ b/app/assets/stylesheets/moj/_forms.scss
@@ -4,6 +4,7 @@ form {
       border-left-width: 3px;
       .form-control{
         border-width: 2px;
+        border-color: $error-colour;
       }
     }
     label {
@@ -124,7 +125,7 @@ button.search {
 }
 
 // Required when you need to clear values and disable field but still submit values
-.form-control:read-only {
+input.form-control:read-only {
   @extend .form-control:disabled;
 }
 

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -13,4 +13,12 @@ Config.setup do |config|
   # Parse numeric values as integers instead of strings.
   #
   # config.env_parse_values = false
+
+  # This removes the wrapper `div.fields_with_errors` around
+  # elements where validations fail
+  # This wrapper breaks the new style Radio / Check boxes
+  ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+    html_tag
+  end
+
 end


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/story/show/155396815
https://www.pivotaltracker.com/story/show/154276163

Why are we doing this?
- new style radio / check boxes are not dispayed correctly
- all select dropdowns have `readonly` styles applied

What this PR does:
- error issues is related to the `field_with_errors` that rails adds in
- CSS specific to inputs