### PR TITLE
Refactor case worker claim updater

### DIFF
--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -22,7 +22,6 @@ module Claims
       event = Claims::InputEventMapper.input_event(state)
 
       claim.class.transaction do
-        # @claim.update(@params)
         update_assessment if assessment_params
         add_redetermination if redetermination_params
         claim.send(event, audit_attributes) unless state_not_updateable?
@@ -34,7 +33,7 @@ module Claims
     end
 
     def state_not_updateable?
-      state.blank? || state == claim.state
+      state.blank? || state.eql?(claim.state)
     end
 
     def update_assessment
@@ -45,11 +44,10 @@ module Claims
       claim.redeterminations.create(redetermination_params)
     end
 
-    # rubocop:disable Metrics/LineLength
     def add_message
-      claim.messages.create(sender_id: current_user.id, body: transition_message) if Release.reject_refuse_messaging_released?
+      return unless Release.reject_refuse_messaging_released?
+      claim.messages.create(sender_id: current_user.id, body: transition_message)
     end
-    # rubocop:enable Metrics/LineLength
 
     def transition_message
       StateTransitionMessageBuilder.new(state, transition_reasons, transition_reason_text).call

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -27,7 +27,7 @@ module Claims
         claim.send(event, audit_attributes) unless state_not_updateable?
         add_message if transition_reasons.present?
       rescue StandardError => err
-        add_error(err.message)
+        @result = validator.add_error(err.message)
         raise ActiveRecord::Rollback
       end
     end

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -52,16 +52,18 @@ module Claims
 
     def validate_params
       if @assessment_params_present || @redetermination_params_present
-        validate_state_when_value_params_present
+        validate_state_when_assessment_present
+        clear_transition_reasons
       elsif @state.blank?
         add_error 'You should select a status'
+
       else
-        validate_state_when_no_value_params
+        validate_state_when_no_assessment_present
         validate_reason_presence
       end
     end
 
-    def validate_state_when_value_params_present
+    def validate_state_when_assessment_present
       if @state.blank?
         add_error 'You must specify authorised or part authorised if you supply values'
       elsif @state == 'refused'
@@ -71,7 +73,12 @@ module Claims
       end
     end
 
-    def validate_state_when_no_value_params
+    def clear_transition_reasons
+      @transition_reasons = nil
+      @transition_reason_text = nil
+    end
+
+    def validate_state_when_no_assessment_present
       return unless @state.in?(%w[authorised part_authorised])
       add_error 'You must specify positive values if authorising or part authorising a claim'
     end

--- a/app/services/claims/case_worker_claim_updater.rb
+++ b/app/services/claims/case_worker_claim_updater.rb
@@ -1,168 +1,65 @@
 module Claims
   class CaseWorkerClaimUpdater
-    attr_reader :current_user, :claim, :result, :messages
+    include CaseWorkerClaimParamReadable
+    attr_reader :claim, :params, :result, :messages, :validator
 
     def initialize(claim_id, params)
       @params = params
       @claim = Claim::BaseClaim.active.find(claim_id)
+      @validator = ClaimStateTransitionValidator.new(claim, params.dup)
       @messages = @claim.messages.most_recent_last
-      extract_transition_params
-      extract_assessment_params
-      extract_redetermination_params
-      @result = :ok
     end
 
     def update!
-      validate_params
-      update_and_transition_state if @result == :ok
+      @result = validator.call
+      update_and_transition_state if result.eql?(:ok)
       self
     end
 
     private
 
