### PR TITLE
[CBO-34] injection report successes/errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,6 +31,7 @@ Metrics/ClassLength:
 Metrics/LineLength:
   Exclude:
     - 'app/services/ccr/fee/misc_fee_adapter.rb'
+    - 'app/services/reports/injection_errors.rb'
     - 'app/interfaces/api/entities/full_claim.rb' # not used
     - 'lib/data_migrator/*rb'
 
@@ -76,6 +77,7 @@ Metrics/MethodLength:
     - 'app/services/injection_response_service.rb'
     - 'app/services/message_queue/aws_client.rb'
     - 'app/services/message_queue/message_template.rb'
+    - 'app/services/reports/injection_errors.rb'
     - 'app/services/slack_notifier.rb'
     - 'app/services/stats/management_information_generator.rb'
     - 'app/services/vat_auditor.rb'

--- a/app/interfaces/api/entities/injection_error_category.rb
+++ b/app/interfaces/api/entities/injection_error_category.rb
@@ -1,0 +1,8 @@
+module API
+  module Entities
+    class InjectionErrorCategory < BaseEntity
+      expose :error_category
+      expose :total
+    end
+  end
+end

--- a/app/interfaces/api/v2/mi/injection_errors.rb
+++ b/app/interfaces/api/v2/mi/injection_errors.rb
@@ -1,0 +1,45 @@
+module API
+  module V2
+    module MI
+      class InjectionErrors < Grape::API
+        require 'csv'
+        helpers API::V2::MIHelper
+
+        content_type :csv, 'text/csv; utf-8'
+        default_format :json
+
+        resource :mi, desc: 'MI endpoint' do
+          resource :injection_errors do
+            helpers do
+              def date_range
+                hash = { start_date: 1.day.ago.utc.beginning_of_day, end_date: 1.day.ago.utc.end_of_day }
+                return hash unless params[:date].present?
+                hash[:start_date] = params[:date].to_date.beginning_of_day.utc
+                hash[:end_date] = params[:date].to_date.end_of_day.utc
+                hash
+              end
+            end
+
+            desc 'Retrieve totals for injection error categories'
+            params do
+              optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the user'
+              optional :date, type: String, desc: 'OPTIONAL: Occurence Date (YYYY-MM-DD). Defaults to yesterday'
+              optional :format, type: String, desc: 'JSON or CSV. Defaults to JSON', values: %w[json csv]
+            end
+            get do
+              results = Reports::InjectionErrors.call(date_range)
+              if params[:format].eql?('csv')
+                csv = build_csv_from(results, Reports::InjectionErrors::COLUMNS)
+                header 'Content-Disposition', "attachment; filename=injection_errors_categories-#{params[:date]}.csv"
+                present csv
+              else
+                present JSON.parse(results.to_json, object_class: OpenStruct),
+                        with: API::Entities::InjectionErrorCategory
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v2/mi_helper.rb
+++ b/app/interfaces/api/v2/mi_helper.rb
@@ -14,9 +14,9 @@ module API
         [sanitize_and_format(start_date), sanitize_and_format(end_date)]
       end
 
-      def build_csv_from(data)
+      def build_csv_from(data, headers = [])
         CSV.generate do |build_csv|
-          fields = data.first.keys
+          fields = headers.empty? ? data.first.keys : headers
           build_csv << fields
           data.each do |row|
             build_csv << row.values

--- a/app/interfaces/api/v2/root.rb
+++ b/app/interfaces/api/v2/root.rb
@@ -17,6 +17,7 @@ module API
           mount API::V2::Claim
           mount API::V2::Search
           mount API::V2::MI::AGFSSchemeTenClaims
+          mount API::V2::MI::InjectionErrors
 
           namespace :ccr, desc: 'CCR injection specific claim format' do
             mount API::V2::CCRClaim

