### PR TITLE
Cracked (re)trial fixed notice and fixed date comparision

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -171,13 +171,15 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be in the future
   # cannot be before earliest rep order
   # cannot be more than 5 years old
+  # must be more than 2 days before trial_fixed_notice_at
   def validate_trial_fixed_notice_at
     return unless @record.case_type && @record.requires_cracked_dates?
     validate_presence(:trial_fixed_notice_at, 'blank')
     validate_on_or_before(Date.today, :trial_fixed_notice_at, 'check_not_in_future')
     validate_presence(:trial_fixed_notice_at, 'blank')
     validate_too_far_in_past(:trial_fixed_notice_at)
-    validate_before(@record.trial_fixed_at, :trial_fixed_notice_at, 'check_before_trial_fixed_at')
+    validate_before(@record.trial_fixed_at - 1.day, :trial_fixed_notice_at, 'check_before_trial_fixed_at')
+    # validate_before(@record.trial_fixed_at - 1.days, :trial_fixed_notice_at, 'check_2_days_before_trial_fixed_at')
     validate_before(@record.trial_cracked_at, :trial_fixed_notice_at, 'check_before_trial_cracked_at')
   end
 
@@ -186,12 +188,13 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be before earliest rep order
   # cannot be more than 5 years old
   # cannot be before trial_fixed_notice_at
+  # must be more than 2 days after trial_fixed_at
   def validate_trial_fixed_at
     return if ignore_validation_for_cracked_trials?
     validate_presence(:trial_fixed_at, 'blank')
     validate_too_far_in_past(:trial_fixed_at)
-    validate_on_or_after(@record.trial_fixed_notice_at, :trial_fixed_at,
-                         'check_not_earlier_than_trial_fixed_notice_at')
+    validate_on_or_after(@record.trial_fixed_notice_at + 2.days, :trial_fixed_at, 'check_not_earlier_than_trial_fixed_notice_at')
+    # validate_on_or_after(@record.trial_fixed_notice_at + 2.days, :trial_fixed_at, 'check_2_days_after_trial_fixed_notice_at')
   end
 
   # required when case type is cracked, cracked before retrial

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -360,7 +360,7 @@ trial_fixed_notice_at:
     api: 'Check the date for "Notice of 1st fixed/warned issued"'
   check_before_trial_fixed_at:
     long: 'Check the date for "Notice of 1st fixed/warned issued"'
-    short: 'Must be before the "1st fixed/warned trial date"'
+    short: 'Must be 2+ days before the "1st fixed/warned trial date"'
     api: '"Notice of 1st fixed/warned issued" must be on or before "1st fixed/warned trial date"'
   check_before_trial_cracked_at:
     long: 'Check the date for "Notice of 1st fixed/warned issued"'
@@ -383,7 +383,7 @@ trial_fixed_at:
     api: 'Check the date for "1st fixed/warned trial"'
   check_not_earlier_than_trial_fixed_notice_at:
     long: 'Check the date for "1st fixed/warned trial"'
-    short: Can't be before the "Notice of 1st fixed/warned issued"
+    short: Must be 2+ days after "Notice of 1st fixed/warned issued"
     api: 'Check the date for "1st fixed/warned trial"'
   invalid_date:
       long: 'Enter a valid date for the "1st fixed/warned trial"'

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -381,7 +381,7 @@ trial_fixed_at:
     long: 'Check the date for "1st fixed/warned trial"'
     short: *too_far_in_past
     api: 'Check the date for "1st fixed/warned trial"'
-  check_not_earlier_than_trial_fixed_notice_at:
+  check_after_trial_fixed_notice_at:
     long: 'Check the date for "1st fixed/warned trial"'
     short: Must be 2+ days after "Notice of 1st fixed/warned issued"
     api: 'Check the date for "1st fixed/warned trial"'
@@ -404,14 +404,14 @@ trial_cracked_at:
     long: 'Check the date for "Case cracked"'
     short: *too_far_in_past
     api: 'Check the date for "Case cracked"'
-  check_not_earlier_than_trial_fixed_notice_at:
+  check_after_trial_fixed_notice_at:
     long: 'Check the date for "Case cracked"'
     short: Can't be before the "Notice of 1st fixed/warned issued"
     api: 'Check the date for "Case cracked"'
