### PR TITLE
origin supplier name and postcode helper

### DIFF
--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -340,6 +340,11 @@ class Claim::BaseClaimPresenter < BasePresenter
       SupplierNumber.find_by(supplier_number: claim.supplier_number)&.name
   end
 
+  def supplier_name_with_postcode
+    return "#{supplier_name} (#{supplier_postcode})" if supplier_postcode
+    supplier_name
+  end
+
   private
 
   # a blank assessment is created when the claim is created,

--- a/app/views/shared/summary/expenses/_details.html.haml
+++ b/app/views/shared/summary/expenses/_details.html.haml
@@ -4,7 +4,8 @@
       %span.bold
         = succeed ':' do
           = t('.origin')
-      = "#{claim.supplier_name} (#{claim.supplier_postcode})"
+      = claim.supplier_name_with_postcode
+      / = # "#{claim.supplier_name} (#{claim.supplier_postcode})"
       %br/
       %span.bold
         = succeed ':' do

--- a/app/views/shared/summary/expenses/_details.html.haml
+++ b/app/views/shared/summary/expenses/_details.html.haml
@@ -1,16 +1,18 @@
 .details
   %ul
+    - if claim.lgfs?
+      %li
+        %span.bold
+          = succeed ':' do
+            = t('.origin')
+        = claim.supplier_name_with_postcode
+        %br/
     %li
-      %span.bold
-        = succeed ':' do
-          = t('.origin')
-      = claim.supplier_name_with_postcode
-      / = # "#{claim.supplier_name} (#{claim.supplier_postcode})"
-      %br/
       %span.bold
         = succeed ':' do
           = t('.destination')
       = expense.location_with_postcode
+      %br/
 
     - if current_user_is_caseworker? && expense.distance?
       %li{ class: ('error' if expense.distance_gt_calculated?) }

--- a/spec/factories/supplier_numbers.rb
+++ b/spec/factories/supplier_numbers.rb
@@ -12,5 +12,6 @@ FactoryBot.define do
     provider
     postcode { Faker::Address.postcode }
     supplier_number { [rand(0..9), ('A'..'Z').to_a[rand(0..25)], rand(100..999), ('A'..'Z').to_a[rand(0..25)]].join }
+    name Faker::Company.name
   end
 end

--- a/spec/presenters/base_claim_presenter_spec.rb
+++ b/spec/presenters/base_claim_presenter_spec.rb
@@ -413,6 +413,27 @@ RSpec.describe Claim::BaseClaimPresenter do
     end
   end
 
+  describe '#supplier_name' do
+    subject { presenter.supplier_name }
+
+    context 'AGFS' do
+      it 'returns nil' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'LGFS' do
+      let(:claim) { create(:litigator_claim) }
+      let(:supplier) do
+        SupplierNumber.find_by(supplier_number: claim.supplier_number)
+      end
+
+      it 'returns claim supplier\'s name' do
+        is_expected.to eql supplier.name
+      end
+    end
+  end
+
   describe '#supplier_postcode' do
     subject { presenter.supplier_postcode }
 
@@ -424,11 +445,46 @@ RSpec.describe Claim::BaseClaimPresenter do
 
     context 'LGFS' do
       let(:claim) { create(:litigator_claim) }
-      let(:supplier_postcode) { SupplierNumber.find_by(supplier_number: claim.supplier_number).postcode }
+      let(:supplier) { SupplierNumber.find_by(supplier_number: claim.supplier_number) }
 
       it 'returns claim suppliers postcode' do
         is_expected.to_not be_nil
-        is_expected.to eql supplier_postcode
+        is_expected.to eql supplier.postcode
+      end
+    end
+  end
+
+  describe '#supplier_name_with_postcode' do
+    subject { presenter.supplier_name_with_postcode }
+
+    context 'AGFS' do
+      it 'returns nil' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'LGFS' do
+      let(:claim) { create(:litigator_claim) }
+      let(:supplier) { SupplierNumber.find_by(supplier_number: claim.supplier_number) }
+
+      context 'when claim supplier has name and postcode' do
+        it 'returns name and postcode' do
+          is_expected.to_not be_nil
+          is_expected.to eql "#{supplier.name} (#{supplier.postcode})"
+        end
+      end
+
+      context 'when claim supplier has name but NOT postcode' do
+        before { supplier.update(postcode: nil) }
+
+        it 'returns name' do
+          is_expected.to eql "#{supplier.name}"
+        end
+      end
+
+      context 'when claim supplier has no name or postcode' do
+        before { supplier.update(name: nil, postcode: nil) }
+        it { is_expected.to be_nil }
       end
     end
   end


### PR DESCRIPTION
#### What
Presenter for supplier name and postcode and conditional display

#### Why
Abstract view logic to presenter. Can be used to 
handle AGFS providers/external user postcodes 
in the future.

Do not show origin for AGFS expenses for now.

