### PR TITLE
Change copy for trial dates/ rep order dates error checks

### DIFF
--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -16,8 +16,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         trial_fixed_notice_at
         trial_fixed_at
         trial_cracked_at
-        first_day_of_trial
-        trial_concluded_at
+        trial_dates
         retrial_started_at
         retrial_concluded_at
         case_concluded_at

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -15,9 +15,8 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
       defendants: [],
       offence_details: %i[offence],
       interim_fees: %i[
-        first_day_of_trial
+        trial_dates
         estimated_trial_length
-        trial_concluded_at
         retrial_started_at
         retrial_estimated_length
         effective_pcmh_date
@@ -35,6 +34,11 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
 
   def validate_case_concluded_at
     validate_absence(:case_concluded_at, 'present')
+  end
+
+  def validate_trial_dates
+    validate_first_day_of_trial
+    validate_trial_concluded_at
   end
 
   def validate_first_day_of_trial

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -169,9 +169,9 @@ first_day_of_trial:
     short: *too_far_in_past
     api: 'Check the date for "First day of trial"'
   check_not_earlier_than_rep_order:
-    long: 'Check the date for "First day of trial"'
-    short: *before_rep_order
-    api: 'Check the date for "First day of trial"'
+    long: 'Check the combination of the representation order date and the dates of trial'
+    short: 'Check combination of representation order date and trial dates'
+    api: 'Check combination of rep order date and trial dates'
   invalid_date:
     long: Enter a valid date for the first day of trial
     short: *enter_valid_date
@@ -226,9 +226,9 @@ trial_concluded_at:
     short: *too_far_in_past
     api: 'Check the date for "Trial concluded"'
   check_not_earlier_than_rep_order:
-    long: 'Check the date for "Trial concluded"'
-    short: *before_rep_order
-    api: 'Check the date for "Trial concluded"'
+    long: 'Check the combination of the representation order date and the dates of trial'
+    short: 'Check combination of representation order date and trial dates'
+    api: 'Check combination of rep order date and trial dates'
   invalid_date:
     long: 'Enter a valid date for trial concluded'
     short: *enter_valid_date

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -338,8 +338,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
           trial_fixed_notice_at
           trial_fixed_at
           trial_cracked_at
-          first_day_of_trial
-          trial_concluded_at
+          trial_dates
           retrial_started_at
           retrial_concluded_at
           case_concluded_at

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -600,7 +600,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       before { contempt_claim_with_nil_first_day.force_validation = true }
       it { should_error_if_not_present(contempt_claim_with_nil_first_day, :first_day_of_trial, "blank", translated_message: 'Enter a date') }
       it { should_errror_if_later_than_other_date(contempt_claim_with_nil_first_day, :first_day_of_trial, :trial_concluded_at, 'check_other_date', translated_message: 'Can\'t be after the date "Trial concluded"') }
-      it { should_error_if_earlier_than_earliest_repo_date(contempt_claim_with_nil_first_day, :first_day_of_trial, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
+      it { should_error_if_earlier_than_earliest_repo_date(contempt_claim_with_nil_first_day, :first_day_of_trial, 'check_not_earlier_than_rep_order', translated_message: 'Check combination of representation order date and trial dates') }
       it { should_error_if_too_far_in_the_past(contempt_claim_with_nil_first_day, :first_day_of_trial, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
     end
 
@@ -609,7 +609,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       before { contempt_claim_with_nil_concluded_at.force_validation = true }
       it { should_error_if_not_present(contempt_claim_with_nil_concluded_at, :trial_concluded_at, "blank", translated_message: 'Enter a date') }
       it { should_error_if_earlier_than_other_date(contempt_claim_with_nil_concluded_at, :trial_concluded_at, :first_day_of_trial, 'check_other_date', translated_message: 'Can\'t be before the "First day of trial"') }
-      it { should_error_if_earlier_than_earliest_repo_date(contempt_claim_with_nil_concluded_at, :trial_concluded_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
+      it { should_error_if_earlier_than_earliest_repo_date(contempt_claim_with_nil_concluded_at, :trial_concluded_at, 'check_not_earlier_than_rep_order', translated_message: 'Check combination of representation order date and trial dates') }
       it { should_error_if_too_far_in_the_past(contempt_claim_with_nil_concluded_at, :trial_concluded_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
     end
   end

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -24,9 +24,8 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
     [],
     %i[offence],
     %i[
-      first_day_of_trial
+      trial_dates
       estimated_trial_length
-      trial_concluded_at
       retrial_started_at
       retrial_estimated_length
       effective_pcmh_date


### PR DESCRIPTION
#### What

- It only displays a single error instead of the current two (for each of
the trial dates)
- Changed the wording for the error message displayed in both cases

#### Ticket

[Validation error messaging - defendant details page](https://www.pivotaltracker.com/n/projects/2145949/stories/155852933)