### PR TITLE
Add `[4.2]` to all migration

### DIFF
--- a/db/migrate/20150325120724_create_chambers.rb
+++ b/db/migrate/20150325120724_create_chambers.rb
@@ -1,4 +1,4 @@
-class CreateChambers < ActiveRecord::Migration
+class CreateChambers < ActiveRecord::Migration[4.2]
   def change
     create_table :chambers do |t|
       t.string :name

--- a/db/migrate/20150325142122_create_claims.rb
+++ b/db/migrate/20150325142122_create_claims.rb
@@ -1,4 +1,4 @@
-class CreateClaims < ActiveRecord::Migration
+class CreateClaims < ActiveRecord::Migration[4.2]
   def change
     create_table :claims do |t|
       t.text :additional_information

--- a/db/migrate/20150325144103_create_case_worker_claims.rb
+++ b/db/migrate/20150325144103_create_case_worker_claims.rb
@@ -1,4 +1,4 @@
-class CreateCaseWorkerClaims < ActiveRecord::Migration
+class CreateCaseWorkerClaims < ActiveRecord::Migration[4.2]
   def change
     create_table :case_worker_claims do |t|
       t.references :case_worker, index: true

--- a/db/migrate/20150326114342_create_fee_types.rb
+++ b/db/migrate/20150326114342_create_fee_types.rb
@@ -1,4 +1,4 @@
-class CreateFeeTypes < ActiveRecord::Migration
+class CreateFeeTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :fee_types do |t|
       t.string :description

--- a/db/migrate/20150326115934_create_fees.rb
+++ b/db/migrate/20150326115934_create_fees.rb
@@ -1,4 +1,4 @@
-class CreateFees < ActiveRecord::Migration
+class CreateFees < ActiveRecord::Migration[4.2]
   def change
     create_table :fees do |t|
       t.references :claim, index: true

--- a/db/migrate/20150326140238_create_expense_types.rb
+++ b/db/migrate/20150326140238_create_expense_types.rb
@@ -1,4 +1,4 @@
-class CreateExpenseTypes < ActiveRecord::Migration
+class CreateExpenseTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :expense_types do |t|
       t.string :name

--- a/db/migrate/20150326140817_create_expenses.rb
+++ b/db/migrate/20150326140817_create_expenses.rb
@@ -1,4 +1,4 @@
-class CreateExpenses < ActiveRecord::Migration
+class CreateExpenses < ActiveRecord::Migration[4.2]
   def change
     create_table :expenses do |t|
       t.references :expense_type, index: true

--- a/db/migrate/20150326145555_create_defendants.rb
+++ b/db/migrate/20150326145555_create_defendants.rb
@@ -1,4 +1,4 @@
-class CreateDefendants < ActiveRecord::Migration
+class CreateDefendants < ActiveRecord::Migration[4.2]
   def change
     create_table :defendants do |t|
       t.string :first_name

--- a/db/migrate/20150327103635_devise_create_users.rb
+++ b/db/migrate/20150327103635_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20150330084305_create_courts.rb
+++ b/db/migrate/20150330084305_create_courts.rb
@@ -1,4 +1,4 @@
-class CreateCourts < ActiveRecord::Migration
+class CreateCourts < ActiveRecord::Migration[4.2]
   def change
     create_table :courts do |t|
       t.string :code

--- a/db/migrate/20150331133748_create_documents.rb
+++ b/db/migrate/20150331133748_create_documents.rb
@@ -1,4 +1,4 @@
-class CreateDocuments < ActiveRecord::Migration
+class CreateDocuments < ActiveRecord::Migration[4.2]
   def change
     create_table :documents do |t|
       t.references :claim, index: true

--- a/db/migrate/20150416144357_alter_documents_add_paperclip_attachement.rb
+++ b/db/migrate/20150416144357_alter_documents_add_paperclip_attachement.rb
@@ -1,4 +1,4 @@
-class AlterDocumentsAddPaperclipAttachement < ActiveRecord::Migration
+class AlterDocumentsAddPaperclipAttachement < ActiveRecord::Migration[4.2]
   def change
     change_table(:documents) do |t|
       t.remove      :document

--- a/db/migrate/20150423082903_create_document_types.rb
+++ b/db/migrate/20150423082903_create_document_types.rb
@@ -1,4 +1,4 @@
-class CreateDocumentTypes < ActiveRecord::Migration
+class CreateDocumentTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :document_types do |t|
       t.string :description

--- a/db/migrate/20150423142919_create_offences.rb
+++ b/db/migrate/20150423142919_create_offences.rb
@@ -1,4 +1,4 @@
-class CreateOffences < ActiveRecord::Migration
+class CreateOffences < ActiveRecord::Migration[4.2]
   def change
     create_table :offences do |t|
       t.string :description

--- a/db/migrate/20150424102029_create_features.rb
+++ b/db/migrate/20150424102029_create_features.rb
@@ -1,4 +1,4 @@
-class CreateFeatures < ActiveRecord::Migration
+class CreateFeatures < ActiveRecord::Migration[4.2]
   def change
     create_table :features do |t|
       t.string :key, null: false

--- a/db/migrate/20150424132253_create_advocates.rb
+++ b/db/migrate/20150424132253_create_advocates.rb
@@ -1,4 +1,4 @@
-class CreateAdvocates < ActiveRecord::Migration
+class CreateAdvocates < ActiveRecord::Migration[4.2]
   def change
     create_table :advocates do |t|
       t.string :role

--- a/db/migrate/20150424140231_create_case_workers.rb
+++ b/db/migrate/20150424140231_create_case_workers.rb
@@ -1,4 +1,4 @@
-class CreateCaseWorkers < ActiveRecord::Migration
+class CreateCaseWorkers < ActiveRecord::Migration[4.2]
   def change
     create_table :case_workers do |t|
       t.string :role

--- a/db/migrate/20150428123404_create_offence_classes.rb
+++ b/db/migrate/20150428123404_create_offence_classes.rb
@@ -1,4 +1,4 @@
-class CreateOffenceClasses < ActiveRecord::Migration
+class CreateOffenceClasses < ActiveRecord::Migration[4.2]
   def change
     create_table :offence_classes do |t|
       t.string :class_letter

--- a/db/migrate/20150430115328_create_schemes.rb
+++ b/db/migrate/20150430115328_create_schemes.rb
@@ -1,4 +1,4 @@
-class CreateSchemes < ActiveRecord::Migration
+class CreateSchemes < ActiveRecord::Migration[4.2]
   def change
     create_table :schemes do |t|
       t.string :name

--- a/db/migrate/20150511103114_amend_claim_add_valid_until.rb
+++ b/db/migrate/20150511103114_amend_claim_add_valid_until.rb
@@ -1,4 +1,4 @@
-class AmendClaimAddValidUntil < ActiveRecord::Migration
+class AmendClaimAddValidUntil < ActiveRecord::Migration[4.2]
   def change
     change_table(:claims) do |t|
       t.datetime :valid_until

--- a/db/migrate/20150511152610_create_versions.rb
+++ b/db/migrate/20150511152610_create_versions.rb
@@ -1,4 +1,4 @@
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def change
     create_table :versions do |t|
       t.string   :item_type, :null => false

--- a/db/migrate/20150514153916_add_cms_number_to_claims.rb
+++ b/db/migrate/20150514153916_add_cms_number_to_claims.rb
@@ -1,4 +1,4 @@
-class AddCmsNumberToClaims < ActiveRecord::Migration
+class AddCmsNumberToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :cms_number, :string
     add_index :claims, :cms_number

--- a/db/migrate/20150515082101_add_paid_at_to_claims.rb
+++ b/db/migrate/20150515082101_add_paid_at_to_claims.rb
@@ -1,4 +1,4 @@
-class AddPaidAtToClaims < ActiveRecord::Migration
+class AddPaidAtToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :paid_at, :datetime
   end

--- a/db/migrate/20150518132415_alter_documents_add_advocate_id.rb
+++ b/db/migrate/20150518132415_alter_documents_add_advocate_id.rb
@@ -1,4 +1,4 @@
-class AlterDocumentsAddAdvocateId < ActiveRecord::Migration
+class AlterDocumentsAddAdvocateId < ActiveRecord::Migration[4.2]
   def change
     change_table(:documents) do |t|
       t.references :advocate, index: true

--- a/db/migrate/20150522134938_add_attachment_converted_preview_document_to_documents.rb
+++ b/db/migrate/20150522134938_add_attachment_converted_preview_document_to_documents.rb
@@ -1,4 +1,4 @@
-class AddAttachmentConvertedPreviewDocumentToDocuments < ActiveRecord::Migration
+class AddAttachmentConvertedPreviewDocumentToDocuments < ActiveRecord::Migration[4.2]
   def self.up
     change_table :documents do |t|
       t.attachment :converted_preview_document

--- a/db/migrate/20150527102833_create_messages.rb
+++ b/db/migrate/20150527102833_create_messages.rb
@@ -1,4 +1,4 @@
-class CreateMessages < ActiveRecord::Migration
+class CreateMessages < ActiveRecord::Migration[4.2]
   def change
     create_table :messages do |t|
       t.string :subject

--- a/db/migrate/20150527131251_remove_recipient_id_from_messages.rb
+++ b/db/migrate/20150527131251_remove_recipient_id_from_messages.rb
@@ -1,4 +1,4 @@
-class RemoveRecipientIdFromMessages < ActiveRecord::Migration
+class RemoveRecipientIdFromMessages < ActiveRecord::Migration[4.2]
   def change
     remove_column :messages, :recipient_id
   end

--- a/db/migrate/20150528101244_move_first_name_and_lastname_to_user_model.rb
+++ b/db/migrate/20150528101244_move_first_name_and_lastname_to_user_model.rb
@@ -1,4 +1,4 @@
-class MoveFirstNameAndLastnameToUserModel < ActiveRecord::Migration
+class MoveFirstNameAndLastnameToUserModel < ActiveRecord::Migration[4.2]
   def change
     remove_column :advocates, :first_name
     remove_column :advocates, :last_name

--- a/db/migrate/20150528151004_add_account_num_to_advocates.rb
+++ b/db/migrate/20150528151004_add_account_num_to_advocates.rb
@@ -1,4 +1,4 @@
-class AddAccountNumToAdvocates < ActiveRecord::Migration
+class AddAccountNumToAdvocates < ActiveRecord::Migration[4.2]
   def change
     add_column :advocates, :account_number, :string
     add_index  :advocates, :account_number

--- a/db/migrate/20150528152825_add_creator_id_to_claims.rb
+++ b/db/migrate/20150528152825_add_creator_id_to_claims.rb
@@ -1,4 +1,4 @@
-class AddCreatorIdToClaims < ActiveRecord::Migration
+class AddCreatorIdToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :creator_id, :integer
     add_index :claims, :creator_id

--- a/db/migrate/20150529152928_add_amount_assessed_to_claim.rb
+++ b/db/migrate/20150529152928_add_amount_assessed_to_claim.rb
@@ -1,4 +1,4 @@
-class AddAmountAssessedToClaim < ActiveRecord::Migration
+class AddAmountAssessedToClaim < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :amount_assessed, :decimal
   end

