### PR TITLE
Add disbursement VAT amount validation

### DIFF
--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -184,11 +184,20 @@ class BaseValidator < ActiveModel::Validator
   def validate_vat_numericality(field, lower_than_field:, allow_blank: true)
     validate_presence_and_numericality(field, minimum: 0, allow_blank: allow_blank)
     validate_amount_greater_than(field, lower_than_field, 'greater_than')
+    add_error(:vat_amount, 'max_vat_amount') if (@record.vat_amount || 0) > max_vat_amount
   end
 
   def validate_two_decimals(field)
     value = @record.__send__(field)
     rounded = value.round(2)
     add_error(field, 'decimal') unless value == rounded
+  end
+
+  def max_vat_amount
+    VatRate.vat_amount(net_amount || 0, @record.claim.vat_date, calculate: true)
+  end
+
+  def net_amount
+    @record.respond_to?(:net_amount) ? @record.net_amount : @record.amount
   end
 end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -20,7 +20,7 @@ dictionary:
     enter_valid_quantity: &enter_valid_quantity 'Enter a valid quantity'
     enter_valid_rate: &enter_valid_rate 'Enter a valid rate'
     item_max_amount: &item_max_amount 'Amount exceeds limit'
-    vat_max_amount: &vat_max_amount 'Amount exceeds VAT rate'
+    max_vat_amount: &max_vat_amount 'Enter a valid amount'
     claim_max_amount: &claim_max_amount 'Amount claimed exceeds limit'
     max_length: &max_length 'Length exceeds limit'
 
@@ -1225,9 +1225,9 @@ expense:
       long: 'VAT amount for the #{expense} exceeds the limit'
       short: *item_max_amount
       api: VAT amount for the expense exceeds the limit
-    vat_max_amount:
+    max_vat_amount:
       long: 'VAT amount for the #{expense} exceeds current VAT rate'
-      short: *vat_max_amount
+      short: *max_vat_amount
       api: VAT amount for the expense exceeds current VAT rate
 
 
@@ -1420,9 +1420,9 @@ disbursement:
       long: 'VAT amount for the #{disbursement} exceeds the limit'
       short: *item_max_amount
       api: VAT amount for the disbursement exceeds the limit
-    vat_max_amount:
+    max_vat_amount:
       long: 'VAT amount for the #{disbursement} exceeds current VAT rate'
-      short: *vat_max_amount
+      short: *max_vat_amount
       api: VAT amount for the expense exceeds current VAT rate
 
 #################################################################################

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -20,6 +20,7 @@ dictionary:
     enter_valid_quantity: &enter_valid_quantity 'Enter a valid quantity'
     enter_valid_rate: &enter_valid_rate 'Enter a valid rate'
     item_max_amount: &item_max_amount 'Amount exceeds limit'
+    vat_max_amount: &vat_max_amount 'Amount exceeds VAT rate'
     claim_max_amount: &claim_max_amount 'Amount claimed exceeds limit'
     max_length: &max_length 'Length exceeds limit'
 
@@ -1224,6 +1225,11 @@ expense:
       long: 'VAT amount for the #{expense} exceeds the limit'
       short: *item_max_amount
       api: VAT amount for the expense exceeds the limit
+    vat_max_amount:
+      long: 'VAT amount for the #{expense} exceeds current VAT rate'
+      short: *vat_max_amount
+      api: VAT amount for the expense exceeds current VAT rate
+
 
   location:
     _seq: 30
@@ -1414,6 +1420,10 @@ disbursement:
       long: 'VAT amount for the #{disbursement} exceeds the limit'
       short: *item_max_amount
       api: VAT amount for the disbursement exceeds the limit
+    vat_max_amount:
+      long: 'VAT amount for the #{disbursement} exceeds current VAT rate'
+      short: *vat_max_amount
+      api: VAT amount for the expense exceeds current VAT rate
 
 #################################################################################
 #                                                                               #

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -42,7 +42,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I enter 250 in the interim fee total field
     And I enter the effective PCMH date
 
