### PR TITLE
Update the MI display of Claim::AdvocateInterimClaims

### DIFF
--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -61,7 +61,7 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def scheme
-    if type == 'Claim::AdvocateClaim'
+    if %w[Claim::AdvocateClaim Claim::AdvocateInterimClaim].include? type
       'AGFS'
     elsif %w[Claim::LitigatorClaim Claim::InterimClaim Claim::TransferClaim].include? type
       'LGFS'

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe ClaimCsvPresenter do
           end
         end
 
+        context 'AGFS' do
+          it 'scheme' do
+            subject.update_column(:type, 'Claim::AdvocateInterimClaim')
+
+            subject.present! do |claim_journeys|
+              expect(claim_journeys.first).to include('AGFS')
+              expect(claim_journeys.second).to include('AGFS')
+            end
+          end
+        end
+
         context 'LGFS' do
           it 'scheme' do
             subject.update_column(:type, 'Claim::LitigatorClaim')


### PR DESCRIPTION
#### What/Why
Due to an oversight when implementing the new AGFS warrant type,
the classification was not extended to the claim_csv_presenter.
Only Claim::AdvocateClaims are set as AGFS, therefore the new
Claim::AdvocateInterimClaim type is classed as unknown

#### Ticket
[CBO-418](https://dsdmoj.atlassian.net/browse/CBO-418)
