### PR TITLE
Api basic fee creation fix

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -173,8 +173,8 @@ module Claim
       # TODO: this should return a list based on the current given fee scheme
       # rather than conditionally return scheme 10 specifically
       # TBD once all the fee scheme work is integrated
-      return Fee::BasicFeeType.all if from_api? || from_json_import?
-      return Fee::BasicFeeType.unscoped.agfs_scheme_10s.order(:position) if fee_scheme.eql?('fee_reform')
+      return Fee::BasicFeeType.all if from_json_import?
+      return Fee::BasicFeeType.unscoped.agfs_scheme_10s.order(:position) if scheme_10?
       Fee::BasicFeeType.agfs_scheme_9s
     end
 
@@ -184,6 +184,10 @@ module Claim
       # TBD once all the fee scheme work is integrated
       return Fee::MiscFeeType.agfs_scheme_10s if fee_scheme == 'fee_reform'
       Fee::MiscFeeType.agfs_scheme_9s
+    end
+
+    def scheme_10?
+      fee_scheme.eql?('fee_reform') || offence&.scheme_ten?
     end
 
     def eligible_fixed_fee_types

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -129,6 +129,11 @@ describe API::V1::ExternalUsers::Fee do
 
         context 'agfs scheme 10' do
           let!(:claim) { create(:claim, :agfs_scheme_10, source: 'api', actual_trial_length: 5).reload }
+          before do
+            # Replicate the creation of this by the API submission of the claim
+            create(:basic_fee, fee_type: basic_fee_dat_type, claim: claim, quantity: 0, rate: 0.0, case_numbers: '')
+          end
+
           let!(:valid_params) { { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: basic_fee_dat_type.id, quantity: 2, rate: 600.00 } }
 
           it 'should return 200 and fee JSON output including UUID' do


### PR DESCRIPTION
#### What
Update the basic fees generated by API submitted Advocate Claims
#### Ticket[Update the Advocate Claim basic fees for API claims](https://www.pivotaltracker.com/story/show/157423560)
#### Why
Due to an earlier bug where **no** fees were generated, a decision was made to add _all_ basic fees on api creation.
#### How
This extends the test for `scheme_10?` claims by checking for the presence of a scheme_ten offence
