### PR TITLE
[AGFS fee reform] Graduated & Miscellaneous fees changes

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -245,7 +245,7 @@ module Claim
       self.basic_fees = basic_fees.reject { |fee| not_eligible_ids.include?(fee.fee_type_id) }
       eligible_basic_fee_types.each do |basic_fee_type|
         next if fee_type_ids.include?(basic_fee_type.id)
-        basic_fees << Fee::BasicFee.new_blank(self, basic_fee_type)
+        basic_fees.build(fee_type: basic_fee_type, quantity: 0, amount: 0)
       end
     end
 

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -184,7 +184,11 @@ module Claim
     end
 
     def eligible_misc_fee_types
-      Fee::MiscFeeType.agfs
+      # TODO: this should return a list based on the current given fee scheme
+      # rather than conditionally return scheme 10 specifically
+      # TBD once all the fee scheme work is integrated
+      return Fee::MiscFeeType.agfs_scheme_10s if fee_scheme == 'fee_reform'
+      Fee::MiscFeeType.agfs_scheme_9s
     end
 
     def eligible_fixed_fee_types

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -242,7 +242,7 @@ module Claim
       fee_type_ids = basic_fees.map(&:fee_type_id)
       eligible_basic_fee_type_ids = eligible_basic_fee_types.map(&:id)
       not_eligible_ids = fee_type_ids - eligible_basic_fee_type_ids
-      basic_fees.where(fee_type_id: not_eligible_ids).delete_all
+      self.basic_fees = basic_fees.reject { |fee| not_eligible_ids.include?(fee.fee_type_id) }
       eligible_basic_fee_types.each do |basic_fee_type|
         next if fee_type_ids.include?(basic_fee_type.id)
         basic_fees << Fee::BasicFee.new_blank(self, basic_fee_type)

--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -5,16 +5,18 @@ module Claims::Calculations
     # calculate_amount followed by amount.
     fees.reload
     if category.blank?
-      fees.map do |fee|
-        fee.calculate_amount
-        fee.amount
-      end.compact.sum
+      calculate_total_for(fees)
     else
-      __send__("#{category.downcase}_fees").map do |fee|
-        fee.calculate_amount
-        fee.amount
-      end.compact.sum
+      fee_category_items = __send__("#{category.downcase}_fees")
+      calculate_total_for(fee_category_items)
     end
+  end
+
+  def calculate_total_for(fees_collection)
+    fees_collection.map do |fee|
+      fee.calculate_amount
+      fee.amount
+    end.compact.sum
   end
 
   # returns totals for all klass records belonging to the named claim

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -25,7 +25,7 @@ module Fee
   end
 
   class BaseFeeType < ActiveRecord::Base
-    ROLES = %w[lgfs agfs].freeze
+    ROLES = %w[lgfs agfs agfs_scheme_9 agfs_scheme_10].freeze
     include ActionView::Helpers::NumberHelper
     include Comparable
     include Roles

--- a/app/models/fee/basic_fee.rb
+++ b/app/models/fee/basic_fee.rb
@@ -26,10 +26,6 @@ class Fee::BasicFee < Fee::BaseFee
 
   default_scope { order(claim_id: :asc, fee_type_id: :asc) }
 
-  def self.new_blank(claim, fee_type)
-    new(claim: claim, fee_type: fee_type, quantity: 0, amount: 0)
-  end
-
   def is_basic?
     true
   end

--- a/app/models/fee/basic_fee_type.rb
+++ b/app/models/fee/basic_fee_type.rb
@@ -18,11 +18,8 @@
 
 class Fee::BasicFeeType < Fee::BaseFeeType
   DATES_ATTENDED_APPLICABLE_FEES = %w[BAF DAF DAH DAJ PCM SAF].freeze
-  FEE_REFORM_UNIQUE_CODES_BLACKLIST = %w[BANPW].freeze
 
   default_scope { order(id: :asc) }
-
-  scope :fee_reform, -> { where.not(unique_code: FEE_REFORM_UNIQUE_CODES_BLACKLIST) }
 
   def requires_dates_attended?
     DATES_ATTENDED_APPLICABLE_FEES.include?(code)

--- a/app/models/fee/basic_fee_type.rb
+++ b/app/models/fee/basic_fee_type.rb
@@ -18,8 +18,11 @@
 
 class Fee::BasicFeeType < Fee::BaseFeeType
   DATES_ATTENDED_APPLICABLE_FEES = %w[BAF DAF DAH DAJ PCM SAF].freeze
+  FEE_REFORM_UNIQUE_CODES_BLACKLIST = %w[BANPW].freeze
 
   default_scope { order(id: :asc) }
+
+  scope :fee_reform, -> { where.not(unique_code: FEE_REFORM_UNIQUE_CODES_BLACKLIST) }
 
   def requires_dates_attended?
     DATES_ATTENDED_APPLICABLE_FEES.include?(code)

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -35,6 +35,7 @@ class Offence < ActiveRecord::Base
   scope :unique_name,   -> { unscoped.in_scheme_nine.select(:description).distinct.order(:description) }
   scope :miscellaneous, -> { where(description: 'Miscellaneous/other') }
   scope :in_scheme_nine, -> { joins(:fee_schemes).merge(FeeScheme.nine).distinct }
+  scope :in_scheme_ten, -> { joins(:fee_schemes).merge(FeeScheme.ten).distinct }
 
   def offence_class_description
     offence_class.letter_and_description

--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -1,2 +1,18 @@
 class Fee::BasicFeePresenter < Fee::BaseFeePresenter
