### PR TITLE
Use claim's apply_vat flag for expenses

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -152,6 +152,6 @@ class Expense < ApplicationRecord
   # we only calculate VAT for AGFS claims for vatable providers.  On LGFS claims, the VAT amount is entered in the form.
   def calculate_vat
     return unless claim&.agfs? && amount
-    self.vat_amount = VatRate.vat_amount(amount, claim.vat_date, calculate: claim.vat_registered?)
+    self.vat_amount = VatRate.vat_amount(amount, claim.vat_date, calculate: claim.apply_vat?)
   end
 end


### PR DESCRIPTION
#### What
Change expense VAT calculation to rely on claims apply_vat flag

#### Ticket

[CBO-393](https://dsdmoj.atlassian.net/browse/CBO-393)

#### Why
A bug was raised by a vender in which they
were submitting final advocate claims via
the API explicitly setting the apply_vat=true,
but there user was not vat_registered. This
showed up a bug whereby fees where respecting
the claims apply_vat flag but expenses were
not.

In addition the Sidebar calculations were respecting
the claims apply vat flag but the backend was
not. This meant the sidebar would update expense VAT when a
fee or expense was edited but moving to the next
page would display the persisted vat in sidebar - which
for expenses had not been saved.


#### How
Alter the expense vat calculation to rely on the claims apply_vat
flag, inline with how fees work and how the sidebar works, and 
instead of the vat_registered flag. Note the claims apply_vat flag 
is set by the vat_registered flag at claim creation in any event.
