### PR TITLE
Add safe navigator to collection of case numbers

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_fixed_fee.rb
@@ -36,7 +36,7 @@ module API
           return @case_numbers if @case_numbers
           @case_numbers = []
           matching_case_uplift_fees.each_with_object(@case_numbers) do |fee, memo|
-            fee.case_numbers.split(',').inject(memo, :<<)
+            fee.case_numbers&.split(',')&.inject(memo, :<<)
           end
           @case_numbers = @case_numbers.map(&:strip).uniq.join(',')
         end


### PR DESCRIPTION
#### What
Prevent 500 error on DI as in [sentry](https://sentry.service.dsd.io/mojds/private-beta/issues/33170/)

#### Ticket

[relates to](https://dsdmoj.atlassian.net/browse/CBO-347)

#### Why
Currently it is possible to, as a separate bug,
to step through a path of form submission
which ends up with a valid claim submission but
with a fixed fee case uplift that has no value
and no additional case numbers.

Until this bug is resolved the addition of
the safe navigator will prevent a 500 on
injection of such a claim.
