### PR TITLE
Ignore conference and view fees for DI

### DIFF
--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -39,6 +39,8 @@ module CCR
         MIWOA: zip(%w[AGFS_MISC_FEES AGFS_WRTN_ORAL]) # Written / oral advice
       }.freeze
 
+      MISC_FEE_BILL_MAPPING_EXCLUSIONS = %i[BACAV].freeze
+
       def claimed?
         maps? && charges?
       end
@@ -46,7 +48,7 @@ module CCR
       private
 
       def bill_mappings
-        MISC_FEE_BILL_MAPPINGS
+        MISC_FEE_BILL_MAPPINGS.except(*MISC_FEE_BILL_MAPPING_EXCLUSIONS)
       end
 
       def bill_key

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -584,6 +584,22 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
         end
 
+        context 'when CCCD fee exists but is excluded from injection' do
+          context 'Conferences and views cannot be adapted' do
+            let(:basic_fees) { [build(:basic_fee, :cav_fee, rate: 1, quantity: 8)] }
+            let(:claim) { create_claim(:authorised_claim, :without_fees, case_type: case_type, basic_fees: basic_fees) }
+
+            before do
+              # TODO: this should probably be using seeds instead
+              create(:basic_fee_type, :cav)
+            end
+
+            it 'not added to bills if it is of an excluded fee type' do
+              is_expected.to have_json_size(0).at_path("bills")
+            end
+          end
+        end
+
         context 'when CCCD fee maps to a CCR misc fee' do
           let(:rate) { 0 }
           let(:quantity) { 0 }

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -81,6 +81,13 @@ FactoryBot.define do
       unique_code 'BAPCM'
     end
 
+    trait :cav do
+      description 'Conferences and views'
+      code 'CAV'
+      unique_code 'BACAV'
+      quantity_is_decimal true
+    end
+
     trait :npw do
       description 'Number of prosecution witnesses'
       code 'NPW'

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -191,6 +191,10 @@ FactoryBot.define do
       fee_type { Fee::BasicFeeType.find_by(unique_code: 'BAPCM') || build(:basic_fee_type, :pcm) }
     end
 
+    trait :cav_fee do
+      fee_type { Fee::BasicFeeType.find_by(unique_code: 'BACAV') || build(:basic_fee_type, :cav) }
+    end
+
     trait :ppe_fee do
       rate 0
       amount 25

--- a/spec/services/ccr/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/misc_fee_adapter_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
 
   it_behaves_like 'a mapping fee adapter'
 
+  EXCLUSIONS = %i[BACAV].freeze
+
   MAPPINGS = {
     BACAV: %w[AGFS_MISC_FEES AGFS_CONFERENCE], # Conferences and views (basic fee)
     BAPCM: %w[AGFS_MISC_FEES AGFS_PLEA], # Plea & Case management hearing
@@ -48,7 +50,7 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
     MIUAV2: %w[AGFS_MISC_FEES AGFS_UN_VAC_WL], # Unsuccessful application to vacate a guilty plea (whole day)
     MIWPF: %w[AGFS_MISC_FEES AGFS_WSTD_PREP], # Wasted preparation fee
     MIWOA: %w[AGFS_MISC_FEES AGFS_WRTN_ORAL], # Written / oral advice
-  }.freeze
+  }.except(*EXCLUSIONS).freeze
 
   describe '#bill_type' do
     subject { described_class.new.call(fee).bill_type }
@@ -105,7 +107,6 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
       is_expected.to be true
     end
 
-
     it 'returns false when the misc has zero values for quantity, rate and amount' do
       allow(fee).to receive_messages(quantity: 0, rate: 0, amount: 0)
       is_expected.to be false
@@ -113,6 +114,12 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
 
     it 'returns false when the misc has nil values for quantity, rate and amount'do
       allow(fee).to receive_messages(quantity: nil, rate: nil, amount: nil)
+      is_expected.to be false
+    end
+
+    it 'returns false when the fee is of an explicitly excluded type' do
+      allow(fee).to receive_messages(quantity: 1, rate: 1, amount: 1)
+      allow(fee_type).to receive(:unique_code).and_return 'BACAV'
       is_expected.to be false
     end
   end

--- a/spec/services/claims/fee_calculator/fee_type_mappings_spec.rb
+++ b/spec/services/claims/fee_calculator/fee_type_mappings_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Claims::FeeCalculator::FeeTypeMappings do
   it { is_expected.to respond_to :all }
   it { is_expected.to respond_to :primary_fee_types }
 
-  let(:fixed_fee_mappings) { CCR::Fee::FixedFeeAdapter::FIXED_FEE_BILL_MAPPINGS.keys }
-  let(:misc_fee_mappings) { CCR::Fee::MiscFeeAdapter::MISC_FEE_BILL_MAPPINGS.keys }
+  let(:fixed_fee_mappings) { CCR::Fee::FixedFeeAdapter.new.mappings.keys }
+  let(:misc_fee_mappings) { CCR::Fee::MiscFeeAdapter.new.mappings.keys }
   let(:all_fee_mappings) { fixed_fee_mappings + misc_fee_mappings }
   let(:primary_fee_types) { %i[FXACV FXASE FXCBR FXCSE FXCON FXENP] }
 


### PR DESCRIPTION
#### What
Do not send adapted conference and view fees regardless

#### Ticket

[CBO-417 Ignore CAVs on a case and inject everything else in to CCR](https://dsdmoj.atlassian.net/browse/CBO-417)

#### Why
Adapted CAV fees currently cause data injection failures
from CCR. To prevent DI failure and enable the majority
of the claims details to be sent over it has been decided
to exclude them from DI altogether

The CAV fees themselves cannot be reliably adapted for
DI because current handling of CAVs in CCCD and CCR is incompatible.
Too many assumptions would have to be made to get them
to inject and result in inaccurate calculated amounts CCR-side.

#### How
Rather than removing the mapping completely, add an exclusion list to be more explicit.

