### PR TITLE
[AGFS fee reform] Supporting evidence & Additional information page changes

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -1,6 +1,5 @@
 class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   include PaginationHelpers
-  include DocTypes
 
   skip_load_and_authorize_resource
   authorize_resource class: Claim::BaseClaim
@@ -14,9 +13,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   before_action :filter_current_claims,   only: [:index]
   before_action :filter_archived_claims,  only: [:archived]
   before_action :sort_claims,             only: %i[index archived]
-
   before_action :set_claim, only: %i[show messages publish enquire download_zip]
-  before_action :set_doctypes, only: %i[show update]
 
   include ReadMessages
   include MessageControlsDisplay
@@ -46,7 +43,6 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
   def update
     updater = Claims::CaseWorkerClaimUpdater.new(params[:id], claim_params.merge(current_user: current_user)).update!
     @claim = updater.claim
-    @doc_types = DocType.all
     if updater.result == :ok
       redirect_to case_workers_claim_path(params.slice(:messages))
     else
@@ -60,7 +56,6 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
 
   def prepare_show_action
     @claim.assessment = Assessment.new if @claim.assessment.nil?
-    @doc_types = DocType.all
     @messages = @claim.messages.most_recent_last
     @message = @claim.messages.build
   end

--- a/app/controllers/concerns/doc_types.rb
+++ b/app/controllers/concerns/doc_types.rb
@@ -1,9 +1,0 @@
-module DocTypes
-  extend ActiveSupport::Concern
-
-  private
-
-  def set_doctypes
-    @doc_types = DocType.all
-  end
-end

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -1,7 +1,6 @@
 class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   # This performs magic
   include PaginationHelpers
-  include DocTypes
 
   class ResourceClassNotDefined < StandardError; end
 
@@ -20,7 +19,6 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
                                                    confirmation show_message_controls messages disc_evidence]
   before_action :redirect_unless_editable, only: %i[edit update]
   before_action :set_form_step, only: %i[edit]
-  before_action :set_doctypes, only: [:show]
   before_action :generate_form_id, only: %i[new edit]
   before_action :initialize_submodel_counts
 

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -600,6 +600,10 @@ module Claim
         .sort_by(&:representation_order_date).first
     end
 
+    def eligible_document_types
+      Claims::FetchEligibleDocumentTypes.for(self)
+    end
+
     private
 
     # called from state_machine before_transition on submit - override in subclass

--- a/app/models/doc_type.rb
+++ b/app/models/doc_type.rb
@@ -21,8 +21,14 @@ class DocType
     DocType.new(11, 1200,  'Prior authority CRM4')
   ].sort_by(&:sequence)
 
+  FEE_REFORM_DOC_TYPE_IDS = [1, 3, 4, 6].freeze
+
   def self.all
     DOCTYPES
+  end
+
+  def self.for_fee_reform
+    DOCTYPES.select { |doc| FEE_REFORM_DOC_TYPE_IDS.include?(doc.id) }
   end
 
   def self.all_first_half

--- a/app/services/claims/fetch_eligible_document_types.rb
+++ b/app/services/claims/fetch_eligible_document_types.rb
@@ -1,0 +1,29 @@
+module Claims
+  class FetchEligibleDocumentTypes
+    def self.for(claim)
+      new(claim).call
+    end
+
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def call
+      return default_doc_types unless claim&.agfs?
+      return fee_reform_doc_types if claim.interim?
+      default_doc_types
+    end
+
+    private
+
+    attr_reader :claim
+
+    def default_doc_types
+      DocType.all
+    end
+
+    def fee_reform_doc_types
+      DocType.for_fee_reform
+    end
+  end
+end

--- a/app/validators/claim/advocate_interim_claim_sub_model_validator.rb
+++ b/app/validators/claim/advocate_interim_claim_sub_model_validator.rb
@@ -13,7 +13,8 @@ class Claim::AdvocateInterimClaimSubModelValidator < Claim::BaseClaimSubModelVal
       case_details: [],
       defendants: %i[defendants],
       offence_details: [],
-      travel_expenses: %i[expenses]
+      travel_expenses: %i[expenses],
+      supporting_evidence: %i[documents]
     }
   end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -150,7 +150,7 @@ class Claim::BaseClaimValidator < BaseValidator
   def check_array_elements
     # prevent array elements that do no represent a doctype
     @record.evidence_checklist_ids.each do |id|
-      unless DocType.all.map(&:id).include?(id)
+      unless @record.eligible_document_types.map(&:id).include?(id)
         add_error(:evidence_checklist_ids,
                   "Evidence checklist id #{id} is invalid, please use valid evidence checklist ids")
       end

--- a/app/views/external_users/advocates/interim_claims/_additional_information_form_step.html.haml
+++ b/app/views/external_users/advocates/interim_claims/_additional_information_form_step.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'external_users/claims/additional_information/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_submit_claim' }

