### PR TITLE
Conditionally expose warrant attributes for interim fees

### DIFF
--- a/app/interfaces/api/entities/cclf/adapted_interim_fee.rb
+++ b/app/interfaces/api/entities/cclf/adapted_interim_fee.rb
@@ -4,7 +4,11 @@ module API
       class AdaptedInterimFee < AdaptedBaseBill
         expose :quantity, format_with: :integer_string
         expose :amount, format_with: :string
-        expose :warrant_issued_date, :warrant_executed_date, format_with: :utc
+
+        expose  :warrant_issued_date,
+                :warrant_executed_date,
+                format_with: :utc,
+                if: ->(instance, _options) { instance.is_interim_warrant? }
 
         private
 

--- a/spec/api/entities/cclf/adapted_disbursement_spec.rb
+++ b/spec/api/entities/cclf/adapted_disbursement_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe API::Entities::CCLF::AdaptedDisbursement, type: :adapter do
   let(:claim) { instance_double(::Claim::BaseClaim, case_type: case_type) }
   let(:disbursement) { instance_double(::Disbursement, claim: claim, disbursement_type: disbursement_type, net_amount: 9.99, vat_amount: 1.99) }
 
+  it_behaves_like 'a bill types delegator', ::CCLF::DisbursementAdapter do
+    let(:bill) { disbursement }
+  end
+
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype net_amount vat_amount])
   end
@@ -19,13 +23,5 @@ RSpec.describe API::Entities::CCLF::AdaptedDisbursement, type: :adapter do
       net_amount: '9.99',
       vat_amount: '1.99'
     )
-  end
-
-  it 'delegates bill type attributes to DisbursementAdapter' do
-    adapter = instance_double(::CCLF::DisbursementAdapter)
-    expect(::CCLF::DisbursementAdapter).to receive(:new).with(disbursement).and_return(adapter)
-    expect(adapter).to receive(:bill_type)
-    expect(adapter).to receive(:bill_subtype)
-    subject
   end
 end

--- a/spec/api/entities/cclf/adapted_expense_spec.rb
+++ b/spec/api/entities/cclf/adapted_expense_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe API::Entities::CCLF::AdaptedExpense, type: :adapter do
   let(:claim) { instance_double(::Claim::BaseClaim, case_type: case_type) }
   let(:expense) { instance_double(::Expense, claim: claim, expense_type: expense_type, amount: 9.99, vat_amount: 1.99) }
 
+  it_behaves_like 'a bill types delegator', ::CCLF::ExpenseAdapter do
+    let(:bill) { expense }
+  end
+
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype net_amount vat_amount])
   end
@@ -19,13 +23,5 @@ RSpec.describe API::Entities::CCLF::AdaptedExpense, type: :adapter do
       net_amount: '9.99',
       vat_amount: '1.99'
     )
-  end
-
-  it 'delegates bill type attributes to ExpenseAdapter' do
-    adapter = instance_double(::CCLF::ExpenseAdapter)
-    expect(::CCLF::ExpenseAdapter).to receive(:new).with(expense).and_return(adapter)
-    expect(adapter).to receive(:bill_type)
-    expect(adapter).to receive(:bill_subtype)
-    subject
   end
 end

--- a/spec/api/entities/cclf/adapted_fixed_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_fixed_fee_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe API::Entities::CCLF::AdaptedFixedFee, type: :adapter do
   let(:fee_type) { instance_double('fee_type', unique_code: 'FXCBR') }
   let(:case_type) { instance_double('case_type', fee_type_code: 'FXCBR') }
   let(:claim) { instance_double('claim', case_type: case_type) }
-  let(:fixed_fee) { instance_double('fixed_fee', claim: claim, fee_type: fee_type, quantity: 0.0) }
-  let(:adapter) { instance_double(::CCLF::Fee::FixedFeeAdapter) }
+  let(:fixed_fee) { instance_double(::Fee::FixedFee, claim: claim, fee_type: fee_type, quantity: 0.0) }
+
+  it_behaves_like 'a bill types delegator', ::CCLF::Fee::FixedFeeAdapter do
+    let(:bill) { fixed_fee }
+  end
 
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype quantity])
@@ -19,12 +22,5 @@ RSpec.describe API::Entities::CCLF::AdaptedFixedFee, type: :adapter do
       bill_subtype: 'LIT_FEE',
       quantity: "0"
     )
