### PR TITLE
Fix flakey test related with non unique location generation

### DIFF
--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -10,6 +10,6 @@
 
 FactoryBot.define do
   factory :location do
-    name { Faker::Address.city }
+    name { Faker::Address.unique.city }
   end
 end


### PR DESCRIPTION
#### What

Tests like the following:
https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/0ea00787062887099785c2c2ea6ec307d34ef53a/spec/controllers/external_users/claims_controller_spec.rb#L657

were creating factory data for a location using `Faker::Address.city` but even though the location model expects unique names, the existent definition (using Faker) did not guarantee that, causing a validation error:

```
Location name already exists
```

This fixes makes use of the `unique` method in Faker:
https://github.com/stympy/faker#ensuring-unique-values