### PR TITLE
Safeguard for court name not be filled in disk evidence page

### DIFF
--- a/app/services/disc_evidence_coversheet_builder.rb
+++ b/app/services/disc_evidence_coversheet_builder.rb
@@ -20,7 +20,7 @@ class DiscEvidenceCoversheetBuilder
     fill :date_year, Date.today.year.to_s
     fill :fee_scheme, @claim.agfs? ? 'AGFS' : 'LGFS'
     fill :case_number, @claim.case_number
-    fill :court_name, @claim.court.name
+    fill :court_name, @claim.court&.name
     fill :date_claim_submitted_day, @claim&.last_submitted_at&.day.to_s
     fill :date_claim_submitted_month, @claim&.last_submitted_at&.month.to_s
     fill :date_claim_submitted_year, @claim&.last_submitted_at&.year.to_s


### PR DESCRIPTION
#### What

If the user saves some of the pages as draft and goes to the disk evidence page and tries to submit it, the PDF generation was exploding as some of the information that is pre-filled is still not set.

#### Ticket

[Disk evidence PDF generation failing](https://dsdmoj.atlassian.net/browse/CBO-252)