### PR TITLE
Add travel distance calc postcode validation.

### DIFF
--- a/app/services/expenses/travel_distance_calculator.rb
+++ b/app/services/expenses/travel_distance_calculator.rb
@@ -38,6 +38,7 @@ module Expenses
       return Failure.new(:invalid_claim_type) unless claim.lgfs?
       return Failure.new(:missing_origin) unless origin
       return Failure.new(:missing_destination) unless destination
+      return Failure.new(:invalid_destination) unless destination.match?(Settings.postcode_regexp)
       Success.new(:valid)
     end
 

--- a/app/services/expenses/travel_distance_calculator.rb
+++ b/app/services/expenses/travel_distance_calculator.rb
@@ -34,12 +34,27 @@ module Expenses
     end
 
     def validate_inputs
-      return Failure.new(:claim_not_found) unless claim
-      return Failure.new(:invalid_claim_type) unless claim.lgfs?
-      return Failure.new(:missing_origin) unless origin
-      return Failure.new(:missing_destination) unless destination
-      return Failure.new(:invalid_destination) unless destination.match?(Settings.postcode_regexp)
+      validate_claim
+      validate_origin
+      validate_destination
+
       Success.new(:valid)
+    rescue RuntimeError => err
+      Failure.new(err.message.to_sym)
+    end
+
+    def validate_claim
+      raise 'claim_not_found' unless claim
+      raise 'invalid_claim_type' unless claim.lgfs?
+    end
+
+    def validate_origin
+      raise 'missing_origin' unless origin
+    end
+
+    def validate_destination
+      raise 'missing_destination' unless destination
+      raise 'invalid_destination' unless destination.match?(Settings.postcode_regexp)
     end
 
     def origin

--- a/spec/services/expenses/travel_distance_calculator_spec.rb
+++ b/spec/services/expenses/travel_distance_calculator_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe Expenses::TravelDistanceCalculator, type: :service do
     end
   end
 
+  context 'but the destination is not a postcode' do
+    let(:params) { { destination: 'London' } }
+
+    it 'returns a failure result with the appropriate error code' do
+      result = service.call
+
+      expect(result).to be_failure
+      expect(result.failure).to eq(:invalid_destination)
+    end
+  end
+
   context 'but the distance cannot be calculated' do
     it 'returns nil as the calculated distance' do
       expect(Maps::DistanceCalculator).to receive(:call).with(supplier_postcode, destination).and_return(nil)


### PR DESCRIPTION
#### What
prevent distance calc to destinations by `name`

#### Why
This reverts commit 20d329b9d1fe9f00b37627e91a986a8cd7f95c30.

Is to prevent calculating distances based on a name such as Nottingham.
Google maps API will not complain if given a general destination name
but the resulting distance will be to what google considers to be 
the "center" of the named place.

#### How
add validation to raise error when given a destination that is not
a postcode.
