### PR TITLE
Fix issue with interim fee validation

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -213,6 +213,15 @@ module Claim
       @form_step = step.nil? ? nil : step.to_sym
     end
 
+    def steps_range
+      from_api? ? (0..9) : (0..current_step_index)
+    end
+
+    def step_in_steps_range?(step)
+      step_index = submission_stages.index(step)
+      steps_range.include?(step_index)
+    end
+
     # Override the corresponding method in the subclass
     def agfs?
       false

--- a/app/models/fee/interim_fee.rb
+++ b/app/models/fee/interim_fee.rb
@@ -35,4 +35,17 @@ class Fee::InterimFee < Fee::BaseFee
   def code
     fee_type.try(:code)
   end
+
+  def perform_validation?
+    (claim&.perform_validation? && validation_required?) || claim&.from_json_import?
+  end
+
+  def validation_required?
+    # TODO: all these validations processes should be much simpler
+    # than they are now.
+    # - The validations for the API should be isolated instead of having
+    # ternaries all around the code to deal with it :S
+    return true if claim&.from_api?
+    claim&.step_in_steps_range?(:fees)
+  end
 end

--- a/spec/models/fee/interim_fee_spec.rb
+++ b/spec/models/fee/interim_fee_spec.rb
@@ -97,5 +97,79 @@ module Fee
         expect(retrial_new_solicitor_fee.is_retrial_new_solicitor?).to be true
       end
     end
+
+    describe '#perform_validation?' do
+      let(:claim) { fee.claim }
+
+      subject { fee.perform_validation? }
+
+      before do
+        allow(claim).to receive(:perform_validation?).and_return(false)
+        allow(claim).to receive(:from_json_import?).and_return(false)
+        allow(fee).to receive(:validation_required?).and_return(false)
+      end
+
+      specify { is_expected.to be_falsey }
+
+      context 'when the associated claim is from a JSON import' do
+        before do
+          allow(claim).to receive(:from_json_import?).and_return(true)
+        end
+
+        specify { is_expected.to be_truthy }
+      end
+
+      context 'when the associated claim needs validation' do
+        before do
+          allow(claim).to receive(:perform_validation?).and_return(true)
+        end
+
+        context 'and the fee also needs validation' do
+          before do
+            allow(fee).to receive(:validation_required?).and_return(true)
+          end
+
+          specify { is_expected.to be_truthy }
+        end
+
+        context 'and the fee does not require validation' do
+          before do
+            allow(fee).to receive(:validation_required?).and_return(false)
+          end
+
+          specify { is_expected.to be_falsey }
+        end
+      end
+    end
+
+    describe '#validation_required?' do
+      let(:claim) { fee.claim }
+      let(:step) { :fees }
+
+      subject { fee.validation_required? }
+
+      before do
+        allow(claim).to receive(:from_api?).and_return(false)
+        allow(claim).to receive(:step_in_steps_range?).with(step).and_return(false)
+      end
+
+      specify { is_expected.to be_falsey }
+
+      context 'when the claim submission source is the API' do
+        before do
+          allow(claim).to receive(:from_api?).and_return(true)
+        end
+
+        specify { is_expected.to be_truthy }
+      end
+
+      context 'when the submission stage requires the fee to be validated' do
+        before do
+          allow(claim).to receive(:step_in_steps_range?).with(step).and_return(true)
+        end
+
+        specify { is_expected.to be_truthy }
+      end
+    end
   end
 end

--- a/spec/services/claims/update_draft_spec.rb
+++ b/spec/services/claims/update_draft_spec.rb
@@ -1,17 +1,18 @@
 require 'rails_helper'
 
-describe Claims::UpdateDraft do
+RSpec.describe Claims::UpdateDraft do
 
   after(:all) do
     clean_database
   end
 
   context 'draft claim updates' do
-    let(:claim) { FactoryBot.create :advocate_claim, case_number: 'A20161234' }
+    let(:original_case_number) { 'A20161234' }
+    let(:claim) { FactoryBot.create :advocate_claim, case_number: original_case_number }
     let(:claim_params) { { case_number: 'A20165555' } }
     let(:validate) { true }
 
-    subject { described_class.new(claim, params: claim_params, validate: validate) }
+    subject(:update_draft) { described_class.new(claim, params: claim_params, validate: validate) }
 
     it 'defines the action' do
       expect(subject.action).to eq(:edit)
@@ -71,6 +72,65 @@ describe Claims::UpdateDraft do
 
         expect(subject.result.success?).to be_falsey
         expect(subject.result.error_code).to eq(:rollback)
+      end
+    end
+
+    context 'updating a previously submitted claim that was saved as a draft with an invalid associated record' do
+      let(:fee_type) { create(:interim_fee_type, :warrant) }
+      let(:claim) { FactoryBot.create :interim_claim, case_number: 'A20161234' }
+      let(:draft_claim_params) {
+        {
+          "form_step" => "fees",
+          "interim_fee_attributes" => {
+            "fee_type_id" => fee_type.id,
+            "quantity"=>"",
+            "warrant_issued_date_dd" => "",
+            "warrant_issued_date_mm" => "",
+            "warrant_issued_date_yyyy" => "",
+            "warrant_executed_date_dd" => "",
+            "warrant_executed_date_mm" => "",
+            "warrant_executed_date_yyyy" => "",
+            "amount" => ""
+          }
+        }
+      }
+
+      before do
+        described_class.new(claim, params: draft_claim_params, validate: false).call
+      end
+
+      context 'when current form step does not require the invalid record to be validated' do
+        let(:new_case_number) { 'A20165555' }
+        let(:claim_params) {
+          {
+            "form_step" => "case_details",
+            "case_number" => new_case_number
+          }
+        }
+
+        it 'successfully updates the claim with the submitted params' do
+          result = update_draft.call
+
+          expect(result).to be_success
+          expect(claim.reload.case_number).to eq(new_case_number)
+        end
+      end
+
+      context 'when current form step requires the invalid record to be validated' do
+        let(:claim_params) {
+          {
+            "form_step" => "fees",
+            "case_number" => 'A20165555'
+          }
+        }
+
+        it 'does not update the claim' do
+          result = update_draft.call
+
+          expect(result).not_to be_success
+          expect(result.error_code).to eq(:rollback)
+          expect(claim.reload.case_number).to eq(original_case_number)
+        end
       end
     end
   end


### PR DESCRIPTION
#### What

The validation was being triggered incorrectly on a step of the submission flow where the interim fee is not required (e.g. case details).

This ensures the validation is only triggered when the claim is in a stage where that validation is actually required.

#### Ticket

[PT](https://www.pivotaltracker.com/story/show/155593565)

#### Why

The interim fee that was saved as a draft was being validated in the submission of the case details, which is the first step of the submission process and should not require the interim fee to be validated.

#### How

By ensuring that the interim fee is only validated at a stage in the submission where its expected to already been submitted (currently the **fees** page).