--- a/db/migrate/20150602101638_add_default_value_to_amount_assessed.rb
+++ b/db/migrate/20150602101638_add_default_value_to_amount_assessed.rb
@@ -1,4 +1,4 @@
-class AddDefaultValueToAmountAssessed < ActiveRecord::Migration
+class AddDefaultValueToAmountAssessed < ActiveRecord::Migration[4.2]
   def up
     change_column :claims, :amount_assessed, :decimal, :default => 0
   end

--- a/db/migrate/20150602131128_create_dates_attended.rb
+++ b/db/migrate/20150602131128_create_dates_attended.rb
@@ -1,4 +1,4 @@
-class CreateDatesAttended < ActiveRecord::Migration
+class CreateDatesAttended < ActiveRecord::Migration[4.2]
   def change
     create_table :dates_attended do |t|
       t.datetime :date

--- a/db/migrate/20150602150201_add_date_to_to_dates_attended.rb
+++ b/db/migrate/20150602150201_add_date_to_to_dates_attended.rb
@@ -1,4 +1,4 @@
-class AddDateToToDatesAttended < ActiveRecord::Migration
+class AddDateToToDatesAttended < ActiveRecord::Migration[4.2]
   def change
     add_column :dates_attended, :date_to, :datetime
   end

--- a/db/migrate/20150604143054_create_user_message_statuses.rb
+++ b/db/migrate/20150604143054_create_user_message_statuses.rb
@@ -1,4 +1,4 @@
-class CreateUserMessageStatuses < ActiveRecord::Migration
+class CreateUserMessageStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :user_message_statuses do |t|
       t.references :user, index: true

--- a/db/migrate/20150608154716_create_representation_orders.rb
+++ b/db/migrate/20150608154716_create_representation_orders.rb
@@ -1,4 +1,4 @@
-class CreateRepresentationOrders < ActiveRecord::Migration
+class CreateRepresentationOrders < ActiveRecord::Migration[4.2]
   def change
     create_table :representation_orders do |t|
       t.integer   :defendant_id

--- a/db/migrate/20150609093857_remove_hours_from_expenses.rb
+++ b/db/migrate/20150609093857_remove_hours_from_expenses.rb
@@ -1,4 +1,4 @@
-class RemoveHoursFromExpenses < ActiveRecord::Migration
+class RemoveHoursFromExpenses < ActiveRecord::Migration[4.2]
   def change
     remove_column :expenses, :hours
   end

--- a/db/migrate/20150610141015_create_evidence_list_items.rb
+++ b/db/migrate/20150610141015_create_evidence_list_items.rb
@@ -1,4 +1,4 @@
-class CreateEvidenceListItems < ActiveRecord::Migration
+class CreateEvidenceListItems < ActiveRecord::Migration[4.2]
   def change
     create_table :evidence_list_items do |t|
       t.string :description, null: false

--- a/db/migrate/20150610154552_create_evidence_list_item_claims.rb
+++ b/db/migrate/20150610154552_create_evidence_list_item_claims.rb
@@ -1,4 +1,4 @@
-class CreateEvidenceListItemClaims < ActiveRecord::Migration
+class CreateEvidenceListItemClaims < ActiveRecord::Migration[4.2]
   def change
     create_table :evidence_list_item_claims do |t|
       t.belongs_to :claim, null: false, index: true

--- a/db/migrate/20150615132927_add_granting_body_to_representation_orders.rb
+++ b/db/migrate/20150615132927_add_granting_body_to_representation_orders.rb
@@ -1,4 +1,4 @@
-class AddGrantingBodyToRepresentationOrders < ActiveRecord::Migration
+class AddGrantingBodyToRepresentationOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :representation_orders, :granting_body, :string
   end

--- a/db/migrate/20150616090644_drop_evidence_list_items_table.rb
+++ b/db/migrate/20150616090644_drop_evidence_list_items_table.rb
@@ -1,4 +1,4 @@
-class DropEvidenceListItemsTable < ActiveRecord::Migration
+class DropEvidenceListItemsTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :evidence_list_items
   end

--- a/db/migrate/20150616093010_drop_evidence_list_item_claims_table.rb
+++ b/db/migrate/20150616093010_drop_evidence_list_item_claims_table.rb
@@ -1,4 +1,4 @@
-class DropEvidenceListItemClaimsTable < ActiveRecord::Migration
+class DropEvidenceListItemClaimsTable < ActiveRecord::Migration[4.2]
  def up
     drop_table :evidence_list_item_claims
   end

--- a/db/migrate/20150616094245_create_document_type_claims_table.rb
+++ b/db/migrate/20150616094245_create_document_type_claims_table.rb
@@ -1,4 +1,4 @@
-class CreateDocumentTypeClaimsTable < ActiveRecord::Migration
+class CreateDocumentTypeClaimsTable < ActiveRecord::Migration[4.2]
    def change
     create_table :document_type_claims do |t|
       t.belongs_to :claim, null: false, index: true

--- a/db/migrate/20150619123014_add_notes_to_claims.rb
+++ b/db/migrate/20150619123014_add_notes_to_claims.rb
@@ -1,4 +1,4 @@
-class AddNotesToClaims < ActiveRecord::Migration
+class AddNotesToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :notes, :text
   end

--- a/db/migrate/20150623101845_move_rep_order_date_and_maat_from_defendant_to_reporder.rb
+++ b/db/migrate/20150623101845_move_rep_order_date_and_maat_from_defendant_to_reporder.rb
@@ -1,4 +1,4 @@
-class MoveRepOrderDateAndMaatFromDefendantToReporder < ActiveRecord::Migration
+class MoveRepOrderDateAndMaatFromDefendantToReporder < ActiveRecord::Migration[4.2]
   def up
     add_column :representation_orders, :maat_reference, :string
     add_column :representation_orders, :representation_order_date, :date

--- a/db/migrate/20150625090816_remove_document_from_rep_orders.rb
+++ b/db/migrate/20150625090816_remove_document_from_rep_orders.rb
@@ -1,4 +1,4 @@
-class RemoveDocumentFromRepOrders < ActiveRecord::Migration
+class RemoveDocumentFromRepOrders < ActiveRecord::Migration[4.2]
 
   def up
     remove_column :representation_orders, :document_file_name

--- a/db/migrate/20150625122755_drop_document_types.rb
+++ b/db/migrate/20150625122755_drop_document_types.rb
@@ -1,4 +1,4 @@
-class DropDocumentTypes < ActiveRecord::Migration
+class DropDocumentTypes < ActiveRecord::Migration[4.2]
   def up
     drop_table :document_types
     drop_table :document_type_claims

--- a/db/migrate/20150625123904_add_evidence_notes_to_claim.rb
+++ b/db/migrate/20150625123904_add_evidence_notes_to_claim.rb
@@ -1,4 +1,4 @@
-class AddEvidenceNotesToClaim < ActiveRecord::Migration
+class AddEvidenceNotesToClaim < ActiveRecord::Migration[4.2]
   def up
     add_column :claims, :evidence_notes, :text
     remove_column :documents, :notes

--- a/db/migrate/20150625125502_add_evidence_checklist_to_claims.rb
+++ b/db/migrate/20150625125502_add_evidence_checklist_to_claims.rb
@@ -1,4 +1,4 @@
-class AddEvidenceChecklistToClaims < ActiveRecord::Migration
+class AddEvidenceChecklistToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :evidence_checklist_ids, :string
   end

--- a/db/migrate/20150701104143_add_trial_concluded_at_to_claims.rb
+++ b/db/migrate/20150701104143_add_trial_concluded_at_to_claims.rb
@@ -1,4 +1,4 @@
-class AddTrialConcludedAtToClaims < ActiveRecord::Migration
+class AddTrialConcludedAtToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :trial_concluded_at, :date
   end

--- a/db/migrate/20150701154619_add_trial_columns_to_claims.rb
+++ b/db/migrate/20150701154619_add_trial_columns_to_claims.rb
@@ -1,4 +1,4 @@
-class AddTrialColumnsToClaims < ActiveRecord::Migration
+class AddTrialColumnsToClaims < ActiveRecord::Migration[4.2]
    def change
     add_column :claims, :trial_fixed_notice_at,   :date
     add_column :claims, :trial_fixed_at,          :date

--- a/db/migrate/20150702103451_add_vat_rate_and_dates_to_schemes.rb
+++ b/db/migrate/20150702103451_add_vat_rate_and_dates_to_schemes.rb
@@ -1,4 +1,4 @@
-class AddVatRateAndDatesToSchemes < ActiveRecord::Migration
+class AddVatRateAndDatesToSchemes < ActiveRecord::Migration[4.2]
   def change
     add_column :schemes, :vat_rate, :float
     add_column :schemes, :start_date, :datetime

--- a/db/migrate/20150702131509_create_locations.rb
+++ b/db/migrate/20150702131509_create_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocations < ActiveRecord::Migration
+class CreateLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :locations do |t|
       t.string :name

--- a/db/migrate/20150702131548_add_location_id_to_case_workers.rb
+++ b/db/migrate/20150702131548_add_location_id_to_case_workers.rb
@@ -1,4 +1,4 @@
-class AddLocationIdToCaseWorkers < ActiveRecord::Migration
+class AddLocationIdToCaseWorkers < ActiveRecord::Migration[4.2]
   def change
     add_reference :case_workers, :location, index: true
   end

--- a/db/migrate/20150703112739_add_quantity_modifier_to_fee_types.rb
+++ b/db/migrate/20150703112739_add_quantity_modifier_to_fee_types.rb
@@ -1,4 +1,4 @@
-class AddQuantityModifierToFeeTypes < ActiveRecord::Migration
+class AddQuantityModifierToFeeTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :fee_types, :quantity_modifier, :integer
   end

--- a/db/migrate/20150710093937_remove_vat_rate_from_schemes.rb
+++ b/db/migrate/20150710093937_remove_vat_rate_from_schemes.rb
@@ -1,4 +1,4 @@
-class RemoveVatRateFromSchemes < ActiveRecord::Migration
+class RemoveVatRateFromSchemes < ActiveRecord::Migration[4.2]
   def change
     remove_column :schemes, :vat_rate
   end

--- a/db/migrate/20150715123540_change_scheme_datetimes_to_date.rb
+++ b/db/migrate/20150715123540_change_scheme_datetimes_to_date.rb
@@ -1,4 +1,4 @@
-class ChangeSchemeDatetimesToDate < ActiveRecord::Migration
+class ChangeSchemeDatetimesToDate < ActiveRecord::Migration[4.2]
   def up
     change_column :schemes, :start_date, :date
     change_column :schemes, :end_date, :date

--- a/db/migrate/20150721095559_source.rb
+++ b/db/migrate/20150721095559_source.rb
@@ -1,4 +1,4 @@
-class Source < ActiveRecord::Migration
+class Source < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :source, :string
   end

--- a/db/migrate/20150727141710_add_object_changes_to_versions.rb
+++ b/db/migrate/20150727141710_add_object_changes_to_versions.rb
@@ -1,4 +1,4 @@
-class AddObjectChangesToVersions < ActiveRecord::Migration
+class AddObjectChangesToVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :object_changes, :text
   end

--- a/db/migrate/20150728093252_add_vat_rates_table.rb
+++ b/db/migrate/20150728093252_add_vat_rates_table.rb
@@ -1,4 +1,4 @@
-class AddVatRatesTable < ActiveRecord::Migration
+class AddVatRatesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :vat_rates do |t|
       t.integer :rate_base_points

