### PR TITLE
Patch autosave associations to support conditional validations

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -66,8 +66,18 @@ module Claim
   class AdvocateClaim < BaseClaim
     route_key_name 'advocates_claim'
 
-    has_many :basic_fees, foreign_key: :claim_id, class_name: 'Fee::BasicFee', dependent: :destroy, inverse_of: :claim
-    has_many :fixed_fees, foreign_key: :claim_id, class_name: 'Fee::FixedFee', dependent: :destroy, inverse_of: :claim
+    has_many :basic_fees,
+             foreign_key: :claim_id,
+             class_name: 'Fee::BasicFee',
+             dependent: :destroy,
+             inverse_of: :claim,
+             validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :basic_fees }
+    has_many :fixed_fees,
+             foreign_key: :claim_id,
+             class_name: 'Fee::FixedFee',
+             dependent: :destroy,
+             inverse_of: :claim,
+             validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :fixed_fees }
 
     accepts_nested_attributes_for :basic_fees, reject_if: all_blank_or_zero, allow_destroy: true
     accepts_nested_attributes_for :fixed_fees, reject_if: all_blank_or_zero, allow_destroy: true

--- a/app/models/claim/advocate_interim_claim.rb
+++ b/app/models/claim/advocate_interim_claim.rb
@@ -6,7 +6,12 @@ module Claim
                    unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
     validates_with ::Claim::AdvocateInterimClaimSubModelValidator
 
-    has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
+    has_one :warrant_fee,
+            foreign_key: :claim_id,
+            class_name: 'Fee::WarrantFee',
+            dependent: :destroy,
+            inverse_of: :claim,
+            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :interim_fees }
 
     accepts_nested_attributes_for :warrant_fee, allow_destroy: false
 

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -683,7 +683,6 @@ module Claim
 
     def default_values
       self.source ||= 'web'
-      self.form_step ||= submission_stages.first
     end
 
     def default_case_transferred_from_another_court

--- a/app/models/claim/interim_claim.rb
+++ b/app/models/claim/interim_claim.rb
@@ -70,7 +70,12 @@ module Claim
     validates_with ::Claim::LitigatorSupplierNumberValidator
     validates_with ::Claim::InterimClaimSubModelValidator
 
-    has_one :interim_fee, foreign_key: :claim_id, class_name: 'Fee::InterimFee', dependent: :destroy, inverse_of: :claim
+    has_one :interim_fee,
+            foreign_key: :claim_id,
+            class_name: 'Fee::InterimFee',
+            dependent: :destroy,
+            inverse_of: :claim,
+            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :interim_fees }
 
     accepts_nested_attributes_for :interim_fee, reject_if: :all_blank, allow_destroy: false
 

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -70,13 +70,19 @@ module Claim
     validates_with ::Claim::LitigatorSupplierNumberValidator, on: :create
     validates_with ::Claim::LitigatorClaimSubModelValidator
 
-    has_one :fixed_fee, foreign_key: :claim_id, class_name: 'Fee::FixedFee', dependent: :destroy, inverse_of: :claim
+    has_one :fixed_fee,
+            foreign_key: :claim_id,
+            class_name: 'Fee::FixedFee',
+            dependent: :destroy,
+            inverse_of: :claim,
+            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :fixed_fees }
     has_one :warrant_fee, foreign_key: :claim_id, class_name: 'Fee::WarrantFee', dependent: :destroy, inverse_of: :claim
     has_one :graduated_fee,
             foreign_key: :claim_id,
             class_name: 'Fee::GraduatedFee',
             dependent: :destroy,
-            inverse_of: :claim
+            inverse_of: :claim,
+            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :graduated_fees }
 
     accepts_nested_attributes_for :fixed_fee, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :warrant_fee, reject_if: :all_blank, allow_destroy: false

--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -66,8 +66,20 @@ module Claim
   class TransferClaim < BaseClaim
     route_key_name 'litigators_transfer_claim'
 
