### PR TITLE
Replace LGFS case uplifts with defendant uplifts

### DIFF
--- a/app/models/concerns/case_upliftable.rb
+++ b/app/models/concerns/case_upliftable.rb
@@ -3,9 +3,9 @@
 # important for consolidating records for injection
 # into CCR.
 #
-# In addition, specific basic and fixed fee types (and one LGFS only
-# miscellaneous fee) that require additional cases are flagged
-# here for use in validation and presentation layers
+# In addition, specific basic and fixed fee types that
+# require additional cases are flagged here for use in
+# validation and presentation layers.
 #
 module CaseUpliftable
   extend ActiveSupport::Concern
@@ -22,7 +22,7 @@ module CaseUpliftable
 
   included do
     def case_uplift?
-      unique_code.in?(%w[BANOC FXNOC FXACU FXASU FXCBU FXCSU FXCDU FXENU MIUPL])
+      unique_code.in?(%w[BANOC FXNOC FXACU FXASU FXCBU FXCSU FXCDU FXENU])
     end
   end
 end

--- a/app/models/concerns/defendant_upliftable.rb
+++ b/app/models/concerns/defendant_upliftable.rb
@@ -35,7 +35,7 @@ module DefendantUpliftable
       MIUAV2: 'MIUAV4', # Unsuccessful application to vacate a guilty plea (whole day uplift)
     }.with_indifferent_access.freeze
 
-    ORPHAN_DEFENDANT_UPLIFTS = %w[BANDR FXNDR].freeze
+    ORPHAN_DEFENDANT_UPLIFTS = %w[BANDR FXNDR MIUPL].freeze
 
     def defendant_uplifts
       where(unique_code: defendant_uplift_unique_codes)

--- a/app/presenters/fee/misc_fee_type_presenter.rb
+++ b/app/presenters/fee/misc_fee_type_presenter.rb
@@ -1,3 +1,4 @@
+# TODO: no misc fees are case uplifts any longer, remove whole class
 class Fee::MiscFeeTypePresenter < BasePresenter
   presents :fee_type
 

--- a/app/services/cclf/fee/misc_fee_adapter.rb
+++ b/app/services/cclf/fee/misc_fee_adapter.rb
@@ -1,7 +1,7 @@
 module CCLF
   module Fee
     class MiscFeeAdapter < MappingBillAdapter
