### PR TITLE
Replace all string fee reform comparisons with FeeScheme instance check

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -196,7 +196,7 @@ module Claim
       # rather than conditionally return scheme 10 specifically
       # TBD once all the fee scheme work is integrated
       return Fee::BasicFeeType.all if from_json_import?
-      return Fee::BasicFeeType.unscoped.agfs_scheme_10s.order(:position) if scheme_10?
+      return Fee::BasicFeeType.unscoped.agfs_scheme_10s.order(:position) if agfs_reform?
       Fee::BasicFeeType.agfs_scheme_9s
     end
 
@@ -204,7 +204,7 @@ module Claim
       # TODO: this should return a list based on the current given fee scheme
       # rather than conditionally return scheme 10 specifically
       # TBD once all the fee scheme work is integrated
-      return Fee::MiscFeeType.agfs_scheme_10s if scheme_10?
+      return Fee::MiscFeeType.agfs_scheme_10s if agfs_reform?
       Fee::MiscFeeType.agfs_scheme_9s
     end
 

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -102,7 +102,7 @@ module Claim
 
     delegate :provider_id, :provider, to: :creator
     delegate :requires_trial_dates?, :requires_retrial_dates?, to: :case_type, allow_nil: true
-    delegate :scheme_10?, to: :fee_scheme, allow_nil: true
+    delegate :agfs_reform?, to: :fee_scheme, allow_nil: true
 
     has_many :case_worker_claims, foreign_key: :claim_id, dependent: :destroy
     has_many :case_workers, through: :case_worker_claims

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -72,7 +72,7 @@ class ExternalUser < ApplicationRecord
   end
 
   def advocate_claim_types
-    [Claim::AdvocateClaim].tap { |array| array << Claim::AdvocateInterimClaim if FeatureFlag.active?(:agfs_fee_reform) }
+    [Claim::AdvocateClaim, Claim::AdvocateInterimClaim]
   end
 
   def litigator_claim_types

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -21,8 +21,8 @@ class FeeScheme < ApplicationRecord
     name.eql?('AGFS')
   end
 
-  def scheme_10?
-    version.eql?(10)
+  def agfs_reform?
+    agfs? && version >= 10
   end
 
   def self.current_agfs

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -34,7 +34,6 @@ class FeeScheme < ApplicationRecord
   end
 
   def self.for_claim(claim)
-    # TODO: Align this with Fee reform SPIKE
     date = claim.earliest_representation_order&.representation_order_date
     scheme = claim.agfs? ? 'AGFS' : 'LGFS'
     if date.present?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -120,7 +120,7 @@ class Provider < ApplicationRecord
   end
 
   def agfs_claim_types
-    [Claim::AdvocateClaim].tap { |array| array << Claim::AdvocateInterimClaim if FeatureFlag.active?(:agfs_fee_reform) }
+    [Claim::AdvocateClaim, Claim::AdvocateInterimClaim]
   end
 
   def lgfs_claim_types

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -52,6 +52,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
   end
 
   def requires_interim_claim_info?
-    claim.scheme_10?
+    claim.agfs_reform?
   end
 end

--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -26,7 +26,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
   end
 
   def display_help_text?
-    return false unless claim.fee_scheme == 'fee_reform'
+    return false unless claim.scheme_10?
     OFFENCE_CATEGORIES_WITHOUT_RESTRICTED_DISPLAY.include?(offence_category_number)
   end
 

--- a/app/presenters/fee/basic_fee_presenter.rb
+++ b/app/presenters/fee/basic_fee_presenter.rb
@@ -11,7 +11,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
   end
 
   def should_be_displayed?
-    return true unless claim.scheme_10?
+    return true unless claim.agfs_reform?
     return true unless FEE_CODES_RESTRICTED_DISPLAY.include?(code)
     OFFENCE_CATEGORIES_WITHOUT_RESTRICTED_DISPLAY.include?(offence_category_number)
   end
@@ -20,13 +20,13 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
     # TODO: this is not really ideal, but right now I
     # can't see any other way to achieve this specific
     # requirement :/
-    return true unless claim.scheme_10?
+    return true unless claim.agfs_reform?
     return false if FEE_CODES_WITHOUT_AMOUNT.include?(code)
     true
   end
 
   def display_help_text?
-    return false unless claim.scheme_10?
+    return false unless claim.agfs_reform?
     OFFENCE_CATEGORIES_WITHOUT_RESTRICTED_DISPLAY.include?(offence_category_number)
   end
 
