### PR TITLE
CBO-243 create mi model

### DIFF
--- a/app/models/stats/mi_data.rb
+++ b/app/models/stats/mi_data.rb
@@ -1,0 +1,61 @@
+module Stats
+  class MIData < ApplicationRecord
+    self.table_name = 'mi_data'
+
+    DUPLICATE = %w[disk_evidence retrial_reduction case_concluded_at effective_pcmh_date first_day_of_trial
+                   legal_aid_transfer_date retrial_concluded_at retrial_started_at trial_concluded_at
+                   trial_cracked_at trial_fixed_at trial_fixed_notice_at authorised_at created_at
+                   last_submitted_at original_submission_date disbursements_total disbursements_vat
+                   expenses_total expenses_vat fees_total fees_vat total vat_amount actual_trial_length
+                   estimated_trial_length retrial_actual_length retrial_estimated_length advocate_category
+                   trial_cracked_at_third source supplier_number].freeze
+
+    COUNT = {
+      num_of_documents: { object: :documents, where: '' },
+      num_of_defendants: { object: :defendants, where: '' },
+      rejections: { object: :claim_state_transitions, where: "\"to\"='rejected'" },
+      refusals: { object: :claim_state_transitions, where: "\"to\"='refused'" }
+    }.freeze
+
+    OBJECT_VALUE = {
+      court: { object: :court, att: :name },
+      transfer_court: { object: :transfer_court, att: :name },
+      case_type: { object: :case_type, att: :name },
+      offence_name: { object: :offence, att: :description },
+      date_last_assessed: { object: :assessment, att: :created_at },
+      provider_name: { object: :provider, att: :name },
+      provider_type: { object: :provider, att: :provider_type },
+      assessment_total: { object: :assessment, att: :total },
+      assessment_vat: { object: :assessment, att: :vat_amount },
+      scheme_name: { object: :fee_scheme, att: :name },
+      scheme_number: { object: :fee_scheme, att: :version }
+    }.freeze
+
+    CALCULATIONS = {
+      amount_claimed: %i[total vat_amount],
+      amount_authorised: %i[assessment_total assessment_vat]
+    }.freeze
+
+    CLAIM_TYPE_CONVERSIONS = {
+      'Claim::AdvocateInterimClaim' =>  'Advocate interim claim',
+      'Claim::AdvocateClaim'        =>  'Advocate final claim',
+      'Claim::InterimClaim'         =>  'Litigator interim claim',
+      'Claim::LitigatorClaim'       =>  'Litigator final claim',
+      'Claim::TransferClaim'        =>  'Litigator transfer claim'
+    }.freeze
+
+    class << self
+      def import(claim)
+        new_mi = Stats::MIData.new
+        DUPLICATE.each { |att| new_mi.send("#{att}=", claim.send(att)) }
+        COUNT.each { |att, source| new_mi.send("#{att}=", claim.send(source[:object]).where(source[:where]).count) }
+        OBJECT_VALUE.each { |att, source| new_mi.send("#{att}=", claim.send(source[:object])&.send(source[:att])) }
+        CALCULATIONS.each { |att, sum| new_mi.send("#{att}=", new_mi.send(sum[0]) + new_mi.send(sum[1])) }
+        new_mi.ppe = claim.fees.find_by(fee_type_id: 11)&.quantity.to_i
+        new_mi.claim_type = CLAIM_TYPE_CONVERSIONS[claim.type.to_s]
+        new_mi.offence_type = claim.offence&.offence_band&.description || claim.offence&.offence_class&.class_letter
+        new_mi.save
+      end
+    end
+  end
+end

--- a/app/models/stats/mi_data.rb
+++ b/app/models/stats/mi_data.rb
@@ -2,58 +2,10 @@ module Stats
   class MIData < ApplicationRecord
     self.table_name = 'mi_data'
 
