### PR TITLE
[AGFS fee reform] Case details page updates

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,8 +108,4 @@ class ApplicationController < ActionController::Base
   def suppress_hotline_link
     @suppress_contact_us_message = true
   end
-
-  def disable_primary_navigation
-    @primary_navigation_disabled = true
-  end
 end

--- a/app/controllers/external_users/claim_types_controller.rb
+++ b/app/controllers/external_users/claim_types_controller.rb
@@ -2,7 +2,7 @@ class ExternalUsers::ClaimTypesController < ExternalUsers::ApplicationController
   skip_load_and_authorize_resource
 
   before_action :set_available_claim_types_for_provider, only: %i[selection]
-  before_action :disable_primary_navigation, only: %i[selection]
+  layout 'claim_forms', only: %i[selection]
 
   def selection
     if @available_claim_types.empty?

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -259,6 +259,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
       :external_user_id,
       :supplier_number,
       :court_id,
+      :case_transferred_from_another_court,
       :transfer_court_id,
       :transfer_case_number,
       :case_number,

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -16,12 +16,15 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   before_action :set_and_authorize_claim, only: %i[show edit update unarchive clone_rejected destroy summary
                                                    confirmation show_message_controls messages disc_evidence]
+  before_action :set_form_step, only: %i[edit]
   before_action :set_doctypes, only: [:show]
   before_action :generate_form_id, only: %i[new edit]
   before_action :initialize_submodel_counts
 
   include ReadMessages
   include MessageControlsDisplay
+
+  layout 'claim_forms', only: %i[new create edit update]
 
   def index
     track_visit(url: 'external_user/claims', title: 'Your claims')
@@ -247,6 +250,12 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def set_and_authorize_claim
     @claim = Claim::BaseClaim.active.find(params[:id])
     authorize! params[:action].to_sym, @claim
+  end
+
+  def set_form_step
+    return unless @claim
+    return unless params[:step].present?
+    @claim.form_step = params[:step]
   end
 
   def claim_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -141,10 +141,6 @@ module ApplicationHelper
     [number[0..3], number[4..6], number[7..10]].join(' ')
   end
 
-  def display_primary_navigation?
-    @primary_navigation_disabled != true
-  end
-
   def yes_no_options
     [%w[Yes true], %w[No false]]
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,4 +144,8 @@ module ApplicationHelper
   def display_primary_navigation?
     @primary_navigation_disabled != true
   end
+
+  def yes_no_options
+    [%w[Yes true], %w[No false]]
+  end
 end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -223,6 +223,10 @@ module Claim
       steps_range.include?(step_index)
     end
 
+    def step_back?
+      previous_step.present?
+    end
+
     # Override the corresponding method in the subclass
     def agfs?
       false
@@ -425,15 +429,31 @@ module Claim
       form_step
     end
 
+    def previous_step
+      return if current_step_index.zero?
+      step = submission_stages[current_step_index - 1]
+      until step_required?(step)
+        break unless step
+        previous_step_index = submission_stages.index(step) - 1
+        return nil if previous_step_index.negative?
+        step = submission_stages[previous_step_index]
+      end
+      step
+    end
+
     def current_step_index
       submission_stages.index(current_step)
     end
 
     def current_step_required?
+      step_required?(form_step)
+    end
+
+    def step_required?(step)
       # NOTE: offence details step is only required when the
       # case type does not have a fixed fee
       # TODO: move this logic to a workflow management
-      return true unless current_step == :offence_details
+      return true unless step.to_s == 'offence_details'
       !fixed_fee_case?
     end
 

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -188,7 +188,7 @@ module Claim
     before_validation do
       errors.clear
       destroy_all_invalid_fee_types
-      reset_transfer_details unless case_transferred_from_another_court
+      reset_transfer_court_details unless case_transferred_from_another_court
       documents.each { |d| d.external_user_id = external_user_id }
     end
 
@@ -607,7 +607,7 @@ module Claim
 
     def destroy_all_invalid_fee_types; end
 
-    def reset_transfer_details
+    def reset_transfer_court_details
       self.transfer_court = nil
       self.transfer_case_number = nil
     end

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -86,7 +86,7 @@ class ExternalUser < ActiveRecord::Base
   end
 
   def name_and_number
-    "#{user.last_name}, #{user.first_name}: #{supplier_number}"
+    "#{user.last_name}, #{user.first_name} (#{supplier_number})"
   end
 
   def before_soft_delete

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -5,9 +5,9 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         case_type
         court
         case_number
