### PR TITLE
Add dates attended to Daily attendance (2+) fee type

### DIFF
--- a/app/models/fee/basic_fee_type.rb
+++ b/app/models/fee/basic_fee_type.rb
@@ -17,7 +17,7 @@
 #
 
 class Fee::BasicFeeType < Fee::BaseFeeType
-  DATES_ATTENDED_APPLICABLE_FEES = %w[BAF DAF DAH DAJ PCM SAF].freeze
+  DATES_ATTENDED_APPLICABLE_FEES = %w[BAF DAF DAH DAJ PCM SAF DAT].freeze
 
   default_scope { order(id: :asc) }
 

--- a/app/models/fee/basic_fee_type.rb
+++ b/app/models/fee/basic_fee_type.rb
@@ -18,6 +18,7 @@
 
 class Fee::BasicFeeType < Fee::BaseFeeType
   DATES_ATTENDED_APPLICABLE_FEES = %w[BAF DAF DAH DAJ PCM SAF DAT].freeze
+  ADDITIONAL_DAILY_ATTENDANCE_FEE_CODES = %w[DAF DAH DAJ DAT].freeze
 
   default_scope { order(id: :asc) }
 

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -33,6 +33,12 @@ FactoryBot.define do
       roles %w[agfs agfs_scheme_10]
     end
 
+    trait :dat do
+      description 'Daily Attendance Fee (2+)'
+      code 'DAT'
+      unique_code 'BADAT'
+    end
+
     trait :ppe do
       description 'Pages of prosecution evidence'
       code 'PPE'

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -150,6 +150,10 @@ FactoryBot.define do
       fee_type { build :basic_fee_type, description: 'Daily Attendance Fee (50+)', code: 'DAJ', unique_code: 'BADAJ' }
     end
 
+    trait :dat_fee do
+      fee_type { build(:basic_fee_type, :dat) }
+    end
+
     trait :pcm_fee do
       fee_type { build :basic_fee_type, description: 'Plea and Case Management Hearing', code: 'PCM' }
     end

--- a/spec/models/fee/basic_fee_type_spec.rb
+++ b/spec/models/fee/basic_fee_type_spec.rb
@@ -22,7 +22,7 @@ module Fee
   describe BasicFeeType do
 
     let(:fee_type)  { build :basic_fee_type }
-    DATES_ATTENDED_APPLICABLE_FEES = %w( BAF DAF DAH DAJ PCM SAF )
+    DATES_ATTENDED_APPLICABLE_FEES = %w( BAF DAF DAH DAJ PCM SAF DAT )
     DATES_ATTENDED_NOT_APPLICABLE_FEES = %w( CAV NDR NOC PPE NPW )
 
     describe '#requires_dates_attended?' do


### PR DESCRIPTION
#### What

Add dates attended to Daily attendance (2+) fee type.

#### Ticket

[Graduated fee page 'add dates' for daily attendance fee 2+](https://www.pivotaltracker.com/story/show/156577049)

#### Why

Missing configuration on _fee reform_ release for this specific fee type