### PR TITLE
Formally remove Postgresql adminpack

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20180314084912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "adminpack"
   enable_extension "uuid-ossp"
 
   create_table "case_types", force: :cascade do |t|


### PR DESCRIPTION
Not required and running db:migrate is removing it in any event.
