### PR TITLE
Move postcode regex to settings.yml

### DIFF
--- a/config/initializers/regexps.rb
+++ b/config/initializers/regexps.rb
@@ -1,1 +1,0 @@
-Settings.postcode_regexp = /\A([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})\z/

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -139,3 +139,5 @@ govuk_notify:
     unlock_instructions: 'unlock_instructions_template_uuid'
 
 notify_report_errors: <%= ENV["ENV"].in?(%w[api-sandbox demo disaster gamma]) %>
+
+postcode_regexp: !ruby/regexp '/\A([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})\z/'


### PR DESCRIPTION
#### What
Move postcode regex to settings.yml

#### Why
The use of an initialiser to set `Settings` explicitly
outside of the settings.yml file conflicts with the 
Config gems methods providing `Settings`
and caused failure in local development.

Could be related to an initializer race condition.