-    def extract_transition_params
-      @state = @params.delete('state')
-      @transition_reasons = @params.delete('state_reason')&.reject(&:empty?)
-      @transition_reason_text = extract_reason_text
-      @current_user = @params.delete(:current_user)
-    end
-
-    def extract_reason_text
-      reasons = {
-        rejected: @params.delete('reject_reason_text'),
-        refused: @params.delete('refuse_reason_text')
-      }
-      reasons[@state.to_sym] if @state.present?
-    end
-
-    def extract_assessment_params
-      @assessment_params = extract_present_params(@params.delete('assessment_attributes'))
-      @assessment_params_present = params_present?(@assessment_params)
-    end
-
-    def extract_redetermination_params
-      @redetermination_params = @params.delete('redeterminations_attributes')
-      @redetermination_params = extract_present_params(@redetermination_params['0']) unless @redetermination_params.nil?
-      @redetermination_params_present = params_present?(@redetermination_params)
-    end
-
-    def extract_present_params(params)
-      (params || {}).reject { |_k, v| v.nil? || v.is_a?(String) && v.blank? }
-    end
-
-    def validate_params
-      if @assessment_params_present || @redetermination_params_present
-        validate_state_when_assessment_present
-        clear_transition_reasons
-      elsif @state.blank?
-        add_error 'You should select a status'
-
-      else
-        validate_state_when_no_assessment_present
-        validate_reason_presence
-      end
-    end
-
-    def validate_state_when_assessment_present
-      if @state.blank?
-        add_error 'You must specify authorised or part authorised if you supply values'
-      elsif @state == 'refused'
-        add_error 'You cannot specify values when refusing a claim'
-      elsif @state == 'rejected'
-        add_error 'You cannot specify values when rejecting a claim'
-      end
-    end
-
-    def clear_transition_reasons
-      @transition_reasons = nil
-      @transition_reason_text = nil
-    end
-
-    def validate_state_when_no_assessment_present
-      return unless @state.in?(%w[authorised part_authorised])
-      add_error 'You must specify positive values if authorising or part authorising a claim'
-    end
-
-    def validate_reason_presence
-      return unless %w[rejected refused].include?(@state)
-      add_error("requires a reason when #{state_verb}", state_symbol(false)) if @transition_reasons&.empty?
-      add_error('needs a description', state_symbol) if transition_reason_text_missing?
-    end
-
-    def state_verb
-      @state_verb ||= @state.eql?('refused') ? 'refusing' : 'rejecting'
-    end
-
-    def state_symbol(other_suffix = true)
-      @state_noun ||= "#{@state}_reason#{'_other' if other_suffix}".to_sym
-    end
-
-    def transition_reason_text_missing?
-      @transition_reasons&.any? { |reason| %w[other other_refuse].include?(reason) } && @transition_reason_text.blank?
-    end
-
-    def params_present?(params)
-      return false unless params.present?
-      %w[fees expenses disbursements].any? { |field| params[field].to_f > 0.0 }
-    end
-
     def update_and_transition_state
-      event = Claims::InputEventMapper.input_event(@state)
+      event = Claims::InputEventMapper.input_event(state)
 
-      @claim.class.transaction do
-        @claim.update(@params)
-        update_assessment if @assessment_params_present
-        add_redetermination if @redetermination_params_present
-        @claim.send(event, audit_attributes) unless state_not_updateable?
-        add_message if @transition_reasons.present?
+      claim.class.transaction do
+        # @claim.update(@params)
+        update_assessment if assessment_params
+        add_redetermination if redetermination_params
+        claim.send(event, audit_attributes) unless state_not_updateable?
+        add_message if transition_reasons.present?
       rescue StandardError => err
-        add_error err.message
+        add_error(err.message)
         raise ActiveRecord::Rollback
       end
     end
 
     def state_not_updateable?
-      @state.blank? || @state == @claim.state
+      state.blank? || state == claim.state
     end
 
     def update_assessment
-      params_with_defaults = {
-        'fees' => '0.00',
-        'expenses' => '0.00',
-        'disbursements' => '0.00'
-      }.merge(@assessment_params)
-      @claim.assessment.update(params_with_defaults)
+      claim.assessment.update(assessment_params)
     end
 
     def add_redetermination
-      params_with_defaults = {
-        'fees' => '0.00',
-        'expenses' => '0.00',
-        'disbursements' => '0.00'
-      }.merge(@redetermination_params)
-      @claim.redeterminations << Redetermination.new(params_with_defaults)
+      claim.redeterminations.create(redetermination_params)
     end
 
     # rubocop:disable Metrics/LineLength
     def add_message
-      @claim.messages.create(sender_id: @current_user.id, body: transition_message) if Release.reject_refuse_messaging_released?
+      claim.messages.create(sender_id: current_user.id, body: transition_message) if Release.reject_refuse_messaging_released?
     end
     # rubocop:enable Metrics/LineLength
 
     def transition_message
-      StateTransitionMessageBuilder.new(@state, @transition_reasons, @transition_reason_text).call
-    end
-
-    def add_error(message, attribute = :determinations)
-      @claim.errors[attribute] << message
-      @result = :error
+      StateTransitionMessageBuilder.new(state, transition_reasons, transition_reason_text).call
     end
 
     def audit_attributes
       {
         author_id: current_user&.id,
-        reason_code: @transition_reasons,
-        reason_text: @transition_reason_text
+        reason_code: transition_reasons,
+        reason_text: transition_reason_text
       }
     end
   end

