### PR TITLE
Tweak case worker claim update validation error messages

### DIFF
--- a/app/services/claims/claim_state_transition_validator.rb
+++ b/app/services/claims/claim_state_transition_validator.rb
@@ -21,9 +21,13 @@ module Claims
     private
 
     def validate
-      add_error('You must select a status') if state.blank?
+      validate_state
       send("validate_#{state}") if state&.in?(%w[authorised part_authorised refused rejected])
       result
+    end
+
+    def validate_state
+      add_error('must select a status') if state.blank?
     end
 
     def validate_authorised
@@ -43,13 +47,13 @@ module Claims
     end
 
     def common_determination_validations
-      add_error('You must provide values when [part] authorising') unless determination_present?
-      add_error('You cannot provide reject/refuse reasons with an assessment') if reasons_present?
+      add_error('require values when authorising') unless determination_present?
+      add_error('must not provide reject/refuse reasons') if reasons_present?
     end
 
     def common_undetermined_validations
-      add_error("You cannot specify values when #{state_verb} a claim") if determination_present?
-      add_error("requires a reason when #{state_verb}", state_symbol(false)) if transition_reasons&.empty?
+      add_error("must not have values when #{state_verb} a claim") if determination_present?
+      add_error('requires a reason', state_symbol(false)) if transition_reasons&.empty?
       add_error('needs a description', state_symbol) if transition_reason_text_missing?
     end
   end

--- a/spec/services/claims/case_worker_claim_updater_spec.rb
+++ b/spec/services/claims/case_worker_claim_updater_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Claims::CaseWorkerClaimUpdater do
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
         expect(updater.claim.assessment).to be_zero
-        expect(updater.claim.errors[:determinations]).to eq(['You must select a status'])
+        expect(updater.claim.errors[:determinations]).to eq(['must select a status'])
       end
 
       it 'errors if part auth selected and no values' do
@@ -174,21 +174,21 @@ RSpec.describe Claims::CaseWorkerClaimUpdater do
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
         expect(updater.claim.assessment).to be_zero
-        expect(updater.claim.errors[:determinations]).to include('You must provide values when [part] authorising')
+        expect(updater.claim.errors[:determinations]).to include('require values when authorising')
       end
 
       it 'errors if assessment data is present in the params but no state specified' do
         params = {'state' => '', 'assessment_attributes' => {'fees' => '128.33', 'expenses' => '42.88'}}
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
-        expect(updater.claim.errors[:determinations]).to include('You must select a status')
+        expect(updater.claim.errors[:determinations]).to include('must select a status')
       end
 
       it 'errors if values are supplied with refused' do
         params = {'state' => 'refused', 'assessment_attributes' => {'fees' => '93.65','expenses' => '42.88'}}
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
-        expect(updater.claim.errors[:determinations]).to include('You cannot specify values when refusing a claim')
+        expect(updater.claim.errors[:determinations]).to include('must not have values when refusing a claim')
         expect(updater.claim.state).to eq 'allocated'
         expect(updater.claim.assessment.fees.to_f).to eq 0.0
         expect(updater.claim.assessment.expenses).to eq 0.0
@@ -199,7 +199,7 @@ RSpec.describe Claims::CaseWorkerClaimUpdater do
         params = {'state' => 'rejected', 'assessment_attributes' => {'fees' => '93.65','expenses' => '42.88'}}
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
-        expect(updater.claim.errors[:determinations]).to include('You cannot specify values when rejecting a claim')
+        expect(updater.claim.errors[:determinations]).to include('must not have values when rejecting a claim')
         expect(updater.claim.state).to eq 'allocated'
         expect(updater.claim.assessment.fees.to_f).to eq 0.0
         expect(updater.claim.assessment.expenses).to eq 0.0