-    has_one :transfer_detail, foreign_key: :claim_id, class_name: Claim::TransferDetail, dependent: :destroy
-    has_one :transfer_fee, foreign_key: :claim_id, class_name: Fee::TransferFee, dependent: :destroy, inverse_of: :claim
+    has_one :transfer_detail,
+            foreign_key: :claim_id,
+            class_name: Claim::TransferDetail,
+            dependent: :destroy,
+            inverse_of: :claim,
+            validate: proc { |claim|
+              claim.from_api? || claim.form_step.nil? || claim.form_step == :transfer_fee_details
+            }
+    has_one :transfer_fee,
+            foreign_key: :claim_id,
+            class_name: Fee::TransferFee,
+            dependent: :destroy,
+            inverse_of: :claim,
+            validate: proc { |claim| claim.from_api? || claim.form_step.nil? || claim.form_step == :transfer_fees }
 
     accepts_nested_attributes_for :transfer_detail, reject_if: :all_blank, allow_destroy: false
     accepts_nested_attributes_for :transfer_fee, reject_if: :all_blank, allow_destroy: false

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -20,10 +20,6 @@ class Claim::BaseClaimPresenter < BasePresenter
         transfer_fee_details].include? claim.current_step
   end
 
-  def can_be_saved_as_draft?
-    claim.draft? && !%i[case_details transfer_fee_details].include?(claim.current_step)
-  end
-
   # NOTE: this is an interim solution for what probably should be
   # some sort of DSL to describe what fields are required for a given section
   # for that section to be considered completed

--- a/app/validators/claim/base_claim_sub_model_validator.rb
+++ b/app/validators/claim/base_claim_sub_model_validator.rb
@@ -19,10 +19,14 @@ class Claim::BaseClaimSubModelValidator < BaseSubModelValidator
 
   private
 
+  def validate_all_steps?(record)
+    record.from_api? || record.form_step.nil?
+  end
+
   def associations_for_has_many_validations(record)
     # NOTE: keeping existent validation for API purposes
     # The form validations just validate the fields for the current step
-    return (has_many_association_names_for_steps[record.form_step] || []) unless record.from_api?
+    return (has_many_association_names_for_steps[record.form_step] || []) unless validate_all_steps?(record)
     has_many_association_names_for_steps.select do |k, _v|
       record.submission_current_flow.map(&:to_sym).include?(k)
     end.values.flatten
@@ -42,7 +46,7 @@ class Claim::BaseClaimSubModelValidator < BaseSubModelValidator
   def associations_for_has_one_validations(record)
     # NOTE: keeping existent validation for API purposes
     # The form validations just validate the fields for the current step
-    return (has_one_association_names_for_steps[record.form_step] || []) unless record.from_api?
+    return (has_one_association_names_for_steps[record.form_step] || []) unless validate_all_steps?(record)
     has_one_association_names_for_steps.select do |k, _v|
       record.submission_current_flow.map(&:to_sym).include?(k)
     end.values.flatten

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -8,7 +8,8 @@ class Claim::BaseClaimValidator < BaseValidator
   def step_fields_for_validation
     # NOTE: keeping existent validation for API purposes
     # The form validations just validate the fields for the current step
-    return (self.class.fields_for_steps[@record.form_step] || []) unless @record.from_api?
+    return (self.class.fields_for_steps[@record.form_step] || []) unless @record.from_api? || @record.form_step.nil?
+    return self.class.fields_for_steps.values.flatten if !@record.from_api? && @record.form_step.nil?
     self.class.fields_for_steps.select do |k, _v|
       @record.submission_current_flow.map(&:to_sym).include?(k)
     end.values.flatten

--- a/app/views/external_users/claims/buttons/_continue.html.haml
+++ b/app/views/external_users/claims/buttons/_continue.html.haml
@@ -3,5 +3,4 @@
     - commit = claim.next_step? ? 'commit_continue' : 'commit_submit_claim'
     = f.submit t('buttons.continue'), name: commit, class: 'button left btn-spacer-20'
 
-    - if claim.can_be_saved_as_draft?
-      = f.submit t('buttons.save_a_draft'), name: 'commit_save_draft', class: 'button-gray-3 left'
+    = f.submit t('buttons.save_a_draft'), name: 'commit_save_draft', class: 'button-gray-3 left'

