### PR TITLE
add interim fee validation for quantity

### DIFF
--- a/app/validators/fee/interim_fee_validator.rb
+++ b/app/validators/fee/interim_fee_validator.rb
@@ -11,7 +11,7 @@ class Fee::InterimFeeValidator < Fee::BaseFeeValidator
     if @record.is_disbursement? || @record.is_interim_warrant?
       validate_absence_or_zero(:quantity, 'present')
     else
-      validate_numericality(:quantity, 'numericality', 0, 99_999)
+      validate_numericality(:quantity, 'numericality', 1, 99_999)
     end
   end
 

--- a/app/validators/fee/interim_fee_validator.rb
+++ b/app/validators/fee/interim_fee_validator.rb
@@ -8,10 +8,12 @@ class Fee::InterimFeeValidator < Fee::BaseFeeValidator
   end
 
   def validate_quantity
-    if @record.is_disbursement? || @record.is_interim_warrant?
+    if quantity_must_be_zero?
       validate_absence_or_zero(:quantity, 'present')
-    else
+    elsif quantity_required?
       validate_numericality(:quantity, 'numericality', 1, 99_999)
+    elsif quantity_optional?
+      validate_numericality(:quantity, 'numericality', 0, 99_999)
     end
   end
 
@@ -46,5 +48,19 @@ class Fee::InterimFeeValidator < Fee::BaseFeeValidator
     return unless @record.is_interim_warrant?
     validate_on_or_after(@record.warrant_issued_date, :warrant_executed_date, 'warrant_executed_before_issued')
     validate_on_or_before(Date.today, :warrant_executed_date, 'check_not_in_future')
+  end
+
+  private
+
+  def quantity_optional?
+    @record.is_effective_pcmh? || @record.is_retrial_new_solicitor?
+  end
+
+  def quantity_required?
+    @record.is_trial_start? || @record.is_retrial_start?
+  end
+
+  def quantity_must_be_zero?
+    @record.is_disbursement? || @record.is_interim_warrant?
   end
 end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1508,17 +1508,17 @@ interim_fee:
   quantity:
     _seq: 20
     blank:
-      long: Enter a quantity for the interim fee
+      long: Enter a PPE quantity for the interim fee
       short: *enter_quantity
-      api: Enter a quantity for the interim fee
+      api: Enter a PPE quantity for the interim fee
     numericality:
-      long: Enter a valid quantity for the interim fee
+      long: Enter a valid PPE quantity for the interim fee
       short: *enter_valid_quantity
-      api: Enter a valid quantity for the interim fee
+      api: Enter a valid PPE quantity for the interim fee
     present:
-      long: Do not enter a quantity for the interim fee
-      short: Do not enter a quantity
-      api: Do not enter a quantity for the interim fee
+      long: Do not enter a PPE quantity for the interim fee
+      short: Do not enter a PPE quantity
+      api: Do not enter a PPE quantity for the interim fee
 
   amount:
     _seq: 30

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -88,8 +88,8 @@ FactoryBot.define do
   factory :interim_fee, class: Fee::InterimFee do
     claim { build :interim_claim }
     fee_type { build :interim_fee_type }
-    quantity  2
-    amount  245.56
+    quantity 2
+    amount 245.56
     uuid SecureRandom.uuid
     rate nil
 
@@ -109,13 +109,22 @@ FactoryBot.define do
 
     trait :effective_pcmh do
       fee_type { build :interim_fee_type, :effective_pcmh }
-      quantity 1
+      quantity nil
     end
 
     trait :trial_start do
       fee_type { build :interim_fee_type, :trial_start }
       quantity 1
-      amount 21.21
+    end
+
+    trait :retrial_start do
+      fee_type { build :interim_fee_type, :retrial_start }
+      quantity 1
+    end
+
+    trait :retrial_new_solicitor do
+      fee_type { build :interim_fee_type, :retrial_new_solicitor }
+      quantity nil
     end
   end
 

--- a/spec/validators/fee/interim_fee_validator_spec.rb
+++ b/spec/validators/fee/interim_fee_validator_spec.rb
@@ -72,10 +72,10 @@ RSpec.describe Fee::InterimFeeValidator, type: :validator do
       it 'numericality, must be between 0 and 999999' do
         # note: before validation hook sets nil to zero
         fee.quantity = nil
-        expect(fee).to be_valid
+        expect(fee).to be_invalid
 
         fee.quantity = 0
-        expect(fee).to be_valid
+        expect(fee).to be_invalid
 
         fee.quantity = 1
         expect(fee).to be_valid


### PR DESCRIPTION
#### What
Modify interim fee validation for quantity

#### Ticket

[pivotal ticket](https://www.pivotaltracker.com/story/show/155513265)

#### Why
Pages of prosecution evidence (PPE) is the quantity 
attribute for interim fees. There should be a minimum of 1
PPE both logically and for injection if a fee is to be claimed except
for the 'effective PCMH' and 'retrial new solicitor' interim fee. 
  ##### Injection *
  CCLF permits 0 PPE/quantity for  `Effective PCMH` and `Retrial new solicitor` but requires 
  a minimum of 1 for `re/trial start`.

#### How
Modify existing numericality check from 0 to 99999 to 1 to 99999
