### PR TITLE
Increase allocation logging

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -32,6 +32,16 @@ class Allocation
     @deallocate = [true, 'true'].include?(attributes[:deallocate])
     @allocating = attributes[:allocating]
     @successful_claims = []
+    LogStuff.send(:info, 'Allocation',
+                  action: 'allocation',
+                  allocating_user_id: @current_user&.id,
+                  allocating_to_user_id: @case_worker_id,
+                  claim_ids: @claim_ids,
+                  allocating: @allocating,
+                  deallocate: @deallocate,
+                  reallocate: !@allocating && !@deallocate) do
+      'Start allocation'
+    end
   end
 
   def save
@@ -132,24 +142,41 @@ class Allocation
   end
 
   def allocate_claim!(claim)
+    LogStuff.send(:info, 'Allocation',
+                  action: 'allocating',
+                  allocating_user_id: @current_user&.id,
+                  allocating_to_user_id: @case_worker_id,
+                  claim_id: claim.id,
+                  allocating: @allocating,
+                  deallocate: @deallocate,
+                  reallocate: !@allocating && !@deallocate) do
+      "Allocating #{claim.id}"
+    end
+
     claim.deallocate!(audit_attributes) if claim.allocated?
     claim.allocate!(audit_attributes)
 
     claim.case_workers << case_worker
     if claim.case_workers.empty?
       LogStuff.send(:error, 'Allocation',
-                    action: 'allocating',
-                    claim_id: claim.id,
-                    allocating_user_id: @current_user.id,
+                    action: 'allocated',
+                    allocating_user_id: @current_user&.id,
                     allocating_to_user_id: @case_worker_id,
-                    claim_ids: @claim_ids,
-                    allocating: @allocating,
-                    deallocate: @deallocate) do
-        "Allocating claim #{claim.id} failed"
+                    claim_id: claim.id,
+                    case_workers: claim.case_workers.pluck(:id)) do
+        "Allocating #{claim.id} failed"
       end
 
       errors.add(:base, "Allocating Claim #{claim.case_number} to #{case_worker&.name} was unsuccessful")
     else
+      LogStuff.send(:info, 'Allocation',
+                    action: 'allocated',
+                    allocating_user_id: @current_user&.id,
+                    allocating_to_user_id: @case_worker_id,
+                    claim_id: claim.id,
+                    case_workers: claim.case_workers.pluck(:id)) do
+        "Allocated #{claim.id}"
+      end
       successful_claims << claim
     end
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -163,7 +163,7 @@ class Allocation
                     allocating_user_id: @current_user&.id,
                     allocating_to_user_id: @case_worker_id,
                     claim_id: claim.id,
-                    case_workers: claim.case_workers.pluck(:id)) do
+                    case_workers: claim&.case_workers&.pluck(:id)) do
         "Allocating #{claim.id} failed"
       end
 
@@ -174,7 +174,7 @@ class Allocation
                     allocating_user_id: @current_user&.id,
                     allocating_to_user_id: @case_worker_id,
                     claim_id: claim.id,
-                    case_workers: claim.case_workers.pluck(:id)) do
+                    case_workers: claim&.case_workers&.pluck(:id)) do
         "Allocated #{claim.id}"
       end
       successful_claims << claim

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Allocation, type: :model do
         let(:case_worker_dbl) { double(Array, empty?: true, exists?: false) }
         before do
           allow(case_worker_dbl).to receive(:<<)
+          allow(case_worker_dbl).to receive(:pluck).and_return(['1'])
           allow_any_instance_of(Claim::BaseClaim).to receive(:case_workers).and_return(case_worker_dbl)
         end
 


### PR DESCRIPTION
#### What
We are seeing a small number of cases that, despite the error handling in allocate!, end up in a state where the claim is allocated, but no link is made to a case worker.

#### Why
This results in the claim disappearing from the re/allocation tables and , co-incidentally, MI breaking.

#### How
Despite our best efforts, the error handling is not trapping this, so this increase in logging will hopefully allow us to track down the circumstances where this occurs.
