### PR TITLE
CBO-430 travel automation report

### DIFF
--- a/app/interfaces/api/entities/additional_travel_expense_information.rb
+++ b/app/interfaces/api/entities/additional_travel_expense_information.rb
@@ -1,0 +1,8 @@
+module API
+  module Entities
+    class AdditionalTravelExpenseInformation < BaseEntity
+      expose :claim_id
+      expose :travel_expense_additional_information
+    end
+  end
+end

--- a/app/interfaces/api/v2/mi/additional_information_expenses.rb
+++ b/app/interfaces/api/v2/mi/additional_information_expenses.rb
@@ -24,10 +24,10 @@ module API
 
             desc 'Retrieve additional travel expenses information from between two dates'
             params do
-              optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the user'
-              optional :start_date, type: String, desc: 'OPTIONAL: Claims submitted on or after date (YYYY-MM-DD). Defaults to yesterday'
-              optional :end_date, type: String, desc: 'OPTIONAL/REQUIRED: Claims submitted on or before date (YYYY-MM-DD). Required if start date set'
-              optional :format, type: String, desc: 'JSON or CSV. Defaults to JSON', values: %w[json csv]
+              optional :api_key, type: String, desc: t('api.v2.generic.params.api_key')
+              optional :start_date, type: String, desc: t('api.v2.mi.travel_automation.date_from')
+              optional :end_date, type: String, desc: t('api.v2.mi.travel_automation.date_to')
+              optional :format, type: String, desc: t('api.v2.generic.params.format'), values: %w[json csv]
             end
             get do
               results = Reports::AdditionalTravelExpenseInformationByDates.call(date_range)

--- a/app/interfaces/api/v2/mi/additional_information_expenses.rb
+++ b/app/interfaces/api/v2/mi/additional_information_expenses.rb
@@ -12,10 +12,12 @@ module API
           resource :additional_travel_expense_information do
             helpers do
               def date_range
+                default_hash = { start_date: 1.day.ago.utc.beginning_of_day, end_date: 1.day.ago.utc.end_of_day }
+                return default_hash unless params[:start_date].present?
                 @start_date = params[:start_date].to_date.beginning_of_day.utc
                 @end_date = params[:end_date].to_date.end_of_day.utc
                 { start_date: @start_date, end_date: @end_date }
-              rescue NoMethodError
+              rescue NoMethodError, ArgumentError
                 error!('Please provide both dates in the format YYYY-MM-DD', 400)
               end
             end
@@ -23,8 +25,8 @@ module API
             desc 'Retrieve additional travel expenses information from between two dates'
             params do
               optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the user'
-              optional :start_date, type: String, desc: 'REQUIRED: Claims submitted on or after date (YYYY-MM-DD).'
-              optional :end_date, type: String, desc: 'REQUIRED: Claims submitted on or before date (YYYY-MM-DD).'
+              optional :start_date, type: String, desc: 'OPTIONAL: Claims submitted on or after date (YYYY-MM-DD). Defaults to yesterday'
+              optional :end_date, type: String, desc: 'OPTIONAL/REQUIRED: Claims submitted on or before date (YYYY-MM-DD). Required if start date set'
               optional :format, type: String, desc: 'JSON or CSV. Defaults to JSON', values: %w[json csv]
             end
             get do

--- a/app/interfaces/api/v2/mi/additional_information_expenses.rb
+++ b/app/interfaces/api/v2/mi/additional_information_expenses.rb
@@ -1,0 +1,47 @@
+module API
+  module V2
+    module MI
+      class AdditionalInformationExpenses < Grape::API
+        require 'csv'
+        helpers API::V2::MIHelper
+
+        content_type :csv, 'text/csv; utf-8'
+        default_format :json
+
+        resource :mi, desc: 'MI endpoint' do
+          resource :additional_travel_expense_information do
+            helpers do
+              def date_range
+                @start_date = params[:start_date].to_date.beginning_of_day.utc
+                @end_date = params[:end_date].to_date.end_of_day.utc
+                { start_date: @start_date, end_date: @end_date }
+              rescue NoMethodError
+                error!('Please provide both dates in the format YYYY-MM-DD', 400)
+              end
+            end
+
+            desc 'Retrieve additional travel expenses information from between two dates'
+            params do
+              optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the user'
+              optional :start_date, type: String, desc: 'REQUIRED: Claims submitted on or after date (YYYY-MM-DD).'
+              optional :end_date, type: String, desc: 'REQUIRED: Claims submitted on or before date (YYYY-MM-DD).'
+              optional :format, type: String, desc: 'JSON or CSV. Defaults to JSON', values: %w[json csv]
+            end
+            get do
+              results = Reports::AdditionalTravelExpenseInformationByDates.call(date_range)
+              if params[:format].eql?('csv')
+                csv = build_csv_from(results, Reports::AdditionalTravelExpenseInformationByDates::COLUMNS)
+                filename = "travel-expense-information-#{params[:start_date]}-#{params[:end_date]}"
+                header 'Content-Disposition', "attachment; filename=#{filename}.csv"
+                present csv
+              else
+                present JSON.parse(results.to_json, object_class: OpenStruct),
+                        with: API::Entities::AdditionalTravelExpenseInformation
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v2/mi/additional_information_expenses.rb
+++ b/app/interfaces/api/v2/mi/additional_information_expenses.rb
@@ -24,10 +24,10 @@ module API
 
             desc 'Retrieve additional travel expenses information from between two dates'
             params do
