### PR TITLE
Replace DB storage with S3 storage for MI reports

### DIFF
--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -13,7 +13,14 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
 
   def download
     record = Stats::StatsReport.most_recent_by_type(params[:report_type])
-    send_data record.report, filename: record.download_filename, type: 'text/csv'
+    if record.document?
+      data = open(record.document_url).read
+      content_type = record.document_content_type
+    else
+      data = record.report
+      content_type = 'text/csv'
+    end
+    send_data data, filename: record.download_filename, type: content_type
   end
 
   def generate

--- a/app/models/stats/management_information_generator.rb
+++ b/app/models/stats/management_information_generator.rb
@@ -13,10 +13,13 @@ module Stats
     end
 
     def call
-      generate_new_report
+      output = generate_new_report
+      Stats::Result.new(output, format)
     end
 
     private
+
+    attr_reader :format
 
     # TODO: separate data retrieval from exporting the data itself
     # keeping existent behaviour for now

--- a/app/models/stats/result.rb
+++ b/app/models/stats/result.rb
@@ -1,0 +1,17 @@
+module Stats
+  class Result
+    attr_reader :content, :format
+
+    def initialize(content, format)
+      @content = content
+      @format = format
+    end
+
+    def content_type
+      {
+        csv: 'text/csv',
+        json: 'application/json'
+      }[format.to_sym]
+    end
+  end
+end

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -25,6 +25,16 @@ module Stats
     scope :management_information, -> { not_errored.where(report_name: 'management_information') }
     scope :provisional_assessment, -> { not_errored.where(report_name: 'provisional_assessment') }
 
+    has_attached_file :document,
+                      { s3_headers: {
+                        'x-amz-meta-Cache-Control' => 'no-cache',
+                        'Expires' => 3.months.from_now.httpdate
+                      },
+                        s3_permissions: :private,
+                        s3_region: 'eu-west-1' }.merge(REPORTS_STORAGE_OPTIONS)
+
+    validates_attachment_content_type :document, content_type: ['text/csv']
+
     def self.clean_up(report_name)
       destroy_reports_older_than(report_name, 1.month.ago)
       destroy_unfinished_reports_older_than(report_name, 2.hours.ago)
@@ -46,16 +56,28 @@ module Stats
       create!(report_name: report_name, status: 'started', started_at: Time.now)
     end
 
-    def write_report(report_contents)
-      update(report: report_contents, status: 'completed', completed_at: Time.now)
+    def write_report(report_result)
+      update(
+        document: StringIO.new(report_result.content),
+        document_file_name: "#{report_name}_#{started_at.to_s(:number)}.#{report_result.format}",
+        document_content_type: report_result.content_type,
+        status: 'completed',
+        completed_at: Time.now
+      )
     end
 
     def write_error(report_contents)
       update(report: report_contents, status: 'error', completed_at: nil)
     end
 
+    def document_url(timeout = 10_000)
+      return unless document?
+      document.options[:storage] == :filesystem ? document.path : document.expiring_url(timeout)
+    end
+
     def download_filename
-      "#{report_name}_#{started_at.strftime('%Y_%m_%d_%H_%M_%S')}.csv"
+      # TODO: set the appropriate format as required
+      "#{report_name}_#{started_at.to_s(:number)}.csv"
     end
 
     def self.destroy_reports_older_than(report_name, timestamp)

--- a/app/services/stats/provisional_assessment_report_generator.rb
+++ b/app/services/stats/provisional_assessment_report_generator.rb
@@ -12,7 +12,8 @@ module Stats
 
     def call
       data = Reports::ProvisionalAssessments.call
-      Stats::CsvExporter.call(data, headers: Reports::ProvisionalAssessments::COLUMNS)
+      output = Stats::CsvExporter.call(data, headers: Reports::ProvisionalAssessments::COLUMNS)
+      Stats::Result.new(output, format)
     end
 
     private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,6 +7,12 @@ Rails.application.configure do
     url: "assets/dev/images/docs/:id_partition/:filename"
   }
 
+  REPORTS_STORAGE_OPTIONS = {
+    storage: :filesystem,
+    path: "tmp/dev/reports/:filename",
+    url: "tmp/dev/reports/:filename"
+  }
+
   # logging
   jsonlogger = LogStuff.new_logger("#{Rails.root}/log/logstash_development.log", Logger::INFO)
   config.logstasher.enabled = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,13 @@ Rails.application.configure do
     url: "reporders/:id_partition/:filename"
   }
 