-  check_before_trial_fixed_at:
-    long: 'Check the date for "Case cracked"'
-    short: 'Must be on or before the "1st fixed/warned trial date"'
-    api: '"Case cracked" must be on or before "1st fixed/warned trial date"'
+  # check_before_trial_fixed_at:
+  #   long: 'Check the date for "Case cracked"'
+  #   short: 'Must be on or before the "1st fixed/warned trial date"'
+  #   api: '"Case cracked" must be on or before "1st fixed/warned trial date"'
   invalid_date:
     long: 'Enter a valid date for "Case cracked"'
     short: *enter_valid_date

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -408,10 +408,6 @@ trial_cracked_at:
     long: 'Check the date for "Case cracked"'
     short: Can't be before the "Notice of 1st fixed/warned issued"
     api: 'Check the date for "Case cracked"'
-  # check_before_trial_fixed_at:
-  #   long: 'Check the date for "Case cracked"'
-  #   short: 'Must be on or before the "1st fixed/warned trial date"'
-  #   api: '"Case cracked" must be on or before "1st fixed/warned trial date"'
   invalid_date:
     long: 'Enter a valid date for "Case cracked"'
     short: *enter_valid_date
@@ -1274,7 +1270,6 @@ expense:
       long: 'Check the date for the #{expense}'
       short: *expense_before_rep_order
       api: Check the date for the expense
-    
 
   expense_type:
     _seq: 10

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -63,7 +63,7 @@ base:
     short: Too many defendant uplifts
     api: Defendant uplift sums must match number of additional defendants
   defendant_uplifts_misc_fees_mismatch:
-    long: The quantity of miscelaneous fees defendant uplifts exceeds the number of additional defendants
+    long: The quantity of miscellaneous fees defendant uplifts exceeds the number of additional defendants
     short: Too many defendant uplifts
     api: Defendant uplift sums must match number of additional defendants
   defendant_uplifts_mismatch:

--- a/spec/support/matchers/validation_matchers.rb
+++ b/spec/support/matchers/validation_matchers.rb
@@ -1,17 +1,13 @@
 require 'rspec/expectations'
 
-RSpec::Matchers.define :have_date_error_if_earlier_than_other_field do |options|
-  options.assert_valid_keys :field, :other_field, :message, :translated_message, :translated_message_type, :by
+RSpec::Matchers.define :include_field_error_when do |options|
+  options.assert_valid_keys :field, :other_field, :field_value, :other_field_value, :message, :translated_message, :translated_message_type
   match do |record|
-    date1 = 365.days.ago
-    date2 = date1 + options.fetch(:by, 1.day)
-    record.send("#{options[:field]}=", date1)
-    record.send("#{options[:other_field]}=", date2)
+    record.send("#{options[:field]}=", options[:field_value])
+    record.send("#{options[:other_field]}=", options[:other_field_value])
     record.valid?
     result = record.errors[options[:field]].include?(options[:message]) if options.fetch(:message, nil).present?
-    if options.fetch(:translated_message, nil).present? && result
-      result = translation_match?(options)
-    end
+    result = translation_match?(options) if result && options.fetch(:translated_message, nil).present?
     result
   end
 
@@ -27,7 +23,7 @@ RSpec::Matchers.define :have_date_error_if_earlier_than_other_field do |options|
   end
 
   description do
-    "error when earlier than #{options[:other_field]}#{" by #{options[:by]/86400} days" if options.fetch(:by, nil).present?}"
+    "include error on #{options[:field]} when #{options[:field]}: #{options[:field_value]} and #{options[:other_field]}: #{options[:other_field_value]}"
   end
 
   failure_message do |record|

--- a/spec/support/matchers/validation_matchers.rb
+++ b/spec/support/matchers/validation_matchers.rb
@@ -1,0 +1,40 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_date_error_if_earlier_than_other_field do |options|
+  options.assert_valid_keys :field, :other_field, :message, :translated_message, :translated_message_type, :by
+  match do |record|
+    date1 = 365.days.ago
+    date2 = date1 + options.fetch(:by, 1.day)
+    record.send("#{options[:field]}=", date1)
+    record.send("#{options[:other_field]}=", date2)
+    record.valid?
+    result = record.errors[options[:field]].include?(options[:message]) if options.fetch(:message, nil).present?
+    if options.fetch(:translated_message, nil).present? && result
+      result = translation_match?(options)
+    end
+    result
+  end
+
+  def translation_match?(options)
+    @translations ||= YAML.load_file("#{Rails.root}/config/locales/error_messages.en.yml") # lazy load translations
+    message_type = options[:translated_message_type] || 'short'
+    field = options[:field].to_s
+    [
+      @translations.has_key?(field),
+      @translations[field].has_key?(options[:message]),
+      @translations[field][options[:message]][message_type].eql?(options[:translated_message])
+    ].all?
+  end
+
+  description do
+    "error when earlier than #{options[:other_field]}#{" by #{options[:by]/86400} days" if options.fetch(:by, nil).present?}"
+  end
+
+  failure_message do |record|
+    "expected #{record.errors.messages}} to include errors for #{options[:field]}"
+  end
+
+  failure_message_when_negated do |record|
+    "expected #{record.errors.messages}} NOT to include errors for #{options[:field]}"
+  end
+end

