### PR TITLE
Prevent message creation for [Part] Authorised claims

### DIFF
--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -107,7 +107,7 @@ module Claims
         update_assessment if @assessment_params_present
         add_redetermination if @redetermination_params_present
         @claim.send(event, audit_attributes) unless state_not_updateable?
-        add_message if @transition_reasons
+        add_message if @transition_reasons.present?
       rescue StandardError => err
         add_error err.message
         raise ActiveRecord::Rollback


### PR DESCRIPTION
#### What
prevent messages being created for authorised and part authorised claims

#### Why
Should only create messages when there are reasons (rejected/refused transitions)