### PR TITLE
Add validations to representation order date

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -101,7 +101,7 @@ module Claim
     belongs_to :case_type
 
     delegate :provider_id, :provider, to: :creator
-    delegate :requires_trial_dates?, :requires_retrial_dates?, to: :case_type
+    delegate :requires_trial_dates?, :requires_retrial_dates?, to: :case_type, allow_nil: true
 
     has_many :case_worker_claims, foreign_key: :claim_id, dependent: :destroy
     has_many :case_workers, through: :case_worker_claims
@@ -564,6 +564,14 @@ module Claim
         end
       end
       provider_delegator.vat_registered?
+    end
+
+    def trial_length
+      if requires_retrial_dates?
+        retrial_actual_length
+      elsif requires_trial_dates?
+        actual_trial_length
+      end
     end
 
     def allows_graduated_fees?

--- a/app/services/ccr/daily_attendance_adapter.rb
+++ b/app/services/ccr/daily_attendance_adapter.rb
@@ -51,7 +51,7 @@ module CCR
     end
 
     def trial_length
-      claim&.case_type&.requires_retrial_dates? ? claim&.retrial_actual_length : claim&.actual_trial_length
+      claim&.trial_length
     end
 
     def eligible_fee_type_unique_codes

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -215,11 +215,11 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def validate_trial_dates
-    return unless @record.case_type&.requires_trial_dates?
+    return unless @record&.requires_trial_dates?
     validate_trial_start_and_end(:first_day_of_trial, :trial_concluded_at, false)
     validate_trial_start_and_end(:first_day_of_trial, :trial_concluded_at, true)
 
-    return if @record.case_type&.requires_retrial_dates?
+    return if @record&.requires_retrial_dates?
     error_code = 'check_not_earlier_than_rep_order'
     validate_on_or_after(earliest_rep_order, :first_day_of_trial, error_code)
     return if @record.errors[:first_day_of_trial]&.include?(error_code)
@@ -332,7 +332,7 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def validate_retrial_start_and_end(start_attribute, end_attribute, inverse = false)
-    return unless @record.case_type&.requires_retrial_dates?
+    return unless @record&.requires_retrial_dates?
     start_attribute, end_attribute = end_attribute, start_attribute if inverse
     # TODO: this condition is a temproary workaround for live data that existed prior to addition of retrial details
     validate_presence(start_attribute, 'blank') if @record.editable?

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -158,11 +158,7 @@ module Fee
     end
 
     def trial_length
-      if @record.claim.try(:case_type).try(:requires_retrial_dates?)
-        @record.try(:claim).try(:retrial_actual_length) || 0
-      else
-        @record.try(:claim).try(:actual_trial_length) || 0
-      end
+      @record&.claim&.trial_length || 0
     end
 
     def daf_trial_length_combination_invalid(lower_bound, trial_length_modifier, max_quantity = nil)

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -17,12 +17,38 @@ class RepresentationOrderValidator < BaseValidator
     validate_presence(:representation_order_date, 'blank')
     validate_on_or_before(Date.today, :representation_order_date, 'in_future')
     validate_on_or_after(earliest_permitted[:date], :representation_order_date, earliest_permitted[:error])
-    if scheme_ten?
-      validate_on_or_after(Settings.agfs_fee_reform_release_date, :representation_order_date, 'scheme_ten_offence')
-    end
 
+    validate_against_agfs_fee_reform_release_date
+    validate_against_trial_dates
+    validate_against_retrial_dates
+    validate_against_case_concluded_date
+    validate_against_first_rep_order_date
+  end
+
+  def validate_against_agfs_fee_reform_release_date
+    return unless scheme_ten?
+    validate_on_or_after(Settings.agfs_fee_reform_release_date, :representation_order_date, 'scheme_ten_offence')
+  end
+
+  def validate_against_trial_dates
+    return unless claim&.requires_trial_dates?
+    return if claim&.requires_retrial_dates?
+    validate_on_or_before(claim.first_day_of_trial, :representation_order_date, 'not_on_or_before_first_day_of_trial')
+  end
+
+  def validate_against_retrial_dates
+    return unless claim&.requires_retrial_dates?
+    validate_on_or_before(claim.retrial_started_at, :representation_order_date, 'not_on_or_before_first_day_of_retrial')
+  end
+
+  def validate_against_case_concluded_date
+    return unless claim&.requires_case_concluded_date?
+    validate_on_or_before(claim.case_concluded_at, :representation_order_date, 'not_on_or_before_case_concluded_date')
+  end
+
+  def validate_against_first_rep_order_date
     return if @record.is_first_reporder_for_same_defendant?