--- a/app/views/external_users/advocates/interim_claims/_supporting_evidence_form_step.html.haml
+++ b/app/views/external_users/advocates/interim_claims/_supporting_evidence_form_step.html.haml
@@ -1,0 +1,5 @@
+= render partial: 'external_users/claims/supporting_documents/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/supporting_evidence_checklist/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/buttons/continue', locals: { f: f, commit: 'commit_continue' }

--- a/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
@@ -3,4 +3,4 @@
     %h3.heading-medium
       = t('.supporting_evidence_checklist')
 
-  = render partial: 'external_users/claims/supporting_evidence_checklist/evidence_checklist', locals: { f: f, collection: DocType.all }
+  = render partial: 'external_users/claims/supporting_evidence_checklist/evidence_checklist', locals: { f: f, collection: f.object.eligible_document_types }

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CaseWorkers::ClaimsController, type: :controller do
-
   before do
     @case_worker = create(:case_worker)
     sign_in @case_worker.user
@@ -18,7 +17,7 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
       'action' => 'index'
     }
     end
-    
+
     let(:criteria) do
       {
         sorting: 'last_submitted_at',
@@ -79,7 +78,6 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
 
     it 'populates instance variables' do
       expect(assigns(:claim)).to eq claim
-      expect(assigns(:doc_types)).to eq DocType.all
       expect(assigns(:messages)).to be_empty
       expect(assigns(:message)).to be_instance_of(Message)
     end

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -439,7 +439,6 @@ module Claim
   end
 
   describe '#earliest_representation_order_date' do
-
     let(:april_1) { Date.new(2016, 4, 1) }
     let(:march_10) { Date.new(2016, 3, 10) }
     let(:jun_30) { Date.new(2016, 6, 30) }
@@ -475,6 +474,16 @@ module Claim
       expect(claim.representation_orders.size).to eq 3
       expect(claim.earliest_representation_order_date).to eq march_10
     end
+  end
+
+  describe '#eligible_document_types' do
+    let(:claim) { MockBaseClaim.new }
+    let(:mock_doc_types) { double(:doc_types) }
+
+    specify {
+      expect(Claims::FetchEligibleDocumentTypes).to receive(:for).with(claim).and_return(mock_doc_types)
+      expect(claim.eligible_document_types).to eq(mock_doc_types)
+    }
   end
 
   describe '#fee_scheme' do

--- a/spec/models/doc_type_spec.rb
+++ b/spec/models/doc_type_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
+RSpec.describe DocType do
+  describe '.for_fee_reform' do
+    subject(:doc_types) { described_class.for_fee_reform }
 
-describe DocType do
+    specify { expect(doc_types.map(&:id)).to match_array([1, 3, 4, 6]) }
+  end
 
   describe '.find' do
     it 'should return a DocTypeInstance with the specified id' do
@@ -16,7 +20,6 @@ describe DocType do
       }.to raise_error ArgumentError, "No DocType with id 888"
     end
   end
-
 
   describe '.find_by_ids' do
     it 'should return a list of matching ids in id order when ids given as a list' do
@@ -46,5 +49,4 @@ describe DocType do
       expect(DocType.all_second_half).to eq expected
     end
   end
-
 end

--- a/spec/services/claims/fetch_eligible_document_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_document_types_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Claims::FetchEligibleDocumentTypes do
+  subject(:document_types) { described_class.for(claim) }
+
+  context 'when claim is for LGFS' do
+    let(:claim) { build(:litigator_claim) }
+
+    it 'returns all the available document types' do
+      expect(document_types).to eq(DocType.all)
+    end
+  end
+
+  context 'when claim is for AGFS final' do
+    let(:claim) { build(:advocate_claim) }
+
+    it 'returns all the available document types' do
+      expect(document_types).to eq(DocType.all)
+    end
+  end
+
+  context 'when claim is for AGFS final' do
+    let(:claim) { build(:advocate_interim_claim) }
+
+    it 'returns a subset of the document types that apply to the new fee reform' do
+      expect(document_types).to eq(DocType.for_fee_reform)
+    end
+  end
+end

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -789,4 +789,147 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       }
     end
   end