--- a/config/initializers/01_autosave_association_patch.rb
+++ b/config/initializers/01_autosave_association_patch.rb
@@ -1,0 +1,38 @@
+# NOTE: This is a MAJOR shoehorn patch to get around the convoluted way the validations in this application work.
+# Its main intent is to solve the problem of having validations for a claim per step/stage and because of the fact
+# that Rails autosaves and validates associations that have been defined as with 'accept_nested_attributes_for'.
+# What that causes is that for a given step/stage that does not require a given association to be validated, as long as
+# the association itself exists, Rails will automatically save and validate it which is not the expected behaviour here.
+#
+# The initial approach was to define the association with the option validate: Proc.new { |claim| claim.condition_to_validate? }
+# Unfortunately, the association definition support Procs or lambdas but does not evaluate them, just checks if the value is not false.
+#
+# The next approach was to define the association with the option validate: false and have an explicity validation for the association
+# conditional to the step/stage it belongs:
+#
+# validates_associated :association_name, if: Proc.new { |claim| claim.condition_to_validate? }
+#
+# This approach works as intended with a caveat: the errors produced are not attached to the parent object anymore (as they were with the
+# default autosave/validaton set in the association definition)
+#
+# So, that gets us here, patching the autosave association to check if the validate option is a proc, and if so evaluated it to determine
+# if the associated records needs to be validated or not.
+#
+# WARNING: This patch will likely cause any further Rails updates/upgrades to break, so do keep that in mind!!!
+#
+# This should probably be re-thinked going forward, so a cleaner/less disruptive solution is choosen instead.
+# This is not a recommended approach to take!!!, but rather a last resort approach to get around a very unsual behaviour (saving invalid records into the database).
+
+module ActiveRecord
+  module AutosaveAssociation
+    private
+      alias old_association_valid? association_valid?
+
+      def association_valid?(reflection, record, index=nil)
+        if reflection.options[:validate].is_a?(Proc)
+          return true unless reflection.options[:validate].call(self)
+        end
+        old_association_valid?(reflection, record, index)
+      end
+  end
+end

--- a/features/step_definitions/authorise_claim_steps.rb
+++ b/features/step_definitions/authorise_claim_steps.rb
@@ -1,5 +1,12 @@
 Given(/^there is a claim allocated to the case worker with case number '(.*?)'$/) do |case_number|
-  @claim = create(:allocated_claim, external_user: @advocate, case_number: case_number)
+  # TODO: this does not create a valid submitted claim
+  # creates some sort of claim with some information that happens
+  # to be in the submitted state
+  # To go around this I'm preserving old functionality for the factory by
+  # setting the form_step.
+  # Going forward this should be properly fixed with an actual factory that is valid
+  # for a submitted claim
+  @claim = create(:allocated_claim, external_user: @advocate, case_number: case_number, form_step: :case_details)
   @case_worker.claims << @claim
 end
 