-    DUPLICATE = %w[disk_evidence retrial_reduction case_concluded_at effective_pcmh_date first_day_of_trial
-                   legal_aid_transfer_date retrial_concluded_at retrial_started_at trial_concluded_at
-                   trial_cracked_at trial_fixed_at trial_fixed_notice_at authorised_at created_at
-                   last_submitted_at original_submission_date disbursements_total disbursements_vat
-                   expenses_total expenses_vat fees_total fees_vat total vat_amount actual_trial_length
-                   estimated_trial_length retrial_actual_length retrial_estimated_length advocate_category
-                   trial_cracked_at_third source supplier_number].freeze
-
-    COUNT = {
-      num_of_documents: { object: :documents, where: '' },
-      num_of_defendants: { object: :defendants, where: '' },
-      rejections: { object: :claim_state_transitions, where: "\"to\"='rejected'" },
-      refusals: { object: :claim_state_transitions, where: "\"to\"='refused'" }
-    }.freeze
-
-    OBJECT_VALUE = {
-      court: { object: :court, att: :name },
-      transfer_court: { object: :transfer_court, att: :name },
-      case_type: { object: :case_type, att: :name },
-      offence_name: { object: :offence, att: :description },
-      date_last_assessed: { object: :assessment, att: :created_at },
-      provider_name: { object: :provider, att: :name },
-      provider_type: { object: :provider, att: :provider_type },
-      assessment_total: { object: :assessment, att: :total },
-      assessment_vat: { object: :assessment, att: :vat_amount },
-      scheme_name: { object: :fee_scheme, att: :name },
-      scheme_number: { object: :fee_scheme, att: :version }
-    }.freeze
-
-    CALCULATIONS = {
-      amount_claimed: %i[total vat_amount],
-      amount_authorised: %i[assessment_total assessment_vat]
-    }.freeze
-
-    CLAIM_TYPE_CONVERSIONS = {
-      'Claim::AdvocateInterimClaim' =>  'Advocate interim claim',
-      'Claim::AdvocateClaim'        =>  'Advocate final claim',
-      'Claim::InterimClaim'         =>  'Litigator interim claim',
-      'Claim::LitigatorClaim'       =>  'Litigator final claim',
-      'Claim::TransferClaim'        =>  'Litigator transfer claim'
-    }.freeze
-
     class << self
       def import(claim)
-        new_mi = Stats::MIData.new
-        DUPLICATE.each { |att| new_mi.send("#{att}=", claim.send(att)) }
-        COUNT.each { |att, source| new_mi.send("#{att}=", claim.send(source[:object]).where(source[:where]).count) }
-        OBJECT_VALUE.each { |att, source| new_mi.send("#{att}=", claim.send(source[:object])&.send(source[:att])) }
-        CALCULATIONS.each { |att, sum| new_mi.send("#{att}=", new_mi.send(sum[0]) + new_mi.send(sum[1])) }
-        new_mi.ppe = claim.fees.find_by(fee_type_id: 11)&.quantity.to_i
-        new_mi.claim_type = CLAIM_TYPE_CONVERSIONS[claim.type.to_s]
-        new_mi.offence_type = claim.offence&.offence_band&.description || claim.offence&.offence_class&.class_letter
+        transformed_attributes = Transform::Claim.call(claim)
+        new_mi = Stats::MIData.new(transformed_attributes)
         new_mi.save
       end
     end

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -77,7 +77,7 @@ module TimedTransitions
                     dummy_run: @dummy) do
         'Destroying soft-deleted claim'
       end
-      @claim.destroy unless is_dummy?
+      Stats::MIData.import(@claim) && @claim.destroy unless is_dummy?
       self.success = true
     end
   end

