### PR TITLE
[AGFS fee reform] Extra changes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -89,9 +89,9 @@ if (!String.prototype.supplant) {
   });
 
 
-  $('.defendants').on('cocoon:after-insert', function(e, el){
+  $('.form-actions').on('cocoon:after-insert', function(e, el){
     var $el = $(el);
-    if($el.hasClass('defendant-details')){
+    if($el.hasClass('resource-details')){
       $el.find('a.add_fields').click();
     }
   });

--- a/app/assets/javascripts/modules/Modules.Autocomplete.js
+++ b/app/assets/javascripts/modules/Modules.Autocomplete.js
@@ -241,7 +241,7 @@ moj.Modules.Autocomplete = {
       {
         name: $element.attr('name'),
         display: 'value',
-        limit: 100,
+        limit: 1000,
         source: dataSource,
         templates: {
           empty: self.emptyTemplate(),

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -179,8 +179,8 @@ module Claim
       # TODO: this should return a list based on the current given fee scheme
       # rather than conditionally return scheme 10 specifically
       # TBD once all the fee scheme work is integrated
-      return Fee::BasicFeeType.agfs unless fee_scheme == 'fee_reform'
-      Fee::BasicFeeType.agfs_scheme_10s
+      return Fee::BasicFeeType.agfs_scheme_9s unless fee_scheme == 'fee_reform'
+      Fee::BasicFeeType.unscoped.agfs_scheme_10s.order(:position)
     end
 
     def eligible_misc_fee_types

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -23,7 +23,7 @@ class Offence < ActiveRecord::Base
     end
   end
 
-  delegate :offence_category, to: :offence_band
+  delegate :offence_category, to: :offence_band, allow_nil: true
 
   validates :offence_class, presence: true, unless: :offence_band_id
   validates :offence_band, presence: true, unless: :offence_class_id

--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -1,16 +1,36 @@
 class Fee::BasicFeePresenter < Fee::BaseFeePresenter
+  def prompt_text
+    return unless FEE_CODES_WITH_PROMPT_TEXT.include?(code)
+
+    t_scope = %i[external_users claims basic_fees basic_fee_calculated_fields]
+
+    case code
+    when 'BAF'
+      key = claim.fee_scheme == 'fee_reform' ? 'basic_fee_reform_prompt_text' : 'basic_fee_prompt_text'
+      I18n.t(key, scope: t_scope)
+    when 'SAF'
+      return if claim.fee_scheme == 'fee_reform'
+      I18n.t('saf_prompt_text', scope: t_scope)
+    end
+  end
+
   def display_amount?
     # TODO: this is not really ideal, but right now I
     # can't see any other way to achieve this specific
     # requirement :/
     return true unless claim.fee_scheme == 'fee_reform'
-    return false if FEE_CODES_WITHOUT_AMOUNT.include?(fee.fee_type.code)
+    return false if FEE_CODES_WITHOUT_AMOUNT.include?(code)
     true
   end
 
   private
 
+  FEE_CODES_WITH_PROMPT_TEXT = %w[BAF SAF].freeze
   FEE_CODES_WITHOUT_AMOUNT = %w[PPE].freeze
+
+  def code
+    fee.fee_type.code
+  end
 
   def claim
     fee.claim

--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -4,14 +4,10 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
 
     t_scope = %i[external_users claims basic_fees basic_fee_calculated_fields]
 
-    case code
-    when 'BAF'
-      key = claim.fee_scheme == 'fee_reform' ? 'basic_fee_reform_prompt_text' : 'basic_fee_prompt_text'
-      I18n.t(key, scope: t_scope)
-    when 'SAF'
-      return if claim.fee_scheme == 'fee_reform'
-      I18n.t('saf_prompt_text', scope: t_scope)
-    end
+    key = prompt_text_key_for(code)
+
+    return unless key
+    I18n.t(key, scope: t_scope)
   end
 
   def display_amount?
@@ -25,7 +21,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
 
   private
 
-  FEE_CODES_WITH_PROMPT_TEXT = %w[BAF SAF].freeze
+  FEE_CODES_WITH_PROMPT_TEXT = %w[BAF SAF PPE].freeze
   FEE_CODES_WITHOUT_AMOUNT = %w[PPE].freeze
 
   def code
@@ -34,5 +30,24 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
 
   def claim
     fee.claim
+  end
+
+  def prompt_text_key_for(code)
+    return default_prompt_text_for(code) unless claim.fee_scheme == 'fee_reform'
+    fee_reform_prompt_text_for(code)
+  end
+
+  def default_prompt_text_for(code)
+    {
+      'BAF' => 'basic_fee_prompt_text',
+      'SAF' => 'saf_prompt_text'
+    }[code]
+  end
+
+  def fee_reform_prompt_text_for(code)
+    {
+      'BAF' => 'basic_fee_reform_prompt_text',
+      'PPE' => 'ppe_fee_reform_prompt_text'
+    }[code]
   end
 end

--- a/app/services/fee_reform/search_offences.rb
+++ b/app/services/fee_reform/search_offences.rb
@@ -28,6 +28,7 @@ module FeeReform
 
     def description_scope(description)
       offences_table[:description].matches("%#{description}%")
+                                  .or(offences_table[:contrary].matches("%#{description}%"))
                                   .or(bands_table[:description].matches("%#{description}%"))
                                   .or(categories_table[:description].matches("%#{description}%"))
     end

--- a/app/services/fee_reform/search_offences.rb
+++ b/app/services/fee_reform/search_offences.rb
@@ -15,7 +15,8 @@ module FeeReform
       offences = Offence.unscoped.in_scheme_ten
                         .joins(offence_band: :offence_category)
                         .includes(offence_band: :offence_category)
-                        .group('offences.description, offences.id, offence_bands.id, offence_categories.id')
+                        .group('offence_categories.id, offence_bands.id, offences.id')
+                        .order('offence_categories.description, offence_bands.description, offences.description')
 
       offences = offences.where(description_scope(filters[:search_offence])) if filters[:search_offence].present?
 

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -4,7 +4,7 @@
 
 = form_for @certification, builder: AdpFormBuilder, url: external_users_claim_certification_path(@claim) do |f|
   %div.certification.normal
-    - if @claim.is_a? Claim::AdvocateClaim
+    - if @claim.agfs?
 
       .grid-row
         .column-two-thirds

--- a/app/views/external_users/claims/basic_fees/_basic_fee_calculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_calculated_fields.html.haml
@@ -4,12 +4,10 @@
       = t('.fee_type')
 
     = f.object.description
-    - if fee.fee_type.code == 'BAF'
+
+    - if fee.prompt_text
       .form-hint
-        = raw t('.basic_fee_prompt_text')
-    - if fee.fee_type.code == 'SAF'
-      .form-hint
-        = raw t('.saf_prompt_text')
+        = fee.prompt_text
 
   .column-one-quarter.fee-quantity
     = f.adp_text_field :quantity,

--- a/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_uncalculated_fields.html.haml
@@ -3,6 +3,9 @@
     = fee.section_header('external_users.claims.basic_fees.basic_fee_uncalculated_fields')
   .column-one-half.fee-type
     = fee.section_hint('external_users.claims.basic_fees.basic_fee_uncalculated_fields')
+    - if fee.prompt_text
+      .form-hint
+        = fee.prompt_text
 
   .column-one-quarter.fee-quantity
     = f.adp_text_field :quantity,

--- a/app/views/external_users/claims/basic_fees/_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_fields.html.haml
@@ -6,6 +6,6 @@
     %p
       = raw t('.fee_prompt_text')
 
-    = f.fields_for :basic_fees do |basic_fee_fields|
+    = f.fields_for :basic_fees, f.object.basic_fees.sort_by { |fee| fee.fee_type.position } do |basic_fee_fields|
       - @basic_fee_count += 1
       = render 'external_users/claims/basic_fees/basic_fee_fields', f: basic_fee_fields

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -1,4 +1,4 @@
-.nested-fields.defendant-details
+.nested-fields.resource-details.defendant-details
   %h2.heading-large
     = t('.defendant')
   .form-group.first-name

--- a/app/views/external_users/claims/defendants/_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_fields.html.haml
@@ -2,6 +2,6 @@
   %fieldset
     = f.fields_for :defendants do |defendant|
       = render partial: 'external_users/claims/defendants/defendant_fields', locals: { f: defendant }
-.form-section.defendants-actions
+.form-section.form-actions.defendants-actions
   %hr
   = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields', class: 'button button-secondary blue'

--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -1,7 +1,8 @@
 - locale_scope = 'external_users.claims.offence_details'
 - selected_offence = f.object.offence
+- valid_offence = selected_offence.present? && selected_offence.offence_category.present?
 
-- if selected_offence.present?
+- if valid_offence
   .grid-row
     .column-two-thirds
       .selected-offence
@@ -22,7 +23,7 @@
     %span.form-hint
       = t('search_offence_hint', scope: "#{locale_scope}.fields")
     %input{ type: :text, id: 'search_offence', name: 'search_offence', class: 'form-control form-control-2-3 typeahead typeahead-textfield', data: { url: "/offences?fee_scheme=#{@claim.fee_scheme}",  menu: '#offence-list' } }
-    = f.hidden_field :offence_id, value: f.object.offence.present? ? f.object.offence.id : nil, class: 'clearable-fields', data: { selection: '.selected-offence' }
+    = f.hidden_field :offence_id, value: valid_offence ? f.object.offence.id : nil, class: 'clearable-fields', data: { selection: '.selected-offence' }
 
   %details
     %summary

--- a/app/views/external_users/claims/offence_details/_fee_reform_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_summary.html.haml
@@ -4,13 +4,13 @@
   %th{scope: 'row'}
     = t('offence_class', scope: claim_fields)
   %td
-    = claim.offence ? claim.offence.offence_category.description : t("general.not_provided")
+    = claim.offence&.offence_category ? claim.offence.offence_category.description : t("general.not_provided")
 
 %tr
   %th{scope: 'row'}
     = t('offence_band', scope: claim_fields)
   %td
-    = claim.offence ? claim.offence.offence_band.description : t("general.not_provided")
+    = claim.offence&.offence_band ? claim.offence.offence_band.description : t("general.not_provided")
 
 %tr
   %th{scope: 'row'}

--- a/app/views/external_users/claims/supporting_documents/_new.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_new.html.haml
@@ -1,4 +1,5 @@
-= render partial: 'external_users/claims/supporting_documents/disk_evidence', locals: { f: f }
+- unless @claim.agfs? && @claim.interim?
+  = render partial: 'external_users/claims/supporting_documents/disk_evidence', locals: { f: f }
 
 %h3.heading-medium
   = t('.supporting_evidence_docs')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -503,6 +503,8 @@ en:
           basic_fee_reform_prompt_text: |
             The basic fee for Scheme 10 claims includes the first day of trial and 3 conferences and views. All other hearings must be added in the relevant sections below
           fee_type: Fee type
+          ppe_fee_reform_prompt_text: |
+            Please enter the volume of PPE to help the caseworker assess the correct offence band
           quantity: Quantity
           rate: Rate
           case_numbers: *case_numbers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,6 +500,8 @@ en:
         basic_fee_calculated_fields:
           basic_fee_prompt_text: |
             Please include dates for those Standard appearance fees and PTPH's included in the Basic Fee
+          basic_fee_reform_prompt_text: |
+            The basic fee for Scheme 10 claims includes the first day of trial and 3 conferences and views. All other hearings must be added in the relevant sections below
           fee_type: Fee type
           quantity: Quantity
           rate: Rate

--- a/db/migrate/20180329145753_add_priority_to_fee_types.rb
+++ b/db/migrate/20180329145753_add_priority_to_fee_types.rb
@@ -1,0 +1,5 @@
+class AddPriorityToFeeTypes < ActiveRecord::Migration
+  def change
+    add_column :fee_types, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180314084912) do
+ActiveRecord::Schema.define(version: 20180329145753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "adminpack"
   enable_extension "uuid-ossp"
 
   create_table "case_types", force: :cascade do |t|
@@ -338,6 +337,7 @@ ActiveRecord::Schema.define(version: 20180314084912) do
     t.integer  "parent_id"
     t.boolean  "quantity_is_decimal", default: false
     t.string   "unique_code"
+    t.integer  "position"
   end
 
   add_index "fee_types", ["code"], name: "index_fee_types_on_code", using: :btree

--- a/db/seeds/fee_types/csv_row_mapper.rb
+++ b/db/seeds/fee_types/csv_row_mapper.rb
@@ -12,7 +12,7 @@ module Seeds
 
       def to_h
         {
-          id: row_attrs.fetch(:id),
+          id: primary_key,
           description: row_attrs.fetch(:description),
           code: row_attrs.fetch(:code),
           unique_code: row_attrs.fetch(:unique_code),
@@ -21,13 +21,18 @@ module Seeds
           type: row_attrs.fetch(:fee_type),
           parent_id: parent_id,
           roles: mapped_roles,
-          quantity_is_decimal: row_attrs.fetch(:quantity_is_decimal)
+          quantity_is_decimal: row_attrs.fetch(:quantity_is_decimal),
+          position: mapped_position
         }
       end
 
       private
 
       attr_reader :row_attrs, :parent_id
+
+      def primary_key
+        row_attrs.fetch(:id)
+      end
 
       def mapped_roles
         row_attrs.fetch(:roles).split(';')
@@ -44,6 +49,10 @@ module Seeds
       def mapped_max_amount
         return if max_amount.to_s.strip.blank?
         max_amount
+      end
+
+      def mapped_position
+        row_attrs[:position] || primary_key
       end
     end
   end

--- a/db/seeds/fee_types/csv_seeder.rb
+++ b/db/seeds/fee_types/csv_seeder.rb
@@ -37,7 +37,7 @@ module Seeds
       end
 
       def process_row(row)
-        id, description, code, unique_code, max_amount, calculated, fee_type, roles, parent_id, quantity_is_decimal = row
+        id, description, code, unique_code, max_amount, calculated, fee_type, roles, parent_id, quantity_is_decimal, position = row
         row_attributes = {
           id: id,
           description: description,
@@ -47,7 +47,8 @@ module Seeds
           calculated: calculated,
           fee_type: fee_type,
           roles: roles,
-          quantity_is_decimal: quantity_is_decimal
+          quantity_is_decimal: quantity_is_decimal,
+          position: position
         }
         klass = fee_type.constantize
         parent_id = parent_id.nil? ? nil : klass.find_by(description: parent_id.strip).try(:id)

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -1,100 +1,101 @@
-ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUANTITY_IS_DECIMAL,
-1,Basic fee,BAF,BABAF,9999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
-2,Daily attendance fee (3 to 40),DAF,BADAF,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-3,Daily attendance fee (41 to 50),DAH,BADAH,9999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-4,Daily attendance fee (51+),DAJ,BADAJ,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-5,Standard appearance fee,SAF,BASAF,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-6,Plea and trial preparation hearing,PCM,BAPCM,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-7,Conferences and views,CAV,BACAV,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
-8,Number of defendants uplift,NDR,BANDR,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-9,Number of cases uplift,NOC,BANOC,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-10,Number of prosecution witnesses,NPW,BANPW,,FALSE,Fee::BasicFeeType,agfs;agfs_scheme_9,,FALSE,N
-11,Pages of prosecution evidence,PPE,BAPPE,,FALSE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-12,Appeals to the crown court against conviction,ACV,FXACV,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-13,Appeals to the crown court against conviction uplift,ACU,FXACU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-14,Appeals to the crown court against sentence,ASE,FXASE,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-15,Appeals to the crown court against sentence uplift,ASU,FXASU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-16,Breach of a crown court order,CBR,FXCBR,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-17,Breach of a crown court order uplift,CBU,FXCBU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-20,Committal for sentence hearings,CSE,FXCSE,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-21,Committal for sentence hearings uplift,CSU,FXCSU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-22,Cracked case discontinued,CCD,FXCCD,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-23,Cracked case discontinued uplift,CDU,FXCDU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-24,Elected case not proceeded,ENP,FXENP,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-25,Elected case not proceeded uplift,ENU,FXENU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-26,Number of cases uplift,NOC,FXNOC,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-27,Number of defendants uplift,NDR,FXNDR,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,N
-28,Standard appearance fee,SAF,FXSAF,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-29,Abuse of process hearings (half day),APH,MIAPH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-30,Abuse of process hearings (whole day),APW,MIAPW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-31,Abuse of process hearings (half day uplift),AHU,MIAHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-32,Abuse of process hearings (whole day uplift),AWU,MIAWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-33,Adjourned appeals,SAF,MISAF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-34,Application to dismiss a charge (half day),PAH,MIADC1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-35,Application to dismiss a charge (whole day),PAW,MIADC2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-36,Application to dismiss a charge (half day uplift),PHU,MIADC3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-37,Application to dismiss a charge (whole day uplift),PWU,MIADC4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-38,Confiscation hearings (half day),DTH,MIDTH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-39,Confiscation hearings (whole day),DTW,MIDTW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-40,Confiscation hearings (half day uplift),DHU,MIDHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-41,Confiscation hearings (whole day uplift),DWU,MIDWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-42,Deferred sentence hearings,DSE,MIDSE,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-43,Deferred sentence hearings uplift,DSU,MIDSU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-44,Hearings relating to admissibility of evidence (half day),AEH,MIAEH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-45,Hearings relating to admissibility of evidence (whole day),AEW,MIAEW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-46,Hearings relating to admissibility of evidence (half day uplift),EHU,MIEHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-47,Hearings relating to admissibility of evidence (whole day uplift),EWU,MIEWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-48,Hearings relating to disclosure (half day),HDH,MIHDH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-49,Hearings relating to disclosure (whole day),HDW,MIHDW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-50,Hearings relating to disclosure (half day uplift),HHU,MIHHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-51,Hearings relating to disclosure (whole day uplift),HWU,MIHWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-52,Noting brief fee,NBR,MINBR,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-53,Paper plea & case management,PPC,MIPPC,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9,,FALSE,N
-54,Paper plea & case management uplift,PCU,MIPCU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9,,FALSE,N
-55,Proceeds of crime hearings (half day),PCH,MIPCH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-56,Proceeds of crime hearings (whole day),PCW,MIPCW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-57,Proceeds of crime hearings (half day uplift),CHU,MICHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-58,Proceeds of crime hearings (whole day uplift),CHW,MICHW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-59,Public interest immunity hearings (half day),PAH,MIPIH1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-60,Public interest immunity hearings (whole day),PAW,MIPIH2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-61,Public interest immunity hearings (half day uplift),PHU,MIPIU3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-62,Public interest immunity hearings (whole day uplift),PWU,MIPIH4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-63,Research of very unusual or novel factual issue,RNF,MIRNF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
-64,Research of very unusual or novel point of law,RNL,MIRNL,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
-65,Standard appearance fee uplift,SAU,MISAU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-66,Sentence hearings,SHR,MISHR,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-67,Sentence hearings uplift,SHU,MISHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-68,Special preparation fee,SPF,MISPF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10;lgfs,,TRUE,N
-69,Trial not proceed,TNP,MITNP,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-70,Trial not proceed uplift,TNU,MITNU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-71,Unsuccessful application to vacate a guilty plea (half day),PAH,MIUAV1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-72,Unsuccessful application to vacate a guilty plea (whole day),PAW,MIUAV2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-73,Unsuccessful application to vacate a guilty plea (half day uplift),PHU,MIUAV3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-74,Unsuccessful application to vacate a guilty plea (whole day uplift),PWU,MIUAV4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,N
-75,Written / oral advice,WOA,MIWOA,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
-76,Wasted preparation fee,WPF,MIWPF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,N
-77,Trial,GTRL,GRTRL,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
-78,Retrial,GRTR,GRRTR,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
-79,Guilty plea,GGLTY,GRGLT,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
-80,Discontinuance,GDIS,GRDIS,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
-81,Cracked trial,GCRAK,GRRAK,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
-82,Cracked before retrial,GCBR,GRCBR,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,N
-83,Hearing subsequent to sentence,XH2S,FXH2S,,FALSE,Fee::FixedFeeType,lgfs,,FALSE,N
-84,Vary/discharge an ASBO s1c Crime and Disorder Act 1998,XASB,FXASB,,FALSE,Fee::FixedFeeType,lgfs,83,FALSE,N
-85,Alteration of Crown Court sentence s155 Powers of Criminal Courts (Sentencing Act 2000),XALT,FXALT,,FALSE,Fee::FixedFeeType,lgfs,83,FALSE,N
-86,Assistance by defendant: review of sentence s74 Serious Organised Crime and Police Act 2005,XASS,FXASS,,FALSE,Fee::FixedFeeType,lgfs,83,FALSE,N
-87,Evidence provision fee,XEVI,MIEVI,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,N
-88,Costs judge application,XCJA,MICJA,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,N
-89,Costs judge preparation,XCJP,MICJP,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,N
-90,Case uplift,XUPL,MIUPL,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,N
-91,Warrant Fee,XWAR,WARR,,FALSE,Fee::WarrantFeeType,lgfs,,FALSE,N
-92,Contempt,ZCON,FXCON,,TRUE,Fee::FixedFeeType,agfs,,FALSE,N
-93,Effective PCMH,IPCMH,INPCM,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
-94,Trial start,ITST,INTDT,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
-95,Retrial New solicitor,IRNS,INRNS,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
-96,Retrial start,IRST,INRST,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
-97,Disbursement only,IDISO,INDIS,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
-98,Warrant,IWARR,INWAR,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,N
-99,Transfer,TRANS,TRANS,,FALSE,Fee::TransferFeeType,lgfs,,FALSE,N
-100,Further case management hearing,FCM,MIFCM,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,N
-101,Ground rules hearing,GRH,MIGRH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,N
+ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUANTITY_IS_DECIMAL,POSITION
+1,Basic fee,BAF,BABAF,9999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,1
+2,Daily attendance fee (3 to 40),DAF,BADAF,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9,,FALSE,2
+3,Daily attendance fee (41 to 50),DAH,BADAH,9999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9,,FALSE,3
+4,Daily attendance fee (51+),DAJ,BADAJ,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9,,FALSE,4
+5,Standard appearance fee,SAF,BASAF,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,5
+6,Plea and trial preparation hearing,PCM,BAPCM,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,6
+7,Conferences and views,CAV,BACAV,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,7
+8,Number of defendants uplift,NDR,BANDR,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,8
+9,Number of cases uplift,NOC,BANOC,,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,9
+10,Number of prosecution witnesses,NPW,BANPW,,FALSE,Fee::BasicFeeType,agfs;agfs_scheme_9,,FALSE,10
+11,Pages of prosecution evidence,PPE,BAPPE,,FALSE,Fee::BasicFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,11
+12,Appeals to the crown court against conviction,ACV,FXACV,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+13,Appeals to the crown court against conviction uplift,ACU,FXACU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+14,Appeals to the crown court against sentence,ASE,FXASE,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+15,Appeals to the crown court against sentence uplift,ASU,FXASU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+16,Breach of a crown court order,CBR,FXCBR,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+17,Breach of a crown court order uplift,CBU,FXCBU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+20,Committal for sentence hearings,CSE,FXCSE,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+21,Committal for sentence hearings uplift,CSU,FXCSU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+22,Cracked case discontinued,CCD,FXCCD,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+23,Cracked case discontinued uplift,CDU,FXCDU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+24,Elected case not proceeded,ENP,FXENP,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+25,Elected case not proceeded uplift,ENU,FXENU,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+26,Number of cases uplift,NOC,FXNOC,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+27,Number of defendants uplift,NDR,FXNDR,,TRUE,Fee::FixedFeeType,agfs;lgfs,,FALSE,
+28,Standard appearance fee,SAF,FXSAF,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+29,Abuse of process hearings (half day),APH,MIAPH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+30,Abuse of process hearings (whole day),APW,MIAPW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+31,Abuse of process hearings (half day uplift),AHU,MIAHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+32,Abuse of process hearings (whole day uplift),AWU,MIAWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+33,Adjourned appeals,SAF,MISAF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+34,Application to dismiss a charge (half day),PAH,MIADC1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+35,Application to dismiss a charge (whole day),PAW,MIADC2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+36,Application to dismiss a charge (half day uplift),PHU,MIADC3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+37,Application to dismiss a charge (whole day uplift),PWU,MIADC4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+38,Confiscation hearings (half day),DTH,MIDTH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+39,Confiscation hearings (whole day),DTW,MIDTW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+40,Confiscation hearings (half day uplift),DHU,MIDHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+41,Confiscation hearings (whole day uplift),DWU,MIDWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+42,Deferred sentence hearings,DSE,MIDSE,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+43,Deferred sentence hearings uplift,DSU,MIDSU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+44,Hearings relating to admissibility of evidence (half day),AEH,MIAEH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+45,Hearings relating to admissibility of evidence (whole day),AEW,MIAEW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+46,Hearings relating to admissibility of evidence (half day uplift),EHU,MIEHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+47,Hearings relating to admissibility of evidence (whole day uplift),EWU,MIEWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+48,Hearings relating to disclosure (half day),HDH,MIHDH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+49,Hearings relating to disclosure (whole day),HDW,MIHDW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+50,Hearings relating to disclosure (half day uplift),HHU,MIHHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+51,Hearings relating to disclosure (whole day uplift),HWU,MIHWU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+52,Noting brief fee,NBR,MINBR,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+53,Paper plea & case management,PPC,MIPPC,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9,,FALSE,
+54,Paper plea & case management uplift,PCU,MIPCU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9,,FALSE,
+55,Proceeds of crime hearings (half day),PCH,MIPCH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+56,Proceeds of crime hearings (whole day),PCW,MIPCW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+57,Proceeds of crime hearings (half day uplift),CHU,MICHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+58,Proceeds of crime hearings (whole day uplift),CHW,MICHW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+59,Public interest immunity hearings (half day),PAH,MIPIH1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+60,Public interest immunity hearings (whole day),PAW,MIPIH2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+61,Public interest immunity hearings (half day uplift),PHU,MIPIU3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+62,Public interest immunity hearings (whole day uplift),PWU,MIPIH4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+63,Research of very unusual or novel factual issue,RNF,MIRNF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,
+64,Research of very unusual or novel point of law,RNL,MIRNL,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,
+65,Standard appearance fee uplift,SAU,MISAU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+66,Sentence hearings,SHR,MISHR,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+67,Sentence hearings uplift,SHU,MISHU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+68,Special preparation fee,SPF,MISPF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10;lgfs,,TRUE,
+69,Trial not proceed,TNP,MITNP,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+70,Trial not proceed uplift,TNU,MITNU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+71,Unsuccessful application to vacate a guilty plea (half day),PAH,MIUAV1,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+72,Unsuccessful application to vacate a guilty plea (whole day),PAW,MIUAV2,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+73,Unsuccessful application to vacate a guilty plea (half day uplift),PHU,MIUAV3,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+74,Unsuccessful application to vacate a guilty plea (whole day uplift),PWU,MIUAV4,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE,
+75,Written / oral advice,WOA,MIWOA,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,
+76,Wasted preparation fee,WPF,MIWPF,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,TRUE,
+77,Trial,GTRL,GRTRL,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,
+78,Retrial,GRTR,GRRTR,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,
+79,Guilty plea,GGLTY,GRGLT,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,
+80,Discontinuance,GDIS,GRDIS,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,
+81,Cracked trial,GCRAK,GRRAK,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,
+82,Cracked before retrial,GCBR,GRCBR,9999,FALSE,Fee::GraduatedFeeType,lgfs,,FALSE,
+83,Hearing subsequent to sentence,XH2S,FXH2S,,FALSE,Fee::FixedFeeType,lgfs,,FALSE,
+84,Vary/discharge an ASBO s1c Crime and Disorder Act 1998,XASB,FXASB,,FALSE,Fee::FixedFeeType,lgfs,83,FALSE,
+85,Alteration of Crown Court sentence s155 Powers of Criminal Courts (Sentencing Act 2000),XALT,FXALT,,FALSE,Fee::FixedFeeType,lgfs,83,FALSE,
+86,Assistance by defendant: review of sentence s74 Serious Organised Crime and Police Act 2005,XASS,FXASS,,FALSE,Fee::FixedFeeType,lgfs,83,FALSE,
+87,Evidence provision fee,XEVI,MIEVI,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
+88,Costs judge application,XCJA,MICJA,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
+89,Costs judge preparation,XCJP,MICJP,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
+90,Case uplift,XUPL,MIUPL,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
+91,Warrant Fee,XWAR,WARR,,FALSE,Fee::WarrantFeeType,lgfs,,FALSE,
+92,Contempt,ZCON,FXCON,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
+93,Effective PCMH,IPCMH,INPCM,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,
+94,Trial start,ITST,INTDT,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,
+95,Retrial New solicitor,IRNS,INRNS,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,
+96,Retrial start,IRST,INRST,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,
+97,Disbursement only,IDISO,INDIS,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,
+98,Warrant,IWARR,INWAR,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,
+99,Transfer,TRANS,TRANS,,FALSE,Fee::TransferFeeType,lgfs,,FALSE,
+100,Further case management hearing,FCM,MIFCM,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,
+101,Ground rules hearing,GRH,MIGRH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,
+102,Daily attendance fee (2+),DAT,BADAT,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_10,,FALSE,2

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     sequence(:description) { |n| "AGFS, Basic fee type, basic fee -#{n}" }
     code { random_safe_code }
     calculated true
-    roles ['agfs']
+    roles %w[agfs agfs_scheme_9]
     quantity_is_decimal false
     unique_code { generate_unique_code }
 

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -173,6 +173,10 @@ FactoryBot.define do
       amount 25
       fee_type { build :basic_fee_type, description: 'Number of prosecution witnesses', code: 'NPW', unique_code: 'BANPW', calculated: false }
     end
+
+    trait :saf_fee do
+      fee_type { build :basic_fee_type, description: 'Standard appearance fee', code: 'SAF', unique_code: 'BASAF' }
+    end
   end
 
   factory :transfer_fee, class: Fee::TransferFee do

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
   context 'eligible misc and fixed fee types' do
     before(:all) do
-      @bft1 = create :basic_fee_type, :agfs_scheme_10
+      @bft1 = create :basic_fee_type, roles: %w[agfs agfs_scheme_9 agfs_scheme_10]
       @bft2 = create :basic_fee_type, :lgfs
       @bft3 = create :basic_fee_type
       @mft1 = create :misc_fee_type, :agfs_scheme_9

--- a/spec/presenters/fee/basic_fee_presenter_spec.rb
+++ b/spec/presenters/fee/basic_fee_presenter_spec.rb
@@ -6,6 +6,42 @@ RSpec.describe Fee::BasicFeePresenter, type: :presenter do
 
   subject(:presenter) { described_class.new(fee, view) }
 
+  describe '#prompt_text' do
+    context 'when the fee type code does not require a prompt text' do
+      let(:fee) { build(:basic_fee, :daf_fee, claim: claim) }
+
+      specify { expect(presenter.prompt_text).to be_nil }
+    end
+
+    context 'when the fee type code is BAF' do
+      let(:fee) { build(:basic_fee, :baf_fee, claim: claim) }
+
+      specify { expect(presenter.prompt_text).to eq("Please include dates for those Standard appearance fees and PTPH's included in the Basic Fee\n") }
+
+      context 'and the claim is under the fee reform scheme' do
+        before do
+          allow(claim).to receive(:fee_scheme).and_return('fee_reform')
+        end
+
+        specify { expect(presenter.prompt_text).to eq("The basic fee for Scheme 10 claims includes the first day of trial and 3 conferences and views. All other hearings must be added in the relevant sections below\n") }
+      end
+    end
+
+    context 'when the fee type code is SAF' do
+      let(:fee) { build(:basic_fee, :saf_fee, claim: claim) }
+
+      specify { expect(presenter.prompt_text).to eq("Include any additional PTPH fees under SAF") }
+
+      context 'and the claim is under the fee reform scheme' do
+        before do
+          allow(claim).to receive(:fee_scheme).and_return('fee_reform')
+        end
+
+        specify { expect(presenter.prompt_text).to be_nil }
+      end
+    end
+  end
+
   describe '#display_amount?' do
     context 'when the associated claim is not under the new fee reform' do
       before do

--- a/spec/presenters/fee/basic_fee_presenter_spec.rb
+++ b/spec/presenters/fee/basic_fee_presenter_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe Fee::BasicFeePresenter, type: :presenter do
         specify { expect(presenter.prompt_text).to be_nil }
       end
     end
+
+    context 'when the fee type code is PPE' do
+      let(:fee) { build(:basic_fee, :ppe_fee, claim: claim) }
+
+      specify { expect(presenter.prompt_text).to be_nil }
+
+      context 'and the claim is under the fee reform scheme' do
+        before do
+          allow(claim).to receive(:fee_scheme).and_return('fee_reform')
+        end
+
+        specify { expect(presenter.prompt_text).to eq("Please enter the volume of PPE to help the caseworker assess the correct offence band\n") }
+      end
+    end
   end
 
   describe '#display_amount?' do

--- a/spec/services/fee_reform/search_offences_spec.rb
+++ b/spec/services/fee_reform/search_offences_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe FeeReform::SearchOffences, type: :service do
   }
   let!(:scheme_10_offences) {
     [
-      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-1'),
-      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-4 paTTern'),
-      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-5', contrary: 'Matches pattERN'),
-      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-3', offence_band: create(:offence_band, description: 'Bla bla Patterns bla bla')),
+      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-1', offence_band: create(:offence_band, description: 'OB-A', offence_category: create(:offence_category, description: 'OC-A'))),
+      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-4 paTTern', offence_band: create(:offence_band, description: 'OB-B', offence_category: create(:offence_category, description: 'OC-A'))),
+      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-5', contrary: 'Matches pattERN', offence_band: create(:offence_band, description: 'OB-A', offence_category: create(:offence_category, description: 'OC-Z'))),
+      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-3', offence_band: create(:offence_band, description: 'Bla bla Patterns bla bla', offence_category: create(:offence_category, description: 'OC-C'))),
       create(:offence, :with_fee_scheme_ten, description: 'Offence 10-2', offence_band: create(:offence_band, offence_category: create(:offence_category, description: 'PaTterN bla bla')))
     ]
   }
@@ -24,7 +24,7 @@ RSpec.describe FeeReform::SearchOffences, type: :service do
     it 'returns all existent offences under fee scheme 10' do
       offences = described_class.call(filters)
       expect(offences.length).to eq(5)
-      expect(offences.map(&:description)).to match_array(['Offence 10-1', 'Offence 10-4 paTTern', 'Offence 10-5', 'Offence 10-3', 'Offence 10-2'])
+      expect(offences.map(&:description)).to eq(['Offence 10-1', 'Offence 10-4 paTTern', 'Offence 10-3', 'Offence 10-5', 'Offence 10-2'])
     end
   end
 
@@ -34,7 +34,7 @@ RSpec.describe FeeReform::SearchOffences, type: :service do
     it 'returns all offences under fee scheme 10 that match the provided pattern (including band description and category description)' do
       offences = described_class.call(filters)
       expect(offences.length).to eq(4)
-      expect(offences.map(&:description)).to match_array(['Offence 10-4 paTTern', 'Offence 10-5', 'Offence 10-3', 'Offence 10-2'])
+      expect(offences.map(&:description)).to eq(['Offence 10-4 paTTern', 'Offence 10-3', 'Offence 10-5', 'Offence 10-2'])
     end
   end
 end

--- a/spec/services/fee_reform/search_offences_spec.rb
+++ b/spec/services/fee_reform/search_offences_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe FeeReform::SearchOffences, type: :service do
     [
       create(:offence, :with_fee_scheme_ten, description: 'Offence 10-1'),
       create(:offence, :with_fee_scheme_ten, description: 'Offence 10-4 paTTern'),
+      create(:offence, :with_fee_scheme_ten, description: 'Offence 10-5', contrary: 'Matches pattERN'),
       create(:offence, :with_fee_scheme_ten, description: 'Offence 10-3', offence_band: create(:offence_band, description: 'Bla bla Patterns bla bla')),
       create(:offence, :with_fee_scheme_ten, description: 'Offence 10-2', offence_band: create(:offence_band, offence_category: create(:offence_category, description: 'PaTterN bla bla')))
     ]
@@ -22,8 +23,8 @@ RSpec.describe FeeReform::SearchOffences, type: :service do
 
     it 'returns all existent offences under fee scheme 10' do
       offences = described_class.call(filters)
-      expect(offences.length).to eq(4)
-      expect(offences.map(&:description)).to match_array(['Offence 10-1', 'Offence 10-4 paTTern', 'Offence 10-3', 'Offence 10-2'])
+      expect(offences.length).to eq(5)
+      expect(offences.map(&:description)).to match_array(['Offence 10-1', 'Offence 10-4 paTTern', 'Offence 10-5', 'Offence 10-3', 'Offence 10-2'])
     end
   end
 
@@ -32,8 +33,8 @@ RSpec.describe FeeReform::SearchOffences, type: :service do
 
     it 'returns all offences under fee scheme 10 that match the provided pattern (including band description and category description)' do
       offences = described_class.call(filters)
-      expect(offences.length).to eq(3)
-      expect(offences.map(&:description)).to match_array(['Offence 10-4 paTTern', 'Offence 10-3', 'Offence 10-2'])
+      expect(offences.length).to eq(4)
+      expect(offences.map(&:description)).to match_array(['Offence 10-4 paTTern', 'Offence 10-5', 'Offence 10-3', 'Offence 10-2'])
     end
   end
 end


### PR DESCRIPTION
#### > What

[Pivotal Tracker](https://www.pivotaltracker.com/story/show/156468243)

- **Daily attendance 2+** is the only Daily attendance fee [advocate final - graduate fees]
- Certification page for advocate interims should be the same as the AGFS final one
- Copy for Basic fee guidance text under the new fee reform scheme changes
- Remove help text for SAF fee under the new fee reform scheme
- Add contrary to the filter of offences search
- Disk evidence is not required for advocates interim claims
- Display PPE help text
- Order offences by alphabetic category description > alphabetic band description > alphabetic offence description
- Fix bug with adding a new defendant not displaying associated representation order details

#### > Why

All the changes implemented out of feedback on previous tickets related to _fee reform_.

#### > Deployment requirements

* New migration adding a _position_ field to **fee types** table
* **Fee types** data needs to be re-seeded:

```
SEEDS_DRY_MODE=false bundle exec rake fee_types:seed
```