### PR TITLE
Clearing form inputs as they change state

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -367,24 +367,23 @@ moj.Helpers.Blocks = {
       return def.promise();
     };
 
+    // Setting the view error state and message
     this.viewErrorHandler = function(message) {
       var el = this.$el.find('.fx-general-errors');
       el.find('span').text(message);
       el.css('display', 'inline-block');
     };
 
-    /**
-     * setLocationElement
-     * @param  obj Config extracted from the selected option
-     * @return {[type]}     [description]
-     */
+    // The location elment is an input or a select
+    // This method will return the html to append to the dom
     this.setLocationElement = function(obj) {
       if (!obj) throw Error('Missing param: obj, cannot build element');
 
       // cache selected value
       var selectedValue = this.$el.find('.fx-location-model').val();
 
-      // Travel reason
+      // If a locationType is present render the select
+      // This will set the selected value if present
       // <option data-location-type="crown_court|prison|etc" />
       if (obj.locationType) {
         this.attachSelectWithOptions(obj.locationType, selectedValue);
@@ -395,7 +394,7 @@ moj.Helpers.Blocks = {
       return this.displayLocationInput();
     };
 
-    //
+    // Display the input and hide the select
     this.displayLocationInput = function() {
       this.$el.find('.location_wrapper').css('display', 'block');
       this.$el.find('.fx-establishment-select').css('display', 'none');
@@ -476,6 +475,11 @@ moj.Helpers.Blocks = {
         'vatAmount'
       ].forEach(function(value, idx) {
         $detached.find(self.stateLookup[value]).css('display', (state.config[value] ? 'block' : 'none'));
+
+        // Clear out the value for this input
+        if(!state.config[value]){
+          $detached.find(self.stateLookup[value] +' input:not([type=radio])').val('');
+        }
       });
 
       // net amount
@@ -533,6 +537,7 @@ moj.Helpers.Blocks = {
       });
 
       $detached = this.radioStateManager($detached, state);
+
       return $parent.append($detached);
     };
 
@@ -543,10 +548,19 @@ moj.Helpers.Blocks = {
      * @return $dom return the $dom referance
      */
     this.radioStateManager = function($dom, state) {
+
+      // Clearing the radio buttons if they are not required
+      if(!state.config.mileage){
+        $dom.find('.fx-travel-mileage input[type=radio]').is(function () {
+          $(this).removeAttr('checked').prop('disabled', true);
+        });
+        return $dom;
+      }
+
       // Mileage radios: BIKE
       if (state.config.mileageType === 'bike') {
         this.config.mileageFactor = 0.20;
-        this.setRadioState($dom, {
+        return this.setRadioState($dom, {
           car: 'none',
           carModel: false,
           bike: 'block',
@@ -557,7 +571,7 @@ moj.Helpers.Blocks = {
       // Mileage radios: BIKE
       if (state.config.mileageType === 'car') {
         this.config.mileageFactor = 0.45;
-        this.setRadioState($dom, {
+        return this.setRadioState($dom, {
           car: 'block',
           carModel: true,
           bike: 'none',
@@ -580,6 +594,7 @@ moj.Helpers.Blocks = {
       $dom.find('.fx-travel-mileage-bike input[type=radio]').is(function() {
         $(this).prop('checked', config.bikeModel).prop('disabled', !config.bikeModel).change();
       });
+      return $dom;
     };
   },
 

--- a/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -491,6 +491,14 @@ moj.Helpers.Blocks = {
 
       // location
       $detached.find(this.stateLookup.location).css('display', (state.config.location ? 'block' : 'none'));
+
+      // remove the location data from the form
+      if(!state.config.location){
+        $detached.find('.fx-location-model').val('');
+        $detached.find('.fx-travel-location > .location_wrapper:first input').val('');
+        $detached.find('.fx-travel-location > .fx-establishment-select select').prop('selectedIndex', 0);
+      }
+
       if (this.config.featureDistance) {
         $detached.find(this.stateLookup.location + ' .has-select label').contents().first()[0].textContent = state.config.locationLabel;
       }

--- a/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -18,7 +18,7 @@ moj.Helpers.Blocks = {
         }
         return this.$el.find(selector).css('display', state ? 'block' : 'none');
       }
-      throw Error('Selector did not return an element: ' + selector);
+      throw new Error('Selector did not return an element: ' + selector);
     };
 
     this.setVal = function(selector, val) {
@@ -26,7 +26,7 @@ moj.Helpers.Blocks = {
         this.$el.find(selector).val(val).change();
         return;
       }
-      throw Error('Selector did not return an element: ' + selector);
+      throw new Error('Selector did not return an element: ' + selector);
     };
 
     this.setNumber = function(selector, val, points) {
@@ -352,15 +352,19 @@ moj.Helpers.Blocks = {
       }
     };
 
-    // TO DO: specs
+    // Call the Distance helper and return the
+    // id for the checked ra
     this.getDistance = function(ajaxConfig) {
       var def = $.Deferred();
       var self = this;
       moj.Helpers.API.Distance.query(ajaxConfig).then(function(result) {
         var number = self.$el.find('.fx-travel-mileage input[type=radio]:visible:checked').val();
+
         result.miles = Math.round((result.distance / self.config.metersPerMile));
         self.$el.find('.fx-travel-calculated-distance').val(result.miles);
+
         def.resolve(number, result);
+
       }, function(result) {
         def.reject(result.error);
       });
@@ -377,7 +381,7 @@ moj.Helpers.Blocks = {
     // The location elment is an input or a select
     // This method will return the html to append to the dom
     this.setLocationElement = function(obj) {
-      if (!obj) throw Error('Missing param: obj, cannot build element');
+      if (!obj) throw new Error('Missing param: obj, cannot build element');
 
       // cache selected value
       var selectedValue = this.$el.find('.fx-location-model').val();
@@ -405,7 +409,7 @@ moj.Helpers.Blocks = {
       var self = this;
       var $detachedSelect;
 
-      if (!locationType) return new Error('Missing param: locationType');
+      if (!locationType) throw new Error('Missing param: locationType');
 
       moj.Helpers.API.Establishments.getAsSelectWithOptions(locationType, {
         prop: 'name',
@@ -425,7 +429,7 @@ moj.Helpers.Blocks = {
         self.$el.find('.fx-travel-location .has-select label').text(staticdata.locationLabel[locationType] || staticdata.locationLabel.default);
 
       }, function() {
-        return Error('Attach options failed:', arguments);
+        throw new Error('Attach options failed:', arguments);
       });
     };
 

--- a/spec/javascripts/helpers-sidebar_spec.js
+++ b/spec/javascripts/helpers-sidebar_spec.js
@@ -695,6 +695,7 @@ describe('Helpers.Blocks.js', function() {
         beforeEach(function() {
           fixtureDom = [
             '<div class="js-block fx-do-init">',
+            '<p class="fx-general-errors" style="display: none;"><span></span></p>',
             '<input class="fx-location-model" value ="sample"/>',
             '<input class="quantity" value="11.11"/>',
             '<input class="rate" value="22.22"/>',
@@ -705,7 +706,7 @@ describe('Helpers.Blocks.js', function() {
             '<div class="fx-travel-reason-other" style="display:none"><span>here</span></div>',
             '<div class="fx-travel-location">',
             '<div class="location_wrapper"><label>Destination</label><input type="text" value=""></div>',
-            '<div class="fx-establishment-select"><label class="form-label-bold" for="location">Crown court</label><select id="location"><option value="">please select</option><option value="1" data-postcode="POSTCODE" selected>establishment selected</option></select></div>',
+            '<div class="fx-establishment-select has-select" style="display:none;"><label class="form-label-bold" for="location">Destination</label><select id="location"><option value="">please select</option><option value="1" data-postcode="POSTCODE" selected>establishment selected</option></select></div>',
             '</div>',
             '<div class="fx-travel-mileage">',
             ' <div class="fx-travel-mileage-bike">',
@@ -1016,27 +1017,51 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        xdescribe('...getDistance', function() {
-          it('should behave...', function() {
+        describe('...getDistance', function() {
+          it('should return the id and augmented distance object...', function() {
             var deferred = $.Deferred();
             spyOn(moj.Helpers.API.Distance, 'query').and.returnValue(deferred.promise());
-
+            instance.$el.find('#mileage_rate_id_1').prop('checked', true);
             instance.getDistance({
               claimid: 2,
-              destination: "Aylesbury"
-            }).then(function(result) {
+              destination: "POSTCODE"
+            }).then(function(number, result) {
               expect(moj.Helpers.API.Distance.query).toHaveBeenCalledWith({
                 claimid: 2,
-                destination: 'Aylesbury'
+                destination: 'POSTCODE'
               });
+
               expect(result).toEqual({
                 distance: 204993,
                 miles: 127
               });
+
+              expect(number).toEqual('1');
             });
 
             deferred.resolve({
               distance: 204993
+            });
+          });
+          it('should populate and return an error ...', function() {
+            var deferred = $.Deferred();
+            spyOn(moj.Helpers.API.Distance, 'query').and.returnValue(deferred.promise());
+            instance.$el.find('#mileage_rate_id_1').prop('checked', true);
+
+            instance.getDistance({
+              claimid: 2,
+              destination: "POSTCODE"
+            }).then(undefined, function(result) {
+              expect(moj.Helpers.API.Distance.query).toHaveBeenCalledWith({
+                claimid: 2,
+                destination: 'POSTCODE'
+              });
+
+              expect(result).toEqual('error');
+            });
+
+            deferred.reject({
+              error: 'error'
             });
 
           });
@@ -1057,6 +1082,60 @@ describe('Helpers.Blocks.js', function() {
             instance.init();
             instance.$el.find('.fx-travel-mileage input[type=radio]:last').prop('checked', true);
             expect(instance.getRateId()).toEqual('2');
+          });
+        });
+
+        describe('...viewErrorHandler', function() {
+          it('...should set the correct view state', function() {
+            instance.init();
+            instance.viewErrorHandler('This is the message');
+            expect(instance.$el.find('.fx-general-errors span').text()).toEqual('This is the message');
+            expect(instance.$el.find('.fx-general-errors').is(':visible')).toEqual(true);
+          });
+        });
+
+        describe('...attachSelectWithOptions', function() {
+          var optionsFixture = ['<option value="">Please select</option>',
+              '<option value="135" data-postcode="SY23 1AS">Aberystwyth Justice Centre</option>',
+              '<option value="136" selected="" data-postcode="GU11 1NY">Aldershot Magistrates\' Court</option>',
+              '<option value="137" data-postcode="HP6 5AJ">Amersham Law Courts</option>',
+              '<option value="139" data-postcode="HP21 7QZ">Aylesbury Magistrates\' Court and Family Court</option>")'
+            ];
+          it('should return an error if no locationType', function() {
+            instance.init();
+            expect(function() {
+              instance.attachSelectWithOptions();
+            }).toThrowError('Missing param: locationType');
+          });
+
+          it('should call the Establishments API with the correct params ', function() {
+            var deferred = $.Deferred();
+            spyOn(moj.Helpers.API.Establishments, 'getAsSelectWithOptions').and.returnValue(deferred.promise());
+
+            instance.attachSelectWithOptions('crown_court', 'SomeThing');
+            expect(moj.Helpers.API.Establishments.getAsSelectWithOptions).toHaveBeenCalledWith('crown_court', {
+              prop: 'name',
+              value: 'SomeThing'
+            });
+
+          });
+          it('should update the view correctly', function() {
+            var deferred = $.Deferred();
+            spyOn(moj.Helpers.API.Establishments, 'getAsSelectWithOptions').and.returnValue(deferred.promise());
+            expect(instance.$el.find('.fx-establishment-select').is(':visible')).toEqual(false);
+            expect(instance.$el.find('.fx-establishment-select option').length).toEqual(2);
+            expect(instance.$el.find('.location_wrapper').is(':visible')).toEqual(true);
+            expect(instance.$el.find('.fx-travel-location .has-select label').text()).toEqual('Destination');
+
+
+            instance.attachSelectWithOptions('crown_court', 'SomeThing');
+            deferred.resolve(optionsFixture);
+
+            expect(instance.$el.find('.fx-establishment-select').is(':visible')).toEqual(true);
+            expect(instance.$el.find('.fx-establishment-select option').length).toEqual(5);
+            expect(instance.$el.find('.location_wrapper').is(':visible')).toEqual(false);
+            expect(instance.$el.find('.fx-travel-location .has-select label').text()).toEqual('Crown court');
+
           });
         });
       });


### PR DESCRIPTION
#### What
- Removing any user entered values when elements are hidden
- this relates to the current bug where errors are shown on hidden fields

#### Ticket

CBO-415

#### Why
Validation errors are displayed on fields that are hidden at the time of submit.
STEPS:
1. Add an expense
2. Choose car travel and fill in the all the inputs
3. Change the expense type field to parking
4. Save and continue

Currently:
An error relating to distance, hours or mileage rate might be displayed  (depending on your choices)

Should be:
The form should submit as normal and not return you to the expense page

