### PR TITLE
Warrant fee info in final claims

### DIFF
--- a/app/assets/javascripts/modules/show-hide-content.js
+++ b/app/assets/javascripts/modules/show-hide-content.js
@@ -16,7 +16,7 @@
 
     // Escape name attribute for use in DOM selector
     function escapeElementName (str) {
-      var result = str.replace('[', '\\[').replace(']', '\\]')
+      var result = str.replace(/\[/g, '\\[').replace(/\]/g, '\\]')
       return result
     }
 

--- a/app/controllers/external_users/advocates/claims_controller.rb
+++ b/app/controllers/external_users/advocates/claims_controller.rb
@@ -7,6 +7,7 @@ class ExternalUsers::Advocates::ClaimsController < ExternalUsers::ClaimsControll
 
   def build_nested_resources
     @claim.fixed_fees.build if @claim.fixed_fees.none?
+    @claim.build_interim_claim_info if @claim.interim_claim_info.nil?
 
     %i[misc_fees expenses].each do |association|
       build_nested_resource(@claim, association)

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -401,6 +401,11 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
         date_attributes_for(:date),
         :_destroy,
         common_dates_attended_attributes
+      ],
+      interim_claim_info_attributes: [
+        :warrant_fee_paid,
+        date_attributes_for(:warrant_issued_date),
+        date_attributes_for(:warrant_executed_date)
       ]
     )
   end

--- a/app/controllers/external_users/litigators/claims_controller.rb
+++ b/app/controllers/external_users/litigators/claims_controller.rb
@@ -9,6 +9,7 @@ class ExternalUsers::Litigators::ClaimsController < ExternalUsers::ClaimsControl
     @claim.build_graduated_fee if @claim.graduated_fee.nil?
     @claim.build_warrant_fee if @claim.warrant_fee.nil?
     @claim.build_fixed_fee if @claim.fixed_fee.nil?
+    @claim.build_interim_claim_info if @claim.interim_claim_info.nil?
 
     %i[misc_fees disbursements expenses].each do |association|
       build_nested_resource(@claim, association)

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -71,18 +71,18 @@ module Claim
              class_name: 'Fee::BasicFee',
              dependent: :destroy,
              inverse_of: :claim,
-             validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :basic_fees }
+             validate: proc { |claim| claim.step_validation_required?(:basic_fees) }
     has_many :fixed_fees,
              foreign_key: :claim_id,
              class_name: 'Fee::FixedFee',
              dependent: :destroy,
              inverse_of: :claim,
-             validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :fixed_fees }
+             validate: proc { |claim| claim.step_validation_required?(:fixed_fees) }
     has_one :interim_claim_info,
             foreign_key: :claim_id,
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :miscellaneous_fees }
+            validate: proc { |claim| claim.step_validation_required?(:miscellaneous_fees) }
 
     accepts_nested_attributes_for :basic_fees, reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees, reject_if: all_blank_or_zero, allow_destroy: true

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -219,6 +219,10 @@ module Claim
       self.class.agfs?
     end
 
+    def final?
+      true
+    end
+
     def eligible_advocate_categories
       Claims::FetchEligibleAdvocateCategories.for(self)
     end

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -78,10 +78,15 @@ module Claim
              dependent: :destroy,
              inverse_of: :claim,
              validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :fixed_fees }
-    has_one :interim_claim_info, dependent: :destroy, foreign_key: :claim_id
+    has_one :interim_claim_info,
+            foreign_key: :claim_id,
+            dependent: :destroy,
+            inverse_of: :claim,
+            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :miscellaneous_fees }
 
     accepts_nested_attributes_for :basic_fees, reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees, reject_if: all_blank_or_zero, allow_destroy: true
+    accepts_nested_attributes_for :interim_claim_info, reject_if: :all_blank, allow_destroy: false
 
     validates_with ::Claim::AdvocateClaimValidator, unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
     validates_with ::Claim::AdvocateClaimSubModelValidator

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -78,6 +78,7 @@ module Claim
              dependent: :destroy,
              inverse_of: :claim,
              validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :fixed_fees }
+    has_one :interim_claim_info, dependent: :destroy, foreign_key: :claim_id
 
     accepts_nested_attributes_for :basic_fees, reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees, reject_if: all_blank_or_zero, allow_destroy: true

--- a/app/models/claim/advocate_interim_claim.rb
+++ b/app/models/claim/advocate_interim_claim.rb
@@ -11,7 +11,7 @@ module Claim
             class_name: 'Fee::WarrantFee',
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :interim_fees }
+            validate: proc { |claim| claim.step_validation_required?(:interim_fees) }
 
     accepts_nested_attributes_for :warrant_fee, allow_destroy: false
 

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -451,6 +451,10 @@ module Claim
       true
     end
 
