### PR TITLE
Clarify API dropdown offence tests

### DIFF
--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -60,7 +60,7 @@ describe API::V1::DropdownData do
         ADVOCATE_CATEGORY_ENDPOINT => Settings.advocate_categories.to_json,
         CRACKED_THIRD_ENDPOINT => Settings.trial_cracked_at_third.to_json,
         OFFENCE_CLASS_ENDPOINT => API::Entities::OffenceClass.represent(OffenceClass.all).to_json,
-        OFFENCE_ENDPOINT => API::Entities::Offence.represent(FeeScheme.current_agfs.offences).to_json,
+        OFFENCE_ENDPOINT => API::Entities::Offence.represent(FeeScheme.nine.agfs.first.offences).to_json,
         FEE_TYPE_ENDPOINT => API::Entities::BaseFeeType.represent(Fee::BaseFeeType.all).to_json,
         EXPENSE_TYPE_ENDPOINT => API::Entities::ExpenseType.represent(ExpenseType.all).to_json,
         EXPENSE_REASONS_ENDPOINT => API::Entities::ExpenseReasonSet.represent(ExpenseType.reason_sets).to_json,
@@ -75,6 +75,7 @@ describe API::V1::DropdownData do
       create_list(:court, 2)
       create_list(:offence_class, 2, :with_lgfs_offence)
       create_list(:offence, 2, :with_fee_scheme)
+      create_list(:offence, 2, :with_fee_scheme_ten)
       create_list(:basic_fee_type, 2)
       create_list(:expense_type, 2)
       create_list(:disbursement_type, 2)


### PR DESCRIPTION
#### What
After the month switch to April, the seeded data for the dropdown tests broke.
#### Why
The seeds meant that `FeeScheme.current_agfs` no longer matched scheme nine 
#### How
Clarified the setup to use `FeeScheme.nine.agfs.first`