+  def display_amount?
+    # TODO: this is not really ideal, but right now I
+    # can't see any other way to achieve this specific
+    # requirement :/
+    return true unless claim.fee_scheme == 'fee_reform'
+    return false if FEE_CODES_WITHOUT_AMOUNT.include?(fee.fee_type.code)
+    true
+  end
+
+  private
+
+  FEE_CODES_WITHOUT_AMOUNT = %w[PPE].freeze
+
+  def claim
+    fee.claim
+  end
 end

--- a/app/services/claims/fetch_eligible_offences.rb
+++ b/app/services/claims/fetch_eligible_offences.rb
@@ -24,11 +24,10 @@ module Claims
     end
 
     def eligible_offences
-      # TODO: Depends on Fee Scheme 10 SPIKE work
+      # TODO: Missing the following steps
       # 1. Checks fee scheme associated with claim
       # 2. Retrieves list of offences associated with that fee scheme
-      # 3. If claim already has an associated offence return list only with that offence
-      [:todo]
+      claim.offence ? [claim.offence] : Offence.in_scheme_ten
     end
 
     def default_offences

--- a/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
@@ -12,10 +12,11 @@
                         value: fee.quantity,
                         errors: @error_presenter
 
-  .column-one-quarter.fee-rate
-    = f.adp_text_field :amount,
-                        label: t('.total'),
-                        input_classes:'total',
-                        input_type: 'currency',
-                        value: number_with_precision(fee.fee.amount, precision: 2),
-                        errors: @error_presenter
+  - if fee.display_amount?
+    .column-one-quarter.fee-rate
+      = f.adp_text_field :amount,
+                          label: t('.total'),
+                          input_classes:'total',
+                          input_type: 'currency',
+                          value: number_with_precision(fee.fee.amount, precision: 2),
+                          errors: @error_presenter

--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -7,6 +7,9 @@
   #search-field.form-group
     = f.anchored_label t('search_offence', scope: locale_scope), 'search_offence', { label_attributes: { class: 'form-label-bold' } }
     %input{ type: :text, class: 'form-control form-control-2-3' }
+    -# TODO: replace the fields below with the actual selected values
+    = f.hidden_field :offence_category, value: @offence_descriptions.first.description
+    = f.hidden_field :offence_id, value: @offences.first.id
 
   %details
     %summary

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -497,16 +497,14 @@ en:
           no_dates: 'No dates currently selected.'
           add_date_attended: 'Add dates'
           remove: *remove
-          # basic_fee_prompt_text: |
-          #   Please include dates for those Standard appearance fees and PCMH's included in the Basic Fee
         basic_fee_calculated_fields:
           basic_fee_prompt_text: |
-            Please include dates for those Standard appearance fees and PCMH's included in the Basic Fee
+            Please include dates for those Standard appearance fees and PTPH's included in the Basic Fee
           fee_type: Fee type
           quantity: Quantity
           rate: Rate
           case_numbers: *case_numbers
-          saf_prompt_text: Include any additional PCMH fees under SAF
+          saf_prompt_text: Include any additional PTPH fees under SAF
         basic_fee_uncalculated_fields:
           quantity: Quantity
           rate: Rate

--- a/db/seeds/fee_types.rb
+++ b/db/seeds/fee_types.rb
@@ -1,5 +1,6 @@
 require 'csv'
 require Rails.root.join('db','seed_helper')
+require Rails.root.join('db','seeds', 'fee_types', 'csv_seeder')
 
 Fee::BaseFeeType.reset_column_information
 Fee::BasicFeeType.reset_column_information
@@ -7,40 +8,6 @@ Fee::MiscFeeType.reset_column_information
 Fee::FixedFeeType.reset_column_information
 Fee::GraduatedFeeType.reset_column_information
 
-file_path = Rails.root.join('lib', 'assets', 'data', 'fee_types.csv')
-data = CSV.read(file_path)
-data.shift
-max_id = 0
+dry_mode = ENV['SEEDS_DRY_MODE'].to_s.downcase.strip == 'true'
 
-
-data.each do |row|
-  begin
-    id, description, code, unique_code, max_amount, calculated, fee_type, roles, parent_id, quantity_is_decimal = row
-    max_id = [max_id, id.to_i].max
-    klass = fee_type.constantize
-    roles = roles.split(';')
-
-    calculated = 'false' if calculated.nil?
-    max_amount = 'nil' if max_amount.nil?
-    calculated = calculated.downcase.strip == 'false' ? false : true
-    max_amount = nil if max_amount.downcase.strip == 'nil'
-    parent_id = parent_id.nil? ? nil : klass.find_by(description: parent_id.strip).try(:id)
-    klass.create!(
-      id: id,
-      description: description,
-      code: code,
-      unique_code: unique_code,
-      max_amount: max_amount,
-      calculated: calculated,
-      type: fee_type,
-      parent_id: parent_id,
-      roles: roles,
-      quantity_is_decimal: quantity_is_decimal)
-  rescue => err
-    puts "***************** #{err.class}  #{err.message} *********** #{__FILE__}::#{__LINE__} ***********\n"
-    puts err.backtrace
-    puts row
-  end
-end
-
-Fee::BaseFeeType.connection.execute("ALTER SEQUENCE fee_types_id_seq restart with #{max_id + 100}")
+Seeds::FeeTypes::CsvSeeder.new(dry_mode: dry_mode).call