+    def step_validation_required?(step)
+      from_api? || form_step.nil? || form_step == step
+    end
+
     def disabled_for_transition?
       disable_for_state_transition.present?
     end

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -75,7 +75,7 @@ module Claim
             class_name: 'Fee::InterimFee',
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :interim_fees }
+            validate: proc { |claim| claim.step_validation_required?(:interim_fees) }
 
     accepts_nested_attributes_for :interim_fee, reject_if: :all_blank, allow_destroy: false
 

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -83,6 +83,7 @@ module Claim
             dependent: :destroy,
             inverse_of: :claim,
             validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :graduated_fees }
+    has_one :interim_claim_info, dependent: :destroy, foreign_key: :claim_id
 
     accepts_nested_attributes_for :fixed_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -83,11 +83,16 @@ module Claim
             dependent: :destroy,
             inverse_of: :claim,
             validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :graduated_fees }
-    has_one :interim_claim_info, dependent: :destroy, foreign_key: :claim_id
+    has_one :interim_claim_info,
+            foreign_key: :claim_id,
+            dependent: :destroy,
+            inverse_of: :claim,
+            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :miscellaneous_fees }
 
     accepts_nested_attributes_for :fixed_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :graduated_fee, reject_if: :all_blank, allow_destroy: false
+    accepts_nested_attributes_for :interim_claim_info, reject_if: :all_blank, allow_destroy: false
 
     before_validation do
       assign_total_attrs

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -75,19 +75,19 @@ module Claim
             class_name: 'Fee::FixedFee',
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :fixed_fees }
+            validate: proc { |claim| claim.step_validation_required?(:fixed_fees) }
     has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
     has_one :graduated_fee,
             foreign_key: :claim_id,
             class_name: 'Fee::GraduatedFee',
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :graduated_fees }
+            validate: proc { |claim| claim.step_validation_required?(:graduated_fees) }
     has_one :interim_claim_info,
             foreign_key: :claim_id,
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :miscellaneous_fees }
+            validate: proc { |claim| claim.step_validation_required?(:miscellaneous_fees) }
 
     accepts_nested_attributes_for :fixed_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -71,15 +71,13 @@ module Claim
             class_name: Claim::TransferDetail,
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim|
-              claim.from_api? || claim.form_step.nil? || claim.form_step == :transfer_fee_details
-            }
+            validate: proc { |claim| claim.step_validation_required?(:transfer_fee_details) }
     has_one :transfer_fee,
             foreign_key: :claim_id,
             class_name: Fee::TransferFee,
             dependent: :destroy,
             inverse_of: :claim,
-            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :transfer_fees }
+            validate: proc { |claim| claim.step_validation_required?(:transfer_fees) }
 
     accepts_nested_attributes_for :transfer_detail, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :transfer_fee, reject_if: :all_blank, allow_destroy: false

--- a/app/models/interim_claim_info.rb
+++ b/app/models/interim_claim_info.rb
@@ -1,3 +1,15 @@
 class InterimClaimInfo < ApplicationRecord
+  MINIMUM_PERIOD_SINCE_ISSUED = 3.months
+
   self.table_name = 'interim_claim_info'
+
+  belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
+
+  validates_with InterimClaimInfoValidator
+
+  acts_as_gov_uk_date :warrant_issued_date, :warrant_executed_date
+
+  def perform_validation?
+    claim&.perform_validation?
+  end
 end

--- a/app/models/interim_claim_info.rb
+++ b/app/models/interim_claim_info.rb
@@ -1,0 +1,3 @@
+class InterimClaimInfo < ApplicationRecord
+  self.table_name = 'interim_claim_info'
+end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -50,4 +50,8 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
   def mandatory_case_details?
     claim.case_type && claim.court && claim.case_number && claim.external_user
   end
+
+  def requires_interim_claim_info?
+    claim.fee_scheme == 'fee_reform'
+  end
 end

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -266,6 +266,10 @@ class Claim::BaseClaimPresenter < BasePresenter
     true
   end
 
+  def requires_interim_claim_info?
+    false
+  end
+
   def assessment_date
     claim.assessment.blank? ? 'not yet assessed' : assessment_or_determination_date.strftime(Settings.date_format)
   end

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -52,4 +52,8 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
   def mandatory_case_details?
     claim.court && claim.case_number && claim.supplier_number
   end
+
+  def requires_interim_claim_info?
+    true
+  end
 end

--- a/app/presenters/interim_claim_info_presenter.rb
+++ b/app/presenters/interim_claim_info_presenter.rb
@@ -1,0 +1,11 @@
+class InterimClaimInfoPresenter < BasePresenter
+  presents :interim_claim_info
+
+  def warrant_issued_date
+    format_date(interim_claim_info.warrant_issued_date)
+  end
+
+  def warrant_executed_date
+    format_date(interim_claim_info.warrant_executed_date)
+  end
+end

