### PR TITLE
Display only applicable interim fee types

### DIFF
--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -93,7 +93,14 @@ module Claim
     end
 
     def eligible_interim_fee_types
-      Fee::InterimFeeType.top_levels
+      case case_type&.fee_type_code
+      when 'GRTRL'
+        Fee::InterimFeeType.for_trials
+      when 'GRRTR'
+        Fee::InterimFeeType.for_retrials
+      else
+        Fee::InterimFeeType.all
+      end
     end
 
     def external_user_type

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -93,14 +93,7 @@ module Claim
     end
 
     def eligible_interim_fee_types
-      case case_type&.fee_type_code
-      when 'GRTRL'
-        Fee::InterimFeeType.for_trials
-      when 'GRRTR'
-        Fee::InterimFeeType.for_retrials
-      else
-        Fee::InterimFeeType.all
-      end
+      Fee::InterimFeeType.by_case_type(case_type)
     end
 
     def external_user_type

--- a/app/models/fee/interim_fee_type.rb
+++ b/app/models/fee/interim_fee_type.rb
@@ -21,8 +21,6 @@ class Fee::InterimFeeType < Fee::BaseFeeType
 
   default_scope -> { order(parent_id: :desc, description: :asc) }
 
-  # FIXME: all interim fee types have nil parent_ids - remove if not needed
-  # scope :top_levels, -> { where(parent_id: nil) }
   scope :for_trials, -> { where.not(unique_code: RETRIAL_APPLICABLE) }
   scope :for_retrials, -> { where.not(unique_code: TRIAL_APPLICABLE) }
 
@@ -32,5 +30,16 @@ class Fee::InterimFeeType < Fee::BaseFeeType
 
   def self.by_unique_code(code)
     where(unique_code: code).first
+  end
+
+  def self.by_case_type(case_type)
+    case case_type&.fee_type_code
+    when 'GRTRL'
+      for_trials
+    when 'GRRTR'
+      for_retrials
+    else
+      all
+    end
   end
 end

--- a/app/models/fee/interim_fee_type.rb
+++ b/app/models/fee/interim_fee_type.rb
@@ -21,7 +21,10 @@ class Fee::InterimFeeType < Fee::BaseFeeType
 
   default_scope -> { order(parent_id: :desc, description: :asc) }
 
-  scope :top_levels, -> { where(parent_id: nil) }
+  # FIXME: all interim fee types have nil parent_ids - remove if not needed
+  # scope :top_levels, -> { where(parent_id: nil) }
+  scope :for_trials, -> { where.not(unique_code: RETRIAL_APPLICABLE) }
+  scope :for_retrials, -> { where.not(unique_code: TRIAL_APPLICABLE) }
 
   def fee_category_name
     'Interim Fees'

--- a/app/models/fee/interim_fee_type_codes.rb
+++ b/app/models/fee/interim_fee_type_codes.rb
@@ -1,5 +1,8 @@
 module Fee
   module InterimFeeTypeCodes
+    TRIAL_APPLICABLE = ['INPCM','INTDT'].freeze
+    RETRIAL_APPLICABLE = ['INRST','INRNS'].freeze
+
     def is_disbursement?
       code == 'IDISO'
     end
@@ -22,6 +25,14 @@ module Fee
 
     def is_retrial_new_solicitor?
       code == 'IRNS'
+    end
+
+    def is_trial_applicable?
+      !unique_code.in? self.class::RETRIAL_APPLICABLE
+    end
+
+    def is_retrial_applicable?
+      !unique_code.in? self.class::TRIAL_APPLICABLE
     end
   end
 end

--- a/app/models/fee/interim_fee_type_codes.rb
+++ b/app/models/fee/interim_fee_type_codes.rb
@@ -26,14 +26,5 @@ module Fee
     def is_retrial_new_solicitor?
       code == 'IRNS'
     end
-
-    # TODO: remove unless need to use
-    # def is_trial_applicable?
-    #   !unique_code.in? self.class::RETRIAL_APPLICABLE
-    # end
-
-    # def is_retrial_applicable?
-    #   !unique_code.in? self.class::TRIAL_APPLICABLE
-    # end
   end
 end

--- a/app/models/fee/interim_fee_type_codes.rb
+++ b/app/models/fee/interim_fee_type_codes.rb
@@ -1,7 +1,7 @@
 module Fee
   module InterimFeeTypeCodes
-    TRIAL_APPLICABLE = ['INPCM','INTDT'].freeze
-    RETRIAL_APPLICABLE = ['INRST','INRNS'].freeze
+    TRIAL_APPLICABLE = %w[INPCM INTDT].freeze
+    RETRIAL_APPLICABLE = %w[INRST INRNS].freeze
 
     def is_disbursement?
       code == 'IDISO'
@@ -27,12 +27,13 @@ module Fee
       code == 'IRNS'
     end
 
-    def is_trial_applicable?
-      !unique_code.in? self.class::RETRIAL_APPLICABLE
-    end
+    # TODO: remove unless need to use
+    # def is_trial_applicable?
+    #   !unique_code.in? self.class::RETRIAL_APPLICABLE
+    # end
 