-  end
-
-  it 'delegates bill mappings to FixedFeeAdapter' do
-    expect(::CCLF::Fee::FixedFeeAdapter).to receive(:new).with(fixed_fee).and_return(adapter)
-    expect(adapter).to receive(:bill_type)
-    expect(adapter).to receive(:bill_subtype)
-    subject
   end
 end

--- a/spec/api/entities/cclf/adapted_graduated_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_graduated_fee_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe API::Entities::CCLF::AdaptedGraduatedFee, type: :adapter do
   let(:case_type) { instance_double('case_type', fee_type_code: 'GRTRL') }
   let(:claim) { instance_double('claim', case_type: case_type) }
   let(:graduated_fee) { instance_double('graduated_fee', claim: claim, fee_type: fee_type, quantity: 999.0) }
-  let(:adapter) { instance_double(::CCLF::Fee::GraduatedFeeAdapter) }
+
+  it_behaves_like 'a bill types delegator', ::CCLF::Fee::GraduatedFeeAdapter do
+    let(:bill) { graduated_fee }
+  end
 
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype quantity])
@@ -19,12 +22,5 @@ RSpec.describe API::Entities::CCLF::AdaptedGraduatedFee, type: :adapter do
       bill_subtype: 'LIT_FEE',
       quantity: '999',
     )
-  end
-
-  it 'delegates bill mappings to GraduatedFeeAdapter' do
-    expect(::CCLF::Fee::GraduatedFeeAdapter).to receive(:new).with(graduated_fee).and_return(adapter)
-    expect(adapter).to receive(:bill_type)
-    expect(adapter).to receive(:bill_subtype)
-    subject
   end
 end

--- a/spec/api/entities/cclf/adapted_interim_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_interim_fee_spec.rb
@@ -3,10 +3,21 @@ require 'rails_helper'
 RSpec.describe API::Entities::CCLF::AdaptedInterimFee, type: :adapter do
   subject(:response) { JSON.parse(described_class.represent(interim_fee).to_json, symbolize_names: true) }
 
+  let(:adapter) { instance_double(::CCLF::Fee::InterimFeeAdapter) }
   let(:claim) { instance_double(::Claim::InterimClaim) }
   let(:fee_type) { instance_double(::Fee::InterimFeeType, unique_code: 'INTDT') }
-  let(:interim_fee) { instance_double(::Fee::InterimFee, claim: claim, fee_type: fee_type, quantity: 0.0, amount: 0.0, warrant_issued_date: nil, warrant_executed_date: nil, is_interim_warrant?: false) }
-  let(:adapter) { instance_double(::CCLF::Fee::InterimFeeAdapter) }
+  let(:interim_fee) do
+      instance_double(
+        ::Fee::InterimFee,
+        claim: claim,
+        fee_type: fee_type,
+        quantity: 0.0,
+        amount: 0.0,
+        warrant_issued_date: nil,
+        warrant_executed_date: nil,
+        is_interim_warrant?: false
+      )
+    end
 
   it 'formats amount as string' do
     expect(response).to include(amount: '0.0')
@@ -20,26 +31,23 @@ RSpec.describe API::Entities::CCLF::AdaptedInterimFee, type: :adapter do
     expect(::CCLF::Fee::InterimFeeAdapter).to receive(:new).with(interim_fee).and_return(adapter)
     expect(adapter).to receive(:bill_type)
     expect(adapter).to receive(:bill_subtype)
-    subject
+    response
   end
 
   context 'interim warrants' do
     let(:fee_type) { instance_double(::Fee::InterimFeeType, unique_code: 'INWAR') }
-    let(:interim_fee) do
-      instance_double(
-        ::Fee::InterimFee,
-        claim: claim,
-        fee_type: fee_type,
-        quantity: 0.0,
-        amount: 101.01,
-        warrant_issued_date: '01-Jun-2017'.to_date,
-        warrant_executed_date: '01-Aug-2017'.to_date,
-        is_interim_warrant?: true
-      )
+
+    before do
+      allow(interim_fee).to receive_messages(
+          amount: 101.01,
+          warrant_issued_date: '01-Jun-2017'.to_date,
+          warrant_executed_date: '01-Aug-2017'.to_date,
+          is_interim_warrant?: true
+        )
     end
 
     it 'exposes expected json key-value pairs' do