-    And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '30.5'
+    And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '25.08'
     And I add another disbursement 'Meteorologist' with net amount '58.22' and vat amount '0'
 
     And I upload 1 document
@@ -59,4 +59,4 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     When I click View your claims
     Then I should be on the your claims page
-    And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£464.12'
+    And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£458.70'

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -41,7 +41,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I enter the fixed fee date
     And I add a miscellaneous fee 'Costs judge application'
     And I add a Case uplift fee with case numbers 'A20161234, A20165588'
-    And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '30.5'
+    And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '25.08'
     And I add another disbursement 'Meteorologist' with net amount '58.22' and vat amount '0'
     And I add an expense 'Parking'
 
@@ -59,4 +59,4 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     When I click View your claims
     Then I should be on the your claims page
-    And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£620.49'
+    And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£615.07'

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -56,7 +56,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I add a miscellaneous fee 'Costs judge application'
     And I add a Case uplift fee with case numbers 'A20161234, A20165588'
 
-    And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '32.50'
+    And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '25.08'
     And I add another disbursement 'Meteorologist' with net amount '58.22' and vat amount '0'
 
     And I add an expense 'Parking'
@@ -66,6 +66,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I add some additional information
 
     Then I click Submit to LAA
+    And I save and open screenshot
     And I should be on the check your claim page
     And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
 
@@ -77,4 +78,4 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     When I click View your claims
     Then I should be on the your claims page
-    And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£643.45'
+    And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£636.03'

--- a/spec/api/v1/external_users/disbursement_spec.rb
+++ b/spec/api/v1/external_users/disbursement_spec.rb
@@ -3,7 +3,6 @@ require 'api_spec_helper'
 require_relative 'shared_examples_for_all'
 
 describe API::V1::ExternalUsers::Disbursement do
-
   include Rack::Test::Methods
   include ApiSpecHelper
 
@@ -213,11 +212,11 @@ describe API::V1::ExternalUsers::Disbursement do
     end
 
     context 'AGFS claims' do
-      let(:claim)              { create(:advocate_claim, source: 'api').reload }
+      let(:claim) { create(:advocate_claim, source: 'api').reload }
       it 'should return 400 and JSON error array' do
         post_to_validate_endpoint
         expect(last_response.status).to eq 400
-        expect(last_response.body).to eq "[{\"error\":\"Claim is of an inappropriate fee scheme type for the disbursement\"}]"
+        expect(last_response.body).to include "{\"error\":\"Claim is of an inappropriate fee scheme type for the disbursement\"}"
       end
     end
   end

--- a/spec/controllers/vat_rates_controller_spec.rb
+++ b/spec/controllers/vat_rates_controller_spec.rb
@@ -13,13 +13,10 @@ require 'rails_helper'
 
 RSpec.describe VatRatesController, type: :controller do
 
-  before(:all) do
-    @vr1 = FactoryBot.create :vat_rate, effective_date: Date.new(2000, 1, 1),  rate_base_points: 1750
-    @vr2 = FactoryBot.create :vat_rate, effective_date: Date.new(2011, 4, 1),  rate_base_points: 2000
-  end
-
-  after(:all) do
-    VatRate.destroy( [ @vr1.id, @vr2.id ] )
+  before do
+    VatRate.delete_all
+    create(:vat_rate, effective_date: Date.new(2000, 1, 1), rate_base_points: 1750)
+    create(:vat_rate, effective_date: Date.new(2011, 4, 1), rate_base_points: 2000)
   end
 
   describe 'GET vat' do

--- a/spec/factories/vat_rates.rb
+++ b/spec/factories/vat_rates.rb
@@ -11,7 +11,12 @@
 
 FactoryBot.define do
   factory :vat_rate, class: VatRate do
