### PR TITLE
Display only non-zero basic fees in the summary page

### DIFF
--- a/app/views/external_users/claims/basic_fees/_summary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_summary.html.haml
@@ -1,3 +1,3 @@
 - unless claim.fixed_fee_case?
   .form-section
-    = render partial: 'external_users/claims/summary_fees', locals: { claim: claim, header: t('external_users.claims.basic_fees.summary.header'), collection: claim.basic_fees, editable: editable, section: section, step: :basic_fees }
+    = render partial: 'external_users/claims/summary_fees', locals: { claim: claim, header: t('external_users.claims.basic_fees.summary.header'), collection: claim.basic_fees.reject(&:blank?), editable: editable, section: section, step: :basic_fees }


### PR DESCRIPTION
#### What

AGFS basic fees are pre-initialised with zeros (needs to be addressed atsome point) so any fee that has not been configured by the advocate should not be display if it remains a zero fee.

#### Ticket

[If there is a '0' element in the basic fees, it should not be shown on the CYC page](https://dsdmoj.atlassian.net/browse/CBO-191)