### PR TITLE
Amend contact email addresses for service

### DIFF
--- a/app/views/pages/contact_us.html.haml
+++ b/app/views/pages/contact_us.html.haml
@@ -1,8 +1,5 @@
 = render partial: 'layouts/header', locals: {page_heading: 'Contact us'}
 
-- advocates_email  = 'advocates-fee@legalaid.gsi.gov.uk'
-- litigators_email = 'litigators-fee@legalaid.gsi.gov.uk'
-
 %section.contact-us
   %p
     For any queries about your claim, contact the following:
@@ -11,14 +8,14 @@
     %li
       Advocates’ graduated fee scheme
     %li
-      Email: #{mail_to advocates_email, advocates_email}
+      Email: #{mail_to Settings.advocates_email, Settings.advocates_email}
     %li.last-element
       Phone:
       %a{:href => 'tel:01158526000'} 0115 852 6000
     %li
       Litigators’ graduated fee scheme
     %li
-      Email: #{mail_to litigators_email, litigators_email}
+      Email: #{mail_to Settings.litigators_email, Settings.litigators_email}
     %li
       Phone:
       %a{:href => 'tel:01158526000'} 0115 852 6000

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -107,8 +107,8 @@ remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') +
 
 # contact email address
 laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
-advocates_email: advocates-fee@legalaid.gsi.gov.uk
-litigators_email: litigators-fee@legalaid.gsi.gov.uk
+advocates_email: advocates-fee@justice.gov.uk
+litigators_email: litigators-fee@justice.gov.uk
 phone_contact: '01158526000'
 
 aws:


### PR DESCRIPTION
#### What
Amend contact email addresses for service

#### Why
Following office365 rollout @legalaid.gsi.gov.uk
email domain has been moved to @justice.gov.uk.

#### Ticket

[change "help with completing this form" email addresses to .justice](https://dsdmoj.atlassian.net/browse/CBO-42)