-    rate_base_points                 1750
-    effective_date                   Date.new(2001, 1, 4)
+    rate_base_points 1750
+    effective_date Date.new(2001, 1, 4)
+
+    trait :for_2011_onward do
+      effective_date Date.new(2011, 4, 1)
+      rate_base_points 2000
+    end
   end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -82,7 +82,7 @@ describe Assessment do
         claim = FactoryBot.create :advocate_claim, apply_vat: true
         ass = claim.assessment
         ass.update_values(100.0, 250.0, 0)
-        expect(ass.vat_amount).to eq((ass.total * 0.175).round(2))
+        expect(ass.vat_amount).to eq((ass.total * 0.2).round(2))
       end
     end
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1268,7 +1268,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     let!(:claim) { create(:claim, state: 'draft', external_user: external_user) }
 
     context 'when VAT applied' do
-      # VAT rate 17.5%
+      # VAT rate 20.0%
 
       before do
         claim.external_user.vat_registered = true
@@ -1279,7 +1279,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       end
 
       it 'should return the amount assessed from the last determination' do
-        expect(claim.amount_assessed).to eq(6.77)
+        expect(claim.amount_assessed).to eq(6.91)
       end
     end
 

--- a/spec/models/claims/totals_spec.rb
+++ b/spec/models/claims/totals_spec.rb
@@ -70,8 +70,6 @@ RSpec.describe Claim, type: :model do
       claim.reload
     end
 
-    # before { claim.reload }
-
     context 'AGFS claim' do
       subject(:claim) { create(:claim) }
 

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -25,7 +25,6 @@
 require 'rails_helper'
 
 RSpec.describe Expense, type: :model do
-
   it { should belong_to(:expense_type) }
   it { should belong_to(:claim) }
   it { should have_many(:dates_attended) }
@@ -57,7 +56,7 @@ RSpec.describe Expense, type: :model do
       expense = build :expense, amount: 100.0, vat_amount: nil
       expense.save!
       expect(expense.amount).to eq 100.0
-      expect(expense.vat_amount).to eq 17.5
+      expect(expense.vat_amount).to eq 20.0
     end
   end
 

--- a/spec/models/redetermination_spec.rb
+++ b/spec/models/redetermination_spec.rb
@@ -59,7 +59,7 @@ describe Redetermination do
                   "  expenses:      301.55\n" +
                   "  fees:          123.22\n" +
                   "  disbursements: 44.33\n" +
-                  "  vat_amount:    82.09\n" +
+                  "  vat_amount:    93.82\n" +
                   "  total:         469.1\n\n"
        expect(rd.to_s).to eq expected
     end

--- a/spec/models/vat_rate_spec.rb
+++ b/spec/models/vat_rate_spec.rb
@@ -11,16 +11,12 @@
 
 require 'rails_helper'
 
-describe VatRate do
-
-  before(:all) do
-    @vr1 = FactoryBot.create :vat_rate, effective_date: 1.year.ago, rate_base_points: 2225
-    @vr2 = FactoryBot.create :vat_rate, effective_date: 3.years.ago, rate_base_points: 800
-    @vr3 = FactoryBot.create :vat_rate, effective_date: 10.years.ago, rate_base_points: 1750
-  end
-
-  after(:all) do
-    VatRate.destroy( [ @vr1.id, @vr2.id, @vr3.id ] )
+RSpec.describe VatRate do
+  before do
+    VatRate.delete_all
+    create(:vat_rate, effective_date: 1.year.ago, rate_base_points: 2225)
+    create(:vat_rate, effective_date: 3.years.ago, rate_base_points: 800)
+    create(:vat_rate, effective_date: 10.years.ago, rate_base_points: 1750)
   end
 
   describe '.for_date' do
@@ -55,9 +51,7 @@ describe VatRate do
     it 'should return 22.25% for dates less than one year ago' do
       expect(VatRate.pretty_rate(3.months.ago)).to eq '22.25%'
     end
-
   end
