### PR TITLE
Update rack-protection gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'shell-spinner', '~> 1.0', '>= 1.0.4'
 gem 'ruby-progressbar'
 gem 'geckoboard-ruby'
 gem 'posix-spawn', '~> 0.3.13'
+gem 'rack-protection',         '~> 1.5.4'
 
 group :production, :devunicorn do
   gem 'rails_12factor', '0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,14 +429,14 @@ GEM
     puma (3.11.2)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.8)
+    rack (1.6.9)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-contrib (1.8.0)
       rack (~> 1.4)
     rack-livereload (0.3.16)
       rack
-    rack-protection (1.5.3)
+    rack-protection (1.5.4)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -721,6 +721,7 @@ DEPENDENCIES
   puma
   quiet_assets
   rack-livereload (~> 0.3.16)
+  rack-protection (~> 1.5.4)
   rails (~> 4.2)
   rails_12factor (= 0.0.3)
   redis (~> 3.3.1)


### PR DESCRIPTION
#### What
Update rack-protection to 1.5.4

#### Why
This is because of CVE-2018-7212 (windows vulnerabilities)
