### PR TITLE
CBO-293 reinstate grad fee calculator link

### DIFF
--- a/app/views/external_users/claims/_fees_shared_header.html.haml
+++ b/app/views/external_users/claims/_fees_shared_header.html.haml
@@ -4,3 +4,6 @@
 
   %p
     = local_assigns.has_key?(:page_hint) ? page_hint : t('.fees_header_prompt_text_html')
+
+  %p
+    = t(".fees_calculator_html")

--- a/app/views/external_users/claims/graduated_fees/_fields.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_fields.html.haml
@@ -1,7 +1,4 @@
 
-%p
-  = t(".page_intro_html")
-
 - if @claim.allows_graduated_fees?
   #graduated-fees.mod-graduated-fees
     = f.fields_for :graduated_fee do |gradfee|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -977,8 +977,6 @@ en:
           date: "Date"
           page_header: "Graduated fees"
           page_hint: *fees_vat_prompt
-          page_intro_html: |
-            Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a> for help.
         summary:
           header: Graduated fees
           actual_trial_length:
@@ -1084,6 +1082,8 @@ en:
       fees_shared_header:
         fees: Fees
         fees_header_prompt_text_html: *fees_vat_prompt
+        fees_calculator_html: |
+            Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a> for help.
       summary_claims_sidebar:
         button_label: *continue_to_certification_button
         continue: 'Continue'


### PR DESCRIPTION
Changes for CBO-293 to reinstate calculator link for advocates.

#### What

Changes detailed on CBO-293, to add link to fee calculator for advocates on Fees screens, to make it consistent with the similar litigator screens.

#### Ticket

CBO-293

#### Why

So that advocates can easily access the calculators (because fee calculation will not be fully implemented for some time).

#### How

Added requested links to fee screens.