-    def is_retrial_applicable?
-      !unique_code.in? self.class::TRIAL_APPLICABLE
-    end
+    # def is_retrial_applicable?
+    #   !unique_code.in? self.class::TRIAL_APPLICABLE
+    # end
   end
 end

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -35,8 +35,9 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
-    Then I click "Continue" in the claim form
+    When I click "Continue" in the claim form
 
+    Then I should see interim fee types applicable to a 'Trial'
     And I select an interim fee type of 'Effective PCMH'
     And I enter 10 in the PPE total field
     And I enter 250 in the interim fee total field

--- a/features/page_objects/sections/interim_fee_section.rb
+++ b/features/page_objects/sections/interim_fee_section.rb
@@ -1,6 +1,10 @@
+class SelectOptionSection < SitePrism::Section
+end
+
 class InterimFeeSection < SitePrism::Section
   include SelectHelper
 
+  sections :fee_type_select_options, SelectOptionSection, 'select#claim_interim_fee_attributes_fee_type_id option', visible: false
   element :select_container, 'select#claim_interim_fee_attributes_fee_type_id', visible: false
 
   element :total, '#claim_interim_fee_attributes_amount'
@@ -8,7 +12,10 @@ class InterimFeeSection < SitePrism::Section
   section :effective_pcmh_date, CommonDateSection, '.js-interim-effectivePcmh'
 
   def select_fee_type(name)
-    id = select_container[:id]
-    select name, from: id, autocomplete: false
+    select name, from: select_container[:id], autocomplete: false
+  end
+
+  def fee_type_select_names
+    fee_type_select_options.map(&:text)
   end
 end

--- a/features/step_definitions/interim_claim_steps.rb
+++ b/features/step_definitions/interim_claim_steps.rb
@@ -18,3 +18,13 @@ end
 And(/^I enter the effective PCMH date$/) do
   @interim_claim_form_page.interim_fee.effective_pcmh_date.set_date "2016-01-01"
 end
+
+Then(/^I should see interim fee types applicable to a '(.*?)'$/) do |name|
+  expect(@interim_claim_form_page.interim_fee.fee_type_select_names).to include(*expected_interim_fees_for(name))
+end
+
+def expected_interim_fees_for(case_type_name)
+  expected = ['Disbursement only', 'Warrant']
+  expected += ['Effective PCMH', 'Trial start'] if case_type_name.casecmp('trial').eql?(0)
+  expected += ['Retrial start','Retrial new solicitor'] if case_type_name.casecmp('retrial').eql?(0)
+end

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -223,7 +223,7 @@ describe API::V1::ExternalUsers::Fee do
 
       context 'quantity is forbidden' do
         context 'for interim fee disbursement only' do
-          let!(:interim_fee_type) { create(:interim_fee_type, :disbursement) }
+          let!(:interim_fee_type) { create(:interim_fee_type, :disbursement_only) }
           let!(:valid_params) { {api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: interim_fee_type.id, quantity: 3, rate: 50.00} }
 
           it 'should raise error if quantity is provided' do

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -204,7 +204,7 @@ FactoryBot.define do
       calculated false
       roles ['lgfs']
 
-      trait :disbursement do
+      trait :disbursement_only do
         code 'IDISO'
         unique_code 'INDIS'
         description 'Disbursement only'

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -95,7 +95,7 @@ FactoryBot.define do
 
     trait :disbursement do
       claim { build :interim_claim, disbursements: build_list(:disbursement, 1) }
-      fee_type { build :interim_fee_type, :disbursement }
+      fee_type { build :interim_fee_type, :disbursement_only }
       amount nil
       quantity nil
     end

--- a/spec/models/claim/interim_claim_spec.rb
+++ b/spec/models/claim/interim_claim_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe Claim::InterimClaim, type: :model do
 
     before { allow(claim).to receive(:case_type).and_return(case_type) }
 
-
     let!(:trial_start_fee_type) { create(:interim_fee_type, :trial_start) }
     let!(:retrial_start_fee_type) { create(:interim_fee_type, :retrial_start) }
 
@@ -132,5 +131,4 @@ RSpec.describe Claim::InterimClaim, type: :model do
   end
 
   include_examples "common litigator claim attributes"
-
 end

--- a/spec/models/claim/interim_claim_spec.rb
+++ b/spec/models/claim/interim_claim_spec.rb
@@ -91,6 +91,40 @@ RSpec.describe Claim::InterimClaim, type: :model do
     end
   end
 
