### PR TITLE
Fixes bug - validate dates attended without earliest rep order

### DIFF
--- a/app/validators/date_attended_validator.rb
+++ b/app/validators/date_attended_validator.rb
@@ -15,7 +15,9 @@ class DateAttendedValidator < BaseValidator
   # must not be before the earliest_permitted_date
   def validate_date
     validate_presence(:date, 'blank')
-    validate_on_or_after(@record.earliest_date_before_reporder - 2.years, :date, 'too_long_before_earliest_reporder')
+    if @record.earliest_date_before_reporder
+      validate_on_or_after(@record.earliest_date_before_reporder - 2.years, :date, 'too_long_before_earliest_reporder')
+    end
     validate_on_or_after(Settings.earliest_permitted_date, :date, 'not_before_earliest_permitted_date')
     validate_on_or_before(Date.today, :date, 'not_after_today')
   end

--- a/spec/validators/date_attended_validator_spec.rb
+++ b/spec/validators/date_attended_validator_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe DateAttendedValidator, type: :validator do
     it { should_error_if_too_far_in_the_past(date_attended, :date, 'not_before_earliest_permitted_date') }
     it { should_error_if_in_future(date_attended, :date, 'not_after_today') }
 
+    context 'when there is no representation order date set' do
+      before do
+        claim.defendants.each do |defendant|
+          defendant.representation_orders.clear
+        end
+      end
+
+      it { expect(date_attended).to be_valid }
+    end
+
     it 'should not error if less than two years before earliest rep order date' do
       date_attended.date = earliest_reporder_date - 369.days
       date_attended.date_to = nil


### PR DESCRIPTION
#### What

https://sentry.service.dsd.io/mojds/private-beta/issues/32841/

**NOTE:** This assumes that the representation order is mandatory part of filling a defendant, so the claim won't be valid for submission until that is set.

#### Ticket

[Claim show page 500 when dates attended validation fails](https://dsdmoj.atlassian.net/browse/CBO-264)