--- a/db/seeds/fee_types/csv_row_mapper.rb
+++ b/db/seeds/fee_types/csv_row_mapper.rb
@@ -1,0 +1,50 @@
+module Seeds
+  module FeeTypes
+    class CsvRowMapper
+      def self.call(row_attrs, parent_id)
+        new(row_attrs, parent_id).to_h
+      end
+
+      def initialize(row_attrs, parent_id)
+        @row_attrs = row_attrs
+        @parent_id = parent_id
+      end
+
+      def to_h
+        {
+          id: row_attrs.fetch(:id),
+          description: row_attrs.fetch(:description),
+          code: row_attrs.fetch(:code),
+          unique_code: row_attrs.fetch(:unique_code),
+          max_amount: mapped_max_amount,
+          calculated: mapped_calculated,
+          type: row_attrs.fetch(:fee_type),
+          parent_id: parent_id,
+          roles: mapped_roles,
+          quantity_is_decimal: row_attrs.fetch(:quantity_is_decimal)
+        }
+      end
+
+      private
+
+      attr_reader :row_attrs, :parent_id
+
+      def mapped_roles
+        row_attrs.fetch(:roles).split(';')
+      end
+
+      def mapped_calculated
+        row_attrs.fetch(:calculated).to_s.downcase.strip == 'true'
+      end
+
+      def max_amount
+        row_attrs.fetch(:max_amount)
+      end
+
+      def mapped_max_amount
+        return if max_amount.to_s.strip.blank?
+        max_amount
+      end
+    end
+  end
+end

--- a/db/seeds/fee_types/csv_seeder.rb
+++ b/db/seeds/fee_types/csv_seeder.rb
@@ -11,57 +11,73 @@ module Seeds
       def call
         data = CSV.read(file_path)
         data.shift
-        total = 0
-        total_created = 0
-        total_updated = 0
+
+        reset_totals
 
         data.each do |row|
-          begin
-            id, description, code, unique_code, max_amount, calculated, fee_type, roles, parent_id, quantity_is_decimal = row
-            row_attributes = {
-              id: id,
-              description: description,
-              code: code,
-              unique_code: unique_code,
-              max_amount: max_amount,
-              calculated: calculated,
-              fee_type: fee_type,
-              roles: roles,
-              quantity_is_decimal: quantity_is_decimal
-            }
-            klass = fee_type.constantize
-            parent_id = parent_id.nil? ? nil : klass.find_by(description: parent_id.strip).try(:id)
-            attributes = Seeds::FeeTypes::CsvRowMapper.call(row_attributes, parent_id)
-
-            record = klass.find_by(id: id)
-            if record
-              log "[EXISTENT RECORD] Updating attributes: #{attributes.inspect}"
-              record.update_attributes!(attributes) unless dry_mode
-              total += 1
-              total_updated += 1
-            else
-              log "[NEW RECORD] Creating with attributes: #{attributes.inspect}"
-              klass.create!(attributes) unless dry_mode
-              total += 1
-              total_created += 1
-            end
-          rescue => err
-            log "***************** #{err.class}  #{err.message} *********** #{__FILE__}::#{__LINE__} ***********\n"
-            log err.backtrace
-            log row
-          end
-          log "[OUTPUT] Created: #{total_created} | Updated: #{total_updated} | Total: #{total}"
+          process_row(row)
         end
+
+        log "[OUTPUT] Created: #{total_created} | Updated: #{total_updated} | Error: #{total_with_error} | Total: #{total}", stdout: true
       end
+
+      protected
+
+      attr_accessor :total_created, :total_updated, :total_with_error, :total
 
       private
 
       attr_reader :file_path, :dry_mode
 
-      def log(message)
+      def reset_totals
+        self.total = 0
+        self.total_created = 0
+        self.total_updated = 0
+        self.total_with_error = 0
+      end
+
+      def process_row(row)
+        id, description, code, unique_code, max_amount, calculated, fee_type, roles, parent_id, quantity_is_decimal = row
+        row_attributes = {
+          id: id,
+          description: description,
+          code: code,
+          unique_code: unique_code,
+          max_amount: max_amount,
+          calculated: calculated,
+          fee_type: fee_type,
+          roles: roles,
+          quantity_is_decimal: quantity_is_decimal
+        }
+        klass = fee_type.constantize
+        parent_id = parent_id.nil? ? nil : klass.find_by(description: parent_id.strip).try(:id)
+        attributes = Seeds::FeeTypes::CsvRowMapper.call(row_attributes, parent_id)
+
+        record = klass.find_by(id: id)
+        if record
+          log "[EXISTENT RECORD] Updating attributes: #{attributes.inspect}"
+          record.update_attributes!(attributes) unless dry_mode
+          self.total_updated += 1
+        else
+          log "[NEW RECORD] Creating with attributes: #{attributes.inspect}"
+          klass.create!(attributes) unless dry_mode
+          self.total_created += 1
+        end
+      rescue => err
+        log "***************** #{err.class}  #{err.message} *********** #{__FILE__}::#{__LINE__} ***********\n"
+        log err.backtrace
+        log row
+        self.total_with_error += 1
+      ensure
+        self.total += 1
+      end
+
+      def log(message, stdout: false)
         contents = dry_mode ? ['[DRY MODE]'] : []
         contents << message
-        Rails.logger.info contents.join(' ')
+        output = contents.join(' ')
+        Rails.logger.info output
+        puts output if stdout
       end
     end
   end

