### PR TITLE
CCLF injection reporting

### DIFF
--- a/app/services/claims/injection_channel.rb
+++ b/app/services/claims/injection_channel.rb
@@ -2,7 +2,7 @@ module Claims
   class InjectionChannel
     def self.for(claim)
       return 'cccd_development' if claim.nil?
-      claim.agfs? ? Settings.slack.channel : 'cccd_cclf_injection'
+      claim.agfs? ? 'cccd_ccr_injection' : 'cccd_cclf_injection'
     end
   end
 end

--- a/app/services/claims/injection_channel.rb
+++ b/app/services/claims/injection_channel.rb
@@ -1,0 +1,8 @@
+module Claims
+  class InjectionChannel
+    def self.for(claim)
+      return 'cccd_development' if claim.nil?
+      claim.agfs? ? Settings.slack.channel : 'cccd_cclf_injection'
+    end
+  end
+end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -3,6 +3,7 @@ class InjectionResponseService
     @response = json.stringify_keys
     raise ParseError, 'Invalid JSON string' unless @response.keys.sort.eql?(%w[errors from messages uuid])
     @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
+    @channel = Claims::InjectionChannel.for(@claim)
   end
 
   def run!
@@ -17,7 +18,7 @@ class InjectionResponseService
   private
 
   def slack
-    @slack ||= SlackNotifier.new
+    @slack ||= SlackNotifier.new(@channel)
   end
 
   def failure(options = {})

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,5 +1,5 @@
 class SlackNotifier
-  def initialize(channel = Settings.slack.channel)
+  def initialize(channel)
     @slack_url = Settings.slack.bot_url
     @ready_to_send = false
     @payload = {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -119,7 +119,6 @@ aws:
 
 slack:
   bot_url: 'slack_bot_url'
-  channel: '#channel_name'
   bot_name: 'bot_name'
   success_icon: ':icon:'
   fail_icon: ':icon:'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,7 +108,6 @@ RSpec.configure do |config|
 
   config.before :each, slack_bot: true do
     allow(Settings.slack).to receive(:bot_url).and_return('https://hooks.slack.com/services/fake/endpoint')
-    allow(Settings.slack).to receive(:channel).and_return('#monitoring')
     allow(Settings.slack).to receive(:bot_name).and_return('monitor_bot')
     allow(Settings.slack).to receive(:success_icon).and_return(':good_icon:')
     allow(Settings.slack).to receive(:fail_icon).and_return(':bad_icon:')

--- a/spec/services/claims/injection_channel_spec.rb
+++ b/spec/services/claims/injection_channel_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe Claims::InjectionChannel, type: :service do
   subject(:injection_channel) { described_class.for(claim) }
 
-  before { allow(Settings).to receive_message_chain(:slack, :channel).and_return('ccr_target_channel') }
-
   context 'when claim is for LGFS' do
     let(:claim) { create(:litigator_claim) }
 
@@ -14,7 +12,7 @@ RSpec.describe Claims::InjectionChannel, type: :service do
   context 'when claim is for AGFS' do
     let(:claim) { create(:claim) }
 
-    it { is_expected.to eql('ccr_target_channel') }
+    it { is_expected.to eql('cccd_ccr_injection') }
   end
 
   context 'when claim type can not be inferred' do

--- a/spec/services/claims/injection_channel_spec.rb
+++ b/spec/services/claims/injection_channel_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Claims::InjectionChannel, type: :service do
+  subject(:injection_channel) { described_class.for(claim) }
+
+  before { allow(Settings).to receive_message_chain(:slack, :channel).and_return('ccr_target_channel') }
+
+  context 'when claim is for LGFS' do
+    let(:claim) { create(:litigator_claim) }
+
+    it { is_expected.to eql('cccd_cclf_injection') }
+  end
+
+  context 'when claim is for AGFS' do
+    let(:claim) { create(:claim) }
+
+    it { is_expected.to eql('ccr_target_channel') }
+  end
+
+  context 'when claim type can not be inferred' do
+    let(:claim) { nil }
+
+    it { is_expected.to eql('cccd_development') }
+  end
+end

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SlackNotifier, slack_bot: true do
-  subject(:slack_notifier) { described_class.new() }
+  subject(:slack_notifier) { described_class.new(claim) }
 
   let(:claim) { create :claim }
   let(:valid_json_on_success) { { "from":"external application", "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }


### PR DESCRIPTION
#### What
Allow CCLF injection reports to be logged separately in Slack

#### Why
To allow easier tracking of the CCLF injection development 
#### How
Provide different channels for AGFS and LGFS injection reports
In the event that the claim type cannot be inferred, e.g. bad API key, log the message in the #cccd_development channel to allow quicker resolution of errors when they don't get lost in successful messages in the other channels