--- a/app/services/claims/claim_state_transition_validator.rb
+++ b/app/services/claims/claim_state_transition_validator.rb
@@ -30,21 +30,20 @@ module Claims
     end
 
     def validate_refused
-      add_error('You cannot specify values when refusing a claim') if determination_present?
       common_undetermined_validations
     end
 
     def validate_rejected
-      add_error('You cannot specify values when rejecting a claim') if determination_present?
       common_undetermined_validations
     end
 
     def common_determination_validations
-      add_error('You must provide an assessment with positive values when [part] authorising') unless determination_present?
+      add_error('You must provide values when [part] authorising') unless determination_present?
       add_error('You cannot provide reject/refuse reasons with an assessment') if reasons_present?
     end
 
     def common_undetermined_validations
+      add_error("You cannot specify values when #{state_verb} a claim") if determination_present?
       add_error("requires a reason when #{state_verb}", state_symbol(false)) if transition_reasons&.empty?
       add_error('needs a description', state_symbol) if transition_reason_text_missing?
     end

--- a/app/services/claims/claim_state_transition_validator.rb
+++ b/app/services/claims/claim_state_transition_validator.rb
@@ -13,6 +13,11 @@ module Claims
       validate
     end
 
+    def add_error(message, attribute = :determinations)
+      claim.errors[attribute] << message
+      @result = :error
+    end
+
     private
 
     def validate

--- a/app/services/claims/claim_state_transition_validator.rb
+++ b/app/services/claims/claim_state_transition_validator.rb
@@ -1,0 +1,52 @@
+module Claims
+  class ClaimStateTransitionValidator
+    include CaseWorkerClaimParamReadable
+    attr_accessor :claim, :params, :result
+
+    def initialize(claim, params)
+      @claim = claim
+      @params = params
+      @result = :ok
+    end
+
+    def call
+      validate
+    end
+
+    private
+
+    def validate
+      add_error('You must select a status') if state.blank?
+      send("validate_#{state}") if state&.in?(%w[authorised part_authorised refused rejected])
+      result
+    end
+
+    def validate_authorised
+      common_determination_validations
+    end
+
+    def validate_part_authorised
+      common_determination_validations
+    end
+
+    def validate_refused
+      add_error('You cannot specify values when refusing a claim') if determination_present?
+      common_undetermined_validations
+    end
+
+    def validate_rejected
+      add_error('You cannot specify values when rejecting a claim') if determination_present?
+      common_undetermined_validations
+    end
+
+    def common_determination_validations
+      add_error('You must provide an assessment with positive values when [part] authorising') unless determination_present?
+      add_error('You cannot provide reject/refuse reasons with an assessment') if reasons_present?
+    end
+
+    def common_undetermined_validations
+      add_error("requires a reason when #{state_verb}", state_symbol(false)) if transition_reasons&.empty?
+      add_error('needs a description', state_symbol) if transition_reason_text_missing?
+    end
+  end
+end

