### PR TITLE
Update laa-fee-calculator-client gem to 0.2.0 and use improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'shell-spinner', '~> 1.0', '>= 1.0.4'
 gem 'ruby-progressbar'
 gem 'geckoboard-ruby'
 gem 'posix-spawn', '~> 0.3.13'
-gem 'laa-fee-calculator-client', '~> 0.1.4'
+gem 'laa-fee-calculator-client', '~> 0.2.0'
 
 group :production, :devunicorn do
   gem 'rails_12factor', '0.0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem 'shell-spinner', '~> 1.0', '>= 1.0.4'
 gem 'ruby-progressbar'
 gem 'geckoboard-ruby'
 gem 'posix-spawn', '~> 0.3.13'
-gem 'laa-fee-calculator-client', '~> 0.1.3'
+gem 'laa-fee-calculator-client', '~> 0.1.4'
 
 group :production, :devunicorn do
   gem 'rails_12factor', '0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ GEM
     kaminari-rspec (0.16.1)
       kaminari (~> 0.16)
     kgio (2.11.2)
-    laa-fee-calculator-client (0.1.4)
+    laa-fee-calculator-client (0.2.0)
       addressable (~> 2.3, >= 2.3.7)
       faraday (~> 0.9.2)
     launchy (2.4.3)
@@ -715,7 +715,7 @@ DEPENDENCIES
   json_spec
   kaminari (~> 0.17.0)
   kaminari-rspec
-  laa-fee-calculator-client (~> 0.1.4)
+  laa-fee-calculator-client (~> 0.2.0)
   launchy (~> 2.4.3)
   libreconv (~> 0.9.0)
   listen (~> 2.10.0)
@@ -781,4 +781,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ GEM
     kaminari-rspec (0.16.1)
       kaminari (~> 0.16)
     kgio (2.11.2)
-    laa-fee-calculator-client (0.1.3)
+    laa-fee-calculator-client (0.1.4)
       addressable (~> 2.3, >= 2.3.7)
       faraday (~> 0.9.2)
     launchy (2.4.3)
@@ -715,7 +715,7 @@ DEPENDENCIES
   json_spec
   kaminari (~> 0.17.0)
   kaminari-rspec
-  laa-fee-calculator-client (~> 0.1.3)
+  laa-fee-calculator-client (~> 0.1.4)
   launchy (~> 2.4.3)
   libreconv (~> 0.9.0)
   listen (~> 2.10.0)

--- a/app/services/claims/fee_calculator/calculate.rb
+++ b/app/services/claims/fee_calculator/calculate.rb
@@ -92,13 +92,7 @@ module Claims
       # - less "safe" but faster/negates the need to query the API??
       #
       def scenario
-        # TODO: create select/find_by calls to retrieve endpoint data by attribute value
-        # as opposed to being limited to parameter queries
-        # e.g. fee_scheme.scenarios.find_by(code: bill_scenario)
-        #
-        fee_scheme.scenarios.select do |s|
-          s.code.eql?(bill_scenario)
-        end&.first
+        fee_scheme.scenarios.find_by(code: bill_scenario)
       end
 
       # Send a default offence as fee calc currently requires offences

--- a/vcr/cassettes/spec/services/claims/fee_calculator/unit_price_spec.yml
+++ b/vcr/cassettes/spec/services/claims/fee_calculator/unit_price_spec.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.3
+      - laa-fee-calculator-client/0.2.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 Sep 2018 11:20:37 GMT
+      - Wed, 19 Sep 2018 10:20:15 GMT
       Server:
       - nginx/1.15.3
       Vary:
@@ -39,7 +39,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}]}'
     http_version: 
-  recorded_at: Mon, 17 Sep 2018 11:20:37 GMT
+  recorded_at: Wed, 19 Sep 2018 10:20:15 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/scenarios/
@@ -50,7 +50,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.3
+      - laa-fee-calculator-client/0.2.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 Sep 2018 11:20:38 GMT
+      - Wed, 19 Sep 2018 10:20:15 GMT
       Server:
       - nginx/1.15.3
       Vary:
@@ -84,48 +84,7 @@ http_interactions:
         of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":12,"name":"Elected
         case not proceeded","code":"AS000014"}]}'
     http_version: 
-  recorded_at: Mon, 17 Sep 2018 11:20:38 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_STD_APPRNC&limit_from=1&offence_class=K&scenario=5&unit=DAY
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.1.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 17 Sep 2018 11:20:38 GMT
-      Server:
-      - nginx/1.15.3
-      Vary:
-      - Accept, Cookie
-      - Accept-Encoding
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":3260,"scenario":5,"advocate_type":"JRALONE","fee_type":27,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"87.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-    http_version: 
-  recorded_at: Mon, 17 Sep 2018 11:20:38 GMT
+  recorded_at: Wed, 19 Sep 2018 10:20:15 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_APPEAL_CON&limit_from=1&offence_class=K&scenario=5&unit=DAY
@@ -136,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.3
+      - laa-fee-calculator-client/0.2.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -149,7 +108,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 Sep 2018 11:20:39 GMT
+      - Wed, 19 Sep 2018 10:20:15 GMT
       Server:
       - nginx/1.15.3
       Vary:
@@ -167,10 +126,10 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 17 Sep 2018 11:20:39 GMT
+  recorded_at: Wed, 19 Sep 2018 10:20:15 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_FEE&limit_from=1&offence_class=K&scenario=12&unit=DAY
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_STD_APPRNC&limit_from=1&offence_class=K&scenario=5&unit=DAY
     body:
       encoding: US-ASCII
       string: ''
@@ -178,7 +137,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - laa-fee-calculator-client/0.1.3
+      - laa-fee-calculator-client/0.2.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -191,7 +150,48 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 Sep 2018 11:20:42 GMT
+      - Wed, 19 Sep 2018 10:20:19 GMT
+      Server:
+      - nginx/1.15.3
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '319'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":3260,"scenario":5,"advocate_type":"JRALONE","fee_type":27,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"87.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 10:20:19 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_FEE&limit_from=1&offence_class=K&scenario=12&unit=DAY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 Sep 2018 10:20:21 GMT
       Server:
       - nginx/1.15.3
       Vary:
@@ -209,5 +209,5 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Mon, 17 Sep 2018 11:20:42 GMT
+  recorded_at: Wed, 19 Sep 2018 10:20:21 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### What
Update laa-fee-calculator-client gem to 0.1.4 and use improvements

#### Why
New release enables searching of result sets using
a `find_by` method. This method can query data
based on attribute values in the "records" rather
than being limited to the APIs query parameters.