@@ -54,7 +54,7 @@ class Fee::BasicFeePresenter < Fee::BaseFeePresenter
   end
 
   def prompt_text_key_for(code)
-    return default_prompt_text_for(code) unless claim.scheme_10?
+    return default_prompt_text_for(code) unless claim.agfs_reform?
     fee_reform_prompt_text_for(code)
   end
 

--- a/app/services/ccr/daily_attendance_adapter.rb
+++ b/app/services/ccr/daily_attendance_adapter.rb
@@ -47,7 +47,7 @@ module CCR
     private
 
     def daily_attendances_in_basic
-      claim.scheme_10? ? 1 : 2
+      claim.agfs_reform? ? 1 : 2
     end
 
     def trial_length
@@ -55,7 +55,7 @@ module CCR
     end
 
     def eligible_fee_type_unique_codes
-      claim.scheme_10? ? 'BADAT' : %w[BADAF BADAH BADAJ]
+      claim.agfs_reform? ? 'BADAT' : %w[BADAF BADAH BADAJ]
     end
 
     def daily_attendance_fee_types

--- a/app/services/claims/fetch_eligible_advocate_categories.rb
+++ b/app/services/claims/fetch_eligible_advocate_categories.rb
@@ -10,7 +10,7 @@ module Claims
 
     def call
       return unless claim&.agfs?
-      return agfs_reform_categories if agfs_reform? || Offence.in_scheme_ten.include?(claim.offence)
+      return agfs_reform_categories if agfs_reform?
       default_categories
     end
 
@@ -27,7 +27,7 @@ module Claims
     end
 
     def agfs_reform?
-      claim.fee_scheme&.agfs? && claim.fee_scheme.version >= 10
+      claim.agfs_reform? || Offence.in_scheme_ten.include?(claim.offence)
     end
   end
 end

--- a/app/services/claims/fetch_eligible_advocate_categories.rb
+++ b/app/services/claims/fetch_eligible_advocate_categories.rb
@@ -26,16 +26,8 @@ module Claims
       Settings.agfs_reform_advocate_categories
     end
 
-    # TODO: to be changed to solely use fee_scheme objects once rest of app cleared up
     def agfs_reform?
-      case claim.fee_scheme
-      when 'default'
-        false
-      when 'fee_reform'
-        true
-      else
-        claim.fee_scheme&.agfs? && claim.fee_scheme.version >= 10
-      end
+      claim.fee_scheme&.agfs? && claim.fee_scheme.version >= 10
     end
   end
 end

--- a/app/services/claims/fetch_eligible_offences.rb
+++ b/app/services/claims/fetch_eligible_offences.rb
@@ -18,9 +18,7 @@ module Claims
     attr_reader :claim
 
     def using_fee_reform?
-      claim.agfs? &&
-        FeatureFlag.active?(:agfs_fee_reform) &&
-        claim.fee_scheme == 'fee_reform'
+      claim.agfs? && claim.scheme_10?
     end
 
     def eligible_offences

--- a/app/services/claims/fetch_eligible_offences.rb
+++ b/app/services/claims/fetch_eligible_offences.rb
@@ -9,7 +9,7 @@ module Claims
     end
 
     def call
-      return eligible_offences if using_fee_reform?
+      return agfs_reform_offences if claim.agfs_reform?
       default_offences
     end
 
@@ -17,14 +17,7 @@ module Claims
 
     attr_reader :claim
 
-    def using_fee_reform?
-      claim.agfs? && claim.scheme_10?
-    end
-
-    def eligible_offences
-      # TODO: Missing the following steps
-      # 1. Checks fee scheme associated with claim
-      # 2. Retrieves list of offences associated with that fee scheme
+    def agfs_reform_offences
       Offence.unscoped.in_scheme_ten
              .joins(offence_band: :offence_category)
              .includes(offence_band: :offence_category)

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -60,7 +60,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
 
   def validate_offence
     return if fixed_fee_case?
-    error_message = @record.scheme_10? ? 'new_blank' : 'blank'
+    error_message = @record.agfs_reform? ? 'new_blank' : 'blank'
     validate_presence(:offence, error_message)
   end
 

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
@@ -28,7 +28,7 @@
           Basic fees include:
         %ul.list.list-bullet
 
-          - if f.object.claim.scheme_10?
+          - if f.object.claim.agfs_reform?
             %li
               1 daily attendance fee
 

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
@@ -28,7 +28,7 @@
           Basic fees include:
         %ul.list.list-bullet
 
