### PR TITLE
Eligible fixed fee types

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -209,7 +209,7 @@ module Claim
     end
 
     def eligible_fixed_fee_types
-      Fee::FixedFeeType.top_levels.agfs
+      Fee::FixedFeeType.agfs
     end
 
     def external_user_type

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -209,7 +209,7 @@ module Claim
     end
 
     def eligible_fixed_fee_types
-      Fee::FixedFeeType.agfs
+      Claims::FetchEligibleFixedFeeTypes.new(self).call
     end
 
     def external_user_type

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -187,7 +187,7 @@ module Claim
     end
 
     def eligible_fixed_fee_types
-      Fee::FixedFeeType.lgfs
+      Claims::FetchEligibleFixedFeeTypes.new(self).call
     end
 
     def external_user_type

--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -187,7 +187,7 @@ module Claim
     end
 
     def eligible_fixed_fee_types
-      Fee::FixedFeeType.top_levels.lgfs
+      Fee::FixedFeeType.lgfs
     end
 
     def external_user_type

--- a/app/models/fee/fixed_fee_type.rb
+++ b/app/models/fee/fixed_fee_type.rb
@@ -21,7 +21,6 @@ class Fee::FixedFeeType < Fee::BaseFeeType
   belongs_to :parent, class_name: Fee::FixedFeeType, foreign_key: :parent_id
 
   default_scope -> { order(parent_id: :desc, description: :asc) }
-  scope :top_levels, -> { where(parent_id: nil) }
 
   def fee_category_name
     'Fixed Fees'

--- a/app/services/claims/fetch_eligible_fixed_fee_types.rb
+++ b/app/services/claims/fetch_eligible_fixed_fee_types.rb
@@ -1,0 +1,40 @@
+module Claims
+  class FetchEligibleFixedFeeTypes
+    def initialize(claim)
+      @claim = claim
+    end
+
+    def call
+      return nil unless claim
+      return nil if claim&.interim?
+      eligible_fee_types
+    end
+
+    private
+
+    AGFS_FIXED_FEE_ELIGIBILITY = {
+      FXACV: %w[FXACV FXNOC FXNDR FXSAF],
+      FXASE: %w[FXASE FXNOC FXNDR FXSAF],
+      FXCBR: %w[FXCBR FXNOC FXNDR FXSAF],
+      FXCSE: %w[FXCSE FXNOC FXNDR FXSAF],
+      FXCON: %w[FXCON FXSAF],
+      FXENP: %w[FXENP FXNOC FXNDR]
+    }.with_indifferent_access.freeze
+
+    delegate :case_type, :agfs?, :lgfs?, to: :claim, allow_nil: true
+    attr_reader :claim
+
+    def eligible_fee_types
+      return eligible_agfs_fixed_fee_types if agfs?
+      return eligible_lgfs_fixed_fee_types if lgfs?
+    end
+
+    def eligible_agfs_fixed_fee_types
+      Fee::FixedFeeType.agfs.where(unique_code: AGFS_FIXED_FEE_ELIGIBILITY[case_type&.fee_type_code])
+    end
+
+    def eligible_lgfs_fixed_fee_types
+      Fee::FixedFeeType.lgfs
+    end
+  end
+end

--- a/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
@@ -25,6 +25,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
 
     And I should see the advocate categories 'Junior alone,Led junior,Leading junior,QC'
     And I select an advocate category of 'Junior alone'
+    And the last fixed fee should have fee type options 'Appeals to the crown court against sentence,Number of cases uplift,Number of defendants uplift,Standard appearance fee'
     And I add a fixed fee 'Appeals to the crown court against sentence'
     Then the last fixed fee case numbers section should not be visible
     Then the last fixed fee rate should be populated with '108.00'

--- a/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
@@ -28,7 +28,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     And I add a fixed fee 'Appeals to the crown court against conviction'
     Then the last fixed fee case numbers section should not be visible
     Then the last fixed fee rate should be populated with '250.00'
-    And I add a fixed fee 'Appeals to the crown court against conviction uplift' with case numbers
+    And I add a fixed fee 'Number of cases uplift' with case numbers
     Then the last fixed fee case numbers section should be visible
     Then the last fixed fee rate should be populated with '50.00'
 