--- a/db/seeds/fee_types/csv_seeder.rb
+++ b/db/seeds/fee_types/csv_seeder.rb
@@ -1,0 +1,68 @@
+require_relative 'csv_row_mapper'
+
+module Seeds
+  module FeeTypes
+    class CsvSeeder
+      def initialize(dry_mode: true)
+        @dry_mode = dry_mode.to_s.downcase.strip == 'true'
+        @file_path = Rails.root.join('lib', 'assets', 'data', 'fee_types.csv')
+      end
+
+      def call
+        data = CSV.read(file_path)
+        data.shift
+        total = 0
+        total_created = 0
+        total_updated = 0
+
+        data.each do |row|
+          begin
+            id, description, code, unique_code, max_amount, calculated, fee_type, roles, parent_id, quantity_is_decimal = row
+            row_attributes = {
+              id: id,
+              description: description,
+              code: code,
+              unique_code: unique_code,
+              max_amount: max_amount,
+              calculated: calculated,
+              fee_type: fee_type,
+              roles: roles,
+              quantity_is_decimal: quantity_is_decimal
+            }
+            klass = fee_type.constantize
+            parent_id = parent_id.nil? ? nil : klass.find_by(description: parent_id.strip).try(:id)
+            attributes = Seeds::FeeTypes::CsvRowMapper.call(row_attributes, parent_id)
+
+            record = klass.find_by(id: id)
+            if record
+              log "[EXISTENT RECORD] Updating attributes: #{attributes.inspect}"
+              record.update_attributes!(attributes) unless dry_mode
+              total += 1
+              total_updated += 1
+            else
+              log "[NEW RECORD] Creating with attributes: #{attributes.inspect}"
+              klass.create!(attributes) unless dry_mode
+              total += 1
+              total_created += 1
+            end
+          rescue => err
+            log "***************** #{err.class}  #{err.message} *********** #{__FILE__}::#{__LINE__} ***********\n"
+            log err.backtrace
+            log row
+          end
+          log "[OUTPUT] Created: #{total_created} | Updated: #{total_updated} | Total: #{total}"
+        end
+      end
+
+      private
+
+      attr_reader :file_path, :dry_mode
+
+      def log(message)
+        contents = dry_mode ? ['[DRY MODE]'] : []
+        contents << message
+        Rails.logger.info contents.join(' ')
+      end
+    end
+  end
+end

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -1,15 +1,15 @@
 ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUANTITY_IS_DECIMAL,
-1,Basic fee,BAF,BABAF,9999,TRUE,Fee::BasicFeeType,agfs,,FALSE,
-2,Daily attendance fee (3 to 40),DAF,BADAF,999,TRUE,Fee::BasicFeeType,agfs,,FALSE,N
-3,Daily attendance fee (41 to 50),DAH,BADAH,9999,TRUE,Fee::BasicFeeType,agfs,,FALSE,N
-4,Daily attendance fee (51+),DAJ,BADAJ,999,TRUE,Fee::BasicFeeType,agfs,,FALSE,N
-5,Standard appearance fee,SAF,BASAF,999,TRUE,Fee::BasicFeeType,agfs,,FALSE,N
-6,Plea and case management hearing,PCM,BAPCM,999,TRUE,Fee::BasicFeeType,agfs,,FALSE,N
-7,Conferences and views,CAV,BACAV,,TRUE,Fee::BasicFeeType,agfs,,TRUE,N
-8,Number of defendants uplift,NDR,BANDR,,TRUE,Fee::BasicFeeType,agfs,,FALSE,N
-9,Number of cases uplift,NOC,BANOC,,TRUE,Fee::BasicFeeType,agfs,,FALSE,N
-10,Number of prosecution witnesses,NPW,BANPW,,FALSE,Fee::BasicFeeType,agfs,,FALSE,N
-11,Pages of prosecution evidence,PPE,BAPPE,,FALSE,Fee::BasicFeeType,agfs,,FALSE,N
+1,Basic fee,BAF,BABAF,9999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+2,Daily attendance fee (3 to 40),DAF,BADAF,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+3,Daily attendance fee (41 to 50),DAH,BADAH,9999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+4,Daily attendance fee (51+),DAJ,BADAJ,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+5,Standard appearance fee,SAF,BASAF,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+6,Plea and trial preparation hearing,PCM,BAPCM,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+7,Conferences and views,CAV,BACAV,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
+8,Number of defendants uplift,NDR,BANDR,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+9,Number of cases uplift,NOC,BANOC,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+10,Number of prosecution witnesses,NPW,BANPW,,FALSE,Fee::BasicFeeType,agfs;agfs_scheme_9,,FALSE,N
+11,Pages of prosecution evidence,PPE,BAPPE,,FALSE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
 12,Appeals to the crown court against conviction,ACV,FXACV,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
 13,Appeals to the crown court against conviction uplift,ACU,FXACU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
 14,Appeals to the crown court against sentence,ASE,FXASE,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -25,54 +25,54 @@ ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUAN
 26,Number of cases uplift,NOC,FXNOC,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
 27,Number of defendants uplift,NDR,FXNDR,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
 28,Standard appearance fee,SAF,FXSAF,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-29,Abuse of process hearings (half day),APH,MIAPH,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-30,Abuse of process hearings (whole day),APW,MIAPW,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-31,Abuse of process hearings (half day uplift),AHU,MIAHU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-32,Abuse of process hearings (whole day uplift),AWU,MIAWU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-33,Adjourned appeals,SAF,MISAF,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-34,Application to dismiss a charge (half day),PAH,MIADC1,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-35,Application to dismiss a charge (whole day),PAW,MIADC2,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-36,Application to dismiss a charge (half day uplift),PHU,MIADC3,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-37,Application to dismiss a charge (whole day uplift),PWU,MIADC4,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-38,Confiscation hearings (half day),DTH,MIDTH,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-39,Confiscation hearings (whole day),DTW,MIDTW,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-40,Confiscation hearings (half day uplift),DHU,MIDHU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-41,Confiscation hearings (whole day uplift),DWU,MIDWU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-42,Deferred sentence hearings,DSE,MIDSE,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-43,Deferred sentence hearings uplift,DSU,MIDSU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-44,Hearings relating to admissibility of evidence (half day),AEH,MIAEH,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-45,Hearings relating to admissibility of evidence (whole day),AEW,MIAEW,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-46,Hearings relating to admissibility of evidence (half day uplift),EHU,MIEHU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-47,Hearings relating to admissibility of evidence (whole day uplift),EWU,MIEWU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-48,Hearings relating to disclosure (half day),HDH,MIHDH,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-49,Hearings relating to disclosure (whole day),HDW,MIHDW,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-50,Hearings relating to disclosure (half day uplift),HHU,MIHHU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-51,Hearings relating to disclosure (whole day uplift),HWU,MIHWU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-52,Noting brief fee,NBR,MINBR,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-53,Paper plea & case management,PPC,MIPPC,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-54,Paper plea & case management uplift,PCU,MIPCU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-55,Proceeds of crime hearings (half day),PCH,MIPCH,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-56,Proceeds of crime hearings (whole day),PCW,MIPCW,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-57,Proceeds of crime hearings (half day uplift),CHU,MICHU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-58,Proceeds of crime hearings (whole day uplift),CHW,MICHW,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-59,Public interest immunity hearings (half day),PAH,MIPIH1,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-60,Public interest immunity hearings (whole day),PAW,MIPIH2,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-61,Public interest immunity hearings (half day uplift),PHU,MIPIU3,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-62,Public interest immunity hearings (whole day uplift),PWU,MIPIH4,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-63,Research of very unusual or novel factual issue,RNF,MIRNF,,TRUE,Fee::MiscFeeType,agfs,,TRUE,N
