### PR TITLE
Disable NewRelic monitor for non-prod environments

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -38,3 +38,4 @@ test:
 production:
   <<: *default_settings
   app_name: <%= "CCCD (#{ENV['ENV']})" %>
+  monitor_mode: <%= ENV['ENV'] == 'gamma' %>


### PR DESCRIPTION
Now that production officially started reporting to NewRelic the non-prod environments are not required to report anymore (were mainly for testing reasons) and it does help keep prices cost to a low.