### PR TITLE
Fix where chain exception

### DIFF
--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -41,7 +41,7 @@ class ClaimStateTransition < ApplicationRecord
   end
 
   def self.decided_this_month(state)
-    where { (to == state.to_s) & (created_at >= Time.now.beginning_of_month) }.count('DISTINCT claim_id')
+    where(to: state.to_s).where(arel_table[:created_at].gteq(Time.now.beginning_of_month)).count('DISTINCT claim_id')
   end
 
   def update_author_id(value)

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -4,7 +4,7 @@ namespace :claims do
     total = 0
     current_id = 0
     start_id = args[:start_id] || 1
-    Claim::BaseClaim.active.where { id >= start_id }.where.not(state: %w(draft archived_pending_delete)).order(id: :asc).find_each(batch_size: 100) do |claim|
+    Claim::BaseClaim.active.where(Claim::BaseClaim.arel_table[:id].gteq(start_id)).where.not(state: %w(draft archived_pending_delete)).order(id: :asc).find_each(batch_size: 100) do |claim|
       total += 1
       current_id = claim.id
       message = Messaging::ExportRequest.new(claim)

--- a/spec/factories/claim_state_transitions.rb
+++ b/spec/factories/claim_state_transitions.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :claim_state_transition do
+  end
+end

--- a/spec/models/claim_state_transition_spec.rb
+++ b/spec/models/claim_state_transition_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe ClaimStateTransition, type: :model do
+  describe '.decided_this_month' do
+    let(:state) { :rejected }
+
+    context 'when there are no transitions with the "to" provided state' do
+      let(:claim) { create(:advocate_claim) }
+
+      before do
+        create(:claim_state_transition, claim: claim, to: 'foo')
+        create(:claim_state_transition, claim: claim, to: 'bar')
+      end
+
+      it 'returns 0' do
+        expect(described_class.decided_this_month(state)).to eq(0)
+      end
+    end
+
+    context 'when there are no transitions decided this month' do
+      let(:claim) { create(:advocate_claim) }
+
+      before do
+        travel_to(3.months.ago) do
+          create(:claim_state_transition, claim: claim, to: 'rejected')
+          create(:claim_state_transition, claim: claim, to: 'bar')
+        end
+      end
+
+      it 'returns 0' do
+        expect(described_class.decided_this_month(state)).to eq(0)
+      end
+    end
+
+    context 'when there are transitions decided this month' do
+      let(:claim) { create(:advocate_claim) }
+      let(:other_claim) { create(:advocate_claim) }
+
+      before do
+        travel_to(3.months.ago) do
+          create(:claim_state_transition, claim: claim, to: 'rejected')
+          create(:claim_state_transition, claim: claim, to: 'bar')
+        end
+        create(:claim_state_transition, claim: claim, to: 'foo')
+        create(:claim_state_transition, claim: claim, to: 'rejected')
+        create(:claim_state_transition, claim: claim, to: 'zzz')
+        create(:claim_state_transition, claim: claim, to: 'rejected')
+        create(:claim_state_transition, claim: other_claim, to: 'rejected')
+      end
+
+      it 'returns the total claims that transitioned to the provided state for the current month' do
+        expect(described_class.decided_this_month(state)).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sentry Issue: https://sentry.service.dsd.io/mojds/private-beta/issues/30658/

```
undefined method `count' for #<ActiveRecord::QueryMethods::WhereChain
```

#### What

Fix where chain exception

#### How

Use of the normal brackets syntax instead of the curly brackets syntax to perform the query.