--- a/app/validators/claim/advocate_claim_sub_model_validator.rb
+++ b/app/validators/claim/advocate_claim_sub_model_validator.rb
@@ -3,7 +3,8 @@ class Claim::AdvocateClaimSubModelValidator < Claim::BaseClaimSubModelValidator
     {
       case_details: [],
       defendants: [],
-      offence_details: []
+      offence_details: [],
+      miscellaneous_fees: [{ name: :interim_claim_info }]
     }
   end
 

--- a/app/validators/claim/litigator_claim_sub_model_validator.rb
+++ b/app/validators/claim/litigator_claim_sub_model_validator.rb
@@ -5,7 +5,8 @@ class Claim::LitigatorClaimSubModelValidator < Claim::BaseClaimSubModelValidator
       defendants: [],
       offence_details: [],
       fixed_fees: [{ name: :fixed_fee }],
-      graduated_fees: [{ name: :graduated_fee }]
+      graduated_fees: [{ name: :graduated_fee }],
+      miscellaneous_fees: [{ name: :interim_claim_info }]
     }
   end
 

--- a/app/validators/interim_claim_info_validator.rb
+++ b/app/validators/interim_claim_info_validator.rb
@@ -9,9 +9,6 @@ class InterimClaimInfoValidator < BaseValidator
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, 'check_not_too_far_in_past')
     return if @record.warrant_issued_date.nil?
     validate_on_or_before(Date.today, :warrant_issued_date, 'check_not_in_future')
-    validate_on_or_before(InterimClaimInfo::MINIMUM_PERIOD_SINCE_ISSUED.ago, :warrant_issued_date, 'on_or_before')
-    check_date = @record.claim&.earliest_representation_order&.representation_order_date
-    validate_on_or_after(check_date, :warrant_issued_date, 'check_on_or_after_earliest_representation_order')
   end
 
   def validate_warrant_executed_date

--- a/app/validators/interim_claim_info_validator.rb
+++ b/app/validators/interim_claim_info_validator.rb
@@ -1,0 +1,25 @@
+class InterimClaimInfoValidator < BaseValidator
+  def self.fields
+    %i[warrant_issued_date warrant_executed_date]
+  end
+
+  def validate_warrant_issued_date
+    return unless @record.warrant_fee_paid?
+    validate_presence(:warrant_issued_date, 'blank')
+    validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, 'check_not_too_far_in_past')
+    return if @record.warrant_issued_date.nil?
+    validate_on_or_before(Date.today, :warrant_issued_date, 'check_not_in_future')
+    validate_on_or_before(InterimClaimInfo::MINIMUM_PERIOD_SINCE_ISSUED.ago, :warrant_issued_date, 'on_or_before')
+    check_date = @record.claim&.earliest_representation_order&.representation_order_date
+    validate_on_or_after(check_date, :warrant_issued_date, 'check_on_or_after_earliest_representation_order')
+  end
+
+  def validate_warrant_executed_date
+    return unless @record.warrant_fee_paid?
+    validate_presence(:warrant_executed_date, 'blank')
+    validate_on_or_after(@record.warrant_issued_date, :warrant_executed_date, 'warrant_executed_before_issued')
+    validate_on_or_after(Settings.earliest_permitted_date, :warrant_executed_date, 'check_not_too_far_in_past')
+    return if @record.warrant_executed_date.nil?
+    validate_on_or_before(Date.today, :warrant_executed_date, 'check_not_in_future')
+  end
+end

--- a/app/views/external_users/advocates/claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/claims/_miscellaneous_fees_form_step.html.haml
@@ -6,3 +6,5 @@
 = render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope)}
 
 = render partial: 'external_users/claims/misc_fees/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/interim_claim_info/fields', locals: { f: f, claim: claim }

