### PR TITLE
Add extra permitted parameters

### DIFF
--- a/app/controllers/offences_controller.rb
+++ b/app/controllers/offences_controller.rb
@@ -29,7 +29,7 @@ class OffencesController < ApplicationController
   private
 
   def permitted_params
-    params.permit(:fee_scheme, :description)
+    params.permit(:fee_scheme, :description, :search_offence, :category_id, :band_id)
   end
 
   def offence_filter


### PR DESCRIPTION
#### What
Fix the broken OffenceController
#### Why
In turning on strong parameters, I missed some that were only used downstream
#### How
Added the parameters that are required downstream by `search_offences.rb`
#### Future
See issue #2368 for reasons of not extending tests as part of this PR, updating Gems is well outside the timescale for fixing this!