### PR TITLE
Tweak cracked trial notice/fixed_at error messages

### DIFF
--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -360,8 +360,8 @@ trial_fixed_notice_at:
     api: 'Check the date for "Notice of 1st fixed/warned issued"'
   check_before_trial_fixed_at:
     long: 'Check the date for "Notice of 1st fixed/warned issued"'
-    short: 'Must be 2+ days before the "1st fixed/warned trial date"'
-    api: '"Notice of 1st fixed/warned issued" must be on or before "1st fixed/warned trial date"'
+    short: 'Must be 2+ days before the "1st fixed/warned trial" date'
+    api: 'Must be 2+ days before the "1st fixed/warned trial" date'
   check_before_trial_cracked_at:
     long: 'Check the date for "Notice of 1st fixed/warned issued"'
     short: 'Must be before the "Case cracked"'
@@ -383,8 +383,8 @@ trial_fixed_at:
     api: 'Check the date for "1st fixed/warned trial"'
   check_after_trial_fixed_notice_at:
     long: 'Check the date for "1st fixed/warned trial"'
-    short: Must be 2+ days after "Notice of 1st fixed/warned issued"
-    api: 'Check the date for "1st fixed/warned trial"'
+    short: 'Must be 2+ days after "Notice of 1st fixed/warned issued" date'
+    api: 'Must be 2+ days after "Notice of 1st fixed/warned issued" date'
   invalid_date:
       long: 'Enter a valid date for the "1st fixed/warned trial"'
       short: *enter_valid_date

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
             field: :trial_fixed_notice_at,
             other_field: :trial_fixed_at,
             message: 'check_before_trial_fixed_at',
-            translated_message: 'Must be 2+ days before the "1st fixed/warned trial date"'
+            translated_message: 'Must be 2+ days before the "1st fixed/warned trial" date'
           }
         end
 
@@ -568,7 +568,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
             field: :trial_fixed_at,
             other_field: :trial_fixed_notice_at,
             message: 'check_after_trial_fixed_notice_at',
-            translated_message: 'Must be 2+ days after "Notice of 1st fixed/warned issued"'
+            translated_message: 'Must be 2+ days after "Notice of 1st fixed/warned issued" date'
           }
         end
 


### PR DESCRIPTION
#### What 
tweak error messages on Cracked (re)trial dates

#### Why
Feedback from PM. Also made api error more descriptive of the problem

#### Before
![screen shot 2018-09-25 at 09 22 25](https://user-images.githubusercontent.com/7016425/46002698-a7602400-c0a6-11e8-96f1-78bec4e0f131.png)

#### After
![screen shot 2018-09-25 at 09 37 58](https://user-images.githubusercontent.com/7016425/46002727-b7780380-c0a6-11e8-999e-c7b85ce5bf95.png)