--- a/features/step_definitions/claim_allocation_steps.rb
+++ b/features/step_definitions/claim_allocation_steps.rb
@@ -66,7 +66,14 @@ Given(/^submitted claims? exists? with case numbers? "(.*?)$/) do |case_numbers|
   @claims = []
 
   case_numbers.each do |case_number|
-    @claims << create(:submitted_claim, case_number: case_number)
+    # TODO: this does not create a valid submitted claim
+    # creates some sort of claim with some information that happens
+    # to be in the submitted state
+    # To go around this I'm preserving old functionality for the factory by
+    # setting the form_step.
+    # Going forward this should be properly fixed with an actual factory that is valid
+    # for a submitted claim
+    @claims << create(:submitted_claim, case_number: case_number, form_step: :case_details)
   end
 end
 

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -315,12 +315,12 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
               create :fixed_fee_type, unique_code: 'ZXY'
               ct = create :case_type, :fixed_fee,  fee_type_code: 'ZXY'
               claim_params['case_type_id'] = ct.id
-              response = post :create, params: { claim: claim_params }
+              post :create, params: { claim: claim_params }
               claim = assigns(:claim)
 
               # basic fees are cleared, but not destroyed, implicitly for fixed-fee case types
               expect(claim.basic_fees.size).to eq 4
-              expect(claim.basic_fees.map(&:amount).sum.to_f).to eql 0.00
+              expect(claim.basic_fees.map(&:amount).compact.sum.to_f).to eql 0.00
 
               # miscellaneous fees are NOT destroyed implicitly by claim model for fixed-fee case types
               expect(claim.misc_fees.size).to eq 1

--- a/spec/controllers/external_users/advocates/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/interim_claims_controller_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
   let(:unauthorized_user) { create(:external_user, :litigator) }
   let(:authorized_user) { create(:external_user, :advocate) }
 
+  def create_claim(*args)
+    claim = build(*args)
+    claim.save
+    claim.reload
+  end
+
   describe "GET #new" do
     subject(:new_request) { get :new }
 
@@ -255,7 +261,7 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
 
         context 'but the user is not the creator of the claim' do
           let(:other_authorized_user) { create(:external_user, :advocate) }
-          let(:claim) { create(:advocate_interim_claim, external_user: other_authorized_user, creator: other_authorized_user) }
+          let(:claim) { create_claim(:advocate_interim_claim, external_user: other_authorized_user, creator: other_authorized_user) }
 
           it 'redirects the user to its home page with an unauthorised error' do
             edit_request
@@ -266,7 +272,9 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
         end
 
         context 'but the claim is not longer editable' do
-          let(:claim) { create(:advocate_interim_claim, :submitted, external_user: authorized_user, creator: authorized_user) }
+          # TODO: there seems to be problems with the factories which previously allowed claims to be in submitted state without the
+          # necessary valid information. Needs looking at!
+          let!(:claim) { create_claim(:advocate_interim_claim, :submitted, external_user: authorized_user, creator: authorized_user).tap { |c| c.submit! } }
 
           it 'redirects the user to its home page with an unauthorised error' do
             edit_request
@@ -363,7 +371,9 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
         end
 
         context 'but the claim is not longer editable' do
-          let!(:claim) { create(:advocate_interim_claim, :submitted, external_user: authorized_user, creator: authorized_user) }
+          # TODO: there seems to be problems with the factories which previously allowed claims to be in submitted state without the
+          # necessary valid information. Needs looking at!
+          let!(:claim) { create_claim(:advocate_interim_claim, :submitted, external_user: authorized_user, creator: authorized_user).tap { |c| c.submit! } }
 
           it 'redirects the user to its home page with an unauthorised error' do
             update_request

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
     end
 
     context 'uneditable claim' do
-      let(:claim) { create(:interim_claim, :allocated, creator: litigator) }
+      let(:claim) { create(:interim_claim, :allocated, :interim_effective_pcmh_fee, creator: litigator) }
 
       it 'redirects to the claims index' do
         expect(response).to redirect_to(external_users_claims_path)

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -66,7 +66,3 @@ FactoryBot.define do
     end
   end
 end
-
-
-
-

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -37,6 +37,12 @@ FactoryBot.define do
       roles %w[agfs agfs_scheme_9 agfs_scheme_10]
     end
 
+    trait :baf do
+      description 'Basic Fee'
+      code 'BAF'
+      unique_code 'BABAF'
+    end
+
     trait :dat do
       description 'Daily Attendance Fee (2+)'
       agfs_scheme_10
@@ -44,11 +50,35 @@ FactoryBot.define do
       unique_code 'BADAT'
     end
 
+    trait :daf do
+      description 'Daily Attendance Fee (3 to 40)'
+      code 'DAF'
+      unique_code 'BADAF'
+    end
+
+    trait :dah do
+      description 'Daily Attendance Fee (41 to 50)'
+      code 'DAH'
+      unique_code 'BADAH'
+    end
+
+    trait :daj do
+      description 'Daily Attendance Fee (50+)'
+      code 'DAJ'
+      unique_code 'BADAJ'
+    end
+
     trait :ppe do
       description 'Pages of prosecution evidence'
       code 'PPE'
       calculated false
       unique_code 'BAPPE'
+    end
+
+    trait :pcm do
+      description 'Plea and Case Management Hearing'
+      code 'PCM'
+      unique_code 'BAPCM'
     end
 
     trait :npw do
@@ -65,8 +95,8 @@ FactoryBot.define do
     end
 
     trait :ndr do
-      description 'Number of cases uplift'
-      code 'NOC'
+      description 'Number of defendants uplift'
+      code 'NDR'
       unique_code 'BANDR'
     end
 

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -41,15 +41,19 @@ FactoryBot.define do
     end
 
     trait :fxndr_fee do
-      fee_type { build(:fixed_fee_type, :fxndr) }
+      fee_type { Fee::FixedFeeType.find_by(unique_code: 'FXNDR') || build(:fixed_fee_type, :fxndr) }
     end
 
     trait :fxcbr_fee do
-      fee_type { build :fixed_fee_type, :fxcbr }
+      fee_type { Fee::FixedFeeType.find_by(unique_code: 'FXCBR') || build(:fixed_fee_type, :fxcbr) }
     end
 
     trait :fxcbu_fee do
-      fee_type { build :fixed_fee_type, :fxcbu }
+      fee_type { Fee::FixedFeeType.find_by(unique_code: 'FXCBU') || build(:fixed_fee_type, :fxcbu) }
+    end
+
+    trait :fxacv_fee do
+      fee_type { Fee::FixedFeeType.find_by(unique_code: 'FXACV') || build(:fixed_fee_type, :fxacv) }
     end
   end
 
@@ -73,6 +77,10 @@ FactoryBot.define do
     trait :mispf_fee do
       fee_type { build :misc_fee_type, :mispf }
     end
+
+    trait :miaph_fee do
+      fee_type { Fee::FixedFeeType.find_by(unique_code: 'MIAPH') || build(:misc_fee_type, :miaph) }
+    end
   end
 
   factory :warrant_fee, class: Fee::WarrantFee do
@@ -83,6 +91,10 @@ FactoryBot.define do
 
     trait :warrant_executed do
       warrant_exectuted_date { warrant_issued_date + 5.days }
+    end
+
+    trait :warr_fee do
+      fee_type { Fee::WarrantFeeType.find_by(unique_code: 'WARR') || build(:warrant_fee_type, :warr) }
     end
 
     after(:build) do |fee|
@@ -140,47 +152,47 @@ FactoryBot.define do
     rate 25
 
     trait :baf_fee do
-      fee_type { build :basic_fee_type, description: 'Basic Fee', code: 'BAF', unique_code: 'BABAF' }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BABAF') || build(:basic_fee_type, :baf) }
     end
 
     trait :daf_fee do
-      fee_type {build  :basic_fee_type, description: 'Daily Attendance Fee (3 to 40)', code: 'DAF', unique_code: 'BADAF' }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BADAF') || build(:basic_fee_type, :daf) }
     end
 
     trait :dah_fee do
-      fee_type { build :basic_fee_type, description: 'Daily Attendance Fee (41 to 50)', code: 'DAH', unique_code: 'BADAH' }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BADAH') || build(:basic_fee_type, :dah) }
     end
 
     trait :daj_fee do
-      fee_type { build :basic_fee_type, description: 'Daily Attendance Fee (50+)', code: 'DAJ', unique_code: 'BADAJ' }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BADAJ') || build(:basic_fee_type, :daj) }
     end
 
     trait :dat_fee do
-      fee_type { build(:basic_fee_type, :dat) }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BADAT') || build(:basic_fee_type, :dat) }
     end
 
     trait :pcm_fee do
-      fee_type { build :basic_fee_type, description: 'Plea and Case Management Hearing', code: 'PCM' }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BAPCM') || build(:basic_fee_type, :pcm) }
     end
 
     trait :ppe_fee do
       rate 0
       amount 25
-      fee_type { build :basic_fee_type, description: 'Pages of prosecution evidence', code: 'PPE', unique_code: 'BAPPE', calculated: false }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BAPPE') || build(:basic_fee_type, :ppe) }
     end
 
     trait :ndr_fee do
-      fee_type { build :basic_fee_type, description: 'Number of defendants uplift', code: 'NDR', unique_code: 'BANDR', calculated: true }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BANDR') || build(:basic_fee_type, :ndr) }
     end
 
     trait :noc_fee do
-      fee_type { build :basic_fee_type, description: 'Number of cases uplift', code: 'NOC', unique_code: 'BANOC', calculated: true }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BANOC') || build(:basic_fee_type, :noc) }
     end
 
     trait :npw_fee do
       rate 0
       amount 25
-      fee_type { build :basic_fee_type, description: 'Number of prosecution witnesses', code: 'NPW', unique_code: 'BANPW', calculated: false }
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BANPW') || build(:basic_fee_type, :npw) }
     end
 
     trait :saf_fee do

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -355,6 +355,7 @@ RSpec.describe Claim::BaseClaim do
     context 'when condition 3B is met' do
       before do
         allow(claim).to receive(:fixed_fee_case?).and_return(false)
+        claim.form_step = step
       end
 
       it 'does not change the current step' do
@@ -374,7 +375,7 @@ RSpec.describe Claim::BaseClaim do
   end
 
   describe '#next_step!' do
-    let(:claim) { MockSteppableClaim.new }
+    let(:claim) { MockSteppableClaim.new(form_step: :step_1) }
 
     context 'when condition 3A is met' do
       before do

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
 
     describe 'on create' do
       describe 'the claim is invalid' do
-        let(:claim) { build :litigator_claim, :fixed_fee, :forced_validation }
+        let(:claim) { build(:litigator_claim, :fixed_fee, :forced_validation, fixed_fee: build(:fixed_fee, :lgfs)) }
 
         it { is_expected.to be false }
       end
@@ -164,7 +164,7 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
 
     describe 'on edit' do
       describe 'the claim is valid' do
-        let(:claim) { create :litigator_claim, :fixed_fee, :forced_validation }
+        let(:claim) { create(:litigator_claim, :fixed_fee, :forced_validation, fixed_fee: build(:fixed_fee, :lgfs)) }
 
         it { is_expected.to be true }
       end

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe ClaimStateTransitionReason, type: :model do
     let(:all_reasons) { (reasons + disbursement_only_reasons) }
 
     context 'for an advocate claim' do
-      let(:claim) { create(:advocate_claim, state: 'rejected') }
+      let(:basic_fee) { build(:basic_fee, :baf_fee, quantity: 1, amount: 21.01) }
+      let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee], state: 'refused') }
 
       it 'returns base rejection reasons' do
         expect(reject_reasons_for.map(&:code)).to match_array(reasons)
