### PR TITLE
Amend dump scripts to enable dump to new disaster stack

### DIFF
--- a/script/db_dump.rb
+++ b/script/db_dump.rb
@@ -11,6 +11,7 @@ ENVIRONMENTS = {
   'staging' => %w(staging adp_staging),
   'api-sandbox' => %w(api-sandbox adp_api-sandbox),
   'demo' => %w(demo adp_demo),
+  'disaster' => %w(disaster adp_disaster),
   'gamma' => %w(gamma adp_gamma)
 }
 

--- a/script/db_upload.rb
+++ b/script/db_upload.rb
@@ -9,7 +9,8 @@ require 'ruby-progressbar'
 ENVIRONMENTS = {
   'dev' => 'dev',
   'demo' => 'demo',
-  'staging' => 'staging'
+  'staging' => 'staging',
+  'disaster' => 'disaster'
 }
 
 def ssh_user


### PR DESCRIPTION
#### What
Allow dumping of anonymised data to the disaster stack

#### Why
To have a Disaster recovery testing environment 
that matches prod as closely as possible.