@@ -60,7 +60,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     And I should see 'Junior'
 
     And I should see 'Appeals to the crown court against conviction'
-    And I should see 'Appeals to the crown court against conviction uplift'
+    And I should see 'Number of cases uplift'
     And I should see 'Adjourned appeals'
     And I should see 'Parking'
 

--- a/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
@@ -25,6 +25,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
 
     And I should see the advocate categories 'Junior,Leading junior,QC'
     And I select an advocate category of 'Junior'
+    And the last fixed fee should have fee type options 'Appeals to the crown court against conviction,Number of cases uplift,Number of defendants uplift,Standard appearance fee'
     And I add a fixed fee 'Appeals to the crown court against conviction'
     Then the last fixed fee case numbers section should not be visible
     Then the last fixed fee rate should be populated with '250.00'

--- a/features/page_objects/sections/typed_fee_section.rb
+++ b/features/page_objects/sections/typed_fee_section.rb
@@ -1,4 +1,5 @@
 class TypedFeeSection < SitePrism::Section
+  sections :select_options, "select.js-fee-type > option" do end
   element :select_input, "input.tt-input", visible: true
   element :quantity, "input.quantity"
   element :rate, "input.rate"
@@ -13,6 +14,10 @@ class TypedFeeSection < SitePrism::Section
   # by entering text into the input text field.
   def select_fee_type(name)
     fill_in(select_input[:id], with: name)
+  end
+
+  def fee_type_descriptions
+    select_options.map(&:text).reject(&:empty?)
   end
 
   def populated?

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -151,6 +151,11 @@ Then(/^the last fixed fee case numbers section should (not )?be visible$/) do |n
   end
 end
 
+Then(/^the last fixed fee should have fee type options\s*'([^']*)'$/) do |fee_type_descriptions|
+  fee_type_descriptions = fee_type_descriptions.split(',')
+  expect(@claim_form_page.fixed_fees.last.fee_type_descriptions).to match_array(fee_type_descriptions)
+end
+
 Then(/^the fixed fee '(.*?)' should have a rate of '(\d+\.\d+)'$/) do |fee_type, rate|
   fixed_fee = @claim_form_page.fixed_fees.find { |section| section.select_input.value.eql?(fee_type) }
   expect(fixed_fee.rate.value).to eql rate

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -218,8 +218,16 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
 
     describe '#eligible_fixed_fee_types' do
-      it 'returns only fixed fee types for AGFS' do
-        expect(@claim.eligible_fixed_fee_types).to eq([@fft1])
+      subject { @claim.eligible_fixed_fee_types }
+      let(:case_type) { create(:case_type, :appeal_against_conviction) }
+      let!(:fee_type) { create(:fixed_fee_type, :fxacv) }
+
+      before do
+        allow(@claim).to receive(:case_type).and_return case_type
+      end
+
+      it 'returns only fixed fee types applicable to the case type' do
+        is_expected.to match_array [fee_type]
       end
     end
   end

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -142,8 +142,7 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
     end
 
     describe '#eligible_fixed_fee_types' do
-      it 'returns only top level fixed fee types for LGFS' do
-        @fft3 = create :child_fee_type, parent: @fft2
+      it 'returns only fixed fee types for LGFS' do
         expect(@claim.eligible_fixed_fee_types).to eq([@fft2])
       end
     end

--- a/spec/models/fee/fixed_fee_type_spec.rb
+++ b/spec/models/fee/fixed_fee_type_spec.rb
@@ -26,23 +26,6 @@ module Fee
     it { should belong_to(:parent) }
     it { should have_many(:children) }
 
-    describe '.top_levels' do
-      before(:all) do
-        @parent_1 = create :fixed_fee_type
-        @parent_2 = create :fixed_fee_type
-        @child_1 = create :child_fee_type, description: 'child 1', parent: @parent_1
-        @child_2 = create :child_fee_type, description: 'child 2', parent: @parent_2
-      end
-
-      after(:all) do
-        clean_database
-      end
-
-      it 'only returns top level parent fixed fees' do
-        expect(Fee::FixedFeeType.top_levels).to match_array([@parent_1, @parent_2])
-      end
-    end
-
     describe 'default scope' do
       before do
         create(:fixed_fee_type, description: 'Ppppp')

