### PR TITLE
Fix travis test run failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ before_install:
   - export TZ=Europe/London
   - sudo apt-get -qq update
   - sudo apt-get install -y pdftk
-  - gem update --system
-  - gem install bundler
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - cp config/database.yml.travis config/database.yml


### PR DESCRIPTION
Remove `gem install bundler` and `gem update --system`
install script commands that had been used to patch travis errors
previously as these now seem to be breaking the build.

[example issue](https://github.com/travis-ci/travis-ci/issues/8969)