--- a/app/views/external_users/claims/interim_claim_info/_fields.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_fields.html.haml
@@ -1,0 +1,34 @@
+- if claim.requires_interim_claim_info?
+  #interim-claim-info
+    %h2.bold-medium
+      = t('.warrant_fee')
+
+    = f.fields_for :interim_claim_info do |ff|
+      .form-row
+        %fieldset
+          = ff.anchored_label t('.warrant_fee_paid'), 'warrant_fee_paid', label_attributes: { class: 'form-label' }
+          = ff.collection_radio_buttons(:warrant_fee_paid, yes_no_options, :last, :first, { include_hidden: false, checked: ff.object.warrant_fee_paid ? 'true' : 'false' }) do |b|
+            .multiple-choice{ 'data-target' => b.value.to_bool ? 'interim-claim-info-details' : nil }
+              = b.radio_button
+              = b.label { b.text }
+
+            - if b.value.to_bool
+              #interim-claim-info-details.panel.panel-border-narrow.js-hidden
+                .form-group
+                  %fieldset
+                    %legend.visuallyhidden
+                      = t('.warrant_fee')
+                    .warrant-fee-issued-date-group
+                      = ff.gov_uk_date_field :warrant_issued_date,
+                                              legend_text: t('.date_issued'),
+                                              legend_class: 'form-label-bold',
+                                              id: 'interim_claim_info.warrant_issued_date',
+                                              error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_issued_date')
+
+                .form-group
+                  .warrant-fee-executed-date-group
+                    = ff.gov_uk_date_field :warrant_executed_date,
+                                            legend_text: t('.date_executed'),
+                                            legend_class: 'govuk-legend',
+                                            id: 'interim_claim_info.warrant_executed_date',
+                                            error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_executed_date')

--- a/app/views/external_users/claims/interim_claim_info/_summary.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_summary.html.haml
@@ -1,0 +1,17 @@
+- claim.interim_claim_info && present(claim.interim_claim_info) do |info|
+  - if info.warrant_fee_paid?
+    %table{ class: 'summary', summary: t('.summary') }
+      %caption
+        %span.table-caption.visuallyhidden
+          = t('.caption')
+      %tbody
+        %tr
+          %th{ scope: 'row', class: 'bold' }
+            = t('shared.claims.interim_claim_info.fields.date_issued')
+          %td
+            = info.warrant_issued_date
+        %tr
+          %th{ scope: 'row', class: 'bold' }
+            = t('shared.claims.interim_claim_info.fields.date_executed')
+          %td
+            = info.warrant_executed_date

--- a/app/views/external_users/claims/misc_fees/_summary.html.haml
+++ b/app/views/external_users/claims/misc_fees/_summary.html.haml
@@ -1,2 +1,5 @@
 .form-section
   = render partial: 'summary_fees', locals: { claim: claim, header: t('external_users.claims.misc_fees.summary.header'), collection: claim.misc_fees, editable: editable, section: section, step: :miscellaneous_fees }
+
+  - if claim.requires_interim_claim_info?
+    = render partial: 'external_users/claims/interim_claim_info/summary', locals: { claim: claim }

--- a/app/views/external_users/litigators/claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/litigators/claims/_miscellaneous_fees_form_step.html.haml
@@ -1,1 +1,3 @@
 = render partial: 'external_users/claims/misc_fees/litigators/fields', locals: { f: f }
+
+= render partial: 'external_users/claims/interim_claim_info/fields', locals: { f: f, claim: claim }

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -76,6 +76,26 @@
             %td.numeric
               = claim.fees_gross
 
+    - if claim.final? && claim.interim_claim_info.present?
+      - present(claim.interim_claim_info) do |info|
+        %h3.heading-medium
+          = t('common.interim_claim_info')
+        - if info.warrant_fee_paid?
+          %table.table-summary
+            %caption.hidden
+              = t('.fees.caption')
+            %tbody
+              %tr
+                %th.col-date{ scope: 'col' }
+                  = t('shared.claims.interim_claim_info.fields.date_issued')
+                %td
+                  = info.warrant_issued_date
+              %tr
+                %th.col-date{ scope: 'col' }
+                  = t('shared.claims.interim_claim_info.fields.date_executed')
+                %td
+                  = info.warrant_executed_date
+
     - if claim.can_have_expenses?
       - if claim.expenses.empty?
         %h3.heading-medium

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -50,6 +50,26 @@
         = t('.fees_total')
         = claim.fees_total
 
+    - if claim.final? && claim.interim_claim_info.present?
+      - present(claim.interim_claim_info) do |info|
+        %h3.heading-medium
+          = t('common.interim_claim_info')
+        - if info.warrant_fee_paid?
+          %table.table-summary
+            %caption.hidden
+              = t('.fees.caption')
+            %tbody
+              %tr
+                %th.col-date{ scope: 'col' }
+                  = t('shared.claims.interim_claim_info.fields.date_issued')
+                %td
+                  = info.warrant_issued_date
+              %tr
+                %th.col-date{ scope: 'col' }
+                  = t('shared.claims.interim_claim_info.fields.date_executed')
+                %td
+                  = info.warrant_executed_date
+
     - if claim.can_have_expenses?
       - if claim.expenses.empty?
         %h3.heading-medium

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -869,6 +869,12 @@ en:
         rejected: Rejected
         submitted: Submitted to LAA
         show_count: 'Showing %{page_count} of %{total} claims'
