### PR TITLE
Seeding fixes

### DIFF
--- a/db/seeds/expense_types.rb
+++ b/db/seeds/expense_types.rb
@@ -13,6 +13,7 @@ expense_types = [
 ]
 
 max_id = 0
+ExpenseType.reset_column_information
 expense_types.each do |fields|
   record_id, name, roles, reason_set, code = fields
   max_id = [max_id, record_id].max

--- a/db/seeds/offences.rb
+++ b/db/seeds/offences.rb
@@ -1,6 +1,8 @@
 require 'csv'
 require_relative '../offence_code_seeder.rb'
 
+Offence.reset_column_information
+
 file_path = Rails.root.join('lib', 'assets', 'data', 'offences.csv')
 csv_file = File.open(file_path, 'r:ISO-8859-1')
 csv = CSV.parse(csv_file, headers: true)

--- a/lib/demo_data/basic_fee_generator.rb
+++ b/lib/demo_data/basic_fee_generator.rb
@@ -1,10 +1,8 @@
 module DemoData
-
   class BasicFeeGenerator
-
     def initialize(claim)
       @claim       = claim
-      @fee_types   = Fee::BasicFeeType.all
+      @fee_types   = Fee::BasicFeeType.agfs_scheme_9s.all
       @codes_added = []
     end
 
@@ -18,7 +16,6 @@ module DemoData
     end
 
     private
-
 
     def update_basic_fee(basic_fee_code, attributes={})
       fee = @claim.basic_fees.find_by(fee_type_id: basic_fee_type_by_code(basic_fee_code))
@@ -94,10 +91,5 @@ module DemoData
       raise RuntimeError.new "Unable to find Fee Type with code #{code}" if fee_type.nil?
       fee_type
     end
-
   end
-
 end
-
-
-


### PR DESCRIPTION
#### What

- Reload column data information in seed services to ensure they're using the most update ones.
- Seed demo data with scheme 9 basic fees only (preserving the existent behaviour)

#### Why

Migrations/seeds load the model multiple times at different stages and they cache the column information, causing errors like these:

```ruby
Caused by:
NoMethodError: undefined method `unique_code=' for #<ExpenseType:0x00007f8604cad3e8>
db/seed_helper.rb:58:in `find_or_create_expense_type!'
db/seeds/expense_types.rb:19:in `block in <top (required)>'
``` 