--- a/db/migrate/20150728103353_remove_quantity_modifier_from_fee_types.rb
+++ b/db/migrate/20150728103353_remove_quantity_modifier_from_fee_types.rb
@@ -1,4 +1,4 @@
-class RemoveQuantityModifierFromFeeTypes < ActiveRecord::Migration
+class RemoveQuantityModifierFromFeeTypes < ActiveRecord::Migration[4.2]
   def change
     remove_column :fee_types, :quantity_modifier, :integer
   end

--- a/db/migrate/20150728104047_remove_rate_from_fees.rb
+++ b/db/migrate/20150728104047_remove_rate_from_fees.rb
@@ -1,4 +1,4 @@
-class RemoveRateFromFees < ActiveRecord::Migration
+class RemoveRateFromFees < ActiveRecord::Migration[4.2]
   def change
     remove_column :fees, :rate, :decimal
   end

--- a/db/migrate/20150729135413_create_claim_state_transitions.rb
+++ b/db/migrate/20150729135413_create_claim_state_transitions.rb
@@ -1,4 +1,4 @@
-class CreateClaimStateTransitions < ActiveRecord::Migration
+class CreateClaimStateTransitions < ActiveRecord::Migration[4.2]
   def change
     create_table :claim_state_transitions do |t|
       t.references :claim, index: true

--- a/db/migrate/20150729140240_add_vat_to_claims.rb
+++ b/db/migrate/20150729140240_add_vat_to_claims.rb
@@ -1,4 +1,4 @@
-class AddVatToClaims < ActiveRecord::Migration
+class AddVatToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :vat_amount, :decimal, default: 0.0
   end

--- a/db/migrate/20150804095250_enable_uuid.rb
+++ b/db/migrate/20150804095250_enable_uuid.rb
@@ -1,4 +1,4 @@
-class EnableUuid < ActiveRecord::Migration
+class EnableUuid < ActiveRecord::Migration[4.2]
   def up
     enable_extension 'uuid-ossp'
   end

--- a/db/migrate/20150804100037_add_uuids.rb
+++ b/db/migrate/20150804100037_add_uuids.rb
@@ -1,4 +1,4 @@
-class AddUuids < ActiveRecord::Migration
+class AddUuids < ActiveRecord::Migration[4.2]
   def change
     add_column :advocates,              :uuid, :uuid, default: 'uuid_generate_v4()', index: true
     add_column :chambers,               :uuid, :uuid, default: 'uuid_generate_v4()', index: true

--- a/db/migrate/20150805144206_add_attachment_attachment_to_messages.rb
+++ b/db/migrate/20150805144206_add_attachment_attachment_to_messages.rb
@@ -1,4 +1,4 @@
-class AddAttachmentAttachmentToMessages < ActiveRecord::Migration
+class AddAttachmentAttachmentToMessages < ActiveRecord::Migration[4.2]
   def self.up
     change_table :messages do |t|
       t.attachment :attachment

--- a/db/migrate/20150806090257_create_determinations.rb
+++ b/db/migrate/20150806090257_create_determinations.rb
@@ -1,4 +1,4 @@
-class CreateDeterminations < ActiveRecord::Migration
+class CreateDeterminations < ActiveRecord::Migration[4.2]
   def change
     create_table :determinations do |t|
       t.integer :claim_id

--- a/db/migrate/20150807085212_alter_table_dates_attended.rb
+++ b/db/migrate/20150807085212_alter_table_dates_attended.rb
@@ -1,4 +1,4 @@
-class AlterTableDatesAttended < ActiveRecord::Migration
+class AlterTableDatesAttended < ActiveRecord::Migration[4.2]
   def change
     remove_column    :dates_attended, :fee_id, :integer
     add_reference    :dates_attended, :attended_item, polymorphic: true

--- a/db/migrate/20150807120316_remove_date_from_expenses.rb
+++ b/db/migrate/20150807120316_remove_date_from_expenses.rb
@@ -1,4 +1,4 @@
-class RemoveDateFromExpenses < ActiveRecord::Migration
+class RemoveDateFromExpenses < ActiveRecord::Migration[4.2]
   def change
     remove_column :expenses, :date, :datetime
   end

--- a/db/migrate/20150810085147_drop_amount_assessed_from_claims.rb
+++ b/db/migrate/20150810085147_drop_amount_assessed_from_claims.rb
@@ -1,4 +1,4 @@
-class DropAmountAssessedFromClaims < ActiveRecord::Migration
+class DropAmountAssessedFromClaims < ActiveRecord::Migration[4.2]
   def up
     remove_column :claims, :amount_assessed
   end

--- a/db/migrate/20150812151337_add_days_worked_to_case_workers.rb
+++ b/db/migrate/20150812151337_add_days_worked_to_case_workers.rb
@@ -1,4 +1,4 @@
-class AddDaysWorkedToCaseWorkers < ActiveRecord::Migration
+class AddDaysWorkedToCaseWorkers < ActiveRecord::Migration[4.2]
   def change
     add_column :case_workers, :days_worked, :string
   end

--- a/db/migrate/20150813142826_create_case_types_table.rb
+++ b/db/migrate/20150813142826_create_case_types_table.rb
@@ -1,4 +1,4 @@
-class CreateCaseTypesTable < ActiveRecord::Migration
+class CreateCaseTypesTable < ActiveRecord::Migration[4.2]
   def change
     create_table :case_types do |t|
       t.string :name

--- a/db/migrate/20150813160624_add_case_type_id_to_claim.rb
+++ b/db/migrate/20150813160624_add_case_type_id_to_claim.rb
@@ -1,4 +1,4 @@
-class AddCaseTypeIdToClaim < ActiveRecord::Migration
+class AddCaseTypeIdToClaim < ActiveRecord::Migration[4.2]
   def up
     add_column :claims, :case_type_id, :integer
     remove_column :claims, :case_type

--- a/db/migrate/20150813163440_add_approval_levels_to_case_worker.rb
+++ b/db/migrate/20150813163440_add_approval_levels_to_case_worker.rb
@@ -1,4 +1,4 @@
-class AddApprovalLevelsToCaseWorker < ActiveRecord::Migration
+class AddApprovalLevelsToCaseWorker < ActiveRecord::Migration[4.2]
   def change
     add_column :case_workers, :approval_level, :string, default: 'Low'
   end

--- a/db/migrate/20150819095328_create_certifications.rb
+++ b/db/migrate/20150819095328_create_certifications.rb
@@ -1,4 +1,4 @@
-class CreateCertifications < ActiveRecord::Migration
+class CreateCertifications < ActiveRecord::Migration[4.2]
   def change
     create_table :certifications do |t|
       t.integer :claim_id

--- a/db/migrate/20150821093532_remove_prosecuting_authority_from_claims.rb
+++ b/db/migrate/20150821093532_remove_prosecuting_authority_from_claims.rb
@@ -1,4 +1,4 @@
-class RemoveProsecutingAuthorityFromClaims < ActiveRecord::Migration
+class RemoveProsecutingAuthorityFromClaims < ActiveRecord::Migration[4.2]
   def change
     remove_column :claims, :prosecuting_authority
   end

--- a/db/migrate/20150824155035_rename_advocate_account_numberto_supplier_number.rb
+++ b/db/migrate/20150824155035_rename_advocate_account_numberto_supplier_number.rb
@@ -1,4 +1,4 @@
-class RenameAdvocateAccountNumbertoSupplierNumber < ActiveRecord::Migration
+class RenameAdvocateAccountNumbertoSupplierNumber < ActiveRecord::Migration[4.2]
 def self.up
     rename_column :advocates, :account_number, :supplier_number
     rename_column :chambers, :account_number, :supplier_number

--- a/db/migrate/20150902105354_remove_notes_from_claims.rb
+++ b/db/migrate/20150902105354_remove_notes_from_claims.rb
@@ -1,4 +1,4 @@
-class RemoveNotesFromClaims < ActiveRecord::Migration
+class RemoveNotesFromClaims < ActiveRecord::Migration[4.2]
   def change
     remove_column :claims, :notes
   end

--- a/db/migrate/20150903110418_change_defendant_date_of_birth_from_date_time_to_date.rb
+++ b/db/migrate/20150903110418_change_defendant_date_of_birth_from_date_time_to_date.rb
@@ -1,4 +1,4 @@
-class ChangeDefendantDateOfBirthFromDateTimeToDate < ActiveRecord::Migration
+class ChangeDefendantDateOfBirthFromDateTimeToDate < ActiveRecord::Migration[4.2]
   def up
     change_column :defendants, :date_of_birth, :date
     change_column :dates_attended, :date, :date

--- a/db/migrate/20150904142706_add_form_id_to_documents.rb
+++ b/db/migrate/20150904142706_add_form_id_to_documents.rb
@@ -1,4 +1,4 @@
-class AddFormIdToDocuments < ActiveRecord::Migration
+class AddFormIdToDocuments < ActiveRecord::Migration[4.2]
   def change
     add_column :documents, :form_id, :string
   end

--- a/db/migrate/20150904144306_add_date_required_fields_to_case_type.rb
+++ b/db/migrate/20150904144306_add_date_required_fields_to_case_type.rb
@@ -1,4 +1,4 @@
-class AddDateRequiredFieldsToCaseType < ActiveRecord::Migration
+class AddDateRequiredFieldsToCaseType < ActiveRecord::Migration[4.2]
   def change
     add_column :case_types, :requires_cracked_dates, :boolean
     add_column :case_types, :requires_trial_dates, :boolean

--- a/db/migrate/20150909102159_add_creator_id_to_documents.rb
+++ b/db/migrate/20150909102159_add_creator_id_to_documents.rb
@@ -1,4 +1,4 @@
-class AddCreatorIdToDocuments < ActiveRecord::Migration
+class AddCreatorIdToDocuments < ActiveRecord::Migration[4.2]
   def change
     add_column :documents, :creator_id, :integer
     add_index :documents, :creator_id

--- a/db/migrate/20150914111917_add_pcmh_to_case_types.rb
+++ b/db/migrate/20150914111917_add_pcmh_to_case_types.rb
@@ -1,4 +1,4 @@
-class AddPcmhToCaseTypes < ActiveRecord::Migration
+class AddPcmhToCaseTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :case_types, :allow_pcmh_fee_type, :boolean, default: false
   end

--- a/db/migrate/20150914131814_add_max_values_to_fee_types.rb
+++ b/db/migrate/20150914131814_add_max_values_to_fee_types.rb
@@ -1,4 +1,4 @@
-class AddMaxValuesToFeeTypes < ActiveRecord::Migration
+class AddMaxValuesToFeeTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :fee_types, :max_amount, :decimal, default_value: nil
   end

--- a/db/migrate/20150915110319_add_requires_maat_reference_to_case_types.rb
+++ b/db/migrate/20150915110319_add_requires_maat_reference_to_case_types.rb
@@ -1,4 +1,4 @@
-class AddRequiresMaatReferenceToCaseTypes < ActiveRecord::Migration
+class AddRequiresMaatReferenceToCaseTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :case_types, :requires_maat_reference, :boolean, default: false
   end

--- a/db/migrate/20150916083058_remove_subject_from_message.rb
+++ b/db/migrate/20150916083058_remove_subject_from_message.rb
@@ -1,4 +1,4 @@
-class RemoveSubjectFromMessage < ActiveRecord::Migration
+class RemoveSubjectFromMessage < ActiveRecord::Migration[4.2]
   def change
     remove_column :messages, :subject, :string
   end

