### PR TITLE
Certify and submit

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -132,9 +132,6 @@ form{
 }
 
 .button-secondary.blue {
-  margin: 0;
-  padding-left: $gutter;
-  padding-right: $gutter;
   background-color: $link-hover-colour;
   color: $page-colour;
   box-shadow: 0 2px 0 $link-colour;

--- a/app/assets/stylesheets/moj/_buttons.scss
+++ b/app/assets/stylesheets/moj/_buttons.scss
@@ -31,9 +31,9 @@ p.file-upload-name {
 .certify-claim {
   display: block;
   width: 8.8em;
-  margin: 10px 0 !important;
+  margin: 10px 0;
 }
 
-.delete-draft {
-  color: $red !important;
+a.delete-draft {
+  color: $red;
 }

--- a/app/assets/stylesheets/moj/_buttons.scss
+++ b/app/assets/stylesheets/moj/_buttons.scss
@@ -27,3 +27,13 @@ p.file-upload-name {
     text-align: center;
   }
 }
+
+.certify-claim {
+  display: block;
+  width: 8.8em;
+  margin: 10px 0 !important;
+}
+
+.delete-draft {
+  color: $red !important;
+}

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -39,6 +39,8 @@
           = "Actions:"
           %div.action-wrapper
             = link_to 'Edit this claim', edit_polymorphic_path(claim), class: 'button edit-claim'
+            -if claim.from_api?
+              = link_to 'Continue and certify',  summary_external_users_claim_path(claim), class: 'button-secondary blue certify-claim'
             = link_to 'Delete draft', external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete-draft'
 
         - if claim.archivable?


### PR DESCRIPTION
#### What
AS A provider who uses an API from my case management system to transfer cases into CCCD
I WANT to be able to 'certify and submit' my claim straight away,

#### Why
SO THAT I do not have to go through a lot of pages of my claim to be able to submit.

#### How
Added an optional button to the external_user display view for api claims
When a claim is from the API it should appear:
![image](https://user-images.githubusercontent.com/6757677/36674403-de0e2ee2-1afd-11e8-9149-63727e11c65e.png)

When it is web sourced, it should still look like:
![image](https://user-images.githubusercontent.com/6757677/36674379-cc4b14b8-1afd-11e8-9fc6-5cf96d181760.png)

#### Ticket
[Add `certify and submit` option for providers](https://www.pivotaltracker.com/story/show/155429494)
