### PR TITLE
Ignore certain DI errors entirely

### DIFF
--- a/app/models/injection_attempt.rb
+++ b/app/models/injection_attempt.rb
@@ -14,6 +14,7 @@
 class InjectionAttempt < ApplicationRecord
   include SoftlyDeletable
   include JsonAttrParser
+  scope :exclude_error, ->(error_ilike) { where.not('coalesce(error_messages::text,\'\') ILIKE ?', error_ilike) }
 
   belongs_to :claim, class_name: Claim::BaseClaim, foreign_key: :claim_id
 

--- a/lib/geckoboard_publisher/injection_record.rb
+++ b/lib/geckoboard_publisher/injection_record.rb
@@ -36,8 +36,8 @@ module GeckoboardPublisher
 
     def totals_fields
       {
-        total_succeeded: InjectionAttempt.where(succeeded: true).where(created_at: date_range).count,
-        total: InjectionAttempt.where(created_at: date_range).count
+        total_succeeded: total_ccr_succeeded + total_cclf_succeeded,
+        total: total
       }
     end
 
@@ -50,19 +50,31 @@ module GeckoboardPublisher
     end
 
     def total_ccr_succeeded
-      ccr_injections.where(succeeded: true).where(created_at: date_range).count
-    end
-
-    def total_ccr
-      ccr_injections.where(created_at: date_range).count
+      @total_ccr_succeeded ||=
+        ccr_injections.where(succeeded: true).where(created_at: date_range).count
     end
 
     def total_cclf_succeeded
-      cclf_injections.where(succeeded: true).where(created_at: date_range).count
+      @total_cclf_succeeded ||=
+        cclf_injections.where(succeeded: true).where(created_at: date_range).count
+    end
+
+    def total_ccr
+      ccr_injections
+        .where(created_at: date_range)
+        .exclude_error('%already exist%')
+        .count
     end
 
     def total_cclf
       cclf_injections.where(created_at: date_range).count
+    end
+
+    def total
+      InjectionAttempt
+        .where(created_at: date_range)
+        .exclude_error('%already exist%')
+        .count
     end
 
     def percentage(numerator, denominator)

--- a/spec/factories/injection_attempts.rb
+++ b/spec/factories/injection_attempts.rb
@@ -21,6 +21,11 @@ FactoryBot.define do
       succeeded false
       error_messages "{\"errors\":[ {\"error\":\"injection error 1\"},{\"error\":\"injection error 2\"}]}"
     end
+
+    trait :with_stat_excluded_errors do
+      succeeded false
+      error_messages "{\"errors\":[ {\"error\":\"case already exists\"}]}"
+    end
   end
 end
 


### PR DESCRIPTION
#### What
exclude certain DI errors from DI stats

#### Why
Injection of claims that already exist on
CCR results in one of two "already exist"
errors. Since these are more of a warning
the PM would like to exclude them.

#### Ticket

[CBO-361](https://dsdmoj.atlassian.net/browse/CBO-361)


#### How
create injection attempt scope to exclude certain errors
and modify data injection geckoboard report to use this
for totals counts (totals therefore represent only successes
and "true" errors)
