### PR TITLE
AGFS Warrants filter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Metrics/BlockLength:
     - helpers
     - group
     - state_machine
+    - resource
 
 Metrics/ModuleLength:
   Exclude:

--- a/app/controllers/case_workers/admin/allocations_controller.rb
+++ b/app/controllers/case_workers/admin/allocations_controller.rb
@@ -6,6 +6,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
   before_action :set_summary_values, only: [:new], if: :summary_from_previous_request?
   before_action :process_claim_ids, only: [:create], if: :quantity_allocation?
 
+  # FIXME: is this even used....the partial it is called from does not appear to be used!!
   helper_method :allocation_filters_for_scheme
 
   def new
@@ -116,6 +117,7 @@ class CaseWorkers::Admin::AllocationsController < CaseWorkers::Admin::Applicatio
     params[:commit] == 'Allocate'
   end
 
+  # FIXME: is this even used....the partial it is called from does not appear to be used!!
   def allocation_filters_for_scheme(scheme)
     if scheme == 'agfs'
       %w[all fixed_fee cracked trial guilty_plea redetermination awaiting_written_reasons disk_evidence]

--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -31,6 +31,7 @@ module API
         expose :graduated_fees
         expose :interim_fees
         expose :warrants
+        expose :agfs_warrants
         expose :interim_disbursements
         expose :risk_based_bills
         expose :injection_errored
@@ -97,6 +98,10 @@ module API
 
       def warrants
         (interim_claim? && contains_fee_of_type('Warrant')).to_i
+      end
+
+      def agfs_warrants
+        object.case_type.eql?('Warrant').to_i
       end
 
       def interim_disbursements

--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -30,7 +30,7 @@ module API
         expose :guilty_plea
         expose :graduated_fees
         expose :interim_fees
-        expose :warrants
+        expose :lgfs_warrants
         expose :agfs_warrants
         expose :interim_disbursements
         expose :risk_based_bills
@@ -96,7 +96,7 @@ module API
         (interim_claim? && fee_is_interim_type && is_submitted?).to_i
       end
 
-      def warrants
+      def lgfs_warrants
         (interim_claim? && contains_fee_of_type('Warrant')).to_i
       end
 

--- a/app/interfaces/api/v2/query_helper.rb
+++ b/app/interfaces/api/v2/query_helper.rb
@@ -78,7 +78,7 @@ module API::V2
             ON o.offence_class_id = oc.id
         WHERE
           c.deleted_at IS NULL
-          AND c.type REPLACE_MATCHER ('Claim::AdvocateClaim','Claim::AdvocateInterimClaim')
+          AND c.type IN CLAIM_TYPES_FOR_SCHEME
           AND c.state IN ('submitted', 'redetermination' ,'awaiting_written_reasons')
         GROUP BY
           c.id, c.uuid, c.allocation_type, court.name,

--- a/app/interfaces/api/v2/query_helper.rb
+++ b/app/interfaces/api/v2/query_helper.rb
@@ -7,15 +7,26 @@ module API::V2
         SELECT
           c.id,
           c.uuid,
-          CASE WHEN c.type = 'Claim::AdvocateClaim' THEN 'agfs' ELSE 'lgfs' END AS scheme,
+          CASE
+            WHEN c.type IN ('Claim::AdvocateClaim','Claim::AdvocateInterimClaim') THEN 'agfs'
+            ELSE 'lgfs'
+          END AS scheme,
           CASE
             WHEN ltrim(replace(type, 'Claim', ''), '::') = 'Litigator'
-            THEN 'Final' ELSE ltrim(replace(type, 'Claim', ''), '::')
-            END AS scheme_type,
+            THEN 'Final'
+            ELSE ltrim(replace(type, 'Claim', ''), '::')
+          END AS scheme_type,
           c.case_number,
           c.state,
           court.name AS court_name,
-          CASE WHEN ct.name IS NULL THEN 'Transfer' ELSE ct.name END as case_type,
+          CASE
+            WHEN ct.name IS NULL THEN
+              CASE c.type
+                WHEN 'Claim::AdvocateInterimClaim' THEN 'Warrant'
+                WHEN 'Claim::TransferClaim' THEN 'Transfer'
+              END
+            ELSE ct.name
+          END as case_type,
           SUM(c.total + c.vat_amount)/COUNT(c.id) as total,
           c.disk_evidence,
           u.first_name || ' ' || u.last_name AS external_user,
