### PR TITLE
CBO-403 - Extend Fee calculation hint text to Fixed fees

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/FeeCalculator.js
+++ b/app/assets/javascripts/modules/external_users/claims/FeeCalculator.js
@@ -68,7 +68,8 @@ moj.Modules.FeeCalculator = {
         $result = 'half day';
         break;
       case 'DEFENDANT':
-        $result = 'additional defendant';
+      case 'CASE':
+        $result = 'additional ' + data;
         break;
       default:
         $result = data;

--- a/app/views/external_users/claims/fixed_fees/_fixed_fee_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/_fixed_fee_fields.html.haml
@@ -27,6 +27,8 @@
 
   = f.adp_text_field :quantity,
       label: t('.quantity'),
+      hint_text: t('.quantity_hint'),
+      hide_hint: true,
       input_classes:"quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity",
       input_type: 'number',
       value: fee.quantity,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -919,6 +919,7 @@ en:
         fixed_fee_fields:
           fixed_fee: "Fixed fee"
           quantity: 'Quantity'
+          quantity_hint: 'Enter a quantity'
           rate: *rate
           case_numbers: *case_numbers
           no_dates: 'No dates currently selected.'

--- a/features/fee_calculator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/fixed_fee_calculator.feature
@@ -30,7 +30,7 @@ Feature: Advocate completes fixed fee page using calculator
     And I add a fixed fee 'Standard appearance fee'
 
     Then the 'fixed' fee 'Appeals to the crown court against conviction' should have a rate of '130.00' and a hint of 'Number of days'
-    Then the 'fixed' fee 'Number of cases uplift' should have a rate of '26.00' and a hint of 'Number of cases'
+    Then the 'fixed' fee 'Number of cases uplift' should have a rate of '26.00' and a hint of 'Number of additional cases'
     Then the 'fixed' fee 'Number of defendants uplift' should have a rate of '26.00' and a hint of 'Number of additional defendants'
     Then the 'fixed' fee 'Standard appearance fee' should have a rate of '87.00' and a hint of 'Number of days'
 

--- a/features/fee_calculator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/fixed_fee_calculator.feature
@@ -29,10 +29,10 @@ Feature: Advocate completes fixed fee page using calculator
     And I add a fixed fee 'Number of defendants uplift'
     And I add a fixed fee 'Standard appearance fee'
 
-    Then the 'fixed' fee 'Appeals to the crown court against conviction' should have a rate of '130.00'
-    Then the 'fixed' fee 'Number of cases uplift' should have a rate of '26.00'
-    Then the 'fixed' fee 'Number of defendants uplift' should have a rate of '26.00'
-    Then the 'fixed' fee 'Standard appearance fee' should have a rate of '87.00'
+    Then the 'fixed' fee 'Appeals to the crown court against conviction' should have a rate of '130.00' and a hint of 'Number of days'
+    Then the 'fixed' fee 'Number of cases uplift' should have a rate of '26.00' and a hint of 'Number of cases'
+    Then the 'fixed' fee 'Number of defendants uplift' should have a rate of '26.00' and a hint of 'Number of additional defendants'
+    Then the 'fixed' fee 'Standard appearance fee' should have a rate of '87.00' and a hint of 'Number of days'
 
     And I select an advocate category of 'QC'
     Then the 'fixed' fee 'Appeals to the crown court against conviction' should have a rate of '260.00'

--- a/features/page_objects/sections/typed_fee_section.rb
+++ b/features/page_objects/sections/typed_fee_section.rb
@@ -2,7 +2,7 @@ class TypedFeeSection < SitePrism::Section
   sections :select_options, "select.js-fee-type > option" do end
   element :select_input, "input.tt-input", visible: true
   element :quantity, "input.quantity"
-    element :hint, "span.form-hint"
+    element :quantity_hint, ".quantity_wrapper span.form-hint"
   element :rate, "input.rate"
   element :amount, nil
   element :case_numbers, "input.fx-fee-case-numbers"

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -163,7 +163,7 @@ end
 Then(/^the '(.*?)' fee '(.*?)' should have a rate of '(\d+\.\d+)'(?: and a hint of '(.*?)')?$/) do |fee_type, fee, rate, hint|
   fee = @claim_form_page.send("#{fee_type}_fees").find { |section| section.select_input.value.eql?(fee) }
   expect(fee.rate.value).to eql rate
-  expect(fee.hint.text).to eql hint if hint.present?
+  expect(fee.quantity_hint.text).to eql hint if hint.present?
 end
 
 Then(/^the last '(.*?)' fee rate should be populated with '(\d+\.\d+)'$/) do |fee_type, rate|


### PR DESCRIPTION
#### What
Extend the fee hint text feature, implemented on misc fees, to fixed fees

#### Ticket
[Extend Fee calculation hint text to Fixed fees](https://dsdmoj.atlassian.net/browse/CBO-403)

#### Why
Improve the user experience
#### How
Duplicate the hint labels on the fixed_fee view.  Then refactor the feature steps to support multiple, similar fees
