### PR TITLE
Update Injection Attempt error display

### DIFF
--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -57,7 +57,13 @@ module API
 
       # for display purposes we only want to use the injection error header
       def injection_errors
-        I18n.t(:error, scope: %i[shared injection_errors]) if object.injection_errors.present?
+        I18n.t(:error, scope: %i[shared injection_errors]) if parse_injection_errors
+      end
+
+      def parse_injection_errors
+        JSON.parse(object.injection_errors)['errors'].present?
+      rescue TypeError
+        false
       end
 
       def disk_evidence
@@ -113,7 +119,7 @@ module API
       end
 
       def injection_errored
-        object.injection_errors.present?.to_i
+        parse_injection_errors.to_i
       end
     end
   end

--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -57,10 +57,10 @@ module API
 
       # for display purposes we only want to use the injection error header
       def injection_errors
-        I18n.t(:error, scope: %i[shared injection_errors]) if parse_injection_errors
+        I18n.t(:error, scope: %i[shared injection_errors]) if injection_errors_present
       end
 
-      def parse_injection_errors
+      def injection_errors_present
         JSON.parse(object.injection_errors)['errors'].present?
       rescue TypeError
         false
@@ -119,7 +119,7 @@ module API
       end
 
       def injection_errored
-        parse_injection_errors.to_i
+        injection_errors_present.to_i
       end
     end
   end

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -25,7 +25,7 @@ describe API::Entities::SearchResult do
         'is_fixed_fee'=>false,
         'fee_type_code'=>'GRRAK',
         'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR',
-        'injection_errors'=>''
+        'injection_errors'=>"{\"errors\":[]}"
       )
     end
 
@@ -141,7 +141,7 @@ describe API::Entities::SearchResult do
       end
 
       context 'when passed an advocate claims with an injection attempt error' do
-        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>false, 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>false, 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_errors'=>'Claim not injected') }
+        let(:claim) { OpenStruct.new('id'=>'19932', 'uuid'=>'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme'=>'agfs', 'scheme_type'=>'Advocate', 'case_number'=>'T20160427', 'state'=>'submitted', 'court_name'=>'Newcastle', 'case_type'=>'Contempt', 'total'=>'426.36', 'disk_evidence'=>false, 'external_user'=>'Theodore Schumm', 'maat_references'=>'2320144', 'defendants'=>'Junius Lesch', 'fees'=>'0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 34.0~Pages of prosecution evidence~Fee::BasicFeeType', 'last_submitted_at'=>'2017-07-06 09:33:30.932017', 'class_letter'=>'F', 'is_fixed_fee'=>false, 'fee_type_code'=>'GRRAK', 'graduated_fee_types'=>'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_errors'=>'{"errors":[{"error":"Claim not injected"}]}') }
         before { result.merge!(graduated_fees: 1, injection_errored: 1) }
         include_examples 'returns expected JSON filter values'
       end


### PR DESCRIPTION
#### What
As the data type of the error return has changed (it used to be a plain string), this needed to be
reflected in the tests and search objects

#### Why 
The previous configuration showed all claims as having an injection error because `errors: []` was counted as being `.present?`

#### How
This checks for the presence of, and parses, the errors and checks for the presence of entries in the array