@@ -78,7 +79,7 @@ RSpec.describe ClaimStateTransitionReason, type: :model do
     end
 
     context 'when the claim has no fees' do
-      let(:claim) { create(:advocate_claim, :without_fees, state: 'rejected') }
+      let(:claim) { build(:advocate_claim, :without_fees, state: 'rejected') }
 
       it 'returns base rejection reasons' do
         expect(reject_reasons_for.map(&:code)).to match_array(reasons)
@@ -89,20 +90,27 @@ RSpec.describe ClaimStateTransitionReason, type: :model do
   describe '.refuse_reasons_for' do
     subject(:refuse_reasons_for) { described_class.refuse_reasons_for(claim) }
 
-    context 'for a Litigator claim' do
-      let(:claim) { create(:transfer_claim, state: 'refused') }
+    context 'for a litigator final claim' do
+      let(:claim) { create(:litigator_claim, :fixed_fee, fixed_fee: build(:fixed_fee, :lgfs), state: 'refused') }
 
       it { expect(subject.count).to eq 2 }
     end
 
-    context 'for a Litigator interim claim' do
-      let(:claim) { create(:interim_claim, state: 'refused') }
+    context 'for a litigator transfer claim' do
+      let(:claim) { create(:transfer_claim, transfer_fee: build(:transfer_fee), state: 'refused') }
+
+      it { expect(subject.count).to eq 2 }
+    end
+
+    context 'for a litigator interim claim' do
+      let(:claim) { create(:interim_claim, interim_fee: build(:interim_fee), state: 'refused') }
 
       it { expect(subject.count).to eq 5 }
     end
 