-64,Research of very unusual or novel point of law,RNL,MIRNL,,TRUE,Fee::MiscFeeType,agfs,,TRUE,N
-65,Standard appearance fee uplift,SAU,MISAU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-66,Sentence hearings,SHR,MISHR,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-67,Sentence hearings uplift,SHU,MISHU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-68,Special preparation fee,SPF,MISPF,,TRUE,Fee::MiscFeeType,agfs;lgfs,,TRUE,N
-69,Trial not proceed,TNP,MITNP,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-70,Trial not proceed uplift,TNU,MITNU,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-71,Unsuccessful application to vacate a guilty plea (half day),PAH,MIUAV1,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-72,Unsuccessful application to vacate a guilty plea (whole day),PAW,MIUAV2,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-73,Unsuccessful application to vacate a guilty plea (half day uplift),PHU,MIUAV3,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-74,Unsuccessful application to vacate a guilty plea (whole day uplift),PWU,MIUAV4,,TRUE,Fee::MiscFeeType,agfs,,FALSE,N
-75,Written / oral advice,WOA,MIWOA,,TRUE,Fee::MiscFeeType,agfs,,TRUE,N
-76,Wasted preparation fee,WPF,MIWPF,,TRUE,Fee::MiscFeeType,agfs,,TRUE,N
+29,Abuse of process hearings (half day),APH,MIAPH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+30,Abuse of process hearings (whole day),APW,MIAPW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+31,Abuse of process hearings (half day uplift),AHU,MIAHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+32,Abuse of process hearings (whole day uplift),AWU,MIAWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+33,Adjourned appeals,SAF,MISAF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+34,Application to dismiss a charge (half day),PAH,MIADC1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+35,Application to dismiss a charge (whole day),PAW,MIADC2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+36,Application to dismiss a charge (half day uplift),PHU,MIADC3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+37,Application to dismiss a charge (whole day uplift),PWU,MIADC4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+38,Confiscation hearings (half day),DTH,MIDTH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+39,Confiscation hearings (whole day),DTW,MIDTW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+40,Confiscation hearings (half day uplift),DHU,MIDHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+41,Confiscation hearings (whole day uplift),DWU,MIDWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+42,Deferred sentence hearings,DSE,MIDSE,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+43,Deferred sentence hearings uplift,DSU,MIDSU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+44,Hearings relating to admissibility of evidence (half day),AEH,MIAEH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+45,Hearings relating to admissibility of evidence (whole day),AEW,MIAEW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+46,Hearings relating to admissibility of evidence (half day uplift),EHU,MIEHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+47,Hearings relating to admissibility of evidence (whole day uplift),EWU,MIEWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+48,Hearings relating to disclosure (half day),HDH,MIHDH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+49,Hearings relating to disclosure (whole day),HDW,MIHDW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+50,Hearings relating to disclosure (half day uplift),HHU,MIHHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+51,Hearings relating to disclosure (whole day uplift),HWU,MIHWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+52,Noting brief fee,NBR,MINBR,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+53,Paper plea & case management,PPC,MIPPC,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9,,FALSE,N
+54,Paper plea & case management uplift,PCU,MIPCU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9,,FALSE,N
+55,Proceeds of crime hearings (half day),PCH,MIPCH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+56,Proceeds of crime hearings (whole day),PCW,MIPCW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+57,Proceeds of crime hearings (half day uplift),CHU,MICHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+58,Proceeds of crime hearings (whole day uplift),CHW,MICHW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+59,Public interest immunity hearings (half day),PAH,MIPIH1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+60,Public interest immunity hearings (whole day),PAW,MIPIH2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+61,Public interest immunity hearings (half day uplift),PHU,MIPIU3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+62,Public interest immunity hearings (whole day uplift),PWU,MIPIH4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+63,Research of very unusual or novel factual issue,RNF,MIRNF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
+64,Research of very unusual or novel point of law,RNL,MIRNL,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
+65,Standard appearance fee uplift,SAU,MISAU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+66,Sentence hearings,SHR,MISHR,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+67,Sentence hearings uplift,SHU,MISHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+68,Special preparation fee,SPF,MISPF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10;lgfs,,TRUE,N
+69,Trial not proceed,TNP,MITNP,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+70,Trial not proceed uplift,TNU,MITNU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+71,Unsuccessful application to vacate a guilty plea (half day),PAH,MIUAV1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+72,Unsuccessful application to vacate a guilty plea (whole day),PAW,MIUAV2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+73,Unsuccessful application to vacate a guilty plea (half day uplift),PHU,MIUAV3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+74,Unsuccessful application to vacate a guilty plea (whole day uplift),PWU,MIUAV4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
+75,Written / oral advice,WOA,MIWOA,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
+76,Wasted preparation fee,WPF,MIWPF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
 77,Trial,GTRL,GRTRL,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
 78,Retrial,GRTR,GRRTR,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
 79,Guilty plea,GGLTY,GRGLT,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