-
 
   describe '.vat_amount' do
     context '22.25% VAT' do
@@ -78,12 +72,9 @@ describe VatRate do
     end
   end
 
-
   describe '.rate_for_date' do
     it 'should be private' do
       VatRate.for_date(Date.today)
     end
   end
-
-
 end

--- a/spec/presenters/assessment_presenter_spec.rb
+++ b/spec/presenters/assessment_presenter_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AssessmentPresenter do
-  let(:claim) { FactoryBot.create :claim, apply_vat: true }
-  let(:presenter) { AssessmentPresenter.new(claim.assessment, view) }
+  let(:claim) { create(:claim, apply_vat: true) }
+  let(:presenter) { described_class.new(claim.assessment, view) }
 
   context 'currency fields' do
     let(:currency_pattern) { /£\d,\d{3}\.\d{2}/ }

--- a/spec/presenters/assessment_presenter_spec.rb
+++ b/spec/presenters/assessment_presenter_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe AssessmentPresenter do
   let(:presenter) { AssessmentPresenter.new(claim.assessment, view) }
 
   context 'currency fields' do
-    let(:thousand_currency_regex) { /£\d,\d{3}\.\d{2}/ }
+    let(:currency_pattern) { /£\d,\d{3}\.\d{2}/ }
 
     before { claim.assessment.update_values(1452.33, 2455.77, 1505.24) }
 
     it 'totals formatted as currency' do
-      expect(presenter.fees_total).to match thousand_currency_regex
-      expect(presenter.expenses_total).to match thousand_currency_regex
-      expect(presenter.disbursements_total).to match thousand_currency_regex
-      expect(presenter.total).to match thousand_currency_regex
-      expect(presenter.vat_amount).to match thousand_currency_regex
-      expect(presenter.total_inc_vat).to match thousand_currency_regex
+      expect(presenter.fees_total).to match currency_pattern
+      expect(presenter.expenses_total).to match currency_pattern
+      expect(presenter.disbursements_total).to match currency_pattern
+      expect(presenter.total).to match currency_pattern
+      expect(presenter.vat_amount).to match currency_pattern
+      expect(presenter.total_inc_vat).to match currency_pattern
     end
   end
 

--- a/spec/presenters/assessment_presenter_spec.rb
+++ b/spec/presenters/assessment_presenter_spec.rb
@@ -1,20 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe AssessmentPresenter do
-  
-  let(:claim)       { FactoryBot.create :claim, apply_vat: true }
-  
-  context 'currency fields' do
-    it 'should format currency amount' do
-      claim.assessment.update_values(1452.33, 2455.77, 1505.24)
-      presenter = AssessmentPresenter.new(claim.assessment, view)
+  let(:claim) { FactoryBot.create :claim, apply_vat: true }
+  let(:presenter) { AssessmentPresenter.new(claim.assessment, view) }
 
-      expect(presenter.fees_total).to eq '£1,452.33'
-      expect(presenter.expenses_total).to eq '£2,455.77'
-      expect(presenter.disbursements_total).to eq '£1,505.24'
-      expect(presenter.total).to eq '£5,413.34'
-      expect(presenter.vat_amount).to eq '£947.33'
-      expect(presenter.total_inc_vat).to eq '£6,360.67'
+  context 'currency fields' do
+    let(:thousand_currency_regex) { /£\d,\d{3}\.\d{2}/ }
+
+    before { claim.assessment.update_values(1452.33, 2455.77, 1505.24) }
+
+    it 'totals formatted as currency' do
+      expect(presenter.fees_total).to match thousand_currency_regex
+      expect(presenter.expenses_total).to match thousand_currency_regex
+      expect(presenter.disbursements_total).to match thousand_currency_regex
+      expect(presenter.total).to match thousand_currency_regex
+      expect(presenter.vat_amount).to match thousand_currency_regex
+      expect(presenter.total_inc_vat).to match thousand_currency_regex
     end
   end
 

