### PR TITLE
Quieten RSpec output

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,20 +4,20 @@ class ErrorsController < ApplicationController
 
   def not_endpoint
     logger.info("Data POSTed to root with API key: #{not_endpoint_params[:api_key]}") if params.present?
-    render status: 403, text: 'Not a valid api endpoint'
+    render status: 403, plain: 'Not a valid api endpoint'
   end
 
   def not_found
     respond_to do |format|
       format.html { render status: 404 }
-      format.all { render status: 404, text: 'not found' }
+      format.all { render status: 404, plain: 'not found' }
     end
   end
 
   def internal_server_error
     respond_to do |format|
       format.html { render status: 500 }
-      format.all { render status: 500, text: 'error' }
+      format.all { render status: 500, plain: 'error' }
     end
   end
 

--- a/app/controllers/offences_controller.rb
+++ b/app/controllers/offences_controller.rb
@@ -13,8 +13,8 @@ class OffencesController < ApplicationController
   skip_load_and_authorize_resource only: [:index]
 
   def index
-    if params[:fee_scheme] && params[:fee_scheme] == 'fee_reform'
-      @offences = FeeReform::SearchOffences.call(params)
+    if permitted_params[:fee_scheme] && permitted_params[:fee_scheme] == 'fee_reform'
+      @offences = FeeReform::SearchOffences.call(permitted_params)
 
       respond_to do |format|
         format.json do
@@ -28,9 +28,13 @@ class OffencesController < ApplicationController
 
   private
 
+  def permitted_params
+    params.permit(:fee_scheme, :description)
+  end
+
   def offence_filter
     {}.tap do |filters|
-      filters.merge!(description: params[:description]) if params[:description].present?
+      filters.merge!(description: permitted_params[:description]) if permitted_params[:description].present?
     end
   end
 end

--- a/app/controllers/user_message_statuses_controller.rb
+++ b/app/controllers/user_message_statuses_controller.rb
@@ -21,7 +21,7 @@ class UserMessageStatusesController < ApplicationController
     @user_message_status.update(read: true)
 
     respond_to do |format|
-      format.html { redirect_to :back }
+      format.html { redirect_back(fallback_location: :root_path) }
       format.js
     end
   end

--- a/spec/api/posting_to_root_spec.rb
+++ b/spec/api/posting_to_root_spec.rb
@@ -5,7 +5,7 @@ describe 'POSTING to root' do
   let!(:claim)    { create(:claim, source: 'api').reload }
   let(:payload)   { {  api_key: provider.api_key, claim_id: claim.uuid, first_name: "JohnAPI", last_name: "SmithAPI", date_of_birth: "1980-05-10"} }
 
-  before { post '/', payload, format: :json }
+  before { post '/', params: payload.merge(format: :json) } 
 
   it 'returns an error' do
     expect(response.status).to eq(403)

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
     before(:each) do
       expect(CaseWorkerService).to receive(:new).and_return(case_worker_service_instance)
       expect(Claims::CaseWorkerClaims).to receive(:new).and_return(case_worker_claims_instance)
-      expect(Allocation).to receive(:new).with(ActionController::Parameters.new(expected_params).permit!)
-      expect(Allocation).to receive(:new).with(ActionController::Parameters.new(expected_params_with_user).permit!).and_return(allocation)
+      expect(Allocation).to receive(:new).with(strong_params(expected_params))
+      expect(Allocation).to receive(:new).with(strong_params(expected_params_with_user)).and_return(allocation)
     end
 
     context 'success' do

--- a/spec/controllers/case_workers/admin/allocations_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/allocations_controller_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe CaseWorkers::Admin::AllocationsController, type: :controller do
     before(:each) do
       expect(CaseWorkerService).to receive(:new).and_return(case_worker_service_instance)
       expect(Claims::CaseWorkerClaims).to receive(:new).and_return(case_worker_claims_instance)
-      expect(Allocation).to receive(:new).with(expected_params)
-      expect(Allocation).to receive(:new).with(expected_params_with_user).and_return(allocation)
+      expect(Allocation).to receive(:new).with(ActionController::Parameters.new(expected_params).permit!)
+      expect(Allocation).to receive(:new).with(ActionController::Parameters.new(expected_params_with_user).permit!).and_return(allocation)
     end
 
     context 'success' do

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
 
     let(:claim) {create :allocated_claim }
     let(:updater) { double Claims::CaseWorkerClaimUpdater }
