### PR TITLE
Ensure transfer claims have a transfer fee

### DIFF
--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -46,6 +46,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
   private
 
   def validate_transfer_fee
+    return if @record.from_api?
     add_error(:transfer_fee, 'blank') if @record.transfer_fee.nil?
   end
 

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -32,7 +32,10 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
       ],
       defendants: [],
       offence_details: %i[offence],
-      fees: %i[total]
+      fees: %i[
+        transfer_fee
+        total
+      ]
     }
   end
 

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -47,7 +47,12 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     And I click "Continue" in the claim form
 
-    And I fill in '121.21' as the transfer fee total
+    When I click Submit to LAA
+    Then I should see the error 'Add a transfer fee'
+    And I should see the error 'Total value claimed must be greater than £0.00'
+
+    Then I fill in '121.21' as the transfer fee total
+
     And I add a miscellaneous fee 'Costs judge application'
     And I add a Case uplift fee with case numbers 'A20161234, A20165588'
 

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
     [],
     [ :offence ],
     [
+      :transfer_fee,
       :total,
     ]
   ]


### PR DESCRIPTION
#### What
Ensure transfer claims have a transfer fee - confirmed by BA

#### Why
This validation logic seems to have gone missing
(not fired) in the page break up.

#### Ticket

[bug ticket 🐛 ](https://www.pivotaltracker.com/story/show/155628354)

#### How
The transfer claim validator should have a transfer_fee in its
fee step array to ensure presence of a transfer fee. This in addition
to the transfer fee itself being validated via the transfer claim submodel validator.

