### PR TITLE
Hide additional case numbers on fixed fees

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
@@ -1,6 +1,5 @@
 moj.Modules.FeeFieldsDisplay = {
   init: function() {
-    var self = this;
     this.addFeeChangeEvent($('.fx-fee-group'));
   },
   addFeeChangeEvent: function(el) {
@@ -18,7 +17,6 @@ moj.Modules.FeeFieldsDisplay = {
     });
   },
   showHideFeeFields: function(el) {
-    var self = this;
     var currentElement = $(el);
     var caseNumbersInput = currentElement.find('input.fx-fee-case-numbers');
 
@@ -34,4 +32,4 @@ moj.Modules.FeeFieldsDisplay = {
       }
     }
   }
-}
+};

--- a/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/FeeFieldsDisplay.js
@@ -24,14 +24,13 @@ moj.Modules.FeeFieldsDisplay = {
 
     if (caseNumbersInput.exists()) {
       var showCaseNumbers = currentElement.find('option:selected').data('case-numbers');
+      var caseNumbersWrapper = caseNumbersInput.closest('.case_numbers_wrapper');
 
       if (showCaseNumbers) {
-        caseNumbersInput.prop('readonly', false);
-        caseNumbersInput.prop('tabindex', 0);
+        caseNumbersWrapper.show();
       } else {
         caseNumbersInput.val('');
-        caseNumbersInput.prop('readonly', true);
-        caseNumbersInput.prop('tabindex', -1);
+        caseNumbersWrapper.hide();
       }
     }
   }

--- a/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
@@ -22,7 +22,9 @@ Feature: Advocate submits a claim for a Contempt case
 
     And I select an advocate category of 'Junior alone'
     And I add a fixed fee 'Contempt'
+    Then the last fixed fee case numbers field should not be visible
     And I add a fixed fee 'Number of cases uplift' with case numbers
+    Then the last fixed fee case numbers field should be visible
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
+++ b/features/claims/advocate/advocate_contempt_claim_edit_submit.feature
@@ -22,9 +22,9 @@ Feature: Advocate submits a claim for a Contempt case
 
     And I select an advocate category of 'Junior alone'
     And I add a fixed fee 'Contempt'
-    Then the last fixed fee case numbers field should not be visible
+    Then the last fixed fee case numbers section should not be visible
     And I add a fixed fee 'Number of cases uplift' with case numbers
-    Then the last fixed fee case numbers field should be visible
+    Then the last fixed fee case numbers section should be visible
 
     Then I click "Continue" in the claim form
 

--- a/features/page_objects/sections/typed_fee_section.rb
+++ b/features/page_objects/sections/typed_fee_section.rb
@@ -6,6 +6,7 @@ class TypedFeeSection < SitePrism::Section
   element :rate, "input.rate"
   element :amount, nil
   element :case_numbers, "input.fx-fee-case-numbers"
+  element :case_numbers_section, ".case_numbers_wrapper"
   element :add_dates, ".dates-wrapper .add_fields"
   section :dates, FeeDatesSection, ".fee-dates"
 

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -202,7 +202,10 @@ Then(/^I should see retrial fields$/) do
   expect(@claim_form_page.retrial_details).to be_all_there
 end
 
-Then(/^the last fixed fee case numbers field should (not )?be visible$/) do |negate|
-  visible = !negate.present?
-  expect(@claim_form_page.fixed_fees.last.case_numbers(visible: visible)).to be_present
+Then(/^the last fixed fee case numbers section should (not )?be visible$/) do |negate|
+  if negate
+    expect(@claim_form_page.fixed_fees.last).to_not have_case_numbers_section
+  else
+    expect(@claim_form_page.fixed_fees.last).to have_case_numbers_section
+  end
 end

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -201,3 +201,8 @@ Then(/^I should see retrial fields$/) do
   expect(@claim_form_page.retrial_details).to be_visible
   expect(@claim_form_page.retrial_details).to be_all_there
 end
+
+Then(/^the last fixed fee case numbers field should (not )?be visible$/) do |negate|
+  visible = !negate.present?
+  expect(@claim_form_page.fixed_fees.last.case_numbers(visible: visible)).to be_present
+end


### PR DESCRIPTION
#### What
Hide additional case numbers on fixed fees

#### Ticket

[Hide additional case numbers](https://www.pivotaltracker.com/story/show/157771129)

#### Why
So user is not burdened with unnecessary fields on the page

#### How
existing enabling disabling of this field swapped out for show/hide