--- a/db/migrate/20150928133144_add_lockable_to_users.rb
+++ b/db/migrate/20150928133144_add_lockable_to_users.rb
@@ -1,4 +1,4 @@
-class AddLockableToUsers < ActiveRecord::Migration
+class AddLockableToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :failed_attempts, :integer, default: 0, null: false
     add_column :users, :locked_at, :datetime

--- a/db/migrate/20150930123017_rename_paid_at.rb
+++ b/db/migrate/20150930123017_rename_paid_at.rb
@@ -1,4 +1,4 @@
-class RenamePaidAt < ActiveRecord::Migration
+class RenamePaidAt < ActiveRecord::Migration[4.2]
   def change
     rename_column :claims , :paid_at, :authorised_at
   end

--- a/db/migrate/20151005154211_add_form_id_to_claims.rb
+++ b/db/migrate/20151005154211_add_form_id_to_claims.rb
@@ -1,4 +1,4 @@
-class AddFormIdToClaims < ActiveRecord::Migration
+class AddFormIdToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :form_id, :string
     add_index :claims, :form_id

--- a/db/migrate/20151006101319_create_claim_intentions.rb
+++ b/db/migrate/20151006101319_create_claim_intentions.rb
@@ -1,4 +1,4 @@
-class CreateClaimIntentions < ActiveRecord::Migration
+class CreateClaimIntentions < ActiveRecord::Migration[4.2]
   def change
     create_table :claim_intentions do |t|
       t.string :form_id

--- a/db/migrate/20151013153042_remove_middle_name_from_defendants.rb
+++ b/db/migrate/20151013153042_remove_middle_name_from_defendants.rb
@@ -1,4 +1,4 @@
-class RemoveMiddleNameFromDefendants < ActiveRecord::Migration
+class RemoveMiddleNameFromDefendants < ActiveRecord::Migration[4.2]
   def change
     remove_column :defendants, :middle_name
   end

--- a/db/migrate/20151016112932_add_original_submission_date_claims.rb
+++ b/db/migrate/20151016112932_add_original_submission_date_claims.rb
@@ -1,4 +1,4 @@
-class AddOriginalSubmissionDateClaims < ActiveRecord::Migration
+class AddOriginalSubmissionDateClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :original_submission_date, :datetime
   end

--- a/db/migrate/20151016113001_rename_submitted_at_to_last_submitted_at.rb
+++ b/db/migrate/20151016113001_rename_submitted_at_to_last_submitted_at.rb
@@ -1,4 +1,4 @@
-class RenameSubmittedAtToLastSubmittedAt < ActiveRecord::Migration
+class RenameSubmittedAtToLastSubmittedAt < ActiveRecord::Migration[4.2]
   def change
     rename_column :claims, :submitted_at, :last_submitted_at
   end

--- a/db/migrate/20151019151911_add_apply_vat_to_advocates.rb
+++ b/db/migrate/20151019151911_add_apply_vat_to_advocates.rb
@@ -1,4 +1,4 @@
-class AddApplyVatToAdvocates < ActiveRecord::Migration
+class AddApplyVatToAdvocates < ActiveRecord::Migration[4.2]
   def change
     add_column :advocates, :apply_vat, :boolean, default: true
   end

--- a/db/migrate/20151019203522_add_api_key_to_chambers.rb
+++ b/db/migrate/20151019203522_add_api_key_to_chambers.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToChambers < ActiveRecord::Migration
+class AddApiKeyToChambers < ActiveRecord::Migration[4.2]
   def change
     add_column :chambers, :api_key, :uuid, default: 'uuid_generate_v4()', index: true
   end

--- a/db/migrate/20151021091240_remove_schemes.rb
+++ b/db/migrate/20151021091240_remove_schemes.rb
@@ -1,4 +1,4 @@
-class RemoveSchemes < ActiveRecord::Migration
+class RemoveSchemes < ActiveRecord::Migration[4.2]
   def change
     drop_table :schemes
   end

--- a/db/migrate/20151021091610_remove_scheme_id_from_claims.rb
+++ b/db/migrate/20151021091610_remove_scheme_id_from_claims.rb
@@ -1,4 +1,4 @@
-class RemoveSchemeIdFromClaims < ActiveRecord::Migration
+class RemoveSchemeIdFromClaims < ActiveRecord::Migration[4.2]
   def change
     remove_column :claims, :scheme_id
   end

--- a/db/migrate/20151115214327_create_super_admins.rb
+++ b/db/migrate/20151115214327_create_super_admins.rb
@@ -1,4 +1,4 @@
-class CreateSuperAdmins < ActiveRecord::Migration
+class CreateSuperAdmins < ActiveRecord::Migration[4.2]
   def change
     create_table :super_admins do |t|
       t.timestamps null: true

--- a/db/migrate/20151120101159_create_providers.rb
+++ b/db/migrate/20151120101159_create_providers.rb
@@ -1,4 +1,4 @@
-class CreateProviders < ActiveRecord::Migration
+class CreateProviders < ActiveRecord::Migration[4.2]
   def change
     create_table :providers do |t|
       t.string :name

--- a/db/migrate/20151125161619_add_provider_id_to_advocates.rb
+++ b/db/migrate/20151125161619_add_provider_id_to_advocates.rb
@@ -1,4 +1,4 @@
-class AddProviderIdToAdvocates < ActiveRecord::Migration
+class AddProviderIdToAdvocates < ActiveRecord::Migration[4.2]
   def change
     add_reference :advocates, :provider, index: true, foreign_key: true
   end

--- a/db/migrate/20151126143208_change_quantity_format_in_expenses.rb
+++ b/db/migrate/20151126143208_change_quantity_format_in_expenses.rb
@@ -1,4 +1,4 @@
-class ChangeQuantityFormatInExpenses < ActiveRecord::Migration
+class ChangeQuantityFormatInExpenses < ActiveRecord::Migration[4.2]
   def up
     change_column :expenses, :quantity, :float
   end

--- a/db/migrate/20151130155527_add_rate_to_fees.rb
+++ b/db/migrate/20151130155527_add_rate_to_fees.rb
@@ -1,4 +1,4 @@
-class AddRateToFees < ActiveRecord::Migration
+class AddRateToFees < ActiveRecord::Migration[4.2]
   def change
     add_column :fees, :rate, :decimal
   end

--- a/db/migrate/20151207135840_add_vat_amount_to_determinations.rb
+++ b/db/migrate/20151207135840_add_vat_amount_to_determinations.rb
@@ -1,4 +1,4 @@
-class AddVatAmountToDeterminations < ActiveRecord::Migration
+class AddVatAmountToDeterminations < ActiveRecord::Migration[4.2]
   def up
     add_column :determinations, :vat_amount, :float, default: 0.0
 

--- a/db/migrate/20151221141154_remove_approval_levels_from_case_worker.rb
+++ b/db/migrate/20151221141154_remove_approval_levels_from_case_worker.rb
@@ -1,4 +1,4 @@
-class RemoveApprovalLevelsFromCaseWorker < ActiveRecord::Migration
+class RemoveApprovalLevelsFromCaseWorker < ActiveRecord::Migration[4.2]
   def change
     remove_column :case_workers, :approval_level, :string, default: 'Low'
   end

--- a/db/migrate/20151230155512_remove_chambers.rb
+++ b/db/migrate/20151230155512_remove_chambers.rb
@@ -1,4 +1,4 @@
-class RemoveChambers < ActiveRecord::Migration
+class RemoveChambers < ActiveRecord::Migration[4.2]
   def change
     drop_table :chambers
   end

--- a/db/migrate/20151230155527_remove_chamber_id_from_advocates.rb
+++ b/db/migrate/20151230155527_remove_chamber_id_from_advocates.rb
@@ -1,4 +1,4 @@
-class RemoveChamberIdFromAdvocates < ActiveRecord::Migration
+class RemoveChamberIdFromAdvocates < ActiveRecord::Migration[4.2]
   def change
     remove_column :advocates, :chamber_id
   end

--- a/db/migrate/20160104152536_rename_advocates_apply_vat_to_vat_registered.rb
+++ b/db/migrate/20160104152536_rename_advocates_apply_vat_to_vat_registered.rb
@@ -1,4 +1,4 @@
-class RenameAdvocatesApplyVatToVatRegistered < ActiveRecord::Migration
+class RenameAdvocatesApplyVatToVatRegistered < ActiveRecord::Migration[4.2]
   def change
     rename_column :advocates, :apply_vat, :vat_registered
   end

--- a/db/migrate/20160106161350_remove_granting_body_from_representation_orders.rb
+++ b/db/migrate/20160106161350_remove_granting_body_from_representation_orders.rb
@@ -1,4 +1,4 @@
-class RemoveGrantingBodyFromRepresentationOrders < ActiveRecord::Migration
+class RemoveGrantingBodyFromRepresentationOrders < ActiveRecord::Migration[4.2]
   def change
     remove_column :representation_orders, :granting_body
   end

--- a/db/migrate/20160107095327_rename_advocates_to_external_users.rb
+++ b/db/migrate/20160107095327_rename_advocates_to_external_users.rb
@@ -1,4 +1,4 @@
-class RenameAdvocatesToExternalUsers < ActiveRecord::Migration
+class RenameAdvocatesToExternalUsers < ActiveRecord::Migration[4.2]
   def self.up
     rename_table :advocates, :external_users
   end

--- a/db/migrate/20160107125913_rename_advocate_id_to_external_user_id.rb
+++ b/db/migrate/20160107125913_rename_advocate_id_to_external_user_id.rb
@@ -1,4 +1,4 @@
-class RenameAdvocateIdToExternalUserId < ActiveRecord::Migration
+class RenameAdvocateIdToExternalUserId < ActiveRecord::Migration[4.2]
   def change
     rename_column :claims, :advocate_id, :external_user_id
     rename_column :documents, :advocate_id, :external_user_id

--- a/db/migrate/20160107163538_remove_features.rb
+++ b/db/migrate/20160107163538_remove_features.rb
@@ -1,4 +1,4 @@
-class RemoveFeatures < ActiveRecord::Migration
+class RemoveFeatures < ActiveRecord::Migration[4.2]
   def up
     drop_table :features
   end

--- a/db/migrate/20160112171540_move_role_to_roles.rb
+++ b/db/migrate/20160112171540_move_role_to_roles.rb
@@ -1,4 +1,4 @@
-class MoveRoleToRoles < ActiveRecord::Migration
+class MoveRoleToRoles < ActiveRecord::Migration[4.2]
   def change
     add_column :external_users, :roles, :string
     add_column :case_workers, :roles, :string

--- a/db/migrate/20160118180130_add_calculation_to_fee_types.rb
+++ b/db/migrate/20160118180130_add_calculation_to_fee_types.rb
@@ -1,4 +1,4 @@
-class AddCalculationToFeeTypes < ActiveRecord::Migration
+class AddCalculationToFeeTypes < ActiveRecord::Migration[4.2]
   def up
     add_column :fee_types, :calculated, :boolean, default: true
 

--- a/db/migrate/20160119133632_create_certification_types.rb
+++ b/db/migrate/20160119133632_create_certification_types.rb
@@ -1,4 +1,4 @@
-class CreateCertificationTypes < ActiveRecord::Migration
+class CreateCertificationTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :certification_types do |t|
       t.string :name, index: true

