### PR TITLE
Implement the warrant fee step for advocates interim claims

### DIFF
--- a/app/controllers/external_users/advocates/interim_claims_controller.rb
+++ b/app/controllers/external_users/advocates/interim_claims_controller.rb
@@ -2,4 +2,9 @@ class ExternalUsers::Advocates::InterimClaimsController < ExternalUsers::ClaimsC
   skip_load_and_authorize_resource
 
   resource_klass Claim::AdvocateInterimClaim
+
+  def build_nested_resources
+    @claim.build_warrant_fee if @claim.warrant_fee.nil?
+    super
+  end
 end

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -32,6 +32,8 @@ module API
         end
 
         resource :advocate_categories do
+          # TODO: this might need to be changed given there's a different list
+          # of advocate categories depending on the fee scheme in use
           desc 'Return all Advocate Categories'
           get { Settings.advocate_categories }
         end

--- a/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
@@ -13,6 +13,8 @@ module API::V1::ExternalUsers
         use :common_params
         optional :advocate_email, type: String, desc: local_t(:advocate_email)
         optional :user_email, type: String, desc: local_t(:user_email)
+        # TODO: this might need to be changed given there's a different list
+        # of advocate categories depending on the fee scheme in use
         optional :advocate_category,
                  type: String,
                  desc: local_t(:advocate_category),

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -195,6 +195,10 @@ module Claim
       self.class.agfs?
     end
 
+    def eligible_advocate_categories
+      Claims::FetchEligibleAdvocateCategories.for(self)
+    end
+
     def update_claim_document_owners
       documents.each { |d| d.update_column(:external_user_id, external_user_id) }
     end

--- a/app/models/claim/advocate_interim_claim.rb
+++ b/app/models/claim/advocate_interim_claim.rb
@@ -6,6 +6,10 @@ module Claim
                    unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
     validates_with ::Claim::AdvocateInterimClaimSubModelValidator
 
+    has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
+
+    accepts_nested_attributes_for :warrant_fee, allow_destroy: false
+
     before_validation do
       set_supplier_number
     end
@@ -63,6 +67,22 @@ module Claim
 
     def requires_case_type?
       false
+    end
+
+    def agfs?
+      true
+    end
+
+    def final?
+      false
+    end
+
+    def interim?
+      true
+    end
+
+    def eligible_advocate_categories
+      Claims::FetchEligibleAdvocateCategories.for(self)
     end
 
     private

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -400,7 +400,7 @@ module Claim
     end
 
     def redeterminable?
-      VALID_STATES_FOR_REDETERMINATION.include?(state) && !interim?
+      VALID_STATES_FOR_REDETERMINATION.include?(state) && !(lgfs? && interim?)
     end
 
     def applicable_for_written_reasons?

--- a/app/models/fee/warrant_fee.rb
+++ b/app/models/fee/warrant_fee.rb
@@ -32,6 +32,11 @@ class Fee::WarrantFee < Fee::BaseFee
     true
   end
 
+  def requires_executed_date?
+    return false if claim&.agfs? && claim&.interim?
+    true
+  end
+
   def self.instance
     Fee::WarrantFee.first
   end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -26,7 +26,6 @@ class BasePresenter < SimpleDelegator
 
   private
 
-  def h
-    @view
-  end
+  attr_reader :view
+  alias h view
 end

--- a/app/presenters/claim/advocate_interim_claim_presenter.rb
+++ b/app/presenters/claim/advocate_interim_claim_presenter.rb
@@ -10,4 +10,9 @@ class Claim::AdvocateInterimClaimPresenter < Claim::BaseClaimPresenter
   def can_have_disbursements?
     false
   end
+
+  def raw_warrant_fees_total
+    claim.warrant_fee&.amount || 0
+  end
+  present_with_currency :warrant_fees_total
 end