-    let(:params) { ActionController::Parameters.new({'additional_information' => 'foo bar', 'current_user'=> @case_worker.user}).permit! }
+    let(:params) { strong_params('additional_information' => 'foo bar', 'current_user'=> @case_worker.user) }
 
     before(:each) do
       expect(updater).to receive(:update!).and_return(updater)

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -100,11 +100,12 @@ RSpec.describe CaseWorkers::ClaimsController, type: :controller do
 
     let(:claim) {create :allocated_claim }
     let(:updater) { double Claims::CaseWorkerClaimUpdater }
+    let(:params) { ActionController::Parameters.new({'additional_information' => 'foo bar', 'current_user'=> @case_worker.user}).permit! }
 
     before(:each) do
       expect(updater).to receive(:update!).and_return(updater)
       expect(updater).to receive(:claim).and_return(claim)
-      expect(Claims::CaseWorkerClaimUpdater).to receive(:new).with(claim.id.to_s, {'additional_information' => 'foo bar', 'current_user'=> @case_worker.user}).and_return(updater)
+      expect(Claims::CaseWorkerClaimUpdater).to receive(:new).with(claim.id.to_s, params).and_return(updater)
     end
 
     it 'should call updater service with params' do

--- a/spec/controllers/offences_controller_spec.rb
+++ b/spec/controllers/offences_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe OffencesController, type: :controller do
       end
 
       it 'calls the fee reform search offences service with the provided filters' do
-        expected_args = { fee_scheme: 'fee_reform', controller: 'offences', action: 'index' }
+        expected_args = ActionController::Parameters.new(fee_scheme: 'fee_reform', controller: 'offences', action: 'index')
         expect(FeeReform::SearchOffences).to receive(:call).with(expected_args).and_call_original
         get :index, params: params, xhr: true
       end

--- a/spec/controllers/offences_controller_spec.rb
+++ b/spec/controllers/offences_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe OffencesController, type: :controller do
       end
 
       it 'calls the fee reform search offences service with the provided filters' do
-        expected_args = ActionController::Parameters.new(fee_scheme: 'fee_reform', controller: 'offences', action: 'index')
+        expected_args = strong_params(fee_scheme: 'fee_reform')
         expect(FeeReform::SearchOffences).to receive(:call).with(expected_args).and_call_original
         get :index, params: params, xhr: true
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe UsersController, type: :controller do
 
     it 'updates the setting' do
       do_put(api_promo_seen: 'test')
-      expect(assigns(:settings).to_a).to eq([%w(api_promo_seen test)])
+      expect(assigns(:settings).to_h).to eq({'api_promo_seen' => 'test'})
       expect(user.settings).to eq({'api_promo_seen' => 'test'})
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include JsonSpec::Helpers
   config.include CCLF::BillScenarioHelpers, type: :adapter
+  config.include StrongParamHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/strong_paramas_helpers.rb
+++ b/spec/support/strong_paramas_helpers.rb
@@ -1,0 +1,5 @@
+module StrongParamHelpers
+  def strong_params(weak_params)
+    ActionController::Parameters.new(weak_params).permit!
+  end
+end

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -98,7 +98,7 @@ describe 'case_workers/claims/show.html.haml', type: :view do
         end
 
         it 'has the correct status display' do
-          expect(rendered).to have_selector('span', 'state state-rejected', text: 'Rejected')
+          expect(rendered).to have_selector('span.state.state-rejected', text: 'Rejected')
         end
 
         it 'renders the reason header with the correct tense' do


### PR DESCRIPTION
#### What
After the rails 5 update, there are a lot of deprecation warnings 

#### Why
This can make it hard to debug errors
#### How
Follow the warnings and update blockers
#### Todo
- [x] OffenceController
- [x] Unused parameters passed to Capybara::Queries::SelectorQuery : ["state state-rejected"]
#### Not doing in this PR
- before_filter is deprecated and will be removed in Rails 5.1. (*possibly* paperclip or papertrail gem)
- Shoulda-matchers - waiting for new build (https://github.com/thoughtbot/shoulda-matchers/pull/1009)