### PR TITLE
Clarify scheme ten offence api

### DIFF
--- a/app/interfaces/api/entities/offence.rb
+++ b/app/interfaces/api/entities/offence.rb
@@ -13,6 +13,7 @@ module API
         expose :offence_class,
                if: ->(instance, _opts) { instance.scheme_nine? },
                using: API::Entities::OffenceClass
+        expose :act_of_law, if: ->(instance, _opts) { instance.scheme_ten? }
         expose :offence_band,
                if: ->(instance, _opts) { !instance.scheme_nine? },
                using: API::Entities::OffenceBand
@@ -22,6 +23,10 @@ module API
 
       def class_description
         object.offence_class.description
+      end
+
+      def act_of_law
+        "#{object.contrary} #{object.year_chapter}"
       end
     end
   end

--- a/app/interfaces/api/entities/offence.rb
+++ b/app/interfaces/api/entities/offence.rb
@@ -15,7 +15,7 @@ module API
                using: API::Entities::OffenceClass
         expose :act_of_law, if: ->(instance, _opts) { instance.scheme_ten? }
         expose :offence_band,
-               if: ->(instance, _opts) { !instance.scheme_nine? },
+               if: ->(instance, _opts) { instance.scheme_ten? },
                using: API::Entities::OffenceBand
       end
 

--- a/spec/api/entities/offence_spec.rb
+++ b/spec/api/entities/offence_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe API::Entities::Offence do
+  subject { described_class.represent(offence) }
+
+  context 'when scheme nine' do
+    let(:offence) { create(:offence, :with_fee_scheme, offence_class: create(:offence_class, :with_lgfs_offence )) }
+
+    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description offence_class_id offence_class] }
+  end
+
+  context 'when scheme ten' do
+    let(:offence) {
+      create(:offence, :with_fee_scheme_ten,
+             offence_band: create(:offence_band,
+                                  offence_category: create(:offence_category, number: 6))) }
+
+    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description act_of_law offence_band] }
+  end
+end


### PR DESCRIPTION
#### What
Add extra `act_of_law` field to offence output in API
#### Ticket
[Clarify scheme ten offence data](https://www.pivotaltracker.com/story/show/157116611)
#### Why
Contact from the Vendor Support Slack raised a query about the offence data... there was nothing to distinguish some offences.
> Codes 2129 and 2133 appear to be identical and both have a description of "Distributing, showing or playing a recording". I think one should be “Distributing, showing or playing a recording - Public Order Act 1986, s.21”, and the other “Distributing, showing or playing a recording - Public Order Act 1986, s.29E”. There are several others that have the same problem. Could you confirm please if this is correct ?

and
> there appear to be some duplicates under Category 17 - Band 17.1 - "TEW Offences" - 1953,2001,2037,2042,2047,2097,2122 (also 1065 / 1741 - but these two are under different bands)
#### How
Expose extra field in the API offence entity