--- a/app/services/concerns/case_worker_claim_param_readable.rb
+++ b/app/services/concerns/case_worker_claim_param_readable.rb
@@ -1,0 +1,86 @@
+module CaseWorkerClaimParamReadable
+  extend ActiveSupport::Concern
+
+  included do
+    def current_user
+      @current_user ||= params[:current_user]
+    end
+
+    def state
+      @state ||= params['state']
+    end
+
+    def transition_reasons
+      @transition_reasons ||= params['state_reason']&.reject(&:empty?)
+    end
+
+    def transition_reason_text
+      @transition_reason_text ||= reason_text
+    end
+
+    def reason_text
+      reasons = {
+        rejected: params['reject_reason_text'],
+        refused: params['refuse_reason_text']
+      }
+      reasons[state.to_sym] if state.present?
+    end
+
+    def assessment_params
+      @assessment_params ||= assessment_attributes
+    end
+
+    def assessment_attributes
+      determination_with_defaults(params['assessment_attributes']) if determination_non_zero?(params['assessment_attributes'])
+    end
+
+    def redetermination_params
+      @redetermination_params ||= redeterminations_attributes
+    end
+
+    def redeterminations_attributes
+      redetermination_params = params.dig('redeterminations_attributes', '0')
+      determination_with_defaults(redetermination_params) if determination_non_zero?(redetermination_params)
+    end
+
+    def state_verb
+      @state_verb ||= state.eql?('refused') ? 'refusing' : 'rejecting'
+    end
+
+    def state_symbol(other_suffix = true)
+      @state_noun ||= "#{state}_reason#{'_other' if other_suffix}".to_sym
+    end
+
+    def transition_reason_text_missing?
+      transition_reasons&.any? { |reason| %w[other other_refuse].include?(reason) } &&
+        transition_reason_text.blank?
+    end
+
+    def determination_with_defaults(attributes)
+      attributes.reject! { |_k, v| v.blank? }
+      {
+        'fees' => '0.00',
+        'expenses' => '0.00',
+        'disbursements' => '0.00'
+      }.merge(attributes)
+    end
+
+    def determination_non_zero?(params)
+      return false unless params.present?
+      %w[fees expenses disbursements].any? { |field| params[field].to_f > 0.0 }
+    end
+
+    def determination_present?
+      assessment_params || redetermination_params
+    end
+
+    def reasons_present?
+      transition_reasons.present? || transition_reason_text.present?
+    end
+
+    def add_error(message, attribute = :determinations)
+      claim.errors[attribute] << message
+      @result = :error
+    end
+  end
+end

--- a/app/services/concerns/case_worker_claim_param_readable.rb
+++ b/app/services/concerns/case_worker_claim_param_readable.rb
@@ -78,10 +78,5 @@ module CaseWorkerClaimParamReadable
     def reasons_present?
       transition_reasons.present? || transition_reason_text.present?
     end
-
-    def add_error(message, attribute = :determinations)
-      claim.errors[attribute] << message
-      @result = :error
-    end
   end
 end

--- a/app/services/concerns/case_worker_claim_param_readable.rb
+++ b/app/services/concerns/case_worker_claim_param_readable.rb
@@ -31,20 +31,21 @@ module CaseWorkerClaimParamReadable
     end
 
     def assessment_attributes
-      determination_with_defaults(params['assessment_attributes']) if determination_non_zero?(params['assessment_attributes'])
+      assessment_attributes = params['assessment_attributes']
+      determination_with_defaults(assessment_attributes) unless determination_zero?(assessment_attributes)
     end
 
     def redetermination_params
-      @redetermination_params ||= redeterminations_attributes
+      @redetermination_params ||= redetermination_attributes
     end
 
-    def redeterminations_attributes
-      redetermination_params = params.dig('redeterminations_attributes', '0')
-      determination_with_defaults(redetermination_params) if determination_non_zero?(redetermination_params)
+    def redetermination_attributes
+      redetermination_attributes = params.dig('redeterminations_attributes', '0')
+      determination_with_defaults(redetermination_attributes) unless determination_zero?(redetermination_attributes)
     end
 
     def state_verb
-      @state_verb ||= state.eql?('refused') ? 'refusing' : 'rejecting'
+      @state_verb ||= state.chomp('ed').concat('ing')
     end
 
     def state_symbol(other_suffix = true)
@@ -65,9 +66,9 @@ module CaseWorkerClaimParamReadable
       }.merge(attributes)
     end
 
-    def determination_non_zero?(params)
-      return false unless params.present?
-      %w[fees expenses disbursements].any? { |field| params[field].to_f > 0.0 }
+    def determination_zero?(params)
+      params.blank? ||
+        %w[fees expenses disbursements].none? { |field| params[field].to_f > 0.0 }
     end
 
     def determination_present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,7 @@ module AdvocateDefencePayments
     # config.autoload_paths += Dir[Rails.root.join('app', 'services', 'stats', '*')]
     config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths << Rails.root.join('app','presenters','concerns')
+    config.autoload_paths << Rails.root.join('app','services','concerns')
 
     config.eager_load_paths << Rails.root.join('lib')
 


### PR DESCRIPTION
#### What
Refactor case worker claim updater service and validate reasons presence

#### Ticket

relates to [Bug: [Part] Authorise can record reject/refuse reasons](https://www.pivotaltracker.com/story/show/156965581)

#### Why
This service object was doing to much and it was possible to 
provide reject/refuse reasons and then authorise the claim,
thereby adding a message to the claim.

#### How
extract validation logic to a validator and share common functionality in concern

#### further actions
ticket to prevent reasons from being sent from form when authorising?!

