### PR TITLE
Update the date regex in tests

### DIFF
--- a/spec/lib/geckoboard_publisher/injections_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/injections_report_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe GeckoboardPublisher::InjectionsReport, geckoboard: true do
     include_examples 'returns valid items structure'
 
     it 'returns dates to day precision in ISO 8601 format - YYYY-MM-DD' do
-      expect(subject.first[:date]).to match(/^(\d{4}-(0[1-9]|1[12])-((0[1-9]|[12]\d)|3[01]))$/)
+      expect(subject.first[:date]).to match(/^(\d{4}-(0[1-9]|1[0-2])-((0[1-9]|[12]\d)|3[01]))$/)
     end
 
     context 'when run without parameters' do

--- a/spec/lib/geckoboard_publisher/providers_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/providers_report_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe GeckoboardPublisher::ProvidersReport, geckoboard: true do
     include_examples 'returns valid items structure'
 
     it 'returns dates to day precision in ISO 8601 format - YYYY-MM-DD' do
-      expect(subject.first[:date]).to match /^(\d{4}-(0[1-9]|1[12])-((0[1-9]|[12]\d)|3[01]))$/
+      expect(subject.first[:date]).to match /^(\d{4}-(0[1-9]|1[0-2])-((0[1-9]|[12]\d)|3[01]))$/
     end
 
     context 'when run without parameters' do


### PR DESCRIPTION
#### What
The regex inadvertently omitted October from the month validation

#### Why
This will prevent all test suites running until updated

#### How
Amend the regex from [12] to [0-2]
