### PR TITLE
Fix some N+1 queries in the external users claims page

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -30,7 +30,9 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def index
     track_visit(url: 'external_user/claims', title: 'Your claims')
 
-    @claims = @claims_context.dashboard_displayable_states
+    @claims = @claims_context
+              .dashboard_displayable_states
+              .includes(:defendants, :case_type, :external_user, :assessment, :messages)
     search if params[:search].present?
     sort_and_paginate(column: 'last_submitted_at', direction: 'asc')
   end
@@ -42,7 +44,9 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def outstanding
-    @claims = @financial_summary.outstanding_claims
+    @claims = @financial_summary
+              .outstanding_claims
+              .includes(:defendants, :case_type, :external_user, :assessment, :messages)
     sort_and_paginate(column: 'last_submitted_at', direction: 'asc')
     @total_value = @financial_summary.total_outstanding_claim_value
   end


### PR DESCRIPTION
#### What

There's quite a lot of associations that were not being preloaded in the page that displays the list of claims.

#### Why

N+1 queries in cases like this (list of objects) are *bad* and should be avoided.