### PR TITLE
Fix for the display of reject reasons

### DIFF
--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -64,7 +64,7 @@ class ClaimStateTransitionReason
 
     def reject_reasons_for(claim)
       reasons = reasons_for('rejected')
-      reasons.insert(6, reasons_for(:disbursement)) if claim.fees.first.fee_type.code.eql?('IDISO')
+      reasons.insert(6, reasons_for(:disbursement)) if claim&.fees&.first&.fee_type&.code.eql?('IDISO')
       reasons.flatten
     end
 

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe ClaimStateTransitionReason, type: :model do
         expect(reject_reasons_for.map(&:code)).to match_array(all_reasons)
       end
     end
+
+    context 'when the claim has no fees' do
+      let(:claim) { create(:advocate_claim, :without_fees, state: 'rejected') }
+
+      it 'returns base rejection reasons' do
+        expect(reject_reasons_for.map(&:code)).to match_array(reasons)
+      end
+    end
   end
 
   describe '.refuse_reasons_for' do


### PR DESCRIPTION
#### What
When a claim was submitted with _no_ fees, the code would error
#### Why
It's a positive check for a single fee type to add the extra value.  So, if there are _no_ fees, we don't need to add it
#### How
Added safe navigation operators (&.) to check for the presence of fees
