### PR TITLE
Add missing index to claims on uuid column

### DIFF
--- a/db/migrate/20180412104444_add_index_to_claims_on_uuid.rb
+++ b/db/migrate/20180412104444_add_index_to_claims_on_uuid.rb
@@ -1,0 +1,7 @@
+class AddIndexToClaimsOnUuid < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def change
+    add_index :claims, :uuid, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180409091300) do
+ActiveRecord::Schema.define(version: 20180412104444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,6 +157,7 @@ ActiveRecord::Schema.define(version: 20180409091300) do
     t.index ["offence_id"], name: "index_claims_on_offence_id", using: :btree
     t.index ["state"], name: "index_claims_on_state", using: :btree
     t.index ["transfer_case_number"], name: "index_claims_on_transfer_case_number", using: :btree
+    t.index ["uuid"], name: "index_claims_on_uuid", unique: true, using: :btree
     t.index ["valid_until"], name: "index_claims_on_valid_until", using: :btree
   end
 


### PR DESCRIPTION
#### What

[This](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/fefa0f40b261c97b745044eb8d683685dd828231/db/migrate/20150804100037_add_uuids.rb#L5) does **NOT** add **ANY** index to the table.

There's a misconception about the use of the Rails migration method `add_column`: `index: true` is ignored

More info about this issue can be [here](https://makandracards.com/makandra/32353-psa-index-true-in-rails-migrations-does-not-work-as-you-d-expect)

This adds the missing index as it's actually being used for querying claims and without it becomes very un-optimized (having to do scan through the whole table to find the required uuid).

Example of use [here](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/8b7412148c569587140e7d78903c53ced8e2e5d9/app/interfaces/api/v2/ccr_claim.rb#L8)

**NOTE:** Creates the index concurrently not to impact the live service given the claims table has quite a lot of records and non-concurrently indexing would block the table until completed.

