### PR TITLE
Reset fee type mapping singleton after spec

### DIFF
--- a/spec/services/claims/fee_calculator/fee_type_mappings_spec.rb
+++ b/spec/services/claims/fee_calculator/fee_type_mappings_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe Claims::FeeCalculator::FeeTypeMappings do
     described_class.reset
   end
 
+  after do
+    # important to not impact other tests
+    described_class.reset
+  end
+
   it { is_expected.to respond_to :all }
   it { is_expected.to respond_to :primary_fee_types }
 


### PR DESCRIPTION
#### What
Prevent flickering unit_price_spec and impact on others.

#### Why
 The fee type mappings spec seeds case types and resets mappings. 
As a singleton class this mapping will "persist" and thereby impact
other tests that may or may not bereliant on it.

#### How
reset the singleton after each example