--- a/app/services/claims/fetch_eligible_advocate_categories.rb
+++ b/app/services/claims/fetch_eligible_advocate_categories.rb
@@ -1,0 +1,33 @@
+module Claims
+  class FetchEligibleAdvocateCategories
+    def self.for(claim)
+      new(claim).call
+    end
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def call
+      return unless claim&.agfs?
+      return fee_reform_categories if using_fee_reform?
+      default_categories
+    end
+
+    private
+
+    attr_reader :claim
+
+    def default_categories
+      Settings.advocate_categories
+    end
+
+    def fee_reform_categories
+      Settings.agfs_reform_advocate_categories
+    end
+
+    def using_fee_reform?
+      claim.fee_scheme == 'fee_reform'
+    end
+  end
+end

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -52,7 +52,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
   def validate_advocate_category
     validate_presence(:advocate_category, 'blank')
     return if @record.advocate_category.blank?
-    validate_inclusion(:advocate_category, Settings.advocate_categories, I18n.t('validators.advocate.category'))
+    validate_inclusion(:advocate_category, @record.eligible_advocate_categories, I18n.t('validators.advocate.category'))
   end
 
   def validate_offence

--- a/app/validators/claim/advocate_interim_claim_sub_model_validator.rb
+++ b/app/validators/claim/advocate_interim_claim_sub_model_validator.rb
@@ -3,7 +3,8 @@ class Claim::AdvocateInterimClaimSubModelValidator < Claim::BaseClaimSubModelVal
     {
       case_details: [],
       defendants: [],
-      offence_details: []
+      offence_details: [],
+      interim_fees: %i[warrant_fee]
     }
   end
 

--- a/app/validators/claim/advocate_interim_claim_validator.rb
+++ b/app/validators/claim/advocate_interim_claim_validator.rb
@@ -10,12 +10,8 @@ class Claim::AdvocateInterimClaimValidator < Claim::BaseClaimValidator
         supplier_number
       ],
       defendants: %i[earliest_representation_order],
-      offence_details: %i[offence],
-      fees: %i[
-        advocate_category
-        total
-        defendant_uplifts
-      ]
+      # offence_details: %i[offence],
+      interim_fees: %i[advocate_category]
     }
   end
 
@@ -29,5 +25,15 @@ class Claim::AdvocateInterimClaimValidator < Claim::BaseClaimValidator
     date = @record.earliest_representation_order&.representation_order_date
     return unless date.present?
     add_error(:base, 'unclaimable') unless date >= Date.parse(Settings.agfs_fee_reform_release_date.to_s)
+  end
+
+  def validate_offence
+    validate_presence(:offence, 'blank')
+  end
+
+  def validate_advocate_category
+    validate_presence(:advocate_category, 'blank')
+    return if @record.advocate_category.blank?
+    validate_inclusion(:advocate_category, @record.eligible_advocate_categories, I18n.t('validators.advocate.category'))
   end
 end

--- a/app/validators/fee/warrant_fee_validator.rb
+++ b/app/validators/fee/warrant_fee_validator.rb
@@ -1,9 +1,14 @@
 class Fee::WarrantFeeValidator < Fee::BaseFeeValidator
+  MINIMUM_PERIOD_SINCE_ISSUED = 3.months
+
   def validate_warrant_issued_date
     validate_presence(:warrant_issued_date, 'blank')
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, 'check_not_too_far_in_past')
     return if @record.warrant_issued_date.nil?
     validate_on_or_before(Date.today, :warrant_issued_date, 'check_not_in_future')
+    validate_on_or_before(MINIMUM_PERIOD_SINCE_ISSUED.ago, :warrant_issued_date, 'on_or_before')
+    check_date = @record.claim&.earliest_representation_order&.representation_order_date
+    validate_on_or_after(check_date, :warrant_issued_date, 'check_on_or_after_earliest_representation_order')
   end
 
   def validate_warrant_executed_date

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -40,7 +40,7 @@ class RepresentationOrderValidator < BaseValidator
   end
 
   def earliest_permitted
-    if claim.try(:interim?)
+    if claim&.lgfs? && claim&.interim?
       { date: Settings.interim_earliest_permitted_repo_date, error: 'not_before_interim_earliest_permitted_date' }
     else
       { date: Settings.earliest_permitted_date, error: 'not_before_earliest_permitted_date' }