@@ -96,3 +96,5 @@ ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUAN
 97,Disbursement only,IDISO,INDIS,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
 98,Warrant,IWARR,INWAR,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
 99,Transfer,TRANS,TRANS,,FALSE,Fee::TransferFeeType,lgfs,,FALSE,N
+100,Further case management hearing,FCM,MIFCM,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,N
+101,Ground rules hearing,GRH,MIGRH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,N

--- a/lib/tasks/fee_types.rake
+++ b/lib/tasks/fee_types.rake
@@ -1,0 +1,7 @@
+namespace :fee_types do
+  desc 'Seed fee types into the database (prefix with SEEDS_DRY_MODE=false to disable DRY mode)'
+  task :seed => :environment do
+    ENV['SEEDS_DRY_MODE'] = 'true' unless ENV['SEEDS_DRY_MODE'].present?
+    load("#{Rails.root}/db/seeds/fee_types.rb")
+  end
+end

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -9,6 +9,15 @@ FactoryBot.define do
     # factory :advocate_claim do
     # end
 
+    # NOTE: this was introduced here because was the only way to get FactoryBot to set
+    # model attributes on initialize (which seems not to be the default behaviour) and
+    # was causing the factory not to assign the appropriate attributes/associations on
+    # initialize which makes after_initialize logic not to behave as expected since the
+    # expected values are not yet set.
+    # More details can be found here:
+    # https://stackoverflow.com/questions/5916162/problem-with-factory-girl-association-and-after-initialize
+    initialize_with { new(attributes) }
+
     form_id SecureRandom.uuid
     court
     case_number { random_case_number }

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -14,9 +14,9 @@ FactoryBot.define do
     case_number { random_case_number }
     external_user
     source { 'web' }
-    apply_vat  false
+    apply_vat false
     providers_ref { random_providers_ref }
-    case_type { FactoryBot.build :case_type }
+    case_type
     offence
     advocate_category 'QC'
     sequence(:cms_number) { |n| "CMS-#{Time.now.year}-#{rand(100..199)}-#{n}" }

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
     quantity_is_decimal false
     unique_code { generate_unique_code }
 
+    trait :agfs_scheme_10 do
+      roles %w[agfs agfs_scheme_10]
+    end
+
     trait :ppe do
       description 'Pages of prosecution evidence'
       code 'PPE'

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
     quantity_is_decimal false
     unique_code { generate_unique_code }
 
+    trait :agfs_scheme_9 do
+      roles %w[agfs agfs_scheme_9]
+    end
+
     trait :agfs_scheme_10 do
       roles %w[agfs agfs_scheme_10]
     end

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -159,9 +159,9 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
   context 'eligible misc and fixed fee types' do
     before(:all) do
-      @bft1 = create :basic_fee_type
+      @bft1 = create :basic_fee_type, :agfs_scheme_10
       @bft2 = create :basic_fee_type, :lgfs
-      @bft3 = create :basic_fee_type, :npw
+      @bft3 = create :basic_fee_type
       @mft1 = create :misc_fee_type
       @mft2 = create :misc_fee_type, :lgfs
       @fft1 = create :fixed_fee_type

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -162,8 +162,9 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       @bft1 = create :basic_fee_type, :agfs_scheme_10
       @bft2 = create :basic_fee_type, :lgfs
       @bft3 = create :basic_fee_type
-      @mft1 = create :misc_fee_type
+      @mft1 = create :misc_fee_type, :agfs_scheme_9
       @mft2 = create :misc_fee_type, :lgfs
+      @mft3 = create :misc_fee_type, :agfs_scheme_10
       @fft1 = create :fixed_fee_type
       @fft2 = create :fixed_fee_type, :lgfs
       @claim = build :unpersisted_claim
@@ -190,8 +191,18 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
 
     describe '#eligible_misc_fee_types' do
-      it 'returns only misc fee types for AGFS' do
+      it 'returns only misc fee types for AGFS scheme 9' do
         expect(@claim.eligible_misc_fee_types).to eq([@mft1])
+      end
+
+      context 'when claim has fee reform scheme' do
+        before do
+          expect(@claim).to receive(:fee_scheme).and_return('fee_reform')
+        end
+
+        it 'returns only misc fee types for AGFS scheme 10' do
+          expect(@claim.eligible_misc_fee_types).to eq([@mft3])
+        end
       end
     end
 

--- a/spec/models/fee/basic_fee_spec.rb
+++ b/spec/models/fee/basic_fee_spec.rb
@@ -35,34 +35,6 @@ module Fee
       end
     end
 
-    describe '.new_blank' do
-
-      it 'should instantiate but not save a fee with all zero values belonging to the claim and fee type' do
-        fee_type = FactoryBot.build :basic_fee_type
-        claim = FactoryBot.build :claim
-
-        fee = Fee::BasicFee.new_blank(claim, fee_type)
-        expect(fee.fee_type).to eq fee_type
-        expect(fee.claim).to eq claim
-        expect(fee.quantity).to eq 0
-        expect(fee.amount).to eq 0
-        expect(fee).to be_new_record
-      end
-
-      # TODO: BAF fee type used to be instatiated to 1 but has been removed - POCA ticket - can remove eventually
-      context 'for the BAF basic fee' do
-        it 'should be called as part of claim instatiation and assign 0 as quantity for BAF fee types' do
-          baf_fee_type = FactoryBot.create :basic_fee_type, code: 'BAF'
-          claim = FactoryBot.build :claim
-          fee = claim.basic_fees.first
-          expect(fee.fee_type.code).to eql 'BAF'
-          expect(fee.amount).to eq 0.00
-          expect(fee.quantity).to eq 0
-          expect(fee).to be_new_record
-        end
-      end
-    end
-
     describe '#calculated?' do
       it 'should return false for fees flagged as uncalculated' do
         ppe = FactoryBot.create(:basic_fee_type, code: 'PPE', calculated: false)

