### PR TITLE
Add index to deleted_at column on the claims table

### DIFF
--- a/db/migrate/20180606094711_add_deleted_at_index_to_claims.rb
+++ b/db/migrate/20180606094711_add_deleted_at_index_to_claims.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtIndexToClaims < ActiveRecord::Migration[5.0]
+  def change
+    add_index :claims, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180531110653) do
+ActiveRecord::Schema.define(version: 20180606094711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 20180531110653) do
     t.index ["cms_number"], name: "index_claims_on_cms_number", using: :btree
     t.index ["court_id"], name: "index_claims_on_court_id", using: :btree
     t.index ["creator_id"], name: "index_claims_on_creator_id", using: :btree
+    t.index ["deleted_at"], name: "index_claims_on_deleted_at", using: :btree
     t.index ["external_user_id"], name: "index_claims_on_external_user_id", using: :btree
     t.index ["form_id"], name: "index_claims_on_form_id", using: :btree
     t.index ["offence_id"], name: "index_claims_on_offence_id", using: :btree


### PR DESCRIPTION
#### What

There's quite a lot of scopes and queries relying on the filter "deleted_at IS NULL" which without the index forces the table to be scanned every single time.

This index should optimise all those queries.