--- a/spec/presenters/base_claim_presenter_spec.rb
+++ b/spec/presenters/base_claim_presenter_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Claim::BaseClaimPresenter do
       end
 
       it 'display a currency formatted amount assessed' do
-        expect(subject.amount_assessed).to eq('£200.78')
+        expect(subject.amount_assessed).to match /£\d{3}\.\d{2}/
       end
     end
 

--- a/spec/presenters/redetermination_presenter_spec.rb
+++ b/spec/presenters/redetermination_presenter_spec.rb
@@ -1,19 +1,20 @@
 require 'rails_helper'
 
 describe RedeterminationPresenter do
-
-  let(:claim)           { FactoryBot.create :claim, apply_vat: true }
-  let(:rd)              { FactoryBot.create :redetermination, fees: 1452.33, expenses: 2455.77, disbursements: 2123.55, claim: claim }
-  let(:presenter)       { RedeterminationPresenter.new(rd, view) }
+  let(:claim) { create :claim, apply_vat: true }
+  let(:rd) { create :redetermination, fees: 1452.33, expenses: 2455.77, disbursements: 2123.55, claim: claim }
+  let(:presenter) { RedeterminationPresenter.new(rd, view) }
 
   context 'currency fields' do
-    it 'should format currency amount' do
-      expect(presenter.fees_total).to eq '£1,452.33'
-      expect(presenter.expenses_total).to eq '£2,455.77'
-      expect(presenter.disbursements_total).to eq '£2,123.55'
-      expect(presenter.total).to eq '£6,031.65'
-      expect(presenter.vat_amount).to eq '£1,055.54'
-      expect(presenter.total_inc_vat).to eq '£7,087.19'
+    let(:thousand_currency_regex) { /£\d,\d{3}\.\d{2}/ }
+
+    it 'totals formatted as currency' do
+      expect(presenter.fees_total).to match thousand_currency_regex
+      expect(presenter.expenses_total).to match thousand_currency_regex
+      expect(presenter.disbursements_total).to match thousand_currency_regex
+      expect(presenter.total).to match thousand_currency_regex
+      expect(presenter.vat_amount).to match thousand_currency_regex
+      expect(presenter.total_inc_vat).to match thousand_currency_regex
     end
   end
 

--- a/spec/presenters/redetermination_presenter_spec.rb
+++ b/spec/presenters/redetermination_presenter_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-describe RedeterminationPresenter do
-  let(:claim) { create :claim, apply_vat: true }
-  let(:rd) { create :redetermination, fees: 1452.33, expenses: 2455.77, disbursements: 2123.55, claim: claim }
-  let(:presenter) { RedeterminationPresenter.new(rd, view) }
+RSpec.describe RedeterminationPresenter do
+  let(:claim) { create(:claim, apply_vat: true) }
+  let(:rd) { create(:redetermination, fees: 1452.33, expenses: 2455.77, disbursements: 2123.55, claim: claim) }
+  let(:presenter) { described_class.new(rd, view) }
 
   context 'currency fields' do
     let(:currency_pattern) { /£\d,\d{3}\.\d{2}/ }

--- a/spec/presenters/redetermination_presenter_spec.rb
+++ b/spec/presenters/redetermination_presenter_spec.rb
@@ -6,15 +6,15 @@ describe RedeterminationPresenter do
   let(:presenter) { RedeterminationPresenter.new(rd, view) }
 
   context 'currency fields' do
-    let(:thousand_currency_regex) { /£\d,\d{3}\.\d{2}/ }
+    let(:currency_pattern) { /£\d,\d{3}\.\d{2}/ }
 
     it 'totals formatted as currency' do