-    context 'for an advocate claim' do
-      let(:claim) { create(:advocate_claim, state: 'refused') }
+    context 'for an advocate final claim' do
+      let(:basic_fee) { build(:basic_fee, :baf_fee, quantity: 1, amount: 21.01) }
+      let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee], state: 'refused') }
 
       it { expect(subject.count).to eq 3 }
     end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Claims::StateMachine, type: :model do
     end
 
     describe 'when supplier number has been invalidated' do
-      let(:claim) { create :litigator_claim, :fixed_fee, force_validation: true }
+      let(:claim) { create(:litigator_claim, :fixed_fee, force_validation: true, fixed_fee: build(:fixed_fee, :lgfs)) }
 
       before { SupplierNumber.find_by(supplier_number: claim.supplier_number).delete }
 
@@ -376,7 +376,7 @@ RSpec.describe Claims::StateMachine, type: :model do
 
   describe 'before submit state transition' do
     it 'sets the allocation_type for trasfer_claims' do
-      claim = build :transfer_claim
+      claim = build(:transfer_claim, transfer_fee: build(:transfer_fee))
       expect(claim.allocation_type).to be nil
       claim.submit!
       expect(claim.allocation_type).to eq 'Grad'

--- a/spec/models/fee/base_fee_spec.rb
+++ b/spec/models/fee/base_fee_spec.rb
@@ -172,9 +172,9 @@ module Fee
 
     describe '#calculate_amount' do
       context 'agfs claims' do
