### PR TITLE
Handle deprecation warning on old migrations adding timestamps

### DIFF
--- a/db/migrate/20150325120724_create_chambers.rb
+++ b/db/migrate/20150325120724_create_chambers.rb
@@ -5,7 +5,7 @@ class CreateChambers < ActiveRecord::Migration
       t.string :account_number
       t.boolean :vat_registered
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :chambers, :name
     add_index :chambers, :account_number

--- a/db/migrate/20150325142122_create_claims.rb
+++ b/db/migrate/20150325142122_create_claims.rb
@@ -23,7 +23,7 @@ class CreateClaims < ActiveRecord::Migration
       t.references :offence, index: true
       t.references :scheme, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150325144103_create_case_worker_claims.rb
+++ b/db/migrate/20150325144103_create_case_worker_claims.rb
@@ -4,7 +4,7 @@ class CreateCaseWorkerClaims < ActiveRecord::Migration
       t.references :case_worker, index: true
       t.references :claim, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150326114342_create_fee_types.rb
+++ b/db/migrate/20150326114342_create_fee_types.rb
@@ -4,7 +4,7 @@ class CreateFeeTypes < ActiveRecord::Migration
       t.string :description
       t.string :code
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :fee_types, :description
     add_index :fee_types, :code

--- a/db/migrate/20150326115934_create_fees.rb
+++ b/db/migrate/20150326115934_create_fees.rb
@@ -8,7 +8,7 @@ class CreateFees < ActiveRecord::Migration
       t.decimal :rate
       t.decimal :amount
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150326140238_create_expense_types.rb
+++ b/db/migrate/20150326140238_create_expense_types.rb
@@ -3,7 +3,7 @@ class CreateExpenseTypes < ActiveRecord::Migration
     create_table :expense_types do |t|
       t.string :name
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :expense_types, :name
   end

--- a/db/migrate/20150326140817_create_expenses.rb
+++ b/db/migrate/20150326140817_create_expenses.rb
@@ -10,7 +10,7 @@ class CreateExpenses < ActiveRecord::Migration
       t.decimal :hours
       t.decimal :amount
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150326145555_create_defendants.rb
+++ b/db/migrate/20150326145555_create_defendants.rb
@@ -10,7 +10,7 @@ class CreateDefendants < ActiveRecord::Migration
       t.string :maat_reference
       t.references :claim, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150327103635_devise_create_users.rb
+++ b/db/migrate/20150327103635_devise_create_users.rb
@@ -32,7 +32,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
 
       t.references :persona, polymorphic: true
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :users, :email,                unique: true

--- a/db/migrate/20150330084305_create_courts.rb
+++ b/db/migrate/20150330084305_create_courts.rb
@@ -5,7 +5,7 @@ class CreateCourts < ActiveRecord::Migration
       t.string :name
       t.string :court_type
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :courts, :code
     add_index :courts, :name

--- a/db/migrate/20150331133748_create_documents.rb
+++ b/db/migrate/20150331133748_create_documents.rb
@@ -6,7 +6,7 @@ class CreateDocuments < ActiveRecord::Migration
       t.text :notes
       t.string :document
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150423082903_create_document_types.rb
+++ b/db/migrate/20150423082903_create_document_types.rb
@@ -3,7 +3,7 @@ class CreateDocumentTypes < ActiveRecord::Migration
     create_table :document_types do |t|
       t.string :description
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150423142919_create_offences.rb
+++ b/db/migrate/20150423142919_create_offences.rb
@@ -4,7 +4,7 @@ class CreateOffences < ActiveRecord::Migration
       t.string :description
       t.references :offence_class, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150424132253_create_advocates.rb
+++ b/db/migrate/20150424132253_create_advocates.rb
@@ -8,7 +8,7 @@ class CreateAdvocates < ActiveRecord::Migration
 
       t.references :chamber, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :advocates, :role
   end

--- a/db/migrate/20150424140231_create_case_workers.rb
+++ b/db/migrate/20150424140231_create_case_workers.rb
@@ -3,7 +3,7 @@ class CreateCaseWorkers < ActiveRecord::Migration
     create_table :case_workers do |t|
       t.string :role
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :case_workers, :role
   end

--- a/db/migrate/20150428123404_create_offence_classes.rb
+++ b/db/migrate/20150428123404_create_offence_classes.rb
@@ -4,7 +4,7 @@ class CreateOffenceClasses < ActiveRecord::Migration
       t.string :class_letter
       t.string :description
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :offence_classes, :class_letter
     add_index :offence_classes, :description

--- a/db/migrate/20150430115328_create_schemes.rb
+++ b/db/migrate/20150430115328_create_schemes.rb
@@ -3,7 +3,7 @@ class CreateSchemes < ActiveRecord::Migration
     create_table :schemes do |t|
       t.string :name
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :schemes, :name
   end

--- a/db/migrate/20150527102833_create_messages.rb
+++ b/db/migrate/20150527102833_create_messages.rb
@@ -7,7 +7,7 @@ class CreateMessages < ActiveRecord::Migration
       t.integer :sender_id
       t.integer :recipient_id
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :messages, :sender_id
     add_index :messages, :recipient_id

--- a/db/migrate/20150602131128_create_dates_attended.rb
+++ b/db/migrate/20150602131128_create_dates_attended.rb
@@ -4,7 +4,7 @@ class CreateDatesAttended < ActiveRecord::Migration
       t.datetime :date
       t.references :fee, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150604143054_create_user_message_statuses.rb
