### PR TITLE
Add utility class and module for (re)injecting claims

### DIFF
--- a/lib/data_injection/injector.rb
+++ b/lib/data_injection/injector.rb
@@ -1,0 +1,21 @@
+# A utility class to inject multiple claims.
+# example:
+#  claims = DataInjection::Queries.claims_with_error("The supplier account code: .* is INVALID!")
+#  injector = DataInjection::Injector.new(claims)
+#  injector.call
+#
+module DataInjection
+  class Injector
+    attr_accessor :claims
+
+    def initialize(claims)
+      @claims = claims
+    end
+
+    def call
+      claims.each do |claim|
+        NotificationQueue::AwsClient.new.send!(claim)
+      end
+    end
+  end
+end

--- a/lib/data_injection/queries.rb
+++ b/lib/data_injection/queries.rb
@@ -1,0 +1,39 @@
+# Utility to retrieve claims with injections errors
+# Note: use unallocated sql that is used by the apps
+# allocation queue to ensure we have only claims that
+# have not bee allocated to case workers and can therefore
+# be safely reinjected.
+#
+module DataInjection
+  module Queries
+    extend API::V2::QueryHelper
+
+    class << self
+      def unallocated
+        sql = unallocated_sql.gsub(/CLAIM_TYPES_FOR_SCHEME/, claim_types_for_scheme('agfs'))
+        ActiveRecord::Base.connection.execute(sql)
+      end
+
+      def with_error(error_regex)
+        unallocated.select do |rec|
+          !rec['injection_errors'].nil? && rec['injection_errors'].match?(error_regex || '.*')
+        end
+      end
+
+      def claims_with_error(error_regex)
+        ::Claim::BaseClaim.where(uuid: with_error(error_regex).map { |err| err['uuid'] })
+      end
+
+      private
+
+      def in_statement_for(arr)
+        arr.map(&:to_s).join('\', \'').prepend('(\'').concat('\')')
+      end
+
+      def claim_types_for_scheme(scheme)
+        return in_statement_for(::Claim::BaseClaim.agfs_claim_types) if scheme.eql?('agfs')
+        in_statement_for(::Claim::BaseClaim.lgfs_claim_types)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Enable re-injection of multiple claims into CCR

#### Ticket

[CBO-351](https://dsdmoj.atlassian.net/browse/CBO-351)

#### Why
Post DI release for CCR some claims were not injecting
because of a CCR bug. To prevent case workers having
to manually create these we are intending to reattempt
the injection of such claims.


#### How
Add utility class for injection multiple claims and module for querying injection attempts
by error.
