### PR TITLE
Zero cost redeterminations

### DIFF
--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -235,7 +235,12 @@ module Claims
     end
 
     def set_amount_assessed_zero!
+      return if has_been_previously_assessed?
       assessment.zeroize! if state == 'allocated'
+    end
+
+    def has_been_previously_assessed?
+      claim_state_transitions.map(&:to).any? { |state| %w[authorised part_authorised].include?(state) }
     end
 
     def remove_case_workers!

--- a/features/refuse_claim.feature
+++ b/features/refuse_claim.feature
@@ -23,3 +23,26 @@ Feature: Case worker rejects a claim, providing a reason
     Then the claim I've just updated is no longer in the list
 
     And I eject the VCR cassette
+
+  Scenario: I refuse a claim after a redetermination request providing a reason
+
+    Given a "case worker" user account exists
+    And an "advocate" user account exists
+    And there is a redetermination claim allocated to the case worker with case number 'A20161234'
+
+    And I insert the VCR cassette 'features/case_workers/claims/reject'
+
+    When I am signed in as the case worker
+    And I select the claim
+    And I click the refused radio button
+    And I select the first refusal reason
+    And I click update
+    Then the status at top of page should be Refused
+    Then the messages should not contain 'Total (inc VAT): £0.00'
+    Then the third message contains 'Claim refused'
+    Then the last message contains 'Your claim has been refused'
+
+    When I click your claims
+    Then the claim I've just updated is no longer in the list
+
+    And I eject the VCR cassette

--- a/features/step_definitions/authorise_claim_steps.rb
+++ b/features/step_definitions/authorise_claim_steps.rb
@@ -11,7 +11,14 @@ Given(/^there is a claim allocated to the case worker with case number '(.*?)'$/
 end
 
 Given(/^there is a redetermination claim allocated to the case worker with case number '(.*?)'$/) do |case_number|
-  @claim = create(:redetermination_claim, external_user: @advocate, case_number: case_number)
+  # TODO: this does not create a valid redetermination claim
+  # creates some sort of claim with some information that happens
+  # to be in the redetermination state
+  # To go around this I'm preserving old functionality for the factory by
+  # setting the form_step.
+  # Going forward this should be properly fixed with an actual factory that is valid
+  # for a redetermination claim
+  @claim = create(:redetermination_claim, external_user: @advocate, case_number: case_number, form_step: :case_details)
   @case_worker.claims << @claim
 end
 

--- a/features/step_definitions/authorise_claim_steps.rb
+++ b/features/step_definitions/authorise_claim_steps.rb
@@ -10,6 +10,11 @@ Given(/^there is a claim allocated to the case worker with case number '(.*?)'$/
   @case_worker.claims << @claim
 end
 
+Given(/^there is a redetermination claim allocated to the case worker with case number '(.*?)'$/) do |case_number|
+  @claim = create(:redetermination_claim, external_user: @advocate, case_number: case_number)
+  @case_worker.claims << @claim
+end
+
 When(/^I select the claim$/) do
   @case_worker_home_page.claim_for(@claim.case_number).case_number.click
 end

--- a/features/step_definitions/messaging_steps.rb
+++ b/features/step_definitions/messaging_steps.rb
@@ -25,6 +25,10 @@ Then(/^the (last|first|second|third|fourth|fifth) message contains '(.*?)'$/) do
   expect(@external_user_claim_show_page.messages_panel.messages.send(method.to_sym)).to have_text(text)
 end
 
+Then(/^the messages should not contain '(.*?)'$/) do |text|
+  expect(@external_user_claim_show_page.messages_panel.messages.map(&:text).join).to_not have_text(text)
+end
+
 When(/^I enter a message '(.*?)'$/) do |text|
   @message = text
   @external_user_claim_show_page.messages_panel.enter_your_message.set @message

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -425,15 +425,16 @@ RSpec.describe Claims::StateMachine, type: :model do
       before do
         claim.submit!
         claim.allocate!
-        claim.assessment.update(fees: 666.00, expenses: 23.45)
+        claim.assessment.update(fees: 123.00, expenses: 23.45)
         claim.authorise_part!
         claim.redetermine!
         claim.allocate!
-        claim.refuse!(reason_code: reason_codes)
       end
 
       it 'does not set the assessment to zero' do
-        expect(claim.assessment.total).to be_positive
+        expect { claim.refuse!(reason_code: reason_codes) }
+          .not_to change { claim.assessment.fees.to_f }
+          .from(123.0)
       end
     end
   end


### PR DESCRIPTION
#### What
I want to be able to see the previously authorised amount on a claim, if my claim then goes on to be refused at the redetermination stage
#### Ticket
[Add feature test for non-display of empty refusal assessment](https://dsdmoj.atlassian.net/browse/CBO-27)
#### Why
So that I can still see what I am paid.
#### How
Added feature and unit tests for updating the StateMachine so that it doesn't `zeroise` assessment values when refusing a claim after an assessment has previously been made