### PR TITLE
Bump Loofah gem version to address CVE-2018-8048

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
     logstuff (0.0.2)
       logstash-event (~> 1.1.0)
       request_store
-    loofah (2.2.0)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)


### PR DESCRIPTION
#### What
Bump Loofah gem version
#### Why
address CVE-2018-8048