--- a/app/views/case_workers/claims/_determination_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_fields.html.haml
@@ -1,4 +1,4 @@
-- unless claim.interim? && claim.disbursement_only?
+- unless claim.lgfs? && claim.interim? && claim.disbursement_only?
   %tr.determination-form-fields
     %td
       Fees

--- a/app/views/external_users/advocates/claims/_advocate_category.html.haml
+++ b/app/views/external_users/advocates/claims/_advocate_category.html.haml
@@ -4,7 +4,7 @@
     %legend{ class: 'form-label-bold' }
       = t('shared.claim.advocate_category')
   .form-group{class: error_class?(@error_presenter, :advocate_category)}
-    = f.collection_radio_buttons(:advocate_category, Settings.advocate_categories.sort, :to_s, :to_s) do |b|
+    = f.collection_radio_buttons(:advocate_category, f.object.eligible_advocate_categories.sort, :to_s, :to_s) do |b|
       .multiple-choice
         = b.radio_button
         = b.label { b.value.to_s }

--- a/app/views/external_users/advocates/interim_claims/_form.html.haml
+++ b/app/views/external_users/advocates/interim_claims/_form.html.haml
@@ -1,7 +1,7 @@
 #claim-form
-  = form_for @claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_for claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
-    = f.hidden_field :form_step, value: @claim.form_step
+    = f.hidden_field :form_step, value: claim.form_step
 
     = render partial: "#{claim.current_step}_form_step", locals: { claim: claim, f: f }

--- a/app/views/external_users/advocates/interim_claims/_form.html.haml
+++ b/app/views/external_users/advocates/interim_claims/_form.html.haml
@@ -1,7 +1,7 @@
 #claim-form
-  = form_for claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_for @claim, as: :claim, builder: AdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
-    = f.hidden_field :form_step, value: claim.form_step
+    = f.hidden_field :form_step, value: @claim.form_step
 
     = render partial: "#{claim.current_step}_form_step", locals: { claim: claim, f: f }

--- a/app/views/external_users/advocates/interim_claims/_interim_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/interim_claims/_interim_fees_form_step.html.haml
@@ -1,0 +1,11 @@
+#fees-header
+  %h2#section-heading.heading-large
+    = t('external_users.claims.interim_fee.heading')
+  %p
+    = t('external_users.claims.interim_fee.header_prompt_text_html')
+
+= render partial: 'external_users/advocates/claims/advocate_category', locals: { f: f }
+
+= render partial: 'external_users/claims/warrant_fee/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/claims/_agfs_interim_claim_sidebar.html.haml
+++ b/app/views/external_users/claims/_agfs_interim_claim_sidebar.html.haml
@@ -1,4 +1,10 @@
 %ul
+  %li.fx-seed-warrantFees{"data-seed": claim.raw_warrant_fees_total, "data-autovat": @claim.apply_vat? ? "true" : "false"}
+    %h3
+      = "Interim fees"
+    %span.total-warrantFees
+      = claim.warrant_fees_total
+
   %li.fx-seed-expenses{"data-seed": claim.raw_expenses_total, "data-autovat": @claim.apply_vat? ? "true" : "false"}
     %h3
       = "Expenses"

--- a/app/views/external_users/claims/_agfs_interim_claim_sidebar.html.haml
+++ b/app/views/external_users/claims/_agfs_interim_claim_sidebar.html.haml
@@ -1,8 +1,8 @@
 %ul
-  %li.fx-seed-warrantFees{"data-seed": claim.raw_warrant_fees_total, "data-autovat": @claim.apply_vat? ? "true" : "false"}
+  %li.fx-seed-interimFees{"data-seed": claim.raw_warrant_fees_total, "data-autovat": @claim.apply_vat? ? "true" : "false"}
     %h3
       = "Interim fees"
-    %span.total-warrantFees
+    %span.total-interimFees
       = claim.warrant_fees_total
 
   %li.fx-seed-expenses{"data-seed": claim.raw_expenses_total, "data-autovat": @claim.apply_vat? ? "true" : "false"}

