### PR TITLE
Add advocate interim claim data injection

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_basic_fee.rb
@@ -1,7 +1,7 @@
 module API
   module Entities
     module CCR
-      class AdaptedBasicFee < API::Entities::CCR::AdaptedBaseFee
+      class AdaptedBasicFee < AdaptedBaseFee
         with_options(format_with: :string) do
           expose :ppe
           expose :number_of_witnesses

--- a/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
@@ -12,7 +12,7 @@
 module API
   module Entities
     module CCR
-      class AdaptedFixedFee < API::Entities::CCR::AdaptedBaseFee
+      class AdaptedFixedFee < AdaptedBaseFee
         with_options(format_with: :string) do
           expose :daily_attendances
           expose :number_of_defendants

--- a/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_misc_fee.rb
@@ -1,7 +1,7 @@
 module API
   module Entities
     module CCR
-      class AdaptedMiscFee < API::Entities::CCR::AdaptedBaseFee
+      class AdaptedMiscFee < AdaptedBaseFee
         with_options(format_with: :string) do
           expose :quantity
           expose :rate

--- a/app/interfaces/api/entities/ccr/adapted_warrant_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_warrant_fee.rb
@@ -1,0 +1,19 @@
+module API
+  module Entities
+    module CCR
+      class AdaptedWarrantFee < AdaptedBaseFee
+        unexpose :case_numbers
+        expose :warrant_issued_date, :warrant_executed_date, format_with: :utc
+        expose :amount, format_with: :string
+
+        private
+
+        delegate :bill_type, :bill_subtype, to: :adapter
+
+        def adapter
+          @adapter ||= ::CCR::Fee::WarrantFeeAdapter.new(object)
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/ccr/adapted_warrant_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_warrant_fee.rb
@@ -3,7 +3,7 @@ module API
     module CCR
       class AdaptedWarrantFee < AdaptedBaseFee
         unexpose :case_numbers
-        expose :warrant_issued_date, :warrant_executed_date, format_with: :utc
+        expose :warrant_issued_date, format_with: :utc
         expose :amount, format_with: :string
 
         private

--- a/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
+++ b/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
@@ -7,22 +7,56 @@ module API
         expose :uuid
         expose :supplier_number
         expose :case_number
-
-        expose  :last_submitted_at,
+        expose  :first_day_of_trial, # will be nil
+                :trial_fixed_notice_at, # will be nil
+                :trial_fixed_at, # will be nil
+                :trial_cracked_at, # will be nil
+                :retrial_started_at, # will be nil
+                :last_submitted_at,
                 format_with: :utc
+        expose :trial_cracked_at_third
 
         expose :adapted_advocate_category, as: :advocate_category
+        # FIXME: dummy a guilty plea for injection purposes
+        # CCR requires a bill scenario in order to calculate fees
+        expose :case_type, using: API::Entities::CCR::CaseType
         expose :court, using: API::Entities::CCR::Court
         expose :offence, using: API::Entities::CCR::Offence
         expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants
 
+        expose :retrial_reduction
+
+        with_options(format_with: :string) do
+          expose :actual_trial_length_or_one, as: :actual_trial_Length # will be nil
+          expose :estimated_trial_length_or_one, as: :estimated_trial_length # will be nil
+          expose :retrial_actual_length_or_one, as: :retrial_actual_length # will be nil
+          expose :retrial_estimated_length_or_one, as: :retrial_estimated_length # will be nil
+        end
+
         expose :additional_information
+
         expose :bills
 
         private
 
         def defendants_with_main_first
           object.defendants.order(created_at: :asc)
+        end
+
+        def estimated_trial_length_or_one
+          object.estimated_trial_length.or_one
+        end
+
+        def actual_trial_length_or_one
+          object.actual_trial_length.or_one
+        end
+
+        def retrial_actual_length_or_one
+          object.retrial_actual_length.or_one
+        end
+
+        def retrial_estimated_length_or_one
+          object.retrial_estimated_length.or_one
         end
 
         def bills

--- a/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
+++ b/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
@@ -27,13 +27,9 @@ module API
 
         def bills
           data = []
-          # data.push AdaptedWarrantFee.represent(warrant_fee) # TODO
-          # data.push AdaptedExpense.represent(object.expenses)
+          data.push AdaptedWarrantFee.represent(object.warrant_fee)
+          data.push AdaptedExpense.represent(object.expenses)
           data.flatten.as_json
-        end
-
-        def warrant_fee
-          # TODO
         end
 
         def adapted_advocate_category

--- a/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
+++ b/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
@@ -2,35 +2,22 @@ module API
   module Entities
     module CCR
       class AdvocateInterimClaim < BaseEntity
-        # TODO: find common functionality with advocate "final" claim and promote to CCR::BaseClaim class
-        #
         expose :uuid
         expose :supplier_number
         expose :case_number
-        expose  :first_day_of_trial, # will be nil
-                :trial_fixed_notice_at, # will be nil
-                :trial_fixed_at, # will be nil
-                :trial_cracked_at, # will be nil
-                :retrial_started_at, # will be nil
-                :last_submitted_at,
-                format_with: :utc
-        expose :trial_cracked_at_third
+        expose :last_submitted_at, format_with: :utc
 
         expose :adapted_advocate_category, as: :advocate_category
-        # FIXME: dummy a guilty plea for injection purposes
-        # CCR requires a bill scenario in order to calculate fees
-        expose :case_type, using: API::Entities::CCR::CaseType
+        expose :dummy_case_type, as: :case_type, using: API::Entities::CCR::CaseType
         expose :court, using: API::Entities::CCR::Court
         expose :offence, using: API::Entities::CCR::Offence
         expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants
 
-        expose :retrial_reduction
-
         with_options(format_with: :string) do
-          expose :actual_trial_length_or_one, as: :actual_trial_Length # will be nil
-          expose :estimated_trial_length_or_one, as: :estimated_trial_length # will be nil
-          expose :retrial_actual_length_or_one, as: :retrial_actual_length # will be nil
-          expose :retrial_estimated_length_or_one, as: :retrial_estimated_length # will be nil
+          expose :actual_trial_length_or_one, as: :actual_trial_Length
+          expose :estimated_trial_length_or_one, as: :estimated_trial_length
+          expose :retrial_actual_length_or_one, as: :retrial_actual_length
+          expose :retrial_estimated_length_or_one, as: :retrial_estimated_length
         end
 
         expose :additional_information
@@ -57,6 +44,14 @@ module API
 
         def retrial_estimated_length_or_one
           object.retrial_estimated_length.or_one
+        end
+
+        # FIXME: dummy a guilty plea for injection purposes as CCR requires a bill scenario regardless
+        # NOTE: In CCR, all case types have the same claimable value/fee for a warrant fee
+        # (all else being equal) except Discontinuance case types that have half the value.
+        #
+        def dummy_case_type
+          ::CaseType.find_by(name: 'Guilty plea')
         end
 
         def bills

--- a/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
+++ b/app/interfaces/api/entities/ccr/advocate_interim_claim.rb
@@ -1,0 +1,45 @@
+module API
+  module Entities
+    module CCR
+      class AdvocateInterimClaim < BaseEntity
+        # TODO: find common functionality with advocate "final" claim and promote to CCR::BaseClaim class
+        #
+        expose :uuid
+        expose :supplier_number
+        expose :case_number
+
+        expose  :last_submitted_at,
+                format_with: :utc
+
+        expose :adapted_advocate_category, as: :advocate_category
+        expose :court, using: API::Entities::CCR::Court
+        expose :offence, using: API::Entities::CCR::Offence
+        expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants
+
+        expose :additional_information
+        expose :bills
+
+        private
+
+        def defendants_with_main_first
+          object.defendants.order(created_at: :asc)
+        end
+
+        def bills
+          data = []
+          # data.push AdaptedWarrantFee.represent(warrant_fee) # TODO
+          # data.push AdaptedExpense.represent(object.expenses)
+          data.flatten.as_json
+        end
+
+        def warrant_fee
+          # TODO
+        end
+
+        def adapted_advocate_category
+          ::CCR::AdvocateCategoryAdapter.code_for(object.advocate_category) if object.advocate_category.present?
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v2/ccr_claim.rb
+++ b/app/interfaces/api/v2/ccr_claim.rb
@@ -5,7 +5,12 @@ module API
 
       helpers do
         def claim
-          ::Claim::AdvocateClaim.find_by(uuid: params[:uuid]) || error!('Claim not found', 404)
+          ::Claim::BaseClaim.agfs.find_by(uuid: params[:uuid]) || error!('Claim not found', 404)
+        end
+
+        def entity_class
+          return API::Entities::CCR::AdvocateInterimClaim if claim.interim?
+          API::Entities::CCR::AdvocateClaim
         end
       end
 
@@ -14,7 +19,7 @@ module API
         params { use :common_injection_params }
 
         get ':uuid' do
-          present claim, with: API::Entities::CCR::AdvocateClaim
+          present claim, with: entity_class
         end
       end
     end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -162,8 +162,8 @@ module Claim
 
     scope :cloned, -> { where.not(clone_source_id: nil) }
 
-    scope :agfs, -> { where(type: 'Claim::AdvocateClaim') }
-    scope :lgfs, -> { where.not(type: 'Claim::AdvocateClaim') }
+    scope :agfs, -> { where(type: agfs_claim_types) }
+    scope :lgfs, -> { where(type: lgfs_claim_types) }
 
     accepts_nested_attributes_for :misc_fees,         reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :expenses,          reject_if: all_blank_or_zero, allow_destroy: true

--- a/app/services/ccr/fee/warrant_fee_adapter.rb
+++ b/app/services/ccr/fee/warrant_fee_adapter.rb
@@ -1,0 +1,7 @@
+module CCR
+  module Fee
+    class WarrantFeeAdapter < SimpleBillAdapter
+      acts_as_simple_bill bill_type: 'AGFS_ADVANCE', bill_subtype: 'AGFS_WARRANT'
+    end
+  end
+end

--- a/app/views/external_users/claims/warrant_fee/_fields.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_fields.html.haml
@@ -7,7 +7,7 @@
       %fieldset
         %legend.visuallyhidden
           = t('.warrant_fee')
-        .form-date.warrant-fee-issued-date-group
+        .warrant-fee-issued-date-group
           = wf.gov_uk_date_field :warrant_issued_date,
                                   legend_text: t('.date_issued'),
                                   legend_class: 'form-label-bold',
@@ -16,7 +16,7 @@
 
     - if f.object.warrant_fee.requires_executed_date?
       .form-group
-        .form-date.warrant-fee-executed-date-group
+        .warrant-fee-executed-date-group
           = wf.gov_uk_date_field :warrant_executed_date,
                                   legend_text: t('.date_executed'),
                                   legend_class: 'govuk-legend',

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -241,7 +241,7 @@
         }
       },
       "type": "object",
-      "required": ["offence_class","unique_code"]
+      "required": ["unique_code"]
     },
     "advocate_category": {
       "id": "/properties/advocate_category",

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -110,6 +110,10 @@
             "id": "/properties/bills/items/properties/amount",
             "type": "string"
           },
+          "warrant_issued_date": {
+            "id": "/properties/bills/items/properties/warrant_issued_date",
+            "type": ["string", "null"]
+          },
           "dates_attended": {
             "id": "/properties/bills/items/properties/dates_attended",
             "items": {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -88,7 +88,7 @@ active_features:
 reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).change(offset: '+100') %>
 
 # agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
-agfs_fee_reform_release_date: <%= ENV["ENV"].eql?('api-sandbox') ? Date.new(2018, 1, 1) : Date.new(2018, 4, 1) %>
+agfs_fee_reform_release_date: <%= ENV["ENV"].in?(['api-sandbox','demo','development']) ? Date.new(2018, 1, 1) : Date.new(2018, 04, 1) %>
 
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -88,7 +88,7 @@ active_features:
 reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).change(offset: '+100') %>
 
 # agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
-agfs_fee_reform_release_date: <%= ENV["ENV"].in?(['api-sandbox','demo','development']) ? Date.new(2018, 1, 1) : Date.new(2018, 04, 1) %>
+agfs_fee_reform_release_date: <%= ENV["ENV"].in?(['api-sandbox', 'demo', 'development']) ? Date.new(2018, 1, 1) : Date.new(2018, 04, 1) %>
 
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16

--- a/features/claims/advocate/advocate_interim_claim_submit.feature
+++ b/features/claims/advocate/advocate_interim_claim_submit.feature
@@ -1,0 +1,60 @@
+@javascript
+Feature: Advocate partially fills out a draft AGFS interim claim for a trial, then later edits and submits it
+
+  Background:
+    Given AGFS reform commenced on "2018-01-01"
+
+  Scenario: I create an AGFS interim claim, save it to draft and later complete it
+
+    Given I am a signed in advocate
+    And I am on the 'Your claims' page
+    And I click 'Start a claim'
+    And I select the fee scheme 'Advocate warrant fee'
+    Then I should be on the advocate interim new claim page
+
+    And I select the court 'Blackfriars'
+    And I enter a case number of 'A20161234'
+
+    Then I click "Continue" in the claim form
+    And I save as draft
+    Then I should see 'Draft claim saved'
+
+    Given I am later on the Your claims page
+    Then Claim 'A20161234' should be listed with a status of 'Draft'
+
+    When I click the claim 'A20161234'
+    And I edit the claim's defendants
+    And I enter a scheme 10 defendant, representation order and MAAT reference
+
+    Then I click "Continue" in the claim form
+
+    And I search for the scheme 10 offence 'Absconding from lawful custody'
+    Then I select the first search result
+
+    And I select an advocate category of 'Junior'
+    And I fill in '2018-01-01' as the warrant issued date
+    And I enter a Warrant net amount of '100'
+
+    Then I click "Continue" in the claim form
+
+    And I add an expense 'Parking'
+
+    Then I click "Continue" in the claim form
+
+    And I upload 3 documents
+    And I check the boxes for the uploaded documents
+    And I add some additional information
+
+    And I click Submit to LAA
+    Then I should be on the check your claim page
+
+    When I click "Continue"
+    Then I should be on the certification page
+
+    When I check “I attended the main hearing”
+    And I click Certify and submit claim
+    Then I should be on the page showing basic claim information
+
+    When I click View your claims
+    Then I should be on the your claims page
+    And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£161.47'

--- a/features/page_objects/advocate_interim_claim_form_page.rb
+++ b/features/page_objects/advocate_interim_claim_form_page.rb
@@ -1,0 +1,8 @@
+require_relative 'claim_form_page'
+
+class AdvocateInterimClaimFormPage < ClaimFormPage
+  set_url "/advocates/interim_claims/new"
+
+  section :warrant_issued_date, CommonDateSection, "div.warrant-fee-issued-date-group"
+  element :warrant_net_amount, '#claim_warrant_fee_attributes_amount'
+end

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -7,6 +7,7 @@ require_relative 'sections/fee_dates_section'
 require_relative 'sections/fee_section'
 require_relative 'sections/typed_fee_section'
 require_relative 'sections/expense_section'
+require_relative 'sections/offence_result_section'
 
 class ClaimFormPage < SitePrism::Page
   include DropzoneHelper
@@ -43,6 +44,9 @@ class ClaimFormPage < SitePrism::Page
   end
 
   element :add_another_defendant, ".defendants-actions a.add_fields"
+
+  element :offence_search, "input[name='offence-search-input']"
+  sections :offence_results, OffenceResultSection, '#offence-list div.fx-result-item'
 
   element :continue_button, 'div.button-holder > input.button.left'
 

--- a/features/page_objects/sections/offence_result_section.rb
+++ b/features/page_objects/sections/offence_result_section.rb
@@ -1,0 +1,3 @@
+class OffenceResultSection < SitePrism::Section
+  element :select_button, 'a.offence-item-button'
+end

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -1,5 +1,8 @@
-
 include WaitForAjax
