### PR TITLE
Evidence provision fee radios

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
@@ -3,6 +3,7 @@ moj.Modules.FeeFieldsDisplay = {
     var self = this;
     this.addFeeChangeEvent();
   },
+
   addFeeChangeEvent: function(el) {
     var self = this;
     var $el = el ? $(el) : $('.fx-fee-group');
@@ -17,11 +18,19 @@ moj.Modules.FeeFieldsDisplay = {
       self.showHideFeeFields(el);
     });
   },
+
   showHideFeeFields: function(el) {
     var self = this;
     var currentElement = $(el);
     var caseNumbersInput = currentElement.find('input.fx-fee-case-numbers');
+    var epfAmountDiv = currentElement.find('.fx-fee-amount-radios-div');
+    var epfAmountRadio = currentElement.find('.fx-fee-amount-radio');
+    var feeAmountDiv = currentElement.find('.fx-fee-amount-div');
+    var feeAmountNumber = currentElement.find('.fx-fee-amount');
 
+    // debugger;
+
+    // enable/disable case numbers field
     if (caseNumbersInput.exists()) {
       var showCaseNumbers = currentElement.find('option:selected').data('case-numbers');
 
@@ -34,5 +43,23 @@ moj.Modules.FeeFieldsDisplay = {
         caseNumbersInput.prop('tabindex', -1);
       }
     }
-  }
+
+    // show/hide Evidence provision fee amount-limiting radios
+    if (epfAmountDiv.exists()) {
+      var showmEpfRadios = currentElement.find('option:selected').data('epf');
+
+      if (showmEpfRadios) {
+        epfAmountDiv.show();
+        epfAmountRadio.prop('disabled', false);
+        feeAmountNumber.prop('disabled', true);
+        feeAmountDiv.hide();
+      } else {
+        epfAmountRadio.prop('disabled', true);
+        epfAmountDiv.hide();
+        feeAmountDiv.show();
+        feeAmountNumber.prop('disabled', false);
+      }
+    }
+  },
+
 }

--- a/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
@@ -47,7 +47,7 @@ moj.Modules.FeeFieldsDisplay = {
 
   toggleEpfRadios: function(el) {
     var currentElement = $(el);
-    var evidenceProvisionFee = currentElement.find('option:selected').data('epf');
+    var evidenceProvisionFee = currentElement.find('option:selected').data('evidence-provision-fee');
     var epfAmountRadios = currentElement.find('.fx-fee-amount-radio-section');
     var epfAmountRadio = currentElement.find('.fx-fee-amount-radio');
     var feeAmount = currentElement.find('.fx-fee-amount-section');
@@ -65,5 +65,4 @@ moj.Modules.FeeFieldsDisplay = {
       feeAmountInput.prop('disabled', false);
     }
   },
-
 }

