### PR TITLE
Switch to `Upload evidence`

### DIFF
--- a/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
@@ -1,9 +1,9 @@
 .form-row{class: error_class?(@error_presenter, :disk_evidence)}
   %h2.bold-medium
-    = f.anchored_label "Evidence supplied on disk", 'evidence_upload'
+    = f.anchored_label t('disk_evidence.header'), 'evidence_upload'
 
   %fieldset
-    = f.anchored_label 'Will you be sending disk evidence for this claim?', 'disk_evidence'
+    = f.anchored_label t('disk_evidence.question'), 'disk_evidence'
     = f.collection_radio_buttons(:disk_evidence, [['Yes','true'],['No','false']], :last, :first ) do |b|
       .multiple-choice{"data-target" => b.text == 'Yes' ? 'evidence-info' : nil}
         = b.radio_button

--- a/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
@@ -1,7 +1,7 @@
-%h2.bold-medium
-  = "Evidence supplied on disk"
-
 .form-row{class: error_class?(@error_presenter, :disk_evidence)}
+  %h2.bold-medium
+    = f.anchored_label "Evidence supplied on disk", 'evidence_upload'
+
   %fieldset
     = f.anchored_label 'Will you be sending disk evidence for this claim?', 'disk_evidence'
     = f.collection_radio_buttons(:disk_evidence, [['Yes','true'],['No','false']], :last, :first ) do |b|

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -39,8 +39,8 @@
           = "Actions:"
           %div.action-wrapper
             = link_to 'Edit this claim', edit_polymorphic_path(claim), class: 'button edit-claim'
-            -if claim.from_api?
-              = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'disk_evidence'), builder: AdpFormBuilder, multipart: true, authenticity_token: true do |f|
+            -if claim.from_api? || claim.api_web_edited?
+              = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'evidence_upload'), builder: AdpFormBuilder, multipart: true, authenticity_token: true do |f|
                 = f.hidden_field :form_step, value: 'offence_details'
                 = f.hidden_field :form_id, value: @claim.form_id
                 = f.submit t('buttons.add_evidence'), name: 'commit_continue', class: 'button left btn-spacer-20 button-secondary blue certify-claim'

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -40,7 +40,10 @@
           %div.action-wrapper
             = link_to 'Edit this claim', edit_polymorphic_path(claim), class: 'button edit-claim'
             -if claim.from_api?
-              = link_to 'Continue and certify',  summary_external_users_claim_path(claim), class: 'button-secondary blue certify-claim'
+              = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'disk_evidence'), builder: AdpFormBuilder, multipart: true, authenticity_token: true do |f|
+                = f.hidden_field :form_step, value: 'offence_details'
+                = f.hidden_field :form_id, value: @claim.form_id
+                = f.submit t('buttons.add_evidence'), name: 'commit_continue', class: 'button left btn-spacer-20 button-secondary blue certify-claim'
             = link_to 'Delete draft', external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete-draft'
 
         - if claim.archivable?

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -38,13 +38,13 @@
         - if claim.editable?
           = "Actions:"
           %div.action-wrapper
-            = link_to 'Edit this claim', edit_polymorphic_path(claim), class: 'button edit-claim'
+            = link_to t('buttons.edit_draft'), edit_polymorphic_path(claim), class: 'button edit-claim'
             -if claim.from_api? || claim.api_web_edited?
               = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'evidence_upload'), builder: AdpFormBuilder, multipart: true, authenticity_token: true do |f|
                 = f.hidden_field :form_step, value: 'offence_details'
                 = f.hidden_field :form_id, value: @claim.form_id
                 = f.submit t('buttons.add_evidence'), name: 'commit_continue', class: 'button left btn-spacer-20 button-secondary blue certify-claim'
-            = link_to 'Delete draft', external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete-draft'
+            = link_to t('buttons.delete_draft'), external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete-draft'
 
         - if claim.archivable?
           = "Actions:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     save_to_drafts: Save to drafts
     save_a_draft: Save a draft
     clear_form: 'Clear form'
+    add_evidence: 'Upload evidence'
   date:
     formats:
       default: "%d/%m/%Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,8 @@ en:
     save_a_draft: Save a draft
     clear_form: 'Clear form'
     add_evidence: 'Upload evidence'
+    edit_draft: 'Edit this claim'
+    delete_draft: 'Delete draft'
   date:
     formats:
       default: "%d/%m/%Y"
@@ -82,7 +84,6 @@ en:
         case_numbers: &case_numbers 'Additional case numbers'
     not_provided: &not_provided 'Not provided'
     not_applicable: &not_applicable 'n/a'
-
   general:
     not_provided: *not_provided
     not_applicable: *not_applicable
@@ -278,6 +279,9 @@ en:
   prep_forms:
     advocates_html: Complete <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/503308/af1-special-prep-form.pdf" target="_blank" rel="external" title="Special Prep Form">special prep form</a> and attach
     litigators_html: Complete <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special Prep Form">special prep form</a> and attach
+  disk_evidence:
+    header: 'Evidence supplied on disk'
+    question: 'Will you be sending disk evidence for this claim?'
 
 
 # en.super_admins


### PR DESCRIPTION
#### What
After adding the `Certify and Submit` link for providers, it was pointed out that most API submissions still require documents added

#### Why
To improve providers speed of access to required steps

#### How
Amended the link to a form submission that takes providers to the correct anchor tag on the fees page.  Soon, once the pages are split, this can point directly to the evidence page.

#### Ticket
[Zendesk ticket](https://ministryofjustice.zendesk.com/agent/tickets/104300)