### PR TITLE
bump rack-protection to remove vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,7 +435,7 @@ GEM
       rack (~> 1.4)
     rack-livereload (0.3.16)
       rack
-    rack-protection (1.5.4)
+    rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
#### What
Bump the rack-protection version
#### Why
A security vulnerability was identified but removing our locked Gemfile version and running update did not clear it
#### How
```ssh
bundle update --source rack-protection
```