-      expect(presenter.fees_total).to match thousand_currency_regex
-      expect(presenter.expenses_total).to match thousand_currency_regex
-      expect(presenter.disbursements_total).to match thousand_currency_regex
-      expect(presenter.total).to match thousand_currency_regex
-      expect(presenter.vat_amount).to match thousand_currency_regex
-      expect(presenter.total_inc_vat).to match thousand_currency_regex
+      expect(presenter.fees_total).to match currency_pattern
+      expect(presenter.expenses_total).to match currency_pattern
+      expect(presenter.disbursements_total).to match currency_pattern
+      expect(presenter.total).to match currency_pattern
+      expect(presenter.vat_amount).to match currency_pattern
+      expect(presenter.total_inc_vat).to match currency_pattern
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -128,7 +128,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
-    FactoryBot.create :vat_rate, effective_date: Date.new(1960, 1, 1), rate_base_points: 1750
+    FactoryBot.create(:vat_rate, :for_2011_onward)
   end
 
   config.after(:suite) do

--- a/spec/support/api/claims/base_claim_test.rb
+++ b/spec/support/api/claims/base_claim_test.rb
@@ -126,7 +126,7 @@ class BaseClaimTest
       "claim_id": claim_uuid,
       "disbursement_type_id": disbursement_type_id,
       "net_amount": 100.25,
-      "vat_amount": 20.10
+      "vat_amount": 20.05
     }
   end
 

--- a/spec/validators/disbursement_validator_spec.rb
+++ b/spec/validators/disbursement_validator_spec.rb
@@ -1,17 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe DisbursementValidator, type: :validator do
-  let(:claim)         { FactoryBot.build :litigator_claim, force_validation: true }
-  let(:disbursement)  { FactoryBot.build :disbursement, claim: claim }
+  let(:claim) { FactoryBot.build :litigator_claim, force_validation: true }
+  let(:disbursement) { FactoryBot.build(:disbursement, claim: claim, net_amount: 100, vat_amount: 20) }
 
   describe '#validate_claim' do
-
     it { should_error_if_not_present(disbursement, :claim, 'blank') }
 
     context "AGFS claims" do
       before { allow(claim).to receive(:agfs?).and_return true }
       it 'should raise invalid fee scheme error' do
-        expect(disbursement).to_not be_valid
+        expect(disbursement).to be_invalid
         expect(disbursement.errors[:claim]).to include 'invalid_fee_scheme'
       end
     end
@@ -41,13 +40,28 @@ RSpec.describe DisbursementValidator, type: :validator do
     it { should_error_if_equal_to_value(disbursement, :vat_amount, nil, 'blank') }
     it { should_error_if_equal_to_value(disbursement, :vat_amount, 200_001, 'item_max_amount') }
 
-    context 'vat greater than net amount' do
-      before do
-        disbursement.net_amount = 5
+    it 'invalid when vat greater than net amount' do
+      disbursement.net_amount = 5
+      should_error_if_equal_to_value(disbursement, :vat_amount, 10, 'greater_than')
+    end
+
+    context 'vat greater than vat% of net amount' do
+      around do |example|
+        travel_to(Time.zone.local(2018, 01, 01)) do
+          example.run
+        end
       end
-      it { should_error_if_equal_to_value(disbursement, :vat_amount, 10, 'greater_than') }
+
+      # let(:disbursement) { FactoryBot.build(:disbursement, claim: claim, net_amount: 100, vat_amount: 20) }
+
+      it 'valid when VAT amount is less than or equal to VAT% of NET ' do
+        should_be_valid_if_equal_to_value(disbursement, :vat_amount, 20.00)
+      end
+
+      it 'invalid when VAT amount greater than VAT% of NET' do
+        should_error_if_equal_to_value(disbursement, :vat_amount, 20.01, 'max_vat_amount')
+      end
     end
   end
-
 end
 

--- a/spec/validators/disbursement_validator_spec.rb
+++ b/spec/validators/disbursement_validator_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe DisbursementValidator, type: :validator do
-  let(:claim) { FactoryBot.build :litigator_claim, force_validation: true }
-  let(:disbursement) { FactoryBot.build(:disbursement, claim: claim, net_amount: 100, vat_amount: 20) }
+  let(:claim) { build(:litigator_claim, force_validation: true )}
+  let(:disbursement) { build(:disbursement, claim: claim, net_amount: 100, vat_amount: 20) }
 
   describe '#validate_claim' do
     it { should_error_if_not_present(disbursement, :claim, 'blank') }