--- a/spec/support/validation_helpers.rb
+++ b/spec/support/validation_helpers.rb
@@ -16,7 +16,7 @@ module ValidationHelpers
 
   def should_error_with(record, field, message)
     expect(record).not_to be_valid
-    expect(record.errors[field]).to include( message )
+    expect(record.errors[field]).to include(message)
   end
 
   def should_not_error(record, field)
@@ -27,22 +27,22 @@ module ValidationHelpers
   def should_error_if_present(record, field, value, message, options={})
     record.send("#{field}=", value)
     expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
   def should_error_if_not_present(record, field, message, options={})
     record.send("#{field}=", nil)
     expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
   def should_error_if_exceeds_length(record, field, value, message, options={})
     record.send("#{field}=", 'x' * (value+1))
     expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
   # checks the translation exists and has expected message
@@ -57,39 +57,41 @@ module ValidationHelpers
   def should_error_if_in_future(record, field, message, options={})
     record.send("#{field}=", 2.days.from_now)
     expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
   def should_error_if_too_far_in_the_past(record, field, message, options={})
     record.send("#{field}=", Settings.earliest_permitted_date - 1.day )
     expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
   def should_error_if_earlier_than_earliest_repo_date(record, field, message, options={})
     stub_earliest_rep_order(record,1.year.ago.to_date)
     record.send("#{field}=", 13.months.ago)
     expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
   def should_error_if_earlier_than_earliest_reporder_date(claim_record, other_record, field, message, options={})
     stub_earliest_rep_order(claim_record,1.year.ago.to_date)
     other_record.send("#{field}=", 13.months.ago)
     expect(other_record.send(:valid?)).to be false