-    first_reporder_date = @record.first_reporder_for_same_defendant.try(:representation_order_date)
+    first_reporder_date = @record.first_reporder_for_same_defendant&.representation_order_date
     return if first_reporder_date.nil?
     validate_on_or_after(first_reporder_date, :representation_order_date, 'check')
   end

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -104,7 +104,7 @@
               = claim&.trial_cracked_at_third&.humanize
 
         - unless claim.lgfs? && claim.interim?
-          - if claim&.case_type && claim.requires_trial_dates?
+          - if claim&.requires_trial_dates?
             %tr
               %th{ scope: 'row', class: 'bold' }
                 = t("first_day_of_trial", scope: trial_detail_fields)
@@ -126,7 +126,7 @@
               %td
                 = claim&.trial_concluded_at&.strftime(Settings.date_format)
 
-          - if claim&.case_type && claim.requires_retrial_dates?
+          - if claim&.requires_retrial_dates?
             %tr
               %th{ scope: 'row', class: 'bold' }
                 = t("retrial_started_at", scope: retrial_detail_fields)

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -101,10 +101,10 @@
       - if claim.transfer?
         = render partial: 'shared/claim_transfer_details', locals: { claim: claim }
 
-      - if claim.case_type && claim.requires_trial_dates?
+      - if claim&.requires_trial_dates?
         = render partial: 'shared/claim_trial_details', locals: { claim: claim }
 
-      - if claim.case_type && claim.requires_retrial_dates?
+      - if claim&.requires_retrial_dates?
         = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
 
   - if claim.defendants.any?

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -676,6 +676,18 @@ representation_order:
       long: 'Representation order date of the #{defendant} cannot be prior to 02/10/14. Please check this date'
       short: *check_date
       api: 'Representation order date of the defendant cannot be prior to 02/10/14. Please check this date'
+    not_on_or_before_case_concluded_date:
+      long: 'Check the combination of the representation order date and the case concluded date'
+      short: 'Check combination of representation order date and case concluded date'
+      api: 'Check combination of rep order date and case concluded date'
+    not_on_or_before_first_day_of_retrial:
+      long: 'Check the combination of the representation order date and the dates of trial'
+      short: 'Check combination of representation order date and trial dates'
+      api: 'Check combination of rep order date and trial dates'
+    not_on_or_before_first_day_of_trial:
+      long: 'Check the combination of the representation order date and the dates of trial'
+      short: 'Check combination of representation order date and trial dates'
+      api: 'Check combination of rep order date and trial dates'
     scheme_ten_offence:
       long: Representation Order Date is not valid for AGFS scheme ten
       short: *check_date

--- a/spec/api/entities/ccr/adapted_basic_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_basic_fee_spec.rb
@@ -3,13 +3,9 @@ require 'rails_helper'
 describe API::Entities::CCR::AdaptedBasicFee, type: :adapter do
   subject(:response) { JSON.parse(described_class.represent(adapted_basic_fees).to_json).deep_symbolize_keys }
 
-  let(:claim) { create(:authorised_claim) }
-  let(:case_type) { instance_double('case_type', fee_type_code: 'GRTRL', requires_retrial_dates?: false) }
+  let(:claim) { create(:authorised_claim, case_type: case_type) }
+  let(:case_type) { build(:case_type, :trial) }
   let(:adapted_basic_fees) { ::CCR::Fee::BasicFeeAdapter.new(claim) }
