### PR TITLE
Fix ordering issue introduced in #2316

### DIFF
--- a/app/interfaces/api/v2/case_workers/claim.rb
+++ b/app/interfaces/api/v2/case_workers/claim.rb
@@ -52,9 +52,9 @@ module API
             end
 
             def current_claims
-              current_user.claims.search(
+              current_user.claims.where(id: ::Claim::BaseClaim.search(
                 search_terms, Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES, *search_options
-              )
+              ))
             end
 
             def archived_claims


### PR DESCRIPTION
#### What

Relates to https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/2316

When searching for claims assigned to a particular user the query performed was setting query params in the wrong order (the way Rails composes the final SQL).

This gets around that by scoping the user claims to the subquery results of the search.

#### Why

When on "Your claims" page, ordering by "Advocate" and providing a search term, we get the following:

```sql
[["persona_type", "ExternalUser"], ["case_worker_id", 2], ["persona_type", "CaseWorker"]]
PG::InvalidTextRepresentation - ERROR:  invalid input syntax for integer: "CaseWorker"
```

Looking at the SQL produced, "CaseWorker" value is being provided as the value for **case_worker_id** 🤦‍♀️ 