### PR TITLE
Improve validations on dates attended

### DIFF
--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -61,6 +61,14 @@ module Fee
       ensure_not_abstract_class
     end
 
+    def self.validation_order
+      :position
+    end
+
+    def validation_order
+      self.class.validation_order
+    end
+
     def ensure_not_abstract_class
       raise BaseFeeAbstractClassError if self.class == BaseFee
     end

--- a/app/validators/base_sub_model_validator.rb
+++ b/app/validators/base_sub_model_validator.rb
@@ -34,6 +34,8 @@ class BaseSubModelValidator < BaseValidator
 
   def validate_collection_for(record, association_name)
     collection = record.__send__(association_name)
+    order_column = collection.detect { |item| item.respond_to?(:validation_order) }&.validation_order
+    collection = collection.sort_by(&:"#{order_column}") if order_column
     collection.each_with_index do |associated_record, i|
       next if associated_record.marked_for_destruction? || associated_record.valid?
       @result = false

--- a/app/validators/date_attended_validator.rb
+++ b/app/validators/date_attended_validator.rb
@@ -17,6 +17,7 @@ class DateAttendedValidator < BaseValidator
     validate_presence(:date, 'blank')
     validate_on_or_after(@record.earliest_date_before_reporder - 2.years, :date, 'too_long_before_earliest_reporder')
     validate_on_or_after(Settings.earliest_permitted_date, :date, 'not_before_earliest_permitted_date')
+    validate_on_or_before(Date.today, :date, 'not_after_today')
   end
 
   # must not be before DateAttended#date

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1365,6 +1365,10 @@ date_attended:
       long: The fixed fee date must not be more than two years before the earliest representation order date
       short: *enter_valid_date
       api: The fixed fee date must not be more than two years before the earliest representation order date
+    not_after_today:
+      long: 'The #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} is invalid'
+      short: Enter a date that is not in the future
+      api: The date attended (from) cannot be in the future
     not_before_earliest_permitted_date:
       long: 'The #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} is invalid'
       short: Enter a date later than two years before the earliest representation order date

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -739,6 +739,10 @@ basic_fee:
       long: The number of daily attendance fees (51+ days) does not fit the actual (re)trial length
       short: Enter a number that fits the actual (re)trial length
       api: The number of daily attendance fees (51+ days) does not fit the actual (re)trial length
+    dat_qty_mismatch:
+      long: The number of daily attendance fees (2+ days) does not fit the actual (re)trial length
+      short: Enter a number that fits the actual (re)trial length
+      api: The number of daily attendance fees (2+ days) does not fit the actual (re)trial length
     pcm_not_applicable:
       long: Plea and case management hearing fee not applicable to case type
       short: Remove quantity as not applicable
@@ -765,6 +769,10 @@ basic_fee:
       long: Enter a valid quantity for daily attendance fees (51+ days)
       short: *enter_valid_quantity
       api: Enter a valid quantity for daily attendance fees (51+ days)
+    dat_invalid:
+      long: Enter a valid quantity for daily attendance fees (2+ days)
+      short: *enter_valid_quantity
+      api: Enter a valid quantity for daily attendance fees (2+ days)
     saf_invalid:
       long: Enter a valid quantity for standard appearance fees
       short: *enter_valid_quantity
@@ -816,6 +824,10 @@ basic_fee:
       long: Enter a valid rate for daily attendance fees (51+ days)
       short: *enter_valid_rate
       api: Enter a valid rate for daily attendance fees (51+ days)
+    dat_invalid:
+      long: Enter a valid rate for daily attendance fees (2+ days)
+      short: *enter_valid_rate
+      api: Enter a valid rate for daily attendance fees (2+ days)
     saf_invalid:
       long: Enter a valid rate for standard appearance fees
       short: *enter_valid_rate

--- a/spec/validators/date_attended_validator_spec.rb
+++ b/spec/validators/date_attended_validator_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe DateAttendedValidator, type: :validator do
     it { should_error_if_not_present(date_attended, :date, 'blank') }
     it { should_error_if_before_specified_date(date_attended, :date, earliest_reporder_date - 2.years - 1.day, 'too_long_before_earliest_reporder') }
     it { should_error_if_too_far_in_the_past(date_attended, :date, 'not_before_earliest_permitted_date') }
+    it { should_error_if_in_future(date_attended, :date, 'not_after_today') }
 
     it 'should not error if less than two years before earliest rep order date' do
       date_attended.date = earliest_reporder_date - 369.days


### PR DESCRIPTION
#### What

- Validate that "date from" is not in the future
- The order the fees are validated should be the same as the one used to display them because the validation messages relies on the index of a given fee.

#### Ticket

Relates to [Graduated fee page 'add dates' for daily attendance fee 2+](https://www.pivotaltracker.com/story/show/156577049c)