### PR TITLE
Add safe navigator to misc fee adapter

### DIFF
--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -54,7 +54,7 @@ module CCR
       end
 
       def charges?
-        object.amount.positive? || object.quantity.positive? || object.rate.positive?
+        [object.amount&.positive? || object.quantity&.positive? || object.rate&.positive?].any?
       end
     end
   end

--- a/spec/services/ccr/fee/basic_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/basic_fee_adapter_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe CCR::Fee::BasicFeeAdapter, type: :adapter do
       is_expected.to be false
     end
 
+    it 'returns false when the basic fee has nil values for quantity, rate and amount'do
+      allow(basic_fee).to receive_messages(quantity: nil, rate: nil, amount: nil)
+      is_expected.to be false
+    end
+
     it 'returns false when the basic fee is not part of the CCR advocate fee' do
       allow(basic_fee_type).to receive(:unique_code).and_return 'BAPCM'
       is_expected.to be false

--- a/spec/services/ccr/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/misc_fee_adapter_spec.rb
@@ -100,8 +100,19 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
       is_expected.to be true
     end
 
-    it 'returns false when the misc is not being claimed'do
+    it 'returns true when the misc fee has a positive quantity rate or amount' do
+      allow(fee).to receive_messages(quantity: nil, rate: 0, amount: 1)
+      is_expected.to be true
+    end
+
+
+    it 'returns false when the misc has zero values for quantity, rate and amount' do
       allow(fee).to receive_messages(quantity: 0, rate: 0, amount: 0)
+      is_expected.to be false
+    end
+
+    it 'returns false when the misc has nil values for quantity, rate and amount'do
+      allow(fee).to receive_messages(quantity: nil, rate: nil, amount: nil)
       is_expected.to be false
     end
   end


### PR DESCRIPTION
#### What
prevent 500 error when adapting basic fees with nil rate, quantity or amount.
This covers the misc fee adapter that is used by some basic fees that
map to CCR misc fees

#### Ticket

[CBO-359](https://dsdmoj.atlassian.net/browse/CBO-359)


#### Why
There may possibly be a path through the app that
results in a fixed fee claim having nil value basic fees
which should have been destroyed.

see [sentry error](https://sentry.service.dsd.io/mojds/private-beta/issues/33190/)