+
+Given(/^AGFS reform commenced on "([^"]*)"$/) do |agfs_reform_start_date|
+  allow(Settings).to receive(:agfs_fee_reform_release_date).and_return Date.parse(agfs_reform_start_date)
+end
 
 Given(/^I am on the new claim page$/) do
   @claim_form_page.load
@@ -47,13 +50,14 @@ When(/I enter trial start and end dates$/) do
   end
 end
 
-When(/^I enter defendant, representation order and MAAT reference$/) do
+When(/^I enter (.*?)defendant, representation order and MAAT reference$/) do |scheme_text|
+    date = scheme_text.match?('scheme 10') ? Settings.agfs_fee_reform_release_date.strftime : "2016-01-01"
     using_wait_time(6) do
       @claim_form_page.wait_for_defendants
       @claim_form_page.defendants.first.first_name.set "Bob"
       @claim_form_page.defendants.first.last_name.set "Billiards"
       @claim_form_page.defendants.first.dob.set_date "1955-01-01"
-      @claim_form_page.defendants.last.representation_orders.first.date.set_date "2016-01-01"
+      @claim_form_page.defendants.last.representation_orders.first.date.set_date date
       @claim_form_page.defendants.last.representation_orders.first.maat_reference.set "1234567890"
     end
 end
@@ -76,6 +80,15 @@ When(/^I add another defendant, representation order and MAAT reference$/) do
     @claim_form_page.defendants.last.representation_orders.first.date.set_date "2016-01-01"
     @claim_form_page.defendants.last.representation_orders.first.maat_reference.set "1234567890"
   end
+end
+
+When(/^I search for the scheme 10 offence '(.*?)'$/) do |search_text|
+  @claim_form_page.offence_search.set search_text
+end
+
+Then(/^I select the first search result$/) do
+  sleep Capybara.default_max_wait_time
+  @claim_form_page.offence_results.first.select_button(visible: false).trigger('click')
 end
 
 When(/^I add a basic fee with dates attended$/) do

--- a/features/step_definitions/advocate_interim_claim_steps.rb
+++ b/features/step_definitions/advocate_interim_claim_steps.rb
@@ -1,0 +1,11 @@
+Then(/^I should be on the advocate interim new claim page$/) do
+  expect(@advocate_interim_claim_form_page).to be_displayed
+end
+
+And(/^I fill in '(.*)' as the warrant issued date$/) do |date|
+  @advocate_interim_claim_form_page.warrant_issued_date.set_date date
+end
+
+And(/^I enter a Warrant net amount of '(.*?)'$/) do |amount|
+  @advocate_interim_claim_form_page.warrant_net_amount.set amount
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -15,7 +15,7 @@ When(/^I start a claim/) do
 end
 
 And(/^I select the fee scheme '(.*)'$/) do |fee_scheme|
-  method_name = fee_scheme.downcase.gsub(' ', '_').to_sym
+  method_name = fee_scheme.downcase.gsub(' ', '_').gsub('warrant','interim').to_sym
   @fee_scheme_selector.send(method_name).click
   @fee_scheme_selector.continue.click
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -9,6 +9,7 @@ Before('~@no-site-prism') do
   @case_worker_claim_show_page = CaseWorkerClaimShowPage.new
 
   @claim_form_page = ClaimFormPage.new
+  @advocate_interim_claim_form_page = AdvocateInterimClaimFormPage.new
   @litigator_claim_form_page = LitigatorClaimFormPage.new
   @interim_claim_form_page = InterimClaimFormPage.new
   @transfer_claim_form_page = TransferClaimFormPage.new

--- a/spec/api/entities/cclf/adapted_transfer_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_transfer_fee_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe API::Entities::CCLF::AdaptedTransferFee, type: :adapter do
   end
 
   it 'exposes expected json key-value pairs' do
