### PR TITLE
Evidence provision fees

### DIFF
--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -23,6 +23,8 @@ module Fee
     def validate_amount
       if run_base_fee_validators? || fee_code.nil?
         super
+      elsif @record.fee_type.unique_code.eql?('MIEVI')
+        validate_evidence_provision_fee
       else
         validate_presence_and_numericality(:amount, minimum: 0.1)
       end
@@ -30,6 +32,12 @@ module Fee
 
     def run_base_fee_validators?
       !@record.claim.lgfs?
+    end
+
+    def validate_evidence_provision_fee
+      valid_values = [45, 90]
+      return if valid_values.include?(@record.amount.to_d)
+      add_error(:amount, 'incorrect_epf')
     end
   end
 end

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -19,7 +19,7 @@
         \/api/external_users/fee
       endpoint with either of the following states will result in a
       %code.code
-        Evidence provision fee should only be £45 or £90
+        Evidence provision fee can only be £45 or £90
       error.
       %br/
       %br/

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -3,6 +3,46 @@
 %section.api-documentation
 
   %hr
+  %h2 24 February 2018
+  %ul.list-bullet
+    %li
+      The Evidence provision fee is now locked to two values, £45 and £90 as described in the
+      = link_to 'guidance', 'https://www.gov.uk/guidance/claim-the-evidence-provision-fee#lower-and-upper-tiers'
+      ='.'
+      %br/
+      %br/
+      These values have always been the only valid values but, prior to this release, the validation had not been enforced.
+      %br/
+      %br/
+      From now on submitting data to the
+      %code.code
+        \/api/external_users/fee
+      endpoint with either of the following states will result in a
+      %code.code
+        Evidence provision fee should only be £45 or £90
+      error.
+      %br/
+      %br/
+      %table
+        %thead
+          %tr
+            %th
+              Field
+            %th
+              Value
+        %tbody
+          %tr
+            %td
+              fee_type_id
+            %td
+              87
+          %tr
+            %td
+              fee_type_unique_code
+            %td
+              MIEVI
+
+  %hr
   %h1 01 November 2017
   %ul.list-bullet
     %li

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -928,9 +928,9 @@ misc_fee:
       short: *enter_valid_amount
       api: Enter a valid amount for the miscellaneous fee
     incorrect_epf:
-      long: 'Evidence provision fee should only be £45 or £90'
+      long: 'Evidence provision fee can only be £45 or £90'
       short: 'Enter £45 or £90'
-      api: 'Evidence provision fee should only be £45 or £90'
+      api: 'Evidence provision fee can only be £45 or £90'
 
 #################################################################################
 #                                                                               #

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -927,6 +927,10 @@ misc_fee:
       long: 'Enter a valid amount for the #{misc_fee}'
       short: *enter_valid_amount
       api: Enter a valid amount for the miscellaneous fee
+    incorrect_epf:
+      long: 'Evidence provision fee should only be £45 or £90'
+      short: 'Enter £45 or £90'
+      api: 'Evidence provision fee should only be £45 or £90'
 
 #################################################################################
 #                                                                               #

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -135,7 +135,7 @@ FactoryBot.define do
         description 'Evidence provision fee'
         code 'XEVI'
         unique_code 'MIEVI'
-        quantity_is_decimal true
+        quantity_is_decimal false
       end
     end
 

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -129,6 +129,14 @@ FactoryBot.define do
         unique_code 'MIUPL'
         quantity_is_decimal true
       end
+
+      trait :mievi do
+        lgfs
+        description 'Evidence provision fee'
+        code 'XEVI'
+        unique_code 'MIEVI'
+        quantity_is_decimal true
+      end
     end
 
     factory :fixed_fee_type, class: Fee::FixedFeeType do

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -45,6 +45,34 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       end
     end
 
+    context 'when misc fee is an evidence provision fee' do
+      subject { fee.valid? }
+
+      let(:fee_type) { build :misc_fee_type, :mievi }
+
+      before { allow(fee).to receive(:fee_type).and_return(fee_type) }
+
+      %w[45 90].each do |value|
+        context "when the amount is #{value}" do
+          before { allow(fee).to receive(:amount).and_return(value) }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when the amount is a decimal' do
+        before { allow(fee).to receive(:amount).and_return('45.10') }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the amount is a zero' do
+        before { allow(fee).to receive(:amount).and_return('0') }
+
+        it { is_expected.to be false }
+      end
+    end
+
     describe '#validate_case_numbers' do
       context 'for a non Case Uplift fee type' do
         before(:each) do

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -50,28 +50,18 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
 
       before { allow(fee).to receive(:fee_type).and_return(fee_type) }
 
-      context 'when the amount is set to' do
-        before { allow(fee).to receive(:amount).and_return(amount) }
-
-        %w[45 90].each do |value|
-          context "£#{value}" do
-            let(:amount) { value }
-
-            it { expect(fee).to be_valid }
-          end
+      %w[45 90].each do |value|
+        it "will be valid if amount is £#{value}" do
+          should_be_valid_if_equal_to_value(fee, :amount, value)
         end
+      end
 
-        context 'a decimal' do
-          let(:amount) { '45.10' }
+      it 'will error if passed a decimal amount' do
+        should_error_if_equal_to_value(fee, :amount, '45.10', 'incorrect_epf')
+      end
 
-          it { should_error_if_equal_to_value(fee, :amount, amount, 'incorrect_epf') }
-        end
-
-        context 'zero' do
-          let(:amount) { '0' }
-
-          it { should_error_if_equal_to_value(fee, :amount, amount, 'incorrect_epf') }
-        end
+      it 'will error is passed a zero amount' do
+        should_error_if_equal_to_value(fee, :amount, '0', 'incorrect_epf')
       end
     end
 

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -46,30 +46,32 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
     end
 
     context 'when misc fee is an evidence provision fee' do
-      subject { fee.valid? }
-
       let(:fee_type) { build :misc_fee_type, :mievi }
 
       before { allow(fee).to receive(:fee_type).and_return(fee_type) }
 
-      %w[45 90].each do |value|
-        context "when the amount is #{value}" do
-          before { allow(fee).to receive(:amount).and_return(value) }
+      context 'when the amount is set to' do
+        before { allow(fee).to receive(:amount).and_return(amount) }
 
-          it { is_expected.to be true }
+        %w[45 90].each do |value|
+          context "£#{value}" do
+            let(:amount) { value }
+
+            it { expect(fee).to be_valid }
+          end
         end
-      end
 
-      context 'when the amount is a decimal' do
-        before { allow(fee).to receive(:amount).and_return('45.10') }
+        context 'a decimal' do
+          let(:amount) { '45.10' }
 
-        it { is_expected.to be false }
-      end
+          it { should_error_if_equal_to_value(fee, :amount, amount, 'incorrect_epf') }
+        end
 
-      context 'when the amount is a zero' do
-        before { allow(fee).to receive(:amount).and_return('0') }
+        context 'zero' do
+          let(:amount) { '0' }
 
-        it { is_expected.to be false }
+          it { should_error_if_equal_to_value(fee, :amount, amount, 'incorrect_epf') }
+        end
       end
     end
 


### PR DESCRIPTION
[Pivotal ticket](https://www.pivotaltracker.com/story/show/155067395)
The EPF has only two allowable amounts that are claimable. 45 and 90 (ex VAT). CCLF enforces this logic.

**As a litigator**
**When** i am claiming an evidence provision fee
**I should** be presented only with the valid amounts that are claimable
**So** i do not make claims for erroneous amounts