-        let(:claim) { build :advocate_claim }
-        let(:misc_fee_type) { build :misc_fee_type }
-        let(:fee) { build :misc_fee, fee_type: misc_fee_type, quantity: 10, rate: 11, amount: 255, claim: claim }
+        let(:claim) { build(:advocate_claim, misc_fees: [fee]) }
+        let(:misc_fee_type) { build(:misc_fee_type) }
+        let(:fee) { build(:misc_fee, fee_type: misc_fee_type, quantity: 10, rate: 11, amount: 255) }
 
         it 'should recalculate amount if fee type is calculated' do
             fee.claim.force_validation = true

--- a/spec/services/ccr/daily_attendance_adapter_spec.rb
+++ b/spec/services/ccr/daily_attendance_adapter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
     end
 
     context 'scheme 10 claim' do
-      let(:claim) { create(:authorised_claim, :agfs_scheme_10) }
+      let(:claim) { create(:authorised_claim, :agfs_scheme_10, form_step: :case_details) }
       attendances_incl_in_basic_fee = 1
 
       context 'for trials' do

--- a/spec/services/claims/create_draft_spec.rb
+++ b/spec/services/claims/create_draft_spec.rb
@@ -7,7 +7,9 @@ describe Claims::CreateDraft do
   end
 
   context 'draft claim creation' do
-    let(:claim) { FactoryBot.build :advocate_claim }
+    # NOTE: a form_step needs to be supplied otherwise the service
+    # will validate all the steps for the claim
+    let(:claim) { build(:advocate_claim, form_step: :case_details) }
     let(:validate) { true }
 
     subject { described_class.new(claim, validate: validate) }

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
   include_context "force-validation"
 
   let(:litigator) { build(:external_user, :litigator) }
-  let(:claim)     { create(:interim_claim) }
+  let(:interim_fee) { build(:interim_fee) }
+  let(:claim) { create(:interim_claim, interim_fee: interim_fee) }
 
   include_examples "common advocate litigator validations", :litigator
-  include_examples "common litigator validations"
+  include_examples "common litigator validations", :interim_claim
 
   include_examples 'common partial validations', {
     case_details: %i[

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -123,8 +123,7 @@ RSpec.shared_examples "common advocate litigator validations" do |external_user_
   end
 end
 
-RSpec.shared_examples "common litigator validations" do
-
+RSpec.shared_examples "common litigator validations" do |*flags|
   let(:advocate)      { build(:external_user, :advocate) }
   let(:offence)       { build(:offence) }
   let(:offence_class) { build(:offence_class, class_letter: 'X', description: 'Offences of dishonesty in Class F where the value in is in excess of £100,000') }
@@ -155,8 +154,12 @@ RSpec.shared_examples "common litigator validations" do
   end
 
   context 'case concluded at date' do
-    let(:claim) { build :litigator_claim }
-    before(:each) { claim.force_validation = true }
+    before do
+      # TODO: refactor shared examples so that things that do not apply to all litigator claims
+      # are not set as common/shared examples :/
+      skip('does not apply to an interim claim') if flags.include?(:interim_claim)
+      claim.force_validation = true
+    end
 
     it 'is invalid when absent' do
       should_error_if_not_present(claim,:case_concluded_at,'blank')

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
       claim.force_validation = true
     end
 
-    let(:claim) { Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id:30, case_conclusion_id: 10) }
+    let(:claim) { build(:transfer_claim, litigator_type: 'new', elected_case: false, transfer_stage_id: 30, case_conclusion_id: 10) }
 
     it 'is valid if a valid case conclusion id' do
       expect_valid_attribute claim, :case_conclusion_id, 20
@@ -163,7 +163,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
     end
 
     context 'presence and absence' do
-      let(:claim) { Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10) }
+      let(:claim) { build(:transfer_claim, litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10) }
 
       it 'should error if absent but required' do
         claim.transfer_stage_id = 30