--- a/app/views/external_users/claims/_summary_claims_content.html.haml
+++ b/app/views/external_users/claims/_summary_claims_content.html.haml
@@ -14,14 +14,14 @@
   Defendants
 = render partial: 'external_users/claims/defendants/summary', locals: { claim: claim }
 
-- if claim.interim?
+- if claim.lgfs? && claim.interim?
   %h2
     = t('common.interim_fees')
   = render partial: 'external_users/claims/interim_fee/summary', locals: { claim: claim }
 - else
   = render partial: 'summary_fees', locals: { claim: claim }
 
-- if @claim.final? || @claim.interim?
+- if @claim.final? || (@claim.lgfs? && @claim.interim?)
   %h2
     = t('common.warrant_fees')
   = render partial: 'external_users/claims/warrant_fee/summary', locals: { claim: claim }

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -53,7 +53,7 @@
             #transfer-court-details.panel.panel-border-narrow.js-hidden
               = render partial: 'external_users/claims/case_details/transfer_court_fields', locals: { f: f }
 
-- if @claim.agfs?
+- if @claim.agfs? && !@claim.interim?
   = render partial: 'external_users/claims/case_details/cracked_trial_fields', locals: { f: f }
   = render partial: 'external_users/claims/case_details/trial_detail_fields', locals: { f: f }
   = render partial: 'external_users/claims/case_details/retrial_detail_fields', locals: { f: f }

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -109,7 +109,7 @@
         %td
           = claim&.trial_cracked_at_third&.humanize
 
-    - unless claim.interim?
+    - unless claim.lgfs? && claim.interim?
       - if claim&.case_type && claim.requires_trial_dates?
         %tr
           %th{scope: 'row'}

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -12,7 +12,7 @@
     %a{:id => "defendant_#{@defendant_count+1}_date_of_birth"}
     = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
 
-  - unless @claim.interim?
+  - unless @claim.lgfs? && @claim.interim?
     .form-group
       %fieldset
         .multiple-choice

--- a/app/views/external_users/claims/defendants/_summary.html.haml
+++ b/app/views/external_users/claims/defendants/_summary.html.haml
@@ -19,7 +19,7 @@
           %td
             = defendant.date_of_birth.strftime('%d/%m/%Y') rescue ''
 
-      - unless claim.interim?
+      - unless claim.lgfs? && claim.interim?
         %tr
           %th{scope:'row'}
             %span.visuallyhidden

--- a/app/views/external_users/claims/warrant_fee/_fields.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_fields.html.haml
@@ -1,33 +1,33 @@
-#warrant_fee.mod-fees
+#warrant_fee
   %h2.bold-medium
     = t('.warrant_fee')
 
   = f.fields_for :warrant_fee do |wf|
-    %fieldset
-      %legend.visuallyhidden
-        = t('.warrant_fee')
-      .form-group.nested-fields.js-block{data:{"type": "warrantFees", autovat: @claim.apply_vat? ? "true" : "false"}}
-        .grid-row
-          .warrant-fee-issued-date-group.column-one-half
-            = wf.gov_uk_date_field :warrant_issued_date,
-                                    legend_text: t('.date_issued'),
-                                    legend_class: 'govuk-legend',
-                                    id: 'warrant_fee.warrant_issued_date',
-                                    error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_issued_date')
+    .form-group.nested-fields.js-block{data:{"type": "warrantFees", autovat: @claim.apply_vat? ? "true" : "false"}}
+      %fieldset
+        %legend.visuallyhidden
+          = t('.warrant_fee')
+        .form-date.warrant-fee-issued-date-group
+          = wf.gov_uk_date_field :warrant_issued_date,
+                                  legend_text: t('.date_issued'),
+                                  legend_class: 'form-label-bold',
+                                  id: 'warrant_fee.warrant_issued_date',
+                                  error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_issued_date')
 