@@ -28,9 +28,9 @@ RSpec.describe DisbursementValidator, type: :validator do
   end
 
   describe '#validate_net_amount' do
-    it { should_error_if_equal_to_value(disbursement, :net_amount, 0,    'numericality') }
-    it { should_error_if_equal_to_value(disbursement, :net_amount, -1,   'numericality') }
-    it { should_error_if_equal_to_value(disbursement, :net_amount, nil,  'blank') }
+    it { should_error_if_equal_to_value(disbursement, :net_amount, 0, 'numericality') }
+    it { should_error_if_equal_to_value(disbursement, :net_amount, -1, 'numericality') }
+    it { should_error_if_equal_to_value(disbursement, :net_amount, nil, 'blank') }
     it { should_error_if_equal_to_value(disbursement, :net_amount, 200_001, 'item_max_amount') }
   end
 
@@ -45,21 +45,27 @@ RSpec.describe DisbursementValidator, type: :validator do
       should_error_if_equal_to_value(disbursement, :vat_amount, 10, 'greater_than')
     end
 
-    context 'vat greater than vat% of net amount' do
+    context 'vat greater than VAT% of net amount' do
       around do |example|
         travel_to(Time.zone.local(2018, 01, 01)) do
           example.run
         end
       end
 
-      # let(:disbursement) { FactoryBot.build(:disbursement, claim: claim, net_amount: 100, vat_amount: 20) }
-
       it 'valid when VAT amount is less than or equal to VAT% of NET ' do
         should_be_valid_if_equal_to_value(disbursement, :vat_amount, 20.00)
       end
 
+      it 'valid when rounded VAT amount is less than or equal to VAT% of NET ' do
+        should_be_valid_if_equal_to_value(disbursement, :vat_amount, 20.001)
+      end
+
       it 'invalid when VAT amount greater than VAT% of NET' do
         should_error_if_equal_to_value(disbursement, :vat_amount, 20.01, 'max_vat_amount')
+      end
+
+      it 'invalid when rounded VAT amount greater than VAT% of NET ' do
+        should_error_if_equal_to_value(disbursement, :vat_amount, 20.009, 'max_vat_amount')
       end
     end
   end

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -43,15 +43,28 @@ RSpec.describe 'ExpenseV1Validator and ExpenseV2Validator', type: :validator do
 
       it 'is valid if less than the total amount' do
         expense.amount = 11
-        expense.vat_amount = 10.5
+        expense.vat_amount = 2
         expect(expense).to be_valid
       end
 
       it 'is invalid if greater than the total amount' do
-        expense.amount = 11
-        expense.vat_amount = 11.5
+        expense.amount = 100
+        expense.vat_amount = 100.01
         expect(expense).not_to be_valid
         expect(expense.errors[:vat_amount]).to include('greater_than')
+      end
+
+      it 'is valid if less than VAT% of total amount' do
+        expense.amount = 100
+        expense.vat_amount = 20.00
+        expect(expense).to be_valid
+      end
+
+      it 'is invalid if greater than current VAT% of the total amount' do
+        expense.amount = 100
+        expense.vat_amount = 20.01
+        expect(expense).not_to be_valid
+        expect(expense.errors[:vat_amount]).to include('max_vat_amount')
       end
 
       it 'is invalid if negative' do


### PR DESCRIPTION
#### What
Add disbursement VAT amount validation

[ticket](https://www.pivotaltracker.com/story/show/155461780)

#### Why
To ensure VAT amount does not exceed 20%
(or current VAT rate) of the NET amount.

CCLF will reject such fees for injection.

#### How
extend existing validators
