### PR TITLE
Update Sidekiq gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.
 gem 'susy',	                  '~> 2.2.12'
 gem 'sentry-raven',           '~> 1.2.2'
 gem 'simple_form',            '~> 3.5.0'
-gem 'sinatra',                '~> 1.4.7', require: false
 gem 'sprockets-rails',        '~> 3.2'
 gem 'squeel',                 '~> 1.2.3'
 gem 'state_machine',          '~> 1.2.0'
@@ -53,7 +52,7 @@ gem 'state_machines-activerecord'
 gem 'state_machines-audit_trail'
 gem 'uglifier',                '>= 1.3.0'
 gem 'zendesk_api'  ,           '1.12.1'
-gem 'sidekiq',                 '4.1.2' # version locked, as 4.1.3 forces Sinatra dependency
+gem 'sidekiq',                 '~> 4.2.9'
 gem 'utf8-cleaner',            '~> 0.2'
 gem 'colorize'
 gem 'shell-spinner', '~> 1.0', '>= 1.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,9 +547,10 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
-    sidekiq (4.1.2)
+    sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
@@ -562,10 +563,6 @@ GEM
       simplecov
     simplecov-html (0.10.2)
     simplecov-multi (0.0.1)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     site_prism (2.9)
       addressable (>= 2.3.3, < 3.0)
       capybara (>= 2.1, < 3.0)
@@ -739,12 +736,11 @@ DEPENDENCIES
   sentry-raven (~> 1.2.2)
   shell-spinner (~> 1.0, >= 1.0.4)
   shoulda-matchers (~> 3.1)
-  sidekiq (= 4.1.2)
+  sidekiq (~> 4.2.9)
   simple_form (~> 3.5.0)
   simplecov
   simplecov-csv
   simplecov-multi
-  sinatra (~> 1.4.7)
   site_prism
   sprockets-rails (~> 3.2)
   squeel (~> 1.2.3)

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -16,7 +16,7 @@ common: &default_settings
     stack_trace_threshold: 0.500
   error_collector:
     enabled: true
-    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound"
+    ignore_errors: "ActionController::RoutingError"
 development:
   <<: *default_settings
   monitor_mode: true


### PR DESCRIPTION
#### What

The new version [no longer requires](https://github.com/mperham/sidekiq/blob/v4.2.9/Changes.md#420) `Sinatra` for the Web UI, it runs directly on `Rack`, hence the reason for removing `Sinatra` from the `Gemfile`, and updating the gem to its most recent **MINOR** version.

#### Why

Github had flagged a security vulnerability with the version of `rack-protection` used by `Sinatra`, which was being used by `Sidekiq::Web`.

![screen shot 2018-03-08 at 12 39 34](https://user-images.githubusercontent.com/67125/37204687-bd3f22d6-2389-11e8-8008-a5cdb35da980.png)

