### PR TITLE
Remove rack-protection gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'shell-spinner', '~> 1.0', '>= 1.0.4'
 gem 'ruby-progressbar'
 gem 'geckoboard-ruby'
 gem 'posix-spawn', '~> 0.3.13'
-gem 'rack-protection',         '~> 1.5.4'
 
 group :production, :devunicorn do
   gem 'rails_12factor', '0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -717,7 +717,6 @@ DEPENDENCIES
   puma
   quiet_assets
   rack-livereload (~> 0.3.16)
-  rack-protection (~> 1.5.4)
   rails (~> 4.2)
   rails_12factor (= 0.0.3)
   redis (~> 3.3.1)


### PR DESCRIPTION
#### What
Remove the rack protection gem
#### Why
This was added, and locked at 1.5.4, due to a previous security vulnerability in the locked, outdated, sinatra.  As sinatra has now been removed, and this was a dependency of it, this should be superfluous.