-    expect(response).to match_array(
+    is_expected.to match_array(
       bill_type: 'LIT_FEE',
       bill_subtype: 'LIT_FEE',
       quantity: '888',

--- a/spec/api/entities/cclf/adapted_warrant_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_warrant_fee_spec.rb
@@ -3,17 +3,23 @@ require 'rails_helper'
 RSpec.describe API::Entities::CCLF::AdaptedWarrantFee, type: :adapter do
   subject(:response) { JSON.parse(described_class.represent(warrant_fee).to_json, symbolize_names: true) }
 
-  let(:fee_type) { instance_double('fee_type', unique_code: 'WARR') }
-  let(:case_type) { instance_double('case_type', fee_type_code: 'FXCBR') }
-  let(:claim) { instance_double('claim', case_type: case_type) }
-  let(:warrant_fee) { instance_double('warrant_fee', claim: claim, fee_type: fee_type, amount: 111.01, warrant_issued_date: '01-Jun-2017'.to_date, warrant_executed_date: '01-Aug-2017'.to_date) }
+  let(:fee_type) { instance_double(Fee::WarrantFeeType, unique_code: 'WARR') }
+  let(:case_type) { instance_double(CaseType, fee_type_code: 'FXCBR') }
+  let(:claim) { instance_double(Claim::LitigatorClaim, case_type: case_type) }
+  let(:warrant_fee) { instance_double(Fee::WarrantFee, claim: claim, fee_type: fee_type, amount: 111.01, warrant_issued_date: '01-Jun-2017'.to_date, warrant_executed_date: '01-Aug-2017'.to_date) }
 
   it_behaves_like 'a bill types delegator', ::CCLF::Fee::WarrantFeeAdapter do
     let(:bill) { warrant_fee }
   end
 
+  it { is_expected.to expose :bill_type }
+  it { is_expected.to expose :bill_subtype }
+  it { is_expected.to expose :warrant_issued_date }
+  it { is_expected.to expose :warrant_executed_date }
+  it { is_expected.to expose :amount }
+
   it 'exposes expected json key-value pairs' do
-    expect(response).to include(
+    is_expected.to include(
       bill_type: 'FEE_ADVANCE',
       bill_subtype: 'WARRANT',
       amount: '111.01',

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe API::Entities::CCR::AdaptedMiscFee, type: :adapter do
   subject(:response) { JSON.parse(described_class.represent(adapted_misc_fee).to_json).deep_symbolize_keys }
 
-  let(:claim) { create(:claim) }
+  let(:claim) { create(:advocate_claim) }
 
   let(:misc_fee) do
     create(:misc_fee, :mispf_fee, :with_date_attended,

--- a/spec/api/entities/ccr/adapted_warrant_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_warrant_fee_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe API::Entities::CCR::AdaptedWarrantFee, type: :adapter do
+  subject(:response) { JSON.parse(described_class.represent(warrant_fee).to_json, symbolize_names: true) }
+
+  let(:fee_type) { instance_double(Fee::WarrantFeeType, unique_code: 'WARR') }
+  let(:claim) { instance_double(Claim::AdvocateInterimClaim) }
+  let(:warrant_fee) { instance_double(Fee::WarrantFee, claim: claim, fee_type: fee_type, amount: 111.01, warrant_issued_date: '01-Apr-2018'.to_date, warrant_executed_date: '01-Jul-2018'.to_date) }
+
+  it_behaves_like 'a bill types delegator', ::CCR::Fee::WarrantFeeAdapter do
+    let(:bill) { warrant_fee }
+  end
+
+  it { is_expected.to expose :bill_type }
+  it { is_expected.to expose :bill_subtype }
+  it { is_expected.not_to expose :case_numbers }
+  it { is_expected.to expose :warrant_issued_date }
+  it { is_expected.to expose :warrant_executed_date }
+  it { is_expected.to expose :amount }
+
+  it 'exposes expected json key-value pairs' do
+    is_expected.to include(
+      bill_type: 'AGFS_ADVANCE',
+      bill_subtype: 'AGFS_WARRANT',
+      amount: '111.01',
+      warrant_issued_date: "2018-04-01",
+      warrant_executed_date: "2018-07-01"
+    )
+  end
+end

--- a/spec/api/entities/ccr/adapted_warrant_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_warrant_fee_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe API::Entities::CCR::AdaptedWarrantFee, type: :adapter do
 
   let(:fee_type) { instance_double(Fee::WarrantFeeType, unique_code: 'WARR') }
   let(:claim) { instance_double(Claim::AdvocateInterimClaim) }
-  let(:warrant_fee) { instance_double(Fee::WarrantFee, claim: claim, fee_type: fee_type, amount: 111.01, warrant_issued_date: '01-Apr-2018'.to_date, warrant_executed_date: '01-Jul-2018'.to_date) }
+  let(:warrant_fee) { instance_double(Fee::WarrantFee, claim: claim, fee_type: fee_type, amount: 111.01, warrant_issued_date: '01-Apr-2018'.to_date) }
 
   it_behaves_like 'a bill types delegator', ::CCR::Fee::WarrantFeeAdapter do
     let(:bill) { warrant_fee }
@@ -15,7 +15,7 @@ RSpec.describe API::Entities::CCR::AdaptedWarrantFee, type: :adapter do
   it { is_expected.to expose :bill_subtype }
   it { is_expected.not_to expose :case_numbers }
   it { is_expected.to expose :warrant_issued_date }
-  it { is_expected.to expose :warrant_executed_date }
+  it { is_expected.not_to expose :warrant_executed_date }
   it { is_expected.to expose :amount }
 
   it 'exposes expected json key-value pairs' do
@@ -23,8 +23,7 @@ RSpec.describe API::Entities::CCR::AdaptedWarrantFee, type: :adapter do
       bill_type: 'AGFS_ADVANCE',
       bill_subtype: 'AGFS_WARRANT',
       amount: '111.01',
-      warrant_issued_date: "2018-04-01",
-      warrant_executed_date: "2018-07-01"
+      warrant_issued_date: "2018-04-01"
     )
   end
 end

--- a/spec/api/entities/ccr/defendant_spec.rb
+++ b/spec/api/entities/ccr/defendant_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe API::Entities::CCR::Defendant do
   subject(:response) { JSON.parse(described_class.represent(defendant).to_json).deep_symbolize_keys }
 
-  let(:claim) { create(:claim) }
+  let(:claim) { create(:advocate_claim) }
   let(:rep_orders) { create_list(:representation_order, 1, uuid: 'uuid', maat_reference: '1234567890', representation_order_date: Date.new(2016, 1, 10)) }
 
   let(:defendant) do

--- a/spec/api/entities/ccr/offence_spec.rb
+++ b/spec/api/entities/ccr/offence_spec.rb
@@ -4,11 +4,8 @@ describe API::Entities::CCR::Offence do
   subject(:response) { JSON.parse(described_class.represent(offence).to_json).deep_symbolize_keys }
 
   context 'scheme 9' do
-    let(:scheme) { create :fee_scheme, :agfs_nine }
     let(:offence_class) { create(:offence_class, class_letter: 'C') }
-    let(:offence) { build(:offence, unique_code: 'ABOCUT_C', offence_class_id: offence_class.id) }
-
-    before {create :offence_fee_scheme, offence: offence, fee_scheme: scheme }
+    let(:offence) { build(:offence, :with_fee_scheme, unique_code: 'ABOCUT_C', offence_class_id: offence_class.id) }
 
     it 'has expected json key-value pairs' do
       expect(response).to include(unique_code: 'ABOCUT_C', offence_class: { class_letter: 'C' })
@@ -16,15 +13,10 @@ describe API::Entities::CCR::Offence do
   end
 
   context 'scheme 10' do
-    let(:scheme) { create :fee_scheme }
-    let(:fee_band) { create :fee_band, description: 'test fee band'}
-    let(:offence) { build(:offence, unique_code: 'ABOCUT_C', fee_band: fee_band) }
+    let(:offence) { build(:offence, :with_fee_scheme_ten, unique_code: 'ACUTY_3.1') }
 
-    before {create :offence_fee_scheme, offence: offence, fee_scheme: scheme }
-
-    # TODO: identify new codes required by CCR
-    xit 'has expected json key-value pairs' do
-      expect(response).to include(unique_code: 'ABOCUT_C', fee_band: { name: 'test fee band' })
+    it 'has expected json key-value pairs' do
+      expect(response).to include(unique_code: 'ACUTY_3.1')
     end
   end
 end

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -588,6 +588,12 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
       end
 
+      context 'warrant fees' do
+        let(:claim) do
+          create(:authorised_claim, :without_fees)
+        end
+      end
+
       context 'expenses' do
         subject(:response) do
           do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -94,17 +94,69 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
     end
 
-    context 'claim' do
+    context 'advocate claim' do
       subject(:response) { do_request.body }
 
       it { is_expected.to expose :uuid }
       it { is_expected.to expose :supplier_number }
       it { is_expected.to expose :case_number }
+      it { is_expected.to expose :first_day_of_trial }
+      it { is_expected.to expose :trial_fixed_notice_at }
+      it { is_expected.to expose :trial_fixed_at }
+      it { is_expected.to expose :trial_cracked_at }
+      it { is_expected.to expose :retrial_started_at }
+      it { is_expected.to expose :trial_cracked_at_third }
       it { is_expected.to expose :last_submitted_at }
+
       it { is_expected.to expose :advocate_category }
+      it { is_expected.to expose :case_type }
       it { is_expected.to expose :court }
       it { is_expected.to expose :offence }
       it { is_expected.to expose :defendants }
+      it { is_expected.to expose :retrial_reduction }
+
+      it { is_expected.to expose :actual_trial_Length }
+      it { is_expected.to expose :estimated_trial_length }
+      it { is_expected.to expose :retrial_actual_length }
+      it { is_expected.to expose :retrial_estimated_length }
+
+      it { is_expected.to expose :additional_information }
+      it { is_expected.to expose :bills }
+    end
+
+    context 'advocate interim claim' do
+      subject(:response) { do_request(claim_uuid: claim.uuid).body }
+      let(:warr) { create(:warrant_fee_type, :warr) }
+      let(:offence) { create(:offence, :with_fee_scheme_ten) }
+      let(:claim) do
+        create(:advocate_interim_claim, :without_fees, :submitted, offence: offence).tap do |claim|
+          create(:warrant_fee, fee_type: warr, claim: claim)
+        end
+      end
+
+      it { is_expected.to expose :uuid }
+      it { is_expected.to expose :supplier_number }
+      it { is_expected.to expose :case_number }
+      it { is_expected.to expose :first_day_of_trial }
+      it { is_expected.to expose :trial_fixed_notice_at }
+      it { is_expected.to expose :trial_fixed_at }
+      it { is_expected.to expose :trial_cracked_at }
+      it { is_expected.to expose :retrial_started_at }
+      it { is_expected.to expose :trial_cracked_at_third }
+      it { is_expected.to expose :last_submitted_at }
+
+      it { is_expected.to expose :advocate_category }
+      it { is_expected.to expose :case_type }
+      it { is_expected.to expose :court }
+      it { is_expected.to expose :offence }
+      it { is_expected.to expose :defendants }
+      it { is_expected.to expose :retrial_reduction }
+
+      it { is_expected.to expose :actual_trial_Length }
+      it { is_expected.to expose :estimated_trial_length }
+      it { is_expected.to expose :retrial_actual_length }
+      it { is_expected.to expose :retrial_estimated_length }
+
       it { is_expected.to expose :additional_information }
       it { is_expected.to expose :bills }
     end

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -137,12 +137,12 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       it { is_expected.to expose :uuid }
       it { is_expected.to expose :supplier_number }
       it { is_expected.to expose :case_number }
-      it { is_expected.to expose :first_day_of_trial }
-      it { is_expected.to expose :trial_fixed_notice_at }
-      it { is_expected.to expose :trial_fixed_at }
-      it { is_expected.to expose :trial_cracked_at }
-      it { is_expected.to expose :retrial_started_at }
-      it { is_expected.to expose :trial_cracked_at_third }
+      it { is_expected.not_to expose :first_day_of_trial }
+      it { is_expected.not_to expose :trial_fixed_notice_at }
+      it { is_expected.not_to expose :trial_fixed_at }
+      it { is_expected.not_to expose :trial_cracked_at }
+      it { is_expected.not_to expose :retrial_started_at }
+      it { is_expected.not_to expose :trial_cracked_at_third }
       it { is_expected.to expose :last_submitted_at }
 
       it { is_expected.to expose :advocate_category }
@@ -150,7 +150,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       it { is_expected.to expose :court }
       it { is_expected.to expose :offence }
       it { is_expected.to expose :defendants }
-      it { is_expected.to expose :retrial_reduction }
+      it { is_expected.not_to expose :retrial_reduction }
 
       it { is_expected.to expose :actual_trial_Length }
       it { is_expected.to expose :estimated_trial_length }
@@ -616,6 +616,13 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           create(:advocate_interim_claim, :without_fees, :submitted, offence: offence).tap do |claim|
             create(:warrant_fee, fee_type: warr, claim: claim)
           end
+        end
+
+        before do
+          # TODO: to be removed as and when case type nil on advocate interim claim issue
+          # is resolved. see case type dummying in advocate interim
+          # claim entity which defaults to using guilty plea if case type is nil
+          create(:case_type, :guilty_plea)
         end
 
         it { is_expected.to be_valid_ccr_claim_json }

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
 
   before(:all) do
     @case_worker = create(:case_worker, :admin)
-    @claim = create(:authorised_claim, :without_fees).tap do |claim|
+    @claim = create(:submitted_claim, :without_fees).tap do |claim|
       # NOTE: this will also create the BABAF basic fee TYPE and MISPF misc fee TYPE
       create(:basic_fee, :baf_fee, claim: claim, quantity: 1)
       create(:misc_fee, :mispf_fee, :with_date_attended, claim: claim)
@@ -149,7 +149,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       let(:bills) { JSON.parse(response)['bills'] }
 
       let(:claim) do
-        create(:authorised_claim, :without_fees)
+        create(:submitted_claim, :without_fees)
       end
 
       it 'returns empty array if no bills found' do
@@ -599,7 +599,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         let(:warr) { create(:warrant_fee_type, :warr) }
         let(:offence) { create(:offence, :with_fee_scheme_ten) }
         let(:claim) do
-          create(:advocate_interim_claim, :without_fees, offence: offence).tap do |claim|
+          create(:advocate_interim_claim, :without_fees, :submitted, offence: offence).tap do |claim|
             create(:warrant_fee, fee_type: warr, claim: claim)
           end
         end

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -121,22 +121,22 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
 
       it 'returns multiple defendants' do
-        expect(response).to have_json_size(2).at_path('defendants')
+        is_expected.to have_json_size(2).at_path('defendants')
       end
 
       it 'returns defendants in order created marking earliest created as the "main" defendant' do
-        expect(response).to be_json_eql('true').at_path('defendants/0/main_defendant')
+        is_expected.to be_json_eql('true').at_path('defendants/0/main_defendant')
       end
 
       context 'representation orders' do
         it 'returns multiple representation orders' do
-          expect(response).to have_json_size(2).at_path('defendants/0/representation_orders')
+          is_expected.to have_json_size(2).at_path('defendants/0/representation_orders')
         end
 
         # NOTE: use of factory defaults results in two rep orders for the first
         # defendant with dates 400 and 380 days before claim created
         it 'returns earliest rep order first (per defendant)' do
-          expect(response).to be_json_eql(@claim.earliest_representation_order_date.to_json).at_path('defendants/0/representation_orders/0/representation_order_date')
+          is_expected.to be_json_eql(@claim.earliest_representation_order_date.to_json).at_path('defendants/0/representation_orders/0/representation_order_date')
         end
       end
     end
@@ -146,35 +146,35 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
       end
 
-      subject(:bills) { JSON.parse(response)['bills'] }
+      let(:bills) { JSON.parse(response)['bills'] }
 
       let(:claim) do
         create(:authorised_claim, :without_fees)
       end
 
       it 'returns empty array if no bills found' do
-        expect(response).to have_json_size(0).at_path("bills")
+        is_expected.to have_json_size(0).at_path("bills")
         expect(bills).to be_an Array
         expect(bills).to be_empty
       end
 
       context 'advocate fee' do
-        it { expect(response).to be_valid_ccr_claim_json }
+        it { is_expected.to be_valid_ccr_claim_json }
 
         it 'not added to bills array when no basic fees are being claimed' do
           allow_any_instance_of(Fee::BasicFee).to receive_messages(rate: 0, quantity: 0, amount: 0)
-          expect(response).to have_json_size(0).at_path("bills")
+          is_expected.to have_json_size(0).at_path("bills")
         end
 
         it 'not added to bills array when only inapplicable basic fees claimed' do
           allow_any_instance_of(Fee::BasicFeeType).to receive(:unique_code).and_return 'BAPCM'
           allow_any_instance_of(Fee::BasicFee).to receive_messages(rate: 1, quantity: 2, amount: 2)
-          expect(response).to_not include("\"bill_type\":\"AGFS_FEE\"")
+          is_expected.to_not include("\"bill_type\":\"AGFS_FEE\"")
         end
 
         it 'not added to bills array when case type does not permit advocate fees' do
           allow_any_instance_of(CaseType).to receive(:fee_type_code).and_return 'FXCON' # mock a contempt case type
-          expect(response).to have_json_size(0).at_path("bills")
+          is_expected.to have_json_size(0).at_path("bills")
         end
 
         context 'bill type' do
@@ -183,15 +183,15 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'property included' do
-            expect(response).to have_json_path("bills/0/bill_type")
+            is_expected.to have_json_path("bills/0/bill_type")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/bill_type"
+            is_expected.to have_json_type(String).at_path "bills/0/bill_type"
           end
 
           it 'valid value included' do
-            expect(response).to be_json_eql("AGFS_FEE".to_json).at_path "bills/0/bill_type"
+            is_expected.to be_json_eql("AGFS_FEE".to_json).at_path "bills/0/bill_type"
           end
         end
 
@@ -201,15 +201,15 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'property included' do
-            expect(response).to have_json_path("bills/0/bill_subtype")
+            is_expected.to have_json_path("bills/0/bill_subtype")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/bill_subtype"
+            is_expected.to have_json_type(String).at_path "bills/0/bill_subtype"
           end
 
           it 'valid value included' do
-            expect(response).to be_json_eql("AGFS_FEE".to_json).at_path "bills/0/bill_subtype"
+            is_expected.to be_json_eql("AGFS_FEE".to_json).at_path "bills/0/bill_subtype"
           end
         end
 
@@ -223,15 +223,15 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'property included' do
-            expect(response).to have_json_path("bills/0/ppe")
+            is_expected.to have_json_path("bills/0/ppe")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/ppe"
+            is_expected.to have_json_type(String).at_path "bills/0/ppe"
           end
 
           it 'value taken from the Pages of prosecution evidence Fee quantity' do
-            expect(response).to be_json_eql("1024".to_json).at_path "bills/0/ppe"
+            is_expected.to be_json_eql("1024".to_json).at_path "bills/0/ppe"
           end
         end
 
@@ -245,15 +245,15 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'property included' do
-            expect(response).to have_json_path("bills/0/number_of_cases")
+            is_expected.to have_json_path("bills/0/number_of_cases")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/number_of_cases"
+            is_expected.to have_json_type(String).at_path "bills/0/number_of_cases"
           end
 
           it 'calculated from Number of Cases uplift Fee quantity plus 1, for the "main" case' do
-            expect(response).to be_json_eql("3".to_json).at_path "bills/0/number_of_cases"
+            is_expected.to be_json_eql("3".to_json).at_path "bills/0/number_of_cases"
           end
         end
 
@@ -267,15 +267,15 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'property included' do
-            expect(response).to have_json_path("bills/0/case_numbers")
+            is_expected.to have_json_path("bills/0/case_numbers")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/case_numbers"
+            is_expected.to have_json_type(String).at_path "bills/0/case_numbers"
           end
 
           it 'value taken from the basic fee - number of case uplifts\' case_numbers attribute' do
-            expect(response).to be_json_eql("T20172765, T20172766".to_json).at_path "bills/0/case_numbers"
+            is_expected.to be_json_eql("T20172765, T20172766".to_json).at_path "bills/0/case_numbers"
           end
         end
 
@@ -291,20 +291,20 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'property included' do
-            expect(response).to have_json_path("bills/0/number_of_defendants")
+            is_expected.to have_json_path("bills/0/number_of_defendants")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/number_of_defendants"
+            is_expected.to have_json_type(String).at_path "bills/0/number_of_defendants"
           end
 
           it 'defaults to 1 if no defendant uplifts claimed' do
-            expect(response).to be_json_eql("1".to_json).at_path "bills/0/number_of_defendants"
+            is_expected.to be_json_eql("1".to_json).at_path "bills/0/number_of_defendants"
           end
 
           it 'calculated from sum of Number of defendant uplift fee quantities plus one for main defendant' do
             create(:basic_fee, fee_type: bandr, claim: claim, quantity: 2)
-            expect(response).to be_json_eql("3".to_json).at_path "bills/0/number_of_defendants"
+            is_expected.to be_json_eql("3".to_json).at_path "bills/0/number_of_defendants"
           end
         end
 
@@ -318,15 +318,15 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'property included' do
-            expect(response).to have_json_path("bills/0/number_of_witnesses")
+            is_expected.to have_json_path("bills/0/number_of_witnesses")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/number_of_witnesses"
+            is_expected.to have_json_type(String).at_path "bills/0/number_of_witnesses"
           end
 
           it 'property value determined from Number of Prosecution Witnesses Fee quantity' do
-            expect(response).to be_json_eql("3".to_json).at_path "bills/0/number_of_witnesses"
+            is_expected.to be_json_eql("3".to_json).at_path "bills/0/number_of_witnesses"
           end
         end
 
@@ -341,8 +341,8 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'includes property' do
-            expect(response).to have_json_path("bills/0/daily_attendances")
-            expect(response).to have_json_type(String).at_path "bills/0/daily_attendances"
+            is_expected.to have_json_path("bills/0/daily_attendances")
+            is_expected.to have_json_type(String).at_path "bills/0/daily_attendances"
           end
 
           context 'upper bound value' do
@@ -354,7 +354,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
             end
 
             it 'calculated from Daily Attendanance Fee quantities if they exist' do
-              expect(response).to be_json_eql("51".to_json).at_path "bills/0/daily_attendances"
+              is_expected.to be_json_eql("51".to_json).at_path "bills/0/daily_attendances"
             end
           end
 
@@ -374,12 +374,12 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
 
               it 'calculated as actual trial length if no daily attendance fees and trial length is less than 2' do
                 claim.update_attributes!(actual_trial_length: 1)
-                expect(response).to be_json_eql("1".to_json).at_path "bills/0/daily_attendances"
+                is_expected.to be_json_eql("1".to_json).at_path "bills/0/daily_attendances"
               end
 
               it 'calculated as 2 for trial lengths over 2' do
                 claim.update_attributes!(actual_trial_length: 4, trial_concluded_at: 6.days.ago,)
-                expect(response).to be_json_eql("2".to_json).at_path "bills/0/daily_attendances"
+                is_expected.to be_json_eql("2".to_json).at_path "bills/0/daily_attendances"
               end
             end
 
@@ -401,7 +401,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
               end
 
               it 'calculated from actual retrial length if no daily attendance fees and retrial length is less than 2' do
-                expect(response).to be_json_eql("1".to_json).at_path "bills/0/daily_attendances"
+                is_expected.to be_json_eql("1".to_json).at_path "bills/0/daily_attendances"
               end
             end
           end
@@ -427,10 +427,10 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
             create(:fixed_fee, fee_type: fxcbr, claim: claim)
           end
 
-          it { expect(response).to be_valid_ccr_claim_json }
+          it { is_expected.to be_valid_ccr_claim_json }
 
           it 'added to bills' do
-            expect(response).to have_json_size(1).at_path("bills")
+            is_expected.to have_json_size(1).at_path("bills")
           end
         end
 
@@ -440,18 +440,18 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'fee does not impact the bill' do
-            expect(response).to have_json_size(1).at_path("bills")
-            expect(response).to_not be_json_eql("13".to_json).at_path "bills/0/daily_attendances"
+            is_expected.to have_json_size(1).at_path("bills")
+            is_expected.to_not be_json_eql("13".to_json).at_path "bills/0/daily_attendances"
           end
         end
 
         context 'when no fixed fee exists' do
           it 'fixed fee matching the case type, with defaults, is added to bills' do
-            expect(response).to have_json_size(1).at_path("bills")
-            expect(response).to be_json_eql("AGFS_ORDER_BRCH".to_json).at_path "bills/0/bill_subtype"
-            expect(response).to be_json_eql("1".to_json).at_path "bills/0/daily_attendances"
-            expect(response).to be_json_eql("1".to_json).at_path "bills/0/number_of_cases"
-            expect(response).to be_json_eql("1".to_json).at_path "bills/0/number_of_defendants"
+            is_expected.to have_json_size(1).at_path("bills")
+            is_expected.to be_json_eql("AGFS_ORDER_BRCH".to_json).at_path "bills/0/bill_subtype"
+            is_expected.to be_json_eql("1".to_json).at_path "bills/0/daily_attendances"
+            is_expected.to be_json_eql("1".to_json).at_path "bills/0/number_of_cases"
+            is_expected.to be_json_eql("1".to_json).at_path "bills/0/number_of_defendants"
           end
         end
 
@@ -462,12 +462,12 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'includes property' do
-            expect(response).to have_json_path("bills/0/daily_attendances")
-            expect(response).to have_json_type(String).at_path "bills/0/daily_attendances"
+            is_expected.to have_json_path("bills/0/daily_attendances")
+            is_expected.to have_json_type(String).at_path "bills/0/daily_attendances"
           end
 
           it 'calculated from sum of all applicable fixed fee quantities' do
-            expect(response).to be_json_eql("5".to_json).at_path "bills/0/daily_attendances"
+            is_expected.to be_json_eql("5".to_json).at_path "bills/0/daily_attendances"
           end
         end
 
@@ -480,24 +480,24 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
 
           context 'number_of_cases' do
             it 'includes property' do
-              expect(response).to have_json_path("bills/0/number_of_cases")
-              expect(response).to have_json_type(String).at_path "bills/0/number_of_cases"
+              is_expected.to have_json_path("bills/0/number_of_cases")
+              is_expected.to have_json_type(String).at_path "bills/0/number_of_cases"
             end
 
             it 'calculated from the count of UNIQUE additional case numbers for all uplift fees of the applicable variety' do
-              expect(response).to be_json_eql("4".to_json).at_path "bills/0/number_of_cases"
+              is_expected.to be_json_eql("4".to_json).at_path "bills/0/number_of_cases"
             end
           end
 
           context 'case_numbers' do
             it 'includes property' do
-              expect(response).to have_json_path("bills/0/case_numbers")
-              expect(response).to have_json_type(String).at_path "bills/0/case_numbers"
+              is_expected.to have_json_path("bills/0/case_numbers")
+              is_expected.to have_json_type(String).at_path "bills/0/case_numbers"
             end
 
             it 'consolidated list of UNIQUE additional case numbers for all uplift fees of the applicable variety' do
               %w{S20170001 S20170002 S20170003}.each do |case_number|
-                expect(response).to include_json("#{case_number}".to_json).at_path "bills/0/case_numbers"
+                is_expected.to include_json("#{case_number}".to_json).at_path "bills/0/case_numbers"
               end
             end
           end
@@ -510,12 +510,12 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'includes property', :skip_uplifts do
-            expect(response).to have_json_path("bills/0/number_of_defendants")
-            expect(response).to have_json_type(String).at_path "bills/0/number_of_defendants"
+            is_expected.to have_json_path("bills/0/number_of_defendants")
+            is_expected.to have_json_type(String).at_path "bills/0/number_of_defendants"
           end
 
           it 'calculated from sum of "number of defendants uplift" fee quanitities on claim plus one' do
-            expect(response).to be_json_eql("2".to_json).at_path "bills/0/number_of_defendants"
+            is_expected.to be_json_eql("2".to_json).at_path "bills/0/number_of_defendants"
           end
         end
       end
@@ -531,10 +531,10 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
 
         context 'when relevant CCCD fees exist' do
-          it { expect(response).to be_valid_ccr_claim_json }
+          it { is_expected.to be_valid_ccr_claim_json }
 
           it 'added to bills' do
-            expect(response).to have_json_size(1).at_path("bills")
+            is_expected.to have_json_size(1).at_path("bills")
           end
         end
 
@@ -544,7 +544,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'not added to bills if it is not a miscellaneous fee' do
-            expect(response).to have_json_size(0).at_path("bills")
+            is_expected.to have_json_size(0).at_path("bills")
           end
         end
 
@@ -556,37 +556,37 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
 
           it 'added to bills if it has a value' do
             allow_any_instance_of(Fee::BasicFee).to receive_messages(rate: 1, quantity: 2)
-            expect(response).to have_json_size(1).at_path("bills")
-            expect(response).to be_json_eql("AGFS_MISC_FEES".to_json).at_path "bills/0/bill_type"
+            is_expected.to have_json_size(1).at_path("bills")
+            is_expected.to be_json_eql("AGFS_MISC_FEES".to_json).at_path "bills/0/bill_type"
           end
 
           it 'not added to bills if it has no value' do
-            expect(response).to have_json_size(0).at_path("bills")
+            is_expected.to have_json_size(0).at_path("bills")
           end
         end
 
         context 'bill type' do
           it 'property included' do
-            expect(response).to have_json_path("bills/0/bill_type")
+            is_expected.to have_json_path("bills/0/bill_type")
           end
 
           it 'property type valid' do
-            expect(response).to have_json_type(String).at_path "bills/0/bill_type"
+            is_expected.to have_json_type(String).at_path "bills/0/bill_type"
           end
 
           it 'property value valid' do
-            expect(response).to be_json_eql("AGFS_MISC_FEES".to_json).at_path "bills/0/bill_type"
+            is_expected.to be_json_eql("AGFS_MISC_FEES".to_json).at_path "bills/0/bill_type"
           end
         end
 
         context 'bill sub type' do
           it 'property included' do
-            expect(response).to have_json_path("bills/0/bill_subtype")
-            expect(response).to have_json_type(String).at_path "bills/0/bill_subtype"
+            is_expected.to have_json_path("bills/0/bill_subtype")
+            is_expected.to have_json_type(String).at_path "bills/0/bill_subtype"
           end
 
           it 'valid value included' do
-            expect(response).to be_json_eql("AGFS_ABS_PRC_HF".to_json).at_path "bills/0/bill_subtype"
+            is_expected.to be_json_eql("AGFS_ABS_PRC_HF".to_json).at_path "bills/0/bill_subtype"
           end
         end
       end

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -110,9 +110,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
     end
 
     context 'defendants' do
-      subject(:response) do
-        do_request(claim_uuid: @claim.uuid, api_key: @case_worker.user.api_key).body
-      end
+      subject(:response) { do_request.body }
 
       before do
         travel_to 2.day.from_now do
@@ -214,10 +212,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
 
         context 'pages of prosecution evidence' do
-          subject(:response) do
-            do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-          end
-
           before do
             create(:basic_fee, :ppe_fee, claim: claim, quantity: 1024)
           end
@@ -236,10 +230,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
 
         context 'number of cases uplifts' do
-          subject(:response) do
-            do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-          end
-
           before do
             create(:basic_fee, :noc_fee, claim: claim, quantity: 2, case_numbers: 'T20170001,T20170002')
           end
@@ -258,10 +248,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
 
        context 'case numbers' do
-          subject(:response) do
-            do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-          end
-
           before do
             create(:basic_fee, :noc_fee, claim: claim, quantity: 2, case_numbers: 'T20172765, T20172766')
           end
@@ -280,10 +266,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
 
         context 'number_of_defendants' do
-          subject(:response) do
-            do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-          end
-
           let(:bandr) { create(:basic_fee_type, :ndr) }
 
           before do
@@ -309,10 +291,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
 
         context 'number of prosecution witnesses' do
-          subject(:response) do
-            do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-          end
-
           before do
             create(:basic_fee, :npw_fee, claim: claim, quantity: 3)
           end
@@ -331,10 +309,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
         end
 
         context 'daily attendances' do
-          subject(:response) do
-            do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-          end
-
           before do
             # NOTE: you must be claiming at least on basic fee for an advocate fee to be submitted
             claim.basic_fees.find_by(fee_type_id: Fee::BasicFeeType.find_by(unique_code: 'BABAF')).update(quantity: 1)
@@ -409,10 +383,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
 
       context 'fixed fees' do
-        subject(:response) do
-          do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-        end
-
         let(:fxcbr) { create(:fixed_fee_type, :fxcbr) }
         let(:fxcbu) { create(:fixed_fee_type, :fxcbu) }
         let(:fxndr) { create(:fixed_fee_type, :fxndr) }
@@ -521,10 +491,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
 
       context 'miscellaneous fees' do
-        subject(:response) do
-          do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-        end
-
         before do
           create(:misc_fee, claim: claim)
           allow_any_instance_of(Fee::MiscFeeType).to receive(:unique_code).and_return 'MIAPH'
@@ -592,10 +558,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
 
       context 'warrant fees' do
-        subject(:response) do
-          do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-        end
-
         let(:warr) { create(:warrant_fee_type, :warr) }
         let(:offence) { create(:offence, :with_fee_scheme_ten) }
         let(:claim) do
@@ -617,10 +579,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
 
       context 'expenses' do
-        subject(:response) do
-          do_request(claim_uuid: claim.uuid, api_key: @case_worker.user.api_key).body
-        end
-
         context 'when an expense is claimed' do
           before { create(:expense, :car_travel, claim: claim) }
 

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
 
   before { sign_in advocate.user }
 
-  let(:claim) { create(:claim) }
+  let(:claim) { create(:advocate_claim) }
 
   describe 'GET #new' do
 
@@ -53,7 +53,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
 
   describe 'POST create' do
     context 'AGFS' do
-      let(:claim) { create(:claim) }
+      let(:claim) { create(:advocate_claim) }
       let(:sns_client) do
         Aws::SNS::Client.new(
             region: 'eu_west_1',
@@ -155,7 +155,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
 
   describe 'PATCH #update' do
     it 'should redirect to claim path with a flash message' do
-      claim = create(:claim)
+      claim = create(:advocate_claim)
       patch :update, params: { claim_id: claim }
       expect(response).to redirect_to(external_users_claim_path(claim))
       expect(flash[:alert]).to eq 'Cannot certify a claim in submitted state'

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe MessagesController, type: :controller do
     end
 
     describe "POST #create" do
-      let(:claim) { create(:claim) }
+      let(:claim) { create(:advocate_claim) }
       let(:message_params) do
         {
           claim_id: claim.id,

--- a/spec/factories/case_types.rb
+++ b/spec/factories/case_types.rb
@@ -54,6 +54,14 @@ FactoryBot.define do
       name 'Contempt'
     end
 
+    trait :guilty_plea do
+      name 'Guilty plea'
+      allow_pcmh_fee_type true
+      requires_retrial_dates false
+      roles %w[agfs lgfs]
+      fee_type_code 'GRGLT'
+    end
+
     trait :trial do
       name 'Trial'
       fee_type_code 'GRTRL'

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -1,11 +1,12 @@
 require_relative 'claim_factory_helpers'
 include ClaimFactoryHelpers
 
+#
+# NOTE: use the :advocate_claim alias when calling this factory to
+# differentiate from other claim types.
+#
 FactoryBot.define do
   factory :claim, aliases: [:advocate_claim], class: Claim::AdvocateClaim do
-
-    # Alias for :claim factory that should be used since we now have a litigator claim factory
-    # TODO: replace all instances for create(:claim) to create(:advocate_claim)
 
     advocate_base_setup
 

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -8,7 +8,18 @@ include ClaimFactoryHelpers
 FactoryBot.define do
   factory :claim, aliases: [:advocate_claim], class: Claim::AdvocateClaim do
 
+    # NOTE: this was introduced because it was the only way to get FactoryBot to set
+    # model attributes on initialize (which seems not to be the default behaviour) and
+    # was causing the factory not to assign the appropriate attributes/associations on
+    # initialize which makes after_initialize logic not to behave as expected since the
+    # expected values are not yet set.
+    # More details can be found here:
+    # https://stackoverflow.com/questions/5916162/problem-with-factory-girl-association-and-after-initialize
+    initialize_with { new(attributes) }
+
     advocate_base_setup
+
+    after(:build) { |claim| post_build_actions_for_draft_final_claim(claim) }
 
     trait :admin_creator do
       after(:build) { |claim| make_claim_creator_advocate_admin(claim) }

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -6,35 +6,8 @@ FactoryBot.define do
 
     # Alias for :claim factory that should be used since we now have a litigator claim factory
     # TODO: replace all instances for create(:claim) to create(:advocate_claim)
-    # factory :advocate_claim do
-    # end
 
-    # NOTE: this was introduced here because was the only way to get FactoryBot to set
-    # model attributes on initialize (which seems not to be the default behaviour) and
-    # was causing the factory not to assign the appropriate attributes/associations on
-    # initialize which makes after_initialize logic not to behave as expected since the
-    # expected values are not yet set.
-    # More details can be found here:
-    # https://stackoverflow.com/questions/5916162/problem-with-factory-girl-association-and-after-initialize
-    initialize_with { new(attributes) }
-    transient do
-      create_defendant_and_rep_order true
-    end
-
-    form_id SecureRandom.uuid
-    court
-    case_number { random_case_number }
-    external_user
-    source { 'web' }
-    apply_vat false
-    providers_ref { random_providers_ref }
-    case_type
-    offence
-    advocate_category 'QC'
-    sequence(:cms_number) { |n| "CMS-#{Time.now.year}-#{rand(100..199)}-#{n}" }
-
-    after(:build) { |claim| post_build_actions_for_draft_claim(claim) }
-    after(:create) { |claim, evaluator| add_defendant_and_reporder(claim) if evaluator.create_defendant_and_rep_order }
+    advocate_base_setup
 
     trait :admin_creator do
       after(:build) { |claim| make_claim_creator_advocate_admin(claim) }

--- a/spec/factories/claim/advocate_interim_claims.rb
+++ b/spec/factories/claim/advocate_interim_claims.rb
@@ -8,7 +8,13 @@ FactoryBot.define do
     end
 
     trait :authorised do
-      state :authorised
+      after(:create) { |c| authorise_claim(c) }
+    end
+
+    trait :without_fees do
+      after(:build) do |claim|
+        claim.fees.destroy_all
+      end
     end
   end
 end

--- a/spec/factories/claim/advocate_interim_claims.rb
+++ b/spec/factories/claim/advocate_interim_claims.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     advocate_base_setup
     case_type nil
 
+    after(:build) do |claim|
+      claim.creator = claim.external_user
+    end
+
     trait :submitted do
       after(:create) { |c| c.submit! }
     end

--- a/spec/factories/claim/advocate_interim_claims.rb
+++ b/spec/factories/claim/advocate_interim_claims.rb
@@ -1,12 +1,14 @@
 FactoryBot.define do
   factory :advocate_interim_claim, class: Claim::AdvocateInterimClaim do
-    court
-    case_number { random_case_number }
-    creator { build(:external_user, :advocate) }
-    external_user { creator }
+
+    advocate_base_setup
 
     trait :submitted do
       state :submitted
+    end
+
+    trait :authorised do
+      state :authorised
     end
   end
 end

--- a/spec/factories/claim/advocate_interim_claims.rb
+++ b/spec/factories/claim/advocate_interim_claims.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :advocate_interim_claim, class: Claim::AdvocateInterimClaim do
-
     advocate_base_setup
+    case_type nil
 
     trait :submitted do
       after(:create) { |c| c.submit! }

--- a/spec/factories/claim/advocate_interim_claims.rb
+++ b/spec/factories/claim/advocate_interim_claims.rb
@@ -4,11 +4,7 @@ FactoryBot.define do
     advocate_base_setup
 
     trait :submitted do
-      state :submitted
-    end
-
-    trait :authorised do
-      after(:create) { |c| authorise_claim(c) }
+      after(:create) { |c| c.submit! }
     end
 
     trait :without_fees do

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -1,18 +1,6 @@
 FactoryBot.define do
 
   trait :advocate_base_setup do
-    # NOTE: this was introduced because it was the only way to get FactoryBot to set
-    # model attributes on initialize (which seems not to be the default behaviour) and
-    # was causing the factory not to assign the appropriate attributes/associations on
-    # initialize which makes after_initialize logic not to behave as expected since the
-    # expected values are not yet set.
-    # More details can be found here:
-    # https://stackoverflow.com/questions/5916162/problem-with-factory-girl-association-and-after-initialize
-    initialize_with { new(attributes) }
-    transient do
-      create_defendant_and_rep_order true
-    end
-
     form_id SecureRandom.uuid
     court
     case_number { random_case_number }
@@ -25,8 +13,13 @@ FactoryBot.define do
     advocate_category 'QC'
     sequence(:cms_number) { |n| "CMS-#{Time.now.year}-#{rand(100..199)}-#{n}" }
 
-    after(:build) { |claim| post_build_actions_for_draft_claim(claim) }
-    after(:create) { |claim, evaluator| add_defendant_and_reporder(claim) if evaluator.create_defendant_and_rep_order }
+    transient do
+      create_defendant_and_rep_order true
+    end
+
+    after(:create) do |claim, evaluator|
+      add_defendant_and_reporder(claim) if evaluator.create_defendant_and_rep_order
+    end
   end
 
   trait :litigator_base_setup do

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -1,5 +1,34 @@
 FactoryBot.define do
 
+  trait :advocate_base_setup do
+    # NOTE: this was introduced because it was the only way to get FactoryBot to set
+    # model attributes on initialize (which seems not to be the default behaviour) and
+    # was causing the factory not to assign the appropriate attributes/associations on
+    # initialize which makes after_initialize logic not to behave as expected since the
+    # expected values are not yet set.
+    # More details can be found here:
+    # https://stackoverflow.com/questions/5916162/problem-with-factory-girl-association-and-after-initialize
+    initialize_with { new(attributes) }
+    transient do
+      create_defendant_and_rep_order true
+    end
+
+    form_id SecureRandom.uuid
+    court
+    case_number { random_case_number }
+    external_user
+    source { 'web' }
+    apply_vat false
+    providers_ref { random_providers_ref }
+    case_type
+    offence
+    advocate_category 'QC'
+    sequence(:cms_number) { |n| "CMS-#{Time.now.year}-#{rand(100..199)}-#{n}" }
+
+    after(:build) { |claim| post_build_actions_for_draft_claim(claim) }
+    after(:create) { |claim, evaluator| add_defendant_and_reporder(claim) if evaluator.create_defendant_and_rep_order }
+  end
+
   trait :litigator_base_setup do
     court
     case_number         { random_case_number }

--- a/spec/factories/claim/claim_factory_helpers.rb
+++ b/spec/factories/claim/claim_factory_helpers.rb
@@ -45,7 +45,7 @@ module ClaimFactoryHelpers
     claim.creator = advocate_admin
   end
 
-  def post_build_actions_for_draft_claim(claim)
+  def post_build_actions_for_draft_final_claim(claim)
     certify_claim(claim)
     add_fee(:misc_fee, claim)
     set_creator(claim)

--- a/spec/factories/offences.rb
+++ b/spec/factories/offences.rb
@@ -21,16 +21,16 @@ FactoryBot.define do
     end
 
     trait :with_fee_scheme do
-      after(:create) do |offence|
-        offence.fee_schemes << (FeeScheme.agfs.first || create(:fee_scheme, :agfs_nine))
+      after(:build) do |offence|
+        offence.fee_schemes << (FeeScheme.agfs.first || build(:fee_scheme, :agfs_nine))
       end
     end
 
     trait :with_fee_scheme_ten do
       offence_class nil
       offence_band
-      after(:create) do |offence|
-        offence.fee_schemes << (FeeScheme.agfs.where(version: 10).first || create(:fee_scheme))
+      after(:build) do |offence|
+        offence.fee_schemes << (FeeScheme.agfs.where(version: 10).first || build(:fee_scheme))
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe ApplicationHelper do
 
   context '#present' do
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:advocate_claim) }
 
     it 'returns a <Classname>Presenter instance' do
      expect(present(claim)).to be_a Claim::BaseClaimPresenter

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -361,7 +361,7 @@ describe Ability do
     end
 
     context 'can update claim when assigned to claim' do
-      let(:claim) { create(:claim) }
+      let(:claim) { create(:advocate_claim) }
 
       before { case_worker.claims << claim }
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   it { should accept_nested_attributes_for(:expenses) }
   it { should accept_nested_attributes_for(:defendants) }
 
-  subject { create(:claim) }
+  subject { create(:advocate_claim) }
 
   describe '.earliest_representation_order' do
     let(:claim)         { FactoryBot.build :unpersisted_claim }
@@ -442,7 +442,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   end
 
   describe '.search' do
-    let!(:other_claim) { create(:claim) }
+    let!(:other_claim) { create(:advocate_claim) }
     let(:states) { nil }
 
     it 'finds only claims with states that match dashboard displayable states' do
@@ -786,7 +786,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   end
 
   describe '#editable?' do
-    let(:draft) { create(:claim) }
+    let(:draft) { create(:advocate_claim) }
     let(:submitted) { create(:submitted_claim) }
     let(:allocated) { create(:allocated_claim) }
 
@@ -804,7 +804,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   end
 
   describe '#archivable?' do
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:advocate_claim) }
 
     it 'should not be archivable from states: allocated, archived_pending_delete, awaiting_written_reasons, draft, redetermination' do
       %w( allocated awaiting_written_reasons draft redetermination ).each do |state|
@@ -1141,7 +1141,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   end
 
   describe '#opened_for_redetermination?' do
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:advocate_claim) }
 
     before do
       claim.submit!
