### PR TITLE
Display PPE field only for claim with offence category 6 or 9

### DIFF
--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -10,6 +10,12 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
     I18n.t(key, scope: t_scope)
   end
 
+  def should_be_displayed?
+    return true unless claim.fee_scheme == 'fee_reform'
+    return true unless FEE_CODES_RESTRICTED_DISPLAY.include?(code)
+    OFFENCE_CATEGORIES_WITHOUT_RESTRICTED_DISPLAY.include?(offence_category_number)
+  end
+
   def display_amount?
     # TODO: this is not really ideal, but right now I
     # can't see any other way to achieve this specific
@@ -23,6 +29,8 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
 
   FEE_CODES_WITH_PROMPT_TEXT = %w[BAF SAF PPE].freeze
   FEE_CODES_WITHOUT_AMOUNT = %w[PPE].freeze
+  FEE_CODES_RESTRICTED_DISPLAY = %w[PPE].freeze
+  OFFENCE_CATEGORIES_WITHOUT_RESTRICTED_DISPLAY = [6, 9].freeze
 
   def code
     fee.fee_type.code
@@ -30,6 +38,10 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
 
   def claim
     fee.claim
+  end
+
+  def offence_category_number
+    claim&.offence&.offence_category&.number
   end
 
   def prompt_text_key_for(code)

--- a/app/views/external_users/claims/basic_fees/_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_fields.html.haml
@@ -8,4 +8,5 @@
 
     = f.fields_for :basic_fees, f.object.basic_fees.sort_by(&:position) do |basic_fee_fields|
       - @basic_fee_count += 1
-      = render 'external_users/claims/basic_fees/basic_fee_fields', f: basic_fee_fields
+      - if present(basic_fee_fields.object).should_be_displayed?
+        = render 'external_users/claims/basic_fees/basic_fee_fields', f: basic_fee_fields

--- a/spec/presenters/fee/basic_fee_presenter_spec.rb
+++ b/spec/presenters/fee/basic_fee_presenter_spec.rb
@@ -83,4 +83,60 @@ RSpec.describe Fee::BasicFeePresenter, type: :presenter do
       end
     end
   end
+
+  describe '#should_be_displayed?' do
+    context 'when claim is NOT under the reformed fee scheme' do
+      before do
+        allow(claim).to receive(:fee_scheme).and_return('default')
+      end
+
+      specify { expect(presenter.should_be_displayed?).to be_truthy }
+    end
+
+    context 'when claim is under the reformed fee scheme' do
+      before do
+        allow(claim).to receive(:fee_scheme).and_return('fee_reform')
+      end
+
+      context 'but fee type does not have any restrictions to be displayed' do
+        let(:fee) { build(:basic_fee, :baf_fee, claim: claim) }
+
+        specify { expect(presenter.should_be_displayed?).to be_truthy }
+      end
+
+      context 'and fee type has restrictions to be displayed' do
+        let(:fee) { build(:basic_fee, :ppe_fee, claim: claim) }
+
+        context 'and the offence category number is neither 6 or 9' do
+          let!(:offence) {
+            create(:offence, :with_fee_scheme_ten,
+                   offence_band: create(:offence_band,
+                                        offence_category: create(:offence_category, number: 2))) }
+          let(:claim) { build(:advocate_claim, offence: offence) }
+
+          specify { expect(presenter.should_be_displayed?).to be_falsey }
+        end
+
+        context 'and the offence category number is 6' do
+          let!(:offence) {
+            create(:offence, :with_fee_scheme_ten,
+                   offence_band: create(:offence_band,
+                                        offence_category: create(:offence_category, number: 6))) }
+          let(:claim) { build(:advocate_claim, offence: offence) }
+
+          specify { expect(presenter.should_be_displayed?).to be_truthy }
+        end
+
+        context 'and the offence category number is 9' do
+          let!(:offence) {
+            create(:offence, :with_fee_scheme_ten,
+                   offence_band: create(:offence_band,
+                                        offence_category: create(:offence_category, number: 9))) }
+          let(:claim) { build(:advocate_claim, offence: offence) }
+
+          specify { expect(presenter.should_be_displayed?).to be_truthy }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What

Self-descriptive.

NOTE: This only applies to claims on the new fee reform scheme.

#### Why

Outstanding change that was deliberately left behind on [ticket](https://www.pivotaltracker.com/story/show/155569366) as it was not a real blocker. 