### PR TITLE
Remove fee reform text

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -208,10 +208,6 @@ module Claim
       Fee::MiscFeeType.agfs_scheme_9s
     end
 
-    def scheme_10?
-      fee_scheme&.version.eql?(10) || offence&.scheme_ten?
-    end
-
     def eligible_fixed_fee_types
       Fee::FixedFeeType.top_levels.agfs
     end

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -204,12 +204,12 @@ module Claim
       # TODO: this should return a list based on the current given fee scheme
       # rather than conditionally return scheme 10 specifically
       # TBD once all the fee scheme work is integrated
-      return Fee::MiscFeeType.agfs_scheme_10s if fee_scheme == 'fee_reform'
+      return Fee::MiscFeeType.agfs_scheme_10s if scheme_10?
       Fee::MiscFeeType.agfs_scheme_9s
     end
 
     def scheme_10?
-      fee_scheme.eql?('fee_reform') || offence&.scheme_ten?
+      fee_scheme&.version.eql?(10) || offence&.scheme_ten?
     end
 
     def eligible_fixed_fee_types

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -102,6 +102,7 @@ module Claim
 
     delegate :provider_id, :provider, to: :creator
     delegate :requires_trial_dates?, :requires_retrial_dates?, to: :case_type, allow_nil: true
+    delegate :scheme_10?, to: :fee_scheme, allow_nil: true
 
     has_many :case_worker_claims, foreign_key: :claim_id, dependent: :destroy
     has_many :case_workers, through: :case_worker_claims

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -17,6 +17,10 @@ class FeeScheme < ApplicationRecord
     where('(:date BETWEEN start_date AND end_date) OR (start_date < :date AND end_date IS NULL)', date: check_date)
   }
 
+  def scheme_10?
+    version.eql?(10)
+  end
+
   def self.current_agfs
     agfs.current.order(end_date: :desc).first
   end

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -27,9 +27,8 @@ class FeeScheme < ApplicationRecord
 
   def self.for_claim(claim)
     # TODO: Align this with Fee reform SPIKE
-    return 'default' if claim.lgfs? || !FeatureFlag.active?(:agfs_fee_reform)
     date = claim.earliest_representation_order&.representation_order_date
     return unless date.present?
-    date >= Date.parse(Settings.agfs_fee_reform_release_date.to_s) ? 'fee_reform' : 'default'
+    FeeScheme.for(date).find_by(name: claim.agfs? ? 'AGFS' : 'LGFS')
   end
 end

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -28,7 +28,10 @@ class FeeScheme < ApplicationRecord
   def self.for_claim(claim)
     # TODO: Align this with Fee reform SPIKE
     date = claim.earliest_representation_order&.representation_order_date
-    return unless date.present?
-    FeeScheme.for(date).find_by(name: claim.agfs? ? 'AGFS' : 'LGFS')
+    if date.present?
+      FeeScheme.for(date).find_by(name: claim.agfs? ? 'AGFS' : 'LGFS')
+    elsif claim.offence.present?
+      claim.offence.fee_schemes.find_by(name: claim.agfs? ? 'AGFS' : 'LGFS')
+    end
   end
 end

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -32,10 +32,11 @@ class FeeScheme < ApplicationRecord
   def self.for_claim(claim)
     # TODO: Align this with Fee reform SPIKE
     date = claim.earliest_representation_order&.representation_order_date
+    scheme = claim.agfs? ? 'AGFS' : 'LGFS'
     if date.present?
-      FeeScheme.for(date).find_by(name: claim.agfs? ? 'AGFS' : 'LGFS')
+      FeeScheme.for(date).find_by(name: scheme)
     elsif claim.offence.present?
-      claim.offence.fee_schemes.find_by(name: claim.agfs? ? 'AGFS' : 'LGFS')
+      claim.offence.fee_schemes.find_by(name: scheme)
     end
   end
 end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -52,6 +52,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
   end
 
   def requires_interim_claim_info?
-    claim.fee_scheme == 'fee_reform'
+    claim.fee_scheme.version.eql?(10)
   end
 end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -52,6 +52,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
   end
 
   def requires_interim_claim_info?
-    claim.fee_scheme.version.eql?(10)
+    claim&.fee_scheme&.version.eql?(10)
   end
 end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -52,6 +52,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
   end
 
   def requires_interim_claim_info?
-    claim&.fee_scheme&.version.eql?(10)
+    claim.scheme_10?
   end
 end

--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -11,7 +11,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
   end
 
   def should_be_displayed?
-    return true unless claim.fee_scheme == 'fee_reform'
+    return true unless claim.fee_scheme.version.eql?(10)
     return true unless FEE_CODES_RESTRICTED_DISPLAY.include?(code)
     OFFENCE_CATEGORIES_WITHOUT_RESTRICTED_DISPLAY.include?(offence_category_number)
   end
