### PR TITLE
Working un-archiving

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -123,7 +123,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def unarchive
     if @claim.archived_pending_delete?
-      @claim = @claim.paper_trail.previous_version
+      @claim = PreviousVersionOfClaim.new(@claim).call
       @claim.zeroise_nil_totals!
       @claim.save!
       redirect_to external_users_claims_url, notice: 'Claim unarchived'

--- a/lib/previous_version_of_claim.rb
+++ b/lib/previous_version_of_claim.rb
@@ -1,0 +1,34 @@
+class PreviousVersionOfClaim
+  def initialize(claim)
+    @claim = claim
+  end
+
+  def call
+    reset if reset_needed?
+    version
+  end
+
+  def reset_needed?
+    version
+  rescue ActiveRecord::SerializationTypeMismatch
+    reset
+  end
+
+  def version
+    @version ||= @claim.paper_trail.previous_version
+  end
+
+  private
+
+  def reset
+    version = PaperTrail::Version.where(item_type: 'Claim::BaseClaim', item_id: @claim.id).last
+    new_object = version.object_deserialized.transform_values do |value|
+      if value.present? && value.is_a?(Array)
+        PaperTrail.serializer.dump value
+      else
+        value
+      end
+    end
+    version.update_columns object: PaperTrail.serializer.dump(new_object)
+  end
+end

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -652,20 +652,22 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
 
   describe "PATCH #unarchive" do
     context 'when archived claim' do
-      subject do
+      let(:claim) do
         claim = create(:authorised_claim, external_user: advocate)
         claim.archive_pending_delete!
         claim
       end
 
-      before { patch :unarchive, params: { id: subject } }
+      context 'when the current version of paper trail is used' do
+        before { patch :unarchive, params: { id: claim } }
 
-      it 'unarchives the claim and restores to state prior to archiving' do
-        expect(subject.reload).to be_authorised
-      end
+        it 'unarchives the claim and restores to state prior to archiving' do
+          expect(claim.reload).to be_authorised
+        end
 
-      it 'redirects to external users root url' do
-        expect(response).to redirect_to(external_users_claims_url)
+        it 'redirects to external users root url' do
+          expect(response).to redirect_to(external_users_claims_url)
+        end
       end
     end
 

--- a/spec/lib/previous_version_of_claim_spec.rb
+++ b/spec/lib/previous_version_of_claim_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 # require File.join(Rails.root, 'lib', 'cleanse_paper_trail_arrays')
 
-describe PreviousVersionOfClaim do
+RSpec.describe PreviousVersionOfClaim do
   subject(:previous_version) { described_class.new(claim) }
 
   let(:claim) { create(:archived_pending_delete_claim, evidence_checklist_ids: [3, 4, 1]) }

--- a/spec/lib/previous_version_of_claim_spec.rb
+++ b/spec/lib/previous_version_of_claim_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+# require File.join(Rails.root, 'lib', 'cleanse_paper_trail_arrays')
+
+describe PreviousVersionOfClaim do
+  subject(:previous_version) { described_class.new(claim) }
+
+  let(:claim) { create(:archived_pending_delete_claim, evidence_checklist_ids: [3, 4, 1]) }
+
+  describe 'call' do
+    subject(:call) { previous_version.call }
+
+    it { is_expected.to be_a Claim::BaseClaim }
+
+    context 'when claim was archived by legacy paper_trail' do
+      before do
+        # manually update the, correctly, archived record to reflect the legacy style
+        version = claim.versions.last
+        new_object = version.object_deserialized.transform_values do |value|
+          if value.present? && value.eql?("---\n- 3\n- 4\n- 1\n")
+            [3, 4, 1]
+          else
+            value
+          end
+        end
+        version.update_columns object: PaperTrail.serializer.dump(new_object)
+      end
+
+      it { expect{ previous_version.version }.to raise_error(ActiveRecord::SerializationTypeMismatch) }
+    end
+  end
+end

--- a/spec/lib/previous_version_of_claim_spec.rb
+++ b/spec/lib/previous_version_of_claim_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-# require File.join(Rails.root, 'lib', 'cleanse_paper_trail_arrays')
 
 RSpec.describe PreviousVersionOfClaim do
   subject(:previous_version) { described_class.new(claim) }


### PR DESCRIPTION
#### What
Providers are currently unable to un-archive claims that were archived using the previous version of the paper-trail gem
#### Ticket
[Un-archiving records raises an error](https://dsdmoj.atlassian.net/browse/CBO-194)
#### Why
Paper trail changed the method of serialising data in an interim version of the gem
#### How
Implement a new class that attempts to load the previous_version of the claim, if it fails, it calls a new block of code that modifies the `Version` record in the database and then return the updated version
The alternative was to loop through the 1.2 million `Version` records in the database and update them, this seems to be more expedient!