### PR TITLE
HOTFIX: Already submitted claim check should be done on the claim itself

### DIFF
--- a/app/services/claims/claim_actions_service.rb
+++ b/app/services/claims/claim_actions_service.rb
@@ -53,7 +53,7 @@ module Claims
     end
 
     def already_submitted?
-      claim.class.where(form_id: claim.form_id).where.not(last_submitted_at: nil).any?
+      claim.last_submitted_at.present?
     end
 
     def already_saved?


### PR DESCRIPTION
Was previously checking for other claims with the same form_id that have not been submitted. It happens production data has quite a lot of claims (mainly API submissions and JSON imports) that do not have a form_id set and have been submitted already, so was causing currently in progress claims from being submitted if they didn't have a form_id set.