### PR TITLE
[AGFS fee reform] Defendants & Offences page

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,3 +169,7 @@ Style/IfInsideElse:
     - 'app/presenters/error_message_translator.rb'
     - 'app/services/vat_auditor.rb'
     - 'app/validators/claim/interim_claim_validator.rb'
+
+Lint/DuplicateMethods:
+  Exclude:
+    - 'app/models/claim/base_claim.rb'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -91,7 +91,7 @@ if (!String.prototype.supplant) {
 
   $('.defendants').on('cocoon:after-insert', function(e, el){
     var $el = $(el);
-    if($el.hasClass('js-test-defendant')){
+    if($el.hasClass('defendant-details')){
       $el.find('a.add_fields').click();
     }
   });

--- a/app/assets/javascripts/modules/external_users/claims/CaseTypeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/CaseTypeFieldsDisplay.js
@@ -7,7 +7,6 @@ moj.Modules.CaseTypeFieldsDisplay = {
     this.$caseTypeSelect = $('#claim_case_type_id');
     this.$trialFieldSet = $('#trial-details');
     this.$retrialFieldSet = $('#retrial-details');
-    this.$defendantFieldSet = $('div.defendants');
 
     if (!this.$caseTypeSelect.exists()) {
       return;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -140,3 +140,25 @@ form{
 .disk-evidence{
   color: $error-colour;
 }
+
+.offence-item {
+  margin: 0px;
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
+}
+
+.offence-item:nth-child(odd) {
+  background-color: #f8f8f8;
+}
+
+.offence-item:hover {
+  background-color: #e7f4fb;
+}
+
+.offence-item a.offence-item-button {
+  visibility: hidden;
+}
+
+.offence-item:hover a.offence-item-button {
+  visibility: visible;
+}

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -190,12 +190,8 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def load_offences_and_case_types
+    @offences = Claims::FetchEligibleOffences.for(@claim)
     @offence_descriptions = Offence.unique_name
-    @offences = if @claim.offence
-                  Offence.where(description: @claim.offence.description)
-                else
-                  Offence.all
-                end
     @case_types = @claim.eligible_case_types
   end
 

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -599,6 +599,18 @@ module Claim
       self.disbursements_vat = 0.0 if disbursements_vat.nil?
     end
 
+    def fee_scheme
+      @fee_scheme ||= FeeScheme.for_claim(self)
+    end
+
+    def earliest_representation_order
+      return if defendants.empty?
+      defendants
+        .map(&:earliest_representation_order)
+        .compact
+        .sort_by(&:representation_order_date).first
+    end
+
     private
 
     # called from state_machine before_transition on submit - override in subclass

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -48,4 +48,11 @@ class Defendant < ActiveRecord::Base
   def validate_date?
     perform_validation? && claim&.case_type.present?
   end
+
+  def earliest_representation_order
+    return if representation_orders.empty?
+    representation_orders.select do |ro|
+      ro.representation_order_date.present?
+    end.sort_by(&:representation_order_date).first
+  end
 end

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -1,0 +1,9 @@
+class FeeScheme
+  def self.for_claim(claim)
+    # TODO: Align this with Fee reform SPIKE
+    return 'default' if claim.lgfs? || !FeatureFlag.active?(:agfs_fee_reform)
+    date = claim.earliest_representation_order&.representation_order_date
+    return unless date.present?
+    date >= Date.parse(Settings.agfs_fee_reform_release_date.to_s) ? 'fee_reform' : 'default'
+  end
+end

--- a/app/services/claims/fetch_eligible_offences.rb
+++ b/app/services/claims/fetch_eligible_offences.rb
@@ -1,0 +1,40 @@
+module Claims
+  class FetchEligibleOffences
+    def self.for(claim)
+      new(claim).call
+    end
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def call
+      return eligible_offences if using_fee_reform?
+      default_offences
+    end
+
+    private
+
+    attr_reader :claim
+
+    def using_fee_reform?
+      claim.agfs? &&
+        FeatureFlag.active?(:agfs_fee_reform) &&
+        claim.fee_scheme == 'fee_reform'
+    end
+
+    def eligible_offences
+      # TODO: Depends on Fee Scheme 10 SPIKE work
+      # 1. Checks fee scheme associated with claim
+      # 2. Retrieves list of offences associated with that fee scheme
+      # 3. If claim already has an associated offence return list only with that offence
+      [:todo]
+    end
+
+    def default_offences
+      # TODO: Eventually they will need to be scoped by fee scheme 9
+      # which currently does not exist
+      claim.offence ? [claim.offence] : Offence.all
+    end
+  end
+end

--- a/app/views/external_users/claims/buttons/_continue.html.haml
+++ b/app/views/external_users/claims/buttons/_continue.html.haml
@@ -1,5 +1,6 @@
-.button-holder
-  = f.submit t('buttons.continue'), name: commit, class: 'button left btn-spacer-20'
+.form-section
+  .form-group.form-buttons.button-holder
+    = f.submit t('buttons.continue'), name: commit, class: 'button left btn-spacer-20'
 
-  - if @claim.draft?
-    = f.submit t('buttons.save_a_draft'), name: 'commit_save_draft', class: 'button-gray-3 left'
+    - if @claim.draft?
+      = f.submit t('buttons.save_a_draft'), name: 'commit_save_draft', class: 'button-gray-3 left'

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -1,35 +1,32 @@
-.nested-fields.js-test-defendant
-  %h2.bold-medium
+.nested-fields.defendant-details
+  %h2.heading-large
     = t('.defendant')
-  .form-row
-    .form-col.first-name
-      - @representation_order_count = 0
-      = f.adp_text_field :first_name, label: t('.first_name'), errors: @error_presenter
+  .form-group.first-name
+    - @representation_order_count = 0
+    = f.adp_text_field :first_name, label: t('.first_name'), errors: @error_presenter
 
-  .form-row
-    .form-col.last-name
-      = f.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
+  .form-group.last-name
+    = f.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
 
-  .form-row
-    .form-col.form-col-two-thirds.dob
-      %a{:id => "defendant_#{@defendant_count+1}_date_of_birth"}
-      = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
+  .form-group.dob
+    %a{:id => "defendant_#{@defendant_count+1}_date_of_birth"}
+    = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
 
   - unless @claim.interim?
-    .form-row
-      .form-col.form-col-two-thirds
-        .form-group
-          .multiple-choice
-            = f.check_box :order_for_judicial_apportionment
-            = f.label :order_for_judicial_apportionment, t('.order_for_judicial_apportionment'), class: 'judicial-apportionment-notice'
-            = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
+    .form-group
+      %fieldset
+        .multiple-choice
+          = f.check_box :order_for_judicial_apportionment
+          = f.label :order_for_judicial_apportionment, t('.order_for_judicial_apportionment'), class: 'judicial-apportionment-notice'
+          = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
 
-        %details
-          %summary
-            %span.summary Help with judicial apportionment
-          .panel.panel-border-narrow
-            %p
-              = t('.order_for_judicial_apportionment_help')
+    .form-group
+      %details
+        %summary
+          %span.summary Help with judicial apportionment
+        .panel.panel-border-narrow
+          %p
+            = t('.order_for_judicial_apportionment_help')
 
   .documents
     = f.fields_for :representation_orders do |repo_form|

--- a/app/views/external_users/claims/defendants/_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_fields.html.haml
@@ -1,6 +1,7 @@
-%fieldset
-  .defendants
+.form-section.defendants
+  %fieldset
     = f.fields_for :defendants do |defendant|
       = render partial: 'external_users/claims/defendants/defendant_fields', locals: { f: defendant }
-    %div
-      = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields'
+.form-section.defendants-actions
+  %hr
+  = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields', class: 'button button-secondary blue'

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -1,24 +1,20 @@
-.nested-fields.indent-fieldset.js-test-rep-order
+.nested-fields.ro-details
   - @representation_order_count += 1
   %a{id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count}_representation_order_date"}
-  %h3.bold-normal
+  %h3.heading-medium
     = t('.representation_order')
-  .form-hint.xsmall.zero-vert-margin
-    &nbsp;
-  .form-row
 
-    .form-col.form-col-two-thirds.ro-date
-      = f.gov_uk_date_field(:representation_order_date,
-                            legend_text: 'Representation order date',
-                            legend_class: 'govuk-legend',
-                            id: "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date",
-                            error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count + 1}_representation_order_#{@representation_order_count}_representation_order_date"))
+  .form-group.ro-date
+    = f.gov_uk_date_field(:representation_order_date,
+                          legend_text: 'Representation order date',
+                          legend_class: 'govuk-legend',
+                          id: "defendant_#{@defendant_count}_representation_order_#{@representation_order_count}_representation_order_date",
+                          error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count + 1}_representation_order_#{@representation_order_count}_representation_order_date"))
 
-  .form-row
-    .form-col.maat
-      = f.adp_text_field :maat_reference,
-                          label: t('.maat_reference_number'),
-                          hint_text: t('.maat_reference_number_eg'),
-                          errors: @error_presenter
+  .form-group.maat
+    = f.adp_text_field :maat_reference,
+                        label: t('.maat_reference_number'),
+                        hint_text: t('.maat_reference_number_eg'),
+                        errors: @error_presenter
 
   = link_to_remove_association t('link.remove_rep_order'), f

--- a/app/views/external_users/claims/offence_details/_default_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_default_fields.html.haml
@@ -1,0 +1,27 @@
+- locale_scope = 'external_users.claims.offence_details.fields'
+
+%fieldset
+  #offence
+    .form-row.js-typeahead
+      .form-col.form-col-one-half{class: error_class?(@error_presenter, :offence)}
+        = f.anchored_label t('offence_category', scope: locale_scope), 'offence_category_description_input', { label_attributes: { class: 'form-label' } }
+        .form-hint.xsmall.zero-vert-margin
+          = t('offence_category_hint', scope: locale_scope)
+        - if @claim.new_record?
+          - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
+        - else
+          - selected_offence_category = @claim.offence.description rescue nil
+
+        = collection_select :offence_category,
+                              :description,
+                              @offence_descriptions,
+                              :description, :description,
+                              { include_blank: ''.html_safe, selected: selected_offence_category },
+                              { class: 'form-control typeahead', id: 'claim_offence_category_description' }
+        = validation_error_message(@error_presenter, :offence)
+
+    .form-row
+      .form-col.form-col-one-half
+        .offence-class-select
+          = render partial: 'external_users/claims/offence_details/offence_select', locals: { offences: @offences }
+        = f.hidden_field :offence_id

--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -1,0 +1,42 @@
+- locale_scope = 'external_users.claims.offence_details.fields'
+
+.error-summary
+  %h1.heading-medium.error-summary-heading Warning: This is just a place holder for new offences page
+
+.form-section
+  #search-field.form-group
+    = f.anchored_label t('search_offence', scope: locale_scope), 'search_offence', { label_attributes: { class: 'form-label-bold' } }
+    %input{ type: :text, class: 'form-control form-control-2-3' }
+
+  %details
+    %summary
+      %span Help with the offence classification
+    .panel.panel-border-narrow
+      %p
+        For more information on offence classification for the
+        %br
+        Advocates' Graduated Fee Scheme (
+        %abbr{ title: "Advocates' Graduated Fee Scheme" } AGFS
+        ),
+        %br
+        please visit the
+        %a{ href: "https://www.gov.uk/government/publications/crown-court-fee-guidance", target: '_blank' } Crown Court fee guidance
+        page on GOV.UK.
+
+.grid-row
+  #offence-list.column-full
+    .grid-row.offence-item
+      .column-two-thirds
+        %a{ href: "#", class: 'font-xsmall link-grey' } Offence category placeholder
+        %span.font-xsmall.font-grey &gt;
+        %a{ href: "#", class: 'font-xsmall link-grey' } Offence band placeholder
+        %br
+        %span Offence placeholder
+        %br
+        %a{ href: "#", class: 'font-xsmall link-grey' } Act placeholder
+
+
+      .column-one-third.align-right
+        %br
+        %a{ href: "#", class: 'button offence-item-button' } Select and continue
+

--- a/app/views/external_users/claims/offence_details/_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fields.html.haml
@@ -1,28 +1,5 @@
-%h2.bold-medium
+%h2.heading-large
   = t('.offence_details')
 
-%fieldset
-  #offence
-    .form-row.js-typeahead
-      .form-col.form-col-one-half{class: error_class?(@error_presenter, :offence)}
-        = f.anchored_label t('.offence_category'), 'offence_category_description_input', { label_attributes: { class: 'form-label' } }
-        .form-hint.xsmall.zero-vert-margin
-          = "If the offence category is not listed, choose \"Miscellaneous/other\""
-        - if @claim.new_record?
-          - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
-        - else
-          - selected_offence_category = @claim.offence.description rescue nil
-
-        = collection_select :offence_category,
-                              :description,
-                              @offence_descriptions,
-                              :description, :description,
-                              { include_blank: ''.html_safe, selected: selected_offence_category },
-                              { class: 'form-control typeahead', id: 'claim_offence_category_description' }
-        = validation_error_message(@error_presenter, :offence)
-
-    .form-row
-      .form-col.form-col-one-half
-        .offence-class-select
-          = render partial: 'external_users/claims/offence_details/offence_select', locals: { offences: @offences }
-        = f.hidden_field :offence_id
+- if @claim.fee_scheme
+  = render partial: "external_users/claims/offence_details/#{@claim.fee_scheme}_fields", locals: { f: f }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,12 +615,12 @@ en:
           order_for_judicial_apportionment_help: Judicial apportionment is when the defendant has applied for and received an order confirming they are not required to pay the full amount of their defence costs. If applicable, please ensure you upload a copy of the order to your claim.
           add_another_rep_order: 'Add another representation order'
           remove_defendant: 'Remove defendant'
-          defendant: 'Defendant'
+          defendant: Defendant details
         fields:
           defendants: 'Defendants'
           add_another_defendant: 'Add another defendant'
         representation_order_fields:
-          representation_order: Representation order
+          representation_order: Representation order details
           maat_reference_number: MAAT reference
           maat_reference_number_eg: 'for example 1234567890'
         summary:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -595,8 +595,10 @@ en:
       offence_details:
         fields:
           offence_class: 'Offence class'
-          offence_category: 'Offence category'
+          offence_category: Offence category
+          offence_category_hint: 'If the offence category is not listed, choose "Miscellaneous/other"'
           offence_details: 'Offence details'
+          search_offence: Search for the offence
         offence_select:
           offence_class: 'Offence class'
           select_offence_class: 'Please select'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,6 +80,9 @@ feature_flags_enabled?: <%= !%w(test api-sandbox gamma).include?(ENV['ENV']) %>
 active_features:
   - :agfs_fee_reform
 
+# TODO: Update date to actual release date
+agfs_fee_reform_release_date: <%= Date.new(2018, 3, 1) %>
+
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16
 

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -27,13 +27,13 @@ class ClaimFormPage < SitePrism::Page
 
   section :retrial_details, RetrialSection, "#retrial-details"
 
-  sections :defendants, "div.defendants > div.js-test-defendant" do
+  sections :defendants, ".defendant-details" do
     element :first_name, "div.first-name input"
     element :last_name, "div.last-name input"
 
     section :dob, CommonDateSection, 'div.dob'
 
-    sections :representation_orders, "div.js-test-rep-order" do
+    sections :representation_orders, ".ro-details" do
       section :date, CommonDateSection, 'div.ro-date'
       element :maat_reference, "div.maat input"
     end
@@ -41,7 +41,7 @@ class ClaimFormPage < SitePrism::Page
     element :add_another_representation_order, "div.links > a"
   end
 
-  element :add_another_defendant, "div.defendants > div:nth-of-type(2) > a.add_fields"
+  element :add_another_defendant, ".defendants-actions a.add_fields"
 
   element :continue_button, 'div.button-holder > input.button.left'
 

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Defendant, type: :model do
     end
 
     context 'draft claim from api' do
-      before { 
-        subject.claim = create(:draft_claim) 
+      before {
+        subject.claim = create(:draft_claim)
         subject.claim.source = 'api'
       }
 
@@ -123,7 +123,40 @@ RSpec.describe Defendant, type: :model do
         expect(defendant.name_and_initial).to eq ''
       end
     end
+  end
 
+  describe '#earliest_representation_order' do
+    subject(:defendant) { described_class.new }
 
+    context 'when there are no representation orders' do
+      subject(:defendant) { build(:defendant, representation_orders: []) }
+
+      specify { expect(defendant.earliest_representation_order).to be_nil }
+    end
+
+    context 'when there are representation orders' do
+      let(:base_date) { 3.months.ago.to_date }
+      let(:expected_representation_order) {
+        build(:representation_order, representation_order_date: base_date - 2.days)
+      }
+      let(:later_representation_order) {
+        build(:representation_order, representation_order_date: base_date + 3.days)
+      }
+      let(:representation_orders) {
+        [
+          build(:representation_order, representation_order_date: nil),
+          later_representation_order,
+          build(:representation_order, representation_order_date: nil),
+          expected_representation_order,
+          build(:representation_order, representation_order_date: nil)
+        ]
+      }
+
+      subject(:defendant) { build(:defendant, representation_orders: representation_orders) }
+
+      it 'returns the earliest representation order' do
+        expect(defendant.earliest_representation_order).to eq(expected_representation_order)
+      end
+    end
   end
 end

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe FeeScheme do
+  describe '.for_claim' do
+    subject(:fee_scheme) { described_class.for_claim(claim) }
+
+    context 'for a LGFS claim' do
+      let(:claim) { build(:litigator_claim) }
+
+      it 'returns the default scheme' do
+        expect(fee_scheme).to eq('default')
+      end
+    end
+
+    context 'for a AGFS claim' do
+      let(:claim) { build(:advocate_claim) }
+
+      context 'when the AGFS fee reform feature is not active' do
+        before do
+          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
+        end
+
+        it 'returns the default scheme' do
+          expect(fee_scheme).to eq('default')
+        end
+      end
+
+      context 'when the AGFS fee reform feature is active' do
+        before do
+          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
+        end
+
+        context 'but there is no representation order dates for the associated defendants' do
+          before do
+            expect(claim).to receive(:earliest_representation_order).and_return(nil)
+          end
+
+          specify { expect(fee_scheme).to be_nil }
+        end
+
+        context 'and there is a representation order but its date is not set' do
+          let(:representation_order) { instance_double(RepresentationOrder) }
+
+          before do
+            expect(claim).to receive(:earliest_representation_order).and_return(representation_order)
+            expect(representation_order).to receive(:representation_order_date).and_return(nil)
+          end
+
+          specify { expect(fee_scheme).to be_nil }
+        end
+
+        context 'and the earliest representation order date is before the AGFS fee reform release date' do
+          let(:representation_order) { instance_double(RepresentationOrder) }
+          let(:release_date) { 3.months.ago.to_date }
+
+          before do
+            expect(Settings).to receive(:agfs_fee_reform_release_date).and_return(release_date.to_s)
+            expect(claim).to receive(:earliest_representation_order).and_return(representation_order)
+            expect(representation_order).to receive(:representation_order_date).and_return(release_date - 1.month)
+          end
+
+          specify { expect(fee_scheme).to eq('default') }
+        end
+
+        context 'and the earliest representation order date is in the AGFS fee reform release date' do
+          let(:representation_order) { instance_double(RepresentationOrder) }
+          let(:release_date) { 3.months.ago.to_date }
+
+          before do
+            expect(Settings).to receive(:agfs_fee_reform_release_date).and_return(release_date.to_s)
+            expect(claim).to receive(:earliest_representation_order).and_return(representation_order)
+            expect(representation_order).to receive(:representation_order_date).and_return(release_date)
+          end
+
+          specify { expect(fee_scheme).to eq('fee_reform') }
+        end
+
+        context 'and the earliest representation order date is after the AGFS fee reform release date' do
+          let(:representation_order) { instance_double(RepresentationOrder) }
+          let(:release_date) { 3.months.ago.to_date }
+
+          before do
+            expect(Settings).to receive(:agfs_fee_reform_release_date).and_return(release_date.to_s)
+            expect(claim).to receive(:earliest_representation_order).and_return(representation_order)
+            expect(representation_order).to receive(:representation_order_date).and_return(release_date + 2.days)
+          end
+
+          specify { expect(fee_scheme).to eq('fee_reform') }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/claims/fetch_eligible_offences_spec.rb
+++ b/spec/services/claims/fetch_eligible_offences_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Claims::FetchEligibleOffences, type: :service do
+  subject(:offences) { described_class.for(claim) }
+
+  shared_examples_for 'a claim with default offences' do
+    context 'and the claim has no associated offence' do
+      before do
+        claim.offence = nil
+      end
+
+      it 'returns a list of all available offences' do
+        expect(offences).to match_array(Offence.all)
+      end
+    end
+
+    context 'and the claim has an associated offence' do
+      let(:offence) { create(:offence) }
+
+      before do
+        claim.offence = offence
+      end
+
+      it 'returns a list containing only the associated offence' do
+        expect(offences).to match_array([offence])
+      end
+    end
+  end
+
+  context 'when claim is for LGFS' do
+    let(:claim) { create(:litigator_claim) }
+
+    include_examples 'a claim with default offences'
+  end
+
+  context 'when claim is for AGFS' do
+    let(:claim) { create(:advocate_claim) }
+
+    context 'and AGFS fee reform feature is not active' do
+      before do
+        allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
+      end
+
+      include_examples 'a claim with default offences'
+    end
+
+    context 'and AGFS fee reform feature is active' do
+      before do
+        allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
+      end
+
+      context 'and fee scheme for the claim is not the AGFS reform scheme' do
+        before do
+          allow(claim).to receive(:fee_scheme).and_return('default')
+        end
+
+        include_examples 'a claim with default offences'
+      end
+
+      context 'and fee scheme for the claim is the AGFS reform scheme' do
+        before do
+          allow(claim).to receive(:fee_scheme).and_return('fee_reform')
+        end
+
+        it 'TODO: returns the eligible offences' do
+          expect(offences).to match_array([:todo])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

- Re-style the defendants page according to the updated designs
- Add behaviour to collect the list of offences based on what type of fee scheme the claim is associated with (in regards to the new fee reform one, there's some extra work that needs to be put in to place once the @colinbruce SPIKE is completed)
- Add behaviour to display the appropriate offences page based on what type of claim and fee scheme associated with the claim

#### Ticket

💎  [PT](https://www.pivotaltracker.com/story/show/155368005)

#### Notes

- The `release date` for the AGFS fee reform was set (for now) to be the **1st March 2018** so that these changes can be tested in the staging/demo environments (AGFS claims with an earliest representation date on or after the `release date` should have a different set of offences list and a different page to display them.
