### PR TITLE
Don't display offence details for fixed fee case types

### DIFF
--- a/app/views/external_users/claims/_summary_claims_content.html.haml
+++ b/app/views/external_users/claims/_summary_claims_content.html.haml
@@ -14,9 +14,10 @@
   Defendants
 = render partial: 'external_users/claims/defendants/summary', locals: { claim: claim }
 
-%h2
-  = t('external_users.claims.offence_details.summary.header')
-= render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }
+- unless claim.fixed_fee_case?
+  %h2
+    = t('external_users.claims.offence_details.summary.header')
+  = render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }
 
 - if claim.lgfs? && claim.interim?
   %h2

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -114,6 +114,7 @@
   - else
     = "No defendant details have been supplied for this claim."
 
-  %h3.heading-medium
-    = t('external_users.claims.offence_details.summary.header')
-  = render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }
+  - unless claim.fixed_fee_case?
+    %h3.heading-medium
+      = t('external_users.claims.offence_details.summary.header')
+    = render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -51,6 +51,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_fixed_fee_case do
+      case_type { association(:case_type, :fixed_fee) }
+    end
+
+    trait :with_graduated_fee_case do
+      case_type { association(:case_type, :graduated_fee) }
+    end
+
     factory :unpersisted_claim do
       court         { FactoryBot.build :court }
       external_user { FactoryBot.build :external_user, provider: FactoryBot.build(:provider) }

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'external_users/claims/show.html.haml', type: :view do
+RSpec.describe 'external_users/claims/show.html.haml', type: :view do
   include ViewSpecHelper
 
   before(:all) do
@@ -15,75 +15,119 @@ describe 'external_users/claims/show.html.haml', type: :view do
     initialize_view_helpers(view)
     sign_in(@external_user.user, scope: :user)
     allow(view).to receive(:current_user_persona_is?).and_return(false)
-    render
   end
 
   context 'for AGFS claims' do
-    before(:all) do
-      @claim = create :claim, evidence_checklist_ids: [1, 9]
-      @messages = @claim.messages.most_recent_last
-      @message  = @claim.messages.build
-    end
-
     describe 'document checklist' do
+      let(:claim) { create(:claim, evidence_checklist_ids: [1, 9]) }
+
+      before do
+        assign(:claim, claim)
+        assign(:messages, claim.messages.most_recent_last)
+        assign(:message, claim.messages.build)
+      end
+
       it 'displays the documents that have been uploaded' do
+        render
         expect(rendered).to have_selector('li', text: 'Representation order')
         expect(rendered).to have_selector('li', text: 'Justification for out of time claim')
       end
 
       it 'does not display a `download all` link' do
+        render
         expect(rendered).to_not have_link('Download all')
       end
     end
 
     describe 'basic claim information' do
+      let(:claim) { create(:claim, evidence_checklist_ids: [1, 9]) }
+
+      before do
+        assign(:claim, claim)
+        assign(:messages, claim.messages.most_recent_last)
+        assign(:message, claim.messages.build)
+      end
+
       it 'displays the advocate category section' do
+        render
         expect(rendered).to have_selector('div', text: 'Advocate category')
       end
 
       it 'displays the advocate account number section' do
+        render
         expect(rendered).to have_selector('div', text: 'Advocate account number')
+      end
+    end
+
+    describe 'offence details information' do
+      context 'when the claim is for a fixed fee case type' do
+        let(:claim) { create(:advocate_claim, :with_fixed_fee_case) }
+
+        it 'does NOT displays offence details section' do
+          assign(:claim, claim)
+          render
+          expect(rendered).not_to have_content('Offence details')
+        end
+      end
+
+      context 'when the claim is NOT for a fixed fee case type' do
+        let(:claim) { create(:advocate_claim, :with_graduated_fee_case) }
+
+        it 'displays offence details section' do
+          assign(:claim, claim)
+          render
+          expect(rendered).to have_content('Offence details')
+        end
       end
     end
   end
 
   context 'for LGFS claims' do
-    before(:all) do
-      @claim = create :litigator_claim
-      @messages = @claim.messages.most_recent_last
-      @message  = @claim.messages.build
+    let(:claim) { create(:litigator_claim) }
+
+    before do
+      assign(:claim, claim)
+      assign(:messages, claim.messages.most_recent_last)
+      assign(:message, claim.messages.build)
     end
 
     describe 'basic claim information' do
       it 'doesn\'t display the litigator category section' do
+        render
         expect(rendered).not_to have_selector('div', text: 'Advocate category')
         expect(rendered).not_to have_selector('div', text: 'Litigator category')
       end
 
       it 'displays the litigator account number section' do
+        render
         expect(rendered).to have_selector('div', text: 'Litigator account number')
       end
     end
   end
 
   context 'Interim claims' do
-    before(:all) do
-      @claim = create(:interim_claim, :interim_effective_pcmh_fee)
-      @messages = @claim.messages.most_recent_last
-      @message  = @claim.messages.build
+    let(:claim) { create(:interim_claim, :interim_effective_pcmh_fee) }
+
+    before do
+      assign(:claim, claim)
+      assign(:messages, claim.messages.most_recent_last)
+      assign(:message, claim.messages.build)
     end
 
     describe 'basic claim information' do
       it 'displays the fee type section' do
+        render
         expect(rendered).to have_selector('div', text: 'Fee type')
       end
 
       context 'Effective PCMH' do
         it 'displays the PPE total section' do
+          render
           expect(rendered).to have_selector('div', text: 'PPE total at the time')
         end
 
         it 'displays the Effective PCMH section' do
+          render
           expect(rendered).to have_selector('div', text: 'Effective PCMH')
         end
       end
@@ -91,6 +135,7 @@ describe 'external_users/claims/show.html.haml', type: :view do
 
     describe 'Fees, expenses and more information' do
       it 'should not show the expenses section' do
+        render
         expect(rendered).not_to have_selector('p', text: 'There are no expenses for this claim')
       end
     end


### PR DESCRIPTION
#### What

Don't display offence details for fixed fee case types in both _summary pages_.

#### Ticket

[Remove offence details from summary when fixed fee](https://www.pivotaltracker.com/story/show/156576898)
