### PR TITLE
Advocate categories CYC display

### DIFF
--- a/app/views/external_users/claims/_advocate_category_summary.html.haml
+++ b/app/views/external_users/claims/_advocate_category_summary.html.haml
@@ -1,0 +1,8 @@
+- if claim.agfs? && claim.advocate_category.present?
+  %table{ class: 'summary' }
+    %tbody
+      %tr
+        %th{ scope: 'row', class: 'bold' }
+          = t("common.external_user.category.#{claim.external_user_type}")
+        %td
+          = claim.advocate_category

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -3,6 +3,14 @@
   - if local_assigns[:editable]
     = link_to 'Change', edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change'
 
+  -# TODO: Avoid use of these checks and just display info
+  -# based on configuration
+  - if claim.agfs? && %i[basic_fees fixed_fees].include?(step)
+    = render partial: 'external_users/claims/advocate_category_summary', locals: { claim: claim }
+
+    %p
+      &nbsp;
+
 - if local_assigns.has_key?(:fee)
   - if fee
     %table{ class: 'summary', summary: t('.summary') }

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -35,11 +35,6 @@
               = t("common.external_user.#{claim.external_user_type}")
             %td
               = claim.external_user.name
-          %tr
-            %th{ scope: 'row', class: 'bold' }
-              = t("common.external_user.category.#{claim.external_user_type}")
-            %td
-              = claim.advocate_category
 
         %tr
           %th{ scope: 'row', class: 'bold' }

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -74,7 +74,7 @@
             %td
               = claim.case_type&.name
 
-        - if claim.final? || claim.transfer?
+        - if claim.requires_case_concluded_date?
           %tr
             %th{ scope: 'row', class: 'bold' }
               = t('external_users.claims.case_details.case_concluded_date.case_concluded_at')

--- a/app/views/external_users/claims/warrant_fee/_summary.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_summary.html.haml
@@ -4,6 +4,12 @@
     - if local_assigns[:editable]
       = link_to 'Change', edit_polymorphic_path(claim, step: :interim_fees, referrer: :summary), class: 'link-change'
 
+  - if claim.agfs?
+    = render partial: 'external_users/claims/advocate_category_summary', locals: { claim: claim }
+
+    %p
+      &nbsp;
+
   - if claim.warrant_fee.nil?
     %p
       There is no warrant fee for this claim


### PR DESCRIPTION
#### What

Display the advocate category information in the relevant summary section:
* Fixed fees summary section for AGFS final claims with fixed case type
* Graduate fees summary section for AGFS final claims with graduated case type
* Warrant fee summary section for AGFS warrant claims

#### Ticket

[AGFS - advocate categories should display in the fee section, not in the case details section](https://dsdmoj.atlassian.net/browse/CBO-189)