-          .warrant-fee-executed-date-group.column-one-half
-            = wf.gov_uk_date_field :warrant_executed_date,
-                                    legend_text: t('.date_executed'),
-                                    legend_class: 'govuk-legend',
-                                    id: 'warrant_fee.warrant_executed_date',
-                                    error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_executed_date')
+    - if f.object.warrant_fee.requires_executed_date?
+      .form-group
+        .form-date.warrant-fee-executed-date-group
+          = wf.gov_uk_date_field :warrant_executed_date,
+                                  legend_text: t('.date_executed'),
+                                  legend_class: 'govuk-legend',
+                                  id: 'warrant_fee.warrant_executed_date',
+                                  error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_executed_date')
 
-        .grid-row.warrant-amount
-          .column-quarter
-            = wf.adp_text_field :amount,
-                                  label: t('.total'),
-                                  input_classes:'total',
-                                  input_type: 'currency',
-                                  errors: @error_presenter,
-                                  value: number_with_precision(wf.object.amount, precision: 2),
-                                  error_key: 'warrant_fee.amount'
+    .form-group
+      = wf.adp_text_field :amount,
+                            label: t('.total'),
+                            input_classes:'form-control-1-4',
+                            input_type: 'currency',
+                            errors: @error_presenter,
+                            value: number_with_precision(wf.object.amount, precision: 2),
+                            error_key: 'warrant_fee.amount'

--- a/app/views/external_users/claims/warrant_fee/_fields.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_fields.html.haml
@@ -3,7 +3,7 @@
     = t('.warrant_fee')
 
   = f.fields_for :warrant_fee do |wf|
-    .form-group.nested-fields.js-block{data:{"type": "warrantFees", autovat: @claim.apply_vat? ? "true" : "false"}}
+    .form-group
       %fieldset
         %legend.visuallyhidden
           = t('.warrant_fee')
@@ -23,10 +23,10 @@
                                   id: 'warrant_fee.warrant_executed_date',
                                   error_messages: gov_uk_date_field_error_messages(@error_presenter, 'warrant_fee.warrant_executed_date')
 
-    .form-group
+    .form-group.nested-fields.js-block{data:{"type": "interimFees", autovat: @claim.apply_vat? ? "true" : "false", "block-type": "FeeBlock"}}
       = wf.adp_text_field :amount,
                             label: t('.total'),
-                            input_classes:'form-control-1-4',
+                            input_classes:'form-control-1-4 total',
                             input_type: 'currency',
                             errors: @error_presenter,
                             value: number_with_precision(wf.object.amount, precision: 2),

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -108,7 +108,7 @@
       - if claim.case_type && claim.case_concluded_at
         = render partial: 'shared/claim_case_concluded_at_details', locals: { claim: claim }
 
-      - if claim.interim? && !claim.interim_fee.nil?
+      - if claim.lgfs? && claim.interim? && !claim.interim_fee.nil?
         = render partial: 'shared/claim_interim_details', locals: { claim: claim }
 
       - if claim.transfer?

--- a/app/views/shared/_claim_defendant_details.html.haml
+++ b/app/views/shared/_claim_defendant_details.html.haml
@@ -16,7 +16,7 @@
           .xsmall
             = defendant.date_of_birth.strftime(Settings.date_format) rescue ''
 
-    - unless @claim.interim?
+    - unless @claim.lgfs? && @claim.interim?
       .judical_apportionment
         %span.b
           Judicial apportionment:

--- a/app/views/shared/_determination_amounts.html.haml
+++ b/app/views/shared/_determination_amounts.html.haml
@@ -1,5 +1,5 @@
 - present(determination) do |determination|
-  - unless claim.interim? && claim.disbursement_only?
+  - unless claim.lgfs? && claim.interim? && claim.disbursement_only?
     %tr.determination-display
       %td
         Fees

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -16,7 +16,7 @@
               = t('.fee_category')
             %th{ scope: 'col' }
               = t('.fee_type')
-            - unless claim.interim?
+            - unless claim.lgfs? && claim.interim?
               %th.numeric{ scope: 'col' }
                 = t('.quantity')
             - if claim.agfs?