+
+  context 'when submission step is supporting evidence details' do
+    before do
+      allow(Settings).to receive(:agfs_fee_reform_release_date).and_return(release_date)
+    end
+
+    let(:form_step) { 'supporting_evidence' }
+    let(:release_date) { 4.months.ago.to_date }
+    let(:earliest_representation_order_date) { release_date + 1.day }
+    let(:warrant_issued_date) { 3.months.ago }
+    let(:court_hearing_reason) { ExpenseType::REASON_SET_A[1] }
+    let(:pre_trial_conference_defendant_reason) { ExpenseType::REASON_SET_A[3] }
+    let(:previous_steps_attributes) {
+      {
+        court_id: court.id,
+        case_number: 'T20170101',
+        external_user_id: external_user.id,
+        creator_id: external_user.id,
+        case_transferred_from_another_court: false,
+        defendants_attributes: {
+          '0' => {
+            first_name: 'John',
+            last_name: 'Doe',
+            date_of_birth_dd: '03',
+            date_of_birth_mm: '11',
+            date_of_birth_yyyy: '1967',
+            order_for_judicial_apportionment: '0',
+            representation_orders_attributes: {
+              '0' => {
+                representation_order_date_dd: earliest_representation_order_date.day.to_s,
+                representation_order_date_mm: earliest_representation_order_date.month.to_s,
+                representation_order_date_yyyy: earliest_representation_order_date.year.to_s
+              },
+              '1' => {
+                representation_order_date_dd: (release_date + 2.day).day.to_s,
+                representation_order_date_mm: (release_date + 2.day).month.to_s,
+                representation_order_date_yyyy: (release_date + 2.day).year.to_s
+              }
+            }
+          },
+          '1' => {
+            first_name: 'Jane',
+            last_name: 'Doe',
+            date_of_birth_dd: '26',
+            date_of_birth_mm: '07',
+            date_of_birth_yyyy: '1959',
+            order_for_judicial_apportionment: '0',
+            representation_orders_attributes: {
+              '0' => {
+                representation_order_date_dd: (release_date + 3.day).day.to_s,
+                representation_order_date_mm: (release_date + 3.day).month.to_s,
+                representation_order_date_yyyy: (release_date + 3.day).year.to_s
+              }
+            }
+          }
+        },
+        advocate_category: 'QC',
+        warrant_fee_attributes: {
+          warrant_issued_date_dd: warrant_issued_date.day.to_s,
+          warrant_issued_date_mm: warrant_issued_date.month.to_s,
+          warrant_issued_date_yyyy: warrant_issued_date.year.to_s,
+          amount: 20
+        },
+        expenses_attributes: {
+          '0' => {
+            expense_type_id: parking_expense_type.id.to_s,
+            reason_id: court_hearing_reason.id.to_s,
+            date_dd: earliest_representation_order_date.day.to_s,
+            date_mm: earliest_representation_order_date.month.to_s,
+            date_yyyy: earliest_representation_order_date.year.to_s,
+            amount: 50
+          },
+          '1' => {
+            expense_type_id: subsistence_expense_type.id.to_s,
+            reason_id: pre_trial_conference_defendant_reason.id.to_s,
+            location: 'Luton',
+            date_dd: (earliest_representation_order_date + 1.day).day.to_s,
+            date_mm: (earliest_representation_order_date + 1.day).month.to_s,
+            date_yyyy: (earliest_representation_order_date + 1.day).year.to_s,
+            amount: 32.5
+          }
+        }
+      }
+    }
+    let(:valid_attributes) {
+      {
+        disk_evidence: false,
+        evidence_checklist_ids: DocType::FEE_REFORM_DOC_TYPE_IDS
+      }
+    }
+
+    subject(:claim) {
+      Claim::AdvocateInterimClaim.create(previous_steps_attributes).tap do |record|
+        record.assign_attributes(params)
+      end
+    }
+
+    context 'with valid attributes' do
+      let(:attributes) { valid_attributes }
+
+      specify { is_expected.to be_valid }
+    end
+
+    context 'when disk evidence flag is not set' do
+      let(:attributes) { valid_attributes.except(:disk_evidence) }
+
+      specify {
+        is_expected.to be_valid
+        expect(claim.disk_evidence).to be_falsey
+      }
+    end
+
+    context 'when disk evidence flag is set to true' do
+      let(:attributes) { valid_attributes.merge(disk_evidence: true) }
+
+      specify {
+        is_expected.to be_valid
+        expect(claim.disk_evidence).to be_truthy
+      }
+    end
+
+    context 'when evidence checklist is not set' do
+      let(:attributes) { valid_attributes.except(:evidence_checklist_ids) }
+
+      specify {
+        is_expected.to be_valid
+        expect(claim.evidence_checklist_ids).to be_empty
+      }
+    end
+
+    context 'when evidence checklist is set with invalid document types for this claim' do
+      let(:invalid_checklist_ids) { [2, 5, 7, 8, 9, 10, 11] }
+      let(:attributes) { valid_attributes.merge(evidence_checklist_ids: invalid_checklist_ids) }
+
+      specify {
+        is_expected.to be_invalid
+        expect(claim.errors[:evidence_checklist_ids].length).to eq(invalid_checklist_ids.length)
+        claim.errors[:evidence_checklist_ids].each do |error_message|
+          expect(error_message).to match(/is invalid/)
+        end
+      }
+    end
+  end
 end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -452,7 +452,6 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
   end
 
   context 'evidence_checklist_ids' do
-
     let(:doc_types) { DocType.all.sample(4).map(&:id) }
     let(:invalid_ids) { ['a','ABC','??','-'] }
 


### PR DESCRIPTION
#### What

Introduces the _supporting evidence_ and _additional information_ pages to the **advocate interim claim** submission through the web interface.

Also:

- Presents a different set of document types the user is able to _check_ if the type of claim is **advocate interim**, preserves the existent list for all other types.

#### Ticket

- 💎  [AGFS final and interim fees: supporting evidence page](https://www.pivotaltracker.com/story/show/155396942)
- 💎  [AGFS final and interim fees: additional information page](https://www.pivotaltracker.com/story/show/155396962)