### PR TITLE
[AGFS fee reform] Travel expenses page changes

### DIFF
--- a/app/controllers/external_users/advocates/interim_claims_controller.rb
+++ b/app/controllers/external_users/advocates/interim_claims_controller.rb
@@ -5,6 +5,11 @@ class ExternalUsers::Advocates::InterimClaimsController < ExternalUsers::ClaimsC
 
   def build_nested_resources
     @claim.build_warrant_fee if @claim.warrant_fee.nil?
+
+    %i[expenses].each do |association|
+      build_nested_resource(@claim, association)
+    end
+
     super
   end
 end

--- a/app/validators/claim/advocate_interim_claim_sub_model_validator.rb
+++ b/app/validators/claim/advocate_interim_claim_sub_model_validator.rb
@@ -12,7 +12,8 @@ class Claim::AdvocateInterimClaimSubModelValidator < Claim::BaseClaimSubModelVal
     {
       case_details: [],
       defendants: %i[defendants],
-      offence_details: []
+      offence_details: [],
+      travel_expenses: %i[expenses]
     }
   end
 end

--- a/app/views/external_users/advocates/interim_claims/_travel_expenses_form_step.html.haml
+++ b/app/views/external_users/advocates/interim_claims/_travel_expenses_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/expenses/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -86,7 +86,7 @@ active_features:
   - :agfs_fee_reform
 
 # TODO: Update date to actual release date
-agfs_fee_reform_release_date: <%= Date.new(2018, 3, 1) %>
+agfs_fee_reform_release_date: <%= Date.new(2017, 12, 1) %>
 
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16


### PR DESCRIPTION
#### What

Introduces the `travel expenses` step to a **advocate interim claim** submission through the web interface.

#### Ticket

[AGFS interim and final fee: travel expenses](https://www.pivotaltracker.com/story/show/155396789)
