### PR TITLE
remove screenshot from feature test

### DIFF
--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -76,7 +76,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I add some additional information
 
     Then I click Submit to LAA
-    And I save and open screenshot
     And I should be on the check your claim page
     And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
 


### PR DESCRIPTION
#### What
Remove the `save_and_open_screenshot` instruction
#### Why
It was, presumably, a debugging step and is now clogging up my temp folder