-
-  before do
-    allow(claim).to receive(:case_type).and_return case_type
-  end
 
   it 'exposes expected json key-value pairs' do
     expect(response).to include(

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -159,44 +159,41 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
 
         context 'multi-step form submit to LAA' do
           let(:case_number) { 'A20168888' }
+          let(:case_concluded_at) { 5.days.ago }
+          let(:representation_order_date) { case_concluded_at }
 
           let(:claim_params_step1) do
             {
-                external_user_id: litigator.id,
-                supplier_number: supplier_number,
-                court_id: court,
-                case_type_id: case_type.id,
-                offence_id: offence,
-                case_number: case_number,
-                case_concluded_at_dd: 5.days.ago.day.to_s,
-                case_concluded_at_mm: 5.days.ago.month.to_s,
-                case_concluded_at_yyyy: 5.days.ago.year.to_s,
-                defendants_attributes: [
-                    { first_name: 'John',
-                      last_name: 'Smith',
-                      date_of_birth_dd: '4',
-                      date_of_birth_mm: '10',
-                      date_of_birth_yyyy: '1980',
-                      representation_orders_attributes: [
-                          {
-                              representation_order_date_dd: Time.now.day.to_s,
-                              representation_order_date_mm: Time.now.month.to_s,
-                              representation_order_date_yyyy: Time.now.year.to_s,
-                              maat_reference: '4561237895'
-                          }
-                      ]
-                    }
-                ]
+              external_user_id: litigator.id,
+              supplier_number: supplier_number,
+              court_id: court,
+              case_type_id: case_type.id,
+              case_number: case_number,
+              case_concluded_at_dd: case_concluded_at.day.to_s,
+              case_concluded_at_mm: case_concluded_at.month.to_s,
+              case_concluded_at_yyyy: case_concluded_at.year.to_s,
             }
           end
 
           let(:claim_params_step2) do
             {
               form_step: :defendants,
-              additional_information: 'foo',
-              expenses_attributes:
-              [
-                expense_params
+              defendants_attributes: [
+                  {
+                    first_name: 'John',
+                    last_name: 'Smith',
+                    date_of_birth_dd: '4',
+                    date_of_birth_mm: '10',
+                    date_of_birth_yyyy: '1980',
+                    representation_orders_attributes: [
+                        {
+                          representation_order_date_dd: representation_order_date.day.to_s,
+                          representation_order_date_mm: representation_order_date.month.to_s,
+                          representation_order_date_yyyy: representation_order_date.year.to_s,
+                          maat_reference: '4561237895'
+                        }
+                    ]
+                  }
               ]
             }
           end

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -534,6 +534,40 @@ RSpec.describe Claim::BaseClaim do
       end
     end
   end
+
+  describe '#trial_length' do
+    let(:actual_trial_length) { 3 }
+    let(:retrial_actual_length) { 5 }
+    let(:claim) { MockSteppableClaim.new(actual_trial_length: actual_trial_length, retrial_actual_length: retrial_actual_length) }
+
+    subject(:trial_length) { claim.trial_length }
+
+    context 'when the claim requires re-trial dates' do
+      before do
+        expect(claim).to receive(:requires_retrial_dates?).and_return(true)
+      end
+
+      specify { is_expected.to eq(retrial_actual_length) }
+    end
+
+    context 'when the claim requires trial dates' do
+      before do
+        expect(claim).to receive(:requires_retrial_dates?).and_return(false)
+        expect(claim).to receive(:requires_trial_dates?).and_return(true)
+      end
+
+      specify { is_expected.to eq(actual_trial_length) }
+    end
+
+    context 'when the claim does not require trial dates or re-trial dates' do
+      before do
+        expect(claim).to receive(:requires_retrial_dates?).and_return(false)
+        expect(claim).to receive(:requires_trial_dates?).and_return(false)
+      end
+
+      specify { is_expected.to be_nil }
+    end
+  end
 end
 
 describe MockBaseClaim do

--- a/spec/services/ccr/daily_attendance_adapter_spec.rb
+++ b/spec/services/ccr/daily_attendance_adapter_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
     subject { described_class.new(claim).attendances }
 
     context 'scheme 9 claim' do
-      let(:claim) { create(:authorised_claim) }
+      let(:claim) { create(:authorised_claim, case_type: case_type) }
       attendances_incl_in_basic_fee = 2
 
       context 'for trials' do
+        let(:case_type) { build(:case_type, :trial) }
+
         context 'when no daily attendance uplift fees applied' do
           [0,1,3,nil].each do |trial_length|
             context "and claim has an actual trial length of #{trial_length || 'nil'}" do
@@ -37,7 +39,7 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
       end
 
       context 'for retrials' do
-        before { claim.update(case_type: retrial) }
+        let(:case_type) { build(:case_type, :retrial) }
 
         context 'when no daily attendance uplift fees applied' do
           [0,1,3,nil].each do |trial_length|
@@ -53,10 +55,12 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
     end
 
     context 'scheme 10 claim' do
-      let(:claim) { create(:authorised_claim, :agfs_scheme_10, form_step: :case_details) }
+      let(:claim) { create(:authorised_claim, :agfs_scheme_10, case_type: case_type, form_step: :case_details) }
       attendances_incl_in_basic_fee = 1
 
       context 'for trials' do
+        let(:case_type) { build(:case_type, :trial) }
+
         context 'when no daily attendance uplift fee (2+) applied' do
           [0,1,2,nil].each do |trial_length|
             context "and claim has an actual trial length of #{trial_length || 'nil'}" do
@@ -81,7 +85,7 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
       end
 
       context 'for retrials' do
-        before { claim.update(case_type: retrial) }
+        let(:case_type) { build(:case_type, :retrial) }
 
         context 'when no daily attendance uplift fee (2+) applied' do
           [0,1,2,nil].each do |trial_length|


### PR DESCRIPTION
#### What

So far most of the validations related with representation order dates were being performed on the trial dates, which means the defendants page that holds the information for the representation order dates was not doing its own checks.

Also:
- Remove indirection on methods that can be delegated directly on the claim object such as `trial_length` and `requires_trial_dates?`

#### Ticket

[LGFS and AGFS final fee: rep oder validation (date of rep order cannot be later than date case concluded)](https://dsdmoj.atlassian.net/browse/CBO-187)