### PR TITLE
Bump the version of postgres to 9.6

### DIFF
--- a/script/db_dump.rb
+++ b/script/db_dump.rb
@@ -40,7 +40,7 @@ end
 
 def install_postgres(ssh)
   ssh.exec! 'sudo docker exec advocatedefencepayments apt-get update'
-  ssh.exec! 'sudo docker exec advocatedefencepayments apt-get -y install postgresql-9.4'
+  ssh.exec! 'sudo docker exec advocatedefencepayments apt-get -y install postgresql-9.6'
 end
 
 def delete_file_question

--- a/script/db_static_data_upload.sh
+++ b/script/db_static_data_upload.sh
@@ -39,7 +39,7 @@ end
 
 def install_postgres(ssh)
   ssh.exec! 'sudo docker exec advocatedefencepayments apt-get update'
-  ssh.exec! 'sudo docker exec advocatedefencepayments apt-get -y install postgresql-9.4'
+  ssh.exec! 'sudo docker exec advocatedefencepayments apt-get -y install postgresql-9.6'
 end
 
 begin

--- a/script/db_upload.rb
+++ b/script/db_upload.rb
@@ -40,7 +40,7 @@ end
 
 def install_postgres(ssh)
   ssh.exec! 'sudo docker exec advocatedefencepayments apt-get update'
-  ssh.exec! 'sudo docker exec advocatedefencepayments apt-get -y install postgresql-9.4'
+  ssh.exec! 'sudo docker exec advocatedefencepayments apt-get -y install postgresql-9.6'
 end
 
 def progress_bar


### PR DESCRIPTION
#### What
Bump the version of postgres to 9.6
#### Why
9.4 was no longer included in Ubuntu and, after the update on gamma,
the builds would no longer install it