+        case_transferred_from_another_court
         transfer_court
         transfer_case_number
-        advocate_category
         estimated_trial_length
         actual_trial_length
         retrial_estimated_length
@@ -26,6 +26,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
       defendants: [],
       offence_details: %i[offence],
       fees: %i[
+        advocate_category
         total
         defendant_uplifts
       ]

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -73,12 +73,20 @@ class Claim::BaseClaimValidator < BaseValidator
     validate_pattern(:case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 
-  def validate_transfer_court
-    validate_presence(:transfer_court, 'blank') if @record.transfer_case_number.present?
+  def validate_case_transferred_from_another_court
+    return unless @record.case_transferred_from_another_court
+    validate_transfer_court(force: true)
+    validate_transfer_case_number
+  end
+
+  def validate_transfer_court(force: false)
+    return if @record.errors[:transfer_court].present?
+    validate_presence(:transfer_court, 'blank') if @record.transfer_case_number.present? || force
     validate_exclusion(:transfer_court, [@record.court], 'same')
   end
 
   def validate_transfer_case_number
+    return if @record.errors[:transfer_case_number].present?
     validate_pattern(:transfer_case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -7,6 +7,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
         case_type
         court
         case_number
+        case_transferred_from_another_court
         transfer_court
         transfer_case_number
         advocate_category

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -7,6 +7,7 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
         case_type
         court
         case_number
+        case_transferred_from_another_court
         transfer_court
         transfer_case_number
         advocate_category

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -22,6 +22,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
       case_details: %i[
         court
         case_number
+        case_transferred_from_another_court
         transfer_court
         transfer_case_number
         advocate_category

--- a/app/views/external_users/advocates/claims/_advocate_category.html.haml
+++ b/app/views/external_users/advocates/claims/_advocate_category.html.haml
@@ -1,0 +1,11 @@
+%fieldset
+	%span
+		= f.anchored_without_label t('shared.claim.advocate_category')
+		= t('shared.claim.advocate_category')
+	.form-group{class: error_class?(@error_presenter, :advocate_category)}
+		= f.collection_radio_buttons(:advocate_category, Settings.advocate_categories.sort, :to_s, :to_s) do |b|
+			.multiple-choice
+				= b.radio_button
+				= b.label { b.value.to_s }
+
+		= validation_error_message(@error_presenter, :advocate_category)

--- a/app/views/external_users/advocates/claims/_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/claims/_fees_form_step.html.haml
@@ -1,3 +1,5 @@
+= render partial: 'external_users/advocates/claims/advocate_category', locals: { f: f }
+
 = render partial: 'external_users/claims/fees_shared_header'
 
 = render partial: 'external_users/claims/basic_fees/fields', locals: { f: f }

--- a/app/views/external_users/advocates/claims/edit.html.haml
+++ b/app/views/external_users/advocates/claims/edit.html.haml
@@ -1,6 +1,6 @@
-= render partial: 'error_summary', locals: { ep: @error_presenter }
+= render partial: 'external_users/claims/error_summary', locals: { ep: @error_presenter }
 
-= render partial: 'layouts/header', locals: {page_heading: t('page_headings.edit_agfs_claim')}
+= render partial: 'layouts/header', locals: { page_heading: t('page_headings.edit_agfs_claim') }
 
 - present(@claim) do |claim|
   .grid-row.grid-sidebar

--- a/app/views/external_users/advocates/claims/new.html.haml
+++ b/app/views/external_users/advocates/claims/new.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'error_summary', locals: { ep: @error_presenter }
 
-= render partial: 'layouts/header', locals: {page_heading: t('external_users.start_agfs_claim_heading')}
+= render partial: 'layouts/header', locals: { page_heading: t('external_users.start_agfs_claim_heading') }
 
 - present(@claim) do |claim|
   .grid-row.grid-sidebar

--- a/app/views/external_users/claim_types/selection.html.haml
+++ b/app/views/external_users/claim_types/selection.html.haml
@@ -1,5 +1,3 @@
-= link_to 'Home', external_users_root_path, class: 'link-back'
-
 = render partial: 'layouts/header', locals: { page_heading: claim_type_prompt_heading_for(current_user) }
 
 .grid-row.grid-row-fix

--- a/app/views/external_users/claims/case_details/_advocate_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_advocate_fields.html.haml
@@ -1,0 +1,33 @@
+.form-group
+  .form-row.js-typeahead
+    .form-col.forced-width{class: error_class?(@error_presenter, :external_user)}
+      %a{id: :external_user}
+      %label.form-label{for: 'claim_external_user_id_input'}
+        = t('.advocate')
+
+      - provider_advocates = @provider.advocates.sort_by(&:name_and_number)
+      - if provider_advocates.length >= 6
+        = f.collection_select :external_user_id, provider_advocates, :id, :name_and_number, { include_blank: ''.html_safe }, { class: 'form-control typeahead' }
+
+      - else
+        - options = provider_advocates.length == 1 ? { checked: provider_advocates.first.id } : {}
+        = f.collection_radio_buttons(:external_user_id, provider_advocates, :id, :name_and_number, options) do |b|
+          .multiple-choice
+            = b.radio_button
+            - if provider_advocates.length == 1
+              = b.label(class: 'selected') { b.text }
+            - else
+              = b.label { b.text }
+
+      = validation_error_message(@error_presenter, :external_user)
+
+.form-group
+  %details
+    %summary
+      %span.summary
+        = t('.help_missing_advocates_summary_heading')
+    .panel.panel-border-narrow
+      %p
+        = 'You can add more advocates in settings under the '
+        = link_to 'manage users', external_users_admin_external_users_path
+        = 'section'

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -4,15 +4,7 @@
 %fieldset
   .form-group
     - if @claim.agfs? && @external_user.admin?
-      .form-row.js-typeahead
-        .form-col.forced-width{class: error_class?(@error_presenter, :external_user)}
-          %a{:id => :external_user}
-          %label.form-label{:for => "claim_external_user_id_input"}
-            = t('.advocate')
-          .form-hint.xsmall.zero-vert-margin
-            = t(".advocate_hint")
-          = f.collection_select :external_user_id, @provider.advocates.sort_by(&:name_and_number), :id, :name_and_number, { include_blank: ''.html_safe }, {class: 'form-control typeahead'}
-          = validation_error_message(@error_presenter, :external_user)
+      = render partial: 'external_users/claims/case_details/advocate_fields', locals: { f: f }
 
     .form-row
       .form-col.forced-width

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -1,19 +1,6 @@
 %h2.bold-medium
   = t('.case_details')
 
-- if @claim.agfs?
-  %fieldset
-    %span
-      = f.anchored_without_label t('.advocate_category')
-      = t('.advocate_category')
-    .form-group{class: error_class?(@error_presenter, :advocate_category)}
-      = f.collection_radio_buttons(:advocate_category, Settings.advocate_categories.sort, :to_s, :to_s) do |b|
-        .multiple-choice
-          = b.radio_button
-          = b.label { b.value.to_s }
-
-      = validation_error_message(@error_presenter, :advocate_category)
-
 %fieldset
   .form-group
     - if @claim.agfs? && @external_user.admin?
@@ -27,12 +14,9 @@
           = f.collection_select :external_user_id, @provider.advocates.sort_by(&:name_and_number), :id, :name_and_number, { include_blank: ''.html_safe }, {class: 'form-control typeahead'}
           = validation_error_message(@error_presenter, :external_user)
 
-
     .form-row
       .form-col.forced-width
         = f.adp_text_field :providers_ref, label: t('common.external_user.providers_ref'), errors: @error_presenter, hint_text: t('common.external_user.providers_ref_hint')
-
-
 
     - if @claim.requires_case_type?
       .form-row.js-typeahead
@@ -41,41 +25,41 @@
           %label.form-label{:for => "claim_case_type_id_input"}
             = t('.case_type')
           .form-hint.xsmall.zero-vert-margin
-            = "for example Trial"
+            = t('.case_type_hint')
           = f.select :case_type_id, @case_types.map{ |ct| [ct.name, ct.id, {data: {'is-fixed-fee' => ct.is_fixed_fee?}}] }, { include_blank: ''.html_safe }, { class: 'form-control typeahead' }
           = validation_error_message(@error_presenter, :case_type)
 
     .form-row.js-typeahead
-      .form-col{class: error_class?(@error_presenter, :court)}
+      .form-col.forced-width{class: error_class?(@error_presenter, :court)}
         %a{:id => "court"}
         %label.form-label{:for => "claim_court_id_input"}
           = t('.court')
 
         .form-hint.xsmall.zero-vert-margin
-          = "for example Cardiff"
+          = t('.court_hint')
         = f.collection_select :court_id, Court.alphabetical, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control typeahead' }
 
         %div.clean
           = validation_error_message(@error_presenter, :court)
 
+    .form-row.js-typeahead
       .form-col
         = f.adp_text_field :case_number,
                             label: t('.case_number'),
-                            hint_text: 'for example A20161234',
+                            hint_text: t('.case_number_hint'),
                             errors: @error_presenter
 
-    .form-row.js-typeahead
-      .form-col{class: error_class?(@error_presenter, :transfer_court)}
-        %span#transfer_court.visually-hidden
-        = f.anchored_label t('.transfer_court'), 'transfer_court_id_input', { label_attributes: { class: 'form-label' } }
-        .form-hint.xsmall.zero-vert-margin
-          = "for example Cardiff"
-        = f.collection_select :transfer_court_id, Court.alphabetical, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control typeahead' }
-        = validation_error_message(@error_presenter, :transfer_court)
+    .form-row
+      %fieldset
+        = f.anchored_label t('.case_transferred_from_another_court'), 'case_transferred_from_another_court', label_attributes: { class: 'form-label' }
+        = f.collection_radio_buttons(:case_transferred_from_another_court, yes_no_options.reverse, :last, :first ) do |b|
+          .multiple-choice{ 'data-target' => b.value.to_bool ? 'transfer-court-details' : nil }
+            = b.radio_button
+            = b.label { b.text }
 
-      .cssfix.form-col.form-col-two-thirds{class: error_class?(@error_presenter, :transfer_case_number)}
-        = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number'), hint_text: 'for example A20161234', input_classes: 'medium-input',  errors: @error_presenter
-
+          - if b.value.to_bool
+            #transfer-court-details.panel.panel-border-narrow.js-hidden
+              = render partial: 'external_users/claims/case_details/transfer_court_fields', locals: { f: f }
 
 - if @claim.agfs?
   = render partial: 'external_users/claims/case_details/cracked_trial_fields', locals: { f: f }

--- a/app/views/external_users/claims/case_details/_transfer_court_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_transfer_court_fields.html.haml
@@ -1,0 +1,12 @@
+.form-row.js-typeahead
+  .form-col.forced-width{class: error_class?(@error_presenter, :transfer_court)}
+    %span#transfer_court.visually-hidden
+    = f.anchored_label t('.transfer_court'), 'transfer_court_id_input', { label_attributes: { class: 'form-label' } }
+    .form-hint.xsmall.zero-vert-margin
+      = t('.transfer_court_hint')
+    = f.collection_select :transfer_court_id, Court.alphabetical, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control typeahead' }
+    = validation_error_message(@error_presenter, :transfer_court)
+
+.form-row.js-typeahead
+  .cssfix.form-col.form-col-two-thirds{class: error_class?(@error_presenter, :transfer_case_number)}
+    = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number'), hint_text: t('.transfer_case_number_hint'), input_classes: 'medium-input',  errors: @error_presenter

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,13 +31,17 @@
         - unless current_user.nil?
           = render partial: 'layouts/user'
 
+- content_for(:default_navigation) do
+  - if user_signed_in? && display_primary_navigation?
+    = render partial: 'layouts/primary_navigation'
+
 = content_for :content do
   = csrf_meta_tags
 
   %main#content
     = render partial: 'shared/phase_banner'
-    - if user_signed_in? && display_primary_navigation?
-      = render partial: 'layouts/primary_navigation'
+
+    = content_for?(:navigation) ? yield(:navigation) : yield(:default_navigation)
 
     = render partial: 'layouts/flashes' unless flash.empty?
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,8 +32,7 @@
           = render partial: 'layouts/user'
 
 - content_for(:default_navigation) do
-  - if user_signed_in? && display_primary_navigation?
-    = render partial: 'layouts/primary_navigation'
+  = render partial: 'layouts/primary_navigation'
 
 = content_for :content do
   = csrf_meta_tags
@@ -41,7 +40,8 @@
   %main#content
     = render partial: 'shared/phase_banner'
 
-    = content_for?(:navigation) ? yield(:navigation) : yield(:default_navigation)
+    - if user_signed_in?
+      = content_for?(:navigation) ? yield(:navigation) : yield(:default_navigation)
 
     = render partial: 'layouts/flashes' unless flash.empty?
     = yield

--- a/app/views/layouts/claim_forms.html.haml
+++ b/app/views/layouts/claim_forms.html.haml
@@ -1,0 +1,7 @@
+= content_for :navigation do
+  - if @claim && @claim.step_back?
+    = link_to 'Back', edit_polymorphic_path(@claim, step: @claim.previous_step), class: 'link-back'
+  - else
+    = link_to 'Home', external_users_root_path, class: 'link-back'
+
+= render template: 'layouts/application'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,10 +37,10 @@ en:
       more_pages:
         display_entries: "<b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b>"
   buttons:
-    continue: Continue
+    continue: Save and continue
     submit_to_laa: Submit to LAA
     save_to_drafts: Save to drafts
-    save_a_draft: Save a draft
+    save_a_draft: Save as draft
     clear_form: 'Clear form'
     add_evidence: 'Upload evidence'
     edit_draft: 'Edit this claim'
@@ -526,24 +526,31 @@ en:
           trial_fixed_notice_at: 'Notice of 1st fixed/warned issued'
           trial_fixed_at: '1st fixed/warned trial'
         fields:
-          advocate: *advocate
+          advocate: Instructed advocate
           advocate_hint: 'The instructed advocate for the case'
           advocate_category: 'Advocate category'
           case_details: 'Case details'
           case_offence: 'Case & offence'
           case_number: 'Case number'
-          transfer_case_number: 'Transfer case number (optional)'
+          case_number_hint: For example T20170101
           case_type: 'Case type'
+          case_type_hint: For example Trial
           court: 'Court'
+          court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
           litigator: *litigator
           offence_class: 'Offence class'
           offence_category: 'Offence category'
           select_category: 'Please select'
-          transfer_court: 'Transfer court (optional)'
+          case_transferred_from_another_court: 'Was this case transferred from another court?'
         offence_select:
           offence_class: 'Offence class'
           select_offence_class: 'Please select'
+        transfer_court_fields:
+          transfer_case_number: Case number
+          transfer_case_number_hint: For example T20170101
+          transfer_court: Court
+          transfer_court_hint: For example Cardiff
         trial_detail_fields:
           actual_trial_length: 'Actual trial length'
           actual_trial_length_hint: 'Number of days'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -517,6 +517,10 @@ en:
           quantity: 'Quantity'
           rate: 'Rate'
       case_details:
+        advocate_fields:
+          advocate: Instructed advocate
+          advocate_hint: The instructed advocate for the case
+          help_missing_advocates_summary_heading: Help with missing instructed advocates
         case_concluded_date:
           case_concluded_at: 'Date case concluded'
         cracked_trial_fields:
@@ -526,8 +530,6 @@ en:
           trial_fixed_notice_at: 'Notice of 1st fixed/warned issued'
           trial_fixed_at: '1st fixed/warned trial'
         fields:
-          advocate: Instructed advocate
-          advocate_hint: 'The instructed advocate for the case'
           advocate_category: 'Advocate category'
           case_details: 'Case details'
           case_offence: 'Case & offence'

--- a/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
@@ -8,8 +8,7 @@ Feature: Advocate admin submits a claim for a Trial case
     And I click 'Start a claim'
     Then I should be on the new claim page
 
-    When I select an advocate category of 'Junior alone'
-    And I select an advocate
+    When I select an advocate
     And I select the court 'Blackfriars'
     And I select a case type of 'Retrial'
     Then I should see retrial fields
@@ -25,6 +24,7 @@ Feature: Advocate admin submits a claim for a Trial case
     And I select the offence category 'Activities relating to opium'
 
     Then I click "Continue" in the claim form
+    And I select an advocate category of 'Junior alone'
     And I add a basic fee with dates attended
     And I add a number of cases uplift fee with additional case numbers
     And I add a miscellaneous fee 'Adjourned appeals' with dates attended

--- a/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_admin_trial_claim_edit_submit.feature
@@ -8,13 +8,24 @@ Feature: Advocate admin submits a claim for a Trial case
     And I click 'Start a claim'
     Then I should be on the new claim page
 
-    When I select an advocate
+    When I choose 'Doe, John (AC135)' as the instructed advocate
+    And I enter a case number of 'A20161234'
+    And I save as draft
+    Then I should see 'Draft claim saved'
+
+    Given I am later on the Your claims page
+    And 6+ advocates exist for my provider
+    Then Claim 'A20161234' should be listed with a status of 'Draft'
+
+    When I click the claim 'A20161234'
+    And I edit this claim
+
+    When I select 'Doe, John (AC135)' as the instructed advocate
     And I select the court 'Blackfriars'
     And I select a case type of 'Retrial'
     Then I should see retrial fields
     And I select a case type of 'Trial'
     And I enter trial start and end dates
-    And I enter a case number of 'A20161234'
 
     Then I click "Continue" in the claim form
     And I enter defendant, representation order and MAAT reference

--- a/features/claims/advocate/advocate_claim_draft_edit_submit.feature
+++ b/features/claims/advocate/advocate_claim_draft_edit_submit.feature
@@ -8,7 +8,6 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     And I click 'Start a claim'
     Then I should be on the new claim page
 
-    When I select an advocate category of 'Junior alone'
     And I select the court 'Blackfriars'
     And I select a case type of 'Trial'
     And I enter a case number of 'A20161234'
@@ -33,6 +32,7 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
 
     Then I click "Continue" in the claim form
 
+    And I select an advocate category of 'Junior alone'
     And I add a basic fee with dates attended
     And I add a daily attendance fee with dates attended
     And I add a miscellaneous fee 'Adjourned appeals' with dates attended

--- a/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
@@ -8,7 +8,6 @@ Feature: Advocate submits a claim for a Contempt case
     And I click 'Start a claim'
     Then I should be on the new claim page
 
-    When I select an advocate category of 'Junior alone'
     And I select the court 'Blackfriars'
     And I select a case type of 'Contempt'
     And I enter a case number of 'A20161234'
@@ -20,6 +19,7 @@ Feature: Advocate submits a claim for a Contempt case
 
     Then I click "Continue" in the claim form
 
+    And I select an advocate category of 'Junior alone'
     And I add a miscellaneous fee 'Adjourned appeals' with dates attended
     And I add a fixed fee 'Contempt'
     And I add a fixed fee 'Number of cases uplift' with case numbers

--- a/features/claims/api_promo.feature
+++ b/features/claims/api_promo.feature
@@ -13,6 +13,6 @@ Feature: An API promotion banner will appear on the create claim page, until the
     When I click the link 'Do not show this message again'
     Then The API promo banner is not visible
 
-    When I click 'Your claims' link
+    When I click the link 'Home'
     And I click 'Start a claim'
     Then The API promo banner is not visible

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -13,8 +13,12 @@ When(/^I select an advocate category of '(.*?)'$/) do |name|
   @claim_form_page.find('label', text: name).click
 end
 
-When(/^I select an advocate$/) do
-  @claim_form_page.select_advocate "Doe, John: AC135"
+When(/^I select '(.*)' as the instructed advocate$/) do |text|
+  @claim_form_page.select_advocate(text)
+end
+
+When(/^I choose '(.*)' as the instructed advocate$/) do |text|
+  @claim_form_page.find('label', text: text).click
 end
 
 When(/^I select the court '(.*?)'$/) do |name|
@@ -170,6 +174,13 @@ Given(/^There are other advocates in my provider$/) do
                      provider: @advocate.provider,
                      user: FactoryBot.create(:user, first_name: 'Joe', last_name: 'Blow'),
                      supplier_number: 'XY455')
+end
+
+Given(/^6\+ advocates exist for my provider$/) do
+  number_to_add = 6 - @advocate.provider.advocates.size
+  number_to_add.times do |index|
+    @advocate.provider.advocates << FactoryBot.create(:external_user, :advocate, provider: @advocate.provider)
+  end
 end
 
 Then(/^I should see retrial fields$/) do

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
               post :create, claim: invalid_claim_params, commit_submit_claim: 'Submit to LAA'
               expect(response.status).to eq 200
               expect(response).to render_template(:new)
-              expect(response.body).to have_content("Choose an advocate category")
+              expect(response.body).to have_content('Case details')
               claim = assigns(:claim)
               expect(claim.basic_fees.size).to eq 4
               expect(claim.fixed_fees.size).to eq 1

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -363,10 +363,12 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
   end
 
   describe "GET #edit" do
-    before { get :edit, id: subject }
+    let(:edit_request) { -> { get :edit, id: claim } }
+
+    before { edit_request.call }
 
     context 'editable claim' do
-      subject { create(:advocate_claim, external_user: advocate) }
+      let(:claim) { create(:advocate_claim, external_user: advocate) }
 
       it "returns http success" do
         expect(response).to have_http_status(:success)
@@ -377,7 +379,20 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
       end
 
       it 'assigns @claim' do
-        expect(assigns(:claim)).to eq(subject)
+        expect(assigns(:claim)).to eq(claim)
+      end
+
+      it 'claim is in the first submission step by default' do
+        expect(assigns(:claim).form_step).to eq(claim.submission_stages.first)
+      end
+
+      context 'when a step is provided' do
+        let(:step) { :defendants }
+        let(:edit_request) { -> { get :edit, id: claim, step: step } }
+
+        it 'claim is submitted submission step' do
+          expect(assigns(:claim).form_step).to eq(:defendants)
+        end
       end
 
       it 'renders the template' do
@@ -386,9 +401,9 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
     end
 
     context 'uneditable claim' do
-      subject { create(:allocated_claim, external_user: advocate) }
+      let(:claim) { create(:allocated_claim, external_user: advocate) }
 
-      it 'doesn\'t update the last_edited_at field' do
+      it 'does not update the last_edited_at field' do
         expect(assigns(:claim).last_edited_at).to be_nil
       end
 

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true do
+  let!(:advocate) { create(:external_user, :advocate) }
 
-  let!(:advocate)       { create(:external_user, :advocate) }
   before { sign_in advocate.user }
 
   context "list views" do
-
     let!(:advocate_admin) { create(:external_user, :admin, provider: advocate.provider) }
     let!(:other_advocate) { create(:external_user, :advocate, provider: advocate.provider) }
 
@@ -78,9 +77,8 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
           end
 
           it 'should assign claims to dashboard displayable state claims for all members of the provder' do
-            expected_claims = [ @draft_claim ]
             get :index
-            expect(assigns(:claims)).to eq( [ @draft_claim] )
+            expect(assigns(:claims)).to eq( [@draft_claim] )
           end
         end
 

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -356,21 +356,36 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
   end
 
   describe "GET #edit" do
-    before { get :edit, id: subject }
+    let(:edit_request) { -> { get :edit, id: claim } }
+
+    before { edit_request.call }
 
     context 'editable claim' do
-      subject { create(:litigator_claim, creator: litigator) }
+      let(:claim) { create(:litigator_claim, creator: litigator) }
 
       it "returns http success" do
         expect(response).to have_http_status(:success)
       end
 
       it 'assigns @claim' do
-        expect(assigns(:claim)).to eq(subject)
+        expect(assigns(:claim)).to eq(claim)
+      end
+
+      it 'claim is in the first submission step by default' do
+        expect(assigns(:claim).form_step).to eq(claim.submission_stages.first)
+      end
+
+      context 'when a step is provided' do
+        let(:step) { :defendants }
+        let(:edit_request) { -> { get :edit, id: claim, step: step } }
+
+        it 'claim is submitted submission step' do
+          expect(assigns(:claim).form_step).to eq(:defendants)
+        end
       end
 
       it 'routes to litigators edit path' do
-        expect(request.path).to eq edit_litigators_claim_path(subject)
+        expect(request.path).to eq edit_litigators_claim_path(claim)
       end
 
       it 'renders the template' do
@@ -379,7 +394,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
     end
 
     context 'uneditable claim' do
-      subject { create(:litigator_claim, :allocated, creator: litigator) }
+      let(:claim) { create(:litigator_claim, :allocated, creator: litigator) }
 
       it 'redirects to the claims index' do
         expect(response).to redirect_to(external_users_claims_path)

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -291,6 +291,48 @@ module Claim
       end
     end
 
+    describe '#previous_step' do
+      let(:claim) { MockBaseClaim.new }
+      let(:step) { :bar }
+
+      before do
+        claim.form_step = step
+      end
+
+      it 'does not change the current step' do
+        expect { claim.previous_step }
+          .not_to change { claim.current_step }
+          .from(step)
+      end
+
+      it 'returns the immediate previous step by default' do
+        expect(claim.previous_step).to eq(:foo)
+        claim.form_step = :foo
+        expect(claim.previous_step).to eq(nil)
+      end
+
+      context 'when the immediate next step is not required' do
+        class MockPreviousStepClaim < BaseClaim
+          def submission_stages
+            %i[foo long_enough bar zzz]
+          end
+
+          def step_required?(step)
+            step && step.to_s.size >= 5
+          end
+        end
+
+        let(:step) { :zzz }
+        let(:claim) { MockPreviousStepClaim.new }
+
+        it 'returns the previous step after that which is required' do
+          expect(claim.previous_step).to eq(:long_enough)
+          claim.form_step = :long_enough
+          expect(claim.previous_step).to eq(nil)
+        end
+      end
+    end
+
     describe '#current_step_required?' do
       let(:claim) { MockBaseClaim.new }
       subject { claim.current_step_required? }

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -366,9 +366,9 @@ RSpec.describe ExternalUser, type: :model do
   end
 
   describe '#name_and_number' do
-    it 'should print last name, first name and supplier number' do
+    it 'returns last name, first name and supplier number' do
       a = create(:external_user, supplier_number: 'XX878', user: create(:user, last_name: 'Smith', first_name: 'John'))
-      expect(a.name_and_number).to eq "Smith, John: XX878"
+      expect(a.name_and_number).to eq 'Smith, John (XX878)'
     end
   end
 

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -5,13 +5,13 @@ require_relative 'shared_examples_for_step_validators'
 RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
   include_context "force-validation"
 
-  let(:litigator)     { create(:external_user, :litigator) }
-  let(:claim)         { create :advocate_claim }
+  let(:litigator) { create(:external_user, :litigator) }
+  let(:claim)     { create(:advocate_claim) }
 
   include_examples "common advocate litigator validations", :advocate
 
   context 'case concluded at date' do
-    let(:claim)    { build :claim }
+    let(:claim) { build(:claim) }
 
     it 'is valid when absent' do
       expect(claim.case_concluded_at).to be_nil
@@ -68,6 +68,10 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
   end
 
   context 'advocate_category' do
+    before do
+      claim.form_step = 'fees'
+    end
+
     it 'should error if not present' do
       claim.advocate_category = nil
       should_error_with(claim, :advocate_category,"blank")
@@ -274,9 +278,9 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
           case_type
           court
           case_number
+          case_transferred_from_another_court
           transfer_court
           transfer_case_number
-          advocate_category
           estimated_trial_length
           actual_trial_length
           retrial_estimated_length
@@ -295,6 +299,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
       [],
       %i[offence],
       %i[
+        advocate_category
         total
         defendant_uplifts
       ]

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
       :case_type,
       :court,
       :case_number,
+      :case_transferred_from_another_court,
       :transfer_court,
       :transfer_case_number,
       :advocate_category,

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
       :case_type,
       :court,
       :case_number,
+      :case_transferred_from_another_court,
       :transfer_court,
       :transfer_case_number,
       :advocate_category,

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -45,6 +45,33 @@ RSpec.shared_examples "common advocate litigator validations" do |external_user_
       claim.transfer_court = claim.court
       should_error_with(claim, :transfer_court, 'same')
     end
+
+    context 'when case was transferred from another court' do
+      before do
+        claim.case_transferred_from_another_court = true
+      end
+
+      context 'and transfer court is not set' do
+        before do
+          claim.transfer_court = nil
+        end
+
+        it 'should error' do
+          should_error_with(claim, :transfer_court, 'blank')
+        end
+      end
+
+      context 'and transfer court is set' do
+        let(:court) { build(:court) }
+
+        before do
+          claim.transfer_court = court
+        end
+
+        specify { expect(claim).to be_valid }
+      end
+
+    end
   end
 
   context 'transfer_case_number' do
@@ -58,6 +85,40 @@ RSpec.shared_examples "common advocate litigator validations" do |external_user_
     it 'should error if wrong format' do
       claim.transfer_case_number = 'ABC'
       should_error_with(claim, :transfer_case_number, 'invalid')
+    end
+
+    context 'when case was transferred from another court' do
+      before do
+        claim.case_transferred_from_another_court = true
+      end
+
+      context 'and transfer court is not set' do
+        before do
+          claim.transfer_court = nil
+        end
+
+        context 'and transfer case number is blank' do
+          before do
+            claim.transfer_case_number = ''
+          end
+
+          it 'does not contain errors on transfer case number' do
+            expect(claim.transfer_case_number).to be_blank
+            expect(claim).not_to be_valid
+            expect(claim.errors[:transfer_case_number]).to be_empty
+          end
+        end
+
+        context 'and transfer case number has an invalid format' do
+          before do
+            claim.transfer_case_number = 'ABC'
+          end
+
+          it 'contains an invalid error on transfer case number' do
+            should_error_with(claim, :transfer_case_number, 'invalid')
+          end
+        end
+      end
     end
   end
 end

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
     [
       :court,
       :case_number,
+      :case_transferred_from_another_court,
       :transfer_court,
       :transfer_case_number,
       :advocate_category,


### PR DESCRIPTION
#### What

- Remove advocate category from case details page
- Change display of transfer court details:
  
  User needs to select if the case was transferred from another court, if yes, further transfer court details are displayed for the user to fill in (they're mandatory as long as it answered to the former question as **yes**)

- Implement a **Back** button for the claim submission forms

- Instructed advocates form field is displayed as a radio if there's 5 or less advocates for the current provider (in case there's only one it's automatically selected). If there's more than 5, a text field with autocomplete is displayed instead.

#### Ticket

💎  [AGFS final fee: case details page](https://www.pivotaltracker.com/story/show/155367082)
