### PR TITLE
Add safe navigator to fee value checks

### DIFF
--- a/app/services/ccr/fee/basic_fee_adapter.rb
+++ b/app/services/ccr/fee/basic_fee_adapter.rb
@@ -29,7 +29,7 @@ module CCR
 
       def claimed?
         filtered_fees.any? do |f|
-          f.amount.positive? || f.quantity.positive? || f.rate.positive?
+          f.amount&.positive? || f.quantity&.positive? || f.rate&.positive?
         end
       end
 


### PR DESCRIPTION
#### What
prevent 500 error when adapting basic fees with nil rate, quantity or amount

#### Ticket

[CBO-359](https://dsdmoj.atlassian.net/browse/CBO-359)


#### Why
There may possibly be a path through the app that
results in a fixed fee claim having nil value basic fees
which should have been destroyed.

see [sentry error](https://sentry.service.dsd.io/mojds/private-beta/issues/33190/)