+      interim_claim_info:
+        fields:
+          warrant_fee: Warrant fees
+          warrant_fee_paid: 'Have you previously been paid for an interim warrant fee?'
+          date_issued: Warrant issued date
+          date_executed: Warrant executed date
       json_document_importer:
         import_claim: Or upload your claims in JSON format
       outstanding:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,6 +261,7 @@ en:
     delete: Delete
     view: View
     warrant_fees: Warrant fees
+    interim_claim_info: Warrant fees
     interim_fees: "Interim fees"
     transfer_fees: Transfer fees
     search:
@@ -870,7 +871,7 @@ en:
         submitted: Submitted to LAA
         show_count: 'Showing %{page_count} of %{total} claims'
       interim_claim_info:
-        fields:
+        fields: &interim_claim_info_fields
           warrant_fee: Warrant fees
           warrant_fee_paid: 'Have you previously been paid for an interim warrant fee?'
           date_issued: Warrant issued date
@@ -1022,6 +1023,9 @@ en:
       reporders: Representation orders
       submit_date: Claim submitted
       trial_concluded: Trial concluded
+    claims:
+      interim_claim_info:
+        fields: *interim_claim_info_fields
     errors:
       error: 'error'
       form_error_hint: 'Check below for more detail'
@@ -1320,6 +1324,8 @@ en:
         none: None
       hint:
         search: for example case number, MAAT reference, defendant name, case worker name or email
+      interim_claim_info:
+        fields: *interim_claim_info_fields
   devise:
     shared:
       links:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -876,6 +876,9 @@ en:
           warrant_fee_paid: 'Have you previously been paid for an interim warrant fee?'
           date_issued: Warrant issued date
           date_executed: Warrant executed date
+        summary:
+          caption: 'Warrant fees: This section contains info related to interim claimed warrant fees.'
+          summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows.'
       json_document_importer:
         import_claim: Or upload your claims in JSON format
       outstanding:

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1087,7 +1087,7 @@ fixed_fee:
 #                                                                               #
 #################################################################################
 
-warrant_fee:
+warrant_fee: &warrant_fee_errors
   _seq: 650
 
   base:
@@ -1175,6 +1175,8 @@ warrant_fee:
       long: Enter a valid amount for the warrant
       short: *enter_valid_amount
       api: Enter a valid amount for the warrant
+
+interim_claim_info: *warrant_fee_errors
 
 #################################################################################
 #                                                                               #