--- a/spec/presenters/fee/basic_fee_presenter_spec.rb
+++ b/spec/presenters/fee/basic_fee_presenter_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Fee::BasicFeePresenter, type: :presenter do
+  let(:claim) { build(:advocate_claim) }
+  let(:fee) { build(:basic_fee, claim: claim) }
+
+  subject(:presenter) { described_class.new(fee, view) }
+
+  describe '#display_amount?' do
+    context 'when the associated claim is not under the new fee reform' do
+      before do
+        expect(claim).to receive(:fee_scheme).and_return('default')
+      end
+
+      specify { expect(presenter.display_amount?).to be_truthy }
+    end
+
+    context 'when the associated claim is under the new fee reform' do
+      before do
+        expect(claim).to receive(:fee_scheme).and_return('fee_reform')
+      end
+
+      context 'but the fee type code is not included in the blacklist' do
+        let(:fee) { build(:basic_fee, :baf_fee, claim: claim) }
+
+        specify { expect(presenter.display_amount?).to be_truthy }
+      end
+
+      context 'but the fee type code is blacklisted' do
+        let(:fee) { build(:basic_fee, :ppe_fee, claim: claim) }
+
+        specify { expect(presenter.display_amount?).to be_falsey }
+      end
+    end
+  end
+end

--- a/spec/services/claims/fetch_eligible_offences_spec.rb
+++ b/spec/services/claims/fetch_eligible_offences_spec.rb
@@ -62,8 +62,26 @@ RSpec.describe Claims::FetchEligibleOffences, type: :service do
           allow(claim).to receive(:fee_scheme).and_return('fee_reform')
         end
 
-        it 'TODO: returns the eligible offences' do
-          expect(offences).to match_array([:todo])
+        context 'and the claim has no associated offence' do
+          before do
+            claim.offence = nil
+          end
+
+          it 'returns a list of all available offences for the associated fee scheme' do
+            expect(offences).to match_array(Offence.in_scheme_ten)
+          end
+        end
+
+        context 'and the claim has an associated offence' do
+          let(:offence) { create(:offence, :with_fee_scheme_ten) }
+
+          before do
+            claim.offence = offence
+          end
+
+          it 'returns a list containing only the associated offence' do
+            expect(offences).to match_array([offence])
+          end
         end
       end
     end

--- a/spec/validators/date_attended_validator_spec.rb
+++ b/spec/validators/date_attended_validator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DateAttendedValidator, type: :validator do
   let(:claim) do
-    create(:claim, :without_fees, total: 10, force_validation: true, first_day_of_trial: 5.weeks.ago).tap do |claim|
+    create(:claim, :without_fees, total: 10, first_day_of_trial: 5.weeks.ago).tap do |claim|
       create(:basic_fee, claim: claim).tap do |fee|
         create(:date_attended, attended_item: fee)
       end
@@ -11,6 +11,10 @@ RSpec.describe DateAttendedValidator, type: :validator do
 
   let(:date_attended)          { claim.fees.first.dates_attended.first }
   let(:earliest_reporder_date) { claim.defendants.first.representation_orders.first.representation_order_date }
+
+  before do
+    claim.force_validation = true
+  end
 
   context 'date' do
     it { should_error_if_not_present(date_attended, :date, 'blank') }

--- a/spec/validators/defendant_validator_spec.rb
+++ b/spec/validators/defendant_validator_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe DefendantValidator, type: :validator do
-  let(:claim)     { FactoryBot.build(:claim, force_validation: true) }
-  let(:defendant) { FactoryBot.build :defendant, claim: claim }
+  let(:claim)     { build(:claim) }
+  let(:defendant) { build(:defendant, claim: claim) }
+
+  before do
+    claim.force_validation = true
+  end
 
   describe '#validate_claim' do
     it { should_error_if_not_present(defendant, :claim, 'blank') }
@@ -30,7 +34,7 @@ RSpec.describe DefendantValidator, type: :validator do
     end
 
     context 'from api' do
-      let(:claim) { FactoryBot.build(:claim, source: 'api') }
+      let(:claim) { build(:claim, source: 'api') }
 
       it 'should not validate for presence of a rep order' do
         expect(defendant).to be_valid
@@ -38,7 +42,7 @@ RSpec.describe DefendantValidator, type: :validator do
     end
 
     context 'not from api' do
-      let(:claim) { FactoryBot.create(:submitted_claim, source: 'web') }
+      let(:claim) { create(:submitted_claim, source: 'web') }
 
       it 'should validate for presence of a rep order' do
         expect(defendant).to_not be_valid

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'ExpenseV1Validator and ExpenseV2Validator', type: :validator do
   context 'schema_version 2' do
-    let(:claim)                       { build :claim, force_validation: true }
+    let(:claim)                       { build :claim }
     let(:expense)                     { build :expense, :train, claim: claim }
     let(:car_travel_expense)          { build(:expense, :car_travel, claim: claim ) }
     let(:bike_travel_expense)         { build(:expense, :bike_travel, claim: claim ) }
@@ -15,7 +15,10 @@ RSpec.describe 'ExpenseV1Validator and ExpenseV2Validator', type: :validator do
     let(:travel_time_expense)         { build(:expense, :travel_time, claim: claim) }
     let(:other_reason_type_expense)   { build(:expense, :train, claim: claim, reason_id: 5)}
 
