### PR TITLE
CBO-356: Fix basic fee JS calculation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -102,6 +102,17 @@ if (!String.prototype.supplant) {
     $(this).trigger('recalculate');
   });
 
+  $('#basic-fees').on('change', '.js-fee-rate, .js-fee-quantity', function() {
+    var $el, quantity, rate, amount;
+
+    $el = $(this).closest('.basic-fee-group');
+    quantity = $el.find('.js-fee-quantity').val();
+    rate = $el.find('.js-fee-rate').val();
+    amount = quantity * rate;
+
+    $el.find('.js-fee-amount').val(amount.toFixed(2));
+  });
+
   // this is a bit hacky
   // TODO: To be moved to more page based controllers
   $('#basic-fees').on('change', '.multiple-choice input[type=checkbox]', function(e){

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields.html.haml
@@ -1,5 +1,4 @@
 - fee = present(f.object)
--# Setting a namespaced locale pointer
 - locale_scope = "external_users.claims.basic_fees.basic_fee_fields_conditional.#{fee.fee_type_code.downcase}"
 -# Check box input
 .multiple-choice{"data-target" => to_slug(f.object.description), "class" => "fx-hook-#{fee.fee_type_code.downcase}"}
@@ -18,7 +17,7 @@
     = f.adp_text_field :quantity,
                           label: t('quantity', scope: locale_scope),
                           hint_text: t('quantity_hint', scope: locale_scope),
-                          input_classes:'quantity form-control-1-4',
+                          input_classes:'quantity js-fee-quantity form-control-1-4',
                           input_type: 'number',
                           value: fee.quantity,
                           errors: @error_presenter
@@ -26,7 +25,7 @@
     - if f.object.calculated?
       = f.adp_text_field :rate,
                           label: t('.rate'),
-                          input_classes:'rate form-input-denote__input form-control-1-4',
+                          input_classes:'rate js-fee-rate form-input-denote__input form-control-1-4',
                           input_type: 'currency',
                           value: number_with_precision(f.object.rate, precision: 2),
                           errors: @error_presenter
@@ -38,10 +37,9 @@
           - f.object.dates_attended.build unless f.object.dates_attended.any?
           = f.fields_for :dates_attended do |date_attended|
             -# TODO: Numbering, the implementation used on fees will not work here.
-            = render partial: 'date_attended_fields', locals: { f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "basic_fee_#{@basic_fee_count}", locale_scope: locale_scope  }
+            = render partial: 'date_attended_fields', locals: { f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "basic_fee_#{@basic_fee_count}", locale_scope: locale_scope }
 
-
-        = link_to_add_association t('.add_dates'), f, :dates_attended, class: 'form-group', partial: 'date_attended_fields',  render_options: { locals: { locale_scope: locale_scope } }, data: {'association-insertion-method' => 'append', 'association-insertion-node' => 'div', 'association-insertion-traversal' => 'prev'}
+        = link_to_add_association t('.add_dates'), f, :dates_attended, class: 'form-group', partial: 'date_attended_fields', render_options: { locals: { locale_scope: locale_scope } }, data: {'association-insertion-method' => 'append', 'association-insertion-node' => 'div', 'association-insertion-traversal' => 'prev'}
 
     -# Case numbers
     - if f.object.fee_type.case_uplift?
@@ -54,8 +52,7 @@
     = f.adp_text_field :amount,
                           label: t('.net_amount'),
                           input_disabled: f.object.calculated? ? true : false,
-                          input_classes:'total form-input-denote__input form-control-1-4',
+                          input_classes:'total js-fee-amount form-input-denote__input form-control-1-4',
                           input_type: 'currency',
                           value: number_with_precision(f.object.amount, precision: 2),
                           errors: @error_presenter
-


### PR DESCRIPTION
#### What
Apply basic fee `quantity x rate` calculation to FE 

#### Ticket

[CBO-356](https://dsdmoj.atlassian.net/browse/CBO-356)

#### Why
Basic fee quantity x rate calculation is only being performed on the
backend. To reflect the simple calculation to the user immediately
we apply the calculation on the front end via JS.

#### How
Add JS to all applicable basic fees to calculate
the net amount (quantity x rate) inline with backend
logic that does this.