-          - if f.object.claim.fee_scheme == 'fee_reform'
+          - if f.object.claim.scheme_10?
             %li
               1 daily attendance fee
 

--- a/app/views/external_users/claims/basic_fees/_offence_display.html.haml
+++ b/app/views/external_users/claims/basic_fees/_offence_display.html.haml
@@ -3,7 +3,7 @@
   Offence
 
 %ul.list.list-bullet
-- if f.object.claim.fee_scheme == 'fee_reform'
+- if f.object.claim.agfs? && f.object.claim.scheme_10?
   %li
     %span.bold>
       = t('offence_class', scope: claim_fields)

--- a/app/views/external_users/claims/basic_fees/_offence_display.html.haml
+++ b/app/views/external_users/claims/basic_fees/_offence_display.html.haml
@@ -3,7 +3,7 @@
   Offence
 
 %ul.list.list-bullet
-- if f.object.claim.agfs? && f.object.claim.scheme_10?
+- if f.object.claim.agfs_reform?
   %li
     %span.bold>
       = t('offence_class', scope: claim_fields)

--- a/app/views/external_users/claims/offence_details/_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fields.html.haml
@@ -1,7 +1,7 @@
 %h2.heading-large
   = t('.offence_details')
 
-- if @claim.scheme_10?
+- if @claim.agfs? && @claim.scheme_10?
   = render partial: "external_users/claims/offence_details/fee_reform_fields", locals: { f: f }
 - else
   = render partial: "external_users/claims/offence_details/default_fields", locals: { f: f }

--- a/app/views/external_users/claims/offence_details/_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fields.html.haml
@@ -1,7 +1,7 @@
 %h2.heading-large
   = t('.offence_details')
 
-- if @claim.agfs? && @claim.scheme_10?
+- if @claim.agfs_reform?
   = render partial: "external_users/claims/offence_details/fee_reform_fields", locals: { f: f }
 - else
   = render partial: "external_users/claims/offence_details/default_fields", locals: { f: f }

--- a/app/views/external_users/claims/offence_details/_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_summary.html.haml
@@ -11,7 +11,7 @@
           %span.table-caption.visuallyhidden
             = t('.caption')
         %tbody
-          - if claim.agfs? && claim.scheme_10?
+          - if claim.agfs_reform?
             = render partial: 'external_users/claims/offence_details/fee_reform_summary', locals: { claim: claim }
           - else
             = render partial: 'external_users/claims/offence_details/default_summary', locals: { claim: claim }

--- a/app/views/external_users/claims/offence_details/_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_summary.html.haml
@@ -11,7 +11,7 @@
           %span.table-caption.visuallyhidden
             = t('.caption')
         %tbody
-          - if claim.scheme_10?
+          - if claim.agfs? && claim.scheme_10?
             = render partial: 'external_users/claims/offence_details/fee_reform_summary', locals: { claim: claim }
           - else
             = render partial: 'external_users/claims/offence_details/default_summary', locals: { claim: claim }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,8 +82,7 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 email_notification_enabled?: true
 
 feature_flags_enabled?: true
-active_features:
-  - :agfs_fee_reform
+active_features: []
 
 reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).change(offset: '+100') %>
 

--- a/spec/controllers/external_users/claim_types_controller_spec.rb
+++ b/spec/controllers/external_users/claim_types_controller_spec.rb
@@ -43,72 +43,28 @@ RSpec.describe ExternalUsers::ClaimTypesController, type: :controller, focus: tr
     context 'admin of AGFS and LGFS provider' do
       let(:external_user) { create(:external_user, :agfs_lgfs_admin) }
 
-      context 'when AGFS fee reform feature flag is NOT active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-        end
-
-        it "assigns bill types based on provider roles" do
-          get :selection
-          expect(assigns(:available_claim_types)).to match_array(%w(agfs lgfs_final lgfs_interim lgfs_transfer))
-        end
-
-        it "renders claim type options page" do
-          get :selection
-          expect(response).to render_template(:selection)
-        end
+      it "assigns bill types based on provider roles" do
+        get :selection
+        expect(assigns(:available_claim_types)).to match_array(%w(agfs agfs_interim lgfs_final lgfs_interim lgfs_transfer))
       end
 