-    before(:each) { allow(Settings).to receive(:expense_schema_version).and_return(2) }
+    before do
+      allow(Settings).to receive(:expense_schema_version).and_return(2)
+      claim.force_validation = true
+    end
 
     it { should_error_if_equal_to_value(expense, :amount, 200_001, 'item_max_amount') }
 

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -1,19 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Fee::BaseFeeValidator, type: :validator do
-  let(:claim)      { FactoryBot.build :advocate_claim, force_validation: true }
-  let(:fee)        { FactoryBot.build :fixed_fee, claim: claim }
-  let(:baf_fee)    { FactoryBot.build :basic_fee, :baf_fee, claim: claim }
-  let(:daf_fee)    { FactoryBot.build :basic_fee, :daf_fee, claim: claim }
-  let(:dah_fee)    { FactoryBot.build :basic_fee, :dah_fee, claim: claim }
-  let(:daj_fee)    { FactoryBot.build :basic_fee, :daj_fee, claim: claim }
-  let(:pcm_fee)    { FactoryBot.build :basic_fee, :pcm_fee, claim: claim }
-  let(:ppe_fee)    { FactoryBot.build :basic_fee, :ppe_fee, claim: claim }
-  let(:npw_fee)    { FactoryBot.build :basic_fee, :npw_fee, claim: claim }
-  let(:spf_fee)    { FactoryBot.build :misc_fee, :spf_fee, claim: claim }
+  let(:claim)   { build :advocate_claim }
+  let(:fee)     { build :fixed_fee, claim: claim }
+  let(:baf_fee) { build :basic_fee, :baf_fee, claim: claim }
+  let(:daf_fee) { build :basic_fee, :daf_fee, claim: claim }
+  let(:dah_fee) { build :basic_fee, :dah_fee, claim: claim }
+  let(:daj_fee) { build :basic_fee, :daj_fee, claim: claim }
+  let(:pcm_fee) { build :basic_fee, :pcm_fee, claim: claim }
+  let(:ppe_fee) { build :basic_fee, :ppe_fee, claim: claim }
+  let(:npw_fee) { build :basic_fee, :npw_fee, claim: claim }
+  let(:spf_fee) { build :misc_fee, :spf_fee, claim: claim }
+
+  before do
+    claim.force_validation = true
+  end
 
   context 'for a JSON imported claim (and no forced validation)' do
-    let(:claim) { FactoryBot.build :advocate_claim, source: 'json_import' }
+    before do
+      claim.force_validation = false
+    end
+
+    let(:claim) { build :advocate_claim, source: 'json_import' }
 
     it 'should not perform claim validation' do
       expect(claim.perform_validation?).to be_falsey

--- a/spec/validators/representation_order_date_validator_spec.rb
+++ b/spec/validators/representation_order_date_validator_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe RepresentationOrderValidator, type: :validator do
-  let(:claim)         { FactoryBot.build :claim, force_validation: true }
-  let(:defendant)     { FactoryBot.build :defendant, claim: claim }
-  let(:reporder)      { FactoryBot.build :representation_order, defendant: defendant }
+  let(:claim)     { build :claim }
+  let(:defendant) { build :defendant, claim: claim }
+  let(:reporder)  { build :representation_order, defendant: defendant }
+
+  before do
+    claim.force_validation = true
+  end
 
   context 'representation_order_date' do
     it { should_error_if_not_present(reporder, :representation_order_date, "blank") }
@@ -12,7 +16,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
   end
 
   context 'for a litigator interim claim' do
-    let(:claim) { FactoryBot.build :interim_claim, force_validation: true }
+    let(:claim) { build :interim_claim }
 
     context 'representation_order_date' do
       let(:earliest_permitted_date) { Date.new(2014,10,2) }
@@ -22,16 +26,15 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
 
   context 'stand-alone rep order' do
     it 'should always be valid if not attached to a defendant or claim' do
-      reporder = FactoryBot.build :representation_order, defendant: nil, representation_order_date: nil
+      reporder = build :representation_order, defendant: nil, representation_order_date: nil
       expect(reporder).to be_valid
     end
   end
 
   context 'multiple representation orders' do
-
-    let(:claim)       { FactoryBot.create :claim }
-    let(:ro1)         { claim.defendants.first.representation_orders.first }
-    let(:ro2)         { claim.defendants.first.representation_orders.last }
+    let(:claim) { create :claim }
+    let(:ro1)   { claim.defendants.first.representation_orders.first }
+    let(:ro2)   { claim.defendants.first.representation_orders.last }
 
     it 'should be valid if the second reporder is dated after the first' do
       ro1.update(representation_order_date: 2.weeks.ago)


### PR DESCRIPTION
#### What

**Graduated fees changes**

- Display only relevant **advocate categories** for new fee scheme **[already in place from previous iterations]**
- Display a custom set of graduate fees for new fee scheme.
  - The approach was to update the seeds for fee types and leverage the existent of `roles` for a fee type, adding extra roles for both current and new fee schemes (ideally, I would say that would be done using some sort of relation with the fee scheme directly, without that in place, I've taken the decision to go with this instead. 
  - Also as part of this I've done some refactoring to the fee type seeds so it can be executed multiple times without incurring into creating duplicate methods (this is on the assumption that the initial seed was made using a specific `id` provided by the CSV file to create the record in the database using that as the primary key.
- Display only the quantity for `PPE` in the graduates page for advocate claims.

**Miscellaneous fees changes**

- Add new miscellaneous fee types for scheme 10 to the seed file and set them under the appropriate roles.
- Display a different set of miscellaneous fees for AGFS scheme 9 and AGFS scheme 10.

#### Ticket

- 💎  [AGFS final fee: Graduated fees](https://www.pivotaltracker.com/story/show/155569366)
- 💎  [AGFS final fee: miscellaneous fees](https://www.pivotaltracker.com/story/show/155569882)