@@ -43,7 +43,7 @@
                   %p
                     = "#{t('.fee_subtype')}: #{fee.sub_type.description}"
 
-              - unless claim.interim?
+              - unless claim.lgfs? && claim.interim?
                 %td.numeric
                   = fee.quantity
               - if claim.agfs?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -832,7 +832,7 @@ en:
           warrant_fee: "Warrant fee"
           date_issued: "Warrant issued"
           date_executed: "Warrant executed (if applicable)"
-          total: "Total"
+          total: "Net amount"
       supplier_number:
         fields:
           lgfs_supplier_number: "LGFS supplier number"
@@ -853,6 +853,10 @@ en:
           number_days_hint: "Number of days"
           warrant_issued: "Warrant issued"
           warrant_executed: "Warrant executed"
+        header_prompt_text_html: |
+          All fees should be entered exclusive of
+          <abbr title="Value Added Tax">VAT</abbr>.
+        heading: Interim fees
         summary:
           caption: 'Interim Fees: This section contains details of any interim fees that have been claimed.'
           summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows.'

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1077,6 +1077,10 @@ warrant_fee:
       long: Enter a valid warrant issued date
       short: *enter_valid_date
       api: Enter a valid warrant issued date
+    check_on_or_after_earliest_representation_order:
+      long: Warrant issued date needs to be on or after the earliest representation order date
+      short: needs to be on or after earliest representation order date
+      api: needs to be on or after earliest rep order date
     check_not_in_future:
       long: Check the warrant issued date
       short: *in_future
@@ -1085,6 +1089,10 @@ warrant_fee:
       long: Check the warrant issued date
       short: *too_far_in_past
       api: Check the warrant issued date
+    on_or_before:
+      long: Warrant cannot be claimed unless it has been issued at least 3 months ago
+      short: needs to have been issued at least 3 months
+      api: needs to have been issued at least 3 months
 
   warrant_executed_date:
     _seq: 30

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1080,7 +1080,7 @@ warrant_fee:
     check_on_or_after_earliest_representation_order:
       long: Warrant issued date needs to be on or after the earliest representation order date
       short: needs to be on or after earliest representation order date
-      api: needs to be on or after earliest rep order date
+      api: needs to be on or after earliest representation order date
     check_not_in_future:
       long: Check the warrant issued date
       short: *in_future
@@ -1090,9 +1090,9 @@ warrant_fee:
       short: *too_far_in_past
       api: Check the warrant issued date
     on_or_before:
-      long: Warrant cannot be claimed unless it has been issued at least 3 months ago
-      short: needs to have been issued at least 3 months
-      api: needs to have been issued at least 3 months
+      long: Warrant fee cannot be claimed until at least 3 months have passed since warrant was issued
+      short: "needs to have been issued at least 3 months prior to today's date"
+      api: "needs to have been issued at least 3 months prior to today's date"
 
   warrant_executed_date:
     _seq: 30

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,11 @@ advocate_categories:
   - Leading junior
   - Junior alone
 
+agfs_reform_advocate_categories:
+  - QC
+  - Leading junior
+  - Junior
+
 court_types:
    - Magistrates' Court
    - Crown Court

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -73,7 +73,7 @@ FactoryBot.define do
   factory :warrant_fee, class: Fee::WarrantFee do
     claim
     fee_type { build :warrant_fee_type }
-    warrant_issued_date    1.month.ago
+    warrant_issued_date Fee::WarrantFeeValidator::MINIMUM_PERIOD_SINCE_ISSUED.ago
     amount 25.01
 
     trait :warrant_executed do

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -186,6 +186,16 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
   end
 
