### PR TITLE
Split Ground Hearing fee into whole and half day

### DIFF
--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -97,5 +97,6 @@ ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUAN
 98,Warrant,IWARR,INWAR,,FALSE,Fee::InterimFeeType,lgfs,,FALSE,
 99,Transfer,TRANS,TRANS,,FALSE,Fee::TransferFeeType,lgfs,,FALSE,
 100,Further case management hearing,FCM,MIFCM,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,
-101,Ground rules hearing,GRH,MIGRH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,
+101,Ground rules hearing (whole day),GRW,MIGRW,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,
 102,Daily attendance fee (2+),DAT,BADAT,999,TRUE,Fee::BasicFeeType,agfs;agfs_scheme_10,,FALSE,2
+103,Ground rules hearing (half day),GRH,MIGRH,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_10,,FALSE,


### PR DESCRIPTION
#### What

**NOTE:** It was discovered post release of the fee reform changes that this fee should be in fact two fees for whole and half day.


#### Ticket

[Ground rules hearing - whole and half day](https://www.pivotaltracker.com/story/show/156687178)

#### Why

#### How

⚠️ Data migration is required:

```shell
SEEDS_DRY_MODE=false bundle exec rake fee_types:seed
```