### PR TITLE
Update display name and help text for advocate interim claims

### DIFF
--- a/app/presenters/claim/advocate_interim_claim_presenter.rb
+++ b/app/presenters/claim/advocate_interim_claim_presenter.rb
@@ -1,6 +1,6 @@
 class Claim::AdvocateInterimClaimPresenter < Claim::BaseClaimPresenter
   def pretty_type
-    'AGFS Interim'
+    'AGFS Warrant'
   end
 
   def type_identifier

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -447,7 +447,7 @@ en:
     your_claims: Your claims
     claim_heading: Claim for Crown Court fees
     agfs_claim_heading: Claim for advocate fees
-    agfs_interim_claim_heading: Claim for advocate interim fees
+    agfs_interim_claim_heading: Claim for advocate warrant fees
     lgfs_claim_heading: Claim for litigator fees
     start_agfs_claim_heading: Claim for advocate fees
     start_lgfs_final_claim_heading: Claim for litigator fees
@@ -467,8 +467,8 @@ en:
           invalid_claim_types: 'Invalid bill type selected'
       selection:
         agfs_rb: Advocate final fee
-        agfs_interim_hint: For claims with the earliest representation order dated on or after 1 April 2018
-        agfs_interim_rb: Advocate interim fee
+        agfs_interim_hint: For warrant fee claims with the earliest representation order dated on or after 1 April 2018
+        agfs_interim_rb: Advocate warrant fee
         claim_type_prompt_section_heading: 'What would you like to do?'
         choose_claim_type_prompt_text: Choose your bill type
         errors:

--- a/spec/presenters/claim/advocate_interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/advocate_interim_claim_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Claim::AdvocateInterimClaimPresenter, type: :presenter do
   # to change that pattern. Something to address in the near future
 
   describe '#pretty_type' do
-    specify { expect(presenter.pretty_type).to eq('AGFS Interim') }
+    specify { expect(presenter.pretty_type).to eq('AGFS Warrant') }
   end
 
   describe '#type_identifier' do


### PR DESCRIPTION
#### What

For display purposes only, advocate interim claims should display as "Advocate warrant".

#### Ticket

[Amend 'advocate interim fee' name and help text](https://www.pivotaltracker.com/story/show/156688811)