### PR TITLE
Remove establishments table definition from schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -255,15 +255,6 @@ ActiveRecord::Schema.define(version: 20180823134645) do
     t.index ["external_user_id"], name: "index_documents_on_external_user_id", using: :btree
   end
 
-  create_table "establishments", force: :cascade do |t|
-    t.string   "name"
-    t.string   "category"
-    t.string   "postcode"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["category"], name: "index_establishments_on_category", using: :btree
-  end
-
   create_table "expense_types", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"


### PR DESCRIPTION
#### What
remove a schema definition entry for establishment table from schema.rb

#### Why
Was probably added inadvertently by work on another
branch related to expense api work. see PR: 
[CBO-300 Travel expenses: Dynamic location/destination field](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/2457)
