### PR TITLE
Optimize case workers archived claims search

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -64,13 +64,6 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
     @claims = @claims.search(search_terms, states, *search_options) unless @claims.remote?
   end
 
-  # no longer used because all claims are remote
-  # def search_options
-  #   options = [:case_number, :maat_reference, :defendant_name]
-  #   options << :case_worker_name_or_email if current_user.persona.admin?
-  #   options
-  # end
-
   def claim_params
     params.require(:claim).permit(
       :state,

--- a/app/interfaces/api/entities/claim.rb
+++ b/app/interfaces/api/entities/claim.rb
@@ -30,11 +30,11 @@ module API
       private
 
       def messages_count
-        object.messages.count
+        object.messages.size
       end
 
       def unread_messages_count(user)
-        object.unread_messages_for(user).count
+        object.unread_messages_for(user).size
       end
     end
   end

--- a/app/interfaces/api/v2/case_workers/claim.rb
+++ b/app/interfaces/api/v2/case_workers/claim.rb
@@ -52,19 +52,19 @@ module API
             end
 
             def current_claims
-              current_user.claims.caseworker_dashboard_under_assessment.search(
+              current_user.claims.search(
                 search_terms, Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES, *search_options
               )
             end
 
             def archived_claims
-              ::Claim::BaseClaim.active.caseworker_dashboard_archived.search(
+              ::Claim::BaseClaim.active.search(
                 search_terms, Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES, *search_options
               )
             end
 
             def allocated_claims
-              ::Claim::BaseClaim.active.__send__(scheme).caseworker_dashboard_under_assessment.search(
+              ::Claim::BaseClaim.active.public_send(scheme).search(
                 search_terms, Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES, *search_options
               )
             end
@@ -82,7 +82,12 @@ module API
             end
 
             def claims
-              claims_scope.sort(params.sorting, params.direction).page(params.page).per(params.limit)
+              claims_scope
+                .includes(:external_user, :case_type, :injection_attempts,
+                          :case_workers, :court, :messages,
+                          defendants: %i[representation_orders])
+                .sort(params.sorting, params.direction)
+                .page(params.page).per(params.limit)
             end
           end
 

--- a/app/models/claims/sort.rb
+++ b/app/models/claims/sort.rb
@@ -51,9 +51,9 @@ module Claims::Sort
   end
 
   def sort_case_type(direction)
-    select('claims.*, "case_types"."name" AS case_type_name')
+    select('"claims".*, "case_types"."name"')
       .joins(:case_type)
-      .order(sort_field_by('case_type_name', direction))
+      .order(sort_field_by('"case_types"."name"', direction))
   end
 
   def sort_total_inc_vat(direction)

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -14,9 +14,11 @@ FactoryBot.define do
     providers_ref       { random_providers_ref }
     disable_for_state_transition nil
     after(:create) do |claim|
-      defendant = create(:defendant, claim: claim)
-      create(:representation_order, defendant: defendant, representation_order_date: 380.days.ago)
-      claim.reload
+      unless claim.defendants.present?
+        defendant = create(:defendant, claim: claim)
+        create(:representation_order, defendant: defendant, representation_order_date: 380.days.ago)
+        claim.reload
+      end
     end
   end
 end

--- a/spec/factories/defendants.rb
+++ b/spec/factories/defendants.rb
@@ -19,11 +19,11 @@ FactoryBot.define do
     last_name                         { Faker::Name.last_name }
     date_of_birth                     30.years.ago
     order_for_judicial_apportionment  false
+    claim
     representation_orders             { [ FactoryBot.create(:representation_order, representation_order_date: 400.days.ago) ] }
 
     trait :without_reporder do
       representation_orders           { [] }
     end
   end
-
 end

--- a/spec/models/claims/search_spec.rb
+++ b/spec/models/claims/search_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe Claims::Search do
+  describe '#search' do
+    let(:searchable) { Claim::BaseClaim }
+    let(:term) { 'search_term' }
+    let(:states) { [] }
+    let(:options) { [] }
+    let(:draft_claim) { create(:litigator_claim, :draft) }
+    let(:authorised_claim) { create(:litigator_claim, :authorised) }
+    let(:part_authorised_claim) {
+      create(:litigator_claim, :part_authorised).tap do |claim|
+        create_list(:defendant, 3, claim: claim)
+      end
+    }
+    let(:rejected_claim) { create(:litigator_claim, :rejected) }
+    let(:refused_claim) {
+      create(:litigator_claim, :refused).tap do |claim|
+        create_list(:defendant, 2, claim: claim)
+      end
+    }
+    let(:archived_pending_delete_claim) { create(:litigator_claim, :archived_pending_delete) }
+
+    # NOTE: Claim::BaseClaim is including this module, hence testing
+    # it on the claim class itself
+    subject(:query) { searchable.search(term, states, *options) }
+
+    before do
+      draft_claim
+      authorised_claim
+      part_authorised_claim
+      rejected_claim
+      refused_claim
+      archived_pending_delete_claim
+    end
+
+    context 'for archived claims' do
+      let(:searchable) { Claim::BaseClaim.active.caseworker_dashboard_archived }
+      let(:states) { Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES }
+      let(:options) { %i[case_number maat_reference defendant_name] }
+
+      context 'when no search terms were provided' do
+        let(:term) { '' }
+
+        it 'does not include related filters in the SQL query' do
+          filters = [
+            /claims.case_number ILIKE/,
+            /representation_orders.maat_reference ILIKE/,
+            %r{lower(defendants.first_name || ' ' || defendants.last_name) ILIKE}
+          ]
+          filters.each do |filter|
+            expect(query.to_sql).not_to match(filter)
+          end
+        end
+
+        it 'returns all archived claims' do
+          expected_claim_ids = [authorised_claim, part_authorised_claim, rejected_claim, refused_claim, archived_pending_delete_claim].map(&:id)
+          expect(query.count).to eq(5)
+          expect(query.map(&:id)).to match_array(expected_claim_ids)
+        end
+      end
+
+      context 'when a search term is provided' do
+        let(:term) { '158' }
+        let(:draft_claim) { create(:litigator_claim, :draft, case_number: 'T20222665') }
+        let(:authorised_claim) {
+          create(:litigator_claim, :authorised, case_number: 'T20158665', defendants: [
+            create(:defendant, first_name: 'Rupert', last_name: 'Doe', representation_orders: [
+              create(:representation_order, maat_reference: '4444444444')
+            ])
+          ])
+        }
+        let(:part_authorised_claim) {
+          create(:litigator_claim, :part_authorised, case_number: 'T20444665', defendants: [
+            create(:defendant, first_name: 'First 158', representation_orders: [
+              create(:representation_order, maat_reference: '4444444111')
+            ]),
+            create(:defendant, last_name: '158 Last', representation_orders: [
+              create(:representation_order, maat_reference: '4444444222')
+            ]),
+            create(:defendant, first_name: 'John', last_name: 'Doe', representation_orders: [
+              create(:representation_order, maat_reference: '4444444333'),
+              create(:representation_order, maat_reference: '4444444666')
+            ])
+          ])
+        }
+        let(:rejected_claim) {
+          create(:litigator_claim, :rejected, case_number: 'T20999665', defendants: [
+            create(:defendant, first_name: 'Olivia', last_name: 'Doe', representation_orders: [
+              create(:representation_order, maat_reference: '5555555555')
+            ])
+          ])
+        }
+        let(:refused_claim) {
+          create(:litigator_claim, :refused, case_number: 'T20555665', defendants: [
+            create(:defendant, first_name: 'Peter', last_name: 'Doe', representation_orders: [
+              create(:representation_order, maat_reference: '7777777777')
+            ]),
+            create(:defendant, first_name: 'Silvia', last_name: 'Doe', representation_orders: [
+              create(:representation_order, maat_reference: '9999999999')
+            ])
+          ])
+        }
+        let(:archived_pending_delete_claim) {
+          create(:litigator_claim, :archived_pending_delete, case_number: 'T20111665', defendants: [
+            create(:defendant, first_name: 'Jane', last_name: 'Doe', representation_orders: [
+              create(:representation_order, maat_reference: '1111158')
+            ])
+          ])
+        }
+
+        it 'includes related filters in the SQL query' do
+          filters = [
+            /claims.case_number ILIKE '%#{term}%'/,
+            /representation_orders.maat_reference ILIKE '%#{term}%'/,
+            /lower\(defendants.first_name || ' ' || defendants.last_name\) ILIKE '%#{term}%'/
+          ]
+          filters.each do |filter|
+            expect(query.to_sql).to match(filter)
+          end
+        end
+
+        it 'returns all matching archived claims' do
+          expected_claim_ids = [authorised_claim, part_authorised_claim, archived_pending_delete_claim].map(&:id)
+          expect(query.count).to eq(3)
+          expect(query.map(&:id)).to match_array(expected_claim_ids)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

Optimize case workers archived claims search

Also:
- Clean up some of the factory creation bad patterns to avoid side
effects on after creation

#### Ticket

[Caseworker admin archive 500 internal server error](https://www.pivotaltracker.com/n/projects/1985371/stories/156224498)

#### Why

As described in the Pivotal Tracker ticket, this page is raising a lot of exceptions, namely `Net::ReadTimeout` mainly todo with un-optimized SQL queries that take too long to return results

#### How

Re-structuring the way the SQL is performed:
- Does not included any filtering when it's not needed (which was creating very un-optmized queries such `field ILIKE '%%'`)
- Replaces the use of `SELECT DISTINCT` in favour of `GROUP BY`, as the `SELECT DISTINCT` produced by Rails was perform `SELECT DISTINCT` on all the claim fields, turning the query plan into a very complicated one. The `GROUP BY` in this case achieves the same by group by claim.id which are already unique anyway.
- Removes duplicate filters injected by status scopes. The `search` method enforces a `states` param to be passed in, which in all the cases, created the same filter as the one defined by the status scope.
- API Eager loads most of the resources associated with the claims to avoid `N+1` queries.