@@ -1231,7 +1231,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   end
 
   describe '#written_reasons_outstanding?' do
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:advocate_claim) }
 
     before do
       claim.submit!

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -64,636 +64,659 @@
 
 require 'rails_helper'
 
-module Claim
-  class MockBaseClaim < BaseClaim
-    SUBMISSION_STAGES = [
-      {
-        name: :step_1,
-        transitions: [
-          { to_stage: :step_2 }
-        ]
-      },
-      { name: :step_2 }
-    ].freeze
+
+class MockBaseClaim < Claim::BaseClaim
+  SUBMISSION_STAGES = [
+    {
+      name: :step_1,
+      transitions: [
+        { to_stage: :step_2 }
+      ]
+    },
+    { name: :step_2 }
+  ].freeze
+end
+
+class MockSteppableClaim < Claim::BaseClaim
+  SUBMISSION_STAGES = [
+    {
+      name: :step_1,
+      transitions: [
+        { to_stage: :step_2 }
+      ]
+    },
+    {
+      name: :step_2,
+      transitions: [
+        {
+          to_stage: :step_3A,
+          condition: ->(claim) { claim.fixed_fee_case? }
+        },
+        {
+          to_stage: :step_3B,
+          condition: ->(claim) { !claim.fixed_fee_case? }
+        }
+      ]
+    },
+    { name: :step_3A },
+    { name: :step_3B }
+  ].freeze
+end
+
+RSpec.describe Claim::BaseClaim do
+  include DatabaseHousekeeping
+
+  let(:advocate) { create :external_user, :advocate }
+  let(:agfs_claim) { create(:advocate_claim) }
+  let(:lgfs_claim) { create(:litigator_claim) }
+
+  context 'scheme scopes' do
+    let!(:agfs_final_claim) { create(:advocate_claim) }
+    let!(:agfs_interim_claim) { create(:advocate_interim_claim) }
+    let!(:lgfs_final_claim) { create(:litigator_claim) }
+    let!(:lgfs_interim_claim) { create(:interim_claim) }
+    let!(:lgfs_transfer_claim) { create(:transfer_claim) }
+
+    describe '.agfs' do
+      subject { described_class.agfs }
+
+      it 'returns advocate final and interim claims' do
+        is_expected.to match_array [agfs_final_claim, agfs_interim_claim]
+      end
+    end
+
+    describe '.lgfs' do
+      subject { described_class.lgfs }
+
+      it 'returns litigator final, interim and transfer claims' do
+        is_expected.to match_array [lgfs_final_claim, lgfs_interim_claim, lgfs_transfer_claim]
+      end
+    end
   end
 