--- a/app/services/transform/claim.rb
+++ b/app/services/transform/claim.rb
@@ -1,0 +1,59 @@
+module Transform
+  class Claim
+    DUPLICATE = %w[disk_evidence retrial_reduction case_concluded_at effective_pcmh_date first_day_of_trial
+                   legal_aid_transfer_date retrial_concluded_at retrial_started_at trial_concluded_at
+                   trial_cracked_at trial_fixed_at trial_fixed_notice_at authorised_at created_at
+                   last_submitted_at original_submission_date disbursements_total disbursements_vat
+                   expenses_total expenses_vat fees_total fees_vat total vat_amount actual_trial_length
+                   estimated_trial_length retrial_actual_length retrial_estimated_length advocate_category
+                   trial_cracked_at_third source supplier_number].freeze
+
+    COUNT = {
+      num_of_documents: { object: :documents, where: '' },
+      num_of_defendants: { object: :defendants, where: '' },
+      rejections: { object: :claim_state_transitions, where: "\"to\"='rejected'" },
+      refusals: { object: :claim_state_transitions, where: "\"to\"='refused'" }
+    }.freeze
+
+    OBJECT_VALUE = {
+      court: { object: :court, att: :name },
+      transfer_court: { object: :transfer_court, att: :name },
+      case_type: { object: :case_type, att: :name },
+      offence_name: { object: :offence, att: :description },
+      date_last_assessed: { object: :assessment, att: :created_at },
+      provider_name: { object: :provider, att: :name },
+      provider_type: { object: :provider, att: :provider_type },
+      assessment_total: { object: :assessment, att: :total },
+      assessment_vat: { object: :assessment, att: :vat_amount },
+      scheme_name: { object: :fee_scheme, att: :name },
+      scheme_number: { object: :fee_scheme, att: :version }
+    }.freeze
+
+    CALCULATIONS = {
+      amount_claimed: %i[total vat_amount],
+      amount_authorised: %i[assessment_total assessment_vat]
+    }.freeze
+
+    CLAIM_TYPE_CONVERSIONS = {
+      'Claim::AdvocateInterimClaim' =>  'Advocate interim claim',
+      'Claim::AdvocateClaim'        =>  'Advocate final claim',
+      'Claim::InterimClaim'         =>  'Litigator interim claim',
+      'Claim::LitigatorClaim'       =>  'Litigator final claim',
+      'Claim::TransferClaim'        =>  'Litigator transfer claim'
+    }.freeze
+
+    class << self
+      def call(claim)
+        hash = {}
+        DUPLICATE.each { |att| hash[att.to_sym] = claim.send(att) }
+        COUNT.each { |att, source| hash[att] = claim.send(source[:object]).where(source[:where]).count }
+        OBJECT_VALUE.each { |att, source| hash[att] = claim.send(source[:object])&.send(source[:att]) }
+        CALCULATIONS.each { |att, sum| hash[att] = (hash[sum[0]] || 0) + (hash[sum[1]] || 0) }
+        hash[:ppe] = claim.fees.find_by(fee_type_id: 11)&.quantity.to_i
+        hash[:claim_type] = CLAIM_TYPE_CONVERSIONS[claim.type.to_s]
+        hash[:offence_type] = claim.offence&.offence_band&.description || claim.offence&.offence_class&.class_letter
+        hash
+      end
+    end
+  end
+end

