### PR TITLE
Changes to validation for cracked trials

### DIFF
--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -44,8 +44,8 @@ class RepresentationOrderValidator < BaseValidator
 
   def validate_against_cracked_trial_dates
     return unless claim&.requires_cracked_dates?
-    validate_on_or_before(claim.trial_fixed_notice_at,
-                          :representation_order_date, 'not_on_or_before_trial_fixed_notice_date')
+    validate_on_or_before(claim.trial_cracked_at,
+                          :representation_order_date, 'not_on_or_before_trial_cracked_date')
   end
 
   def validate_against_case_concluded_date

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -689,10 +689,10 @@ representation_order:
       long: 'Check the combination of the representation order date and the dates of trial'
       short: 'Check combination of representation order date and trial dates'
       api: 'Check combination of rep order date and trial dates'
-    not_on_or_before_trial_fixed_notice_date:
-      long: 'Check the combination of the representation order date and the dates of cracked trial'
-      short: 'Check combination of representation order date and cracked trial dates'
-      api: 'Check combination of rep order date and cracked trial dates'
+    not_on_or_before_trial_cracked_date:
+      long: 'Check the combination of the representation order date and the case cracked date'
+      short: 'Check combination of representation order date and case cracked date'
+      api: 'Check combination of rep order date and case cracked date'
     scheme_ten_offence:
       long: Representation Order Date is not valid for AGFS scheme ten
       short: *check_date

--- a/spec/validators/representation_order_date_validator_spec.rb
+++ b/spec/validators/representation_order_date_validator_spec.rb
@@ -79,61 +79,61 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
       end
 
       context 'with a cracked trial case type' do
-        let(:trial_fixed_notice_at) { 5.days.ago }
+        let(:trial_cracked_at) { 5.days.ago }
         let(:case_type) { build(:case_type, :cracked_trial) }
-        let(:claim) { build(:advocate_claim, case_type: case_type, trial_fixed_notice_at: trial_fixed_notice_at) }
+        let(:claim) { build(:advocate_claim, case_type: case_type, trial_cracked_at: trial_cracked_at) }
 
-        context 'and the representation order date is before the fixed notice date' do
-          let(:rep_order_date) { trial_fixed_notice_at - 2.days }
+        context 'and the representation order date is before the trial cracked date' do
+          let(:rep_order_date) { trial_cracked_at - 2.days }
           let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
-
+           
           specify { expect(reporder).to be_valid }
         end
 
-        context 'and the representation order date matches the first day of trial' do
-          let(:rep_order_date) { trial_fixed_notice_at }
+        context 'and the representation order date matches the trial cracked date' do
+          let(:rep_order_date) { trial_cracked_at }
           let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
-
+          
           specify { expect(reporder).to be_valid }
         end
 
         context 'and the representation order date is later than the first day of trial' do
-          let(:rep_order_date) { trial_fixed_notice_at + 1.day }
+          let(:rep_order_date) { trial_cracked_at + 1.day }
           let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
 
           it 'is invalid' do
             expect(reporder).not_to be_valid
-            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_fixed_notice_date')
+            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_cracked_date')
           end
         end
       end
 
       context 'with a cracked before retrial case type' do
-        let(:trial_fixed_notice_at) { 5.days.ago }
+        let(:trial_cracked_at) { 5.days.ago }
         let(:case_type) { build(:case_type, :cracked_before_retrial) }
-        let(:claim) { build(:advocate_claim, case_type: case_type, trial_fixed_notice_at: trial_fixed_notice_at) }
+        let(:claim) { build(:advocate_claim, case_type: case_type, trial_cracked_at: trial_cracked_at) }
 
         context 'and the representation order date is before the fixed notice date' do
-          let(:rep_order_date) { trial_fixed_notice_at - 2.days }
+          let(:rep_order_date) { trial_cracked_at - 2.days }
           let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
 
           specify { expect(reporder).to be_valid }
         end
 
         context 'and the representation order date matches the first day of trial' do
-          let(:rep_order_date) { trial_fixed_notice_at }
+          let(:rep_order_date) { trial_cracked_at }
           let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
 
           specify { expect(reporder).to be_valid }
         end
 
         context 'and the representation order date is later than the first day of trial' do
-          let(:rep_order_date) { trial_fixed_notice_at + 1.day }
+          let(:rep_order_date) { trial_cracked_at + 1.day }
           let(:reporder) { build(:representation_order, defendant: defendant, representation_order_date: rep_order_date) }
 
           it 'is invalid' do
             expect(reporder).not_to be_valid
-            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_fixed_notice_date')
+            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_cracked_date')
           end
         end
       end


### PR DESCRIPTION
Changes to validation for cracked trials - see CBO-279

#### What

Changes to validation to allow users to enter a rep order date after the "notice of first fixed warned date" and the "first fixed warned date" without the system bringing up error message that prevents this, and to prevent users from entering a rep order date after the date the case cracked

#### Ticket

CBO-279 https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=222&modal=detail&selectedIssue=CBO-279

#### Why

To allow for pre-rep order PTPH in cracked trials