-              optional :api_key, type: String, desc: t('api.v2.generic.params.api_key')
-              optional :start_date, type: String, desc: t('api.v2.mi.travel_automation.date_from')
-              optional :end_date, type: String, desc: t('api.v2.mi.travel_automation.date_to')
-              optional :format, type: String, desc: t('api.v2.generic.params.format'), values: %w[json csv]
+              optional :api_key, type: String, desc: I18n.t('api.v2.generic.params.api_key')
+              optional :start_date, type: String, desc: I18n.t('api.v2.mi.travel_automation.date_from')
+              optional :end_date, type: String, desc: I18n.t('api.v2.mi.travel_automation.date_to')
+              optional :format, type: String, desc: I18n.t('api.v2.generic.params.format'), values: %w[json csv]
             end
             get do
               results = Reports::AdditionalTravelExpenseInformationByDates.call(date_range)

--- a/app/interfaces/api/v2/root.rb
+++ b/app/interfaces/api/v2/root.rb
@@ -19,6 +19,7 @@ module API
           mount API::V2::MI::AGFSSchemeTenClaims
           mount API::V2::MI::InjectionErrors
           mount API::V2::MI::ProvisionalAssessments
+          mount API::V2::MI::AdditionalInformationExpenses
 
           namespace :ccr, desc: 'CCR injection specific claim format' do
             mount API::V2::CCRClaim

--- a/app/services/reports/additional_travel_expense_information_by_dates.rb
+++ b/app/services/reports/additional_travel_expense_information_by_dates.rb
@@ -1,0 +1,36 @@
+module Reports
+  class AdditionalTravelExpenseInformationByDates
+    NAME = 'additional_travel_expense_information'.freeze
+    COLUMNS = %w[claim_id	travel_expense_additional_information].freeze
+
+    def self.call(options = {})
+      new(options).call
+    end
+
+    attr_reader :start_date, :end_date
+
+    def initialize(options = {})
+      @start_date = options[:start_date]
+      @end_date = options[:end_date]
+    end
+
+    def call
+      Expense.connection.execute(query).to_a
+    end
+
+    private
+
+    def query
+      <<~SQL
+        SELECT
+        DISTINCT(c.id) AS claim_id,
+        c.travel_expense_additional_information
+        FROM expenses e
+        INNER JOIN claims c ON c.id = e.claim_id
+        WHERE c.original_submission_date BETWEEN '#{start_date.to_s(:db)}' AND '#{end_date.to_s(:db)}'
+        AND (calculated_distance IS NOT NULL
+        AND LENGTH(c.travel_expense_additional_information)>0)
+      SQL
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1652,6 +1652,7 @@ en:
       generic:
         params:
           api_key: 'REQUIRED: The API authentication key of the case worker'
+          format: 'OPTIONAL: the format to output the data. DEFAULT: json.  CSV will download automatically'
       allocate:
         params:
           case_worker_id: 'REQUIRED: The id of the caseworker'
@@ -1659,6 +1660,9 @@ en:
           claim_ids: 'OPTIONAL: The specific claim ids to be allocated'
           filters: 'OPTIONAL: The filters to be applied if allocating by number'
       mi:
+        travel_automation:
+          date_from: "OPTIONAL: Claims submitted on or after date (YYYY-MM-DD). Defaults to yesterday"
+          date_to: "OPTIONAL/REQUIRED: Claims submitted on or before date (YYYY-MM-DD). Required if start date set"
         scheme_ten:
           format: 'OPTIONAL: the format to output the data. DEFAULT: json.  CSV will download automatically'
   faker:

