### PR TITLE
Display fees in the order of their associated fee types

### DIFF
--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -39,7 +39,7 @@ module Fee
     belongs_to :fee_type, class_name: Fee::BaseFeeType
     belongs_to :sub_type, class_name: Fee::BaseFeeType
 
-    delegate :description, :case_uplift?, :defendant_uplift?, to: :fee_type
+    delegate :description, :case_uplift?, :defendant_uplift?, :position, to: :fee_type
 
     has_many :dates_attended, as: :attended_item, dependent: :destroy, inverse_of: :attended_item
 

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -5,7 +5,7 @@
     %span.table-caption.visuallyhidden
       = t('.caption')
   %tbody
-    - present_collection(claim.fees.select(&:present?)).each do |fee|
+    - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
       %tr
         %th.summary-headings{ scope: 'row'}
           = t('shared.summary.fee_category')

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -5,7 +5,7 @@
     %span.table-caption.visuallyhidden
       = t('.caption')
   %tbody
-    - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
+    - present_collection(claim.fees.select(&:present?).sort_by(&:position)).each do |fee|
       %tr
         %th.summary-headings{ scope: 'row'}
           = t('shared.summary.fee_category')

--- a/app/views/external_users/claims/basic_fees/_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_fields.html.haml
@@ -6,6 +6,6 @@
     %p
       = raw t('.fee_prompt_text')
 
-    = f.fields_for :basic_fees, f.object.basic_fees.sort_by { |fee| fee.fee_type.position } do |basic_fee_fields|
+    = f.fields_for :basic_fees, f.object.basic_fees.sort_by(&:position) do |basic_fee_fields|
       - @basic_fee_count += 1
       = render 'external_users/claims/basic_fees/basic_fee_fields', f: basic_fee_fields

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -25,7 +25,7 @@
             %th.numeric{ scope: 'col' }
               = t('.amount')
         %tbody
-          - present_collection(claim.fees.select(&:present?)).each do |fee|
+          - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
             %tr
               %td
                 = fee.fee_type&.fee_category_name || 'n/a'

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -25,7 +25,7 @@
             %th.numeric{ scope: 'col' }
               = t('.amount')
         %tbody
-          - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
+          - present_collection(claim.fees.select(&:present?).sort_by(&:position)).each do |fee|
             %tr
               %td
                 = fee.fee_type&.fee_category_name || 'n/a'

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -25,7 +25,7 @@
             %th.numeric.col-gross{ scope: 'col' }
               = "Net amount"
         %tbody
-          - present_collection(claim.fees.select(&:present?)).each do |fee|
+          - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
             %tr
               %td
                 = fee.fee_type&.fee_category_name || 'n/a'

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -25,7 +25,7 @@
             %th.numeric.col-gross{ scope: 'col' }
               = "Net amount"
         %tbody
-          - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
+          - present_collection(claim.fees.select(&:present?).sort_by(&:position)).each do |fee|
             %tr
               %td
                 = fee.fee_type&.fee_category_name || 'n/a'

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -21,7 +21,7 @@
             %th.numeric{ scope: 'col' }
               = t('.amount')
         %tbody
-          - present_collection(claim.fees.select(&:present?)).each do |fee|
+          - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
             %tr
               %td
                 = fee.fee_type&.fee_category_name || 'n/a'

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -21,7 +21,7 @@
             %th.numeric{ scope: 'col' }
               = t('.amount')
         %tbody
-          - present_collection(claim.fees.select(&:present?).sort_by { |fee| fee.fee_type.position }).each do |fee|
+          - present_collection(claim.fees.select(&:present?).sort_by(&:position)).each do |fee|
             %tr
               %td
                 = fee.fee_type&.fee_category_name || 'n/a'

--- a/spec/models/fee/base_fee_spec.rb
+++ b/spec/models/fee/base_fee_spec.rb
@@ -71,6 +71,10 @@ module Fee
           subject.case_uplift?
         end
       end
+
+      describe '#position' do
+        specify { is_expected.to delegate_method(:position).to(:fee_type) }
+      end
     end
 
     describe 'blank quantity should be set to zero before validation' do


### PR DESCRIPTION
#### What

Fee types have a position column to determine how they should be displayed.

Summary pages should use that order given there's new fee types that no longer match the expected default order (by fee id).

**NOTE:** Seems that there's quite a lot of repetition to display similar content across multiple templates. This PR does **NOT** address that, even though it should probably be re-visited.