-      context 'when AGFS fee reform feature flag is active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-        end
-
-        it "assigns bill types based on provider roles" do
-          get :selection
-          expect(assigns(:available_claim_types)).to match_array(%w(agfs agfs_interim lgfs_final lgfs_interim lgfs_transfer))
-        end
-
-        it "renders the bill type options page" do
-          get :selection
-          expect(response).to render_template(:selection)
-        end
+      it "renders the bill type options page" do
+        get :selection
+        expect(response).to render_template(:selection)
       end
     end
 
     context 'admin of AGFS provider' do
       let(:external_user) { create(:external_user, :admin, provider: create(:provider, :agfs)) }
 
-      context 'when AGFS fee reform feature flag is NOT active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-        end
-
-        it "assigns bill types based on provider roles" do
-          get :selection
-          expect(assigns(:available_claim_types)).to match_array(%w(agfs))
-        end
-
-        it "redirects to the new advocate claim form page" do
-          get :selection
-          expect(response).to redirect_to(new_advocates_claim_path)
-        end
+      it "assigns bill types based on provider roles" do
+        get :selection
+        expect(assigns(:available_claim_types)).to match_array(%w(agfs agfs_interim))
       end
 
-      context 'when AGFS fee reform feature flag is active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-        end
-
-        it "assigns bill types based on provider roles" do
-          get :selection
-          expect(assigns(:available_claim_types)).to match_array(%w(agfs agfs_interim))
-        end
-
-        it "renders the bill type options page" do
-          get :selection
-          expect(response).to render_template(:selection)
-        end
+      it "renders the bill type options page" do
+        get :selection
+        expect(response).to render_template(:selection)
       end
     end
 

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -704,6 +704,18 @@ describe '#fee_scheme' do
   }
 end
 
+describe '#agfs_reform?' do
+  let(:claim) { MockBaseClaim.new }
+  let(:mock_fee_scheme) { double(:fee_scheme) }
+
+  specify {
+    expect(FeeScheme).to receive(:for_claim).with(claim).and_return(mock_fee_scheme)
+    expect(mock_fee_scheme).to receive(:agfs_reform?)
+    claim.agfs_reform?
+  }
+end
+
+
 describe '#vat_registered?' do
   subject { claim.vat_registered? }
 

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -696,7 +696,7 @@ end
 
 describe '#fee_scheme' do
   let(:claim) { MockBaseClaim.new }
-  let(:mock_fee_scheme) { double(:fee_scheme) }
+  let(:mock_fee_scheme) { instance_double(FeeScheme) }
 
   specify {
     expect(FeeScheme).to receive(:for_claim).with(claim).and_return(mock_fee_scheme)
@@ -706,15 +706,9 @@ end
 
 describe '#agfs_reform?' do
   let(:claim) { MockBaseClaim.new }
-  let(:mock_fee_scheme) { double(:fee_scheme) }
 
-  specify {
-    expect(FeeScheme).to receive(:for_claim).with(claim).and_return(mock_fee_scheme)
-    expect(mock_fee_scheme).to receive(:agfs_reform?)
-    claim.agfs_reform?
-  }
+  specify { expect(claim).to delegate_method(:agfs_reform?).to(:fee_scheme) }
 end
-
 
 describe '#vat_registered?' do
   subject { claim.vat_registered? }

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -263,26 +263,9 @@ RSpec.describe ExternalUser, type: :model do
     context 'for users with only an advocate role' do
       let(:user) { build(:external_user, :advocate) }
 
-      context 'when the AGFS fee reform feature flag is NOT active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-        end
-
-        it 'returns the single advocate claim type available' do
-          expect(user.available_claim_types)
-            .to match_array([Claim::AdvocateClaim])
-        end
-      end
-
-      context 'when the AGFS fee reform feature flag is active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-        end
-
-        it 'returns the list of available advocate claim types' do
-          expect(user.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim])
-        end
+      it 'returns the list of available advocate claim types' do
+        expect(user.available_claim_types)
+          .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim])
       end
     end
 
@@ -298,52 +281,18 @@ RSpec.describe ExternalUser, type: :model do
     context 'for users with an admin role' do
       let(:user) { build(:external_user, :admin) }
 
