### PR TITLE
Add missing scheme 10 misc fee mappings

### DIFF
--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -15,6 +15,9 @@ module CCR
         MIDTH: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_HF]), # Confiscation hearings (half day)
         MIDTW: zip(%w[AGFS_MISC_FEES AGFS_CONFISC_WL]), # Confiscation hearings (whole day)
         MIDSE: zip(%w[AGFS_MISC_FEES AGFS_DEF_SEN_HR]), # Deferred sentence hearings
+        MIFCM: zip(%w[AGFS_MISC_FEES AGFS_FCMH]), # Further case management hearing
+        MIGRH: zip(%w[AGFS_MISC_FEES AGFS_GRH_HALF]), # Ground rules hearing (half day)
+        MIGRW: zip(%w[AGFS_MISC_FEES AGFS_GRH_FULL]), # Ground rules hearing (whole day)
         MIAEH: zip(%w[AGFS_MISC_FEES AGFS_ADM_EVD_HF]), # Hearings relating to admissibility of evidence (half day)
         MIAEW: zip(%w[AGFS_MISC_FEES AGFS_ADM_EVD_WL]), # Hearings relating to admissibility of evidence (whole day)
         MIHDH: zip(%w[AGFS_MISC_FEES AGFS_DISC_HALF]), # Hearings relating to disclosure (half day)

--- a/spec/services/ccr/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/misc_fee_adapter_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
     MIDTH: %w[AGFS_MISC_FEES AGFS_CONFISC_HF], # Confiscation hearings (half day)
     MIDTW: %w[AGFS_MISC_FEES AGFS_CONFISC_WL], # Confiscation hearings (whole day)
     MIDSE: %w[AGFS_MISC_FEES AGFS_DEF_SEN_HR], # Deferred sentence hearings
+    MIFCM: %w[AGFS_MISC_FEES AGFS_FCMH], # Further case management hearing
+    MIGRH: %w[AGFS_MISC_FEES AGFS_GRH_HALF], # Ground rules hearing (half day)
+    MIGRW: %w[AGFS_MISC_FEES AGFS_GRH_FULL], # Ground rules hearing (whole day)
     MIAEH: %w[AGFS_MISC_FEES AGFS_ADM_EVD_HF], # Hearings relating to admissibility of evidence (half day)
     MIAEW: %w[AGFS_MISC_FEES AGFS_ADM_EVD_WL], # Hearings relating to admissibility of evidence (whole day)
     MIHDH: %w[AGFS_MISC_FEES AGFS_DISC_HALF], # Hearings relating to disclosure (half day)


### PR DESCRIPTION
#### What
Add missing scheme 10 misc fee mappings

#### Why
Additional miscellaneous fees were added under AGFS scheme 10

#### How
Extend CCR misc fee adapter mappings to include them