@@ -182,7 +182,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
       claim.force_validation = true
     end
 
-    let(:claim) { Claim::TransferClaim.new(litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10) }
+    let(:claim) { build(:transfer_claim, litigator_type: 'new', elected_case: false, transfer_stage_id: 50, case_conclusion_id: 10) }
 
     it 'adds a transfer detail combination error for invalid combinations' do
       expect(claim).not_to be_valid

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -89,15 +89,6 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       end
     end
 
-    # TODO: to be removed after gamma/private beta claims archived/deleted
-    # context 'for fees entered before rate was reintroduced' do
-    #   it 'should NOT require a rate of more than zero' do
-    #     fee.amount = 255
-    #     fee.rate = nil
-    #     expect(fee).to be_valid
-    #   end
-    # end
-
     context 'for fees on agfs draft claims' do
       it 'should validate presence of rate' do
         fee.amount = nil
@@ -112,6 +103,11 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
     # NOTE: this enables fees that were created and submitted prior to rate being re-introduced to be valid
     context 'for fees on agfs submitted claims' do
       it 'should NOT validate presence of rate' do
+        # TODO: there's some issues the factories related with the validity of its data
+        # historically all claims were by default set with a form_step which is no longer
+        # the case. Without it set, the claim as a whole is validated and other attributes
+        # that are not set in the factories cause validation errors. Needs revisiting!
+        fee.claim.form_step = :case_details
         fee.amount = 255
         fee.claim.submit!
         fee.rate = nil


### PR DESCRIPTION
#### What

For more details please read NOTE in [config/initializers/01_autosave_association_patch.rb](./config/initializers/01_autosave_association_patch.rb)

Claim associations are autovalidated by default as long as they're defined. With this change, they're only validated if they're required for a specific step/stage or if they're being submitted through the API.

#### Ticket

[Check your claim page fixes](https://dsdmoj.atlassian.net/browse/CBO-137)

#### Why

Rails models that accept nested attributes for some of its associations [autosave and validate those associations by default](http://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html).

What this means in effect is that, even though the application has its own stage/step validation setup for the claims model, as long as an association was previously set in another stage, when submitting data for another stage, that association will still be autosaved and validated. (This is noted more so when one of the stages is submitted as a **draft** with invalid data for one of the associations and other stage is then submitted with valid data but fails due to the previously submitted association being invalid, even though we're not at the step of validating that association).

#### How

- The claim model no longer has a default `form_step`, as that information is specifically related with the claim submission process only, and the `form_step` is now set only during that flow.
- Autosave associations in Rails was _patched_ to evaluate the value set for `validate: <value>` as by default it just checks if is _true_ or not. This way it allows us to control when these associations are actually validated, letting the validations classes behave as expected during the submission flow and only validate the data related with that particular _stage_. (**NOTE:** Obviously this patching will **potentially** have an impact on any future Rails updates)

Also, worth of note:

- Some of the fee factories, now detect if the associated **fee type** already exists instead of creating a brand new one. This was done mainly to avoid flakey tests and unexpected behaviours and should also helps making use of the seed data more reliably going forward.
- There's a known [issue](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/issues/2382) with the factories definition that needs to be addressed. The resolution is **not** part of this PR as this would take quite a lot of refactoring. In this PR, the previous behaviour (which was to create a claim with a default _form_step_ was kept). 