### PR TITLE
Add test profiler for factory bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,7 @@ group :test do
   gem 'vcr'
   gem 'webmock'
   gem 'hashdiff'
+  gem 'test-prof'
 end
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,6 +605,7 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
+    test-prof (0.5.0)
     thor (0.20.0)
     thread (0.2.2)
     thread_safe (0.3.6)
@@ -762,6 +763,7 @@ DEPENDENCIES
   state_machines-activerecord
   state_machines-audit_trail
   susy (~> 2.2.14)
+  test-prof
   timecop
   uglifier (>= 1.3.0)
   unicorn-rails (= 2.2.0)


### PR DESCRIPTION
#### What
See [test-prof blog](https://evilmartians.com/chronicles/testprof-2-factory-therapy-for-your-ruby-tests-rspec-minitest). 

#### Why
Factory bot cascading causing a lot of slow tests. This helps identify worst offenders for refactoring

```
# test suite timings
$ EVENT_PROF="factory.create" bundle exec rspec

# factory stats
$ FPROF=1 bundle exec rspec

# interactive graph of factory cascades 
$ FPROF=flamegraph bundle exec rspec
```