@@ -20,7 +20,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
     # TODO: this is not really ideal, but right now I
     # can't see any other way to achieve this specific
     # requirement :/
-    return true unless claim.fee_scheme == 'fee_reform'
+    return true unless claim.fee_scheme.version.eql?(10)
     return false if FEE_CODES_WITHOUT_AMOUNT.include?(code)
     true
   end
@@ -45,7 +45,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
   end
 
   def prompt_text_key_for(code)
-    return default_prompt_text_for(code) unless claim.fee_scheme == 'fee_reform'
+    return default_prompt_text_for(code) unless claim.fee_scheme.version.eql?(10)
     fee_reform_prompt_text_for(code)
   end
 

--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -11,7 +11,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
   end
 
   def should_be_displayed?
-    return true unless claim.fee_scheme.version.eql?(10)
+    return true unless claim.scheme_10?
     return true unless FEE_CODES_RESTRICTED_DISPLAY.include?(code)
     OFFENCE_CATEGORIES_WITHOUT_RESTRICTED_DISPLAY.include?(offence_category_number)
   end
@@ -20,7 +20,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
     # TODO: this is not really ideal, but right now I
     # can't see any other way to achieve this specific
     # requirement :/
-    return true unless claim.fee_scheme.version.eql?(10)
+    return true unless claim.scheme_10?
     return false if FEE_CODES_WITHOUT_AMOUNT.include?(code)
     true
   end
@@ -45,7 +45,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
   end
 
   def prompt_text_key_for(code)
-    return default_prompt_text_for(code) unless claim.fee_scheme.version.eql?(10)
+    return default_prompt_text_for(code) unless claim.scheme_10?
     fee_reform_prompt_text_for(code)
   end
 

--- a/app/services/ccr/daily_attendance_adapter.rb
+++ b/app/services/ccr/daily_attendance_adapter.rb
@@ -47,7 +47,7 @@ module CCR
     private
 
     def daily_attendances_in_basic
-      claim.fee_scheme.version.eql?(10) ? 1 : 2
+      claim.scheme_10? ? 1 : 2
     end
 
     def trial_length
@@ -55,7 +55,7 @@ module CCR
     end
 
     def eligible_fee_type_unique_codes
-      claim.fee_scheme.version.eql?(10) ? 'BADAT' : %w[BADAF BADAH BADAJ]
+      claim.scheme_10? ? 'BADAT' : %w[BADAF BADAH BADAJ]
     end
 
     def daily_attendance_fee_types

--- a/app/services/ccr/daily_attendance_adapter.rb
+++ b/app/services/ccr/daily_attendance_adapter.rb
@@ -47,7 +47,7 @@ module CCR
     private
 
     def daily_attendances_in_basic
-      claim.fee_scheme.eql?('fee_reform') ? 1 : 2
+      claim.fee_scheme.version.eql?(10) ? 1 : 2
     end
 
     def trial_length
@@ -55,7 +55,7 @@ module CCR
     end
 
     def eligible_fee_type_unique_codes
-      claim.fee_scheme.eql?('fee_reform') ? 'BADAT' : %w[BADAF BADAH BADAJ]
+      claim.fee_scheme.version.eql?(10) ? 'BADAT' : %w[BADAF BADAH BADAJ]
     end
 
     def daily_attendance_fee_types

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -60,7 +60,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
 
   def validate_offence
     return if fixed_fee_case?
-    error_message = @record.fee_scheme == 'fee_reform' ? 'new_blank' : 'blank'
+    error_message = @record.fee_scheme&.version.eql?(10) ? 'new_blank' : 'blank'
     validate_presence(:offence, error_message)
   end
 

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -60,7 +60,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
 
   def validate_offence
     return if fixed_fee_case?
-    error_message = @record.fee_scheme&.version.eql?(10) ? 'new_blank' : 'blank'
+    error_message = @record.scheme_10? ? 'new_blank' : 'blank'
     validate_presence(:offence, error_message)
   end
 

--- a/app/views/external_users/claims/offence_details/_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fields.html.haml
@@ -1,5 +1,7 @@
 %h2.heading-large
   = t('.offence_details')
 
-- if @claim.fee_scheme
-  = render partial: "external_users/claims/offence_details/#{@claim.fee_scheme}_fields", locals: { f: f }
+- if @claim.fee_scheme.version.eql?(10)
+  = render partial: "external_users/claims/offence_details/fee_reform_fields", locals: { f: f }
+- else
+  = render partial: "external_users/claims/offence_details/default_fields", locals: { f: f }

