### PR TITLE
Quantity for a fee needs to be greater or equal than 1

### DIFF
--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -83,7 +83,7 @@ module Fee
 
     def validate_any_quantity
       validate_integer_decimal
-      add_error(:quantity, 'invalid') if @record.quantity.negative? || @record.quantity > 99_999
+      add_error(:quantity, 'invalid') unless @record.quantity&.positive? && @record.quantity <= 99_999
     end
 
     def validate_integer_decimal

--- a/app/validators/fee/basic_fee_validator.rb
+++ b/app/validators/fee/basic_fee_validator.rb
@@ -10,5 +10,19 @@ module Fee
         case_numbers
       ] + super
     end
+
+    private
+
+    # TODO: There's no real reason for this validation to accept 0 quantities.
+    # Still, given that the basic fees are being pre-set whenever a claim is initializing
+    # (rather than create them whenever they're actually needed) those pre-sets would not be
+    # valid if the quantity validation checked for greater or equal than 1 (which should be the right
+    # validation to perform on any fee created).
+    # Until we address that pre-initialization of the basic fees, this preserves the existent validation
+    # for basic fees
+    def validate_any_quantity
+      validate_integer_decimal
+      add_error(:quantity, 'invalid') if @record.quantity.negative? || @record.quantity > 99_999
+    end
   end
 end

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -45,15 +45,8 @@ shared_examples 'common amount validations' do
   end
 end
 
-shared_examples 'common AGFS number of cases uplift validations' do
+RSpec.shared_examples 'common AGFS number of cases uplift validations' do
   context 'case numbers list valid' do
-    it 'when case_numbers is blank and quantity is zero' do
-      noc_fee.quantity = 0
-      noc_fee.rate = 0
-      noc_fee.case_numbers = ''
-      should_not_error(noc_fee, :case_numbers)
-    end
-
     context 'when submitted by API' do
       before do
         noc_fee.claim.source = 'api'

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -149,18 +149,6 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         end
       end
     end
-
-    # TODO: max_amount not used in later PR - remove?
-    # context 'fee with max amount' do
-    #   before(:each)       { fee.fee_type.max_amount = 9999 }
-    #   it { should_be_valid_if_equal_to_value(fee, :amount, 9999) }
-    # end
-
-    # context 'fee with no max amount' do
-    #   before(:each)       { fee.fee_type.max_amount = nil }
-    #   it { should_be_valid_if_equal_to_value(fee, :amount, 100_000) }
-    # end
-
   end
 
   describe '#validate_quantity' do
@@ -400,13 +388,27 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
 
       context 'number of cases uplift (BANOC)' do
         let(:noc_fee) { build :basic_fee, :noc_fee, claim: claim }
+
+        context 'when case numbers are blank and quantity is zero' do
+          let(:noc_fee) { build(:basic_fee, :noc_fee, claim: claim, case_numbers: '', quantity: 0, rate: 0) }
+
+          it { should_not_error(noc_fee, :case_numbers) }
+        end
+
         include_examples 'common AGFS number of cases uplift validations'
       end
     end
 
-    context 'Fixed fee types' do
+    context 'fixed fee types' do
       context 'number of cases uplift (FXNOC)' do
         let(:noc_fee) { build :fixed_fee, :noc_fee, claim: claim }
+
+        context 'when case numbers are blank and quantity is zero' do
+          let(:noc_fee) { build(:fixed_fee, :noc_fee, claim: claim, case_numbers: '', quantity: 0) }
+
+          it { should_error_with(noc_fee, :quantity, 'invalid') }
+        end
+
         include_examples 'common AGFS number of cases uplift validations'
       end
     end

--- a/spec/validators/fee/fixed_fee_validator_spec.rb
+++ b/spec/validators/fee/fixed_fee_validator_spec.rb
@@ -86,7 +86,11 @@ RSpec.describe Fee::FixedFeeValidator, type: :validator do
       let!(:unrelated_child) { create :child_fee_type, :s74 }
       let!(:fee) { build :fixed_fee, :lgfs, fee_type: parent, sub_type: child, claim: fixed_fee_claim, date: nil }
 
-      before(:each) { fee.claim.force_validation = true }
+      before do
+        fee.claim.force_validation = true
+        fee.quantity = 1
+        fee.rate = 2.0
+      end
 
       context 'should error if fee type has children but fee has no sub type' do
         it 'should be present' do


### PR DESCRIPTION
#### What

Validations for fee quantities were allowing `0` to be a valid quantity. If the fee exists and is being submitted there's not real reason for the quantity to be `0` (exception are the basic fees which you can find the reason why attached to its own validation changes).

#### Ticket

[Able to create a misc fee without quantity/amount](https://dsdmoj.atlassian.net/browse/CBO-21)
