### PR TITLE
Address CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,8 +457,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
     logstuff (0.0.2)
       logstash-event (~> 1.1.0)
       request_store
-    loofah (2.2.0)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)


### PR DESCRIPTION
What
Bump Loofah and rails-html-sanitizer gem version

Why
address CVE-2018-8048