+  describe '#eligible_advocate_categories' do
+    let(:categories) { double(:mocked_categories_result) }
+    let(:claim) { build(:advocate_claim) }
+
+    specify {
+      expect(Claims::FetchEligibleAdvocateCategories).to receive(:for).with(claim).and_return(categories)
+      expect(claim.eligible_advocate_categories).to eq(categories)
+    }
+  end
+
   context 'State Machine meta states magic methods' do
     let(:claim)       { FactoryBot.build :claim }
     let(:all_states)  { [  'allocated', 'archived_pending_delete',

--- a/spec/models/claim/advocate_interim_claim_spec.rb
+++ b/spec/models/claim/advocate_interim_claim_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Claim::AdvocateInterimClaim, type: :model do
+  specify { expect(subject.external_user_type).to eq(:advocate) }
+  specify { expect(subject.requires_case_type?).to be_falsey }
+  specify { expect(subject.agfs?).to be_truthy }
+  specify { expect(subject.final?).to be_falsey }
+  specify { expect(subject.interim?).to be_truthy }
+
+  describe '#eligible_advocate_categories' do
+    let(:categories) { double(:mocked_categories_result) }
+    let(:claim) { build(:advocate_interim_claim) }
+
+    specify {
+      expect(Claims::FetchEligibleAdvocateCategories).to receive(:for).with(claim).and_return(categories)
+      expect(claim.eligible_advocate_categories).to eq(categories)
+    }
+  end
+end

--- a/spec/presenters/claim/advocate_interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/advocate_interim_claim_presenter_spec.rb
@@ -14,7 +14,40 @@ RSpec.describe Claim::AdvocateInterimClaimPresenter, type: :presenter do
     specify { expect(presenter.pretty_type).to eq('AGFS Interim') }
   end
 
+  describe '#type_identifier' do
+    specify { expect(presenter.type_identifier).to eq('agfs_interim') }
+  end
+
   describe '#can_have_disbursements?' do
     specify { expect(presenter.can_have_disbursements?).to be_falsey }
+  end
+
+  describe '#raw_warrant_fees_total' do
+    context 'when warrant fee is not set' do
+      before do
+        claim.warrant_fee = nil
+      end
+
+      specify { expect(presenter.raw_warrant_fees_total).to eq(0) }
+    end
+
+    context 'when warrant fee is set' do
+      let(:warrant_fee) { build(:warrant_fee, amount: 50.0) }
+
+      before do
+        claim.warrant_fee = warrant_fee
+      end
+
+      specify { expect(presenter.raw_warrant_fees_total).to eq(50.0) }
+    end
+  end
+
+  describe '#warrant_fees_total' do
+    let(:warrant_fee) { build(:warrant_fee, amount: 32.5) }
+    let(:claim) { build(:advocate_interim_claim, warrant_fee: warrant_fee) }
+
+    it 'returns the warrant fee total with the associated currency' do
+      expect(presenter.warrant_fees_total).to eq('£32.50')
+    end
   end
 end

--- a/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
+++ b/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Claims::FetchEligibleAdvocateCategories, type: :service do
+  describe '.for' do
+    subject { described_class.for(claim) }
+
+    context 'when claim is nil' do
+      let(:claim) { nil }
+      specify { is_expected.to eq(nil) }
+    end
+
+    context 'when claim is for an LGFS' do
+      let(:claim) { build(:litigator_claim) }
+      specify { is_expected.to eq(nil) }
+    end
+
+    context 'when claim is for a AGFS' do
+      shared_examples_for 'an AGFS claim' do
+        context 'and it is NOT on the AGFS fee reform scheme' do
+          before do
+            expect(claim).to receive(:fee_scheme).and_return('default')
+          end
+
+          it 'returns the default list for advocate categories' do
+            is_expected.to match_array(["QC", "Led junior", "Leading junior", "Junior alone"])
+          end
+        end
+
+        context 'and it is on the AGFS fee reform scheme' do
+          before do
+            expect(claim).to receive(:fee_scheme).and_return('fee_reform')
+          end
+
+          it 'returns the list for AGFS fee reform advocate categories' do
+            is_expected.to match_array(["QC", "Leading junior", "Junior"])
+          end
+        end
+      end
+
+      context 'and the claim is final' do
+        let(:claim) { build(:advocate_claim) }
+
+        include_examples 'an AGFS claim'
+      end
+
+      context 'and the claim is interim' do
+        let(:claim) { build(:advocate_interim_claim) }
+
+        include_examples 'an AGFS claim'
+      end
+    end
+  end
+end

--- a/spec/support/api/claims/base_claim_test.rb
+++ b/spec/support/api/claims/base_claim_test.rb
@@ -137,7 +137,7 @@ class BaseClaimTest
       "api_key": api_key,
       "claim_id": claim_uuid,
       "fee_type_id": warrant_type_id,
-      "warrant_issued_date": 1.month.ago.as_json,
+      "warrant_issued_date": 3.months.ago.as_json,
       "warrant_executed_date": 1.week.ago.as_json,
       "amount": 100.25
     }

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -82,8 +82,32 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
       should_error_with(claim, :advocate_category, "Advocate category must be one of those in the provided list")
     end
 
-    valid_entries = ['QC', 'Led junior', 'Leading junior', 'Junior alone']
-    valid_entries.each do |valid_entry|
+    default_valid_categories = ['QC', 'Led junior', 'Leading junior', 'Junior alone']
+
+    context 'when on fee reform scheme' do
+      before do
+        allow(claim).to receive(:fee_scheme).and_return('fee_reform')
+      end
+
+      fee_reform_valid_categories = ['QC', 'Leading junior', 'Junior']
+      fee_reform_invalid_categories = ['Led junior', 'Junior alone']
+
+      fee_reform_valid_categories.each do |valid_entry|
+        it "should not error if '#{valid_entry}' specified" do
+          claim.advocate_category = valid_entry
+          should_not_error(claim, :advocate_category)
+        end
+      end
+
+      fee_reform_invalid_categories.each do |valid_entry|
+        it "should not error if '#{valid_entry}' specified" do
+          claim.advocate_category = valid_entry
+          should_error_with(claim, :advocate_category, "Advocate category must be one of those in the provided list")
+        end
+      end
+    end
+
+    default_valid_categories.each do |valid_entry|
       it "should not error if '#{valid_entry}' specified" do
         claim.advocate_category = valid_entry
         should_not_error(claim, :advocate_category)

--- a/spec/validators/fee/warrant_fee_validator_spec.rb
+++ b/spec/validators/fee/warrant_fee_validator_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Fee::WarrantFeeValidator, type: :validator do
   include_examples 'common amount validations'
 
   describe '#validate_warrant_issued_date' do
-    it 'should be valid if present and in the past' do
-      fee.warrant_issued_date = Date.today
+    it 'should be valid if present and issued at least 3 months ago' do
+      fee.warrant_issued_date = 3.months.ago
       expect(fee).to be_valid
     end
 

--- a/spec/validators/representation_order_date_validator_spec.rb
+++ b/spec/validators/representation_order_date_validator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
     it { should_error_if_too_far_in_the_past(reporder, :representation_order_date, "not_before_earliest_permitted_date") }
   end
 
-  context 'for an interim claim' do
+  context 'for a litigator interim claim' do
     let(:claim) { FactoryBot.build :interim_claim, force_validation: true }
 
     context 'representation_order_date' do
@@ -47,5 +47,4 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
       expect(ro2.errors[:representation_order_date]).to include('check')
     end
   end
-
 end


### PR DESCRIPTION
#### What

- Enhances the warrant fee validator to verify that:
  - warrant needs to have been issued at least 3 months ago in order to be claimed
  - issued date needs to be on or after the earliest representation order
- Eligible advocate categories are now conditional on the claim being under the new AGFS fee reform or not. If they are, a different list of advocate categories is used. If they're not the existent list is used as default.
- Preserve existent behaviour with checks for `interim?` (which until now meant `lgfs? && interim?` given that the only claim that was considered _interim_ was a LGFS one). Until we are clear of what behaviour should apply to the new _advocate interim claim_, this changes preserve the existent behaviour by also performing and extra check to verify if the claim is _LGFS_.

#### Ticket

[AGFS interim fee: Interim fee page](https://www.pivotaltracker.com/story/show/155396675)

