### PR TITLE
[AGFS fee reform] Summary/Review pages changes

### DIFF
--- a/app/views/external_users/claims/_summary_claims_content.html.haml
+++ b/app/views/external_users/claims/_summary_claims_content.html.haml
@@ -14,6 +14,10 @@
   Defendants
 = render partial: 'external_users/claims/defendants/summary', locals: { claim: claim }
 
+%h2
+  = t('external_users.claims.offence_details.summary.header')
+= render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }
+
 - if claim.lgfs? && claim.interim?
   %h2
     = t('common.interim_fees')

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -67,19 +67,6 @@
         %td
           = claim.case_type.try(:name)
 
-    - if claim.agfs?
-      %tr
-        %th{scope: 'row'}
-          = t("offence_category", scope: claim_fields)
-        %td
-          = claim.offence ? claim.offence.description : t("general.not_provided")
-
-    %tr
-      %th{scope: 'row'}
-        = t("offence_class", scope: claim_fields)
-      %td
-        = claim.offence ? claim.offence.offence_class : t("general.not_provided")
-
     - if claim.final? || claim.transfer?
       %tr
         %th{scope: 'row'}

--- a/app/views/external_users/claims/offence_details/_default_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_default_summary.html.haml
@@ -1,0 +1,14 @@
+- claim_fields = %i[external_users claims case_details fields]
+
+- if claim.agfs?
+  %tr
+    %th{scope: 'row'}
+      = t("offence_category", scope: claim_fields)
+    %td
+      = claim.offence ? claim.offence.description : t("general.not_provided")
+
+%tr
+  %th{scope: 'row'}
+    = t("offence_class", scope: claim_fields)
+  %td
+    = claim.offence ? claim.offence.offence_class : t("general.not_provided")

--- a/app/views/external_users/claims/offence_details/_fee_reform_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_summary.html.haml
@@ -1,0 +1,19 @@
+- claim_fields = %i[external_users claims offence_details fields]
+
+%tr
+  %th{scope: 'row'}
+    = t('offence_class', scope: claim_fields)
+  %td
+    = claim.offence ? claim.offence.offence_category.description : t("general.not_provided")
+
+%tr
+  %th{scope: 'row'}
+    = t('offence_band', scope: claim_fields)
+  %td
+    = claim.offence ? claim.offence.offence_band.description : t("general.not_provided")
+
+%tr
+  %th{scope: 'row'}
+    = t('offence_category', scope: claim_fields)
+  %td
+    = claim.offence ? claim.offence.description : t("general.not_provided")

--- a/app/views/external_users/claims/offence_details/_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_summary.html.haml
@@ -1,0 +1,9 @@
+%table{class: 'table-summary', summary: t('.summary') }
+  %caption
+    %span.table-caption.visuallyhidden
+      = t('.caption')
+  %tbody
+    - if claim.fee_scheme == 'fee_reform'
+      = render partial: 'external_users/claims/offence_details/fee_reform_summary', locals: { claim: claim }
+    - else
+      = render partial: 'external_users/claims/offence_details/default_summary', locals: { claim: claim }

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -89,19 +89,6 @@
           %td
             = claim.case_type.try(:name)
 
-      - if claim.agfs?
-        %tr
-          %th{scope: "col"}
-            = t('.offence')
-          %td
-            = claim.offence ? claim.offence.description : t('general.not_provided')
-
-      %tr
-        %th{scope: "col"}
-          = t('.offence_class')
-        %td
-          = claim.offence ? claim.offence.offence_class : t('general.not_provided')
-
       - if claim.agfs? && claim.case_type.present? && claim.requires_cracked_dates?
         = render partial: 'shared/claim_cracked_trial_details', locals: { claim: claim }
 
@@ -126,3 +113,7 @@
     = render partial: 'shared/claim_defendants', locals: {defendants: claim.defendants }
   - else
     = "No defendant details have been supplied for this claim."
+
+  %h3.heading-medium
+    = t('external_users.claims.offence_details.summary.header')
+  = render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -14,7 +14,7 @@
             - unless last_claim?
               = next_claim_link 'Next claim &gt;'.html_safe, class: 'next-claim'
 
-  = render partial: 'shared/claim_history', locals: {claim: claim }
+  = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }
 
   %div.js-accordion{"data-accordion-prefix-classes": "minimalist-accordion"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -602,6 +602,7 @@ en:
         actions:
           clear_selection: Clear selection
         fields:
+          offence_band: Offence band
           offence_class: 'Offence class'
           offence_category: Offence category
           offence_category_hint: 'If the offence category is not listed, choose "Miscellaneous/other"'
@@ -618,6 +619,10 @@ en:
           select_offence_class: "Please select"
         scheme_xor:
           one_not_both: 'Specify an Offence or an OffenceBand, not both'
+        summary:
+          caption: 'Offence Details: This section contains information about the offence details.'
+          header: Offence details
+          summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows.'
         selected_offence_header: 'You have chosen the following offence details:'
 
       defendants:


### PR DESCRIPTION
#### What

Display offence details in its own section in both of the summary/review pages.

Also, display different information for it depending on what fee scheme the claim is under.

#### Ticket

[AGFS final and interim fees: review case details page](https://www.pivotaltracker.com/story/show/155397316)