### PR TITLE
Validate rep order against cracked dates

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -91,7 +91,7 @@ module Claim
     validates_with ::Claim::AdvocateClaimValidator, unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
     validates_with ::Claim::AdvocateClaimSubModelValidator
 
-    delegate :requires_cracked_dates?, to: :case_type
+    delegate :requires_cracked_dates?, to: :case_type, allow_nil: true
 
     after_initialize do
       instantiate_basic_fees

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -21,6 +21,7 @@ class RepresentationOrderValidator < BaseValidator
     validate_against_agfs_fee_reform_release_date
     validate_against_trial_dates
     validate_against_retrial_dates
+    validate_against_cracked_trial_dates
     validate_against_case_concluded_date
     validate_against_first_rep_order_date
   end
@@ -39,6 +40,12 @@ class RepresentationOrderValidator < BaseValidator
   def validate_against_retrial_dates
     return unless claim&.requires_retrial_dates?
     validate_on_or_before(claim.retrial_started_at, :representation_order_date, 'not_on_or_before_first_day_of_retrial')
+  end
+
+  def validate_against_cracked_trial_dates
+    return unless claim&.requires_cracked_dates?
+    validate_on_or_before(claim.trial_fixed_notice_at,
+                          :representation_order_date, 'not_on_or_before_trial_fixed_notice_date')
   end
 
   def validate_against_case_concluded_date

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -689,6 +689,10 @@ representation_order:
       long: 'Check the combination of the representation order date and the dates of trial'
       short: 'Check combination of representation order date and trial dates'
       api: 'Check combination of rep order date and trial dates'
+    not_on_or_before_trial_fixed_notice_date:
+      long: 'Check the combination of the representation order date and the dates of cracked trial'
+      short: 'Check combination of representation order date and cracked trial dates'
+      api: 'Check combination of rep order date and cracked trial dates'
     scheme_ten_offence:
       long: Representation Order Date is not valid for AGFS scheme ten
       short: *check_date

--- a/spec/factories/case_types.rb
+++ b/spec/factories/case_types.rb
@@ -79,6 +79,20 @@ FactoryBot.define do
       requires_retrial_dates true
     end
 
+    trait :cracked_trial do
+      name 'Cracked Trial'
+      fee_type_code 'GRRAK'
+      requires_cracked_dates true
+      allow_pcmh_fee_type true
+    end
+
+    trait :cracked_before_retrial do
+      name 'Cracked before retrial'
+      fee_type_code 'GRCBR'
+      requires_cracked_dates true
+      allow_pcmh_fee_type true
+    end
+
     trait :requires_maat_reference do
       requires_maat_reference true
     end

--- a/spec/validators/representation_order_date_validator_spec.rb
+++ b/spec/validators/representation_order_date_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
         let(:claim) { build(:advocate_claim, case_type: case_type, first_day_of_trial: first_day_of_trial) }
 
         context 'and the representation order date is before the first day of trial' do
-          let(:rep_order_date) { first_day_of_trial }
+          let(:rep_order_date) { first_day_of_trial - 2.days }
           let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
 
           specify { expect(reporder).to be_valid }
@@ -74,6 +74,66 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
           it 'is invalid' do
             expect(reporder).not_to be_valid
             expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_first_day_of_retrial')
+          end
+        end
+      end
+
+      context 'with a cracked trial case type' do
+        let(:trial_fixed_notice_at) { 5.days.ago }
+        let(:case_type) { build(:case_type, :cracked_trial) }
+        let(:claim) { build(:advocate_claim, case_type: case_type, trial_fixed_notice_at: trial_fixed_notice_at) }
+
+        context 'and the representation order date is before the fixed notice date' do
+          let(:rep_order_date) { trial_fixed_notice_at - 2.days }
+          let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
+
+          specify { expect(reporder).to be_valid }
+        end
+
+        context 'and the representation order date matches the first day of trial' do
+          let(:rep_order_date) { trial_fixed_notice_at }
+          let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
+
+          specify { expect(reporder).to be_valid }
+        end
+
+        context 'and the representation order date is later than the first day of trial' do
+          let(:rep_order_date) { trial_fixed_notice_at + 1.day }
+          let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
+
+          it 'is invalid' do
+            expect(reporder).not_to be_valid
+            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_fixed_notice_date')
+          end
+        end
+      end
+
+      context 'with a cracked before retrial case type' do
+        let(:trial_fixed_notice_at) { 5.days.ago }
+        let(:case_type) { build(:case_type, :cracked_before_retrial) }
+        let(:claim) { build(:advocate_claim, case_type: case_type, trial_fixed_notice_at: trial_fixed_notice_at) }
+
+        context 'and the representation order date is before the fixed notice date' do
+          let(:rep_order_date) { trial_fixed_notice_at - 2.days }
+          let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
+
+          specify { expect(reporder).to be_valid }
+        end
+
+        context 'and the representation order date matches the first day of trial' do
+          let(:rep_order_date) { trial_fixed_notice_at }
+          let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
+
+          specify { expect(reporder).to be_valid }
+        end
+
+        context 'and the representation order date is later than the first day of trial' do
+          let(:rep_order_date) { trial_fixed_notice_at + 1.day }
+          let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
+
+          it 'is invalid' do
+            expect(reporder).not_to be_valid
+            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_fixed_notice_date')
           end
         end
       end


### PR DESCRIPTION
#### What

For AGFS claims, when the case type requires cracked trial dates perform the necessary validations against them for the representation order.

#### Ticket

[AGFS final fee: rep order validation for cracked trials](https://dsdmoj.atlassian.net/browse/CBO-197)