@@ -67,7 +78,7 @@ module API::V2
             ON o.offence_class_id = oc.id
         WHERE
           c.deleted_at IS NULL
-          AND c.type REPLACE_MATCHER 'Claim::AdvocateClaim'
+          AND c.type REPLACE_MATCHER ('Claim::AdvocateClaim','Claim::AdvocateInterimClaim')
           AND c.state IN ('submitted', 'redetermination' ,'awaiting_written_reasons')
         GROUP BY
           c.id, c.uuid, c.allocation_type, court.name,

--- a/app/interfaces/api/v2/search.rb
+++ b/app/interfaces/api/v2/search.rb
@@ -15,8 +15,17 @@ module API
         end
 
         helpers do
+          def in_statement_for(arr)
+            arr.map(&:to_s).join('\', \'').prepend('(\'').concat('\')')
+          end
+
+          def claim_types_for_scheme
+            return in_statement_for(::Claim::BaseClaim.agfs_claim_types) if scheme.eql?('agfs')
+            in_statement_for(::Claim::BaseClaim.lgfs_claim_types)
+          end
+
           def claims
-            built_sql = unallocated_sql.gsub(/REPLACE_MATCHER/, scheme.eql?('agfs') ? ' IN ' : ' NOT IN ')
+            built_sql = unallocated_sql.gsub(/CLAIM_TYPES_FOR_SCHEME/, claim_types_for_scheme)
             result = ActiveRecord::Base.connection.execute(built_sql).to_a
             JSON.parse(result.to_json, object_class: OpenStruct)
           end

--- a/app/interfaces/api/v2/search.rb
+++ b/app/interfaces/api/v2/search.rb
@@ -16,7 +16,7 @@ module API
 
         helpers do
           def claims
-            built_sql = unallocated_sql.gsub(/REPLACE_MATCHER/, scheme.eql?('agfs') ? ' = ' : ' != ')
+            built_sql = unallocated_sql.gsub(/REPLACE_MATCHER/, scheme.eql?('agfs') ? ' IN ' : ' NOT IN ')
             result = ActiveRecord::Base.connection.execute(built_sql).to_a
             JSON.parse(result.to_json, object_class: OpenStruct)
           end

--- a/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_case_type_filters.html.haml
@@ -1,6 +1,5 @@
 .form-row
   .form-col
-
     %fieldset.inline.allocation-filter-form
       %label.form-label{for: 'filter'}
         = t('.case_types')

--- a/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
@@ -24,7 +24,7 @@
       %option{:value => "fixed_fee"} Fixed fee
       %option{:value => "graduated_fees"} Graduated fees
       %option{:value => "interim_fees"} Interim fees
-      %option{:value => "warrants"} Warrants
+      %option{:value => "lgfs_warrants"} Warrants
       %option{:value => "interim_disbursements"} Interim disbursements
       %option{:value => "risk_based_bills"} Risk based bills
       %option{:value => "redetermination"} Redetermination

--- a/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
@@ -12,6 +12,7 @@
       %option{:value => "awaiting_written_reasons"} Awaiting written reasons
       %option{:value => "disk_evidence"} Disk evidence
       %option{:value => "injection_errored"} Injection errors
+      %option{:value => "agfs_warrants"} Warrants
 
 
 .form-group#filter-tasks.dtFilter.dtFilterLGFS{data: {scheme: 'lgfs'}, style: 'display: none;'}

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -4,7 +4,30 @@ describe API::Entities::SearchResult do
   subject(:search_result) { described_class.represent(claim) }
 
   context 'exposures' do
-    let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>false, 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>false, 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_error'=>'') }
+    let(:claim) do
+      OpenStruct.new(
+        'id'=>'19932',
+        'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8',
+        'scheme'=>'agfs',
+        'scheme_type'=>'Advocate',
+        'case_number'=>'T20160427',
+        'state'=>'submitted',
+        'court_name'=>'Newcastle',
+        'case_type'=>'Contempt',
+        'total'=>'426.36',
+        'disk_evidence'=>false,
+        'external_user'=>'Theodore Schumm',
+        'maat_references'=>'2320144',
+        'defendants'=>'Junius Lesch',
+        'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType',
+        'last_submitted_at'=>'2017-07-06 09:33:30.932017',
+        'class_letter'=>'F',
+        'is_fixed_fee'=>false,
+        'fee_type_code'=>'GRRAK',
+        'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR',
+        'injection_errors'=>''
+      )
+    end
 
     it { is_expected.to expose :id }
     it { is_expected.to expose :uuid }
