### PR TITLE
Ensure last_injection_attempt is correct

### DIFF
--- a/app/interfaces/api/v2/query_helper.rb
+++ b/app/interfaces/api/v2/query_helper.rb
@@ -54,7 +54,7 @@ module API::V2
               SELECT *
               FROM injection_attempts last_ia
               WHERE last_ia.claim_id = c.id
-              ORDER BY last_ia.created_at
+              ORDER BY last_ia.created_at DESC
               LIMIT 1
             ) AS last_injection_attempt
             WHERE last_injection_attempt.deleted_at is NULL


### PR DESCRIPTION
#### What
Prevent successfully injected claims from being flagged as injection errors when allocating

#### Ticket
[Update injection_error filtering for allocation](https://dsdmoj.atlassian.net/browse/CBO-348)

#### Why
When multiple injection attempts have been made, this ensures that the most recent attempt is returned

#### How
Sorting by creation date and limiting was returning the oldest record, switching to `DESC` ensures that the most recent attempt is returned