-  describe BaseClaim do
-    include DatabaseHousekeeping
+  describe '.agfs_claim_types' do
+    specify { expect(described_class.agfs_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim]) }
+  end
 
-    let(:advocate)   { create :external_user, :advocate }
-    let(:agfs_claim) { create(:advocate_claim) }
-    let(:lgfs_claim) { create(:litigator_claim) }
+  describe '.lgfs_claim_types' do
+    specify { expect(described_class.lgfs_claim_types).to match_array([Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim]) }
+  end
 
-    describe '.agfs_claim_types' do
-      specify { expect(BaseClaim.agfs_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim]) }
+  it 'raises if I try to instantiate a base claim' do
+    expect {
+      described_class.new(external_user: advocate, creator: advocate)
+    }.to raise_error ::Claim::BaseClaimAbstractClassError, 'Claim::BaseClaim is an abstract class and cannot be instantiated'
+  end
+
+  describe '#agfs?' do
+    it 'returns true if claim is advocate/agfs claim, false for litigator/lgfs claims' do
+      expect(agfs_claim.agfs?).to eql true
+      expect(lgfs_claim.agfs?).to eql false
+    end
+  end
+
+  describe '#lgfs?' do
+    it 'returns true if claim is litigator/lgfs claim, false for advocate/agfs claims' do
+      expect(lgfs_claim.lgfs?).to eql true
+      expect(agfs_claim.lgfs?).to eql false
+    end
+  end
+
+  describe '.agfs?' do
+    it 'returns true if class is advocate claim, false otherwise' do
+      expect(agfs_claim.class.agfs?).to eql true
+      expect(lgfs_claim.class.agfs?).to eql false
+    end
+  end
+
+  describe '.lgfs?' do
+    it 'returns true if claim is litigator/lgfs claim, false for advocate/agfs claims' do
+      expect(lgfs_claim.class.lgfs?).to eql true
+      expect(agfs_claim.class.lgfs?).to eql false
+    end
+  end
+
+  describe 'has_many documents association' do
+    it 'should return a collection of verified documents only' do
+      claim = create :claim
+      verified_doc_1 = create :document, :verified, claim: claim
+      _unverified_doc_1 = create :document, :unverified, claim: claim
+      _unverified_doc_2 = create :document, :unverified, claim: claim
+      verified_doc_2 = create :document, :verified, claim: claim
+      claim.reload
+      expect(claim.documents.map(&:id)).to match_array([verified_doc_1.id, verified_doc_2.id])
+    end
+  end
+
+  context 'expenses' do
+    before(:all) do
+      @claim = create :litigator_claim
+      @ex1 = create :expense, claim: @claim, amount: 100.0, vat_amount: 20
+      @ex2 = create :expense, claim: @claim, amount: 100.0, vat_amount: 0.0
+      @ex3 = create :expense, claim: @claim, amount: 50.50, vat_amount: 10.10
+      @ex4 = create :expense, claim: @claim, amount: 25.0, vat_amount: 0.0
+      @claim.reload
     end
 
-    describe '.lgfs_claim_types' do
-      specify { expect(BaseClaim.lgfs_claim_types).to match_array([Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim]) }
-    end
+    after(:all) { clean_database }
 
-    it 'raises if I try to instantiate a base claim' do
-      expect {
-        BaseClaim.new(external_user: advocate, creator: advocate)
-      }.to raise_error ::Claim::BaseClaimAbstractClassError, 'Claim::BaseClaim is an abstract class and cannot be instantiated'
-    end
-
-    describe '#agfs?' do
-      it 'returns true if claim is advocate/agfs claim, false for litigator/lgfs claims' do
-        expect(agfs_claim.agfs?).to eql true
-        expect(lgfs_claim.agfs?).to eql false
-      end
-    end
-
-    describe '#lgfs?' do
-      it 'returns true if claim is litigator/lgfs claim, false for advocate/agfs claims' do
-        expect(lgfs_claim.lgfs?).to eql true
-        expect(agfs_claim.lgfs?).to eql false
-      end
-    end
-
-    describe '.agfs?' do
-      it 'returns true if class is advocate claim, false otherwise' do
-        expect(agfs_claim.class.agfs?).to eql true
-        expect(lgfs_claim.class.agfs?).to eql false
-      end
-    end
-
-    describe '.lgfs?' do
-      it 'returns true if claim is litigator/lgfs claim, false for advocate/agfs claims' do
-        expect(lgfs_claim.class.lgfs?).to eql true
-        expect(agfs_claim.class.lgfs?).to eql false
-      end
-    end
-
-    describe 'has_many documents association' do
-      it 'should return a collection of verified documents only' do
-        claim = create :claim
-        verified_doc_1 = create :document, :verified, claim: claim
-        _unverified_doc_1 = create :document, :unverified, claim: claim
-        _unverified_doc_2 = create :document, :unverified, claim: claim
-        verified_doc_2 = create :document, :verified, claim: claim
-        claim.reload
-        expect(claim.documents.map(&:id)).to match_array([verified_doc_1.id, verified_doc_2.id])
-      end
-    end
-
-    context 'expenses' do
-      before(:all) do
-        @claim = create :litigator_claim
-        @ex1 = create :expense, claim: @claim, amount: 100.0, vat_amount: 20
-        @ex2 = create :expense, claim: @claim, amount: 100.0, vat_amount: 0.0
-        @ex3 = create :expense, claim: @claim, amount: 50.50, vat_amount: 10.10
-        @ex4 = create :expense, claim: @claim, amount: 25.0, vat_amount: 0.0
-        @claim.reload
-      end
-
-      after(:all) { clean_database }
-
-      describe '#expenses.with_vat' do
-        it 'returns an array of expenses with VAT' do
-          expect(@claim.expenses.with_vat).to match_array( [ @ex1, @ex3 ] )
-        end
-      end
-
-      describe '#expenses.without_vat' do
-        it 'returns an array of expenses without VAT' do
-          expect(@claim.expenses.without_vat).to match_array( [ @ex2, @ex4 ] )
-        end
-      end
-
-      describe '#expenses_with_vat_total' do
-        it 'return the sum of the amounts for the expenses with vat' do
-          expect(@claim.expenses_with_vat_net). to eq 150.50
-        end
-      end
-
-      describe '#expenses_without_vat_total' do
-        it 'return the sum of the amounts for the expenses without vat' do
-          expect(@claim.expenses_without_vat_net). to eq 125.0
-        end
+    describe '#expenses.with_vat' do
+      it 'returns an array of expenses with VAT' do
+        expect(@claim.expenses.with_vat).to match_array( [ @ex1, @ex3 ] )
       end
     end
 
-
-    context 'disbursements' do
-      before(:all) do
-        @claim = create :litigator_claim
-        @db1 = create :disbursement, claim: @claim, net_amount: 100.0, vat_amount: 20
-        @db2 = create :disbursement, claim: @claim, net_amount: 100.0, vat_amount: 0.0
-        @db3 = create :disbursement, claim: @claim, net_amount: 50.50, vat_amount: 10.10
-        @db4 = create :disbursement, claim: @claim, net_amount: 25.0, vat_amount: 0.0
-        @claim.reload
-      end
-
-      after(:all) { clean_database }
-
-      describe '#disbursements.with_vat' do
-        it 'returns an array of disbursements with VAT' do
-          expect(@claim.disbursements.with_vat).to match_array( [ @db1, @db3 ] )
-        end
-      end
-
-      describe '#disbursements.without_vat' do
-        it 'returns an array of disbursements without VAT' do
-          expect(@claim.disbursements.without_vat).to match_array( [ @db2, @db4 ] )
-        end
-      end
-
-      describe '#disbursements' do
-        it 'return the sum of the amounts for the disbursements with vat' do
-          expect(@claim.disbursements_with_vat_net). to eq 150.50
-        end
-      end
-
-      describe '#disbursements' do
-        it 'return the sum of the amounts for the disbursements without vat' do
-          expect(@claim.disbursements_without_vat_net). to eq 125.0
-        end
+    describe '#expenses.without_vat' do
+      it 'returns an array of expenses without VAT' do
+        expect(@claim.expenses.without_vat).to match_array( [ @ex2, @ex4 ] )
       end
     end
 
-    describe '#assessment' do
+    describe '#expenses_with_vat_total' do
+      it 'return the sum of the amounts for the expenses with vat' do
+        expect(@claim.expenses_with_vat_net). to eq 150.50
+      end
+    end
+
+    describe '#expenses_without_vat_total' do
+      it 'return the sum of the amounts for the expenses without vat' do
+        expect(@claim.expenses_without_vat_net). to eq 125.0
+      end
+    end
+  end
+
+
+  context 'disbursements' do
+    before(:all) do
+      @claim = create :litigator_claim
+      @db1 = create :disbursement, claim: @claim, net_amount: 100.0, vat_amount: 20
+      @db2 = create :disbursement, claim: @claim, net_amount: 100.0, vat_amount: 0.0
+      @db3 = create :disbursement, claim: @claim, net_amount: 50.50, vat_amount: 10.10
+      @db4 = create :disbursement, claim: @claim, net_amount: 25.0, vat_amount: 0.0
+      @claim.reload
+    end
+
+    after(:all) { clean_database }
+
+    describe '#disbursements.with_vat' do
+      it 'returns an array of disbursements with VAT' do
+        expect(@claim.disbursements.with_vat).to match_array( [ @db1, @db3 ] )
+      end
+    end
+
+    describe '#disbursements.without_vat' do
+      it 'returns an array of disbursements without VAT' do
+        expect(@claim.disbursements.without_vat).to match_array( [ @db2, @db4 ] )
+      end
+    end
+
+    describe '#disbursements' do
+      it 'return the sum of the amounts for the disbursements with vat' do
+        expect(@claim.disbursements_with_vat_net). to eq 150.50
+      end
+    end
+
+    describe '#disbursements' do
+      it 'return the sum of the amounts for the disbursements without vat' do
+        expect(@claim.disbursements_without_vat_net). to eq 125.0
+      end
+    end
+  end
+
+  describe '#assessment' do
+    subject { claim.assessment }
+
+    context 'when claim built' do
+      let(:claim) { build(:advocate_claim) }
+
+      it 'builds a zeroized assessment' do
+        expect(claim).to_not be_persisted
+        is_expected.to_not be_nil
+        is_expected.to_not be_persisted
+        is_expected.to have_attributes(fees: 0.0, expenses: 0.0, disbursements: 0.0)
+      end
+    end
+
+    context 'when claim created' do
+      let(:claim) { create(:advocate_claim) }
+
+      it 'creates an zeroized assessment' do
+        expect(claim).to be_persisted
+        is_expected.to_not be_nil
+        is_expected.to be_persisted
+        is_expected.to have_attributes(fees: 0.0, expenses: 0.0, disbursements: 0.0)
+      end
+    end
+
+    describe '#update_amount_assessed' do
       subject { claim.assessment }