--- a/db/migrate/20180515140528_create_interim_claim_info.rb
+++ b/db/migrate/20180515140528_create_interim_claim_info.rb
@@ -1,0 +1,18 @@
+class CreateInterimClaimInfo < ActiveRecord::Migration[5.0]
+  def change
+    # NOTE: I'm being deliberaly pedantic about the name of the table here
+    # to express exactly what it contains.
+    #
+    # This table stands as an interim (pun not included!) solution to what we
+    # really should have which is well establish relationships between different types
+    # of claims (e.g. interim/final)
+    # Unfortunately, the requirements to determine how those relationships should be
+    # established are not yet defined :S
+    create_table :interim_claim_info do |t|
+      t.boolean :warrant_fee_paid
+      t.date :warrant_issued_date
+      t.date :warrant_executed_date
+      t.references :claim
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180409091300) do
+ActiveRecord::Schema.define(version: 20180515140528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -354,6 +354,14 @@ ActiveRecord::Schema.define(version: 20180409091300) do
     t.json     "error_messages"
     t.datetime "deleted_at"
     t.index ["claim_id"], name: "index_injection_attempts_on_claim_id", using: :btree
+  end
+
+  create_table "interim_claim_info", force: :cascade do |t|
+    t.boolean "warrant_fee_paid"
+    t.date    "warrant_issued_date"
+    t.date    "warrant_executed_date"
+    t.integer "claim_id"
+    t.index ["claim_id"], name: "index_interim_claim_info_on_claim_id", using: :btree
   end
 
   create_table "locations", force: :cascade do |t|

--- a/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_fixed_fee_spec.rb
@@ -9,12 +9,13 @@ describe API::Entities::CCR::AdaptedFixedFee, type: :adapter do
   let(:fxndr) { create(:fixed_fee_type, :fxndr) }
   let(:fxnoc) { create(:fixed_fee_type, :fxnoc) }
 
-  let(:case_type) { instance_double('case_type', fee_type_code: 'FXCBR', requires_maat_reference?: false )}
   let(:adapted_fixed_fees) { ::CCR::Fee::FixedFeeAdapter.new.call(claim) }
 
   context 'when an applicable fixed fee is claimed' do
+    let(:case_type) { build(:case_type, :fixed_fee, fee_type_code: 'FXCBR', requires_maat_reference: false) }
+    let(:claim) { create(:authorised_claim, case_number: 'T20160001', case_type: case_type) }
+
     before do |example|
-      allow(claim).to receive(:case_type).and_return case_type
       create(:fixed_fee, fee_type: fxcbr, claim: claim, quantity: 13) unless example.metadata[:skip_fee]
       create(:fixed_fee, fee_type: fxcbu, claim: claim, quantity: 2, case_numbers: 'T20170001,T20170002') unless example.metadata[:skip_uplifts]
     end

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -174,6 +174,7 @@ describe API::V1::ExternalUsers::Fee do
       end
 
       context 'fixed fees of type case uplift' do
+        let!(:claim) { create(:advocate_claim, :with_fixed_fee_case, source: 'api') }
         let!(:fixed_fee_noc_type) { create(:fixed_fee_type, :fxnoc) }
         let!(:valid_params) { { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: fixed_fee_noc_type.id, quantity: 1, rate: 201.01, case_numbers: 'T20170001' } }
 

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -49,6 +49,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_fixed_fee_case do
+      case_type { association(:case_type, :fixed_fee) }
+    end
+
+    trait :with_graduated_fee_case do
+      case_type { association(:case_type, :graduated_fee) }
+    end
+
     trait :fixed_fee do
       after(:build) do |claim|
         fee_type = create :fixed_fee_type

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -22,12 +22,13 @@
 FactoryBot.define do
 
   factory :fixed_fee, class: Fee::FixedFee do
-    claim
+    claim { build(:advocate_claim, :with_fixed_fee_case) }
     fee_type { build :fixed_fee_type }
     quantity 1
     rate 25
 
     trait :lgfs do
+      claim { build(:litigator_claim, :with_fixed_fee_case) }
       fee_type { build :fixed_fee_type, :lgfs }
       quantity 0
       rate 0

--- a/spec/factories/interim_claim_info.rb
+++ b/spec/factories/interim_claim_info.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :interim_claim_info do
+    claim
+    warrant_fee_paid false
+
+    trait :with_warrant_fee_paid do
+      warrant_fee_paid true
+      warrant_issued_date InterimClaimInfo::MINIMUM_PERIOD_SINCE_ISSUED.ago
+      warrant_executed_date { warrant_issued_date + 5.days }
+    end
+  end
+end

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -64,7 +64,6 @@
 
 require 'rails_helper'
 
-
 class MockBaseClaim < Claim::BaseClaim
   SUBMISSION_STAGES = [
     {
@@ -497,6 +496,42 @@ RSpec.describe Claim::BaseClaim do
       end
 
       specify { expect(claim.step_back?).to be_falsey }
+    end
+  end
+
+  describe '#step_validation_required?' do
+    let(:claim) { MockSteppableClaim.new(source: source) }
+
+    context 'when the claim is from an API submission' do
+      let(:source) { 'api' }
+
+      specify { expect(claim.step_validation_required?(:some_step)).to be_truthy }
+    end
+
+    context 'when the claim is not from an API submission' do
+      let(:source) { 'web' }
+
+      context 'and the form step is nil' do
+        before do
+          claim.form_step = nil
+        end
+
+        specify { expect(claim.step_validation_required?(:some_step)).to be_truthy }
+      end
+
+      context 'and the form step is set' do
+        before do
+          claim.form_step = :some_step
+        end
+
+        context 'and it matches the provided step' do
+          specify { expect(claim.step_validation_required?(:some_step)).to be_truthy }
+        end
+
+        context 'but it does not match the provided step' do
+          specify { expect(claim.step_validation_required?(:other_step)).to be_falsey }
+        end
+      end
     end
   end
 end

--- a/spec/models/claims/totals_spec.rb
+++ b/spec/models/claims/totals_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Claim, type: :model do
-  subject(:claim) { create(:advocate_claim) }
+  subject(:claim) { create(:advocate_claim, :with_fixed_fee_case) }
+
   let(:expenses) { [3.5, 1.0, 142.0].each { |amount| create(:expense, claim_id: claim.id, amount: amount) } }
   let(:fee_type) { create(:fixed_fee_type) }
 

--- a/spec/models/fee/base_fee_spec.rb
+++ b/spec/models/fee/base_fee_spec.rb
@@ -45,7 +45,7 @@ module Fee
       end
 
       it 'does not zeroise the amount if not null' do
-        fee = create :fixed_fee, :lgfs, amount: nil, rate: 2, quantity: 150
+        fee = create :fixed_fee, amount: nil, rate: 2, quantity: 150
         fee.save!
         expect(fee.amount).to eq 300.0
       end

--- a/spec/presenters/claim/advocate_claim_presenter_spec.rb
+++ b/spec/presenters/claim/advocate_claim_presenter_spec.rb
@@ -17,6 +17,24 @@ RSpec.describe Claim::AdvocateClaimPresenter, type: :presenter do
     specify { expect(presenter.can_have_disbursements?).to be_falsey }
   end
 
+  describe '#requires_interim_claim_info?' do
+    context 'when claim is not for the AGFS fee reform scheme' do
+      before do
+        allow(claim).to receive(:fee_scheme).and_return('default')
+      end
+
+      specify { expect(presenter.requires_interim_claim_info?).to be_falsey }
+    end
+
+    context 'when claim is for the AGFS fee reform scheme' do
+      before do
+        allow(claim).to receive(:fee_scheme).and_return('fee_reform')
+      end
+
+      specify { expect(presenter.requires_interim_claim_info?).to be_truthy }
+    end
+  end
+
   specify {
     expect(presenter.summary_sections).to eq({
       case_details: :case_details,

--- a/spec/presenters/claim/advocate_interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/advocate_interim_claim_presenter_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Claim::AdvocateInterimClaimPresenter, type: :presenter do
   # it_behaves_like 'a claim presenter'
   # but the spec for the base claim is quite complex to be able
   # to change that pattern. Something to address in the near future
+  #
+
+  include_examples 'a claim presenter'
 
   describe '#pretty_type' do
     specify { expect(presenter.pretty_type).to eq('AGFS Warrant') }

--- a/spec/presenters/claim/interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/interim_claim_presenter_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Claim::InterimClaimPresenter, type: :presenter do
 
   subject(:presenter) { described_class.new(claim, view) }
 
+  include_examples 'a claim presenter'
+
   specify { expect(presenter.requires_trial_dates?).to be_falsey }
   specify { expect(presenter.requires_retrial_dates?).to be_falsey }
   specify { expect(presenter.can_have_expenses?).to be_falsey }

--- a/spec/presenters/claim/litigator_claim_presenter_spec.rb
+++ b/spec/presenters/claim/litigator_claim_presenter_spec.rb
@@ -95,6 +95,10 @@ RSpec.describe Claim::LitigatorClaimPresenter, type: :presenter do
     end
   end
 
+  describe '#requires_interim_claim_info?' do
+    specify { expect(presenter.requires_interim_claim_info?).to be_truthy }
+  end
+
   describe '#summary_sections' do
     specify {
       expect(presenter.summary_sections).to eq({

--- a/spec/presenters/claim/transfer_claim_presenter_spec.rb
+++ b/spec/presenters/claim/transfer_claim_presenter_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Claim::TransferClaimPresenter, type: :presenter do
 
   subject(:presenter) { described_class.new(claim, view) }
 
+  include_examples 'a claim presenter'
+
   specify { expect(presenter.pretty_type).to eq('LGFS Transfer') }
   specify { expect(presenter.type_identifier).to eq('lgfs_transfer') }
 

--- a/spec/presenters/interim_claim_info_presenter_spec.rb
+++ b/spec/presenters/interim_claim_info_presenter_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe InterimClaimInfoPresenter do
+  let(:issued_date) { Date.new(2017, 12, 1) }
+  let(:executed_date) { Date.new(2017, 12, 4) }
+  let(:info) { build(:interim_claim_info, warrant_issued_date: issued_date, warrant_executed_date: executed_date) }
+
+  subject(:presenter) { described_class.new(info, view) }
+
+  describe '#warrant_issued_date' do
+    specify { expect(presenter.warrant_issued_date).to eq('01/12/2017') }
+  end
+
+  describe '#warrant_executed_date' do
+    specify { expect(presenter.warrant_executed_date).to eq('04/12/2017') }
+  end
+end

--- a/spec/support/shared_examples/presenters/base_claim_shared_examples.rb
+++ b/spec/support/shared_examples/presenters/base_claim_shared_examples.rb
@@ -1,0 +1,6 @@
+RSpec.shared_examples_for 'a claim presenter' do
+
+  describe '#requires_interim_claim_info?' do
+    specify { expect(presenter.requires_interim_claim_info?).to be_falsey }
+  end
+end

--- a/spec/validators/claim/advocate_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_sub_model_validator_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Claim::AdvocateClaimSubModelValidator, type: :validator do
     has_one: {
       case_details: [],
       defendants: [],
-      offence_details: []
+      offence_details: [],
+      miscellaneous_fees: [{ name: :interim_claim_info }],
     },
     has_many: {
       case_details: [],

--- a/spec/validators/claim/litigator_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_sub_model_validator_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Claim::LitigatorClaimSubModelValidator, type: :validator do
       defendants: [],
       offence_details: [],
       fixed_fees: [{ name: :fixed_fee }],
-      graduated_fees: [{ name: :graduated_fee }]
+      graduated_fees: [{ name: :graduated_fee }],
+      miscellaneous_fees: [{ name: :interim_claim_info }]
     },
     has_many: {
       case_details: [],

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Fee::BaseFeeValidator, type: :validator do
-  let(:claim)   { build :advocate_claim }
+  let(:claim)   { build :advocate_claim, :with_fixed_fee_case }
   let(:fee)     { build :fixed_fee, claim: claim }
   let(:baf_fee) { build :basic_fee, :baf_fee, claim: claim }
   let(:daf_fee) { build :basic_fee, :daf_fee, claim: claim }
@@ -149,18 +149,6 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         end
       end
     end
-
-    # TODO: max_amount not used in later PR - remove?
-    # context 'fee with max amount' do
-    #   before(:each)       { fee.fee_type.max_amount = 9999 }
-    #   it { should_be_valid_if_equal_to_value(fee, :amount, 9999) }
-    # end
-
-    # context 'fee with no max amount' do
-    #   before(:each)       { fee.fee_type.max_amount = nil }
-    #   it { should_be_valid_if_equal_to_value(fee, :amount, 100_000) }
-    # end
-
   end
 
   describe '#validate_quantity' do
@@ -191,6 +179,8 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
     end
 
     context 'Basic fee types' do
+      let(:claim) { build :advocate_claim, :with_graduated_fee_case }
+
       context 'basic fee (BAF)' do
         context 'when rate present' do
           it 'should be valid with quantity of one' do
@@ -467,5 +457,4 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       end
     end
   end
-
 end

--- a/spec/validators/interim_claim_info_validator_spec.rb
+++ b/spec/validators/interim_claim_info_validator_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe InterimClaimInfoValidator, type: :validator do
+  let(:info) { build(:interim_claim_info) }
+
+  before do
+    allow(info).to receive(:perform_validation?).and_return(true)
+  end
+
+  it 'is valid if warrant issued date is not set' do
+    info.warrant_issued_date = nil
+    expect(info).to be_valid
+  end
+
+  it 'is valid if warrant executed date is not set' do
+    info.warrant_executed_date = nil
+    expect(info).to be_valid
+  end
+
+  context 'when a warrant fee was paid in a previous interim claim' do
+    let(:info) { build(:interim_claim_info, :with_warrant_fee_paid) }
+
+    describe '#validate_warrant_issued_date' do
+      it 'is valid if present and issued at least 3 months ago' do
+        info.warrant_issued_date = 3.months.ago
+        expect(info).to be_valid
+      end
+
+      it 'is invalid if present and too far in the past' do
+        info.warrant_issued_date = 11.years.ago
+        expect(info).to_not be_valid
+        expect(info.errors[:warrant_issued_date]).to include 'check_not_too_far_in_past'
+      end
+
+      it 'is invalid if present and in the future' do
+        info.warrant_issued_date = 3.days.from_now
+        expect(info).not_to be_valid
+        expect(info.errors[:warrant_issued_date]).to include 'check_not_in_future'
+      end
+
+      it 'is invalid if not present' do
+        info.warrant_issued_date = nil
+        expect(info).not_to be_valid
+        expect(info.errors[:warrant_issued_date]).to eq( [ 'blank' ] )
+      end
+    end
+
+    describe '#validate_warrant_executed_date' do
+
+      it 'is invalid if before warrant_issued_date' do
+        info.warrant_executed_date = info.warrant_issued_date - 1.day
+        expect(info).not_to be_valid
+        expect(info.errors[:warrant_executed_date]).to eq( [ 'warrant_executed_before_issued'] )
+      end
+
+      it 'is invalid if present and too far in the past' do
+        info.warrant_executed_date = 11.years.ago
+        expect(info).to_not be_valid
+        expect(info.errors[:warrant_executed_date]).to include 'check_not_too_far_in_past'
+      end
+
+      it 'is invalid if in future' do
+        info.warrant_executed_date = 3.days.from_now
+        expect(info).not_to be_valid
+        expect(info.errors[:warrant_executed_date]).to include 'check_not_in_future'
+      end
+
+      it 'is invalid if absent' do
+        info.warrant_executed_date = nil
+        expect(info).not_to be_valid
+        expect(info.errors[:warrant_executed_date]).to include 'blank'
+      end
+
+      it 'is valid if present and in the past' do
+        info.warrant_executed_date = 1.day.ago
+        expect(info).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

- Adds a new section to the **final** claims (AGFS and LGFS) misc fees section to provide information about warrant fees previously claimed on interim claims related.
- Displays the new section in the summary pages for external users and case workers.

⚠️ **Requires migration**

#### Ticket

[AGFS and LGFS final fee - warrants](https://www.pivotaltracker.com/n/projects/1985371/stories/155688164)

#### Why

Case workers need this information to match it against the interim claims. Personally I still continue to think the actual solution would be to start linking claims, rather than adding extra (duplicate) information to the final claims.