--- a/db/migrate/20180702141736_create_mi_data.rb
+++ b/db/migrate/20180702141736_create_mi_data.rb
@@ -1,0 +1,58 @@
+class CreateMiData < ActiveRecord::Migration[5.0]
+  def change
+    create_table :mi_data do |t|
+      t.boolean   'disk_evidence'
+      t.boolean   'retrial_reduction'
+      t.date      'case_concluded_at'
+      t.date      'effective_pcmh_date'
+      t.date      'first_day_of_trial'
+      t.date      'legal_aid_transfer_date'
+      t.date      'retrial_concluded_at'
+      t.date      'retrial_started_at'
+      t.date      'trial_concluded_at'
+      t.date      'trial_cracked_at'
+      t.date      'trial_fixed_at'
+      t.date      'trial_fixed_notice_at'
+      t.datetime  'authorised_at'
+      t.datetime  'created_at', index: true
+      t.datetime  'date_last_assessed'
+      t.datetime  'last_submitted_at'
+      t.datetime  'original_submission_date'
+      t.decimal   'amount_authorised'
+      t.decimal   'amount_claimed'
+      t.decimal   'disbursements_total'
+      t.decimal   'disbursements_vat'
+      t.decimal   'expenses_total'
+      t.decimal   'expenses_vat'
+      t.decimal   'fees_total'
+      t.decimal   'fees_vat'
+      t.decimal   'total'
+      t.decimal   'vat_amount'
+      t.decimal   'assessment_total'
+      t.decimal   'assessment_vat'
+      t.integer   'actual_trial_length', index: true
+      t.integer   'estimated_trial_length'
+      t.integer   'num_of_defendants'
+      t.integer   'num_of_documents'
+      t.integer   'retrial_actual_length'
+      t.integer   'retrial_estimated_length'
+      t.integer   'ppe', index: true
+      t.integer   'rejections'
+      t.integer   'refusals'
+      t.integer   'scheme_number'
+      t.string    'advocate_category'
+      t.string    'case_type', index: true
+      t.string    'court'
+      t.string    'offence_name'
+      t.string    'offence_type', index: true
+      t.string    'provider_name'
+      t.string    'provider_type'
+      t.string    'source'
+      t.string    'scheme_name'
+      t.string    'supplier_number'
+      t.string    'transfer_court'
+      t.string    'trial_cracked_at_third'
+      t.string    'claim_type'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180612133535) do
+ActiveRecord::Schema.define(version: 20180702141736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -383,6 +383,66 @@ ActiveRecord::Schema.define(version: 20180612133535) do
     t.datetime "attachment_updated_at"
     t.index ["claim_id"], name: "index_messages_on_claim_id", using: :btree
     t.index ["sender_id"], name: "index_messages_on_sender_id", using: :btree
+  end
+
+  create_table "mi_data", force: :cascade do |t|
+    t.boolean  "disk_evidence"
+    t.boolean  "retrial_reduction"
+    t.date     "case_concluded_at"
+    t.date     "effective_pcmh_date"
+    t.date     "first_day_of_trial"
+    t.date     "legal_aid_transfer_date"
+    t.date     "retrial_concluded_at"
+    t.date     "retrial_started_at"
+    t.date     "trial_concluded_at"
+    t.date     "trial_cracked_at"
+    t.date     "trial_fixed_at"
+    t.date     "trial_fixed_notice_at"
+    t.datetime "authorised_at"
+    t.datetime "created_at"
+    t.datetime "date_last_assessed"
+    t.datetime "last_submitted_at"
+    t.datetime "original_submission_date"
+    t.decimal  "amount_authorised"
+    t.decimal  "amount_claimed"
+    t.decimal  "disbursements_total"
+    t.decimal  "disbursements_vat"
+    t.decimal  "expenses_total"
+    t.decimal  "expenses_vat"
+    t.decimal  "fees_total"
+    t.decimal  "fees_vat"
+    t.decimal  "total"
+    t.decimal  "vat_amount"
+    t.decimal  "assessment_total"
+    t.decimal  "assessment_vat"
+    t.integer  "actual_trial_length"
+    t.integer  "estimated_trial_length"
+    t.integer  "num_of_defendants"
+    t.integer  "num_of_documents"
+    t.integer  "retrial_actual_length"
+    t.integer  "retrial_estimated_length"
+    t.integer  "ppe"
+    t.integer  "rejections"
+    t.integer  "refusals"
+    t.integer  "scheme_number"
+    t.string   "advocate_category"
+    t.string   "case_type"
+    t.string   "court"
+    t.string   "offence_name"
+    t.string   "offence_type"
+    t.string   "provider_name"
+    t.string   "provider_type"
+    t.string   "source"
+    t.string   "scheme_name"
+    t.string   "supplier_number"
+    t.string   "transfer_court"
+    t.string   "trial_cracked_at_third"
+    t.string   "claim_type"
+    t.index ["actual_trial_length"], name: "index_mi_data_on_actual_trial_length", using: :btree
+    t.index ["case_type"], name: "index_mi_data_on_case_type", using: :btree
+    t.index ["created_at"], name: "index_mi_data_on_created_at", using: :btree
+    t.index ["offence_type"], name: "index_mi_data_on_offence_type", using: :btree
+    t.index ["ppe"], name: "index_mi_data_on_ppe", using: :btree
   end
 
   create_table "offence_bands", force: :cascade do |t|

--- a/spec/models/stats/mi_data_spec.rb
+++ b/spec/models/stats/mi_data_spec.rb
@@ -16,40 +16,6 @@ module Stats
       let(:claim) { create :archived_pending_delete_claim }
       it { is_expected.to be true }
       it { expect { import }.to change { Stats::MIData.count }.by 1 }
-
-      context 'runs different import types' do
-        before { import }
-
-        let(:new_mi) { Stats::MIData.last }
-
-        it 'retrieves data from linked objects' do
-          expect(new_mi.case_type).to eq claim.case_type.name
-        end
-
-        it 'retrieves data from the claim directly' do
-          expect(new_mi.advocate_category).to eq claim.advocate_category
-        end
-
-        it 'calculates the totals correctly' do
-          expect(new_mi.amount_authorised).to eq claim.assessment.total + claim.assessment.vat_amount
-        end
-
-        it 'counts linked data correctly' do
-          expect(new_mi.num_of_defendants).to eq claim.defendants.count
-        end
-
-        it 'counts linked data with where clauses correctly' do
-          expect(new_mi.refusals).to eq claim.claim_state_transitions.where("\"to\"='refused'").count
-        end
-
-        it 'converts the offence type' do
-          expect(new_mi.offence_type).to eq claim.offence.offence_class.class_letter
-        end
-
-        it 'converts the claim description' do
-          expect(new_mi.claim_type).to eq 'Advocate final claim'
-        end
-      end
     end
   end
 end

--- a/spec/models/stats/mi_data_spec.rb
+++ b/spec/models/stats/mi_data_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+module Stats
+  describe MIData do
+    subject { described_class.new }
+
+    it { is_expected.to be_a Stats::MIData }
+
+    it { expect(subject.attributes.size).to eq 53 }
+
+    it { expect(subject).to_not respond_to :import }
+
+    describe '.import' do
+      subject(:import) { described_class.import(claim) }
+
+      let(:claim) { create :archived_pending_delete_claim }
+      it { is_expected.to be true }
+      it { expect { import }.to change { Stats::MIData.count }.by 1 }
+
+      context 'runs different import types' do
+        before { import }
+
+        let(:new_mi) { Stats::MIData.last }
+
+        it 'retrieves data from linked objects' do
+          expect(new_mi.case_type).to eq claim.case_type.name
+        end
+
+        it 'retrieves data from the claim directly' do
+          expect(new_mi.advocate_category).to eq claim.advocate_category
+        end
+
+        it 'calculates the totals correctly' do
+          expect(new_mi.amount_authorised).to eq claim.assessment.total + claim.assessment.vat_amount
+        end
+
+        it 'counts linked data correctly' do
+          expect(new_mi.num_of_defendants).to eq claim.defendants.count
+        end
+
+        it 'counts linked data with where clauses correctly' do
+          expect(new_mi.refusals).to eq claim.claim_state_transitions.where("\"to\"='refused'").count
+        end
+
+        it 'converts the offence type' do
+          expect(new_mi.offence_type).to eq claim.offence.offence_class.class_letter
+        end
+
+        it 'converts the claim description' do
+          expect(new_mi.claim_type).to eq 'Advocate final claim'
+        end
+      end
+    end
+  end
+end

--- a/spec/models/timed_state_transitions/transitioner_spec.rb
+++ b/spec/models/timed_state_transitions/transitioner_spec.rb
@@ -126,11 +126,18 @@ module TimedTransitions
 
         context 'destroying' do
           context 'soft-deleted claim more than 16 weeks ago' do
+            let(:claim) { create :archived_pending_delete_claim }
+
             it 'should destroy the claim' do
-              claim = instance_double(Claim::LitigatorClaim, id: 123, state: 'allocated', deleted_at: 17.weeks.ago)
               expect(claim).to receive(:softly_deleted?).and_return(true)
               expect(claim).to receive(:destroy)
               Transitioner.new(claim).run
+            end
+
+            it 'creates an MI version of the record' do
+              expect(claim).to receive(:softly_deleted?).and_return(true)
+              expect(claim).to receive(:destroy)
+              expect { Transitioner.new(claim).run }.to change { Stats::MIData.count }.by 1 
             end
           end
 

--- a/spec/services/transform/claim_spec.rb
+++ b/spec/services/transform/claim_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Transform::Claim do
+  let(:claim) { create :archived_pending_delete_claim }
+
+  describe 'call' do
+    subject(:call) { described_class.call(claim) }
+
+    specify { is_expected.to be_a Hash }
+
+    it 'has the required amount of key/value pairs ' do
+      expect(call.count).to eq 52
+    end
+
+    context 'runs different import types' do
+
+      it 'retrieves data from linked objects' do
+        expect(call[:case_type]).to eq claim.case_type.name
+      end
+
+      it 'retrieves data from the claim directly' do
+        expect(call[:advocate_category]).to eq claim.advocate_category
+      end
+
+      it 'calculates the totals correctly' do
+        expect(call[:amount_authorised]).to eq claim.assessment.total + claim.assessment.vat_amount
+      end
+
+      it 'counts linked data correctly' do
+        expect(call[:num_of_defendants]).to eq claim.defendants.count
+      end
+
+      it 'counts linked data with where clauses correctly' do
+        expect(call[:refusals]).to eq claim.claim_state_transitions.where("\"to\"='refused'").count
+      end
+
+      it 'converts the offence type' do
+        expect(call[:offence_type]).to eq claim.offence.offence_class.class_letter
+      end
+
+      it 'converts the claim description' do
+        expect(call[:claim_type]).to eq 'Advocate final claim'
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Create MI model
#### Ticket
[CBO-243](https://dsdmoj.atlassian.net/browse/CBO-243)
#### Why
There is an increased demand for larger MI reports, this creates an MI data model that can, initially, be exported to excel and allow users to run their own filters

#### TODO (wip)

 - [X] Create MI model
 - [X] Run MI import on destroy of archived claim
 - [ ] Index the MI Model once we know the filter columns
   - [x] Time frame of created date – to and from
   - [ ] Bill type – i.e grad fee etc
   - [x] Offence type – a, b etc etc
   - [x] Trial type – GP, TRIAL ETC
   - [x] Number of trial days if applicable
   - [x] PPE ranges