--- a/db/migrate/20160119133708_add_certification_type_id_to_certifications.rb
+++ b/db/migrate/20160119133708_add_certification_type_id_to_certifications.rb
@@ -1,4 +1,4 @@
-class AddCertificationTypeIdToCertifications < ActiveRecord::Migration
+class AddCertificationTypeIdToCertifications < ActiveRecord::Migration[4.2]
   def change
     add_column :certifications, :certification_type_id, :integer
   end

--- a/db/migrate/20160119133748_seed_and_move_to_certification_types.rb
+++ b/db/migrate/20160119133748_seed_and_move_to_certification_types.rb
@@ -1,4 +1,4 @@
-class SeedAndMoveToCertificationTypes < ActiveRecord::Migration
+class SeedAndMoveToCertificationTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :certification_types, :roles, :string
 

--- a/db/migrate/20160120153131_modify_uncalculated_fee_data.rb
+++ b/db/migrate/20160120153131_modify_uncalculated_fee_data.rb
@@ -1,4 +1,4 @@
-class ModifyUncalculatedFeeData < ActiveRecord::Migration
+class ModifyUncalculatedFeeData < ActiveRecord::Migration[4.2]
   def up
     Fee::BasicFee.joins(:fee_type).where(fee_types: { code: ['PPE','NPW'] }).where('fees.rate > 0').each do |fee|
       fee.update_column(:rate, 0)

--- a/db/migrate/20160121161705_modify_fee_type_calculated_data.rb
+++ b/db/migrate/20160121161705_modify_fee_type_calculated_data.rb
@@ -1,4 +1,4 @@
-class ModifyFeeTypeCalculatedData < ActiveRecord::Migration
+class ModifyFeeTypeCalculatedData < ActiveRecord::Migration[4.2]
   def up
     Fee::BasicFeeType.where(code: ['PPE','NPW']).each do |record|
       record.update_column(:calculated, false)

--- a/db/migrate/20160126103102_drop_indictment_from_claims.rb
+++ b/db/migrate/20160126103102_drop_indictment_from_claims.rb
@@ -1,4 +1,4 @@
-class DropIndictmentFromClaims < ActiveRecord::Migration
+class DropIndictmentFromClaims < ActiveRecord::Migration[4.2]
   def change
     remove_column :claims, :indictment_number
   end

--- a/db/migrate/20160126115706_add_retrial_columns_to_claim.rb
+++ b/db/migrate/20160126115706_add_retrial_columns_to_claim.rb
@@ -1,4 +1,4 @@
-class AddRetrialColumnsToClaim < ActiveRecord::Migration
+class AddRetrialColumnsToClaim < ActiveRecord::Migration[4.2]
   def change
     change_table :claims do |t|
       t.date    :retrial_started_at

--- a/db/migrate/20160126121119_add_requires_retrial_details_flag_to_case_types.rb
+++ b/db/migrate/20160126121119_add_requires_retrial_details_flag_to_case_types.rb
@@ -1,4 +1,4 @@
-class AddRequiresRetrialDetailsFlagToCaseTypes < ActiveRecord::Migration
+class AddRequiresRetrialDetailsFlagToCaseTypes < ActiveRecord::Migration[4.2]
   def up
     add_column :case_types, :requires_retrial_dates, :boolean, default: false
     retrial = CaseType.find_by_sql("SELECT * FROM case_types WHERE name = 'Retrial'").first

--- a/db/migrate/20160204110917_add_roles_to_providers.rb
+++ b/db/migrate/20160204110917_add_roles_to_providers.rb
@@ -1,4 +1,4 @@
-class AddRolesToProviders < ActiveRecord::Migration
+class AddRolesToProviders < ActiveRecord::Migration[4.2]
   def change
     add_column :providers, :roles, :string
 

--- a/db/migrate/20160208131812_add_type_to_claims.rb
+++ b/db/migrate/20160208131812_add_type_to_claims.rb
@@ -1,4 +1,4 @@
-class AddTypeToClaims < ActiveRecord::Migration
+class AddTypeToClaims < ActiveRecord::Migration[4.2]
   def up
     add_column :claims, :type, :string
     ActiveRecord::Base.connection.execute "UPDATE claims SET type = 'Claim::AdvocateClaim'"

--- a/db/migrate/20160215174515_modify_claim_type.rb
+++ b/db/migrate/20160215174515_modify_claim_type.rb
@@ -1,4 +1,4 @@
-class ModifyClaimType < ActiveRecord::Migration
+class ModifyClaimType < ActiveRecord::Migration[4.2]
   def change
     # change previous data migration as STI sub-models cannot be cloned
     # by Amoeba gem. Awaiting fix.

--- a/db/migrate/20160216101143_change_type_to_advocate_claim.rb
+++ b/db/migrate/20160216101143_change_type_to_advocate_claim.rb
@@ -1,4 +1,4 @@
-class ChangeTypeToAdvocateClaim < ActiveRecord::Migration
+class ChangeTypeToAdvocateClaim < ActiveRecord::Migration[4.2]
   def up
     ActiveRecord::Base.connection.execute "UPDATE claims SET type = 'Claim::AdvocateClaim'"
   end

--- a/db/migrate/20160217151056_add_type_to_fee_type.rb
+++ b/db/migrate/20160217151056_add_type_to_fee_type.rb
@@ -1,4 +1,4 @@
-class AddTypeToFeeType < ActiveRecord::Migration
+class AddTypeToFeeType < ActiveRecord::Migration[4.2]
   def up
     add_column :fee_types, :type, :string
   end

--- a/db/migrate/20160217161036_add_type_to_fee.rb
+++ b/db/migrate/20160217161036_add_type_to_fee.rb
@@ -1,4 +1,4 @@
-class AddTypeToFee < ActiveRecord::Migration
+class AddTypeToFee < ActiveRecord::Migration[4.2]
   def up
     add_column :fees, :type, :string
 

--- a/db/migrate/20160222163526_add_roles_to_case_type.rb
+++ b/db/migrate/20160222163526_add_roles_to_case_type.rb
@@ -1,4 +1,4 @@
-class AddRolesToCaseType < ActiveRecord::Migration
+class AddRolesToCaseType < ActiveRecord::Migration[4.2]
   def change
     add_column :case_types, :roles, :string
 

--- a/db/migrate/20160223124910_add_roles_to_expense_types.rb
+++ b/db/migrate/20160223124910_add_roles_to_expense_types.rb
@@ -1,4 +1,4 @@
-class AddRolesToExpenseTypes < ActiveRecord::Migration
+class AddRolesToExpenseTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :expense_types, :roles, :string
 

--- a/db/migrate/20160223134824_add_parent_id_to_case_types.rb
+++ b/db/migrate/20160223134824_add_parent_id_to_case_types.rb
@@ -1,4 +1,4 @@
-class AddParentIdToCaseTypes < ActiveRecord::Migration
+class AddParentIdToCaseTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :case_types, :parent_id, :integer, default: nil
   end

--- a/db/migrate/20160224140235_populate_additional_case_types.rb
+++ b/db/migrate/20160224140235_populate_additional_case_types.rb
@@ -1,4 +1,4 @@
-class PopulateAdditionalCaseTypes < ActiveRecord::Migration
+class PopulateAdditionalCaseTypes < ActiveRecord::Migration[4.2]
   def up
     CaseType.reset_column_information
     # load File.join Rails.root, 'db', 'seeds', 'case_types.rb'

--- a/db/migrate/20160227185548_add_roles_to_base_fee_types.rb
+++ b/db/migrate/20160227185548_add_roles_to_base_fee_types.rb
@@ -1,4 +1,4 @@
-class AddRolesToBaseFeeTypes < ActiveRecord::Migration
+class AddRolesToBaseFeeTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :fee_types, :roles, :string
 

--- a/db/migrate/20160301122625_modify_trial_cracked_at_third_data.rb
+++ b/db/migrate/20160301122625_modify_trial_cracked_at_third_data.rb
@@ -1,4 +1,4 @@
-class ModifyTrialCrackedAtThirdData < ActiveRecord::Migration
+class ModifyTrialCrackedAtThirdData < ActiveRecord::Migration[4.2]
   def up
     Claim::BaseClaim.where.not(trial_cracked_at_third: nil).each do |claim|
       clean_trial_cracked_at_third = claim.trial_cracked_at_third.downcase.strip.gsub(/\s/,'_')

--- a/db/migrate/20160309115141_create_disbursement_types.rb
+++ b/db/migrate/20160309115141_create_disbursement_types.rb
@@ -1,4 +1,4 @@
-class CreateDisbursementTypes < ActiveRecord::Migration
+class CreateDisbursementTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :disbursement_types do |t|
       t.string :name

--- a/db/migrate/20160309135448_create_disbursements.rb
+++ b/db/migrate/20160309135448_create_disbursements.rb
@@ -1,4 +1,4 @@
-class CreateDisbursements < ActiveRecord::Migration
+class CreateDisbursements < ActiveRecord::Migration[4.2]
   def change
     create_table :disbursements do |t|
       t.references :disbursement_type, index: true

--- a/db/migrate/20160309152424_add_disbursements_total_to_claim.rb
+++ b/db/migrate/20160309152424_add_disbursements_total_to_claim.rb
@@ -1,4 +1,4 @@
-class AddDisbursementsTotalToClaim < ActiveRecord::Migration
+class AddDisbursementsTotalToClaim < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :disbursements_total, :decimal, default: 0.0
   end

--- a/db/migrate/20160310164911_remove_days_worked_from_case_workers.rb
+++ b/db/migrate/20160310164911_remove_days_worked_from_case_workers.rb
@@ -1,4 +1,4 @@
-class RemoveDaysWorkedFromCaseWorkers < ActiveRecord::Migration
+class RemoveDaysWorkedFromCaseWorkers < ActiveRecord::Migration[4.2]
   def change
     remove_column :case_workers, :days_worked
   end

--- a/db/migrate/20160314122816_create_stats_reports.rb
+++ b/db/migrate/20160314122816_create_stats_reports.rb
@@ -1,4 +1,4 @@
-class CreateStatsReports < ActiveRecord::Migration
+class CreateStatsReports < ActiveRecord::Migration[4.2]
   def change
     create_table :stats_reports do |t|
       t.string :report_name

--- a/db/migrate/20160315090000_add_reason_set_to_expense_type.rb
+++ b/db/migrate/20160315090000_add_reason_set_to_expense_type.rb
@@ -1,4 +1,4 @@
-class AddReasonSetToExpenseType < ActiveRecord::Migration
+class AddReasonSetToExpenseType < ActiveRecord::Migration[4.2]
   def change
     add_column :expense_types, :reason_set, :string
 

--- a/db/migrate/20160315090200_add_expense_reasons_to_expenses.rb
+++ b/db/migrate/20160315090200_add_expense_reasons_to_expenses.rb
@@ -1,4 +1,4 @@
-class AddExpenseReasonsToExpenses < ActiveRecord::Migration
+class AddExpenseReasonsToExpenses < ActiveRecord::Migration[4.2]
   def change
     add_column :expenses, :reason_id, :integer
     add_column :expenses, :reason_text, :string

--- a/db/migrate/20160315090300_add_lgfs_roles_to_expense_types.rb
+++ b/db/migrate/20160315090300_add_lgfs_roles_to_expense_types.rb
@@ -1,4 +1,4 @@
-class AddLgfsRolesToExpenseTypes < ActiveRecord::Migration
+class AddLgfsRolesToExpenseTypes < ActiveRecord::Migration[4.2]
   def up
     expense_types.each do |et|
       et.update(roles: ['agfs', 'lgfs'])

