### PR TITLE
Add scheme 10 advocate category to adapter

### DIFF
--- a/app/services/ccr/advocate_category_adapter.rb
+++ b/app/services/ccr/advocate_category_adapter.rb
@@ -4,7 +4,8 @@ module CCR
       'QC': 'QC',
       'Led junior': 'LEDJR',
       'Leading junior': 'LEADJR',
-      'Junior alone': 'JRALONE'
+      'Junior alone': 'JRALONE',
+      'Junior': 'JUNIOR'
     }.stringify_keys.freeze
 
     class << self

--- a/spec/services/ccr/advocate_category_adapter_spec.rb
+++ b/spec/services/ccr/advocate_category_adapter_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe CCR::AdvocateCategoryAdapter, type: :adapter do
+  describe '.code_for' do
+    subject { described_class.code_for(advocate_category) }
+
+    ADVOCATE_CATEGORY_MAPPINGS = {
+      'QC': 'QC',
+      'Led junior': 'LEDJR',
+      'Leading junior': 'LEADJR',
+      'Junior alone': 'JRALONE',
+      'Junior': 'JUNIOR'
+    }.stringify_keys.freeze
+
+    context 'mappings' do
+      ADVOCATE_CATEGORY_MAPPINGS.each do |description, code|
+        context "maps #{description}" do
+          let(:advocate_category) { description }
+
+          it "returns #{code}" do
+            is_expected.to eql code
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Add scheme 10 advocate category to adapter

#### Why
A new advocate category was added for AGFS
claims under scheme 10 and this was not being
adapted for DI into CCR.