### PR TITLE
Fix 500 error when validating graduated fees with no case type set

### DIFF
--- a/app/validators/fee/graduated_fee_validator.rb
+++ b/app/validators/fee/graduated_fee_validator.rb
@@ -15,7 +15,7 @@ class Fee::GraduatedFeeValidator < Fee::BaseFeeValidator
   def validate_claim
     super
     return unless @record.claim&.final?
-    add_error(:claim, 'Fixed fee invalid on non-fixed fee case types') if @record.claim.case_type.is_fixed_fee?
+    add_error(:claim, :incompatible_case_type) if @record.claim.case_type&.is_fixed_fee?
   end
 
   def validate_quantity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,10 @@ en:
             certification_date:
               after_claim_creation: "must be same day or after claim submission day"
               not_in_the_future: "can't be in the future"
+        fee/graduated_fee:
+          attributes:
+            claim:
+              incompatible_case_type: Fixed fee invalid on non-fixed fee case types
         supplier_number:
           attributes:
             supplier_number:

--- a/spec/validators/fee/graduated_fee_validator_spec.rb
+++ b/spec/validators/fee/graduated_fee_validator_spec.rb
@@ -12,6 +12,35 @@ RSpec.describe Fee::GraduatedFeeValidator, type: :validator do
 
   describe '#validate_claim' do
     it { should_error_if_not_present(fee, :claim, 'blank') }
+
+    context 'when the fee is for an interim claim' do
+      let(:claim) { build(:interim_claim) }
+      let(:fee) { build(:graduated_fee, claim: claim) }
+
+      it 'does not contain errors on the claim' do
+        expect(fee).to be_valid
+      end
+    end
+
+    context 'when the associated claim has no case type defined' do
+      let(:claim) { build(:litigator_claim, case_type: nil) }
+      let(:fee) { build(:graduated_fee, claim: claim) }
+
+      it 'does not container an error on the claim case type' do
+        expect(fee).to be_valid
+      end
+    end
+
+    context 'when the associated claim has a fixed case type' do
+      let(:case_type) { build(:case_type, :fixed_fee) }
+      let(:claim) { build(:litigator_claim, case_type: case_type) }
+      let(:fee) { build(:graduated_fee, claim: claim) }
+
+      it 'is invalid as it can be associated with this type of claim' do
+        expect(fee).not_to be_valid
+        expect(fee.errors[:claim]).to include('Fixed fee invalid on non-fixed fee case types')
+      end
+    end
   end
 
   describe '#validate_fee_type' do


### PR DESCRIPTION
#### What

https://sentry.service.dsd.io/mojds/private-beta/issues/32535/

#### Ticket

[500 error on CYC page with no case type set](https://dsdmoj.atlassian.net/browse/CBO-224)

#### Why

User's sometimes fill in all the information til the graduated fees, then go back to the case details and remove the case type and save as draft. When they come back to the Check your claim page, they get a 500 error as the claim no longer has a case type that is required to validated the graduated fees.