--- a/db/migrate/20160315125656_add_schema_version_to_expenses.rb
+++ b/db/migrate/20160315125656_add_schema_version_to_expenses.rb
@@ -1,4 +1,4 @@
-class AddSchemaVersionToExpenses < ActiveRecord::Migration
+class AddSchemaVersionToExpenses < ActiveRecord::Migration[4.2]
   def up
     add_column :expenses, :schema_version, :integer
     execute 'UPDATE expenses SET schema_version = 1'

--- a/db/migrate/20160315171454_add_fields_to_expenses.rb
+++ b/db/migrate/20160315171454_add_fields_to_expenses.rb
@@ -1,4 +1,4 @@
-class AddFieldsToExpenses < ActiveRecord::Migration
+class AddFieldsToExpenses < ActiveRecord::Migration[4.2]
   def up
     add_column :expenses, :distance, :integer
     add_column :expenses, :mileage_rate_id, :integer

--- a/db/migrate/20160323115212_add_case_concluded_at_to_claims.rb
+++ b/db/migrate/20160323115212_add_case_concluded_at_to_claims.rb
@@ -1,4 +1,4 @@
-class AddCaseConcludedAtToClaims < ActiveRecord::Migration
+class AddCaseConcludedAtToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :case_concluded_at, :date
   end

--- a/db/migrate/20160323161339_add_grad_fee_code_to_case_types.rb
+++ b/db/migrate/20160323161339_add_grad_fee_code_to_case_types.rb
@@ -1,4 +1,4 @@
-class AddGradFeeCodeToCaseTypes < ActiveRecord::Migration
+class AddGradFeeCodeToCaseTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :case_types, :grad_fee_code, :string
   end

--- a/db/migrate/20160405145845_add_roles_to_certification_types.rb
+++ b/db/migrate/20160405145845_add_roles_to_certification_types.rb
@@ -1,4 +1,4 @@
-class AddRolesToCertificationTypes < ActiveRecord::Migration
+class AddRolesToCertificationTypes < ActiveRecord::Migration[4.2]
   def change
     return if ActiveRecord::Base.connection.column_exists?(:certification_types, :roles)
 

--- a/db/migrate/20160406084757_add_dates_to_fees.rb
+++ b/db/migrate/20160406084757_add_dates_to_fees.rb
@@ -1,4 +1,4 @@
-class AddDatesToFees < ActiveRecord::Migration
+class AddDatesToFees < ActiveRecord::Migration[4.2]
   def change
     add_column :fees, :warrant_issued_date, :date
     add_column :fees, :warrant_executed_date, :date

--- a/db/migrate/20160407094104_add_total_to_disbursement.rb
+++ b/db/migrate/20160407094104_add_total_to_disbursement.rb
@@ -1,4 +1,4 @@
-class AddTotalToDisbursement < ActiveRecord::Migration
+class AddTotalToDisbursement < ActiveRecord::Migration[4.2]
   def up
     change_column_default :disbursements, :vat_amount, 0.0
     add_column :disbursements, :total, :decimal, default: 0.0

--- a/db/migrate/20160411100255_remove_parent_id_from_case_types.rb
+++ b/db/migrate/20160411100255_remove_parent_id_from_case_types.rb
@@ -1,4 +1,4 @@
-class RemoveParentIdFromCaseTypes < ActiveRecord::Migration
+class RemoveParentIdFromCaseTypes < ActiveRecord::Migration[4.2]
   def change
     remove_column :case_types, :parent_id
   end

--- a/db/migrate/20160411102202_add_parent_id_to_fee_types.rb
+++ b/db/migrate/20160411102202_add_parent_id_to_fee_types.rb
@@ -1,4 +1,4 @@
-class AddParentIdToFeeTypes < ActiveRecord::Migration
+class AddParentIdToFeeTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :fee_types, :parent_id, :integer, default: nil
   end

--- a/db/migrate/20160412083654_rename_grad_fee_code_to_fee_type_code.rb
+++ b/db/migrate/20160412083654_rename_grad_fee_code_to_fee_type_code.rb
@@ -1,4 +1,4 @@
-class RenameGradFeeCodeToFeeTypeCode < ActiveRecord::Migration
+class RenameGradFeeCodeToFeeTypeCode < ActiveRecord::Migration[4.2]
   def change
     rename_column :case_types, :grad_fee_code, :fee_type_code
   end

--- a/db/migrate/20160413123228_add_transfer_court_id_to_claims.rb
+++ b/db/migrate/20160413123228_add_transfer_court_id_to_claims.rb
@@ -1,4 +1,4 @@
-class AddTransferCourtIdToClaims < ActiveRecord::Migration
+class AddTransferCourtIdToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :transfer_court_id, :integer
   end

--- a/db/migrate/20160413141346_add_sub_type_id_to_fees.rb
+++ b/db/migrate/20160413141346_add_sub_type_id_to_fees.rb
@@ -1,4 +1,4 @@
-class AddSubTypeIdToFees < ActiveRecord::Migration
+class AddSubTypeIdToFees < ActiveRecord::Migration[4.2]
   def change
     add_column :fees, :sub_type_id, :integer
   end

--- a/db/migrate/20160413144330_change_default_vat_value_from_disbursements.rb
+++ b/db/migrate/20160413144330_change_default_vat_value_from_disbursements.rb
@@ -1,4 +1,4 @@
-class ChangeDefaultVatValueFromDisbursements < ActiveRecord::Migration
+class ChangeDefaultVatValueFromDisbursements < ActiveRecord::Migration[4.2]
   def up
     change_column_default :disbursements, :vat_amount, nil
   end

--- a/db/migrate/20160414121855_add_case_numbers_to_fees.rb
+++ b/db/migrate/20160414121855_add_case_numbers_to_fees.rb
@@ -1,4 +1,4 @@
-class AddCaseNumbersToFees < ActiveRecord::Migration
+class AddCaseNumbersToFees < ActiveRecord::Migration[4.2]
   def change
     add_column :fees, :case_numbers, :string
   end

--- a/db/migrate/20160415103043_create_supplier_numbers.rb
+++ b/db/migrate/20160415103043_create_supplier_numbers.rb
@@ -1,4 +1,4 @@
-class CreateSupplierNumbers < ActiveRecord::Migration
+class CreateSupplierNumbers < ActiveRecord::Migration[4.2]
   def change
     create_table :supplier_numbers do |t|
       t.integer :provider_id

--- a/db/migrate/20160415120945_add_supplier_number_to_claims.rb
+++ b/db/migrate/20160415120945_add_supplier_number_to_claims.rb
@@ -1,4 +1,4 @@
-class AddSupplierNumberToClaims < ActiveRecord::Migration
+class AddSupplierNumberToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :supplier_number, :string
   end

--- a/db/migrate/20160418123747_add_disbursement_type_id_to_fees.rb
+++ b/db/migrate/20160418123747_add_disbursement_type_id_to_fees.rb
@@ -1,4 +1,4 @@
-class AddDisbursementTypeIdToFees < ActiveRecord::Migration
+class AddDisbursementTypeIdToFees < ActiveRecord::Migration[4.2]
   def change
     add_column :fees, :disbursement_type_id, :integer
   end

--- a/db/migrate/20160419094947_create_transfer_details.rb
+++ b/db/migrate/20160419094947_create_transfer_details.rb
@@ -1,4 +1,4 @@
-class CreateTransferDetails < ActiveRecord::Migration
+class CreateTransferDetails < ActiveRecord::Migration[4.2]
   def change
     create_table :transfer_details do |t|
       t.integer :claim_id

--- a/db/migrate/20160419100425_add_interim_fields_to_claims.rb
+++ b/db/migrate/20160419100425_add_interim_fields_to_claims.rb
@@ -1,4 +1,4 @@
-class AddInterimFieldsToClaims < ActiveRecord::Migration
+class AddInterimFieldsToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :effective_pcmh_date, :date
     add_column :claims, :legal_aid_transfer_date, :date

--- a/db/migrate/20160421104849_add_vat_amount_to_expenses.rb
+++ b/db/migrate/20160421104849_add_vat_amount_to_expenses.rb
@@ -1,4 +1,4 @@
-class AddVatAmountToExpenses < ActiveRecord::Migration
+class AddVatAmountToExpenses < ActiveRecord::Migration[4.2]
   def change
     add_column :expenses, :vat_amount, :decimal, default: 0.0
   end

--- a/db/migrate/20160422103856_remove_disbursement_type_id_from_fees.rb
+++ b/db/migrate/20160422103856_remove_disbursement_type_id_from_fees.rb
@@ -1,4 +1,4 @@
-class RemoveDisbursementTypeIdFromFees < ActiveRecord::Migration
+class RemoveDisbursementTypeIdFromFees < ActiveRecord::Migration[4.2]
   def up
     remove_column :fees, :disbursement_type_id
   end

--- a/db/migrate/20160425143749_add_allocation_type_to_claims.rb
+++ b/db/migrate/20160425143749_add_allocation_type_to_claims.rb
@@ -1,4 +1,4 @@
-class AddAllocationTypeToClaims < ActiveRecord::Migration
+class AddAllocationTypeToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :allocation_type, :string
   end

--- a/db/migrate/20160426084323_add_disbursements_to_determinations.rb
+++ b/db/migrate/20160426084323_add_disbursements_to_determinations.rb
@@ -1,4 +1,4 @@
-class AddDisbursementsToDeterminations < ActiveRecord::Migration
+class AddDisbursementsToDeterminations < ActiveRecord::Migration[4.2]
   def up
     add_column :determinations, :disbursements, :decimal, default: 0.0
     change_column_default :determinations, :fees, 0.0

--- a/db/migrate/20160428124144_add_transfer_case_number_to_claims.rb
+++ b/db/migrate/20160428124144_add_transfer_case_number_to_claims.rb
@@ -1,4 +1,4 @@
-class AddTransferCaseNumberToClaims < ActiveRecord::Migration
+class AddTransferCaseNumberToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :transfer_case_number, :string
     add_index :claims, :transfer_case_number

--- a/db/migrate/20160518135220_add_verified_file_size_to_documents.rb
+++ b/db/migrate/20160518135220_add_verified_file_size_to_documents.rb
@@ -1,4 +1,4 @@
-class AddVerifiedFileSizeToDocuments < ActiveRecord::Migration
+class AddVerifiedFileSizeToDocuments < ActiveRecord::Migration[4.2]
   def change
     add_column :documents, :verified_file_size, :integer
     add_column :documents, :file_path, :string

--- a/db/migrate/20160520114204_add_clone_source_id_to_claims.rb
+++ b/db/migrate/20160520114204_add_clone_source_id_to_claims.rb
@@ -1,4 +1,4 @@
-class AddCloneSourceIdToClaims < ActiveRecord::Migration
+class AddCloneSourceIdToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :clone_source_id, :integer
   end

--- a/db/migrate/20160524125248_update_graduated_fee_type_calculated.rb
+++ b/db/migrate/20160524125248_update_graduated_fee_type_calculated.rb
@@ -1,4 +1,4 @@
-class UpdateGraduatedFeeTypeCalculated < ActiveRecord::Migration
+class UpdateGraduatedFeeTypeCalculated < ActiveRecord::Migration[4.2]
   def up
      Fee::GraduatedFeeType.update_all(calculated: false)
   end

