### PR TITLE
Fix flickering spec and faulty spec

### DIFF
--- a/spec/models/fee/fixed_fee_type_spec.rb
+++ b/spec/models/fee/fixed_fee_type_spec.rb
@@ -49,9 +49,8 @@ module Fee
 
       context 'for fixed fees that require additional case numbers' do
         %w[FXACU FXASU FXCBU FXCSU FXCDU FXENU FXNOC].each do |unique_code|
-          before { allow(fee_type).to receive(:unique_code).and_return unique_code }
-
           it "#{unique_code} should return true" do
+            expect(fee_type).to receive(:unique_code).at_least(:once).and_return unique_code
             is_expected.to be_truthy
           end
         end
@@ -59,9 +58,8 @@ module Fee
 
       context 'for fixed fees that do not require additional case numbers' do
         %w[FXACV FXASE FXCBR FXCSE FXCON FXCCD FXENP FXH2S FXSAF FXALT FXASS FXASB].each do |unique_code|
-          before { allow(fee_type).to receive(:code).and_return unique_code }
-
           it "#{unique_code} should return false" do
+            expect(fee_type).to receive(:unique_code).at_least(:once).and_return unique_code
             is_expected.to be_falsey
           end
         end

--- a/spec/services/claims/fee_calculator/unit_price_spec.rb
+++ b/spec/services/claims/fee_calculator/unit_price_spec.rb
@@ -96,7 +96,8 @@ RSpec.describe Claims::FeeCalculator::UnitPrice, :fee_calc_vcr do
 
     context 'for a case-type-specific fixed fee with fixed amount (elected case not proceeded)' do
       let(:case_type) { create(:case_type, :elected_cases_not_proceeded) }
-      let(:fee) { create(:fixed_fee, :fxenp_fee, claim: claim, quantity: 1) }
+      let(:fee_type) { create(:fixed_fee_type, :fxenp) }
+      let(:fee) { create(:fixed_fee, fee_type: fee_type, claim: claim, quantity: 1) }
 
       it_returns 'a successful fee calculator response'
       it_returns 'a fee calculator response with amount', amount: 194.0


### PR DESCRIPTION
#### What
Unit price spec was flickering and fixed_fee test was faulty

#### Why
The use of the fxenp_fee factory trait could
result in either use of a persisted fee type
with unique code of FXENP or unpersisted fee
type for the test. This is, in turn, can result
in a different result dependant on order of
test runs.

reproducible with this:
```
rspec --seed 21453
```

The fixed_fee_type_spec for case uplifts
was not testing what was expected.