+      let(:claim) { create(:advocate_claim) }
 
-      context 'when claim built' do
-        let(:claim) { build(:advocate_claim) }
+      before { claim.update_amount_assessed(fees: 100.0, expenses: 200.0) }
 
-        it 'builds a zeroized assessment' do
-          expect(claim).to_not be_persisted
-          is_expected.to_not be_nil
-          is_expected.to_not be_persisted
-          is_expected.to have_attributes(fees: 0.0, expenses: 0.0, disbursements: 0.0)
-        end
+      it 'updates the specified assessment attributes' do
+        is_expected.to have_attributes(fees: 100.0, expenses: 200.0, disbursements: 0.0)
+      end
+    end
+  end
+
+  describe '#fixed_fee_case?' do
+    subject { claim.fixed_fee_case? }
+
+    context 'when the case type does not exist' do
+      let(:claim) { MockBaseClaim.new }
+
+      specify { is_expected.to be_nil }
+    end
+
+    context 'when the case type is set' do
+      let(:case_type) { build(:case_type) }
+      let(:claim) { MockBaseClaim.new(case_type: case_type) }
+
+      context 'and does not have a fixed fee' do
+        let(:case_type) { build(:case_type, is_fixed_fee: false) }
+
+        specify { is_expected.to eq(false) }
       end
 
-      context 'when claim created' do
-        let(:claim) { create(:advocate_claim) }
+      context 'and has a fixed fee' do
+        let(:case_type) { build(:case_type, is_fixed_fee: true) }
 
-        it 'creates an zeroized assessment' do
-          expect(claim).to be_persisted
-          is_expected.to_not be_nil
-          is_expected.to be_persisted
-          is_expected.to have_attributes(fees: 0.0, expenses: 0.0, disbursements: 0.0)
-        end
+        specify { is_expected.to eq(true) }
+      end
+    end
+  end
+
+  describe '#next_step' do
+    let(:claim) { MockSteppableClaim.new }
+    let(:step) { :step_1 }
+
+    context 'when condition 3A is met' do
+      before do
+        allow(claim).to receive(:fixed_fee_case?).and_return(true)
+        claim.form_step = step
       end
 
-      describe '#update_amount_assessed' do
-        subject { claim.assessment }
-        let(:claim) { create(:advocate_claim) }
+      it 'does not change the current step' do
+        expect { claim.next_step }
+          .not_to change { claim.current_step }
+          .from(step)
+      end
 
-        before { claim.update_amount_assessed(fees: 100.0, expenses: 200.0) }
-
-        it 'updates the specified assessment attributes' do
-          is_expected.to have_attributes(fees: 100.0, expenses: 200.0, disbursements: 0.0)
-        end
+      it 'follows the steps path 1 -> 2 -> 3A' do
+        expect(claim.next_step).to eq(:step_2)
+        claim.form_step = claim.next_step
+        expect(claim.next_step).to eq(:step_3A)
+        claim.form_step = claim.next_step
+        expect(claim.next_step).to eq(nil)
       end
     end
 
-    describe '#fixed_fee_case?' do
-      subject { claim.fixed_fee_case? }
-
-      context 'when the case type does not exist' do
-        let(:claim) { MockBaseClaim.new }
-
-        specify { is_expected.to be_nil }
+    context 'when condition 3B is met' do
+      before do
+        allow(claim).to receive(:fixed_fee_case?).and_return(false)
       end
 
-      context 'when the case type is set' do
-        let(:case_type) { build(:case_type) }
-        let(:claim) { MockBaseClaim.new(case_type: case_type) }
+      it 'does not change the current step' do
+        expect { claim.next_step }
+          .not_to change { claim.current_step }
+          .from(step)
+      end
 
-        context 'and does not have a fixed fee' do
-          let(:case_type) { build(:case_type, is_fixed_fee: false) }
+      it 'follows the steps path 1 -> 2 -> 3B' do
+        expect(claim.next_step).to eq(:step_2)
+        claim.form_step = claim.next_step
+        expect(claim.next_step).to eq(:step_3B)
+        claim.form_step = claim.next_step
+        expect(claim.next_step).to eq(nil)
+      end
+    end
+  end
 
-          specify { is_expected.to eq(false) }
-        end
+  describe '#next_step!' do
+    let(:claim) { MockSteppableClaim.new }
 
-        context 'and has a fixed fee' do
-          let(:case_type) { build(:case_type, is_fixed_fee: true) }
+    context 'when condition 3A is met' do
+      before do
+        allow(claim).to receive(:fixed_fee_case?).and_return(true)
+      end
 
-          specify { is_expected.to eq(true) }
-        end
+      it 'follows the steps path 1 -> 2 -> 3A' do
+        expect(claim.next_step!).to eq(:step_2)
+        expect(claim.next_step!).to eq(:step_3A)
+        expect(claim.next_step!).to eq(nil)
       end
     end
 
-    class MockSteppableClaim < BaseClaim
-      SUBMISSION_STAGES = [
-        {
-          name: :step_1,
-          transitions: [
-            { to_stage: :step_2 }
-          ]
-        },
-        {
-          name: :step_2,
-          transitions: [
-            {
-              to_stage: :step_3A,
-              condition: ->(claim) { claim.fixed_fee_case? }
-            },
-            {
-              to_stage: :step_3B,
-              condition: ->(claim) { !claim.fixed_fee_case? }
-            }
-          ]
-        },
-        { name: :step_3A },
-        { name: :step_3B }
-      ].freeze
-    end
+    context 'when condition 3B is met' do
+      before do
+        allow(claim).to receive(:fixed_fee_case?).and_return(false)
+      end
 
-    describe '#next_step' do
-      let(:claim) { MockSteppableClaim.new }
+      it 'follows the steps path 1 -> 2 -> 3B' do
+        expect(claim.next_step!).to eq(:step_2)
+        expect(claim.next_step!).to eq(:step_3B)
+        expect(claim.next_step!).to eq(nil)
+      end
+    end
+  end
+
+  describe '#next_step?' do
+    let(:claim) { MockSteppableClaim.new }
+
+    context 'when there is a next step to go to' do
       let(:step) { :step_1 }
 
-      context 'when condition 3A is met' do
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(true)
-          claim.form_step = step
-        end
-
-        it 'does not change the current step' do
-          expect { claim.next_step }
-            .not_to change { claim.current_step }
-            .from(step)
-        end
-
-        it 'follows the steps path 1 -> 2 -> 3A' do
-          expect(claim.next_step).to eq(:step_2)
-          claim.form_step = claim.next_step
-          expect(claim.next_step).to eq(:step_3A)
-          claim.form_step = claim.next_step
-          expect(claim.next_step).to eq(nil)
-        end
+      before do
+        claim.form_step = step
       end
 
-      context 'when condition 3B is met' do
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(false)
-        end
+      specify { expect(claim.next_step?).to be_truthy }
+    end
 
-        it 'does not change the current step' do
-          expect { claim.next_step }
-            .not_to change { claim.current_step }
-            .from(step)
-        end
+    context 'when there is NOT a next step to go to' do
+      let(:step) { :step_3A }
 
-        it 'follows the steps path 1 -> 2 -> 3B' do
-          expect(claim.next_step).to eq(:step_2)
-          claim.form_step = claim.next_step
-          expect(claim.next_step).to eq(:step_3B)
-          claim.form_step = claim.next_step
-          expect(claim.next_step).to eq(nil)
-        end
+      before do
+        claim.form_step = step
+      end
+
+      specify { expect(claim.next_step?).to be_falsey }
+    end
+  end
+
+  describe '#previous_step' do
+    let(:claim) { MockSteppableClaim.new }
+
+    context 'when condition 3A was met' do
+      let(:step) { :step_3A }
+
+      before do
+        allow(claim).to receive(:fixed_fee_case?).and_return(true)
+        claim.form_step = step
+      end
+
+      it 'does not change the current step' do
+        expect { claim.previous_step }
+          .not_to change { claim.current_step }
+          .from(step)
+      end
+
+      it 'follows the steps path 3A -> 2 -> 1' do
+        expect(claim.previous_step).to eq(:step_2)
+        claim.form_step = claim.previous_step
+        expect(claim.previous_step).to eq(:step_1)
+        claim.form_step = claim.previous_step
+        expect(claim.previous_step).to eq(nil)
       end
     end
 
-    describe '#next_step!' do
-      let(:claim) { MockSteppableClaim.new }
+    context 'when condition 3B was met' do
+      let(:step) { :step_3B }
 
-      context 'when condition 3A is met' do
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(true)
-        end
-
-        it 'follows the steps path 1 -> 2 -> 3A' do
-          expect(claim.next_step!).to eq(:step_2)
-          expect(claim.next_step!).to eq(:step_3A)
-          expect(claim.next_step!).to eq(nil)
-        end
+      before do
+        allow(claim).to receive(:fixed_fee_case?).and_return(false)
+        claim.form_step = step
       end
 
-      context 'when condition 3B is met' do
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(false)
-        end
-
-        it 'follows the steps path 1 -> 2 -> 3B' do
-          expect(claim.next_step!).to eq(:step_2)
-          expect(claim.next_step!).to eq(:step_3B)
-          expect(claim.next_step!).to eq(nil)
-        end
-      end
-    end
-
-    describe '#next_step?' do
-      let(:claim) { MockSteppableClaim.new }
-
-      context 'when there is a next step to go to' do
-        let(:step) { :step_1 }
-
-        before do
-          claim.form_step = step
-        end
-
-        specify { expect(claim.next_step?).to be_truthy }
+      it 'does not change the current step' do
+        expect { claim.previous_step }
+          .not_to change { claim.current_step }
+          .from(step)
       end
 
-      context 'when there is NOT a next step to go to' do
-        let(:step) { :step_3A }
-
-        before do
-          claim.form_step = step
-        end
-
-        specify { expect(claim.next_step?).to be_falsey }
-      end
-    end
-
-    describe '#previous_step' do
-      let(:claim) { MockSteppableClaim.new }
-
-      context 'when condition 3A was met' do
-        let(:step) { :step_3A }
-
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(true)
-          claim.form_step = step
-        end
-
-        it 'does not change the current step' do
-          expect { claim.previous_step }
-            .not_to change { claim.current_step }
-            .from(step)
-        end
-
-        it 'follows the steps path 3A -> 2 -> 1' do
-          expect(claim.previous_step).to eq(:step_2)
-          claim.form_step = claim.previous_step
-          expect(claim.previous_step).to eq(:step_1)
-          claim.form_step = claim.previous_step
-          expect(claim.previous_step).to eq(nil)
-        end
-      end
-
-      context 'when condition 3B was met' do
-        let(:step) { :step_3B }
-
-        before do
-          allow(claim).to receive(:fixed_fee_case?).and_return(false)
-          claim.form_step = step
-        end
-
-        it 'does not change the current step' do
-          expect { claim.previous_step }
-            .not_to change { claim.current_step }
-            .from(step)
-        end
-
-        it 'follows the steps path 3B -> 2 -> 1' do
-          expect(claim.previous_step).to eq(:step_2)
-          claim.form_step = claim.previous_step
-          expect(claim.previous_step).to eq(:step_1)
-          claim.form_step = claim.previous_step
-          expect(claim.previous_step).to eq(nil)
-        end
-      end
-    end
-
-    describe '#step_back?' do
-      let(:claim) { MockSteppableClaim.new }
-
-      context 'when there is a previous step to go to' do
-        let(:step) { :step_2 }
-
-        before do
-          claim.form_step = step
-        end
-
-        specify { expect(claim.step_back?).to be_truthy }
-      end
-
-      context 'when there is NOT a previous step to go to' do
-        let(:step) { :step_1 }
-
-        before do
-          claim.form_step = step
-        end
-
-        specify { expect(claim.step_back?).to be_falsey }
+      it 'follows the steps path 3B -> 2 -> 1' do
+        expect(claim.previous_step).to eq(:step_2)
+        claim.form_step = claim.previous_step
+        expect(claim.previous_step).to eq(:step_1)
+        claim.form_step = claim.previous_step
+        expect(claim.previous_step).to eq(nil)
       end
     end
   end
 
-  describe MockBaseClaim do
-    context 'date formatting' do
-      it 'should accept a variety of formats and populate the date accordingly' do
-        def make_date_params(date_string)
-          day, month, year = date_string.split('-')
-           {
-             "first_day_of_trial_dd" => day,
-             "first_day_of_trial_mm" => month,
-             "first_day_of_trial_yyyy" => year,
-           }
-        end
+  describe '#step_back?' do
+    let(:claim) { MockSteppableClaim.new }
 
-        dates = {
-         '04-10-80'    => Date.new(80, 10, 04),
-         '04-10-1980'  => Date.new(1980, 10, 04),
-         '04-1-1980'   => Date.new(1980, 01, 04),
-         '4-1-1980'    => Date.new(1980, 01, 04),
-         '4-10-1980'   => Date.new(1980, 10, 04),
-         '4-Oct-1980'  => Date.new(1980, 10, 04),
-         '04-Oct-1980' => Date.new(1980, 10, 04),
-         '04-10-10'    => Date.new(10, 10, 04),
-         '04-10-2010'  => Date.new(2010, 10, 04),
-         '04-1-2010'   => Date.new(2010, 01, 04),
-         '4-1-2010'    => Date.new(2010, 01, 04),
-         '4-10-2010'   => Date.new(2010, 10, 04),
-         '4-Oct-2010'  => Date.new(2010, 10, 04),
-         '04-Oct-2010' => Date.new(2010, 10, 04),
-         '04-nov-2001' => Date.new(2001, 11, 04),
-         '4-jAn-1999'  => Date.new(1999, 01, 04),
-        }
-        dates.each do |date_string, date|
-          params = make_date_params(date_string)
-          claim = MockBaseClaim.new(params)
-          expect(claim.first_day_of_trial).to eq date
-        end
+    context 'when there is a previous step to go to' do
+      let(:step) { :step_2 }
+
+      before do
+        claim.form_step = step
+      end
+
+      specify { expect(claim.step_back?).to be_truthy }
+    end
+
+    context 'when there is NOT a previous step to go to' do
+      let(:step) { :step_1 }
+
+      before do
+        claim.form_step = step
+      end
+
+      specify { expect(claim.step_back?).to be_falsey }
+    end
+  end
+end
+
+describe MockBaseClaim do
+  context 'date formatting' do
+    it 'should accept a variety of formats and populate the date accordingly' do
+      def make_date_params(date_string)
+        day, month, year = date_string.split('-')
+         {
+           "first_day_of_trial_dd" => day,
+           "first_day_of_trial_mm" => month,
+           "first_day_of_trial_yyyy" => year,
+         }
+      end
+
+      dates = {
+       '04-10-80'    => Date.new(80, 10, 04),
+       '04-10-1980'  => Date.new(1980, 10, 04),
+       '04-1-1980'   => Date.new(1980, 01, 04),
+       '4-1-1980'    => Date.new(1980, 01, 04),
+       '4-10-1980'   => Date.new(1980, 10, 04),
+       '4-Oct-1980'  => Date.new(1980, 10, 04),
+       '04-Oct-1980' => Date.new(1980, 10, 04),
+       '04-10-10'    => Date.new(10, 10, 04),
+       '04-10-2010'  => Date.new(2010, 10, 04),
+       '04-1-2010'   => Date.new(2010, 01, 04),
+       '4-1-2010'    => Date.new(2010, 01, 04),
+       '4-10-2010'   => Date.new(2010, 10, 04),
+       '4-Oct-2010'  => Date.new(2010, 10, 04),
+       '04-Oct-2010' => Date.new(2010, 10, 04),
+       '04-nov-2001' => Date.new(2001, 11, 04),
+       '4-jAn-1999'  => Date.new(1999, 01, 04),
+      }
+      dates.each do |date_string, date|
+        params = make_date_params(date_string)
+        claim = MockBaseClaim.new(params)
+        expect(claim.first_day_of_trial).to eq date
       end
     end
   end