--- a/db/migrate/20160524161949_add_devise_missing_attributes_to_users.rb
+++ b/db/migrate/20160524161949_add_devise_missing_attributes_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeviseMissingAttributesToUsers < ActiveRecord::Migration
+class AddDeviseMissingAttributesToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :unlock_token, :string
     add_index :users, :unlock_token, unique: true

--- a/db/migrate/20160526100412_add_date_to_fees.rb
+++ b/db/migrate/20160526100412_add_date_to_fees.rb
@@ -1,4 +1,4 @@
-class AddDateToFees < ActiveRecord::Migration
+class AddDateToFees < ActiveRecord::Migration[4.2]
   def change
     add_column :fees, :date, :date
   end

--- a/db/migrate/20160526143740_migrate_dates_attended.rb
+++ b/db/migrate/20160526143740_migrate_dates_attended.rb
@@ -1,4 +1,4 @@
-class MigrateDatesAttended < ActiveRecord::Migration
+class MigrateDatesAttended < ActiveRecord::Migration[4.2]
 
   def up
     migrate_dates_for(Fee::GraduatedFee)

--- a/db/migrate/20160527101526_change_fee_quantity_to_decimal.rb
+++ b/db/migrate/20160527101526_change_fee_quantity_to_decimal.rb
@@ -1,4 +1,4 @@
-class ChangeFeeQuantityToDecimal < ActiveRecord::Migration
+class ChangeFeeQuantityToDecimal < ActiveRecord::Migration[4.2]
   def up
     change_column :fees, :quantity,  :decimal
   end

--- a/db/migrate/20160527102644_add_quantity_is_decimal_to_fee_type.rb
+++ b/db/migrate/20160527102644_add_quantity_is_decimal_to_fee_type.rb
@@ -1,4 +1,4 @@
-class AddQuantityIsDecimalToFeeType < ActiveRecord::Migration
+class AddQuantityIsDecimalToFeeType < ActiveRecord::Migration[4.2]
   def up
     add_column :fee_types, :quantity_is_decimal, :boolean, default: false
     Fee::BaseFeeType.reset_column_information

--- a/db/migrate/20160607120655_add_uuid_to_disbursements.rb
+++ b/db/migrate/20160607120655_add_uuid_to_disbursements.rb
@@ -1,4 +1,4 @@
-class AddUuidToDisbursements < ActiveRecord::Migration
+class AddUuidToDisbursements < ActiveRecord::Migration[4.2]
   def change
     add_column :disbursements, :uuid, :uuid, default: 'uuid_generate_v4()', index: true
   end

--- a/db/migrate/20160608141927_add_last_edited_at_to_claims.rb
+++ b/db/migrate/20160608141927_add_last_edited_at_to_claims.rb
@@ -1,4 +1,4 @@
-class AddLastEditedAtToClaims < ActiveRecord::Migration
+class AddLastEditedAtToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :last_edited_at, :datetime
   end

--- a/db/migrate/20160609114327_modify_qauntity_is_decimal_data.rb
+++ b/db/migrate/20160609114327_modify_qauntity_is_decimal_data.rb
@@ -1,4 +1,4 @@
-class ModifyQauntityIsDecimalData < ActiveRecord::Migration
+class ModifyQauntityIsDecimalData < ActiveRecord::Migration[4.2]
   # this reruns the modified task which has added the RNL fee type code
   def up
     Rake::Task['data:migrate:set_quantity_is_decimal'].invoke

--- a/db/migrate/20160624150208_statistics.rb
+++ b/db/migrate/20160624150208_statistics.rb
@@ -1,4 +1,4 @@
-class Statistics < ActiveRecord::Migration
+class Statistics < ActiveRecord::Migration[4.2]
   def change
     create_table :statistics do |t|
       t.date :date

--- a/db/migrate/20160627083153_change_expense_hours_and_distance_to_decimal.rb
+++ b/db/migrate/20160627083153_change_expense_hours_and_distance_to_decimal.rb
@@ -1,4 +1,4 @@
-class ChangeExpenseHoursAndDistanceToDecimal < ActiveRecord::Migration
+class ChangeExpenseHoursAndDistanceToDecimal < ActiveRecord::Migration[4.2]
   def up
     change_column :expenses, :hours, :decimal
     change_column :expenses, :distance, :decimal

--- a/db/migrate/20160628141647_add_reason_code_to_claim_state_transitions.rb
+++ b/db/migrate/20160628141647_add_reason_code_to_claim_state_transitions.rb
@@ -1,4 +1,4 @@
-class AddReasonCodeToClaimStateTransitions < ActiveRecord::Migration
+class AddReasonCodeToClaimStateTransitions < ActiveRecord::Migration[4.2]
   def change
     add_column :claim_state_transitions, :reason_code, :string
   end

--- a/db/migrate/20160630161501_add_value2_to_statistics.rb
+++ b/db/migrate/20160630161501_add_value2_to_statistics.rb
@@ -1,4 +1,4 @@
-class AddValue2ToStatistics < ActiveRecord::Migration
+class AddValue2ToStatistics < ActiveRecord::Migration[4.2]
   def change
     add_column :statistics, :value_2, :integer, default: 0
   end

--- a/db/migrate/20160706133256_add_user_id_to_claim_intentions.rb
+++ b/db/migrate/20160706133256_add_user_id_to_claim_intentions.rb
@@ -1,4 +1,4 @@
-class AddUserIdToClaimIntentions < ActiveRecord::Migration
+class AddUserIdToClaimIntentions < ActiveRecord::Migration[4.2]
   def change
     add_column :claim_intentions, :user_id, :integer
   end

--- a/db/migrate/20160719114631_remove_external_user_provider_foreign_key.rb
+++ b/db/migrate/20160719114631_remove_external_user_provider_foreign_key.rb
@@ -1,4 +1,4 @@
-class RemoveExternalUserProviderForeignKey < ActiveRecord::Migration
+class RemoveExternalUserProviderForeignKey < ActiveRecord::Migration[4.2]
 
   # Having problems sometimes to find the FK with error: Table 'external_users' has no foreign key on column 'provider_id'
   # This will work around

--- a/db/migrate/20160726141102_add_settings_to_users.rb
+++ b/db/migrate/20160726141102_add_settings_to_users.rb
@@ -1,4 +1,4 @@
-class AddSettingsToUsers < ActiveRecord::Migration
+class AddSettingsToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :settings, :text
   end

--- a/db/migrate/20160817082913_add_deleted_at_to_case_workers.rb
+++ b/db/migrate/20160817082913_add_deleted_at_to_case_workers.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToCaseWorkers < ActiveRecord::Migration
+class AddDeletedAtToCaseWorkers < ActiveRecord::Migration[4.2]
   def change
     add_column :case_workers, :deleted_at, :datetime, default: nil
   end

--- a/db/migrate/20160817083149_add_deleted_at_to_users.rb
+++ b/db/migrate/20160817083149_add_deleted_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToUsers < ActiveRecord::Migration
+class AddDeletedAtToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :deleted_at, :datetime, default: nil
   end

--- a/db/migrate/20160818080705_add_deleted_at_to_external_users.rb
+++ b/db/migrate/20160818080705_add_deleted_at_to_external_users.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToExternalUsers < ActiveRecord::Migration
+class AddDeletedAtToExternalUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :external_users, :deleted_at, :datetime, default: nil
   end

--- a/db/migrate/20160819092435_add_deleted_at_to_claims.rb
+++ b/db/migrate/20160819092435_add_deleted_at_to_claims.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToClaims < ActiveRecord::Migration
+class AddDeletedAtToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :deleted_at, :datetime, default: nil
   end

--- a/db/migrate/20160823134205_add_migration_spikes_table.rb
+++ b/db/migrate/20160823134205_add_migration_spikes_table.rb
@@ -1,4 +1,4 @@
-class AddMigrationSpikesTable < ActiveRecord::Migration
+class AddMigrationSpikesTable < ActiveRecord::Migration[4.2]
   def change
     add_column :courts, :deleted_at, :datetime, default: nil
   end

--- a/db/migrate/20160824095519_remove_deleted_at_from_courts.rb
+++ b/db/migrate/20160824095519_remove_deleted_at_from_courts.rb
@@ -1,4 +1,4 @@
-class RemoveDeletedAtFromCourts < ActiveRecord::Migration
+class RemoveDeletedAtFromCourts < ActiveRecord::Migration[4.2]
   def change
     remove_column :courts, :deleted_at
   end

--- a/db/migrate/20160902084750_add_deleted_at_to_disbursement_type.rb
+++ b/db/migrate/20160902084750_add_deleted_at_to_disbursement_type.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToDisbursementType < ActiveRecord::Migration
+class AddDeletedAtToDisbursementType < ActiveRecord::Migration[4.2]
   def change
     add_column :disbursement_types, :deleted_at, :datetime, default: nil
   end

--- a/db/migrate/20160909150238_add_author_and_subject_to_claim_state_transitions.rb
+++ b/db/migrate/20160909150238_add_author_and_subject_to_claim_state_transitions.rb
@@ -1,4 +1,4 @@
-class AddAuthorAndSubjectToClaimStateTransitions < ActiveRecord::Migration
+class AddAuthorAndSubjectToClaimStateTransitions < ActiveRecord::Migration[4.2]
   def change
     add_column :claim_state_transitions, :author_id, :integer
     add_column :claim_state_transitions, :subject_id, :integer

--- a/db/migrate/20160915090550_add_provider_ref_to_claims.rb
+++ b/db/migrate/20160915090550_add_provider_ref_to_claims.rb
@@ -1,4 +1,4 @@
-class AddProviderRefToClaims < ActiveRecord::Migration
+class AddProviderRefToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :providers_ref, :string
   end

--- a/db/migrate/20160921110245_change_name_of_supplier_number.rb
+++ b/db/migrate/20160921110245_change_name_of_supplier_number.rb
@@ -1,4 +1,4 @@
-class ChangeNameOfSupplierNumber < ActiveRecord::Migration
+class ChangeNameOfSupplierNumber < ActiveRecord::Migration[4.2]
   def up
     rename_column :providers, :supplier_number, :firm_agfs_supplier_number
   end

--- a/db/migrate/20160926133641_add_uuid_to_case_worker.rb
+++ b/db/migrate/20160926133641_add_uuid_to_case_worker.rb
@@ -1,4 +1,4 @@
-class AddUuidToCaseWorker < ActiveRecord::Migration
+class AddUuidToCaseWorker < ActiveRecord::Migration[4.2]
   def change
     add_column :case_workers, :uuid, :uuid, default: 'uuid_generate_v4()', index: true
   end

--- a/db/migrate/20160930085910_add_api_key_to_users.rb
+++ b/db/migrate/20160930085910_add_api_key_to_users.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToUsers < ActiveRecord::Migration
+class AddApiKeyToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :api_key, :uuid, default: 'uuid_generate_v4()', index: true
   end

--- a/db/migrate/20161025155737_add_unique_code_to_fee_types.rb
+++ b/db/migrate/20161025155737_add_unique_code_to_fee_types.rb
@@ -1,4 +1,4 @@
-class AddUniqueCodeToFeeTypes < ActiveRecord::Migration
+class AddUniqueCodeToFeeTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :fee_types, :unique_code, :string
     add_index :fee_types, :unique_code, unique: true