-      expect(response).to include(
+      expect(response).to match_array(
         bill_type: 'FEE_ADVANCE',
         bill_subtype: 'WARRANT',
         amount: '101.01',
@@ -52,10 +60,13 @@ RSpec.describe API::Entities::CCLF::AdaptedInterimFee, type: :adapter do
 
   context 'effective pcmh' do
     let(:fee_type) { instance_double(::Fee::InterimFeeType, unique_code: 'INPCM') }
-    let(:interim_fee) { instance_double(::Fee::InterimFee, claim: claim, fee_type: fee_type, quantity: 999.0, amount: 202.02, warrant_issued_date: nil, warrant_executed_date: nil, is_interim_warrant?: false) }
+
+    before do
+      allow(interim_fee).to receive_messages(quantity: 999.0, amount: 202.02)
+    end
 
     it 'exposes expected json key-value pairs' do
-      expect(response).to include(
+      expect(response).to match_array(
         bill_type: 'LIT_FEE',
         bill_subtype: 'LIT_FEE',
         quantity: '999',

--- a/spec/api/entities/cclf/adapted_interim_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_interim_fee_spec.rb
@@ -3,21 +3,24 @@ require 'rails_helper'
 RSpec.describe API::Entities::CCLF::AdaptedInterimFee, type: :adapter do
   subject(:response) { JSON.parse(described_class.represent(interim_fee).to_json, symbolize_names: true) }
 
-  let(:adapter) { instance_double(::CCLF::Fee::InterimFeeAdapter) }
   let(:claim) { instance_double(::Claim::InterimClaim) }
   let(:fee_type) { instance_double(::Fee::InterimFeeType, unique_code: 'INTDT') }
   let(:interim_fee) do
-      instance_double(
-        ::Fee::InterimFee,
-        claim: claim,
-        fee_type: fee_type,
-        quantity: 0.0,
-        amount: 0.0,
-        warrant_issued_date: nil,
-        warrant_executed_date: nil,
-        is_interim_warrant?: false
-      )
-    end
+    instance_double(
+      ::Fee::InterimFee,
+      claim: claim,
+      fee_type: fee_type,
+      quantity: 0.0,
+      amount: 0.0,
+      warrant_issued_date: nil,
+      warrant_executed_date: nil,
+      is_interim_warrant?: false
+    )
+  end
+
+  it_behaves_like 'a bill types delegator', ::CCLF::Fee::InterimFeeAdapter do
+    let(:bill) { interim_fee }
+  end
 
   it 'formats amount as string' do
     expect(response).to include(amount: '0.0')
@@ -25,13 +28,6 @@ RSpec.describe API::Entities::CCLF::AdaptedInterimFee, type: :adapter do
 
   it 'formats quantity as string integer' do
     expect(response).to include(quantity: '0')
-  end
-
-  it 'delegates bill types to InterimFeeAdapter' do
-    expect(::CCLF::Fee::InterimFeeAdapter).to receive(:new).with(interim_fee).and_return(adapter)
-    expect(adapter).to receive(:bill_type)
-    expect(adapter).to receive(:bill_subtype)
-    response
   end
 
   context 'interim warrants' do

--- a/spec/api/entities/cclf/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_misc_fee_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe API::Entities::CCLF::AdaptedMiscFee, type: :adapter do
   let(:case_type) { instance_double('case_type', fee_type_code: 'GRTRL') }
   let(:claim) { instance_double('claim', case_type: case_type) }
   let(:misc_fee) { instance_double('misc_fee', claim: claim, fee_type: fee_type, amount: 199.50) }
-  let(:adapter) { instance_double(::CCLF::Fee::MiscFeeAdapter) }
+
+  it_behaves_like 'a bill types delegator', ::CCLF::Fee::MiscFeeAdapter do
+    let(:bill) { misc_fee }
+  end
 
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype amount])
@@ -19,12 +22,5 @@ RSpec.describe API::Entities::CCLF::AdaptedMiscFee, type: :adapter do
       bill_subtype: 'SPECIAL_PREP',
       amount: '199.5'
     )
-  end
-
-  it 'delegates bill type attributes to MiscFeeAdapter' do
-    expect(::CCLF::Fee::MiscFeeAdapter).to receive(:new).with(misc_fee).and_return(adapter)
-    expect(adapter).to receive(:bill_type)
-    expect(adapter).to receive(:bill_subtype)
-    subject
   end
 end

--- a/spec/api/entities/cclf/adapted_warrant_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_warrant_fee_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe API::Entities::CCLF::AdaptedWarrantFee, type: :adapter do
   let(:case_type) { instance_double('case_type', fee_type_code: 'FXCBR') }
   let(:claim) { instance_double('claim', case_type: case_type) }
   let(:warrant_fee) { instance_double('warrant_fee', claim: claim, fee_type: fee_type, amount: 111.01, warrant_issued_date: '01-Jun-2017'.to_date, warrant_executed_date: '01-Aug-2017'.to_date) }
-  let(:adapter) { instance_double(::CCLF::Fee::WarrantFeeAdapter) }
+
+  it_behaves_like 'a bill types delegator', ::CCLF::Fee::WarrantFeeAdapter do
+    let(:bill) { warrant_fee }
+  end
 
   it 'exposes the required keys' do
     expect(response.keys).to match_array(%i[bill_type bill_subtype amount warrant_issued_date warrant_executed_date])
@@ -21,12 +24,5 @@ RSpec.describe API::Entities::CCLF::AdaptedWarrantFee, type: :adapter do
       warrant_issued_date: "2017-06-01",
       warrant_executed_date: "2017-08-01"
     )