+end
 
-  describe '#disk_evidence_reference' do
-    context 'when case number is not set' do
-      let(:claim) { MockBaseClaim.new(case_number: nil) }
+describe '#disk_evidence_reference' do
+  context 'when case number is not set' do
+    let(:claim) { MockBaseClaim.new(case_number: nil) }
 
-      specify { expect(claim.disk_evidence_reference).to be_nil }
-    end
-
-    context 'when claim id is not set' do
-      let(:claim) { MockBaseClaim.new(case_number: 'A20161234', id: nil) }
-
-      specify { expect(claim.disk_evidence_reference).to be_nil }
-    end
-
-    context 'when case number and claim id are set' do
-      let(:claim) { MockBaseClaim.new(case_number: 'A20161234', id: 9999) }
-
-      specify { expect(claim.disk_evidence_reference).to eq('A20161234/9999') }
-    end
+    specify { expect(claim.disk_evidence_reference).to be_nil }
   end
 
-  describe '#evidence_doc_types' do
-    it 'returns an array of DocType objects' do
-      claim = MockBaseClaim.new(evidence_checklist_ids: [1, 5, 10])
-      expect(claim.evidence_doc_types.map(&:class)).to eq( [ DocType, DocType, DocType ] )
-      expect(claim.evidence_doc_types.map(&:name)).to match_array( [ 'Representation order', 'Order in respect of judicial apportionment', 'Special preparation form'])
-    end
+  context 'when claim id is not set' do
+    let(:claim) { MockBaseClaim.new(case_number: 'A20161234', id: nil) }
+
+    specify { expect(claim.disk_evidence_reference).to be_nil }
   end
 
-  context 'remote_extension_mixin' do
-    describe '#remote?' do
-      it 'returns false' do
-        claim = MockBaseClaim.new
-        expect(claim.remote?).to be false
-      end
+  context 'when case number and claim id are set' do
+    let(:claim) { MockBaseClaim.new(case_number: 'A20161234', id: 9999) }
+
+    specify { expect(claim.disk_evidence_reference).to eq('A20161234/9999') }
+  end
+end
+
+describe '#evidence_doc_types' do
+  it 'returns an array of DocType objects' do
+    claim = MockBaseClaim.new(evidence_checklist_ids: [1, 5, 10])
+    expect(claim.evidence_doc_types.map(&:class)).to eq( [ DocType, DocType, DocType ] )
+    expect(claim.evidence_doc_types.map(&:name)).to match_array( [ 'Representation order', 'Order in respect of judicial apportionment', 'Special preparation form'])
+  end
+end
+
+context 'remote_extension_mixin' do
+  describe '#remote?' do
+    it 'returns false' do
+      claim = MockBaseClaim.new
+      expect(claim.remote?).to be false
     end
   end
+end
 
-  describe '#earliest_representation_order_date' do
-    let(:april_1) { Date.new(2016, 4, 1) }
-    let(:march_10) { Date.new(2016, 3, 10) }
-    let(:jun_30) { Date.new(2016, 6, 30) }
-    let(:claim) { create :claim }
+describe '#earliest_representation_order_date' do
+  let(:april_1) { Date.new(2016, 4, 1) }
+  let(:march_10) { Date.new(2016, 3, 10) }
+  let(:jun_30) { Date.new(2016, 6, 30) }
+  let(:claim) { create :claim }
 
-    before(:each) do
-      claim.defendants.clear
-      claim.save
-    end
-
-    it 'returns nil if there are no reporders' do
-      expect(claim.representation_orders).to be_empty
-      expect(claim.earliest_representation_order_date).to be nil
-    end
-
-    it 'returns the date of the only rep order' do
-      defendant = create :defendant, :without_reporder, claim: claim
-      create :representation_order, defendant: defendant, representation_order_date: april_1
-
-      claim.reload
-      expect(claim.representation_orders.size).to eq 1
-      expect(claim.earliest_representation_order_date).to eq april_1
-    end
-
-    it 'returns the date of the earliest reporder across multiple defendants' do
-      defendant_1 = create :defendant, :without_reporder, claim: claim
-      create :representation_order, defendant: defendant_1, representation_order_date: april_1
-      create :representation_order, defendant: defendant_1, representation_order_date: jun_30
-      defendant_2 = create :defendant, :without_reporder, claim: claim
-      create :representation_order, defendant: defendant_2, representation_order_date: march_10
-
-      claim.reload
-      expect(claim.representation_orders.size).to eq 3
-      expect(claim.earliest_representation_order_date).to eq march_10
-    end
+  before(:each) do
+    claim.defendants.clear
+    claim.save
   end
 
-  describe '#eligible_document_types' do
-    let(:claim) { MockBaseClaim.new }
-    let(:mock_doc_types) { double(:doc_types) }
+  it 'returns nil if there are no reporders' do
+    expect(claim.representation_orders).to be_empty
+    expect(claim.earliest_representation_order_date).to be nil
+  end
+
+  it 'returns the date of the only rep order' do
+    defendant = create :defendant, :without_reporder, claim: claim
+    create :representation_order, defendant: defendant, representation_order_date: april_1
+
+    claim.reload
+    expect(claim.representation_orders.size).to eq 1
+    expect(claim.earliest_representation_order_date).to eq april_1
+  end
+
+  it 'returns the date of the earliest reporder across multiple defendants' do
+    defendant_1 = create :defendant, :without_reporder, claim: claim
+    create :representation_order, defendant: defendant_1, representation_order_date: april_1
+    create :representation_order, defendant: defendant_1, representation_order_date: jun_30
+    defendant_2 = create :defendant, :without_reporder, claim: claim
+    create :representation_order, defendant: defendant_2, representation_order_date: march_10
+
+    claim.reload
+    expect(claim.representation_orders.size).to eq 3
+    expect(claim.earliest_representation_order_date).to eq march_10
+  end
+end
+
+describe '#eligible_document_types' do
+  let(:claim) { MockBaseClaim.new }
+  let(:mock_doc_types) { double(:doc_types) }
+
+  specify {
+    expect(Claims::FetchEligibleDocumentTypes).to receive(:for).with(claim).and_return(mock_doc_types)
+    expect(claim.eligible_document_types).to eq(mock_doc_types)
+  }
+end
+
+describe '#fee_scheme' do
+  let(:claim) { MockBaseClaim.new }
+  let(:mock_fee_scheme) { double(:fee_scheme) }
+
+  specify {
+    expect(FeeScheme).to receive(:for_claim).with(claim).and_return(mock_fee_scheme)
+    expect(claim.fee_scheme).to eq(mock_fee_scheme)
+  }
+end
+
+describe '#vat_registered?' do
+  subject { claim.vat_registered? }
+
+  let(:claim) { create :claim }
+  let(:mock_provider_delegator) { provider_delegator }
+
+  before { allow(claim).to receive(:provider_delegator).and_return(mock_provider_delegator) }
+
+  context 'when the provider exists' do
+    let(:provider_delegator) { double(:provider_delegator, vat_registered?: true) }
 
     specify {
-      expect(Claims::FetchEligibleDocumentTypes).to receive(:for).with(claim).and_return(mock_doc_types)
-      expect(claim.eligible_document_types).to eq(mock_doc_types)
+      expect(LogStuff).not_to receive(:error)
+      subject
     }
   end
 
-  describe '#fee_scheme' do
-    let(:claim) { MockBaseClaim.new }
-    let(:mock_fee_scheme) { double(:fee_scheme) }
+  context 'when the provider is nil' do
+    # this shouldn't happen but the logger is implemented to trace errors in live
+    let(:provider_delegator) { nil }
 
     specify {
-      expect(FeeScheme).to receive(:for_claim).with(claim).and_return(mock_fee_scheme)
-      expect(claim.fee_scheme).to eq(mock_fee_scheme)
+      expect(LogStuff).to receive(:error).once
+      expect{ subject }.to raise_error NoMethodError
     }
   end
+end
 
-  describe '#vat_registered?' do
-    subject { claim.vat_registered? }
+describe '#earliest_representation_order' do
+  let(:claim) { MockBaseClaim.new }
 
-    let(:claim) { create :claim }
-    let(:mock_provider_delegator) { provider_delegator }
+  subject(:earliest_representation_order) { claim.earliest_representation_order }
 
-    before { allow(claim).to receive(:provider_delegator).and_return(mock_provider_delegator) }
-
-    context 'when the provider exists' do
-      let(:provider_delegator) { double(:provider_delegator, vat_registered?: true) }
-
-      specify {
-        expect(LogStuff).not_to receive(:error)
-        subject
-      }
+  context 'but there are no associated defendants' do
+    before do
+      claim.defendants = []
     end
 
-    context 'when the provider is nil' do
-      # this shouldn't happen but the logger is implemented to trace errors in live
-      let(:provider_delegator) { nil }
-
-      specify {
-        expect(LogStuff).to receive(:error).once
-        expect{ subject }.to raise_error NoMethodError
-      }
-    end
+    specify { expect(earliest_representation_order).to be_nil }
   end
 
-  describe '#earliest_representation_order' do
-    let(:claim) { MockBaseClaim.new }
+  context 'but there are no earliest representation orders for the associated defendants' do
+    let(:defendants) { build_list(:defendant, 2) }
 
-    subject(:earliest_representation_order) { claim.earliest_representation_order }
-
-    context 'but there are no associated defendants' do
-      before do
-        claim.defendants = []
-      end
-
-      specify { expect(earliest_representation_order).to be_nil }
+    before do
+      claim.defendants = defendants
     end
 
-    context 'but there are no earliest representation orders for the associated defendants' do
-      let(:defendants) { build_list(:defendant, 2) }
-
-      before do
-        claim.defendants = defendants
+    specify {
+      defendants.each do |defendant|
+        expect(defendant).to receive(:earliest_representation_order).and_return(nil)
       end
+      expect(earliest_representation_order).to be_nil }
+  end
 
-      specify {
-        defendants.each do |defendant|
-          expect(defendant).to receive(:earliest_representation_order).and_return(nil)
-        end
-        expect(earliest_representation_order).to be_nil }
+  context 'and some of the defendants have an earliest representation order set' do
+    let(:base_date) { 3.months.ago.to_date }
+    let(:expected_representation_order) {
+      build(:representation_order, representation_order_date: base_date - 2.days)
+    }
+    let(:later_representation_order) {
+      build(:representation_order, representation_order_date: base_date + 3.days)
+    }
+    let(:defendant_with_earliest_representation_date) { build(:defendant) }
+    let(:defendant_with_later_representation_date) { build(:defendant) }
+    let(:defendant_with_no_earliest_representation_date) { build(:defendant) }
+    let(:defendants) {
+      [
+        defendant_with_later_representation_date,
+        defendant_with_earliest_representation_date,
+        defendant_with_no_earliest_representation_date
+      ]
+    }
+
+    before do
+      expect(defendant_with_no_earliest_representation_date).to receive(:earliest_representation_order).and_return(nil)
+      expect(defendant_with_later_representation_date).to receive(:earliest_representation_order).and_return(later_representation_order)
+      expect(defendant_with_earliest_representation_date).to receive(:earliest_representation_order).and_return(expected_representation_order)
+      claim.defendants = defendants
     end
 
-    context 'and some of the defendants have an earliest representation order set' do
-      let(:base_date) { 3.months.ago.to_date }
-      let(:expected_representation_order) {
-        build(:representation_order, representation_order_date: base_date - 2.days)
-      }
-      let(:later_representation_order) {
-        build(:representation_order, representation_order_date: base_date + 3.days)
-      }
-      let(:defendant_with_earliest_representation_date) { build(:defendant) }
-      let(:defendant_with_later_representation_date) { build(:defendant) }
-      let(:defendant_with_no_earliest_representation_date) { build(:defendant) }
-      let(:defendants) {
-        [
-          defendant_with_later_representation_date,
-          defendant_with_earliest_representation_date,
-          defendant_with_no_earliest_representation_date
-        ]
-      }
-
-      before do
-        expect(defendant_with_no_earliest_representation_date).to receive(:earliest_representation_order).and_return(nil)
-        expect(defendant_with_later_representation_date).to receive(:earliest_representation_order).and_return(later_representation_order)
-        expect(defendant_with_earliest_representation_date).to receive(:earliest_representation_order).and_return(expected_representation_order)
-        claim.defendants = defendants
-      end
-
-      it 'returns the earliest representation order out of all the defendants' do
-        expect(earliest_representation_order).to eq(expected_representation_order)
-      end
+    it 'returns the earliest representation order out of all the defendants' do
+      expect(earliest_representation_order).to eq(expected_representation_order)
     end
   end
 end

--- a/spec/models/claims/financial_summary_spec.rb
+++ b/spec/models/claims/financial_summary_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Claims::FinancialSummary, type: :model do
     let(:advocate_with_vat)           { create(:external_user, :advocate, vat_registered: true) }
     let(:advocate_without_vat)        { create(:external_user, :advocate, vat_registered: false) }
     let(:another_advocate)            { create(:external_user, :advocate) }
-    let(:other_advocate_claim)        { create(:claim) }
+    let(:other_advocate_claim)        { create(:advocate_claim) }
 
     context 'with VAT applied' do
       before do
@@ -102,7 +102,7 @@ RSpec.describe Claims::FinancialSummary, type: :model do
     let(:advocate1_without_vat)   { create(:external_user, provider: agfs_provider, vat_registered: false) }
     let(:advocate2_without_vat)   { create(:external_user, provider: agfs_provider, vat_registered: false) }
     let(:another_advocate_admin)  { create(:external_user, :admin, provider: other_provider) }
-    let(:other_provider_claim)    { create(:claim) }
+    let(:other_provider_claim)    { create(:advocate_claim) }
 
     before do
       other_provider_claim.external_user = another_advocate_admin

--- a/spec/models/claims/state_machine_scopes_spec.rb
+++ b/spec/models/claims/state_machine_scopes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Claims::StateMachine, type: :model do
   describe 'all available states are scoped' do
-    subject { create(:claim) }
+    subject { create(:advocate_claim) }
 
     let(:states) { subject.class.state_machine.states.map(&:name) }
 
@@ -15,10 +15,10 @@ RSpec.describe Claims::StateMachine, type: :model do
   end
 
   describe 'custom scopes' do
-    let!(:draft_claim) { create(:claim) }
+    let!(:draft_claim) { create(:advocate_claim) }
     let!(:submitted_claim) { create(:submitted_claim) }
     let!(:allocated_claim) { create(:allocated_claim) }
-    let!(:deleted_claim)   { create(:archived_pending_delete_claim) }
+    let!(:deleted_claim) { create(:archived_pending_delete_claim) }
     let!(:redetermination_claim) { create(:redetermination_claim) }
     let!(:awaiting_written_reasons_claim) { create(:awaiting_written_reasons_claim) }
 

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Claims::StateMachine, type: :model do
-  subject(:claim) { create(:claim) }
+  subject(:claim) { create(:advocate_claim) }
 
   describe 'all available states' do
     let(:states) do
@@ -351,7 +351,7 @@ RSpec.describe Claims::StateMachine, type: :model do
   end
 
   describe 'state transition audit trail' do
