### PR TITLE
Correct the spelling of ManagementInformationGenerationJob

### DIFF
--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -15,7 +15,7 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
   end
 
   def generate
-    ManagemenInformationGenerationJob.perform_later
+    ManagementInformationGenerationJob.perform_later
     redirect_to case_workers_admin_management_information_url,
                 alert: t('case_workers.admin.management_information.alert')
   end

--- a/app/jobs/management_information_generation_job.rb
+++ b/app/jobs/management_information_generation_job.rb
@@ -1,4 +1,4 @@
-class ManagemenInformationGenerationJob < ActiveJob::Base
+class ManagementInformationGenerationJob < ActiveJob::Base
   queue_as :default
 
   def perform(*_args)


### PR DESCRIPTION
#### What
The class name had a typo 
#### Why
It has bugged me for months every time I came across it
#### How
I corrected it
