### PR TITLE
Advocate category validation Scheme 10

### DIFF
--- a/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
@@ -15,7 +15,7 @@ module API::V1::ExternalUsers
         optional :advocate_category,
                  type: String,
                  desc: local_t(:advocate_category),
-                 values: Settings.advocate_categories
+                 values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories).uniq
 
         use :common_trial_params
         use :common_agfs_params

--- a/app/services/claims/fetch_eligible_advocate_categories.rb
+++ b/app/services/claims/fetch_eligible_advocate_categories.rb
@@ -10,7 +10,7 @@ module Claims
 
     def call
       return unless claim&.agfs?
-      return fee_reform_categories if using_fee_reform?
+      return fee_reform_categories if using_fee_reform? || Offence.in_scheme_ten.include?(claim.offence)
       default_categories
     end
 

--- a/spec/factories/claim/api_claims.rb
+++ b/spec/factories/claim/api_claims.rb
@@ -1,0 +1,24 @@
+include ClaimFactoryHelpers
+
+FactoryBot.define do
+  factory :api_advocate_claim, class: Claim::AdvocateClaim do
+    # Attempt to create minimal API submitted claims
+    # the main claim factories would have needed too much hacking to
+    # remove the default values required for a web based submission
+
+    external_user
+    court
+    case_type
+    offence
+    case_number { random_case_number }
+    advocate_category 'QC'
+    source { 'api' }
+
+    trait :with_scheme_ten_offence do
+      offence { create :offence, :with_fee_scheme_ten }
+    end
+
+    after(:build) { |claim| set_creator(claim) }
+
+  end
+end

--- a/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
+++ b/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe Claims::FetchEligibleAdvocateCategories, type: :service do
 
         include_examples 'an AGFS claim'
       end
+
+      context 'when the claim has been submitted via the API' do
+        # This will mean the offence will determine the fee_scheme, not the rep_order date
+        context 'with a scheme_ten offence' do
+          let(:claim) { create :api_advocate_claim, :with_scheme_ten_offence }
+
+          it { is_expected.to match_array(['QC', 'Leading junior', 'Junior']) }
+        end
+
+        context 'with a scheme_nine offence' do
+          let(:claim) { create :api_advocate_claim }
+
+          it { is_expected.to match_array(['QC', 'Led junior', 'Leading junior', 'Junior alone']) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
Vendors have been unable to submit claims via the API
#### Ticket

#### Why
This is because API submissions don't have a rep-order, but do have an offence.
#### How
Check for a SchemeTen offence as well as the presence of a post S10 rep order date.

----
#### To do
- [x] extend tests to ensure validations are firing properly