@@ -210,7 +210,7 @@ RSpec.describe Claims::CaseWorkerClaimUpdater do
         params = {'state' => 'rejected', 'state_reason' => [''], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
-        expect(updater.claim.errors[:rejected_reason]).to include('requires a reason when rejecting')
+        expect(updater.claim.errors[:rejected_reason]).to include('requires a reason')
         expect(updater.claim.state).to eq 'allocated'
         expect(updater.claim.assessment.fees.to_f).to eq 0.0
         expect(updater.claim.assessment.expenses).to eq 0.0
@@ -232,7 +232,7 @@ RSpec.describe Claims::CaseWorkerClaimUpdater do
         params = {'state' => 'refused', 'state_reason' => [''], 'assessment_attributes' => {'fees' => '', 'expenses' => '0'}}
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
-        expect(updater.claim.errors[:refused_reason]).to include('requires a reason when refusing')
+        expect(updater.claim.errors[:refused_reason]).to include('requires a reason')
         expect(updater.claim.state).to eq 'allocated'
         expect(updater.claim.assessment.fees.to_f).to eq 0.0
         expect(updater.claim.assessment.expenses).to eq 0.0
@@ -391,22 +391,22 @@ RSpec.describe Claims::CaseWorkerClaimUpdater do
         params = {'state' => '', 'redeterminations_attributes' => {'0' => {'fees' => '128.33', 'expenses' => '42.40'}}}
         updater = described_class.new(claim.id, params).update!
         expect(updater.result).to eq :error
-        expect(updater.claim.errors[:determinations]).to eq(['You must select a status'])
+        expect(updater.claim.errors[:determinations]).to include('must select a status')
       end
 
       context 'when determination values are supplied with refused' do
-        it_behaves_like 'an erroneous determination', 'refused', ['You cannot specify values when refusing a claim'], 'assessment'
-        it_behaves_like 'an erroneous determination', 'refused', ['You cannot specify values when refusing a claim'], 'redeterminations'
+        it_behaves_like 'an erroneous determination', 'refused', ['must not have values when refusing a claim'], 'assessment'
+        it_behaves_like 'an erroneous determination', 'refused', ['must not have values when refusing a claim'], 'redeterminations'
       end
 
       context 'when determination values are supplied with rejected' do
-        it_behaves_like 'an erroneous determination', 'rejected', ['You cannot specify values when rejecting a claim'], 'assessment'
-        it_behaves_like 'an erroneous determination', 'rejected', ['You cannot specify values when rejecting a claim'], 'redeterminations'
+        it_behaves_like 'an erroneous determination', 'rejected', ['must not have values when rejecting a claim'], 'assessment'
+        it_behaves_like 'an erroneous determination', 'rejected', ['must not have values when rejecting a claim'], 'redeterminations'
       end
 
       context 'when no reasons are supplied with rejected/refused' do
-        it_behaves_like 'an erroneous determination', 'rejected', ['requires a reason when rejecting'], 'redeterminations', [''], '', 0, :rejected_reason
-        it_behaves_like 'an erroneous determination', 'refused', ['requires a reason when refusing'], 'redeterminations', [''], '', 0, :refused_reason
+        it_behaves_like 'an erroneous determination', 'rejected', ['requires a reason'], 'redeterminations', [''], '', 0, :rejected_reason
+        it_behaves_like 'an erroneous determination', 'refused', ['requires a reason'], 'redeterminations', [''], '', 0, :refused_reason
       end
 
       context 'when other reason given without reason text' do
@@ -414,8 +414,8 @@ RSpec.describe Claims::CaseWorkerClaimUpdater do
       end
 
       context 'when reasons given for authorised claims' do
-        it_behaves_like 'an erroneous determination', 'authorised', ['You cannot provide reject/refuse reasons with an assessment'], 'assessment', ['no_indictment']
-        it_behaves_like 'an erroneous determination', 'authorised', ['You cannot provide reject/refuse reasons with an assessment'], 'redeterminations', ['wrong_ia']
+        it_behaves_like 'an erroneous determination', 'authorised', ['must not provide reject/refuse reasons'], 'assessment', ['no_indictment']
+        it_behaves_like 'an erroneous determination', 'authorised', ['must not provide reject/refuse reasons'], 'redeterminations', ['wrong_ia']
       end
     end
   end


### PR DESCRIPTION
#### What
change messages displayed to case workers for erroneous transition options

#### Why
example old:
<img width="684" alt="screen shot 2018-04-27 at 14 27 48" src="https://user-images.githubusercontent.com/7016425/39364863-4dc6a46e-4a27-11e8-9dce-d346f7c90fc8.png">
example new: 
<img width="726" alt="screen shot 2018-04-27 at 14 31 13" src="https://user-images.githubusercontent.com/7016425/39364958-b00cb104-4a27-11e8-8f37-40bb3255ccc2.png">