-      context 'when the AGFS fee reform feature flag is NOT active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-        end
-
-        it 'returns the list of all available claims types' do
-          expect(user.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-      end
-
-      context 'when the AGFS fee reform feature flag is active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-        end
-
-        it 'returns the list of available advocate claim types including the feature flagged ones' do
-          expect(user.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
+      it 'returns the list of available advocate claim types including the feature flagged ones' do
+        expect(user.available_claim_types)
+          .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end
     end
 
     context 'for users with both an advocate and litigator role' do
       let(:user) { build(:external_user, :advocate_litigator) }
 
-      context 'when the AGFS fee reform feature flag is NOT active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-        end
-
-        it 'returns the list of claims types available for advocates and litigators' do
-          expect(user.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-      end
-
-      context 'when the AGFS fee reform feature flag is active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-        end
-
-        it 'returns the list of claim types available for advocate and litigators including the feature flagged ones' do
-          expect(user.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
+      it 'returns the list of claim types available for advocate and litigators including the feature flagged ones' do
+        expect(user.available_claim_types)
+          .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end
     end
   end

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe ExternalUser, type: :model do
     context 'for users with an admin role' do
       let(:user) { build(:external_user, :admin) }
 
-      it 'returns the list of available advocate claim types including the feature flagged ones' do
+      it 'returns the list of available advocate claim types' do
         expect(user.available_claim_types)
           .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end
@@ -290,7 +290,7 @@ RSpec.describe ExternalUser, type: :model do
     context 'for users with both an advocate and litigator role' do
       let(:user) { build(:external_user, :advocate_litigator) }
 
-      it 'returns the list of claim types available for advocate and litigators including the feature flagged ones' do
+      it 'returns the list of claim types available for advocate and litigators' do
         expect(user.available_claim_types)
           .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe FeeScheme, type: :model do
   it { should validate_presence_of(:name) }
 
   it { is_expected.to respond_to(:agfs?) }
-  it { is_expected.to respond_to(:scheme_10?) }
+  it { is_expected.to respond_to(:agfs_reform?) }
+  # it { is_expected.to respond_to(:scheme_10?) }
 
   describe '.for_claim' do
     subject(:fee_scheme) { described_class.for_claim(claim) }
@@ -31,8 +32,31 @@ RSpec.describe FeeScheme, type: :model do
       end
     end
 
-    describe '#scheme_10?' do
-      subject(:scheme_10?) { fee_scheme.scheme_10? }
+    # TODO: remove if unsused
+    # describe '#scheme_10?' do
+    #   subject(:scheme_10?) { fee_scheme.scheme_10? }
+
+    #   context 'for an agfs scheme 10 claim' do
+    #     let(:claim) { create(:advocate_claim, :agfs_scheme_10) }
+
+    #     it { is_expected.to be_truthy }
+    #   end
+
+    #   context 'for an agfs scheme 9 claim' do
+    #     let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
+
+    #     it { is_expected.to be_falsey }
+    #   end
+
+    #   context 'for an lgfs claim' do
+    #     let(:claim) { create(:litigator_claim) }
+
+    #     it { is_expected.to be_falsey }
+    #   end
+    # end
+
+    describe '#agfs_reform?' do
+      subject(:agfs_reform?) { fee_scheme.agfs_reform? }
 
       context 'for an agfs scheme 10 claim' do
         let(:claim) { create(:advocate_claim, :agfs_scheme_10) }

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe FeeScheme, type: :model do
 
   it { is_expected.to respond_to(:agfs?) }
   it { is_expected.to respond_to(:agfs_reform?) }
-  # it { is_expected.to respond_to(:scheme_10?) }
 
   describe '.for_claim' do
     subject(:fee_scheme) { described_class.for_claim(claim) }
@@ -31,29 +30,6 @@ RSpec.describe FeeScheme, type: :model do
         it { is_expected.to be_falsey }
       end
     end
-
-    # TODO: remove if unsused
-    # describe '#scheme_10?' do
-    #   subject(:scheme_10?) { fee_scheme.scheme_10? }
-
-    #   context 'for an agfs scheme 10 claim' do
-    #     let(:claim) { create(:advocate_claim, :agfs_scheme_10) }
-
-    #     it { is_expected.to be_truthy }
-    #   end
-
-    #   context 'for an agfs scheme 9 claim' do
-    #     let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
-
-    #     it { is_expected.to be_falsey }
-    #   end
-
-    #   context 'for an lgfs claim' do
-    #     let(:claim) { create(:litigator_claim) }
-
-    #     it { is_expected.to be_falsey }
-    #   end
-    # end
 
     describe '#agfs_reform?' do
       subject(:agfs_reform?) { fee_scheme.agfs_reform? }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Provider, type: :model do
     context 'for an AGFS provider' do
       let(:provider) { build :provider, :agfs }
 
-      it 'returns the list of available claim types including the feature flagged ones' do
+      it 'returns the list of available claim types' do
         expect(provider.available_claim_types)
           .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim])
       end
@@ -179,7 +179,7 @@ RSpec.describe Provider, type: :model do
     context 'for a AGFS and LGFS provider' do
       let(:provider) { build(:provider, :agfs_lgfs) }
 
-      it 'returns the list of available claim types including the feature flagged ones' do
+      it 'returns the list of available claim types' do
         expect(provider.available_claim_types)
           .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -161,26 +161,9 @@ RSpec.describe Provider, type: :model do
     context 'for an AGFS provider' do
       let(:provider) { build :provider, :agfs }
 
-      context 'when the AGFS fee reform feature flag is NOT active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-        end
-
-        it 'return the list of available claim types for AGFS' do
-          expect(provider.available_claim_types)
-            .to match_array([ Claim::AdvocateClaim ])
-        end
-      end
-
-      context 'when the AGFS fee reform feature flag is active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-        end
-
-        it 'returns the list of available claim types including the feature flagged ones' do
-          expect(provider.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim])
-        end
+      it 'returns the list of available claim types including the feature flagged ones' do
+        expect(provider.available_claim_types)
+          .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim])
       end
     end
 