--- a/spec/api/v2/mi/additional_information_expenses_spec.rb
+++ b/spec/api/v2/mi/additional_information_expenses_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+require 'api_spec_helper'
+
+RSpec.describe API::V2::MI::AdditionalInformationExpenses do
+  include Rack::Test::Methods
+  include ApiSpecHelper
+  include DatabaseHousekeeping
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:case_worker_admin) { create(:case_worker, :admin) }
+  let(:external_user) { create(:external_user) }
+  let(:default_params) { { api_key: api_key, start_date: start_date, end_date: end_date } }
+  let(:missing_params) { { api_key: api_key } }
+  let(:params) { default_params }
+  let(:start_date) { Date.new(2018, 01, 01).to_s(:db) }
+  let(:end_date) { Date.new(2018, 01, 31).to_s(:db) }
+  let(:create_data?) { false }
+
+  describe 'GET additional_travel_expense_information' do
+    def populate_expense_data
+      Claim::BaseClaim.delete_all
+      travel_to(Date.new(2018, 01, 15)) do
+        create(:litigator_claim, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) do |lgfs_claim|
+          create(:expense, :with_calculated_distance, date: 3.days.ago, claim: lgfs_claim)
+        end
+        create(:litigator_claim, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) do |lgfs_claim|
+          create(:expense, date: 3.days.ago, claim: lgfs_claim)
+        end
+      end
+      travel_to(Date.new(2018, 02, 14)) do
+        create(:litigator_claim, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) do |lgfs_claim|
+          create(:expense, :with_calculated_distance, date: 3.days.ago,claim: lgfs_claim)
+        end
+        create(:litigator_claim, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) do |lgfs_claim|
+          create(:expense, date: 4.days.ago,claim: lgfs_claim)
+        end
+      end
+    end
+
+    def do_request
+      populate_expense_data if create_data?
+      get '/api/mi/additional_travel_expense_information', params, format: :json
+    end
+
+    context 'when accessed by a CaseWorker' do
+      let(:api_key) { case_worker_admin.user.api_key }
+
+      before do
+        do_request
+      end
+
+      context 'and there is no data available' do
+        context 'and dates are not provided' do
+          let(:params) { missing_params }
+
+          it 'returns an error' do
+            expect(last_response.status).to eq 400
+          end
+
+          it 'returns a specific error message' do
+            expect(last_response.body).to include('Please provide both dates in the format')
+          end
+        end
+
+        context 'and no output format is provided' do
+          let(:params) { default_params }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'returns an empty response' do
+            expect(JSON.parse(last_response.body)).to be_empty
+          end
+        end
+
+        context 'and JSON is requested as the output format' do
+          let(:params) { default_params.merge(format: 'json') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'application/json'
+          end
+
+          it 'returns an empty response' do
+            expect(JSON.parse(last_response.body)).to be_empty
+          end
+        end
+
+        context 'and CSV is requested as the output format' do
+          let(:params) { default_params.merge(format: 'csv') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns JSON' do
+            expect(last_response.headers['content-type']).to eq 'text/csv; utf-8'
+          end
+
+          it 'returns a file with just the headers' do
+            csv_content = CSV.parse(last_response.body)
+            expect(csv_content.count).to eq 1
+            expect(csv_content[0]).to match_array(Reports::AdditionalTravelExpenseInformationByDates::COLUMNS)
+          end
+        end
+      end
+
+      context 'when data is available' do
+        let(:create_data?) { true }
+
+        it 'returns success' do
+          expect(last_response).to be_ok
+        end
+
+        it 'returns JSON' do
+          expect(last_response.headers['content-type']).to eq 'application/json'
+        end
+
+        it 'retrieves travel expense data from the provided date' do
+          expect(JSON.parse(last_response.body).count).to eq(1)
+        end
+
+        context 'and with CSV output format' do
+          let(:params) { default_params.merge(format: 'csv') }
+
+          it 'returns success' do
+            expect(last_response).to be_ok
+          end
+
+          it 'returns CSV' do
+            expect(last_response.headers['content-type']).to eq 'text/csv; utf-8'
+          end
+
+          it 'returns a file with the headers and the data retrieved' do
+            csv_content = CSV.parse(last_response.body)
+            expect(csv_content.count).to eq(2)
+            expect(csv_content[0]).to match_array(Reports::AdditionalTravelExpenseInformationByDates::COLUMNS)
+          end
+        end
+      end
+    end
+
+    context 'when accessed by an user that has no permissions' do
+      let(:api_key) { external_user.user.api_key }
+
+      it 'returns unauthorised' do
+        do_request
+        expect(last_response).to be_unauthorized
+        expect(last_response.body).to include('Unauthorised')
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Create a new report that exports additional travel information where distances where calculated
This should be between two date-times, by default this will be yesterday (start to end), but users can provide additional dates for a wider range if needed

#### Ticket
[Automate travel expense additional information data](https://dsdmoj.atlassian.net/browse/CBO-430)

#### Why
So that we can analyse responses and act accordingly

#### How
Duplicate report structure and API implementation of other reports

--------

#### TODO (wip)

 - [x] Update report to default to yesterday
