### PR TITLE
CBO-335 Changes to validation for travel expenses

### DIFF
--- a/app/validators/expense_v2_validator.rb
+++ b/app/validators/expense_v2_validator.rb
@@ -86,7 +86,8 @@ class ExpenseV2Validator < BaseValidator
   def validate_date
     validate_presence(:date, 'blank')
     validate_on_or_before(Date.today, :date, 'future')
-    validate_on_or_after(Settings.earliest_permitted_date, :date, 'check_not_too_far_in_past')
+    validate_on_or_after(@record.claim.try(:earliest_representation_order_date),
+                         :date, 'check_not_earlier_than_rep_order')
   end
 
   def validate_hours

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -24,7 +24,7 @@ dictionary:
     max_vat_amount: &max_vat_amount 'Enter a valid amount'
     claim_max_amount: &claim_max_amount 'Amount claimed exceeds limit'
     max_length: &max_length 'Length exceeds limit'
-    expense_before_rep_order: &expense_before_rep_order "Date of expense must be on or prior to the date of the earliest representation order"
+    expense_before_rep_order: &expense_before_rep_order "Date of expense must be on or after the date of the earliest representation order"
 
 # applies to defendant, fee, expense
 claim:

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -24,6 +24,7 @@ dictionary:
     max_vat_amount: &max_vat_amount 'Enter a valid amount'
     claim_max_amount: &claim_max_amount 'Amount claimed exceeds limit'
     max_length: &max_length 'Length exceeds limit'
+    expense_before_rep_order: &expense_before_rep_order "Date of expense must be on or prior to the date of the earliest representation order"
 
 # applies to defendant, fee, expense
 claim:
@@ -1271,7 +1272,7 @@ expense:
       api: Check the date for the expense
     check_not_earlier_than_rep_order:
       long: 'Check the date for the #{expense}'
-      short: *before_rep_order
+      short: *expense_before_rep_order
       api: Check the date for the expense
     
 

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1269,10 +1269,11 @@ expense:
       long: 'Check the date for the #{expense}'
       short: *in_future
       api: Check the date for the expense
-    check_not_too_far_in_past:
+    check_not_earlier_than_rep_order:
       long: 'Check the date for the #{expense}'
-      short: *too_far_in_past
+      short: *before_rep_order
       api: Check the date for the expense
+    
 
   expense_type:
     _seq: 10

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -87,7 +87,7 @@ When(/^I add an expense '(.*?)'(?: with total '(.*?)')?(?: and VAT '(.*?)')?( wi
   if invalid_date.present?
     @claim_form_page.expenses.last.expense_date.set_invalid_date
   else
-    @claim_form_page.expenses.last.expense_date.set_date '2016-01-02'
+    @claim_form_page.expenses.last.expense_date.set_date '2018-04-01'
   end
 end
 

--- a/spec/api/v1/external_users/expense_spec.rb
+++ b/spec/api/v1/external_users/expense_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe API::V1::ExternalUsers::Expense do
         reason_id: 5,
         reason_text: "Foo",
         mileage_rate_id: 1,
-        date: "2016-01-01T12:30:00"
+        date: Time.now.strftime('%Y-%m-%dT%H:%M:%S.%L%z')
       }
     end
 

--- a/spec/api/v1/external_users/expense_spec.rb
+++ b/spec/api/v1/external_users/expense_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe API::V1::ExternalUsers::Expense do
         reason_id: 5,
         reason_text: "Foo",
         mileage_rate_id: 1,
-        date: Time.now.strftime('%Y-%m-%dT%H:%M:%S.%L%z')
+        date: "2018-04-01T12:30:00"
       }
     end
 

--- a/spec/support/validation_helpers.rb
+++ b/spec/support/validation_helpers.rb
@@ -76,6 +76,14 @@ module ValidationHelpers
     with_expected_error_translation(field,message,options) if options[:translated_message]
   end
 
+  def should_error_if_earlier_than_earliest_reporder_date(claim_record, other_record, field, message, options={})
+    stub_earliest_rep_order(claim_record,1.year.ago.to_date)
+    other_record.send("#{field}=", 13.months.ago)
+    expect(other_record.send(:valid?)).to be false
+    expect(other_record.errors[field]).to include( message )
+    with_expected_error_translation(field,message,options) if options[:translated_message]
+  end
+
   def should_error_if_earlier_than_other_date(record, field, other_date, message, options={})
     record.send("#{field}=", 5.day.ago)
     record.send("#{other_date}=", 3.day.ago)

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -852,7 +852,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:expense_1_date]).to match_array(['check_not_too_far_in_past'])
+        expect(claim.errors[:expense_1_date]).to match_array(['check_not_earlier_than_rep_order'])
       }
     end
 

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe 'ExpenseV1Validator and ExpenseV2Validator', type: :validator do
         expect(expense).to be_valid
       end
 
-      it 'is invalid for dates too far in the past' do
-        should_error_if_too_far_in_the_past(expense, :date, 'check_not_too_far_in_past')
+      it 'is invalid if before earliest rep order date' do
+        should_error_if_earlier_than_earliest_reporder_date(claim, expense, :date, 'check_not_earlier_than_rep_order')
       end
 
       it 'is invalid for dates in the future' do


### PR DESCRIPTION
Changed travel expense validation to mirror CCR

#### What

Changed validation so that date of travel has to be on or after the earliest representation order date

#### Ticket

CBO-335

#### Why

In order to mirror CCR validation, for data injection.