--- a/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
@@ -23,12 +23,7 @@ moj.Modules.FeeFieldsDisplay = {
     var self = this;
     var currentElement = $(el);
     var caseNumbersInput = currentElement.find('input.fx-fee-case-numbers');
-    var epfAmountDiv = currentElement.find('.fx-fee-amount-radios-div');
-    var epfAmountRadio = currentElement.find('.fx-fee-amount-radio');
-    var feeAmountDiv = currentElement.find('.fx-fee-amount-div');
-    var feeAmountNumber = currentElement.find('.fx-fee-amount');
-
-    // debugger;
+    var epfAmountRadios = currentElement.find('.fx-fee-amount-radio-section');
 
     // enable/disable case numbers field
     if (caseNumbersInput.exists()) {
@@ -45,20 +40,29 @@ moj.Modules.FeeFieldsDisplay = {
     }
 
     // show/hide Evidence provision fee amount-limiting radios
-    if (epfAmountDiv.exists()) {
-      var showmEpfRadios = currentElement.find('option:selected').data('epf');
+    if (epfAmountRadios.exists()) {
+      self.toggleEpfRadios(el);
+    }
+  },
 
-      if (showmEpfRadios) {
-        epfAmountDiv.show();
-        epfAmountRadio.prop('disabled', false);
-        feeAmountNumber.prop('disabled', true);
-        feeAmountDiv.hide();
-      } else {
-        epfAmountRadio.prop('disabled', true);
-        epfAmountDiv.hide();
-        feeAmountDiv.show();
-        feeAmountNumber.prop('disabled', false);
-      }
+  toggleEpfRadios: function(el) {
+    var currentElement = $(el);
+    var evidenceProvisionFee = currentElement.find('option:selected').data('epf');
+    var epfAmountRadios = currentElement.find('.fx-fee-amount-radio-section');
+    var epfAmountRadio = currentElement.find('.fx-fee-amount-radio');
+    var feeAmount = currentElement.find('.fx-fee-amount-section');
+    var feeAmountInput = currentElement.find('.fx-fee-amount');
+
+    if (evidenceProvisionFee) {
+      epfAmountRadios.show();
+      epfAmountRadio.prop('disabled', false);
+      feeAmountInput.prop('disabled', true);
+      feeAmount.hide();
+    } else {
+      epfAmountRadio.prop('disabled', true);
+      epfAmountRadios.hide();
+      feeAmount.show();
+      feeAmountInput.prop('disabled', false);
     }
   },
 

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -93,7 +93,6 @@ module Fee
       Fee::TransferFeeType.all
     end
 
-
     def self.find_by_id_or_unique_code(id_or_code)
       if id_or_code.to_s.digit?
         find_by(id: id_or_code)

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -93,6 +93,7 @@ module Fee
       Fee::TransferFeeType.all
     end
 
+
     def self.find_by_id_or_unique_code(id_or_code)
       if id_or_code.to_s.digit?
         find_by(id: id_or_code)

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -17,6 +17,14 @@
 #
 
 class Fee::MiscFeeType < Fee::BaseFeeType
+  EpfAmount = Struct.new(:description, :amount)
+
+  EPF_AMOUNTS =
+  {
+    1 => EpfAmount.new('£45', 45.00),
+    2 => EpfAmount.new('£90', 90.00),
+  }.freeze
+
   default_scope { order(description: :asc) }
 
   def fee_category_name

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -19,10 +19,9 @@
 class Fee::MiscFeeType < Fee::BaseFeeType
   EpfAmount = Struct.new(:description, :amount)
 
-  EPF_AMOUNTS =
-  {
+  EPF_AMOUNTS = {
     1 => EpfAmount.new('£45', 45.00),
-    2 => EpfAmount.new('£90', 90.00),
+    2 => EpfAmount.new('£90', 90.00)
   }.freeze
 
   default_scope { order(description: :asc) }

--- a/app/presenters/fee/misc_fee_type_presenter.rb
+++ b/app/presenters/fee/misc_fee_type_presenter.rb
@@ -5,7 +5,7 @@ class Fee::MiscFeeTypePresenter < BasePresenter
   def data_attributes
     {
       case_numbers: case_numbers_field?,
-      epf: epf?
+      evidence_provision_fee: evidence_provision_fee?
     }
   end
 
@@ -15,7 +15,7 @@ class Fee::MiscFeeTypePresenter < BasePresenter
     case_uplift?
   end
 
-  def epf?
+  def evidence_provision_fee?
     unique_code == 'MIEVI'
   end
 end

--- a/app/presenters/fee/misc_fee_type_presenter.rb
+++ b/app/presenters/fee/misc_fee_type_presenter.rb
@@ -4,7 +4,8 @@ class Fee::MiscFeeTypePresenter < BasePresenter
 
   def data_attributes
     {
-      case_numbers: case_numbers_field?
+      case_numbers: case_numbers_field?,
+      epf: epf?
     }
   end
 
@@ -12,5 +13,9 @@ class Fee::MiscFeeTypePresenter < BasePresenter
 
   def case_numbers_field?
     case_uplift?
+  end
+
+  def epf?
+    unique_code == 'MIEVI'
   end
 end

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -14,7 +14,7 @@
         = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, { include_blank: ''.html_safe }, {class: 'form-control typeahead js-misc-fee-type js-fee-type', style: 'width:100%'}
         = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
-      .column-one-third.fee-rate.margin-spacer-sm.fx-fee-amount-div
+      .column-one-third.fee-rate.margin-spacer-sm.fx-fee-amount-section
         = f.adp_text_field :amount,
                             label: t('.amount'),
                             input_classes:'total fx-fee-amount',
@@ -22,7 +22,7 @@
                             value: number_with_precision(f.object.amount, precision: 2),
                             errors: @error_presenter
 
-    .column-one-quater.margin-spacer-sm.fx-fee-amount-radios-div
+    .column-one-quater.margin-spacer-sm.fx-fee-amount-radio-section
       %fieldset{class: "inline"}
         %legend
           = "Total"

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -14,12 +14,23 @@
         = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, { include_blank: ''.html_safe }, {class: 'form-control typeahead js-misc-fee-type js-fee-type', style: 'width:100%'}
         = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
-      .column-one-third.fee-rate.margin-spacer-sm
+      .column-one-third.fee-rate.margin-spacer-sm.fx-fee-amount-div
         = f.adp_text_field :amount,
                             label: t('.amount'),
-                            input_classes:'total',
+                            input_classes:'total fx-fee-amount',
                             input_type:'currency',
                             value: number_with_precision(f.object.amount, precision: 2),
                             errors: @error_presenter
+
+    .column-one-quater.margin-spacer-sm.fx-fee-amount-radios-div
+      %fieldset{class: "inline"}
+        %legend
+          = "Total"
+        .js-misc-type-epf
+          = f.collection_radio_buttons(:amount, Fee::MiscFeeType::EPF_AMOUNTS.values, :amount, :description) do |b|
+            .multiple-choice
+              = b.radio_button(class: 'fx-fee-amount-radio')
+              = b.label { b.object.description }
+    %br
 
     = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group' }

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -14,7 +14,9 @@
         = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, { include_blank: ''.html_safe }, {class: 'form-control typeahead js-misc-fee-type js-fee-type', style: 'width:100%'}
         = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
-      .column-one-third.fee-rate.margin-spacer-sm.fx-fee-amount-section
+      - misc_fee_id = "misc_fee_#{@misc_fee_count}_amount"
+      %a{ id: misc_fee_id }
+      .column-one-quarter.fee-rate.margin-spacer-sm.fx-fee-amount-section
         = f.adp_text_field :amount,
                             label: t('.amount'),
                             input_classes:'total fx-fee-amount',
@@ -22,15 +24,17 @@
                             value: number_with_precision(f.object.amount, precision: 2),
                             errors: @error_presenter
 
-    .column-one-quater.margin-spacer-sm.fx-fee-amount-radio-section
+    .margin-spacer-sm.fx-fee-amount-radio-section
       %fieldset{class: "inline"}
-        %legend
-          = "Total"
-        .js-misc-type-epf
+        %span
+          %label.form-label
+            = t('.amount')
+        .js-misc-type-epf.form-group{class: error_class?(@error_presenter, misc_fee_id)}
           = f.collection_radio_buttons(:amount, Fee::MiscFeeType::EPF_AMOUNTS.values, :amount, :description) do |b|
             .multiple-choice
               = b.radio_button(class: 'fx-fee-amount-radio')
               = b.label { b.object.description }
+          = validation_error_message(@error_presenter, misc_fee_id)
     %br
 
     = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group' }

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -946,7 +946,7 @@ misc_fee:
       api: Enter a valid amount for the miscellaneous fee
     incorrect_epf:
       long: 'Evidence provision fee can only be £45 or £90'
-      short: 'Enter £45 or £90'
+      short: 'Choose £45 or £90'
       api: 'Evidence provision fee can only be £45 or £90'
 
 #################################################################################

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -44,6 +44,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I add a miscellaneous fee 'Costs judge application'
     And I add a miscellaneous fee 'Defendant uplift'
+    And I add an Evidence provision fee for '£90'
 
     Then I click "Continue" in the claim form
 

--- a/features/page_objects/sections/typed_fee_amount_section.rb
+++ b/features/page_objects/sections/typed_fee_amount_section.rb
@@ -5,5 +5,7 @@ class TypedFeeAmountSection < TypedFeeSection
 
   def populated?
     amount.value.size > 0
+  rescue Capybara::ElementNotFound
+    false
   end
 end

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -41,6 +41,18 @@ And(/^I add a miscellaneous fee '(.*)'$/) do |name|
   @litigator_claim_form_page.miscellaneous_fees.last.amount.set "135.78"
 end
 
+And(/^I add an Evidence provision fee for '(.*)'$/) do |amount|
+  @litigator_claim_form_page.add_misc_fee_if_required
+  @litigator_claim_form_page.miscellaneous_fees.last.select_fee_type 'Evidence provision fee'
+  @litigator_claim_form_page.miscellaneous_fees.last.find('label', text: amount).click
+end
+
+# needed?? 
+# And(/^I add a Case uplift fee with case numbers '(.*)'$/) do |case_numbers|
+#   step "I add a miscellaneous fee 'Case uplift'"
+#   @litigator_claim_form_page.miscellaneous_fees.last.case_numbers.set case_numbers
+# end
+
 And(/^I add (?:a|another) disbursement '(.*)' with net amount '(.*)' and vat amount '(.*)'$/) do |name, net_amount, vat_amount|
   @litigator_claim_form_page.add_disbursement_if_required
   @litigator_claim_form_page.disbursements.last.select_fee_type name


### PR DESCRIPTION
#### What
Display Evidence provision misc fee amount field as radio buttons

#### Ticket

[pivotal ticket](https://www.pivotaltracker.com/story/show/155700440)

#### Why
EPF amounts can only be 45 or 90 ex VAT

#### How
Store valid EPF values in relevant fee type, display both 
field types and us JS to hide/show && enable/disable.


--------

#### TODO (wip)
 - [X] implement radios with JS show/hide
 - [ ] reflect fee in sidebar
 - [X] feature spec
 - [X] re write fee type amount section (site-prism) to provide radio selectors and use