@@ -196,26 +179,9 @@ RSpec.describe Provider, type: :model do
     context 'for a AGFS and LGFS provider' do
       let(:provider) { build(:provider, :agfs_lgfs) }
 
-      context 'when the AGFS fee reform feature flag is NOT active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-        end
-
-        it 'returns the list of available claim types for AGFS and LGFS' do
-          expect(provider.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-      end
-
-      context 'when the AGFS fee reform feature flag is active' do
-        before do
-          allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-        end
-
-        it 'returns the list of available claim types including the feature flagged ones' do
-          expect(provider.available_claim_types)
-            .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
+      it 'returns the list of available claim types including the feature flagged ones' do
+        expect(provider.available_claim_types)
+          .to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end
     end
   end

--- a/spec/presenters/fee/basic_fee_presenter_spec.rb
+++ b/spec/presenters/fee/basic_fee_presenter_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe Fee::BasicFeePresenter, type: :presenter do
   let(:claim) { create(:advocate_claim, :agfs_scheme_10) }
   let(:claim_9) { create(:advocate_claim, :agfs_scheme_9) }
   let(:fee) { build(:basic_fee, claim: claim) }
-  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
-  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
-  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
+
+  before { seed_fee_schemes }
 
   subject(:presenter) { described_class.new(fee, view) }
 
@@ -133,17 +132,13 @@ RSpec.describe Fee::BasicFeePresenter, type: :presenter do
 
   describe '#display_help_text?' do
     context 'when claim is NOT under the reformed fee scheme' do
-      before do
-        allow(claim).to receive(:fee_scheme).and_return('default')
-      end
+      let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
 
       specify { expect(presenter.display_help_text?).to be_falsey }
     end
 
     context 'when claim is under the reformed fee scheme' do
-      before do
-        allow(claim).to receive(:fee_scheme).and_return('fee_reform')
-      end
+      let(:claim) { create(:advocate_claim, :agfs_scheme_10) }
 
       context 'and fee type has restrictions to be displayed' do
         let(:fee) { build(:basic_fee, :ppe_fee, claim: claim) }

--- a/spec/services/claims/context_mapper_spec.rb
+++ b/spec/services/claims/context_mapper_spec.rb
@@ -10,113 +10,52 @@ RSpec.describe Claims::ContextMapper do
     let(:advocate)      { create(:external_user, :advocate) }
     let(:litigator)     { create(:external_user, :litigator) }
 
-    context 'when the AGFS fee reform feature flag is NOT active' do
-      before do
-        allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-      end
-
-      it 'should return advocate claims for users in AGFS only provider' do
-        context = Claims::ContextMapper.new(advocate)
-        expect(context.available_claim_types).to match_array([Claim::AdvocateClaim])
-      end
-
-      it 'should return litigator claims for users in LGFS only provider' do
-        context = Claims::ContextMapper.new(litigator)
-        expect(context.available_claim_types).to match_array([Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-      end
-
-      context 'AGFS and LGFS providers' do
-
-        it 'should return litigator claim for a litigators' do
-          external_user.roles = ['litigator']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-
-        it 'should return litigator and advocate claim for a litigator admins' do
-          external_user.roles = ['litigator', 'admin']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-
-        it 'should return advocate claim for a advocates' do
-          external_user.roles = ['advocate']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to eql [Claim::AdvocateClaim]
-        end
-
-        it 'should return advocate and litigator claim for a advocate admins' do
-          external_user.roles = ['advocate', 'admin']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-
-        it 'should return advocate AND litigator claims for a admins' do
-          external_user.roles = ['admin']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-
-        it 'should return advocate AND litigator claims for users with admin, litigator and advocate roles' do
-          external_user.roles = ['admin', 'advocate', 'litigator']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-      end
+    it 'should return advocate claims for users in AGFS only provider' do
+      context = Claims::ContextMapper.new(advocate)
+      expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim])
     end
 
-    context 'when the AGFS fee reform feature flag is active' do
-      before do
-        allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-      end
+    it 'should return litigator claims for users in LGFS only provider' do
+      context = Claims::ContextMapper.new(litigator)
+      expect(context.available_claim_types).to match_array([Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
+    end
 
-      it 'should return advocate claims for users in AGFS only provider' do
-        context = Claims::ContextMapper.new(advocate)
-        expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim])
-      end
+    context 'AGFS and LGFS providers' do
 
-      it 'should return litigator claims for users in LGFS only provider' do
-        context = Claims::ContextMapper.new(litigator)
+      it 'should return litigator claim for a litigators' do
+        external_user.roles = ['litigator']
+        context = Claims::ContextMapper.new(external_user)
         expect(context.available_claim_types).to match_array([Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end
 
-      context 'AGFS and LGFS providers' do
+      it 'should return litigator and advocate claim for a litigator admins' do
+        external_user.roles = ['litigator', 'admin']
+        context = Claims::ContextMapper.new(external_user)
+        expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
+      end
 
-        it 'should return litigator claim for a litigators' do
-          external_user.roles = ['litigator']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
+      it 'should return advocate claim for a advocates' do
+        external_user.roles = ['advocate']
+        context = Claims::ContextMapper.new(external_user)
+        expect(context.available_claim_types).to eql [Claim::AdvocateClaim, Claim::AdvocateInterimClaim]
+      end
 
-        it 'should return litigator and advocate claim for a litigator admins' do
-          external_user.roles = ['litigator', 'admin']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
+      it 'should return advocate and litigator claim for a advocate admins' do
+        external_user.roles = ['advocate', 'admin']
+        context = Claims::ContextMapper.new(external_user)
+        expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
+      end
 
-        it 'should return advocate claim for a advocates' do
-          external_user.roles = ['advocate']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to eql [Claim::AdvocateClaim, Claim::AdvocateInterimClaim]
-        end
+      it 'should return advocate AND litigator claims for a admins' do
+        external_user.roles = ['admin']
+        context = Claims::ContextMapper.new(external_user)
+        expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
+      end
 
-        it 'should return advocate and litigator claim for a advocate admins' do
-          external_user.roles = ['advocate', 'admin']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-
-        it 'should return advocate AND litigator claims for a admins' do
-          external_user.roles = ['admin']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
-
-        it 'should return advocate AND litigator claims for users with admin, litigator and advocate roles' do
-          external_user.roles = ['admin', 'advocate', 'litigator']
-          context = Claims::ContextMapper.new(external_user)
-          expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
-        end
+      it 'should return advocate AND litigator claims for users with admin, litigator and advocate roles' do
+        external_user.roles = ['admin', 'advocate', 'litigator']
+        context = Claims::ContextMapper.new(external_user)
+        expect(context.available_claim_types).to match_array([Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim])
       end
     end
   end

--- a/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
+++ b/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
@@ -50,19 +50,6 @@ RSpec.describe Claims::FetchEligibleAdvocateCategories, type: :service do
           it 'returns the list for AGFS scheme 10 advocate categories' do
             is_expected.to match_array(scheme_10_advocate_categories)
           end
-
-          # TODO: to be removed once all use of `fee_scheme` string removed
-          context 'using deprecated `fee_scheme` string' do
-            let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
-
-            before do
-              expect(claim).to receive(:fee_scheme).at_least(:once).and_return('fee_reform')
-            end
-
-            it 'returns the list for AGFS scheme 10 advocate categories' do
-              is_expected.to match_array(scheme_10_advocate_categories)
-            end
-          end
         end
       end
 

--- a/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
+++ b/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
@@ -29,19 +29,6 @@ RSpec.describe Claims::FetchEligibleAdvocateCategories, type: :service do
           it 'returns the list for AGFS scheme 9 advocate categories' do
             is_expected.to match_array(scheme_9_advocate_categories)
           end
-
-          # TODO: to be removed once all use of `fee_scheme` string removed
-          context 'using deprecated `fee_scheme` string' do
-            let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
-
-            before do
-              expect(claim).to receive(:fee_scheme).at_least(:once).and_return(nil)
-            end
-
-            it 'returns the list for AGFS scheme 9 advocate categories' do
-              is_expected.to match_array(scheme_9_advocate_categories)
-            end
-          end
         end
 
         context 'scheme 10' do
@@ -75,7 +62,7 @@ RSpec.describe Claims::FetchEligibleAdvocateCategories, type: :service do
       context 'when the claim has been submitted via the API' do
         # This will mean the offence will determine the fee_scheme, not the rep_order date
         context 'with a scheme 10 offence' do
-          let(:claim) { create :api_advocate_claim, :with_scheme_ten_offence }
+          let(:claim) { create(:api_advocate_claim, :with_scheme_ten_offence) }
 
           it { is_expected.to match_array(scheme_10_advocate_categories) }
         end

--- a/spec/services/claims/fetch_eligible_offences_spec.rb
+++ b/spec/services/claims/fetch_eligible_offences_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Claims::FetchEligibleOffences, type: :service do
   subject(:offences) { described_class.for(claim) }
 
+  before { seed_fee_schemes }
+
   shared_examples_for 'a claim with default offences' do
     context 'and the claim has no associated offence' do
       before do
@@ -34,37 +36,17 @@ RSpec.describe Claims::FetchEligibleOffences, type: :service do
   end
 
   context 'when claim is for AGFS' do
-    let(:claim) { create(:advocate_claim) }
-
-    context 'and AGFS fee reform feature is not active' do
-      before do
-        allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(false)
-      end
+    context 'and fee scheme for the claim is not the AGFS reform scheme' do
+      let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
 
       include_examples 'a claim with default offences'
     end
 
-    context 'and AGFS fee reform feature is active' do
-      before do
-        allow(FeatureFlag).to receive(:active?).with(:agfs_fee_reform).and_return(true)
-      end
+    context 'and fee scheme for the claim is the AGFS reform scheme' do
+      let(:claim) { create(:advocate_claim, :agfs_scheme_10) }
 
-      context 'and fee scheme for the claim is not the AGFS reform scheme' do
-        before do
-          allow(claim).to receive(:fee_scheme).and_return('default')
-        end
-
-        include_examples 'a claim with default offences'
-      end
-
-      context 'and fee scheme for the claim is the AGFS reform scheme' do
-        before do
-          allow(claim).to receive(:fee_scheme).and_return('fee_reform')
-        end
-
-        it 'returns a list of all available offences for the associated fee scheme' do
-          expect(offences).to match_array(Offence.in_scheme_ten)
-        end
+      it 'returns a list of all available offences for the associated fee scheme' do
+        expect(offences).to match_array(Offence.in_scheme_ten)
       end
     end
   end

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
 
   let(:litigator) { create(:external_user, :litigator) }
   let(:claim)     { create(:advocate_claim) }
-  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
-  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
-  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
+
+  before { seed_fee_schemes }
 
   include_examples "common advocate litigator validations", :advocate
 
@@ -86,9 +85,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
       default_valid_categories = ['QC', 'Led junior', 'Leading junior', 'Junior alone']
 
       context 'when on fee reform scheme' do
-        before do
-          allow(claim).to receive(:fee_scheme).and_return(agfs_scheme_ten)
-        end
+        let(:claim) { create(:advocate_claim, :agfs_scheme_10) }
 
         fee_reform_valid_categories = ['QC', 'Leading junior', 'Junior']
         fee_reform_invalid_categories = ['Led junior', 'Junior alone']


### PR DESCRIPTION
#### What

- Removes the feature flag for fee reform since all the AGFS claims are being submitted in the all environments under the fee reform.

Relates to: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/2425
Fixes: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/issues/2433

#### Ticket

[Addressing some tech debt from fee reform release](https://dsdmoj.atlassian.net/browse/CBO-287)

#### Why

There were some checks against the string version of the fee scheme that were left over from the previous refactor.

#### Next steps

To allow us to not have to do things like:

```
- if claim.scheme_10?
  # show scheme 10 eligible offences
```

in the code is to have a settings/configurations file that determine how things are set up on a given scheme, to turn the above code into something like:

```
= claim.eligible_offences
```

and under the hood we check the fee scheme associated with the claim and what sort of configuration is set for the eligible offences for that fee scheme.