+  describe '#eligible_interim_fee_types' do
+    subject { claim.eligible_interim_fee_types }
+
+    before { allow(claim).to receive(:case_type).and_return(case_type) }
+
+
+    let!(:trial_start_fee_type) { create(:interim_fee_type, :trial_start) }
+    let!(:retrial_start_fee_type) { create(:interim_fee_type, :retrial_start) }
+
+    context 'for trials' do
+      let(:case_type) { instance_double(CaseType, fee_type_code: 'GRTRL') }
+
+      it 'returns only fee types applicable for trials' do
+        is_expected.to match_array [trial_start_fee_type]
+      end
+    end
+
+    context 'for retrials' do
+      let(:case_type) { instance_double(CaseType, fee_type_code: 'GRRTR') }
+
+      it 'returns only fee type applicable for retrials' do
+        is_expected.to match_array [retrial_start_fee_type]
+      end
+    end
+
+    context 'for nil' do
+      let(:case_type) { nil }
+
+      it 'returns all interim fee type' do
+        is_expected.to match_array [trial_start_fee_type, retrial_start_fee_type]
+      end
+    end
+  end
+
   describe 'requires_case_type?' do
     it 'returns true' do
       expect(claim.requires_case_type?).to be true

--- a/spec/models/fee/interim_fee_spec.rb
+++ b/spec/models/fee/interim_fee_spec.rb
@@ -25,7 +25,7 @@ module Fee
   describe InterimFee do
 
     let(:fee)               { build :interim_fee }
-    let(:disbursement_fee)  { build :interim_fee, fee_type: build(:interim_fee_type, :disbursement) }
+    let(:disbursement_fee)  { build :interim_fee, fee_type: build(:interim_fee_type, :disbursement_only) }
     let(:warrant_fee)       { build :interim_fee, fee_type: build(:interim_fee_type, :warrant) }
     let(:pcmh_fee)          { build :interim_fee, fee_type: build(:interim_fee_type, :effective_pcmh) }
     let(:trial_start_fee)   { build :interim_fee, fee_type: build(:interim_fee_type, :trial_start) }

--- a/spec/models/fee/interim_fee_type_spec.rb
+++ b/spec/models/fee/interim_fee_type_spec.rb
@@ -26,7 +26,31 @@ module Fee
         create :interim_fee_type, unique_code: 'IFT3'
         ift_2 = create :interim_fee_type, unique_code: 'IFT2'
 
-        expect(InterimFeeType.by_unique_code('IFT2')).to eq ift_2
+        expect(described_class.by_unique_code('IFT2')).to eq ift_2
+      end
+    end
+
+    describe '.by_case_type' do
+      subject { described_class.by_case_type(case_type) }
+
+      let!(:trial_start) { create(:interim_fee_type, :trial_start) }
+      let!(:retrial_start) { create(:interim_fee_type, :retrial_start) }
+      let!(:disbursement_only) { create(:interim_fee_type, :disbursement_only) }
+
+      context 'for trial case types' do
+        let(:case_type) { build(:case_type, :trial) }
+
+        it 'returns trial applicable interim fees' do
+          is_expected.to match_array [disbursement_only, trial_start]
+        end
+      end
+
+      context 'for retrial case types' do
+        let(:case_type) { build(:case_type, :retrial) }
+
+        it 'returns retrial applicable interim fees' do
+          is_expected.to match_array [disbursement_only, retrial_start]
+        end
       end
     end
   end

--- a/spec/models/fee/interim_fee_type_spec.rb
+++ b/spec/models/fee/interim_fee_type_spec.rb
@@ -29,7 +29,6 @@ module Fee
 
         expect(InterimFeeType.by_unique_code('IFT2')).to eq ift_2
       end
-
     end
   end
 end

--- a/spec/models/fee/interim_fee_type_spec.rb
+++ b/spec/models/fee/interim_fee_type_spec.rb
@@ -20,7 +20,6 @@ require 'rails_helper'
 
 module Fee
   describe InterimFeeType do
-
     describe '.by_unique_code' do
       it 'returns the record with the matching unique code' do
         create :interim_fee_type, unique_code: 'IFT1'

--- a/spec/presenters/interim_fee_type_presenter_spec.rb
+++ b/spec/presenters/interim_fee_type_presenter_spec.rb
@@ -7,7 +7,7 @@ describe Fee::InterimFeeTypePresenter do
     let(:presenter)     { Fee::InterimFeeTypePresenter.new(fee_type, view) }
 
     context 'disbursement only' do
-      let(:fee_type) { build :interim_fee_type, :disbursement }
+      let(:fee_type) { build :interim_fee_type, :disbursement_only }
       it 'produces expected data attributes' do
         expect(presenter.data_attributes).to eq expected_data(false, false, false, false, false, false, false, false, true)
       end


### PR DESCRIPTION
#### What
Display only applicable interim fee types base on case type

#### Why
Assist users in selecting applicable Interim fee.

All interim claims can include disbursements
only or warrant fee, however only Interim Claims
for trial are logically eligible to choose
trial start and effective PCMH interim fee types;
while retrials are only logically eligible to choose
retrial start and retrial new solicitor fee types.

#### Ticket

[PT ticket](https://www.pivotaltracker.com/story/show/155404312)


#### How
Store "knowledge" of applicable types in interim claim
and interim fee type. presenter then calls eligible fee types
to populate list