-  end
-
-  it 'delegates bill types to FixedFeeAdapter' do
-    expect(::CCLF::Fee::WarrantFeeAdapter).to receive(:new).with(warrant_fee).and_return(adapter)
-    expect(adapter).to receive(:bill_type)
-    expect(adapter).to receive(:bill_subtype)
-    subject
   end
 end

--- a/spec/services/cclf/disbursement_adapter_spec.rb
+++ b/spec/services/cclf/disbursement_adapter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CCLF::Fee::DisbursementAdapter, type: :adapter do
+RSpec.describe CCLF::DisbursementAdapter, type: :adapter do
   let(:disbursement) { instance_double(::Disbursement) }
 
   # For a given disbursement type the disbursement maps to a given CCLF bill type and sub type

--- a/spec/services/cclf/fee/shared_examples_for_cclf_fee_adapters.rb
+++ b/spec/services/cclf/fee/shared_examples_for_cclf_fee_adapters.rb
@@ -1,11 +1,11 @@
-shared_examples 'returns CCLF Litigator Fee bill (sub)type' do |code|
+RSpec.shared_examples 'returns CCLF Litigator Fee bill (sub)type' do |code|
   before { allow(fee_type).to receive(:unique_code).and_return code }
   it 'returns CCLF Litigator Fee bill (sub)type - LIT_FEE' do
     is_expected.to eql 'LIT_FEE'
   end
 end
 
-shared_examples 'Litigator Fee Adapter' do |bill_scenario_mappings|
+RSpec.shared_examples 'Litigator Fee Adapter' do |bill_scenario_mappings|
   let(:fee) { instance_double('fee') }
   let(:claim) { instance_double('claim', case_type: case_type) }
   let(:case_type) { instance_double(::CaseType) }

--- a/spec/support/shared_examples_for_fee_adapters.rb
+++ b/spec/support/shared_examples_for_fee_adapters.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a mapping fee adapter' do
+RSpec.shared_examples_for 'a mapping fee adapter' do
   describe '#call' do
     it { is_expected.to be_instance_of described_class }
     it { is_expected.to respond_to :bill_type }
@@ -22,7 +22,7 @@ shared_examples_for 'a mapping fee adapter' do
   end
 end
 
-shared_examples_for 'a simple bill adapter' do
+RSpec.shared_examples_for 'a simple bill adapter' do
   subject { described_class.new(instance_double('fee')) }
 
   it { is_expected.to respond_to(:bill_type) }
@@ -30,5 +30,16 @@ shared_examples_for 'a simple bill adapter' do
 
   it 'should respond to .acts_as_simple_bill' do
     expect(described_class).to respond_to :acts_as_simple_bill
+  end
+end
+
+RSpec.shared_examples 'a bill types delegator' do |adapter_klass|
+  let(:adapter) { instance_double(adapter_klass) }
+
+  it "delegates bill types to #{adapter_klass} " do
+    expect(adapter_klass).to receive(:new).with(bill).and_return(adapter)
+    expect(adapter).to receive(:bill_type)
+    expect(adapter).to receive(:bill_subtype)
+    subject
   end
 end


### PR DESCRIPTION
#### What
Interim warrants, alone, of interim fees should expose warrant-related attributes

#### Why
So as not to expose unnecessary attributes in the JSON API. 
CCLF should not, however, be dependant on this conditional 
existence but should consume the attributes it requires based
on the bill type and scenario.

#### How
grape-entity [conditional exposures](https://github.com/ruby-grape/grape-entity#conditional-exposure)
