### PR TITLE
Fixes DivisionByZero raised on Provisional assessment reports

### DIFF
--- a/app/services/reports/provisional_assessments.rb
+++ b/app/services/reports/provisional_assessments.rb
@@ -35,7 +35,7 @@ module Reports
       count(supplier_number) as supplier_claims,
       sum(amount_claimed) as claimed,
       sum(amount_authorised) as authorised,
-      sum(amount_authorised)/sum(amount_claimed) as percent
+      sum(amount_authorised)/NULLIF(sum(amount_claimed), 0) as percent
       FROM mi_data
       GROUP BY provider_name, provider_type, supplier_number}
     end


### PR DESCRIPTION
#### What

Sentry issue here:
https://sentry.service.dsd.io/mojds/private-beta/issues/32914/

There's multiple references where this is show as the suggested solution, [here's one of them](http://www.peachpit.com/blogs/blog.aspx?uk=Avoiding-division-by-zero-with-NULLIF-Five-SQL-Tips-in-Five-Days-Part-5-)

#### Ticket

[Division by Zero error happening in Provisional assessment reports](https://dsdmoj.atlassian.net/browse/CBO-286)