--- a/app/views/external_users/claims/offence_details/_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fields.html.haml
@@ -1,7 +1,7 @@
 %h2.heading-large
   = t('.offence_details')
 
-- if @claim.fee_scheme.version.eql?(10)
+- if @claim.scheme_10?
   = render partial: "external_users/claims/offence_details/fee_reform_fields", locals: { f: f }
 - else
   = render partial: "external_users/claims/offence_details/default_fields", locals: { f: f }

--- a/app/views/external_users/claims/offence_details/_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_summary.html.haml
@@ -11,7 +11,7 @@
           %span.table-caption.visuallyhidden
             = t('.caption')
         %tbody
-          - if claim.fee_scheme == 'fee_reform'
+          - if claim.fee_scheme.version.eql?(10)
             = render partial: 'external_users/claims/offence_details/fee_reform_summary', locals: { claim: claim }
           - else
             = render partial: 'external_users/claims/offence_details/default_summary', locals: { claim: claim }

--- a/app/views/external_users/claims/offence_details/_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_summary.html.haml
@@ -11,7 +11,7 @@
           %span.table-caption.visuallyhidden
             = t('.caption')
         %tbody
-          - if claim.fee_scheme.version.eql?(10)
+          - if claim.scheme_10?
             = render partial: 'external_users/claims/offence_details/fee_reform_summary', locals: { claim: claim }
           - else
             = render partial: 'external_users/claims/offence_details/default_summary', locals: { claim: claim }

--- a/features/claims/advocate/advocate_interim_claim_submit.feature
+++ b/features/claims/advocate/advocate_interim_claim_submit.feature
@@ -1,9 +1,6 @@
 @javascript
 Feature: Advocate partially fills out a draft AGFS interim claim for a trial, then later edits and submits it
 
-  Background:
-    Given AGFS reform commenced on "2018-01-01"
-
   Scenario: I create an AGFS interim claim, save it to draft and later complete it
 
     Given I am a signed in advocate
@@ -32,7 +29,7 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     Then I select the first search result
 
     And I select an advocate category of 'Junior'
-    And I fill in '2018-01-01' as the warrant issued date
+    And I fill in '2018-04-01' as the warrant issued date
     And I enter a Warrant net amount of '100'
 
     Then I click "Continue" in the claim form

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -32,6 +32,9 @@ RSpec.describe API::V1::ExternalUsers::Fee do
   let!(:interim_fee_type)   { create(:interim_fee_type) }
   let!(:graduated_fee_type) { create(:graduated_fee_type) }
   let!(:transfer_fee_type)  { create(:transfer_fee_type) }
+  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
+  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
+  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
 
   let!(:claim)            { create(:claim, source: 'api').reload }
   let(:valid_params)      { { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_type.id, quantity: 3, rate: 50.00 } }

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -54,6 +54,16 @@ FactoryBot.define do
       end
     end
 
+    trait :agfs_scheme_9 do
+      after(:create) do |claim|
+        claim.defendants.each do |defendant|
+          defendant
+            .representation_orders
+            .update_all(representation_order_date: Settings.agfs_fee_reform_release_date-10)
+        end
+      end
+    end
+
     factory :unpersisted_claim do
       court         { FactoryBot.build :court }
       external_user { FactoryBot.build :external_user, provider: FactoryBot.build(:provider) }

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   it { should delegate_method(:requires_retrial_dates?).to(:case_type) }
   it { should delegate_method(:requires_cracked_dates?).to(:case_type) }
 
+  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
+  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
+  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
+
   describe 'validates external user and creator with same provider' do
     let(:provider) { create(:provider) }
     let(:other_provider) { create(:provider) }
@@ -182,15 +186,13 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       end
 
       context 'when claim has fee reform scheme' do
-        before do
-          expect(@claim).to receive(:fee_scheme).and_return('fee_reform')
-        end
+        let(:claim) { create(:claim, :agfs_scheme_10) }
 
         it 'returns only basic fee types for AGFS excluding the ones that are not part of the fee reform' do
-          expect(@claim.eligible_basic_fee_types).to eq([@bft1, @bft5])
+          expect(claim.eligible_basic_fee_types).to eq([@bft1, @bft5])
         end
       end
-      
+
       context 'when claim has a scheme 10 offence (from API)' do
         let(:offence) { create(:offence, :with_fee_scheme_ten) }
         let(:claim) { create(:claim, create_defendant_and_rep_order: false, source: 'api', offence: offence) }
@@ -207,12 +209,10 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       end
 
       context 'when claim has fee reform scheme' do
-        before do
-          expect(@claim).to receive(:fee_scheme).and_return('fee_reform')
-        end
+        let(:claim) { create(:claim, :agfs_scheme_10) }
 
         it 'returns only misc fee types for AGFS scheme 10' do