-      # TODO: MIUPL - Case uplift - no equivalent in LGFS - to be removed from app too?!
+      # TODO: MIUPL - Defendant uplift (repurposed) - quantity used in CCLF to calculate an uplift
       MISC_FEE_BILL_MAPPINGS = {
         MICJA: zip(%w[OTHER COST_JUDGE_FEE]), # Costs judge application
         MICJP: zip(%w[OTHER COST_JUD_EXP]), # Costs judge preparation

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -82,8 +82,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
   def defendant_uplifts
     (@record.basic_fees + @record.fixed_fees + @record.misc_fees).select do |fee|
       !fee.marked_for_destruction? &&
-        fee.fee_type &&
-        Fee::BaseFeeType.defendant_uplift_unique_codes.include?(fee.fee_type.unique_code)
+        fee&.defendant_uplift?
     end
   end
 

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -12,10 +12,6 @@ module Fee
 
       private
 
-      # NOTE: LGFS fee of MIUPL/XUPL implements similar logic
-      # but does not require a quantity and therefore
-      # cannot implement the quantity mismatch validation.
-      #
       # TODO: At time of writing the AGFS case uplift fee types are
       # not requiring case numbers due to impact on the API
       # but this SHOULD change for CCR compatability.

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -4,25 +4,17 @@
 
   .form-group.misc-fee-group.js-block.nested-fields.fx-fee-group{data:{"type": "miscFees", autovat: @claim.apply_vat? ? "true" : "false"}}
     .grid-row.js-typeahead
-      .column-three-quarters
-        .column-half{class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")}
-          %label.form-label
-            = t('.fee_type')
-            %span.form-hint.xsmall.zero-vert-margin
-              &nbsp;<br/>
-          %a{id: "misc_fee_#{@misc_fee_count}_fee_type"}
-          - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
-          = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, { include_blank: ''.html_safe }, {class: 'form-control typeahead js-misc-fee-type js-fee-type', style: 'width:100%'}
-          = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
+      .column-two-thirds{class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")}
+        %label.form-label
+          = t('.fee_type')
+          %span.form-hint.xsmall.zero-vert-margin
+            &nbsp;<br/>
+        %a{id: "misc_fee_#{@misc_fee_count}_fee_type"}
+        - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
+        = f.select :fee_type_id, misc_fee_types_collection.map {|fee| [fee.description, fee.id, { data: fee.data_attributes }]}, { include_blank: ''.html_safe }, {class: 'form-control typeahead js-misc-fee-type js-fee-type', style: 'width:100%'}
+        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
-        .column-half
-          = f.adp_text_field :case_numbers,
-                              label: t('.case_numbers'),
-                              input_classes:'js-misc-fee-case-numbers fx-fee-case-numbers',
-                              hint_text:'Separate by commas',
-                              errors: @error_presenter
-
-      .column-one-quarter.fee-rate.margin-spacer-sm
+      .column-one-third.fee-rate.margin-spacer-sm
         = f.adp_text_field :amount,
                             label: t('.amount'),
                             input_classes:'total',

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -26,6 +26,22 @@
       endpoint to test your submissions against.  This will return any validation errors that will prevent the record being created on the creation endpoint.
 
   %hr
+  %h2 10 April 208
+  %ul.list-bullet
+    %li
+      The LGFS Miscellaneous fee "Case uplift" is being repurposed as a "Defendant uplift"
+      %br/
+      %br/
+      This release changes the LGFS only miscellaneous fee type "Case uplift" with a unique code of
+      %code.code
+        MIUPL
+      to be a Defendant uplift. This means the fee no longer requires case numbers to be supplied
+      %br/
+      %br/
+      This change encapsulates two distinct changes, namely, Case uplifts are not applicable to LGFS
+      claims and Defendant uplifts can be claimed.
+
+  %hr
   %h2 23 March 2018
   %ul.list-bullet
     %li

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -1,6 +1,23 @@
 = render partial: 'layouts/header', locals: {page_heading: 'API release notes'}
 
 %section.api-documentation
+
+  %hr
+  %h2 12 April 2018
+  %ul.list-bullet
+    %li
+      The LGFS Miscellaneous fee "Case uplift" is being repurposed as a "Defendant uplift"
+      %br/
+      %br/
+      This release changes the LGFS only miscellaneous fee type "Case uplift" with a unique code of
+      %code.code
+        MIUPL
+      to be a Defendant uplift. This means the fee no longer requires case numbers to be supplied.
+      %br/
+      %br/
+      This change encapsulates two distinct changes, namely, Case uplifts are not applicable to LGFS
+      claims and Defendant uplifts can be claimed.
+
   %hr
   %h2 6 April 2018
   %ul.list-bullet
@@ -24,22 +41,6 @@
       %code.code
         \/api/external_users/claims/advocates/interim/validate
       endpoint to test your submissions against.  This will return any validation errors that will prevent the record being created on the creation endpoint.
-
-  %hr
-  %h2 10 April 208
-  %ul.list-bullet
-    %li
-      The LGFS Miscellaneous fee "Case uplift" is being repurposed as a "Defendant uplift"
-      %br/
-      %br/
-      This release changes the LGFS only miscellaneous fee type "Case uplift" with a unique code of
-      %code.code
-        MIUPL
-      to be a Defendant uplift. This means the fee no longer requires case numbers to be supplied
-      %br/
-      %br/
-      This change encapsulates two distinct changes, namely, Case uplifts are not applicable to LGFS
-      claims and Defendant uplifts can be claimed.
 
   %hr
   %h2 23 March 2018

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -49,9 +49,13 @@ defendant:
 base:
   _seq: 5
   defendant_uplifts_mismatch:
-    long: The quantity of defendant uplifts exceeds the number of defendants
+    long: The quantity of defendant uplifts exceeds the number of additional defendants
     short: Too many defendant uplifts
-    api: Defendant uplift sums must match number of defendants
+    api: Defendant uplift sums must match number of additional defendants
+  lgfs_defendant_uplifts_mismatch:
+    long: The number of defendant uplifts exceeds the number of additional defendants
+    short: Too many defendant uplifts
+    api: Defendant uplift record counts must match number of additional defendants
   unclaimable:
     long: You cannot submit an interim bill for claims with the earliest representation order before 1 April 2018
     short: Earliest representation order before 1 April 2018

--- a/db/migrate/20180409091300_modify_fee_type_case_uplift.rb
+++ b/db/migrate/20180409091300_modify_fee_type_case_uplift.rb
@@ -1,15 +1,16 @@
 class ModifyFeeTypeCaseUplift < ActiveRecord::Migration
   # repurpose LGFS case uplift as defendant uplift
-  #
+  # NOTE: smoke test on dev build of branch means we
+  # need to cater for type not existing
   def up
     Fee::MiscFeeType
-      .find_by(unique_code: 'MIUPL')
-      .update(description: 'Defendant uplift')
+      .where(unique_code: 'MIUPL')
+      .update_all(description: 'Defendant uplift')
   end
 
   def down
     Fee::MiscFeeType
-      .find_by(unique_code: 'MIUPL')
-      .update(description: 'Case uplift')
+      .where(unique_code: 'MIUPL')
+      .update_all(description: 'Case uplift')
   end
 end

--- a/db/migrate/20180409091300_modify_fee_type_case_uplift.rb
+++ b/db/migrate/20180409091300_modify_fee_type_case_uplift.rb
@@ -1,0 +1,15 @@
+class ModifyFeeTypeCaseUplift < ActiveRecord::Migration
+  # repurpose LGFS case uplift as defendant uplift
+  #
+  def up
+    Fee::MiscFeeType
+      .find_by(unique_code: 'MIUPL')
+      .update(description: 'Defendant uplift')
+  end
+
+  def down
+    Fee::MiscFeeType
+      .find_by(unique_code: 'MIUPL')
+      .update(description: 'Case uplift')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180329145753) do
+ActiveRecord::Schema.define(version: 20180409091300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/static.sql
+++ b/db/static.sql
@@ -634,7 +634,7 @@ COPY fee_types (id, description, code, created_at, updated_at, max_amount, calcu
 87	Evidence provision fee	XEVI	2016-04-11 18:04:55.577483	2016-10-26 19:59:46.684919	\N	f	Fee::MiscFeeType	---\n- lgfs\n	\N	f	MIEVI
 88	Costs judge application	XCJA	2016-04-11 18:04:55.587708	2016-10-26 19:59:46.692956	\N	f	Fee::MiscFeeType	---\n- lgfs\n	\N	f	MICJA
 89	Costs judge preparation	XCJP	2016-04-11 18:04:55.597252	2016-10-26 19:59:46.701265	\N	f	Fee::MiscFeeType	---\n- lgfs\n	\N	f	MICJP
-90	Case uplift	XUPL	2016-04-11 18:04:55.606936	2016-10-26 19:59:46.710336	\N	f	Fee::MiscFeeType	---\n- lgfs\n	\N	f	MIUPL
+90	Defendant uplift	XUPL	2016-04-11 18:04:55.606936	2016-10-26 19:59:46.710336	\N	f	Fee::MiscFeeType	---\n- lgfs\n	\N	f	MIUPL
 91	Warrant Fee	XWAR	2016-04-11 18:04:55.620925	2016-10-26 19:59:46.726819	\N	f	Fee::WarrantFeeType	---\n- lgfs\n	\N	f	WARR
 1	Basic fee	BAF	2015-11-05 17:08:50.446583	2016-10-26 19:59:45.789211	9999.0	t	Fee::BasicFeeType	---\n- agfs\n	\N	f	BABAF
 3	Daily attendance fee (41 to 50)	DAH	2015-11-05 17:08:50.46179	2016-10-26 19:59:45.811226	9999.0	t	Fee::BasicFeeType	---\n- agfs\n	\N	f	BADAH

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -43,7 +43,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     Then I click "Continue" in the claim form
 
     And I add a miscellaneous fee 'Costs judge application'
-    And I add a Case uplift fee with case numbers 'A20161234, A20165588'
+    And I add a miscellaneous fee 'Defendant uplift'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -48,7 +48,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     Then I click "Continue" in the claim form
 
     And I add a miscellaneous fee 'Costs judge application'
-    And I add a Case uplift fee with case numbers 'A20161234, A20165588'
+    And I add a miscellaneous fee 'Defendant uplift'
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -55,7 +55,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     Then I click "Continue" in the claim form
 
     And I add a miscellaneous fee 'Costs judge application'
-    And I add a Case uplift fee with case numbers 'A20161234, A20165588'
+    And I add a miscellaneous fee 'Defendant uplift'
 
     Then I click "Continue" in the claim form
 

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -41,11 +41,6 @@ And(/^I add a miscellaneous fee '(.*)'$/) do |name|
   @litigator_claim_form_page.miscellaneous_fees.last.amount.set "135.78"
 end
 
-And(/^I add a Case uplift fee with case numbers '(.*)'$/) do |case_numbers|
-  step "I add a miscellaneous fee 'Case uplift'"
-  @litigator_claim_form_page.miscellaneous_fees.last.case_numbers.set case_numbers
-end
-
 And(/^I add (?:a|another) disbursement '(.*)' with net amount '(.*)' and vat amount '(.*)'$/) do |name, net_amount, vat_amount|
   @litigator_claim_form_page.add_disbursement_if_required
   @litigator_claim_form_page.disbursements.last.select_fee_type name

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -86,7 +86,7 @@ ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUAN
 87,Evidence provision fee,XEVI,MIEVI,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
 88,Costs judge application,XCJA,MICJA,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
 89,Costs judge preparation,XCJP,MICJP,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
-90,Case uplift,XUPL,MIUPL,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
+90,Defendant uplift,XUPL,MIUPL,,FALSE,Fee::MiscFeeType,lgfs,,FALSE,
 91,Warrant Fee,XWAR,WARR,,FALSE,Fee::WarrantFeeType,lgfs,,FALSE,
 92,Contempt,ZCON,FXCON,,TRUE,Fee::FixedFeeType,agfs,,FALSE,
 93,Effective PCMH,IPCMH,INPCM,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -165,19 +165,18 @@ describe API::V1::ExternalUsers::Fee do
         end
       end
 
-      context 'misc fees of type case uplift' do
+      context 'misc fees of type defendant uplift' do
         context "LGFS fees" do
           let(:claim) { create(:litigator_claim, source: 'api') }
-          let!(:valid_params) { { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_xupl_type.id, amount: 210, case_numbers: 'T20161234' } }
+          let!(:valid_params) { { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_xupl_type.id, amount: 210 } }
 
-          it 'creates the misc fee with the provided amount and case numbers' do
+          it 'creates the misc fee with the provided amount' do
             post_to_create_endpoint
             json = JSON.parse(last_response.body)
             fee = Fee::MiscFee.find_by(uuid: json['id'])
             expect(fee.claim_id).to eq claim.id
             expect(fee.fee_type_id).to eq misc_fee_xupl_type.id
             expect(fee.amount).to eq 210.00
-            expect(fee.case_numbers).to eq 'T20161234'
           end
         end
       end
@@ -188,7 +187,7 @@ describe API::V1::ExternalUsers::Fee do
         { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_type.id, quantity: 3, rate: 50.00 }
       end
 
-      it 'THE basic fee should raise basic fee (code BAF) errors' do
+      it 'basic (code BAF) fee should raise basic fee errors' do
         valid_params.delete(:rate)
         valid_params[:fee_type_id] = basic_fee_type.id
         basic_fee_type.update(code: 'BAF') # need to use real basic fee codes to trigger code specific validation and errors
@@ -206,19 +205,6 @@ describe API::V1::ExternalUsers::Fee do
         post_to_create_endpoint
         expect(last_response.status).to eq 400
         expect_error_response("Pages of prosecution evidence fees must not have a rate",0)
-      end
-
-      context "LGFS fee" do
-        let(:claim) { create(:litigator_claim, source: 'api') }
-        let!(:valid_params) do
-          { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_xupl_type.id, amount: 210.0 }
-        end
-
-        it 'should raise error if case numbers are not provided for miscellaneous fee of type Case Uplift' do
-          post_to_create_endpoint
-          expect(last_response.status).to eq 400
-          expect_error_response("Enter at least one case number for the miscellaneous fee",0)
-        end
       end
 
       context 'quantity is forbidden' do

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       after(:build) do |claim|
         claim.fees.destroy_all
       end
+
+      after(:create) do |claim|
+        claim.fees.destroy_all
+      end
     end
 
     trait :graduated_fee do

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -132,7 +132,7 @@ FactoryBot.define do
 
       trait :miupl do
         lgfs
-        description 'Case uplift'
+        description 'Defendant uplift'
         code 'XUPL'
         unique_code 'MIUPL'
         quantity_is_decimal true

--- a/spec/models/fee/basic_fee_spec.rb
+++ b/spec/models/fee/basic_fee_spec.rb
@@ -20,32 +20,31 @@
 #
 
 require 'rails_helper'
+require_relative 'shared_examples_for_defendant_uplifts'
 
-module Fee
-  describe BasicFee do
-    it { should belong_to(:fee_type) }
+RSpec.describe Fee::BasicFee do
+  it { should belong_to(:fee_type) }
+  it { should validate_presence_of(:claim).with_message('blank')}
+  it { should validate_presence_of(:fee_type).with_message('blank') }
 
-    it { should validate_presence_of(:claim).with_message('blank')}
+  include_examples '#defendant_uplift?'
 
-    it { should validate_presence_of(:fee_type).with_message('blank') }
-
-    describe 'default scope' do
-      it 'should order by claim id and fee type id ascending' do
-        expect(Fee::BasicFee.all.to_sql).to include("ORDER BY \"fees\".\"claim_id\" ASC, \"fees\".\"fee_type_id\" ASC")
-      end
+  describe 'default scope' do
+    it 'should order by claim id and fee type id ascending' do
+      expect(Fee::BasicFee.all.to_sql).to include("ORDER BY \"fees\".\"claim_id\" ASC, \"fees\".\"fee_type_id\" ASC")
     end
+  end
 
-    describe '#calculated?' do
-      it 'should return false for fees flagged as uncalculated' do
-        ppe = FactoryBot.create(:basic_fee_type, code: 'PPE', calculated: false)
-        fee = FactoryBot.create(:basic_fee, fee_type: ppe)
-        expect(fee.calculated?).to be false
-      end
-      it 'should return true for any other fees' do
-        saf = FactoryBot.create(:basic_fee_type,  code: 'SAF')
-        fee = FactoryBot.create(:basic_fee, fee_type: saf)
-        expect(fee.calculated?).to be true
-      end
+  describe '#calculated?' do
+    it 'should return false for fees flagged as uncalculated' do
+      ppe = FactoryBot.create(:basic_fee_type, code: 'PPE', calculated: false)
+      fee = FactoryBot.create(:basic_fee, fee_type: ppe)
+      expect(fee.calculated?).to be false
+    end
+    it 'should return true for any other fees' do
+      saf = FactoryBot.create(:basic_fee_type,  code: 'SAF')
+      fee = FactoryBot.create(:basic_fee, fee_type: saf)
+      expect(fee.calculated?).to be true
     end
   end
 end

--- a/spec/models/fee/fixed_fee_spec.rb
+++ b/spec/models/fee/fixed_fee_spec.rb
@@ -20,13 +20,12 @@
 #
 
 require 'rails_helper'
+require_relative 'shared_examples_for_defendant_uplifts'
 
-module Fee
-  describe FixedFee do 
-    it { should belong_to(:fee_type) }
+RSpec.describe Fee::FixedFee do
+  it { should belong_to(:fee_type) }
+  it { should validate_presence_of(:claim).with_message('blank')}
+  it { should validate_presence_of(:fee_type).with_message('blank') }
 
-    it { should validate_presence_of(:claim).with_message('blank')}
-
-    it { should validate_presence_of(:fee_type).with_message('blank') }
-  end
+  include_examples '#defendant_uplift?'
 end

--- a/spec/models/fee/misc_fee_spec.rb
+++ b/spec/models/fee/misc_fee_spec.rb
@@ -22,21 +22,17 @@
 require 'rails_helper'
 require_relative 'shared_examples_for_defendant_uplifts'
 
-module Fee
-  describe MiscFee do
-    it { should belong_to(:fee_type) }
-    it { should validate_presence_of(:claim).with_message('blank') }
-    it { should validate_presence_of(:fee_type).with_message('blank') }
+RSpec.describe Fee::MiscFee do
+  it { should belong_to(:fee_type) }
+  it { should validate_presence_of(:claim).with_message('blank') }
+  it { should validate_presence_of(:fee_type).with_message('blank') }
 
-    let(:fee_type) { instance_double('fee_type') }
+  include_examples '#defendant_uplift?'
+  include_examples '.defendant_uplift_sums'
 
-    include_examples '#defendant_uplift?'
-    include_examples '.defendant_uplift_sums'
-
-    describe '#is_misc?' do
-      it 'returns true' do
-        expect(build(:misc_fee).is_misc?).to be true
-      end
+  describe '#is_misc?' do
+    it 'returns true' do
+      expect(build(:misc_fee).is_misc?).to be true
     end
   end
 end

--- a/spec/models/fee/misc_fee_type_spec.rb
+++ b/spec/models/fee/misc_fee_type_spec.rb
@@ -44,13 +44,9 @@ module Fee
     describe '#case_uplift?' do
       subject { fee_type.case_uplift? }
 
-      it 'returns true when fee_type is Case Uplift' do
-        fee_type.unique_code = 'MIUPL'
-        is_expected.to be_truthy
-      end
-
+      # No Misc fees are case uplifts
       it 'returns false when fee_type is not Case Uplift' do
-        fee_type.code = 'XXX'
+        fee_type.code = 'MIUPL'
         is_expected.to be_falsey
       end
     end

--- a/spec/models/fee/shared_examples_for_case_uplifts.rb
+++ b/spec/models/fee/shared_examples_for_case_uplifts.rb
@@ -5,7 +5,7 @@ shared_examples 'case upliftable' do
     subject { fee_type.case_uplift? }
 
     context 'for fees that require additional case numbers' do
-      %w[BANOC FXNOC FXACU FXASU FXCBU FXCSU FXCDU FXENU MIUPL].each do |unique_code|
+      %w[BANOC FXNOC FXACU FXASU FXCBU FXCSU FXCDU FXENU].each do |unique_code|
         before { allow(fee_type).to receive(:unique_code).and_return unique_code }
 
         it "#{unique_code} should return true" do

--- a/spec/models/fee/shared_examples_for_defendant_uplifts.rb
+++ b/spec/models/fee/shared_examples_for_defendant_uplifts.rb
@@ -4,6 +4,8 @@ shared_examples '#defendant_uplift?' do
       allow(subject).to receive(:fee_type).and_return fee_type
     end
 
+    let(:fee_type) { instance_double('fee_type') }
+
     it 'delegates to fee type' do
       expect(fee_type).to receive(:defendant_uplift?)
       subject.defendant_uplift?
@@ -12,17 +14,19 @@ shared_examples '#defendant_uplift?' do
 end
 
 shared_examples '.defendant_uplift_sums' do
-  describe '.defendant_uplift_sums' do
-    subject { described_class.defendant_uplift_sums }
-    let(:claim) { create(:claim) }
-    let(:miahu) { create(:misc_fee_type, :miahu) }
+  context 'miscellaneous fees' do
+    describe '.defendant_uplift_sums' do
+      subject { described_class.defendant_uplift_sums }
+      let(:claim) { create(:claim) }
+      let(:miahu) { create(:misc_fee_type, :miahu) }
 
-    before do
-      create(:misc_fee, fee_type: miahu, claim: claim, quantity: 3, amount: 21.01)
-    end
+      before do
+        create(:misc_fee, fee_type: miahu, claim: claim, quantity: 3, amount: 21.01)
+      end
 
-    it 'returns hash of sums grouped by fee\'s unique_code' do
-      is_expected.to eql({ "MIAHU" => 3 })
+      it 'returns hash of sums grouped by fee\'s unique_code' do
+        is_expected.to eql({ "MIAHU" => 3 })
+      end
     end
   end
 end
@@ -37,7 +41,7 @@ shared_examples 'defendant upliftable' do
     end
 
     it 'returns false when fee_type is not a defendant uplift' do
-      fee_type.unique_code = 'MIUPL'
+      fee_type.unique_code = 'MIAPH'
       is_expected.to be_falsey
     end
   end

--- a/spec/presenters/misc_fee_type_presenter_spec.rb
+++ b/spec/presenters/misc_fee_type_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
+# TODO: no misc fees are case uplifts any longer, remove whole class and spec
 RSpec.describe Fee::MiscFeeTypePresenter do
-
   let(:fee_type)  { build :misc_fee_type }
   let(:presenter) { described_class.new(fee_type, view) }
 
@@ -12,7 +12,7 @@ RSpec.describe Fee::MiscFeeTypePresenter do
       end
 
       it 'returns true when is Case uplift' do
-        fee_type.unique_code = 'MIUPL'
+        allow(fee_type).to receive(:case_uplift?).and_return true
         expect(presenter.data_attributes[:case_numbers]).to be_truthy
       end
     end

--- a/spec/services/cclf/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/cclf/fee/misc_fee_adapter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CCLF::Fee::MiscFeeAdapter, type: :adapter do
   # *nb: formula is used CCLF-side only and maps to whether to use quantity or amount???
   #
   MISC_FEE_BILL_TYPES = {
-    # MIUPL: [nil, nil], # Case uplift - no equivalent in LGFS - to be removed from app too?!
+    # MIUPL: [nil, nil], # Defendant uplift - handled via actual defendants on claim at point of injection
     MICJA: ['OTHER', 'COST_JUDGE_FEE'], # Costs judge application
     MICJP: ['OTHER', 'COST_JUD_EXP'], # Costs judge preparation
     MIEVI: ['EVID_PROV_FEE', 'EVID_PROV_FEE'], # Evidence provision fee

--- a/spec/support/api/claims/final_claim_test.rb
+++ b/spec/support/api/claims/final_claim_test.rb
@@ -71,13 +71,12 @@ class FinalClaimTest < BaseClaimTest
   end
 
   def misc_fee_data
-    fee_type_id = json_value_at_index(client.get_dropdown_endpoint(FEE_TYPE_ENDPOINT, api_key, category: 'misc', role: 'lgfs'), 'id') # Case Uplift
+    fee_type_id = json_value_at_index(client.get_dropdown_endpoint(FEE_TYPE_ENDPOINT, api_key, category: 'misc', role: 'lgfs'), 'id') # Costs judge application
 
     {
       "api_key": api_key,
       "claim_id": claim_uuid,
       "fee_type_id": fee_type_id,
-      "case_numbers": 'A20161234',
       "amount": 200.45
     }
   end

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -1,4 +1,4 @@
-  require 'rails_helper'
+require 'rails_helper'
 require_relative 'shared_examples_for_advocate_litigator'
 require_relative 'shared_examples_for_step_validators'
 
@@ -6,7 +6,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
   include_context "force-validation"
 
   let(:litigator) { build(:external_user, :litigator) }
-  let(:claim)     { create(:litigator_claim) }
+  let(:claim) { create(:litigator_claim) }
 
   include_examples "common advocate litigator validations", :litigator
   include_examples "common litigator validations"
@@ -24,6 +24,138 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
     [],
     %i[offence],
     %i[actual_trial_length],
+    %i[defendant_uplifts],
     %i[total]
   ]
+
+  describe '#validate_defendant_uplifts' do
+    let(:claim) { create(:litigator_claim, :without_fees) }
+    let(:miupl) { create(:misc_fee_type, :miupl) }
+
+    before do
+      create(:misc_fee, fee_type: miupl, claim: claim, quantity: 0, amount: 250.01)
+      claim.reload
+      claim.form_step = :miscellaneous_fees
+    end
+
+    it 'test setup' do
+      expect(claim.defendants.size).to eql 1
+      expect(claim.misc_fees.size).to eql 1
+      expect(claim.misc_fees.first.fee_type).to have_attributes(unique_code: 'MIUPL')
+    end
+
+    context 'with 1 defendant' do
+      context 'when there are 0 defendant uplift fees' do
+        before { claim.misc_fees.delete_all }
+
+        it 'test setup' do
+          expect(claim.defendants.size).to eql 1
+          expect(claim.misc_fees).to be_empty
+        end
+
+        it 'should not error' do
+          should_not_error(claim, :base)
+        end
+      end
+
+      context 'when there is 1 defendant uplift fee' do
+        it 'test setup' do
+          expect(claim.defendants.size).to eql 1
+          expect(claim.misc_fees.map { |f| f.fee_type.unique_code }.sort).to eql(%w[MIUPL])
+        end
+
+        it 'should error' do
+          should_error_with(claim, :base, 'lgfs_defendant_uplifts_mismatch')
+        end
+
+        context 'when from api' do
+          before do
+            allow(claim).to receive(:from_api?).and_return true
+          end
+
+         it 'should not error' do
+            should_not_error(claim, :base)
+          end
+        end
+      end
+    end
+
+    context 'with 2 defendants' do
+      before do
+        create(:defendant, claim: claim)
+      end
+
+      context 'when there is 1 defendant uplift fee' do
+        it 'test setup' do
+          expect(claim.defendants.size).to eql 2
+          expect(claim.misc_fees.map { |f| f.fee_type.unique_code }.sort).to eql(%w[MIUPL])
+        end
+
+        it 'should not error' do
+          should_not_error(claim, :base)
+        end
+      end
+
+      context 'when there are multiple defendant uplifts (2 or more), per fee type' do
+        before do
+          create_list(:misc_fee, 2, fee_type: miupl, claim: claim, quantity: 0, amount: 21.01)
+        end
+
+        it 'test setup' do
+          expect(claim.defendants.size).to eql 2
+          expect(claim.misc_fees.map { |f| f.fee_type.unique_code }.sort).to eql(%w[MIUPL MIUPL MIUPL])
+        end
+
+        it 'should add one error only' do
+          should_error_with(claim, :base, 'lgfs_defendant_uplifts_mismatch')
+          expect(claim.errors[:base].size).to eql 1
+        end
+      end
+    end
+
+    context 'defendant uplifts fee marked for destruction' do
+      it 'test setup' do
+        expect(claim.defendants.size).to eql 1
+        expect(claim.misc_fees.map { |f| f.fee_type.unique_code }.sort).to eql(%w[MIUPL])
+        expect(claim).to be_invalid
+      end
+
+      it 'are ignored' do
+        miupl_fee = claim.fees.joins(:fee_type).where(fee_type: { unique_code: 'MIUPL' }).first
+        claim.update_attributes(
+          :misc_fees_attributes => {
+            '0' => {
+              'id' => miupl_fee.id,
+              '_destroy' => '1'
+            }
+          }
+        )
+        expect(claim).to be_valid
+      end
+    end
+
+    context 'defendants marked for destruction' do
+      before do
+        create(:defendant, claim: claim)
+      end
+
+      it 'test setup' do
+        expect(claim.defendants.size).to eql 2
+        expect(claim.misc_fees.map { |f| f.fee_type.unique_code }.sort).to eql(%w[MIUPL])
+        expect(claim).to be_valid
+      end
+
+      it 'are ignored' do
+        claim.update_attributes(
+          :defendants_attributes => {
+            '0' => {
+              'id' => claim.defendants.first.id,
+              '_destroy' => '1'
+            }
+          }
+        )
+        expect(claim).to be_invalid
+      end
+    end
+  end
 end

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -3,16 +3,16 @@ require 'rails_helper'
 RSpec.describe Fee::MiscFeeValidator, type: :validator do
   include_context 'force-validation'
 
-  let(:fee) { FactoryBot.build :misc_fee, claim: claim }
+  let(:fee) { build :misc_fee, claim: claim }
   let(:fee_code) { fee.fee_type.code }
 
   # AGFS claims are validated as part of the base_fee_validator_spec
   #
   context 'LGFS claim' do
-    let(:claim) { FactoryBot.build :litigator_claim }
+    let(:claim) { build :litigator_claim }
 
     before(:each) do
-      fee.clear   # reset some attributes set by the factory
+      fee.clear # reset some attributes set by the factory
       fee.amount = 1.00
     end
 
@@ -45,7 +45,7 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       end
     end
 
-    context 'when misc fee is an evidence provision fee' do
+    describe '#validate_evidence_provision_fee' do
       let(:fee_type) { build :misc_fee_type, :mievi }
 
       before { allow(fee).to receive(:fee_type).and_return(fee_type) }
@@ -70,6 +70,10 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       context 'for a non Case Uplift fee type' do
         before(:each) do
           allow(fee.fee_type).to receive(:case_uplift?).and_return(false)
+        end
+
+        it 'is valid if case_numbers is absent' do
+          should_be_valid_if_equal_to_value(fee, :case_numbers, nil)
         end
 
         it 'should error if case_numbers is present' do

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
     end
 
     describe '#validate_case_numbers' do
+      # NOTE: no case uplift misc fees exist
       context 'for a non Case Uplift fee type' do
         before(:each) do
           allow(fee.fee_type).to receive(:case_uplift?).and_return(false)
@@ -73,44 +74,6 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
 
         it 'should error if case_numbers is present' do
           should_error_if_equal_to_value(fee, :case_numbers, '123', 'present')
-        end
-      end
-
-      context 'for a Case Uplift fee type' do
-        let(:fee_type) do
-          instance_double('fee_type', unique_code: 'MIUPL', case_uplift?: true, lgfs?: true, agfs?: false)
-        end
-
-        before(:each) do
-          allow(fee).to receive(:fee_type).and_return fee_type
-        end
-
-        it 'should error if case_numbers is blank' do
-          should_error_if_equal_to_value(fee, :case_numbers, '', 'blank')
-        end
-
-        it 'should error if case_numbers is invalid' do
-          should_error_if_equal_to_value(fee, :case_numbers, '123', 'invalid')
-        end
-
-        it 'should be valid for a proper case number' do
-          fee.case_numbers = 'A20161234'
-          should_not_error(fee, :case_numbers)
-        end
-
-        it 'should be valid for several proper case number' do
-          fee.case_numbers = 'A20161234,A20158888'
-          should_not_error(fee, :case_numbers)
-        end
-
-        it 'should be valid for several proper case number even with spaces between them' do
-          fee.case_numbers = 'A20161234 , A20158888'
-          should_not_error(fee, :case_numbers)
-        end
-
-        it 'should error if any case number is invalid' do
-          fee.case_numbers = 'A20161234,Z123,A20158888'
-          should_error_with(fee, :case_numbers, 'invalid')
         end
       end
     end


### PR DESCRIPTION
#### What
Replace the misc. fee type for LGFS case uplifts with defendant uplifts

[Ticket/bug](https://www.pivotaltracker.com/story/show/154606747)

#### Why
Feedback from BA and learning from Data Injection into CCLF show
that the Miscellaneous fee type "Case uplift" should not exist. 

Defendant uplifts can exist, but data injection handles defendant uplifts
based purely on the actual number of defendants provided in CCCD 
because it is a calculated fee.

#### How
Repurpose the Case uplift fee type (MIUPL) as a defendant uplift
