### PR TITLE
Add logging for vat_registered sentry errors

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -513,6 +513,15 @@ module Claim
     end
 
     def vat_registered?
+      if provider_delegator.nil?
+        LogStuff.send(:error, 'vat_registration',
+                      action: 'vat_registration',
+                      provider_id: provider&.id,
+                      creator_id: creator&.id,
+                      claim_id: id) do
+          "calculating VAT for #{id}"
+        end
+      end
       provider_delegator.vat_registered?
     end
 

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -496,6 +496,34 @@ module Claim
     }
   end
 
+  describe '#vat_registered?' do
+    subject { claim.vat_registered? }
+
+    let(:claim) { create :claim }
+    let(:mock_provider_delegator) { provider_delegator }
+
+    before { allow(claim).to receive(:provider_delegator).and_return(mock_provider_delegator) }
+
+    context 'when the provider exists' do
+      let(:provider_delegator) { double(:provider_delegator, vat_registered?: true) }
+
+      specify {
+        expect(LogStuff).not_to receive(:error)
+        subject
+      }
+    end
+
+    context 'when the provider is nil' do
+      # this shouldn't happen but the logger is implemented to trace errors in live
+      let(:provider_delegator) { nil }
+
+      specify {
+        expect(LogStuff).to receive(:error).once
+        expect{ subject }.to raise_error NoMethodError
+      }
+    end
+  end
+
   describe '#earliest_representation_order' do
     let(:claim) { MockBaseClaim.new }
 


### PR DESCRIPTION
#### What
Add logging for nil provider errors
#### Why
In sentry we are seeing occasional errors for `undefined method 'vat_registered?' for nil:NilClass`
#### How
This is designed to log when the situation recurs to enable further remediation steps