### PR TITLE
Add injection attempt geckboard report

### DIFF
--- a/active_record test.sql
+++ b/active_record test.sql
@@ -1,0 +1,18 @@
+ActiveRecord::Base.establish_connection(
+  :adapter  => "postgresql",
+  :host     => "ar1ptn3voexnu0i.cefwt7a3h2hb.eu-west-1.rds.amazonaws.com",
+  :username => "adp_disaster",
+  :password => "uFkjagrA4rBLKpNoTfUXi9CpuobrmAfwuyVJtKQd2g",
+  :database => "adp_disaster"
+)
+
+ActiveRecord::Base.establish_connection(
+  :adapter  => "postgresql",
+  :host     => "cccd-disaster-db-restored.cefwt7a3h2hb.eu-west-1.rds.amazonaws.com",
+  :username => "adp_disaster",
+  :password => "uFkjagrA4rBLKpNoTfUXi9CpuobrmAfwuyVJtKQd2g",
+  :database => "adp_disaster"
+)
+
+ActiveRecord::Base.connection.execute("select count(*) from claims").to_a
+

--- a/lib/geckoboard_publisher/injection_attempt_report.rb
+++ b/lib/geckoboard_publisher/injection_attempt_report.rb
@@ -1,0 +1,22 @@
+module GeckoboardPublisher
+  class InjectionAttemptReport < Report
+    def initialize(start_date = Date.yesterday, end_date = nil)
+      super
+      @start_date = start_date
+      @end_date = end_date.present? ? end_date : start_date
+    end
+
+    def fields
+      [
+        Geckoboard::NumberField.new(:succeeded, name: 'Succeeded'),
+        Geckoboard::NumberField.new(:failed, name: 'Failed')
+      ]
+    end
+
+    def items
+      sets = InjectionAttempt.group(:succeeded).count
+      record = { succeeded: sets[true], failed: sets[false] }
+      [record]
+    end
+  end
+end

--- a/spec/factories/injection_attempts.rb
+++ b/spec/factories/injection_attempts.rb
@@ -17,6 +17,11 @@ FactoryBot.define do
     succeeded true
     error_messages nil
 
+    trait :with_success do
+      succeeded true
+      error_messages nil
+    end
+    
     trait :with_errors do
       succeeded false
       error_messages "{\"errors\":[ {\"error\":\"injection error 1\"},{\"error\":\"injection error 2\"}]}"

--- a/spec/lib/geckoboard_publisher/injection_attempt_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/injection_attempt_report_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe GeckoboardPublisher::InjectionAttemptReport, geckoboard: true do
+  it_behaves_like 'geckoboard publishable report'
+
+  # calls to api.geckoboard.com are stubbed in rails_helper in case future reports are generated
+
+  describe '#fields' do
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
+
+    let(:expected_fields) do
+      [
+        Geckoboard::NumberField.new(:succeeded, name: 'Succeeded'),
+        Geckoboard::NumberField.new(:failed, name: 'Failed'),
+      ].map { |field| [field.class, field.id, field.name] }
+    end
+
+    it { is_expected.to eq expected_fields }
+  end
+
+  describe '#items' do
+    subject { described_class.new.items }
+
+    let(:expected_items) { [ { succeeded: 3, failed: 2 } ] }
+
+    before do
+      create_list(:injection_attempt, 3, :with_success)
+      create_list(:injection_attempt, 2, :with_errors)
+    end
+
+    include_examples 'returns valid items structure'
+
+    context 'when run' do
+      it 'returns expected data item count' do
+        expect(subject.size).to eql 1
+      end
+
+      it { is_expected.to match_array expected_items }
+    end
+  end
+end


### PR DESCRIPTION
#### What
add a geckoboard report publisher for sending data on injection attempts

[Ticket: Report of injection errors/success](https://www.pivotaltracker.com/story/show/156566549)

#### Why
So we can switch off slack notifications to avoid flooding
the channel but retain a high level overview of injection
success and failure.

#### How
publish a dataset to geckoboard for consumption/presentation.
may change this to be a controller endpoint depending
on user requirements.

--------

#### TODO (wip)

 - [ ] add date for bar charts
 - [ ] scheduling
 - [ ] confirmation of user requirements
