### PR TITLE
"Check your claim" page fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/BlockLength:
 
 Metrics/ModuleLength:
   Exclude:
+    - 'app/models/claims/calculations.rb'
     - 'app/models/claims/state_machine.rb'
     - 'app/helpers/application_helper.rb'
 

--- a/app/controllers/external_users/litigators/interim_claims_controller.rb
+++ b/app/controllers/external_users/litigators/interim_claims_controller.rb
@@ -7,7 +7,6 @@ class ExternalUsers::Litigators::InterimClaimsController < ExternalUsers::Claims
 
   def build_nested_resources
     @claim.build_interim_fee if @claim.interim_fee.nil?
-    @claim.build_warrant_fee if @claim.warrant_fee.nil?
 
     %i[disbursements expenses].each do |association|
       build_nested_resource(@claim, association)

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -169,17 +169,22 @@ module Claim
       return if from_api?
       assign_fees_total(%i[interim_fee]) if interim_fee_changed?
       assign_expenses_total if expenses_changed?
+      assign_disbursements_total if disbursements_changed?
       return unless total_changes_required?
       assign_total
       assign_vat
     end
 
     def total_changes_required?
-      interim_fee_changed? || expenses_changed?
+      interim_fee_changed? || expenses_changed? || disbursements_changed?
     end
 
     def interim_fee_changed?
       interim_fee&.changed?
+    end
+
+    def disbursements_changed?
+      disbursements.any?(&:changed?)
     end
   end
 end

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -71,10 +71,8 @@ module Claim
     validates_with ::Claim::InterimClaimSubModelValidator
 
     has_one :interim_fee, foreign_key: :claim_id, class_name: 'Fee::InterimFee', dependent: :destroy, inverse_of: :claim
-    has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
 
     accepts_nested_attributes_for :interim_fee, reject_if: :all_blank, allow_destroy: false
-    accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false
 
     before_validation do
       assign_total_attrs
@@ -151,15 +149,10 @@ module Claim
     end
 
     def destroy_all_invalid_fee_types
-      return unless interim_fee
+      return unless interim_fee&.is_interim_warrant?
 
-      if interim_fee.is_interim_warrant?
-        disbursements.destroy_all
-        self.disbursements = []
-      else
-        warrant_fee.try(:destroy)
-        self.warrant_fee = nil
-      end
+      disbursements.destroy_all
+      self.disbursements = []
     end
 
     def assign_total_attrs

--- a/app/presenters/claim/interim_claim_presenter.rb
+++ b/app/presenters/claim/interim_claim_presenter.rb
@@ -1,5 +1,5 @@
 class Claim::InterimClaimPresenter < Claim::BaseClaimPresenter
-  present_with_currency :interim_fees_total, :warrant_fees_total
+  present_with_currency :interim_fees_total
 
   # NOTE: this shows we should probably refactor the template naming
   # to bring some consistency between claim steps and their associated
@@ -40,10 +40,6 @@ class Claim::InterimClaimPresenter < Claim::BaseClaimPresenter
 
   def raw_interim_fees_total
     claim.interim_fee&.amount || 0
-  end
-
-  def raw_warrant_fees_total
-    claim.warrant_fee&.amount || 0
   end
 
   def summary_sections

--- a/app/presenters/claim/interim_claim_presenter.rb
+++ b/app/presenters/claim/interim_claim_presenter.rb
@@ -9,6 +9,7 @@ class Claim::InterimClaimPresenter < Claim::BaseClaimPresenter
     defendants: :defendants,
     offence_details: :offence_details,
     interim_fee: :interim_fees,
+    disbursements: :interim_fees,
     expenses: :travel_expenses,
     supporting_evidence: :supporting_evidence,
     additional_information: :supporting_evidence

--- a/app/views/external_users/claims/_summary_claims_content.html.haml
+++ b/app/views/external_users/claims/_summary_claims_content.html.haml
@@ -16,4 +16,4 @@
 
 - claim.summary_sections.each do |section, associated_step|
   - if claim.accessible_step?(associated_step)
