### PR TITLE
Add claim_id index to determinations table

### DIFF
--- a/db/migrate/20180608101520_add_claim_id_index_to_determinations.rb
+++ b/db/migrate/20180608101520_add_claim_id_index_to_determinations.rb
@@ -1,0 +1,5 @@
+class AddClaimIdIndexToDeterminations < ActiveRecord::Migration[5.0]
+  def change
+    add_index :determinations, :claim_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180531110653) do
+ActiveRecord::Schema.define(version: 20180608101520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -204,6 +204,7 @@ ActiveRecord::Schema.define(version: 20180531110653) do
     t.datetime "updated_at"
     t.float    "vat_amount",    default: 0.0
     t.decimal  "disbursements", default: "0.0"
+    t.index ["claim_id"], name: "index_determinations_on_claim_id", using: :btree
   end
 
   create_table "disbursement_types", force: :cascade do |t|


### PR DESCRIPTION
#### What

Self-descriptive.

#### Why

Historically, some tables were created without these indexes that should be set by default on foreign key columns.