### PR TITLE
CBO-28 Mute "attach indictment" pop up for fixed fees

### DIFF
--- a/app/views/external_users/claims/basic_fees/_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_fields.html.haml
@@ -1,5 +1,5 @@
 - unless @claim.allows_fixed_fees?
-  #basic-fees.mod-fees{"data-mute-indictment": @claim.allows_fixed_fees? ? "true" : "false"}
+  #basic-fees.mod-fees
     %h2.bold-medium
       = t('.basic_fees')
     %p

--- a/app/views/external_users/claims/fixed_fees/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/_fields.html.haml
@@ -1,5 +1,5 @@
 - if @claim.allows_fixed_fees?
-  #fixed-fees.mod-fees{"data-mute-indictment": @claim.allows_fixed_fees? ? "true" : "false"}
+  #fixed-fees.mod-fees
     .fixed-fee-group-wrapper
       = f.fields_for :fixed_fees do |fixed_fee_fields|
         - @fixed_fee_count += 1

--- a/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
@@ -1,6 +1,6 @@
 - if @claim.allows_fixed_fees?
 
-  #fixed-fees.mod-fees{"data-mute-indictment": @claim.allows_fixed_fees? ? "true" : "false"}
+  #fixed-fees.mod-fees
     %h2.bold-medium
       = t('.fixed_fees')
 

--- a/app/views/external_users/claims/graduated_fees/_fields.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_fields.html.haml
@@ -1,6 +1,6 @@
 - if @claim.allows_graduated_fees?
 
-  #graduated-fees.mod-graduated-fees{"data-mute-indictment": @claim.allows_fixed_fees? ? "true" : "false"}
+  #graduated-fees.mod-graduated-fees
     %h2.bold-medium
       = t('.graduated_fees')
     .form-hint.xsmall

--- a/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
@@ -1,4 +1,4 @@
-%fieldset
+%fieldset{"data-mute-indictment": @claim.allows_fixed_fees? ? "true" : "false"}
   %legend
     %h3.heading-medium
       = t('.supporting_evidence_checklist')


### PR DESCRIPTION
#### What
After breaking the pages up - the indictment  message on supporting evidence is appearing all the time. This should only be shown for fixed fees

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-28
[Remove 'remember to attach indictment'](https://www.pivotaltracker.com/story/show/157771232)

#### Why
Broken feature after pages was split up

#### How
Reimplement the `data-attr` on the supporting evidence page