-    = render partial: "external_users/claims/#{section}/summary", locals: { claim: claim, section: section, editable: claim.editable_step?(associated_step) }
+    = render partial: "external_users/claims/#{section}/summary", locals: { claim: claim, step: associated_step, section: section, editable: claim.editable_step?(associated_step) }

--- a/app/views/external_users/claims/disbursements/_summary.html.haml
+++ b/app/views/external_users/claims/disbursements/_summary.html.haml
@@ -1,12 +1,13 @@
+- step = local_assigns[:step] ? local_assigns[:step] : :disbursements
 .form-section
   %h3.heading-medium
     = t('external_users.claims.disbursements.summary.header')
     - if local_assigns[:editable]
-      = link_to 'Change', edit_polymorphic_path(claim, step: :disbursements, referrer: :summary), class: 'link-change'
+      = link_to 'Change', edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change'
 
   - if claim.disbursements.empty?
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]
-      = render partial: 'external_users/claims/summary/section_status', locals: { claim: claim, section: section, step: :disbursements }
+      = render partial: 'external_users/claims/summary/section_status', locals: { claim: claim, section: section, step: step }
     - else
       %p
         = t('shared.summary.no_values.disbursements')

--- a/app/views/external_users/claims/offence_details/_default_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_default_summary.html.haml
@@ -1,11 +1,10 @@
 - claim_fields = %i[external_users claims case_details fields]
 
-- if claim.agfs?
-  %tr
-    %th{ scope: 'row', class: 'bold' }
-      = t("offence_category", scope: claim_fields)
-    %td
-      = claim.offence ? claim.offence.description : t("general.not_provided")
+%tr
+  %th{ scope: 'row', class: 'bold' }
+    = t("offence_category", scope: claim_fields)
+  %td
+    = claim.offence ? claim.offence.description : t("general.not_provided")
 
 %tr
   %th{ scope: 'row', class: 'bold' }

--- a/spec/presenters/claim/interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/interim_claim_presenter_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Claim::InterimClaimPresenter, type: :presenter do
         defendants: :defendants,
         offence_details: :offence_details,
         interim_fee: :interim_fees,
+        disbursements: :interim_fees,
         expenses: :travel_expenses,
         supporting_evidence: :supporting_evidence,
         additional_information: :supporting_evidence

--- a/spec/presenters/claim/interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/interim_claim_presenter_spec.rb
@@ -59,30 +59,6 @@ RSpec.describe Claim::InterimClaimPresenter, type: :presenter do
     end
   end
 
-  describe '#raw_warrant_fees_total' do
-    context 'when the warrant fee is nil' do
-      let(:claim) { build(:interim_claim, warrant_fee: nil) }
-
-      specify { expect(presenter.raw_warrant_fees_total).to eq(0) }
-    end
-
-    context 'when the warrant fee is set' do
-      let(:claim) { build(:interim_claim, warrant_fee: warrant_fee) }
-
-      context 'but amount is not set' do
-        let(:warrant_fee) { build(:warrant_fee, amount: nil) }
-
-        specify { expect(presenter.raw_warrant_fees_total).to eq(0) }
-      end
-
-      context 'and amount is set' do
-        let(:warrant_fee) { build(:warrant_fee, amount: 42.5) }
-
-        specify { expect(presenter.raw_warrant_fees_total).to eq(42.5) }
-      end
-    end
-  end
-
   describe '#summary_sections' do
     specify {
       expect(presenter.summary_sections).to eq({


### PR DESCRIPTION
#### What

* Ensure that, for litigator interim claims, disbursements are added to the claim totals if changed before validations are performed
* Display disbursement section for litigator interim claims
* Display offence category for LGFS claims in the CYC page

Relates to: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/2340


#### Ticket

[Check your claim page fixes](https://www.pivotaltracker.com/n/projects/1985371/stories/157779878)

Some of these

**NOTE:** This PR does not include all the fixes for the ticket, as otherwise it would turn up to be a massive one again, so I'm trying to deliver small pieces at a time.