+  REPORTS_STORAGE_OPTIONS = {
+    storage: :s3,
+    s3_credentials: 'config/aws.yml',
+    path: "reports/:filename",
+    url: "reports/:filename"
+  }
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,6 +15,12 @@ Rails.application.configure do
     url: "assets/test/images/reporders/:filename"
   }
 
+  REPORTS_STORAGE_OPTIONS = {
+    storage: :filesystem,
+    path: "tmp/test/reports/:filename",
+    url: "tmp/test/reports/:filename"
+  }
+
   # logstasher
   # Enable the logstasher logs for the current environment
   config.logstasher.enabled = true

--- a/db/migrate/20180718102824_add_file_to_stats_reports.rb
+++ b/db/migrate/20180718102824_add_file_to_stats_reports.rb
@@ -1,0 +1,9 @@
+class AddFileToStatsReports < ActiveRecord::Migration[5.0]
+  def up
+    add_attachment :stats_reports, :document
+  end
+
+  def down
+    remove_attachment :stats_reports, :document
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180702141736) do
+ActiveRecord::Schema.define(version: 20180718102824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -531,6 +531,10 @@ ActiveRecord::Schema.define(version: 20180702141736) do
     t.string   "status"
     t.datetime "started_at"
     t.datetime "completed_at"
+    t.string   "document_file_name"
+    t.string   "document_content_type"
+    t.integer  "document_file_size"
+    t.datetime "document_updated_at"
   end
 
   create_table "super_admins", force: :cascade do |t|

--- a/spec/factories/stats/stats_reports.rb
+++ b/spec/factories/stats/stats_reports.rb
@@ -17,7 +17,12 @@ FactoryBot.define do
     status 'completed'
     started_at { 2.minutes.ago }
     completed_at { 2.seconds.ago }
-    
+
+    trait :with_document do
+      report nil
+      document { fixture_file_upload "#{Rails.root}/spec/fixtures/files/report.csv", 'text/csv' }
+    end
+
     trait :incomplete do
       status 'started'
       completed_at nil

--- a/spec/fixtures/files/report.csv
+++ b/spec/fixtures/files/report.csv
@@ -1,0 +1,5 @@
+header_1,header_2,header_3
+row_11,row12,row13
+row_21,row22,row23
+row_31,row32,row33
+row_41,row42,row43

--- a/spec/models/stats/management_information_generator_spec.rb
+++ b/spec/models/stats/management_information_generator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
 
     it 'returns CSV content with a header and a row for all active non-draft claims' do
       result = described_class.call
-      expect(result.split("\n").size).to eq(valid_claims.size + 1)
+      expect(result.content.split("\n").size).to eq(valid_claims.size + 1)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -133,7 +133,10 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
-    FileUtils.rm_rf('./public/assets/test/images/') #to delete files from filesystem that were generated during rspec tests
+    # to delete files from filesystem that were generated during rspec tests
+    FileUtils.rm_rf('./public/assets/test/images/')
+    # Deletes report files created during the test suite run
+    FileUtils.rm_rf("#{Rails.root}/tmp/test/reports/")
     VatRate.delete_all
   end
 

--- a/spec/services/stats/provisional_assessment_report_generator_spec.rb
+++ b/spec/services/stats/provisional_assessment_report_generator_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe Stats::ProvisionalAssessmentReportGenerator, type: :service do
         .to receive(:call)
         .with(mocked_data, headers: Reports::ProvisionalAssessments::COLUMNS)
         .and_return(mocked_csv_output)
-      expect(described_class.call).to eq(mocked_csv_output)
+      result = described_class.call
+      expect(result).to be_kind_of(Stats::Result)
+      expect(result.content).to eq(mocked_csv_output)
+      expect(result.format).to eq('csv')
     end
   end
 end


### PR DESCRIPTION
#### What

Solves: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/issues/2431

#### Ticket

[MI reports file storage](https://dsdmoj.atlassian.net/browse/CBO-288)

#### Why

Is preferred to store file contents in a file storage system (e.g. S3) instead of storing them directly in the database as a blob.
