### PR TITLE
Tweak error messages for net amounts

### DIFF
--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -19,6 +19,7 @@ dictionary:
     check_amount: &check_amount 'Check amount'
     enter_valid_quantity: &enter_valid_quantity 'Enter a valid quantity'
     enter_valid_rate: &enter_valid_rate 'Enter a valid rate'
+    enter_valid_net_amount: &enter_valid_net_amount 'Enter a valid net amount'
     item_max_amount: &item_max_amount 'Amount exceeds limit'
     max_vat_amount: &max_vat_amount 'Enter a valid amount'
     claim_max_amount: &claim_max_amount 'Amount claimed exceeds limit'
@@ -936,9 +937,9 @@ misc_fee:
   rate:
     _seq: 20
     invalid:
-      long: 'Enter a valid rate for the #{misc_fee}'
-      short: *enter_valid_rate
-      api: Enter a rate for the miscellaneous fee
+      long: 'Enter a valid net amount for the #{misc_fee}'
+      short: *enter_valid_amount
+      api: Enter a rate/net amount for the miscellaneous fee
 
   quantity:
     _seq: 30
@@ -1002,9 +1003,9 @@ fixed_fee:
   rate:
     _seq: 20
     invalid:
-      long: 'Enter a valid rate for the #{fixed_fee}'
-      short: *enter_valid_rate
-      api: Enter a rate for the fixed fee
+      long: 'Enter a valid net amount for the #{fixed_fee}'
+      short: *enter_valid_amount
+      api: Enter a rate/net amount for the fixed fee
 
   quantity:
     _seq: 30

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -294,14 +294,14 @@ describe API::V1::ExternalUsers::Fee do
             valid_params[:fee_type_id] = misc_fee_type.id
             post_to_create_endpoint
             expect(last_response.status).to eq 400
-            expect_error_response("Enter a rate for the miscellaneous fee",0)
+            expect_error_response("Enter a rate/net amount for the miscellaneous fee",0)
           end
 
-          it 'fixed fees should raise misc fee errors from translations' do
+          it 'fixed fees should raise fixed fee errors from translations' do
             valid_params[:fee_type_id] = fixed_fee_type.id
             post_to_create_endpoint
             expect(last_response.status).to eq 400
-            expect_error_response("Enter a rate for the fixed fee",0)
+            expect_error_response("Enter a rate/net amount for the fixed fee", 0)
           end
         end
 


### PR DESCRIPTION
#### What
Change error message text for Fixed and Miscellaneous fee rate

#### Why
The name/label of these fields is net amount but attribute is rate.


#### before:

<img width="836" alt="screen shot 2018-05-24 at 10 22 44" src="https://user-images.githubusercontent.com/7016425/40476646-759391a8-5f3c-11e8-8cbb-6ec37dbc44e3.png">

#### after:

<img width="724" alt="screen shot 2018-05-24 at 10 23 50" src="https://user-images.githubusercontent.com/7016425/40476706-9ec367b0-5f3c-11e8-8a0f-c321e58281f4.png">