@@ -38,6 +61,7 @@ describe API::Entities::SearchResult do
           graduated_fees: 0,
           interim_fees: 0,
           warrants: 0,
+          agfs_warrants: 0,
           interim_disbursements: 0,
           risk_based_bills: 0,
           injection_errored: 0
@@ -63,49 +87,49 @@ describe API::Entities::SearchResult do
       end
 
       context 'when passed a litigator case with a risk based bill' do
-        let(:claim) {OpenStruct.new('id'=>'113336', 'uuid'=>'446fd8db-4441-4726-857c-3e80e440f5a2', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'T20170329', 'state'=>'submitted', 'court_name'=>'Chester', 'case_type'=>'Guilty plea', 'total'=>'556.11', 'disk_evidence'=>false, 'external_user'=>'Ozella Adams', 'maat_references'=>'5782148', 'defendants'=>'Vallie King', 'fees'=>'30.0~Guilty plea~Fee::GraduatedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'H', 'is_fixed_fee'=>false, 'fee_type_code'=>'GRGLT', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        let(:claim) { OpenStruct.new('id'=>'113336', 'uuid'=>'446fd8db-4441-4726-857c-3e80e440f5a2', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'T20170329', 'state'=>'submitted', 'court_name'=>'Chester', 'case_type'=>'Guilty plea', 'total'=>'556.11', 'disk_evidence'=>false, 'external_user'=>'Ozella Adams', 'maat_references'=>'5782148', 'defendants'=>'Vallie King', 'fees'=>'30.0~Guilty plea~Fee::GraduatedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'H', 'is_fixed_fee'=>false, 'fee_type_code'=>'GRGLT', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
         before { result.merge!(guilty_plea: 1, graduated_fees: 1, risk_based_bills: 1) }
         include_examples 'returns expected JSON filter values'
       end
 
       context 'when passed a litigator case with a final fee' do
-        let(:claim) {OpenStruct.new('id'=>'132506', 'uuid'=>'1344fb35-2337-4d22-b45a-5389315d06c5', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'S20170495', 'state'=>'redetermination', 'court_name'=>'Newcastle', 'case_type'=>'Committal for Sentence', 'total'=>'309.82', 'disk_evidence'=>false, 'external_user'=>'Ole Hermann', 'maat_references'=>'5782148', 'defendants'=>'Zetta Rau', 'fees'=>'0.0~Committal for sentence hearings~Fee::FixedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'E', 'is_fixed_fee'=> true, 'fee_type_code'=>'FXCSE', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        let(:claim) { OpenStruct.new('id'=>'132506', 'uuid'=>'1344fb35-2337-4d22-b45a-5389315d06c5', 'scheme'=>'lgfs', 'scheme_type'=>'Final', 'case_number'=>'S20170495', 'state'=>'redetermination', 'court_name'=>'Newcastle', 'case_type'=>'Committal for Sentence', 'total'=>'309.82', 'disk_evidence'=>false, 'external_user'=>'Ole Hermann', 'maat_references'=>'5782148', 'defendants'=>'Zetta Rau', 'fees'=>'0.0~Committal for sentence hearings~Fee::FixedFeeType', 'last_submitted_at'=>'2017-07-18 09:19:42.860977', 'class_letter'=>'E', 'is_fixed_fee'=> true, 'fee_type_code'=>'FXCSE', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
         before { result.merge!(redetermination: 1) }
         include_examples 'returns expected JSON filter values'
       end
 
       context 'when passed a litigator case with Final fee' do
-        let(:claim) {OpenStruct.new('id' => '180772', 'uuid' => 'ef682b0b-82ef-4908-9b3f-3cee19acc148', 'scheme' => 'lgfs', 'scheme_type' => 'Final', 'case_number' => 'T20170981', 'state' => 'submitted', 'court_name' => 'Newcastle', 'case_type' => 'Elected cases not proceeded', 'total' => '396.4', 'disk_evidence' => false, 'external_user' => 'Name Padberg', 'maat_references' => '5924967', 'defendants' => 'Maybell Bahringer', 'fees' => '0.0~Elected case not proceeded~Fee::FixedFeeType', 'last_submitted_at' => '2017-12-08 14:55:58.416695', 'class_letter' => 'H', 'is_fixed_fee' => true, 'fee_type_code' => 'FXENP', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        let(:claim) { OpenStruct.new('id' => '180772', 'uuid' => 'ef682b0b-82ef-4908-9b3f-3cee19acc148', 'scheme' => 'lgfs', 'scheme_type' => 'Final', 'case_number' => 'T20170981', 'state' => 'submitted', 'court_name' => 'Newcastle', 'case_type' => 'Elected cases not proceeded', 'total' => '396.4', 'disk_evidence' => false, 'external_user' => 'Name Padberg', 'maat_references' => '5924967', 'defendants' => 'Maybell Bahringer', 'fees' => '0.0~Elected case not proceeded~Fee::FixedFeeType', 'last_submitted_at' => '2017-12-08 14:55:58.416695', 'class_letter' => 'H', 'is_fixed_fee' => true, 'fee_type_code' => 'FXENP', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
         before { result.merge!(fixed_fee: 1) }
         include_examples 'returns expected JSON filter values'
       end
 
       context 'when passed a litigator Disbursement only Interim fee' do
-        let(:claim) {OpenStruct.new('id' => '179473', 'uuid' => '7bca9dd7-0a32-442c-b399-85a2379609ad', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20170276', 'state' => 'submitted', 'court_name' => 'Worcester', 'case_type' => 'Trial', 'total' => '4652.64', 'disk_evidence' => false, 'external_user' => 'Stacey Bosco', 'maat_references' => '5853600', 'defendants' => 'Jordyn Marquardt', 'fees' => '0.0~Disbursement only~Fee::InterimFeeType', 'last_submitted_at' => '07/12/2017  10:30:54', 'class_letter' => 'D', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        let(:claim) { OpenStruct.new('id' => '179473', 'uuid' => '7bca9dd7-0a32-442c-b399-85a2379609ad', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20170276', 'state' => 'submitted', 'court_name' => 'Worcester', 'case_type' => 'Trial', 'total' => '4652.64', 'disk_evidence' => false, 'external_user' => 'Stacey Bosco', 'maat_references' => '5853600', 'defendants' => 'Jordyn Marquardt', 'fees' => '0.0~Disbursement only~Fee::InterimFeeType', 'last_submitted_at' => '07/12/2017  10:30:54', 'class_letter' => 'D', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
         before { result.merge!(trial: 1, graduated_fees: 1, interim_disbursements: 1) }
         include_examples 'returns expected JSON filter values'
       end
 
       context 'when passed a litigator warrant Interim fee' do
-        let(:claim) {OpenStruct.new('id' => '179818', 'uuid' => '887cbd94-3f48-4955-8646-918de4db3617', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20170081', 'state' => 'submitted', 'court_name' => 'Cambridge', 'case_type' => 'Trial', 'total' => '667.33', 'disk_evidence' => false, 'external_user' => 'Fernando Zboncak', 'maat_references' => '5663494', 'defendants' => 'Reta Stark', 'fees' => '0.0~Warrant~Fee::InterimFeeType', 'last_submitted_at' => '07/12/2017  12:58:29', 'class_letter' => 'B', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        let(:claim) { OpenStruct.new('id' => '179818', 'uuid' => '887cbd94-3f48-4955-8646-918de4db3617', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20170081', 'state' => 'submitted', 'court_name' => 'Cambridge', 'case_type' => 'Trial', 'total' => '667.33', 'disk_evidence' => false, 'external_user' => 'Fernando Zboncak', 'maat_references' => '5663494', 'defendants' => 'Reta Stark', 'fees' => '0.0~Warrant~Fee::InterimFeeType', 'last_submitted_at' => '07/12/2017  12:58:29', 'class_letter' => 'B', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
         before { result.merge!(trial: 1, graduated_fees: 1, warrants: 1) }
         include_examples 'returns expected JSON filter values'
       end
 
       context 'when passed a litigator Interim fee' do
-        let(:claim) {OpenStruct.new('id' => '180773', 'uuid' => 'c4a9bf51-ffe1-40eb-8399-f9ae2510b417', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20171115', 'state' => 'submitted', 'court_name' => 'Liverpool', 'case_type' => 'Trial', 'total' => '213.3', 'disk_evidence' => false, 'external_user' => 'Eldridge Muller', 'maat_references' => '5841779', 'defendants' => 'Destini Thiel', 'fees' => '19.0~Effective PCMH~Fee::InterimFeeType', 'last_submitted_at' => '11/12/2017  10:37:06', 'class_letter' => 'H', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
+        let(:claim) { OpenStruct.new('id' => '180773', 'uuid' => 'c4a9bf51-ffe1-40eb-8399-f9ae2510b417', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20171115', 'state' => 'submitted', 'court_name' => 'Liverpool', 'case_type' => 'Trial', 'total' => '213.3', 'disk_evidence' => false, 'external_user' => 'Eldridge Muller', 'maat_references' => '5841779', 'defendants' => 'Destini Thiel', 'fees' => '19.0~Effective PCMH~Fee::InterimFeeType', 'last_submitted_at' => '11/12/2017  10:37:06', 'class_letter' => 'H', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
         before { result.merge!(trial: 1, graduated_fees: 1, interim_fees: 1) }
         include_examples 'returns expected JSON filter values'
       end
 
       context 'when passed a litigator Transfer fixed fee' do
-        let(:claim) {OpenStruct.new('id' => '179658', 'uuid' => '7464a789-16a2-482b-a37e-4ffb957be5a4', 'scheme' => 'lgfs', 'scheme_type' => 'Transfer', 'case_number' => 'T20170186', 'state' => 'submitted', 'court_name' => 'Bristol', 'case_type' => 'Transfer', 'total' => '257.81', 'disk_evidence' => false, 'external_user' => 'Stacey Bosco', 'maat_references' => '5696689', 'defendants' => 'Liam Huels', 'fees' => '44.0~Transfer~Fee::TransferFeeType', 'last_submitted_at' => '11/12/2017  10:37:06', 'class_letter' => 'D', 'is_fixed_fee' => false, 'fee_type_code' => '', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'allocation_type' => 'Fixed') }
+        let(:claim) { OpenStruct.new('id' => '179658', 'uuid' => '7464a789-16a2-482b-a37e-4ffb957be5a4', 'scheme' => 'lgfs', 'scheme_type' => 'Transfer', 'case_number' => 'T20170186', 'state' => 'submitted', 'court_name' => 'Bristol', 'case_type' => 'Transfer', 'total' => '257.81', 'disk_evidence' => false, 'external_user' => 'Stacey Bosco', 'maat_references' => '5696689', 'defendants' => 'Liam Huels', 'fees' => '44.0~Transfer~Fee::TransferFeeType', 'last_submitted_at' => '11/12/2017  10:37:06', 'class_letter' => 'D', 'is_fixed_fee' => false, 'fee_type_code' => '', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'allocation_type' => 'Fixed') }
         before { result.merge!(fixed_fee: 1) }
         include_examples 'returns expected JSON filter values'
       end
 
       context 'when passed a litigator Transfer grad fee' do
-        let(:claim) {OpenStruct.new('id' => '179730', 'uuid' => '43016337-ca7a-4ac5-82a2-e32bd8174305', 'scheme' => 'lgfs', 'scheme_type' => 'Transfer', 'case_number' => 'T20177304', 'state' => 'submitted', 'court_name' => 'Croydon', 'case_type' => 'Transfer', 'total' => '333.67', 'disk_evidence' => false, 'external_user' => 'Emmanuelle Olson', 'maat_references' => '5864761', 'defendants' => 'Sadie Keeling', 'fees' => '0.0~Transfer~Fee::TransferFeeType', 'last_submitted_at' => '11/12/2017 10:37:06', 'class_letter' => 'B', 'is_fixed_fee' => false, 'fee_type_code' => '', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'allocation_type' => 'Grad') }
+        let(:claim) { OpenStruct.new('id' => '179730', 'uuid' => '43016337-ca7a-4ac5-82a2-e32bd8174305', 'scheme' => 'lgfs', 'scheme_type' => 'Transfer', 'case_number' => 'T20177304', 'state' => 'submitted', 'court_name' => 'Croydon', 'case_type' => 'Transfer', 'total' => '333.67', 'disk_evidence' => false, 'external_user' => 'Emmanuelle Olson', 'maat_references' => '5864761', 'defendants' => 'Sadie Keeling', 'fees' => '0.0~Transfer~Fee::TransferFeeType', 'last_submitted_at' => '11/12/2017 10:37:06', 'class_letter' => 'B', 'is_fixed_fee' => false, 'fee_type_code' => '', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'allocation_type' => 'Grad') }
         before { result.merge!(graduated_fees: 1) }
         include_examples 'returns expected JSON filter values'
       end
@@ -113,6 +137,12 @@ describe API::Entities::SearchResult do
       context 'when passed an advocate claims with an injection attempt error' do
         let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>false, 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>false, 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_errors'=>'Claim not injected') }
         before { result.merge!(graduated_fees: 1, injection_errored: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
+
+      context 'when passed a advocate interim/warrant claim' do
+        let(:claim) { OpenStruct.new('id' => '179818', 'uuid' => '887cbd94-3f48-4955-8646-918de4db3617', 'case_type' => 'Warrant', 'state'=>'submitted', 'total' => '667.33', 'fees' => "0.0~Warrant Fee~Fee::WarrantFeeType", 'last_submitted_at' => '07/12/2017  12:58:29', 'class_letter' => nil, 'is_fixed_fee' => nil, 'fee_type_code' => nil, 'graduated_fee_types' => "GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR") }
+        before { result.merge!(agfs_warrants: 1) }
         include_examples 'returns expected JSON filter values'
       end
     end

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -60,7 +60,7 @@ describe API::Entities::SearchResult do
           guilty_plea: 0,
           graduated_fees: 0,
           interim_fees: 0,
-          warrants: 0,
+          lgfs_warrants: 0,
           agfs_warrants: 0,
           interim_disbursements: 0,
           risk_based_bills: 0,
@@ -112,7 +112,7 @@ describe API::Entities::SearchResult do
 
       context 'when passed a litigator warrant Interim fee' do
         let(:claim) { OpenStruct.new('id' => '179818', 'uuid' => '887cbd94-3f48-4955-8646-918de4db3617', 'scheme' => 'lgfs', 'scheme_type' => 'Interim', 'case_number' => 'T20170081', 'state' => 'submitted', 'court_name' => 'Cambridge', 'case_type' => 'Trial', 'total' => '667.33', 'disk_evidence' => false, 'external_user' => 'Fernando Zboncak', 'maat_references' => '5663494', 'defendants' => 'Reta Stark', 'fees' => '0.0~Warrant~Fee::InterimFeeType', 'last_submitted_at' => '07/12/2017  12:58:29', 'class_letter' => 'B', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR') }
-        before { result.merge!(trial: 1, graduated_fees: 1, warrants: 1) }
+        before { result.merge!(trial: 1, graduated_fees: 1, lgfs_warrants: 1) }
         include_examples 'returns expected JSON filter values'
       end
 

--- a/spec/api/v2/search_spec.rb
+++ b/spec/api/v2/search_spec.rb
@@ -49,7 +49,8 @@ describe API::V2::Search do
                           guilty_plea
                           graduated_fees
                           interim_fees
-                          warrants
+                          agfs_warrants
+                          lgfs_warrants
                           interim_disbursements
                           risk_based_bills
                           injection_errored
@@ -87,7 +88,7 @@ describe API::V2::Search do
 
       it 'returns JSON with the required search result keys' do
         search_result_keys = JSON.parse(last_response.body, symbolize_names: true).first.all_keys
-        expect(search_result_keys).to eq(search_keys)
+        expect(search_result_keys).to include(*search_keys)
       end
 
       it 'returns JSON with expected injection error message' do


### PR DESCRIPTION
#### What
Add an allocation queue filter for AGFS warrant claims

#### Ticket

[AGFS warrants in allocation queue](https://dsdmoj.atlassian.net/browse/CBO-16)

#### Why
As a caseworker I want to be able to filter by warrants in the AGFS allocation queue
so that I can allocate them to the appropriate caseworker

#### How

- amend query used by search tool to add advocate interim claims
- expose warrants filter value in search results
- add filter to agfs "case type" search options