-    expect(other_record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(other_record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
-  def should_error_if_earlier_than_other_date(record, field, other_date, message, options={})
-    record.send("#{field}=", 5.day.ago)
-    record.send("#{other_date}=", 3.day.ago)
+  def should_error_if_earlier_than_other_date(record, field, other_field, message, options={})
+    date1 = 365.days.ago
+    date2 = date1 + options.fetch(:by, 1.day)
+    record.send("#{field}=", date1)
+    record.send("#{other_field}=", date2)
     expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include( message )
-    with_expected_error_translation(field,message,options) if options[:translated_message]
+    expect(record.errors[field]).to include(message)
+    with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
   def should_error_if_before_specified_date(record, field, specified_date, message)
@@ -114,6 +116,15 @@ module ValidationHelpers
   def should_error_if_after_specified_field(record, field, specified_field, message)
     record.send("#{specified_field}=", 3.days.ago)
     record.send("#{field}=", 2.days.ago)
+    expect(record.send(:valid?)).to be false
+    expect(record.errors[field]).to include(message)
+  end
+
+  def should_error_if_after_specified_field_by(record, field, specified_field, period, message)
+    earlier = 365.days.ago
+    later = earlier.ago(period)
+    record.send("#{specified_field}=", earlier)
+    record.send("#{field}=", later)
     expect(record.send(:valid?)).to be false
     expect(record.errors[field]).to include(message)
   end

--- a/spec/support/validation_helpers.rb
+++ b/spec/support/validation_helpers.rb
@@ -120,15 +120,6 @@ module ValidationHelpers
     expect(record.errors[field]).to include(message)
   end
 
-  def should_error_if_after_specified_field_by(record, field, specified_field, period, message)
-    earlier = 365.days.ago
-    later = earlier.ago(period)
-    record.send("#{specified_field}=", earlier)
-    record.send("#{field}=", later)
-    expect(record.send(:valid?)).to be false
-    expect(record.errors[field]).to include(message)
-  end
-
   def should_errror_if_later_than_other_date(record, field, other_date, message, options={})
     record.send("#{field}=", 5.day.ago)
     record.send("#{other_date}=", 7.day.ago)

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -542,32 +542,50 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       nulify_fields_on_record(claim, :trial_fixed_notice_at, :trial_fixed_at, :trial_cracked_at)
     end
 
+    RSpec.shared_examples 'validates trial_fixed_notice_at compared to trial_fixed_at' do
+      context 'compared to trial_fixed_at' do
+        let(:options) do
+          {
+            field: :trial_fixed_notice_at,
+            other_field: :trial_fixed_at,
+            message: 'check_before_trial_fixed_at',
+            translated_message: 'Must be 2+ days before the "1st fixed/warned trial date"'
+          }
+        end
+
+        [4,3,2].each do |num|
+          it { is_expected.to include_field_error_when(options.merge(field_value: 3.days.ago.to_date, other_field_value: num.days.ago.to_date)) }
+        end
+
+        it { is_expected.to_not include_field_error_when(options.merge(field_value: 3.days.ago.to_date, other_field_value: 1.day.ago.to_date)) }
+      end
+    end
+
+    RSpec.shared_examples 'validates trial_fixed_at compared to trial_fixed_notice_at' do
+      context 'compared to trial_fixed_notice_at' do
+        let(:options) do
+          {
+            field: :trial_fixed_at,
+            other_field: :trial_fixed_notice_at,
+            message: 'check_after_trial_fixed_notice_at',
+            translated_message: 'Must be 2+ days after "Notice of 1st fixed/warned issued"'
+          }
+        end
+
+        [4, 3, 2].each do |num|
+          it { is_expected.to include_field_error_when(options.merge(field_value: 3.days.ago.to_date, other_field_value: num.days.ago.to_date)) }
+        end
+
+        it { is_expected.to_not include_field_error_when(options.merge(field_value: 5.days.ago.to_date, other_field_value: 7.days.ago.to_date)) }
+      end
+    end
+
     before do
       cracked_trial_claim.force_validation = true
       cracked_before_retrial_claim.force_validation = true
     end
 
     context 'trial_fixed_notice_at' do
-
-      RSpec.shared_examples 'validates trial_fixed_notice_at compared to trial_fixed_at' do
-        context 'compared to trial_fixed_at' do
-          let(:options) do
-            {
-              field: :trial_fixed_notice_at,
-              other_field: :trial_fixed_at,
-              message: 'check_before_trial_fixed_at',
-              translated_message: 'Must be 2+ days before the "1st fixed/warned trial date"'
-            }
-          end
-
-          [4,3,2].each do |num|
-            it { is_expected.to include_field_error_when(options.merge(field_value: 3.days.ago.to_date, other_field_value: num.days.ago.to_date)) }
-          end
-
-          it { is_expected.to_not include_field_error_when(options.merge(field_value: 3.days.ago.to_date, other_field_value: 1.day.ago.to_date)) }
-        end
-      end
-
       context 'cracked_trial_claim' do
         subject { cracked_trial_claim }
 
@@ -596,26 +614,6 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
     end
 
     context 'trial fixed at' do
-
-      RSpec.shared_examples 'validates trial_fixed_at compared to trial_fixed_notice_at' do
-        context 'compared to trial_fixed_notice_at' do
-          let(:options) do
-            {
-              field: :trial_fixed_at,
-              other_field: :trial_fixed_notice_at,
-              message: 'check_after_trial_fixed_notice_at',
-              translated_message: 'Must be 2+ days after "Notice of 1st fixed/warned issued"'
-            }
-          end
-
-          [4, 3, 2].each do |num|
-            it { is_expected.to include_field_error_when(options.merge(field_value: 3.days.ago.to_date, other_field_value: num.days.ago.to_date)) }
-          end
-
-          it { is_expected.to_not include_field_error_when(options.merge(field_value: 5.days.ago.to_date, other_field_value: 7.days.ago.to_date)) }
-        end
-      end
-
       context 'cracked trial claim' do
         subject { cracked_trial_claim }
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         it { should_error_if_not_present(cracked_trial_claim, :trial_fixed_notice_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_in_future(cracked_trial_claim, :trial_fixed_notice_at, 'check_not_in_future', translated_message: 'Can\'t be in the future')}
         it { should_error_if_too_far_in_the_past(cracked_trial_claim, :trial_fixed_notice_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_after_specified_field(cracked_trial_claim, :trial_fixed_notice_at, :trial_fixed_at, 'check_before_trial_fixed_at') }
+        it { should_error_if_after_specified_field_by(cracked_trial_claim, :trial_fixed_notice_at, :trial_fixed_at, 1.day, 'check_before_trial_fixed_at')}
         it { should_error_if_after_specified_field(cracked_trial_claim, :trial_fixed_notice_at, :trial_cracked_at, 'check_before_trial_cracked_at') }
         it { should_error_if_field_dates_match(cracked_trial_claim, :trial_fixed_notice_at, :trial_cracked_at, 'check_before_trial_cracked_at') }
         it { should_error_if_field_dates_match(cracked_trial_claim, :trial_fixed_notice_at, :trial_fixed_at, 'check_before_trial_fixed_at') }
@@ -562,7 +562,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         it { should_error_if_not_present(cracked_before_retrial_claim, :trial_fixed_notice_at, 'blank') }
         it { should_error_if_in_future(cracked_before_retrial_claim, :trial_fixed_notice_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_before_retrial_claim, :trial_fixed_notice_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_after_specified_field(cracked_trial_claim, :trial_fixed_notice_at, :trial_fixed_at, 'check_before_trial_fixed_at') }
+        it { should_error_if_after_specified_field_by(cracked_trial_claim, :trial_fixed_notice_at, :trial_fixed_at, 1.day, 'check_before_trial_fixed_at') }
         it { should_error_if_after_specified_field(cracked_trial_claim, :trial_fixed_notice_at, :trial_cracked_at, 'check_before_trial_cracked_at') }
         it { should_error_if_field_dates_match(cracked_trial_claim, :trial_fixed_notice_at, :trial_cracked_at, 'check_before_trial_cracked_at') }
         it { should_error_if_field_dates_match(cracked_trial_claim, :trial_fixed_notice_at, :trial_fixed_at, 'check_before_trial_fixed_at') }
@@ -570,16 +570,39 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
     end
 
     context 'trial fixed at' do
+      let(:options) do
+        {
+          field: :trial_fixed_at,
+          other_field: :trial_fixed_notice_at,
+          message: 'check_after_trial_fixed_notice_at',
+          translated_message: 'Must be 2+ days after "Notice of 1st fixed/warned issued"'
+        }
+      end
+
       context 'cracked trial claim' do
+        subject { cracked_trial_claim }
+
         it { should_error_if_not_present(cracked_trial_claim, :trial_fixed_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_too_far_in_the_past(cracked_trial_claim, :trial_fixed_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_other_date(cracked_trial_claim, :trial_fixed_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
+
+        [1, 0, -1].each do |num|
+          it { is_expected.to have_date_error_if_earlier_than_other_field(options.merge(by: num.days)) }
+        end
+
+        it { is_expected.not_to have_date_error_if_earlier_than_other_field(options.merge(by: -2.days)) }
       end
 
       context 'cracked before retrial' do
+        subject { cracked_before_retrial_claim }
+
         it { should_error_if_not_present(cracked_before_retrial_claim, :trial_fixed_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_too_far_in_the_past(cracked_before_retrial_claim, :trial_fixed_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_other_date(cracked_before_retrial_claim, :trial_fixed_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
+
+        [1, 0, -1].each do |num|
+          it { is_expected.to have_date_error_if_earlier_than_other_field(options.merge(by: num.days)) }
+        end
+
+        it { is_expected.not_to have_date_error_if_earlier_than_other_field(options.merge(by: -2.days)) }
       end
     end
 
@@ -588,14 +611,14 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         it { should_error_if_not_present(cracked_trial_claim, :trial_cracked_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_in_future(cracked_trial_claim, :trial_cracked_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_trial_claim, :trial_cracked_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_other_date(cracked_trial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
+        it { should_error_if_earlier_than_other_date(cracked_trial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_after_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
       end
 
       context 'cracked before retrial' do
         it { should_error_if_not_present(cracked_before_retrial_claim, :trial_cracked_at, 'blank', translated_message: 'Enter a date') }
         it { should_error_if_in_future(cracked_before_retrial_claim, :trial_cracked_at, 'check_not_in_future', translated_message: 'Can\'t be in the future') }
         it { should_error_if_too_far_in_the_past(cracked_before_retrial_claim, :trial_cracked_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
-        it { should_error_if_earlier_than_other_date(cracked_before_retrial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_not_earlier_than_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
+        it { should_error_if_earlier_than_other_date(cracked_before_retrial_claim, :trial_cracked_at, :trial_fixed_notice_at, 'check_after_trial_fixed_notice_at', translated_message: 'Can\'t be before the "Notice of 1st fixed/warned issued"') }
       end
     end
   end


### PR DESCRIPTION
#### What
The dates of **notice** and **fixing** of trial dates should be 2+ days different

#### Ticket

[CBO-367](https://dsdmoj.atlassian.net/browse/CBO-367)

#### Why
CCR validates that the difference between **notice** of trial date fixing
and trial date **fixing** be 2 or more days (e.g. 1st of the month for notice
must be accompanied by a date of fixing of the 3rd of the month or greater).

If these dates do not comply then the claim cannot be injected into CCR.

#### How
Apply a new validation comparing the two  dates and ensuring that
`trial_fixed_at` >= `trial_fixed_notice_at + 2.days`