--- a/db/migrate/20161101091924_add_unique_code_to_disbursement_types.rb
+++ b/db/migrate/20161101091924_add_unique_code_to_disbursement_types.rb
@@ -1,4 +1,4 @@
-class AddUniqueCodeToDisbursementTypes < ActiveRecord::Migration
+class AddUniqueCodeToDisbursementTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :disbursement_types, :unique_code, :string
     add_index :disbursement_types, :unique_code, unique: true

--- a/db/migrate/20161101093559_add_unique_code_to_expense_types.rb
+++ b/db/migrate/20161101093559_add_unique_code_to_expense_types.rb
@@ -1,4 +1,4 @@
-class AddUniqueCodeToExpenseTypes < ActiveRecord::Migration
+class AddUniqueCodeToExpenseTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :expense_types, :unique_code, :string
     add_index :expense_types, :unique_code, unique: true

--- a/db/migrate/20161114093442_create_exported_claims.rb
+++ b/db/migrate/20161114093442_create_exported_claims.rb
@@ -1,4 +1,4 @@
-class CreateExportedClaims < ActiveRecord::Migration
+class CreateExportedClaims < ActiveRecord::Migration[4.2]
   def change
     create_table :exported_claims do |t|
       t.references :claim, index: true, null: false

--- a/db/migrate/20161206103052_add_disk_evidence_to_claims.rb
+++ b/db/migrate/20161206103052_add_disk_evidence_to_claims.rb
@@ -1,4 +1,4 @@
-class AddDiskEvidenceToClaims < ActiveRecord::Migration
+class AddDiskEvidenceToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :disk_evidence, :boolean, default: false
   end

--- a/db/migrate/20161209113727_add_vat_amounts_to_claims.rb
+++ b/db/migrate/20161209113727_add_vat_amounts_to_claims.rb
@@ -1,4 +1,4 @@
-class AddVatAmountsToClaims < ActiveRecord::Migration
+class AddVatAmountsToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :fees_vat, :decimal, default: 0.0
     add_column :claims, :expenses_vat, :decimal, default: 0.0

--- a/db/migrate/20161215175055_add_value_band_id_to_claims.rb
+++ b/db/migrate/20161215175055_add_value_band_id_to_claims.rb
@@ -1,4 +1,4 @@
-class AddValueBandIdToClaims < ActiveRecord::Migration
+class AddValueBandIdToClaims < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :value_band_id, :integer, default: nil
   end

--- a/db/migrate/20170623152835_delete_exported_claims.rb
+++ b/db/migrate/20170623152835_delete_exported_claims.rb
@@ -1,4 +1,4 @@
-class DeleteExportedClaims < ActiveRecord::Migration
+class DeleteExportedClaims < ActiveRecord::Migration[4.2]
   def change
     drop_table :exported_claims
   end

--- a/db/migrate/20170727130618_add_uuid_to_case_types.rb
+++ b/db/migrate/20170727130618_add_uuid_to_case_types.rb
@@ -1,4 +1,4 @@
-class AddUuidToCaseTypes < ActiveRecord::Migration
+class AddUuidToCaseTypes < ActiveRecord::Migration[4.2]
 
   UUIDS = %w(
     a05f6ee1-c9fb-4069-9789-1f68aea85fb8

--- a/db/migrate/20170824203630_add_unique_code_to_offences.rb
+++ b/db/migrate/20170824203630_add_unique_code_to_offences.rb
@@ -1,4 +1,4 @@
-class AddUniqueCodeToOffences < ActiveRecord::Migration
+class AddUniqueCodeToOffences < ActiveRecord::Migration[4.2]
   def up
     add_column :offences, :unique_code, :string, default: 'anyoldrubbish', null: false
     Rake::Task['data:migrate:offence_unique_code'].invoke

--- a/db/migrate/20170919103557_modify_offence_description.rb
+++ b/db/migrate/20170919103557_modify_offence_description.rb
@@ -1,4 +1,4 @@
-class ModifyOffenceDescription < ActiveRecord::Migration
+class ModifyOffenceDescription < ActiveRecord::Migration[4.2]
   # fix typo
   def up
     Offence

--- a/db/migrate/20170921105947_update_invalid_claim_offences.rb
+++ b/db/migrate/20170921105947_update_invalid_claim_offences.rb
@@ -31,7 +31,7 @@ module InvalidOffences
   end
 end
 
-class UpdateInvalidClaimOffences < ActiveRecord::Migration
+class UpdateInvalidClaimOffences < ActiveRecord::Migration[4.2]
   include InvalidOffences
 
   def up

--- a/db/migrate/20171111113526_create_injection_attempts.rb
+++ b/db/migrate/20171111113526_create_injection_attempts.rb
@@ -1,4 +1,4 @@
-class CreateInjectionAttempts < ActiveRecord::Migration
+class CreateInjectionAttempts < ActiveRecord::Migration[4.2]
   def change
     create_table :injection_attempts do |t|
       t.references :claim, index: true, foreign_key: true

--- a/db/migrate/20171211120149_add_retrial_reduction_to_claim.rb
+++ b/db/migrate/20171211120149_add_retrial_reduction_to_claim.rb
@@ -1,4 +1,4 @@
-class AddRetrialReductionToClaim < ActiveRecord::Migration
+class AddRetrialReductionToClaim < ActiveRecord::Migration[4.2]
   def change
     add_column :claims, :retrial_reduction, :boolean, default: false
   end

--- a/db/migrate/20171219122957_add_reason_text_to_claim_state_transition.rb
+++ b/db/migrate/20171219122957_add_reason_text_to_claim_state_transition.rb
@@ -1,4 +1,4 @@
-class AddReasonTextToClaimStateTransition < ActiveRecord::Migration
+class AddReasonTextToClaimStateTransition < ActiveRecord::Migration[4.2]
   def change
     add_column :claim_state_transitions, :reason_text, :string
   end

--- a/db/migrate/20180110144517_add_error_messages_to_injection_attempt.rb
+++ b/db/migrate/20180110144517_add_error_messages_to_injection_attempt.rb
@@ -1,4 +1,4 @@
-class AddErrorMessagesToInjectionAttempt < ActiveRecord::Migration
+class AddErrorMessagesToInjectionAttempt < ActiveRecord::Migration[4.2]
   def change
     add_column :injection_attempts, :error_messages, :json
   end

--- a/db/migrate/20180111161855_remove_error_message_from_injection_attempts.rb
+++ b/db/migrate/20180111161855_remove_error_message_from_injection_attempts.rb
@@ -1,4 +1,4 @@
-class RemoveErrorMessageFromInjectionAttempts < ActiveRecord::Migration
+class RemoveErrorMessageFromInjectionAttempts < ActiveRecord::Migration[4.2]
   def change
     remove_column :injection_attempts, :error_message, :string
   end

--- a/db/migrate/20180115161809_add_deleted_at_to_injection_attempts.rb
+++ b/db/migrate/20180115161809_add_deleted_at_to_injection_attempts.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToInjectionAttempts < ActiveRecord::Migration
+class AddDeletedAtToInjectionAttempts < ActiveRecord::Migration[4.2]
   def change
     add_column :injection_attempts, :deleted_at, :datetime, default: nil
   end

--- a/db/migrate/20180207085503_softly_delete_cost_judge_disbursement_types.rb
+++ b/db/migrate/20180207085503_softly_delete_cost_judge_disbursement_types.rb
@@ -1,4 +1,4 @@
-class SoftlyDeleteCostJudgeDisbursementTypes < ActiveRecord::Migration
+class SoftlyDeleteCostJudgeDisbursementTypes < ActiveRecord::Migration[4.2]
   def up
     DisbursementType.where(unique_code: %i[CJP CJA]).each {|d| d.soft_delete }
   end

--- a/db/migrate/20180301113027_create_fee_schemes.rb
+++ b/db/migrate/20180301113027_create_fee_schemes.rb
@@ -1,4 +1,4 @@
-class CreateFeeSchemes < ActiveRecord::Migration
+class CreateFeeSchemes < ActiveRecord::Migration[4.2]
   def change
     create_table :fee_schemes do |t|
       t.string :name

--- a/db/migrate/20180307100513_create_offence_fee_schemes.rb
+++ b/db/migrate/20180307100513_create_offence_fee_schemes.rb
@@ -1,4 +1,4 @@
-class CreateOffenceFeeSchemes < ActiveRecord::Migration
+class CreateOffenceFeeSchemes < ActiveRecord::Migration[4.2]
   def change
     create_table :offence_fee_schemes do |t|
       t.references :offence, index: true

--- a/db/migrate/20180308094512_create_offence_categories.rb
+++ b/db/migrate/20180308094512_create_offence_categories.rb
@@ -1,4 +1,4 @@
-class CreateOffenceCategories < ActiveRecord::Migration
+class CreateOffenceCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :offence_categories do |t|
       t.integer :number

--- a/db/migrate/20180308095317_create_offence_bands.rb
+++ b/db/migrate/20180308095317_create_offence_bands.rb
@@ -1,4 +1,4 @@
-class CreateOffenceBands < ActiveRecord::Migration
+class CreateOffenceBands < ActiveRecord::Migration[4.2]
   def change
     create_table :offence_bands do |t|
       t.integer :number

--- a/db/migrate/20180312102328_add_offence_band_to_offence.rb
+++ b/db/migrate/20180312102328_add_offence_band_to_offence.rb
@@ -1,4 +1,4 @@
-class AddOffenceBandToOffence < ActiveRecord::Migration
+class AddOffenceBandToOffence < ActiveRecord::Migration[4.2]
   def change
     add_reference :offences, :offence_band, index: true, foreign_key: true
   end

--- a/db/migrate/20180314084912_add_new_data_fields_to_offence.rb
+++ b/db/migrate/20180314084912_add_new_data_fields_to_offence.rb
@@ -1,4 +1,4 @@
-class AddNewDataFieldsToOffence < ActiveRecord::Migration
+class AddNewDataFieldsToOffence < ActiveRecord::Migration[4.2]
   def change
     add_column :offences, :contrary, :string
     add_column :offences, :year_chapter, :string

--- a/db/migrate/20180329145753_add_priority_to_fee_types.rb
+++ b/db/migrate/20180329145753_add_priority_to_fee_types.rb
@@ -1,4 +1,4 @@
-class AddPriorityToFeeTypes < ActiveRecord::Migration
+class AddPriorityToFeeTypes < ActiveRecord::Migration[4.2]
   def change
     add_column :fee_types, :position, :integer
   end

--- a/db/migrate/20180409091300_modify_fee_type_case_uplift.rb
+++ b/db/migrate/20180409091300_modify_fee_type_case_uplift.rb
@@ -1,4 +1,4 @@
-class ModifyFeeTypeCaseUplift < ActiveRecord::Migration
+class ModifyFeeTypeCaseUplift < ActiveRecord::Migration[4.2]
   # repurpose LGFS case uplift as defendant uplift
   # NOTE: smoke test on dev build of branch means we
   # need to cater for type not existing


### PR DESCRIPTION
#### What
Add `[4.2]` to all migrations

#### Why
To prepare for further rails 5 upgrades and remove migration
deprecation warnings

see [issue](https://github.com/RolifyCommunity/rolify/issues/444)