--- a/app/services/reports/injection_errors.rb
+++ b/app/services/reports/injection_errors.rb
@@ -1,0 +1,78 @@
+module Reports
+  class InjectionErrors
+    COLUMNS = %w[error_category total].freeze
+
+    def self.call(options = {})
+      new(options).call
+    end
+
+    attr_reader :start_date, :end_date
+
+    def initialize(options = {})
+      @start_date = options[:start_date]
+      @end_date = options[:end_date]
+    end
+
+    def call
+      InjectionAttempt.connection.execute(query).to_a
+    end
+
+    private
+
+    def query
+      %{SELECT error_category, sum(total) as total
+      FROM (#{aggregrate_query}) AS subquery GROUP BY error_category}
+    end
+
+    def aggregrate_query
+      %{SELECT
+      CASE
+        WHEN obj->>'error' ILIKE '%Cannot create a bill of type%' THEN 'BILL_TYPE#CREATION_ERROR'
+        WHEN obj->>'error' ILIKE '%Bill Sub Type%not found in%' THEN 'BILL_TYPE#NOT_FOUND_ERROR'
+        WHEN obj->>'error' ILIKE '%Invalid scenario%for Bill Sub Type%' THEN 'BILL_TYPE#INVALID_SCENARIO_ERROR'
+        WHEN obj->>'error' ILIKE '%At least one Bill object MUST be included on a claim%' THEN 'CLAIM#MISSING_BILL_ERROR'
+        WHEN obj->>'error' ILIKE '%Offence object MUST not be NULL for a claim.%' THEN 'CLAIM#MISSING_OFFENCE_ERROR'
+        WHEN obj->>'error' ILIKE '%is a mandatory field%' THEN 'CLAIM#MISSING_MANDATORY_FIELD_ERROR'
+        WHEN obj->>'error' ILIKE '%Required field not entered%' THEN 'CLAIM#MISSING_MANDATORY_FIELD_ERROR'
+        WHEN obj->>'error' ILIKE '%A claim already exists for these case details%' THEN 'CLAIM#ALREADY_EXISTS_ERROR'
+        WHEN obj->>'error' ILIKE '%A case already exists for these case details%' THEN 'CLAIM#ALREADY_EXISTS_ERROR'
+        WHEN obj->>'error' ILIKE '%A claim with these details already exists in the system%' THEN 'CLAIM#ALREADY_EXISTS_ERROR'
+        WHEN obj->>'error' ILIKE '%Details of the entered case already exist in%' THEN 'CLAIM#ALREADY_EXISTS_ERROR'
+        WHEN obj->>'error' ILIKE '%First day of Trial%CANNOT come before Rep Order Date%' THEN 'CLAIM#FIRST_DAY_TRIAL_VALIDATION_ERROR'
+        WHEN obj->>'error' ILIKE '%Cannot calculate the fee%' THEN 'FEE#CALCULATION_ERROR'
+        WHEN obj->>'error' ILIKE '%Wasted Preparation Fee%' THEN 'FEE#WASTED_PREPARATION_FEE_ERROR'
+        WHEN obj->>'error' ILIKE '%No defendant found for Rep Order Number%' THEN 'REP_ORDER#DEFENDANT_NOT_FOUND'
+        WHEN obj->>'error' ILIKE '%Error retrieving defendant details for Rep Order Number%' THEN 'REP_ORDER#DEFENDANT_DETAILS_NOT_FOUND'
+        WHEN obj->>'error' ILIKE '%Expense Date Incurred%' THEN 'EXPENSE#DATE_INCURRED_ERROR'
+        WHEN obj->>'error' ILIKE '%The supplier account code%' THEN 'SUPPLIER_NUMBER#INVALID_ERROR'
+        WHEN obj->>'error' ILIKE '%Supplier Account Number cannot be empty%' THEN 'SUPPLIER_NUMBER#CANNOT_BE_EMPTY_ERROR'
+        WHEN obj->>'error' ILIKE '%VAT Amount % is too high for Net Amount supplied %' THEN 'NET_AMOUNT#INVALID_VAT_AMOUNT_ERROR'
+        WHEN obj->>'error' ILIKE '%Read timed out%' THEN 'CONNECTION#TIMEOUT_ERROR'
+        WHEN obj->>'error' ILIKE '%Failed: HTTP Error Code%' THEN 'CONNECTION#HTTP_ERROR'
+        WHEN obj->>'error' ILIKE '%Claim injection failed%' THEN 'GENERIC_FAILED_INJECTION_ERROR'
+        WHEN obj->>'error' ILIKE '%Unrecognized field%' THEN 'PARSING#INVALID_FIELD_ERROR'
+        WHEN obj->>'error' ILIKE '%Text%could not be parsed%' THEN 'PARSING#PARSING_ERROR'
+        WHEN obj->>'error' ILIKE '%The supplied JSON string is EMPTY%' THEN 'PARSING#PARSING_ERROR'
+        WHEN obj->>'error' ILIKE '%no protocol:%' THEN 'INTERNAL_ERROR'
+        WHEN obj->>'error' ILIKE '%A system exception has occurred%' THEN 'INTERNAL_ERROR'
+        WHEN obj->>'error' ILIKE '%An application error has occurred%' THEN 'INTERNAL_ERROR'
+        WHEN obj->>'error' ILIKE '%java.%' THEN 'INTERNAL_ERROR'
+        WHEN ((obj->>'error' = '') IS NOT FALSE) OR (obj->>'error' = 'nil') OR (obj->>'error' = 'null') THEN 'NO_ERROR_DESCRIPTION'
+        ELSE 'UNCATEGORIZED_ERROR'
+      END as error_category,
+      COUNT(*) as total
+      FROM injection_attempts ia, json_array_elements(ia.error_messages->'errors') obj
+      WHERE #{where_conditions}
+      GROUP BY obj->>'error'}
+    end
+
+    def where_conditions
+      ['ia.succeeded = false', date_range_clause].compact.join(' AND ')
+    end
+
+    def date_range_clause
+      return unless start_date && end_date
+      "ia.created_at BETWEEN '#{start_date.to_s(:db)}' AND '#{end_date.to_s(:db)}'"
+    end
+  end
+end

--- a/lib/geckoboard_publisher/injection_record.rb
+++ b/lib/geckoboard_publisher/injection_record.rb
@@ -1,0 +1,73 @@
+module GeckoboardPublisher
+  class InjectionRecord
+    attr_reader :date
+
+    def initialize(date)
+      @date = date.to_date
+      @date_range = @date.beginning_of_day..@date.end_of_day
+    end
+
+    def to_h
+      { date: date.iso8601 }
+        .merge(ccr_fields)
+        .merge(cclf_fields)
+        .merge(totals_fields)
+    end
+
+    private
+
+    attr_reader :date_range
+
+    def ccr_fields
+      {
+        total_ccr_succeeded: total_ccr_succeeded,
+        total_ccr: total_ccr,
+        percentage_ccr_succeeded: percentage(total_ccr_succeeded, total_ccr)
+      }
+    end
+
+    def cclf_fields
+      {
+        total_cclf_succeeded: total_cclf_succeeded,
+        total_cclf: total_cclf,
+        percentage_cclf_succeeded: percentage(total_cclf_succeeded, total_cclf)
+      }
+    end
+
+    def totals_fields
+      {
+        total_succeeded: InjectionAttempt.where(succeeded: true).where(created_at: date_range).count,
+        total: InjectionAttempt.where(created_at: date_range).count
+      }
+    end
+
+    def ccr_injections
+      InjectionAttempt.joins(:claim).merge(Claim::BaseClaim.agfs)
+    end
+
+    def cclf_injections
+      InjectionAttempt.joins(:claim).merge(Claim::BaseClaim.lgfs)
+    end
+
+    def total_ccr_succeeded
+      ccr_injections.where(succeeded: true).where(created_at: date_range).count
+    end
+
+    def total_ccr
+      ccr_injections.where(created_at: date_range).count
+    end
+
+    def total_cclf_succeeded
+      cclf_injections.where(succeeded: true).where(created_at: date_range).count
+    end
+
+    def total_cclf
+      cclf_injections.where(created_at: date_range).count
+    end
+
+    def percentage(numerator, denominator)
+      return 0 if denominator.zero?
+      numerator / denominator.to_f
+    end
+  end
+end

--- a/lib/geckoboard_publisher/injections_report.rb
+++ b/lib/geckoboard_publisher/injections_report.rb
@@ -1,0 +1,52 @@
+module GeckoboardPublisher
+  class InjectionsReport < Report
+    def initialize(start_date = Date.yesterday, end_date = nil)
+      super
+      @start_date = start_date
+      @end_date = end_date.present? ? end_date : start_date
+    end
+
+    def fields
+      [Geckoboard::DateField.new(:date, name: 'Date')] + ccr_fields + cclf_fields + totals_fields
+    end
+
+    def items
+      items = []
+      (@start_date..@end_date).each do |date|
+        items << InjectionRecord.new(date).to_h
+      end
+      items
+    end
+
+    def unique_by
+      [:date]
+    end
+
+    private
+
+    def ccr_fields
+      [
+        Geckoboard::NumberField.new(:total_ccr_succeeded, name: 'Total CCR'),
+        Geckoboard::NumberField.new(:total_ccr, name: 'Total number of CCR injections'),
+        Geckoboard::PercentageField.new(:percentage_ccr_succeeded,
+                                        name: 'Percentage of successful CCR injections', optional: true)
+      ]
+    end
+
+    def cclf_fields
+      [
+        Geckoboard::NumberField.new(:total_cclf_succeeded, name: 'Total CCLF succeeded'),
+        Geckoboard::NumberField.new(:total_cclf, name: 'Total number of CCLF injections'),
+        Geckoboard::PercentageField.new(:percentage_cclf_succeeded,
+                                        name: 'Percentage of successful CCLF injections', optional: true)
+      ]
+    end
+
+    def totals_fields
+      [
+        Geckoboard::NumberField.new(:total_succeeded, name: 'Total succeeded'),
+        Geckoboard::NumberField.new(:total, name: 'Total number of injections')
+      ]
+    end
+  end
+end

--- a/scheduled_tasks/update_geckoboard_injections_report_task.rb
+++ b/scheduled_tasks/update_geckoboard_injections_report_task.rb
@@ -1,0 +1,15 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class UpdateGeckoboardInjectionsReportTask < Scheduler::SchedulerTask
+  every '1d', first_at: Chronic.parse('next 4:50 am')
+
+  def run
+    log('Generating Geckoboard Injections data...')
+    GeckoboardPublisher::InjectionsReport.new.publish!
+  rescue StandardError => ex
+    log('There was an error: ' + ex.message)
+  ensure
+    log('Geckboard Injections data generation finished')
+  end
+end

--- a/spec/api/v2/mi/injection_errors_spec.rb
+++ b/spec/api/v2/mi/injection_errors_spec.rb
@@ -1,0 +1,206 @@
+require 'rails_helper'
+require 'api_spec_helper'
+
+RSpec.describe API::V2::MI::InjectionErrors do
+  include Rack::Test::Methods
+  include ApiSpecHelper
+  include DatabaseHousekeeping
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:case_worker_admin) { create(:case_worker, :admin) }
+  let(:external_user) { create(:external_user) }
+  let(:default_params) { { api_key: api_key } }
+  let(:params) { default_params }
+
+  describe 'GET injection_errors' do
+    def do_request
+      get '/api/mi/injection_errors', params, format: :json
+    end
+
+    context 'when accessed by a CaseWorker' do
+      let(:api_key) { case_worker_admin.user.api_key }
+
+      before do
+        seed_injection_data
+        do_request
+      end
+
+      context 'and there is no data available' do
+        let(:seed_injection_data) do
+          # in this case does nothing, just a placeholder
+        end
+
+        context 'and no output format is provided' do
+          let(:params) { default_params }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'returns an empty response' do
+            expect(JSON.parse(last_response.body)).to be_empty
+          end
+        end
+
+        context 'and JSON is requested as the output format' do
+          let(:params) { default_params.merge(format: 'json') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'returns an empty response' do
+            expect(JSON.parse(last_response.body)).to be_empty
+          end
+        end
+
+        context 'and CSV is requested as the output format' do
+          let(:params) { default_params.merge(format: 'csv') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'text/csv; utf-8'
+          end
+
+          it 'returns a file with just the headers' do
+            csv_content = CSV.parse(last_response.body)
+            expect(csv_content.count).to eq 1
+            expect(csv_content[0]).to match_array(%w[error_category total])
+          end
+        end
+      end
+
+      context 'when data is available' do
+        let!(:yesterday_successful_injections) {
+          travel_to(1.day.ago.utc) do
+            create_list(:injection_attempt, 3)
+          end
+        }
+        let!(:yesterday_failed_injections) {
+          travel_to(1.day.ago.utc) do
+            [
+              create_list(:injection_attempt, 5, :with_errors),
+              create_list(:injection_attempt, 2, :with_errors,
+                          error_messages: { errors: [ { error: "Cannot calculate the fee BLA" } ] }),
+              create_list(:injection_attempt, 1, :with_errors,
+                          error_messages: { errors: [ { error: "The supplier account code ..." } ] }),
+            ]
+          end
+        }
+        let!(:yesterday_injections) { yesterday_successful_injections + yesterday_failed_injections }
+        let(:yesterday_injection_categories) { %w[SUPPLIER_NUMBER#INVALID_ERROR FEE#CALCULATION_ERROR UNCATEGORIZED_ERROR] }
+        let(:older_date) { 2.months.ago.to_date }
+        let!(:older_date_successful_injections) {
+          travel_to(older_date) do
+            create_list(:injection_attempt, 2)
+          end
+        }
+        let!(:older_date_failed_injections) {
+          travel_to(older_date) do
+            [
+              create_list(:injection_attempt, 1, :with_errors),
+              create_list(:injection_attempt, 3, :with_errors,
+                          error_messages: { errors: [ { error: "No defendant found for Rep Order Number BLA" } ] }),
+              create_list(:injection_attempt, 1, :with_errors,
+                          error_messages: { errors: [ { error: "Expense Date Incurred ..." } ] }),
+              create_list(:injection_attempt, 2, :with_errors,
+                          error_messages: { errors: [ { error: "A claim already exists for these case details" } ] }),
+            ]
+          end
+        }
+        let!(:older_date_injections) { older_date_successful_injections + older_date_failed_injections }
+        let(:older_date_injection_categories) { %w[REP_ORDER#DEFENDANT_NOT_FOUND EXPENSE#DATE_INCURRED_ERROR CLAIM#ALREADY_EXISTS_ERROR UNCATEGORIZED_ERROR] }
+        let(:seed_injection_data) {
+          [yesterday_injections, older_date_injections]
+        }
+
+        context 'with no date provided' do
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'retrieves injection errors data from the previous day' do
+            expect(JSON.parse(last_response.body).count).to eq(yesterday_injection_categories.count)
+          end
+
+          context 'and with CSV output format' do
+            let(:params) { default_params.merge(format: 'csv') }
+
+            it 'returns success' do
+              expect(last_response).to be_ok
+            end
+
+            it 'returns JSON' do
+              expect(last_response.headers['content-type']).to eq 'text/csv; utf-8'
+            end
+
+            it 'returns a file with the headers and the data retrieved' do
+              csv_content = CSV.parse(last_response.body)
+              expect(csv_content.count).to eq(yesterday_injection_categories.count + 1)
+              expect(csv_content[0]).to match_array(%w[error_category total])
+            end
+          end
+        end
+
+        context 'with a date provided' do
+          let(:params) { default_params.merge(date: older_date.to_s(:db)) }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'retrieves injection errors data from the provided date' do
+            expect(JSON.parse(last_response.body).count).to eq(older_date_injection_categories.count)
+          end
+
+          context 'and with CSV output format' do
+            let(:params) { default_params.merge(date: older_date.to_s(:db), format: 'csv') }
+
+            it 'returns success' do
+              expect(last_response).to be_ok
+            end
+
+            it 'returns JSON' do
+              expect(last_response.headers['content-type']).to eq 'text/csv; utf-8'
+            end
+
+            it 'returns a file with the headers and the data retrieved' do
+              csv_content = CSV.parse(last_response.body)
+              expect(csv_content.count).to eq(older_date_injection_categories.count + 1)
+              expect(csv_content[0]).to match_array(%w[error_category total])
+            end
+          end
+        end
+      end
+    end
+
+    context 'when accessed by an user that has no permissions' do
+      let(:api_key) { external_user.user.api_key }
+
+      it 'returns unauthorised' do
+        do_request
+        expect(last_response).to be_unauthorized
+        expect(last_response.body).to include('Unauthorised')
+      end
+    end
+  end
+end

--- a/spec/lib/geckoboard_publisher/injections_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/injections_report_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+RSpec.describe GeckoboardPublisher::InjectionsReport, geckoboard: true do
+  it_behaves_like 'geckoboard publishable report'
+
+  # NOTE: calls to api.geckoboard.com are stubbed in rails_helper in case future reports are generated
+
+  describe '#fields' do
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
+
+    let(:expected_fields) do
+      [
+          Geckoboard::DateField.new(:date, name: 'Date'),
+          Geckoboard::NumberField.new(:total_ccr_succeeded, name: 'Total CCR'),
+          Geckoboard::NumberField.new(:total_ccr, name: 'Total number of CCR injections'),
+          Geckoboard::PercentageField.new(:percentage_ccr_succeeded, name: 'Percentage of successful CCR injections'),
+          Geckoboard::NumberField.new(:total_cclf_succeeded, name: 'Total CCLF succeeded'),
+          Geckoboard::NumberField.new(:total_cclf, name: 'Total number of CCLF injections'),
+          Geckoboard::PercentageField.new(:percentage_cclf_succeeded, name: 'Percentage of successful CCLF injections'),
+          Geckoboard::NumberField.new(:total_succeeded, name: 'Total succeeded'),
+          Geckoboard::NumberField.new(:total, name: 'Total number of injections')
+      ].map { |field| [field.class, field.id, field.name] }
+    end
+
+    it { is_expected.to eq expected_fields }
+  end
+
+  describe '#items' do
+    subject { described_class.new.items }
+
+    let(:expected_items) do
+      [
+        {
+          date: "2017-03-19",
+          total_ccr_succeeded: 3,
+          total_ccr: 5,
+          percentage_ccr_succeeded: 0.6,
+          total_cclf_succeeded: 1,
+          total_cclf: 6,
+          percentage_cclf_succeeded: 0.16666666666666666,
+          total_succeeded: 4,
+          total: 11
+        },
+        {
+          date: "2017-03-20",
+          total_ccr_succeeded: 2,
+          total_ccr: 6,
+          percentage_ccr_succeeded: 0.3333333333333333,
+          total_cclf_succeeded: 3,
+          total_cclf: 6,
+          percentage_cclf_succeeded: 0.5,
+          total_succeeded: 5,
+          total: 12
+        },
+        {
+          date: "2017-03-21",
+          total_ccr_succeeded: 5,
+          total_ccr: 6,
+          percentage_ccr_succeeded: 0.8333333333333334,
+          total_cclf_succeeded: 0,
+          total_cclf: 7,
+          percentage_cclf_succeeded: 0.0,
+          total_succeeded: 5,
+          total: 13
+        }
+      ]
+    end
+
+    before do
+      agfs_claim = create(:advocate_claim)
+      lgfs_claim = create(:litigator_claim)
+
+      travel_to(Date.parse('19-MAR-2017')) do
+        create_list(:injection_attempt, 3, claim: agfs_claim)
+        create_list(:injection_attempt, 2, :with_errors, claim: agfs_claim)
+
+        create_list(:injection_attempt, 1, claim: lgfs_claim)
+        create_list(:injection_attempt, 5, :with_errors, claim: lgfs_claim)
+      end
+
+      travel_to(Date.parse('20-MAR-2017')) do
+        create_list(:injection_attempt, 2, claim: agfs_claim)
+        create_list(:injection_attempt, 4, :with_errors, claim: agfs_claim)
+
+        create_list(:injection_attempt, 3, claim: lgfs_claim)
+        create_list(:injection_attempt, 3, :with_errors, claim: lgfs_claim)
+      end
+
+      travel_to(Date.parse('21-MAR-2017')) do
+        create_list(:injection_attempt, 5, claim: agfs_claim)
+        create_list(:injection_attempt, 1, :with_errors, claim: agfs_claim)
+
+        create_list(:injection_attempt, 0, claim: lgfs_claim)
+        create_list(:injection_attempt, 7, :with_errors, claim: lgfs_claim)
+      end
+    end
+
+    include_examples 'returns valid items structure'
+
+    it 'returns dates to day precision in ISO 8601 format - YYYY-MM-DD' do
+      expect(subject.first[:date]).to match(/^(\d{4}-(0[1-9]|1[12])-((0[1-9]|[12]\d)|3[01]))$/)
+    end
+
+    context 'when run without parameters' do
+      it 'returns expected data item count' do
+        expect(subject.size).to eql 1
+      end
+
+      it { is_expected.to match_array(
+        [
+          {
+            date: Date.yesterday.to_s(:db),
+            total_ccr_succeeded: 0,
+            total_ccr: 0,
+            percentage_ccr_succeeded: 0.0,
+            total_cclf_succeeded: 0,
+            total_cclf: 0,
+            percentage_cclf_succeeded: 0.0,
+            total_succeeded: 0,
+            total: 0
+          }
+        ])
+      }
+    end
+
+    context 'when run with parameters' do
+      subject { described_class.new(start_date, end_date).items }
+
+      let(:start_date) { Date.new(2017, 3, 19) }
+      let(:end_date) { Date.new(2017, 3, 21) }
+
+      it 'returns expected data item count' do
+        expect(subject.size).to eql 3
+      end
+
+      it 'returns the expected items' do
+        expected_items.each do |item|
+          is_expected.to include item
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

- Adds a daily task to produce injections success rate data that is then published to a Geckoboard dataset
- Exposes a new MI endpoint that returns an aggregated view of total number of injection errors per error category. This was done as such, since currently the injection error messages are extremely verbose and are not classified/categorised (which is something we should probably consider).

#### Ticket

[Report of injection errors/successes](https://dsdmoj.atlassian.net/browse/CBO-34)