-          expect(@claim.eligible_misc_fee_types).to eq([@mft3])
+          expect(claim.eligible_misc_fee_types).to eq([@mft3])
         end
       end
     end

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -13,6 +13,27 @@ RSpec.describe FeeScheme, type: :model do
     let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
     let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
 
+    describe '#scheme_10?' do
+      subject(:scheme_10?) { fee_scheme.scheme_10? }
+
+      context 'for an agfs scheme 10 claim' do
+        let(:claim) { create(:advocate_claim, :agfs_scheme_10) }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'for an agfs scheme 9 claim' do
+        let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'for an lgfs claim' do
+        let(:claim) { create(:litigator_claim) }
+
+        it { is_expected.to be_falsey }
+      end
+    end
 
     context 'for a LGFS claim' do
       let(:claim) { create :litigator_claim }

--- a/spec/presenters/claim/advocate_claim_presenter_spec.rb
+++ b/spec/presenters/claim/advocate_claim_presenter_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Claim::AdvocateClaimPresenter, type: :presenter do
-  let(:claim) { build(:advocate_claim) }
+  let(:claim_9) { create(:advocate_claim, :agfs_scheme_9) }
+  let(:claim_10) { create(:advocate_claim, :agfs_scheme_10) }
+  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
+  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
+  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
+  let(:claim) { claim_9 }
 
   subject(:presenter) { described_class.new(claim, view) }
 
@@ -19,17 +24,12 @@ RSpec.describe Claim::AdvocateClaimPresenter, type: :presenter do
 
   describe '#requires_interim_claim_info?' do
     context 'when claim is not for the AGFS fee reform scheme' do
-      before do
-        allow(claim).to receive(:fee_scheme).and_return('default')
-      end
 
       specify { expect(presenter.requires_interim_claim_info?).to be_falsey }
     end
 
     context 'when claim is for the AGFS fee reform scheme' do
-      before do
-        allow(claim).to receive(:fee_scheme).and_return('fee_reform')
-      end
+      let(:claim) { claim_10 }
 
       specify { expect(presenter.requires_interim_claim_info?).to be_truthy }
     end

--- a/spec/services/ccr/daily_attendance_adapter_spec.rb
+++ b/spec/services/ccr/daily_attendance_adapter_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
   let(:retrial) { create(:case_type, :retrial) }
 
+  before do
+    FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine)
+    FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine)
+    FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme)
+  end
+
   describe '#attendances' do
     subject { described_class.new(claim).attendances }
 
@@ -55,7 +61,7 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
     end
 
     context 'scheme 10 claim' do
-      let(:claim) { create(:authorised_claim, :agfs_scheme_10, case_type: case_type, form_step: :case_details) }
+      let(:claim) { create(:authorised_claim, :agfs_scheme_10, case_type: case_type, form_step: :case_details, offence: create(:offence, :with_fee_scheme_ten)) }
       attendances_incl_in_basic_fee = 1
 
       context 'for trials' do

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
 
   let(:litigator) { create(:external_user, :litigator) }
   let(:claim)     { create(:advocate_claim) }
+  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
+  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
+  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
 
   include_examples "common advocate litigator validations", :advocate
 
   context 'case concluded at date' do
-    let(:claim) { build(:claim) }
+    let(:claim) { create(:claim, :agfs_scheme_9) }
 
     it 'is valid when absent' do
       expect(claim.case_concluded_at).to be_nil
@@ -147,9 +150,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
     end
 
     context 'when the claim is associated with the new fee reform scheme' do
-      before do
-        allow(claim).to receive(:fee_scheme).and_return('fee_reform')
-      end
+      let(:claim) { create(:claim, :agfs_scheme_10) }
 
       context 'and case type is for non-fixed fees' do
         before do

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 describe 'case_workers/claims/show.html.haml', type: :view do
   include ViewSpecHelper
+  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
+  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
+  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
 
   before do
     @case_worker = create(:case_worker)

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'external_users/claims/show.html.haml', type: :view do
   include ViewSpecHelper
+  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
+  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
+  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
 
   before(:all) do
     @external_user = create(:external_user, :litigator_and_admin)


### PR DESCRIPTION
#### What
Remove the legacy `FeeScheme.for_claim` method of returning string values
#### Ticket
[FeeScheme claim refactoring](https://dsdmoj.atlassian.net/browse/CBO-260)
#### Why
It was unsustainable going forward
#### Next steps?
- add methods to the FeeScheme model that id the exact version
   this would simplify calls allow `.ags_scheme_ten?` checks rather than `.verison.eql?(10)` upcoming changes to the fee schemes may necessitate scheme 11,12,13,etc
