### PR TITLE
Provisional Assessment Report - filters

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -78,6 +78,7 @@ Metrics/MethodLength:
     - 'app/services/message_queue/aws_client.rb'
     - 'app/services/message_queue/message_template.rb'
     - 'app/services/reports/injection_errors.rb'
+    - 'app/services/reports/provisional_assessments_dates.rb'
     - 'app/services/slack_notifier.rb'
     - 'app/services/stats/management_information_generator.rb'
     - 'app/services/vat_auditor.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -78,7 +78,7 @@ Metrics/MethodLength:
     - 'app/services/message_queue/aws_client.rb'
     - 'app/services/message_queue/message_template.rb'
     - 'app/services/reports/injection_errors.rb'
-    - 'app/services/reports/provisional_assessments_dates.rb'
+    - 'app/services/reports/provisional_assessments_by_dates.rb'
     - 'app/services/slack_notifier.rb'
     - 'app/services/stats/management_information_generator.rb'
     - 'app/services/vat_auditor.rb'

--- a/app/assets/javascripts/modules/case_worker/admin/management_information.js
+++ b/app/assets/javascripts/modules/case_worker/admin/management_information.js
@@ -10,7 +10,7 @@ moj.Modules.ManagementInformation = {
 
   buildDataArray: function() {
     var data = {};
-    data.api_key='64c9177b-e5a0-4ac5-9f2b-33166597c436';
+    data.api_key=$('#user_api_key').val();
     data.start_date=$('#start_date').val();
     data.end_date=$('#end_date').val();
     data.format='csv';

--- a/app/assets/javascripts/modules/case_worker/admin/management_information.js
+++ b/app/assets/javascripts/modules/case_worker/admin/management_information.js
@@ -1,0 +1,63 @@
+moj.Modules.ManagementInformation = {
+  init: function () {
+    this.bindEvents();
+  },
+
+  bindEvents: function () {
+    this.provisionalAssessmentsDateFieldChange();
+    this.provisionalAssessmentsDownloadClicked();
+  },
+
+  buildDataArray: function() {
+    var data = {};
+    data.api_key='64c9177b-e5a0-4ac5-9f2b-33166597c436';
+    data.start_date=$('#start_date').val();
+    data.end_date=$('#end_date').val();
+    data.format='csv';
+    return data;
+  },
+
+  buildAttributes: function() {
+    var array=[];
+    var data=this.buildDataArray();
+    $.each(data, function(key, value) { array.push(key+"="+value) });
+    return array.join('&');
+  },
+
+  disableDownloadButton: function() {
+    var downloadButton = $('#provisional_assessments_date_download');
+    if(!downloadButton.hasClass('disabled')) { downloadButton.addClass('disabled'); }
+    downloadButton.removeAttr("href");
+  },
+
+  enableDownloadButton: function() {
+    var downloadButton = $('#provisional_assessments_date_download');
+    var url = '/api/mi/provisional_assessments?'+ this.buildAttributes();
+    downloadButton.attr("href", url );
+    downloadButton.removeClass('disabled');
+  },
+
+  provisionalAssessmentsDateFieldChange: function () {
+    var self=this;
+    $('.provisional_assessments_date_field').change( function() {
+      var disableDownload=false;
+      $('.provisional_assessments_date_field').each( function() {
+        if (this.value == '') { disableDownload = true; }
+      });
+      if(disableDownload) {
+        self.disableDownloadButton();
+      } else {
+        self.enableDownloadButton();
+      }
+    });
+  },
+
+  provisionalAssessmentsDownloadClicked: function () {
+    $('#provisional_assessments_date_download').on('click', function(e) {
+      if ($('#provisional_assessments_date_download').hasClass('disabled')) {
+        e.preventDefault();
+        return false;
+      }
+    });
+  }
+};

--- a/app/interfaces/api/entities/provisional_assessment.rb
+++ b/app/interfaces/api/entities/provisional_assessment.rb
@@ -1,0 +1,28 @@
+module API
+  module Entities
+    class ProvisionalAssessment < BaseEntity
+      expose :scheme
+      expose :provider_name
+      expose :provider_type
+      expose :supplier_number
+      expose :case_type
+      expose :offence_name
+      expose :offence_type
+      expose :ppe
+      expose :number_of_trial_days
+      expose :date_submitted
+      expose :disbursements_claimed
+      expose :fees_claimed
+      expose :expenses_claimed
+      expose :total_claimed
+      expose :disbursements_authorised
+      expose :fees_authorised
+      expose :expenses_authorised
+      expose :total_authorised
+      expose :total_percent_authorised
+      expose :fees_percent_authorised
+      expose :expenses_percent_authorised
+      expose :disbursements_percent_authorised
+    end
+  end
+end

--- a/app/interfaces/api/v2/mi/provisional_assessments.rb
+++ b/app/interfaces/api/v2/mi/provisional_assessments.rb
@@ -28,9 +28,9 @@ module API
               optional :format, type: String, desc: 'JSON or CSV. Defaults to JSON', values: %w[json csv]
             end
             get do
-              results = Reports::ProvisionalAssessmentsDates.call(date_range)
+              results = Reports::ProvisionalAssessmentsByDates.call(date_range)
               if params[:format].eql?('csv')
-                csv = build_csv_from(results, Reports::ProvisionalAssessmentsDates::COLUMNS)
+                csv = build_csv_from(results, Reports::ProvisionalAssessmentsByDates::COLUMNS)
                 filename = "attachment; filename=provisional-assessment-#{params[:start_date]}-#{params[:end_date]}.csv"
                 header 'Content-Disposition', filename
                 present csv

--- a/app/interfaces/api/v2/mi/provisional_assessments.rb
+++ b/app/interfaces/api/v2/mi/provisional_assessments.rb
@@ -1,0 +1,47 @@
+module API
+  module V2
+    module MI
+      class ProvisionalAssessments < Grape::API
+        require 'csv'
+        helpers API::V2::MIHelper
+
+        content_type :csv, 'text/csv; utf-8'
+        default_format :json
+
+        resource :mi, desc: 'MI endpoint' do
+          resource :provisional_assessments do
+            helpers do
+              def date_range
+                @start_date = params[:start_date].to_date.beginning_of_day.utc
+                @end_date = params[:end_date].to_date.end_of_day.utc
+                { start_date: @start_date, end_date: @end_date }
+              rescue NoMethodError
+                error!('Please provide both dates in the format YYYY-MM-DD', 400)
+              end
+            end
+
+            desc 'Retrieve provisional assessment data from between two dates'
+            params do
+              optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the user'
+              optional :start_date, type: String, desc: 'REQUIRED: Claims submitted on or after date (YYYY-MM-DD).'
+              optional :end_date, type: String, desc: 'REQUIRED: Claims submitted on or before date (YYYY-MM-DD).'
+              optional :format, type: String, desc: 'JSON or CSV. Defaults to JSON', values: %w[json csv]
+            end
+            get do
+              results = Reports::ProvisionalAssessmentsDates.call(date_range)
+              if params[:format].eql?('csv')
+                csv = build_csv_from(results, Reports::ProvisionalAssessmentsDates::COLUMNS)
+                filename = "attachment; filename=provisional-assessment-#{params[:start_date]}-#{params[:end_date]}.csv"
+                header 'Content-Disposition', filename
+                present csv
+              else
+                present JSON.parse(results.to_json, object_class: OpenStruct),
+                        with: API::Entities::ProvisionalAssessment
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v2/root.rb
+++ b/app/interfaces/api/v2/root.rb
@@ -18,6 +18,7 @@ module API
           mount API::V2::Search
           mount API::V2::MI::AGFSSchemeTenClaims
           mount API::V2::MI::InjectionErrors
+          mount API::V2::MI::ProvisionalAssessments
 
           namespace :ccr, desc: 'CCR injection specific claim format' do
             mount API::V2::CCRClaim

--- a/app/services/reports/provisional_assessments_by_dates.rb
+++ b/app/services/reports/provisional_assessments_by_dates.rb
@@ -1,5 +1,5 @@
 module Reports
-  class ProvisionalAssessmentsDates
+  class ProvisionalAssessmentsByDates
     NAME = 'provisional_assessment'.freeze
     COLUMNS = %w[scheme provider_name provider_type supplier_number case_type offence_name offence_type ppe
                  number_of_trial_days date_submitted disbursements_claimed fees_claimed expenses_claimed total_claimed

--- a/app/services/reports/provisional_assessments_dates.rb
+++ b/app/services/reports/provisional_assessments_dates.rb
@@ -1,0 +1,54 @@
+module Reports
+  class ProvisionalAssessmentsDates
+    NAME = 'provisional_assessment'.freeze
+    COLUMNS = %w[scheme provider_name provider_type supplier_number case_type offence_name offence_type ppe
+                 number_of_trial_days date_submitted disbursements_claimed fees_claimed expenses_claimed total_claimed
+                 disbursements_authorised fees_authorised expenses_authorised total_authorised total_percent_authorised
+                 fees_percent_authorised expenses_percent_authorised disbursements_percent_authorised].freeze
+
+    def self.call(options = {})
+      new(options).call
+    end
+
+    attr_reader :start_date, :end_date
+
+    def initialize(options = {})
+      @start_date = options[:start_date]
+      @end_date = options[:end_date]
+    end
+
+    def call
+      Stats::MIData.connection.execute(query).to_a
+    end
+
+    private
+
+    def query
+      %{SELECT
+        scheme_name AS scheme,
+        provider_name,
+        provider_type,
+        supplier_number,
+        case_type,
+        offence_name,
+        offence_type,
+        ppe,
+        actual_trial_length AS number_of_trial_days,
+        last_submitted_at AS date_submitted,
+        disbursements_total AS disbursements_claimed,
+        fees_total AS fees_claimed,
+        expenses_total AS expenses_claimed,
+        amount_claimed AS total_claimed,
+        assessment_disbursements AS disbursements_authorised,
+        assessment_fees AS fees_authorised,
+        assessment_expenses AS expenses_authorised,
+        amount_authorised AS total_authorised,
+        amount_authorised/NULLIF(amount_claimed, 0) as total_percent_authorised,
+        assessment_fees /NULLIF(fees_total, 0) as fees_percent_authorised,
+        assessment_disbursements /NULLIF(disbursements_total, 0) as expenses_percent_authorised,
+        amount_authorised/NULLIF(amount_claimed, 0) as disbursements_percent_authorised
+        FROM mi_data
+        WHERE last_submitted_at BETWEEN '#{start_date.to_s(:db)}' AND '#{end_date.to_s(:db)}'}
+    end
+  end
+end

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -27,6 +27,7 @@
         =label_tag(:end_date, 'End date')
         =date_field_tag(:end_date, nil, class: 'provisional_assessments_date_field')
       .report-status
+        =hidden_field_tag :user_api_key, @current_user.api_key
         These reports are not saved and are generated on demand
     %td
       .form-group

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -18,6 +18,19 @@
             = link_to 'Download', case_workers_admin_management_information_download_url(report_type: report_type, format: :csv), class: 'button btn-spacer-20'
 
           = link_to 'Regenerate', case_workers_admin_management_information_generate_url(report_type: report_type), class: 'button'
+  %tr#provisional-assessment-date
+    %td
+      .bold Provisional Assessments by date
+      .report_inputs
+        =label_tag(:start_date, 'Start date')
+        =date_field_tag(:start_date, nil, class: 'provisional_assessments_date_field')
+        =label_tag(:end_date, 'End date')
+        =date_field_tag(:end_date, nil, class: 'provisional_assessments_date_field')
+      .report-status
+        These reports are not saved and are generated on demand
+    %td
+      .form-group
+        =link_to 'Download', "", class: 'button disabled', id: 'provisional_assessments_date_download'
 
 %p.panel.panel-border-wide
   Click 'Download' to download the report now, or click 'Regenerate' to generate a more up to date report and refresh

--- a/spec/api/v2/mi/provisional_assessments_spec.rb
+++ b/spec/api/v2/mi/provisional_assessments_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+require 'api_spec_helper'
+
+RSpec.describe API::V2::MI::ProvisionalAssessments do
+  include Rack::Test::Methods
+  include ApiSpecHelper
+  include DatabaseHousekeeping
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:case_worker_admin) { create(:case_worker, :admin) }
+  let(:external_user) { create(:external_user) }
+  let(:default_params) { { api_key: api_key, start_date: start_date, end_date: end_date } }
+  let(:missing_params) { { api_key: api_key } }
+  let(:params) { default_params }
+  let(:start_date) { Date.new(2018, 01, 01).to_s(:db) }
+  let(:end_date) { Date.new(2018, 01, 31).to_s(:db) }
+  let(:create_data?) { false }
+
+  describe 'GET provisional_assessments' do
+    def populate_mi_data
+      travel_to(Date.new(2018, 01, 15)) { create_list(:archived_pending_delete_claim, 3) }
+      travel_to(Date.new(2018, 02, 14)) { create_list(:archived_pending_delete_claim, 3) }
+      TimedTransitions::BatchTransitioner.new(limit: 10, dummy: false).run
+    end
+
+    def do_request
+      populate_mi_data if create_data?
+      get '/api/mi/provisional_assessments', params, format: :json
+    end
+
+    context 'when accessed by a CaseWorker' do
+      let(:api_key) { case_worker_admin.user.api_key }
+
+      before do
+        do_request
+      end
+
+      context 'and there is no data available' do
+        context 'and dates are not provided' do
+          let(:params) { missing_params }
+
+          it 'returns an error' do
+            expect(last_response.status).to eq 400
+          end
+
+          it 'returns a specific error message' do
+            expect(last_response.body).to include('Please provide both dates in the format')
+          end
+        end
+
+        context 'and no output format is provided' do
+          let(:params) { default_params }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'returns an empty response' do
+            expect(JSON.parse(last_response.body)).to be_empty
+          end
+        end
+
+        context 'and JSON is requested as the output format' do
+          let(:params) { default_params.merge(format: 'json') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'returns an empty response' do
+            expect(JSON.parse(last_response.body)).to be_empty
+          end
+        end
+
+        context 'and CSV is requested as the output format' do
+          let(:params) { default_params.merge(format: 'csv') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'text/csv; utf-8'
+          end
+
+          it 'returns a file with just the headers' do
+            csv_content = CSV.parse(last_response.body)
+            expect(csv_content.count).to eq 1
+            expect(csv_content[0]).to match_array(Reports::ProvisionalAssessmentsDates::COLUMNS)
+          end
+        end
+      end
+
+      context 'when data is available' do
+        let(:create_data?) { true }
+
+        it 'returns success' do
+          expect(last_response).to be_ok
+        end
+
+        it 'returns JSON' do
+          expect(last_response.headers['content-type']).to eq 'application/json'
+        end
+
+        it 'retrieves injection errors data from the provided date' do
+          expect(JSON.parse(last_response.body).count).to eq(3)
+        end
+
+        context 'and with CSV output format' do
+          let(:params) { default_params.merge(format: 'csv') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'text/csv; utf-8'
+          end
+
+          it 'returns a file with the headers and the data retrieved' do
+            csv_content = CSV.parse(last_response.body)
+            expect(csv_content.count).to eq(4)
+            expect(csv_content[0]).to match_array(Reports::ProvisionalAssessmentsDates::COLUMNS)
+          end
+        end
+      end
+    end
+
+    context 'when accessed by an user that has no permissions' do
+      let(:api_key) { external_user.user.api_key }
+
+      it 'returns unauthorised' do
+        do_request
+        expect(last_response).to be_unauthorized
+        expect(last_response.body).to include('Unauthorised')
+      end
+    end
+  end
+end

--- a/spec/api/v2/mi/provisional_assessments_spec.rb
+++ b/spec/api/v2/mi/provisional_assessments_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe API::V2::MI::ProvisionalAssessments do
           it 'returns a file with just the headers' do
             csv_content = CSV.parse(last_response.body)
             expect(csv_content.count).to eq 1
-            expect(csv_content[0]).to match_array(Reports::ProvisionalAssessmentsDates::COLUMNS)
+            expect(csv_content[0]).to match_array(Reports::ProvisionalAssessmentsByDates::COLUMNS)
           end
         end
       end
@@ -128,7 +128,7 @@ RSpec.describe API::V2::MI::ProvisionalAssessments do
           it 'returns a file with the headers and the data retrieved' do
             csv_content = CSV.parse(last_response.body)
             expect(csv_content.count).to eq(4)
-            expect(csv_content[0]).to match_array(Reports::ProvisionalAssessmentsDates::COLUMNS)
+            expect(csv_content[0]).to match_array(Reports::ProvisionalAssessmentsByDates::COLUMNS)
           end
         end
       end


### PR DESCRIPTION
#### What
Add filters to Provisional Assessment Report

#### Ticket
[CBO311 refine provisional assessment](https://dsdmoj.atlassian.net/browse/CBO-311)

#### Why
The business need to drill into the data further than the original, aggregated, report allowed

#### How
Create a new output that the users can create, for a given date range, that allows them to perform Transactional Profiling

--------

#### TODO (wip)

 - [X] implement new API, MI report
 - [X] allow calling of new report from existing MI page
 - [x] improve test coverage
 - [x] refactor JS
 - [ ] implement re-design of MI page - on hold, will be separate ticket