### PR TITLE
Add missing index for defendant_id foreign key on rep orders

### DIFF
--- a/db/migrate/20180531110653_add_defendant_id_index_to_representation_orders.rb
+++ b/db/migrate/20180531110653_add_defendant_id_index_to_representation_orders.rb
@@ -1,0 +1,5 @@
+class AddDefendantIdIndexToRepresentationOrders < ActiveRecord::Migration[5.0]
+  def change
+    add_index :representation_orders, :defendant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180515140528) do
+ActiveRecord::Schema.define(version: 20180531110653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -453,6 +453,7 @@ ActiveRecord::Schema.define(version: 20180515140528) do
     t.string   "maat_reference"
     t.date     "representation_order_date"
     t.uuid     "uuid",                      default: -> { "uuid_generate_v4()" }
+    t.index ["defendant_id"], name: "index_representation_orders_on_defendant_id", using: :btree
   end
 
   create_table "statistics", force: :cascade do |t|


### PR DESCRIPTION
#### Why

Has been noticed that there's tables with missing indexes on foreign keys or columns that are heavily used for querying/filtering data.

This index should help reduce the amount of sequence scans when using the representation orders table to perform joins with other tables.

**Example of query for the archived claims:**

![screen shot 2018-05-31 at 12 17 32](https://user-images.githubusercontent.com/67125/40779375-ae1e488e-64cc-11e8-9741-97fbd908968a.png)