--- a/spec/services/claims/fetch_eligible_fixed_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_fixed_fee_types_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Claims::FetchEligibleFixedFeeTypes, type: :service do
+  before(:all) do
+    seed_fee_schemes
+    seed_case_types
+    seed_fee_types
+  end
+
+  after(:all) { clean_database }
+
+  describe '#call' do
+    subject(:call) { described_class.new(claim).call }
+
+    context 'nil claim' do
+      let(:claim) { nil }
+      it { is_expected.to eq(nil) }
+    end
+
+    # TODO: LGFS eligible fee types currently returns all LGFS fixed fee type
+    # but this is not be needed nor used by view logic because the only fixed fee
+    # claimable on an LGFS fixed fee case type is the "matching" fee type. This service
+    # is not used for LGFS claims.
+    context 'LGFS' do
+      let(:claim) do
+        create(:litigator_claim, :without_fees, case_type: CaseType.find_by(name: 'Appeal against conviction') )
+      end
+
+      it 'returns LGFS only fixed fee types' do
+        expect(call.map(&:lgfs?)).to be_all true
+      end
+    end
+
+    context 'AGFS' do
+      AGFS_FIXED_FEE_ELIGIBILITY = {
+        FXACV: %w[FXACV FXNOC FXNDR FXSAF],
+        FXASE: %w[FXASE FXNOC FXNDR FXSAF],
+        FXCBR: %w[FXCBR FXNOC FXNDR FXSAF],
+        FXCSE: %w[FXCSE FXNOC FXNDR FXSAF],
+        FXCON: %w[FXCON FXSAF],
+        FXENP: %w[FXENP FXNOC FXNDR]
+      }.with_indifferent_access.freeze
+
+      AGFS_GRAD_FEE_ELIGIBILITY = %w[GRRAK GRCBR GRDIS GRGLT GRRTR GRTRL]
+
+      context 'advocate final claim' do
+        let(:claim) { create(:advocate_claim) }
+        it { is_expected.to all(be_a(Fee::FixedFeeType)) }
+
+        context 'fixed fee case types' do
+          AGFS_FIXED_FEE_ELIGIBILITY.each do |fee_type_code, eligible_fee_type_unique_codes|
+            context "case type #{fee_type_code}" do
+              let(:case_type) { CaseType.find_by(fee_type_code: fee_type_code) }
+              before { allow(claim).to receive(:case_type).and_return case_type }
+
+              it "returns fee types with unique codes #{eligible_fee_type_unique_codes}" do
+                expect(call.map(&:unique_code)).to match_array(eligible_fee_type_unique_codes)
+              end
+            end
+          end
+        end
+
+        context 'graduated fee case types' do
+          AGFS_GRAD_FEE_ELIGIBILITY.each do |fee_type_code|
+            context "case type #{fee_type_code}" do
+              let(:case_type) { CaseType.find_by(fee_type_code: fee_type_code) }
+              before { allow(claim).to receive(:case_type).and_return case_type }
+
+              it { is_expected.to be_empty }
+            end
+          end
+        end
+      end
+
+      context 'advocate interim claim' do
+        let(:claim) { create(:advocate_interim_claim, :agfs_scheme_10) }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end

--- a/spec/services/claims/fetch_eligible_fixed_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_fixed_fee_types_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Claims::FetchEligibleFixedFeeTypes, type: :service do
   before(:all) do
-    seed_fee_schemes
     seed_case_types
     seed_fee_types
   end


### PR DESCRIPTION
#### What
Prevent users from selecting inapplicable fixed fees

#### Ticket

[CBO-337 Eligible fixed fee types based on case type](https://dsdmoj.atlassian.net/browse/CBO-337)

#### Why
Restrict the list of available fixed fee types to those eligible for the case type selected by the user. So the end user can correctly claim applicable fixed fees only. Only these combinations can calculate a "price" using the fee calc API

#### How
Create an EligibleFixedFeeType service class to encapsulate the logic 