-    let!(:claim) { create(:claim) }
+    let!(:claim) { create(:advocate_claim) }
     let!(:expected) do
       {
         event: 'submit',

--- a/spec/models/claims/totals_spec.rb
+++ b/spec/models/claims/totals_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Claim, type: :model do
-  subject(:claim) { create(:claim) }
+  subject(:claim) { create(:advocate_claim) }
   let(:expenses) { [3.5, 1.0, 142.0].each { |amount| create(:expense, claim_id: claim.id, amount: amount) } }
   let(:fee_type) { create(:fixed_fee_type) }
 
@@ -71,7 +71,7 @@ RSpec.describe Claim, type: :model do
     end
 
     context 'AGFS claim' do
-      subject(:claim) { create(:claim) }
+      subject(:claim) { create(:advocate_claim) }
 
       it 'calculates the claim expenses VAT' do
         expect(claim.expenses_vat).to eq(29.3)

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Defendant, type: :model do
 
   describe 'validations' do
     context 'draft claim' do
-      before { subject.claim = create(:claim) }
+      before { subject.claim = create(:advocate_claim) }
 
       it { should validate_presence_of(:claim).with_message('blank') }
     end
@@ -69,8 +69,7 @@ RSpec.describe Defendant, type: :model do
   end
 
   context 'representation orders' do
-
-    let(:defendant)  { FactoryBot.create :defendant, claim: FactoryBot.create(:claim) }
+    let(:defendant) { FactoryBot.create :defendant, claim: FactoryBot.create(:advocate_claim) }
 
     it 'should be valid if there is one representation order that isnt blank' do
       expect(defendant).to be_valid
@@ -98,7 +97,7 @@ RSpec.describe Defendant, type: :model do
   end
 
   context 'name presentation methods' do
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:advocate_claim) }
 
     describe '#name' do
       it 'joins first name and last name together' do

--- a/spec/models/fee/shared_examples_for_defendant_uplifts.rb
+++ b/spec/models/fee/shared_examples_for_defendant_uplifts.rb
@@ -17,7 +17,7 @@ shared_examples '.defendant_uplift_sums' do
   context 'miscellaneous fees' do
     describe '.defendant_uplift_sums' do
       subject { described_class.defendant_uplift_sums }
-      let(:claim) { create(:claim) }
+      let(:claim) { create(:advocate_claim) }
       let(:miahu) { create(:misc_fee_type, :miahu) }
 
       before do

--- a/spec/presenters/base_claim_presenter_spec.rb
+++ b/spec/presenters/base_claim_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'cgi'
 
 RSpec.describe Claim::BaseClaimPresenter do
-  let(:claim) { create(:claim) }
+  let(:claim) { create(:advocate_claim) }
   subject(:presenter) { Claim::BaseClaimPresenter.new(claim, view) }
 
   before do

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ExpensePresenter do
 
-  let(:claim)     { create(:claim) }
+  let(:claim)     { create(:advocate_claim) }
   let(:expense_type)  { create(:expense_type) }
   let(:expense)       { create(:expense, quantity: 4, claim: claim, expense_type: expense_type) }
   let(:presenter) {ExpensePresenter.new(expense, view) }

--- a/spec/presenters/fee_presenter_spec.rb
+++ b/spec/presenters/fee_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Fee::BaseFeePresenter do
 
-  let(:claim)     { create(:claim) }
+  let(:claim)     { create(:advocate_claim) }
   let(:fee_type)  { create(:basic_fee_type, description: 'Basic fee type C') }
   let(:fee)       { create(:basic_fee, quantity: 4, claim: claim, fee_type: fee_type) }
   let(:presenter) {Fee::BaseFeePresenter.new(fee, view) }

--- a/spec/services/cclf/fee/fixed_fee_adapter_spec.rb
+++ b/spec/services/cclf/fee/fixed_fee_adapter_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require_relative 'shared_examples_for_cclf_fee_adapters'
 
 RSpec.describe CCLF::Fee::FixedFeeAdapter, type: :adapter do
-  it_behaves_like 'a simple bill adapter'
   it_behaves_like 'Litigator Fee Adapter', fixed_fee_bill_scenarios
+  it_behaves_like 'a simple bill adapter', bill_type: 'LIT_FEE', bill_subtype: 'LIT_FEE' do
+    let(:fee) { instance_double(Fee::FixedFee) }
+  end
 end

--- a/spec/services/cclf/fee/graduated_fee_adapter_spec.rb
+++ b/spec/services/cclf/fee/graduated_fee_adapter_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require_relative 'shared_examples_for_cclf_fee_adapters'
 
 RSpec.describe CCLF::Fee::GraduatedFeeAdapter, type: :adapter do
-  it_behaves_like 'a simple bill adapter'
   it_behaves_like 'Litigator Fee Adapter', graduated_fee_bill_scenarios
+  it_behaves_like 'a simple bill adapter', bill_type: 'LIT_FEE', bill_subtype: 'LIT_FEE' do
+    let(:fee) { instance_double(Fee::GraduatedFee) }
+  end
 end

--- a/spec/services/cclf/fee/transfer_fee_adapter_spec.rb
+++ b/spec/services/cclf/fee/transfer_fee_adapter_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require_relative 'shared_examples_for_cclf_fee_adapters'
 
 RSpec.describe CCLF::Fee::TransferFeeAdapter, type: :adapter do
-  it_behaves_like 'a simple bill adapter'
   it_behaves_like 'Litigator Fee Adapter', transfer_fee_bill_scenarios
+  it_behaves_like 'a simple bill adapter', bill_type: 'LIT_FEE', bill_subtype: 'LIT_FEE' do
+    let(:fee) { instance_double(Fee::TransferFee) }
+  end
 end

--- a/spec/services/cclf/fee/warrant_fee_adapter_spec.rb
+++ b/spec/services/cclf/fee/warrant_fee_adapter_spec.rb
@@ -1,27 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CCLF::Fee::WarrantFeeAdapter, type: :adapter do
-  let(:fee) { instance_double('fee') }
-  let(:claim) { instance_double('claim', case_type: case_type) }
-  let(:case_type) { instance_double('case_type') }
-  let(:fee_type) { instance_double('fee_type', unique_code: 'WARR') }
-
-  before do
-    allow(fee).to receive(:fee_type).and_return fee_type
-    allow(fee).to receive(:claim).and_return claim
-  end
-
-  describe '#bill_type' do
-    subject { described_class.new(fee).bill_type }
-    it 'returns CCLF Warrant Fee bill type - FEE_ADVANCE' do
-      is_expected.to eql 'FEE_ADVANCE'
-    end
-  end
-
-  describe '#bill_subtype' do
-    subject { described_class.new(fee).bill_subtype }
-    it 'returns CCLF Warrant Fee bill subtype - WARRANT' do
-      is_expected.to eql 'WARRANT'
-    end
+  it_behaves_like 'a simple bill adapter', bill_type: 'FEE_ADVANCE', bill_subtype: 'WARRANT' do
+    let(:fee) { instance_double(Fee::WarrantFee) }
   end
 end

--- a/spec/services/ccr/daily_attendance_adapter_spec.rb
+++ b/spec/services/ccr/daily_attendance_adapter_spec.rb
@@ -1,36 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
-  subject { described_class.new(claim) }
-  let(:claim) { create(:authorised_claim) }
+  let(:retrial) { create(:case_type, :retrial) }
 
   describe '#attendances' do
     subject { described_class.new(claim).attendances }
 
-    context 'for trials' do
-      context 'when no daily attendance uplift fees applied' do
-        [0,1,3,nil].each do |trial_length|
-          context "and claim has an actual trial length of #{trial_length || 'nil'}" do
-            before { claim.update(actual_trial_length: trial_length) }
-            it "returns #{[trial_length,2].compact.min} - as least of actual trial length or 2 (included in basic fee)" do
-              is_expected.to eql [trial_length,2].compact.min
+    context 'scheme 9 claim' do
+      let(:claim) { create(:authorised_claim) }
+      attendances_incl_in_basic_fee = 2
+
+      context 'for trials' do
+        context 'when no daily attendance uplift fees applied' do
+          [0,1,3,nil].each do |trial_length|
+            context "and claim has an actual trial length of #{trial_length || 'nil'}" do
+              before { claim.update(actual_trial_length: trial_length) }
+              it "returns #{[trial_length, attendances_incl_in_basic_fee].compact.min} - as least of actual trial length or #{attendances_incl_in_basic_fee} (included in basic fee)" do
+                is_expected.to eql [trial_length, attendances_incl_in_basic_fee].compact.min
+              end
             end
+          end
+        end
+
+        context 'when daily attendance uplift fees applied' do
+          before do
+            claim.actual_trial_length = 51
+            create(:basic_fee, :daf_fee, claim: claim, quantity: 38, rate: 1.0)
+            create(:basic_fee, :dah_fee, claim: claim, quantity: 10, rate: 1.0)
+            create(:basic_fee, :daj_fee, claim: claim, quantity: 1, rate: 1.0)
+          end
+
+          it "returns sum of daily attendance fee types plus #{attendances_incl_in_basic_fee} (included in basic fee)" do
+            is_expected.to eql 51
           end
         end
       end
 
       context 'for retrials' do
-        let(:retrial) { create(:case_type, :retrial) }
-
-        before do
-          claim.update(case_type: retrial)
-        end
+        before { claim.update(case_type: retrial) }
 
         context 'when no daily attendance uplift fees applied' do
           [0,1,3,nil].each do |trial_length|
             context "and claim has an actual retrial length of #{trial_length || 'nil'}" do
               before { claim.update(retrial_actual_length: trial_length) }
-              it "returns #{[trial_length,2].compact.min} - as least of actual retrial length or 2 (included in basic fee)" do
+              it "returns #{[trial_length, attendances_incl_in_basic_fee].compact.min} - as least of actual retrial length or 2 (included in basic fee)" do
                 is_expected.to eql [trial_length,2].compact.min
               end
             end
@@ -39,22 +52,54 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
       end
     end
 
-    context 'when daily attendance uplift fees applied' do
-      before do
-        claim.actual_trial_length = 51
-        create(:basic_fee, :daf_fee, claim: claim, quantity: 38, rate: 1.0)
-        create(:basic_fee, :dah_fee, claim: claim, quantity: 10, rate: 1.0)
-        create(:basic_fee, :daj_fee, claim: claim, quantity: 1, rate: 1.0)
+    context 'scheme 10 claim' do
+      let(:claim) { create(:authorised_claim, :agfs_scheme_10) }
+      attendances_incl_in_basic_fee = 1
+
+      context 'for trials' do
+        context 'when no daily attendance uplift fee (2+) applied' do
+          [0,1,2,nil].each do |trial_length|
+            context "and claim has an actual trial length of #{trial_length || 'nil'}" do
+              before { claim.update(actual_trial_length: trial_length) }
+              it "returns #{[trial_length, attendances_incl_in_basic_fee].compact.min} - as least of actual trial length or #{attendances_incl_in_basic_fee} (included in basic fee)" do
+                is_expected.to eql [trial_length, attendances_incl_in_basic_fee].compact.min
+              end
+            end
+          end
+        end
+
+        context 'when daily attendance uplift fees applied' do
+          before do
+            claim.actual_trial_length = 10
+            create(:basic_fee, :dat_fee, claim: claim, quantity: 9, rate: 1.0)
+          end
+
+          it "returns sum of daily attendance fee types plus #{attendances_incl_in_basic_fee} (included in basic fee)" do
+            is_expected.to eql 10
+          end
+        end
       end
 
-      it 'returns sum of daily attendance fee types plus 2 (included in basic fee)' do
-        is_expected.to eql 51
+      context 'for retrials' do
+        before { claim.update(case_type: retrial) }
+
+        context 'when no daily attendance uplift fee (2+) applied' do
+          [0,1,2,nil].each do |trial_length|
+            context "and claim has an actual retrial length of #{trial_length || 'nil'}" do
+              before { claim.update(retrial_actual_length: trial_length) }
+              it "returns #{[trial_length, attendances_incl_in_basic_fee].compact.min} - as least of actual retrial length or #{attendances_incl_in_basic_fee} (included in basic fee)" do
+                is_expected.to eql [trial_length, attendances_incl_in_basic_fee].compact.min
+              end
+            end
+          end
+        end
       end
     end
   end
 
   describe '.attendances_for' do
     subject { described_class.attendances_for(claim) }
+    let(:claim) { build(:authorised_claim) }
     let(:adapter) { instance_double 'DailyAttendanceAdapter' }
 
     it 'calls #attendances' do

--- a/spec/services/ccr/fee/basic_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/basic_fee_adapter_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe CCR::Fee::BasicFeeAdapter, type: :adapter do
     allow(claim).to receive(:case_type).and_return case_type
   end
 
-  it_behaves_like 'a simple bill adapter'
+  it_behaves_like 'a simple bill adapter', bill_type: 'AGFS_FEE', bill_subtype: 'AGFS_FEE' do
+    let(:fee) { instance_double(Fee::BasicFee) }
+  end
 
   describe '#bill_type' do
     subject { described_class.new(claim).bill_type }

--- a/spec/services/ccr/fee/warrant_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/warrant_fee_adapter_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CCR::Fee::WarrantFeeAdapter, type: :adapter do
+  it_behaves_like 'a simple bill adapter', bill_type: 'AGFS_ADVANCE', bill_subtype: 'AGFS_WARRANT' do
+    let(:fee) { instance_double(Fee::WarrantFee) }
+  end
+end

--- a/spec/services/message_queue/aws_client_spec.rb
+++ b/spec/services/message_queue/aws_client_spec.rb
@@ -17,7 +17,7 @@ module MessageQueue
           }
       )
     end
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:advocate_claim) }
     let(:aws_queue_name) { 'valid_queue_name' }
     let(:stub_queue_response) { stub_queue_response_success }
     let(:stub_send_response) {}

--- a/spec/services/notification_queue/aws_client_spec.rb
+++ b/spec/services/notification_queue/aws_client_spec.rb
@@ -20,7 +20,7 @@ module NotificationQueue
     describe '#send!' do
       subject(:send!) { aws_client.send!(claim) }
 
-      let(:claim) { create(:claim) }
+      let(:claim) { create(:advocate_claim) }
 
       it { is_expected.to eql true}
     end

--- a/spec/support/shared_examples_for_fee_adapters.rb
+++ b/spec/support/shared_examples_for_fee_adapters.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples_for 'a mapping fee adapter' do
   end
 end
 
-RSpec.shared_examples_for 'a simple bill adapter' do
+RSpec.shared_examples_for 'a simple bill adapter' do |options|
   subject { described_class.new(instance_double('fee')) }
 
   it { is_expected.to respond_to(:bill_type) }
@@ -30,6 +30,20 @@ RSpec.shared_examples_for 'a simple bill adapter' do
 
   it 'should respond to .acts_as_simple_bill' do
     expect(described_class).to respond_to :acts_as_simple_bill
+  end
+
+  describe '#bill_type' do
+    subject { described_class.new(fee).bill_type }
+    it "returns expected bill type - #{options[:bill_type]}" do
+      is_expected.to eql options[:bill_type]
+    end
+  end
+
+  describe '#bill_subtype' do
+    subject { described_class.new(fee).bill_subtype }
+    it "returns expected bill type - #{options[:bill_subtype]}" do
+      is_expected.to eql options[:bill_subtype]
+    end
   end
 end
 


### PR DESCRIPTION
#### What
Add adapters for DI of advocate interim claims and new final claim daily attendance

[INJECTION: CCR advocate interim claims](https://www.pivotaltracker.com/story/show/156533432)

[INJECTION: CCR Daily attendance(2+) considerations](https://www.pivotaltracker.com/story/show/156533457)

#### Why
Advocate interim claim - Scheme 10 introduces the ability to claim 
warrant fees on AGFS claims via a new claim type.

Advocate final claim daily attendance changes - scheme 10 introduces
a new simpler daily attendance fee with no banding.

#### How
Add relevant entities and adapters