### PR TITLE
API, AGFS scheme ten rep order validation

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -51,4 +51,8 @@ class Offence < ActiveRecord::Base
   def scheme_nine?
     fee_schemes.map(&:version).any? { |s| s == FeeScheme::NINE }
   end
+
+  def scheme_ten?
+    fee_schemes.map(&:version).any? { |s| s == FeeScheme::TEN }
+  end
 end

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -17,6 +17,9 @@ class RepresentationOrderValidator < BaseValidator
     validate_presence(:representation_order_date, 'blank')
     validate_on_or_before(Date.today, :representation_order_date, 'in_future')
     validate_on_or_after(earliest_permitted[:date], :representation_order_date, earliest_permitted[:error])
+    if scheme_ten?
+      validate_on_or_after(Settings.agfs_fee_reform_release_date, :representation_order_date, 'scheme_ten_offence')
+    end
 
     return if @record.is_first_reporder_for_same_defendant?
     first_reporder_date = @record.first_reporder_for_same_defendant.try(:representation_order_date)
@@ -37,6 +40,10 @@ class RepresentationOrderValidator < BaseValidator
   #
   def claim
     @record.defendant.claim
+  end
+
+  def scheme_ten?
+    claim&.offence&.scheme_ten?
   end
 
   def earliest_permitted

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -656,6 +656,10 @@ representation_order:
       long: 'Representation order date of the #{defendant} cannot be prior to 02/10/14. Please check this date'
       short: *check_date
       api: 'Representation order date of the defendant cannot be prior to 02/10/14. Please check this date'
+    scheme_ten_offence:
+      long: Representation Order Date is not valid for AGFS scheme ten
+      short: *check_date
+      api: Representation Order Date is not valid for AGFS scheme ten
 
   maat_reference:
     _seq: 30

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -13,11 +13,11 @@ describe API::V1::ExternalUsers::RepresentationOrder do
   ALL_REP_ORDER_ENDPOINTS = [VALIDATE_REPRESENTATION_ORDER_ENDPOINT, CREATE_REPRESENTATION_ORDER_ENDPOINT]
   FORBIDDEN_REP_ORDER_VERBS = [:get, :put, :patch, :delete]
 
-  let(:representation_order_date) { 10.days.ago }
+  let(:representation_order_date) { Date.new(2017, 6, 1) }
 
   let!(:provider)      { create(:provider) }
-  let!(:claim)         { create(:claim, source: 'api') }
-  let!(:defendant)     { create(:defendant, claim: claim).reload }
+  let!(:claim)         { create(:claim, create_defendant_and_rep_order: false, source: 'api', offence: create(:offence, :with_fee_scheme)) }
+  let!(:defendant)     { create(:defendant, :without_reporder, claim: claim).reload }
   let!(:valid_params)  {
     {
         api_key: provider.api_key,
@@ -42,8 +42,8 @@ describe API::V1::ExternalUsers::RepresentationOrder do
 
   describe "POST #{CREATE_REPRESENTATION_ORDER_ENDPOINT}" do
 
-    def post_to_create_endpoint
-      post CREATE_REPRESENTATION_ORDER_ENDPOINT, valid_params, format: :json
+    def post_to_create_endpoint(submission_date = Date.new(2017, 7, 1))
+      Timecop.freeze(submission_date) { post CREATE_REPRESENTATION_ORDER_ENDPOINT, valid_params, format: :json }
     end
 
     include_examples "should NOT be able to amend a non-draft claim"

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -111,6 +111,22 @@ describe API::V1::ExternalUsers::RepresentationOrder do
       end
     end
 
+    context 'when a claim has been submitted with an AGFS scheme 10 offence' do
+      let(:claim) { create(:claim, create_defendant_and_rep_order: false, source: 'api', offence: create(:offence, :with_fee_scheme_ten)) }
+      let(:defendant) { create(:defendant, :without_reporder, claim: claim).reload }
+      let(:representation_order_date) { Date.today }
+
+      describe 'and the rep_order_date pre-dates the start of the scheme' do
+
+        before { Timecop.freeze(2018, 1, 1) { post_to_create_endpoint } }
+
+        specify { expect_error_response("Representation Order Date is not valid for AGFS scheme ten") }
+      end
+
+      describe 'and the rep_order_date post-dates the start of the scheme' do
+        specify { expect{ post_to_create_endpoint(Date.new(2018, 5, 1)) }.to change { RepresentationOrder.count }.by(1) }
+      end
+    end
   end
 
   describe "POST #{VALIDATE_REPRESENTATION_ORDER_ENDPOINT}" do

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -17,6 +17,9 @@ FactoryBot.define do
     # More details can be found here:
     # https://stackoverflow.com/questions/5916162/problem-with-factory-girl-association-and-after-initialize
     initialize_with { new(attributes) }
+    transient do
+      create_defendant_and_rep_order true
+    end
 
     form_id SecureRandom.uuid
     court
@@ -31,7 +34,7 @@ FactoryBot.define do
     sequence(:cms_number) { |n| "CMS-#{Time.now.year}-#{rand(100..199)}-#{n}" }
 
     after(:build) { |claim| post_build_actions_for_draft_claim(claim) }
-    after(:create) { |claim| add_defendant_and_reporder(claim) }
+    after(:create) { |claim, evaluator| add_defendant_and_reporder(claim) if evaluator.create_defendant_and_rep_order }
 
     trait :admin_creator do
       after(:build) { |claim| make_claim_creator_advocate_admin(claim) }

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -61,13 +61,29 @@ RSpec.describe Offence, type: :model do
     context 'when the fee_scheme is set to ten' do
       let(:offence) { create(:offence, :with_fee_scheme_ten) }
 
-      it { is_expected.to be_falsey }
+      it { expect(scheme_nine?).to be_falsey }
     end
 
     context 'when the fee_scheme is set to nine' do
       let(:offence) { create(:offence, :with_fee_scheme) }
 
-      it { is_expected.to be_truthy }
+      it { expect(scheme_nine?).to be_truthy }
+    end
+  end
+
+  describe '#scheme_ten?' do
+    subject(:scheme_ten?) { offence.scheme_ten? }
+
+    context 'when the fee_scheme is set to ten' do
+      let(:offence) { create(:offence, :with_fee_scheme_ten) }
+
+      it { expect(scheme_ten?).to be_truthy }
+    end
+
+    context 'when the fee_scheme is set to nine' do
+      let(:offence) { create(:offence, :with_fee_scheme) }
+
+      it { expect(scheme_ten?).to be_falsey }
     end
   end
 end


### PR DESCRIPTION
#### What
Add validation of rep orders after scheme ten implementation
#### Ticket
[Changes to software vendor API ](https://www.pivotaltracker.com/story/show/141298257)
#### Why
In the web site, users are only shown offences after entering a defendants representation order so this validation will not fire as the offence list will be shown after the user has entered a date.

In the API, users create a claim with an offence, then a defendant, then a rep order.  At that point an API user can submit a rep order that is invalid for the previously supplied offence_id.
#### How
Add a validation that only fires if a user attempts to create a rep order on a claim where a Scheme Ten offence has already been set.