+++ b/db/migrate/20150604143054_create_user_message_statuses.rb
@@ -5,7 +5,7 @@ class CreateUserMessageStatuses < ActiveRecord::Migration
       t.references :message, index: true
       t.boolean :read, default: false
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :user_message_statuses, :read
   end

--- a/db/migrate/20150608154716_create_representation_orders.rb
+++ b/db/migrate/20150608154716_create_representation_orders.rb
@@ -11,7 +11,7 @@ class CreateRepresentationOrders < ActiveRecord::Migration
       t.integer   :converted_preview_document_file_size
       t.datetime  :converted_preview_document_updated_at
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150610154552_create_evidence_list_item_claims.rb
+++ b/db/migrate/20150610154552_create_evidence_list_item_claims.rb
@@ -4,7 +4,7 @@ class CreateEvidenceListItemClaims < ActiveRecord::Migration
       t.belongs_to :claim, null: false, index: true
       t.belongs_to :evidence_list_item, null: false, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :evidence_list_item_claims,

--- a/db/migrate/20150616093010_drop_evidence_list_item_claims_table.rb
+++ b/db/migrate/20150616093010_drop_evidence_list_item_claims_table.rb
@@ -8,7 +8,7 @@ class DropEvidenceListItemClaimsTable < ActiveRecord::Migration
       t.belongs_to :claim, null: false, index: true
       t.belongs_to :evidence_list_item, null: false, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :evidence_list_item_claims,

--- a/db/migrate/20150616094245_create_document_type_claims_table.rb
+++ b/db/migrate/20150616094245_create_document_type_claims_table.rb
@@ -4,7 +4,7 @@ class CreateDocumentTypeClaimsTable < ActiveRecord::Migration
       t.belongs_to :claim, null: false, index: true
       t.belongs_to :document_type, null: false, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :document_type_claims,

--- a/db/migrate/20150625122755_drop_document_types.rb
+++ b/db/migrate/20150625122755_drop_document_types.rb
@@ -8,14 +8,14 @@ class DropDocumentTypes < ActiveRecord::Migration
   def down
     create_table :document_types do |t|
       t.string :description
-      t.timestamps
+      t.timestamps null: true
     end
 
     create_table :document_type_claims do |t|
       t.belongs_to :claim, null: false, index: true
       t.belongs_to :document_type, null: false, index: true
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :document_type_claims,

--- a/db/migrate/20150702131509_create_locations.rb
+++ b/db/migrate/20150702131509_create_locations.rb
@@ -3,7 +3,7 @@ class CreateLocations < ActiveRecord::Migration
     create_table :locations do |t|
       t.string :name
 
-      t.timestamps
+      t.timestamps null: true
     end
     add_index :locations, :name
   end

--- a/db/migrate/20150728093252_add_vat_rates_table.rb
+++ b/db/migrate/20150728093252_add_vat_rates_table.rb
@@ -4,7 +4,7 @@ class AddVatRatesTable < ActiveRecord::Migration
       t.integer :rate_base_points
       t.date :effective_date
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150806090257_create_determinations.rb
+++ b/db/migrate/20150806090257_create_determinations.rb
@@ -7,7 +7,7 @@ class CreateDeterminations < ActiveRecord::Migration
       t.decimal :expenses
       t.decimal :total
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150813142826_create_case_types_table.rb
+++ b/db/migrate/20150813142826_create_case_types_table.rb
@@ -3,7 +3,7 @@ class CreateCaseTypesTable < ActiveRecord::Migration
     create_table :case_types do |t|
       t.string :name
       t.boolean :is_fixed_fee
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20150819095328_create_certifications.rb
+++ b/db/migrate/20150819095328_create_certifications.rb
@@ -11,7 +11,7 @@ class CreateCertifications < ActiveRecord::Migration
       t.string  :certified_by
       t.date    :certification_date
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20151115214327_create_super_admins.rb
+++ b/db/migrate/20151115214327_create_super_admins.rb
@@ -1,7 +1,7 @@
 class CreateSuperAdmins < ActiveRecord::Migration
   def change
     create_table :super_admins do |t|
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20160119133632_create_certification_types.rb
+++ b/db/migrate/20160119133632_create_certification_types.rb
@@ -4,7 +4,7 @@ class CreateCertificationTypes < ActiveRecord::Migration
       t.string :name, index: true
       t.boolean :pre_may_2015, default: false
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20160309115141_create_disbursement_types.rb
+++ b/db/migrate/20160309115141_create_disbursement_types.rb
@@ -2,7 +2,7 @@ class CreateDisbursementTypes < ActiveRecord::Migration
   def change
     create_table :disbursement_types do |t|
       t.string :name
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :disbursement_types, :name

--- a/db/migrate/20160309135448_create_disbursements.rb
+++ b/db/migrate/20160309135448_create_disbursements.rb
@@ -5,7 +5,7 @@ class CreateDisbursements < ActiveRecord::Migration
       t.references :claim, index: true
       t.decimal :net_amount
       t.decimal :vat_amount
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end

--- a/db/migrate/20171111113526_create_injection_attempts.rb
+++ b/db/migrate/20171111113526_create_injection_attempts.rb
@@ -4,7 +4,7 @@ class CreateInjectionAttempts < ActiveRecord::Migration
       t.references :claim, index: true, foreign_key: true
       t.boolean :succeeded
       t.string :error_message
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end


### PR DESCRIPTION
#### What
Removes a deprecation warning relating to Rails 5 upgrade.

#### Why
Preparing for rails 5 upgrade

```
DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`.
In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true` to
prevent the behavior of your existing migrations from changing.
```

#### How
explicitly state `null: true` to retain existing functionality. 