### PR TITLE
CBO-413: Reinstating expenses on LGFS interim warrant claims

### DIFF
--- a/app/presenters/claim/interim_claim_presenter.rb
+++ b/app/presenters/claim/interim_claim_presenter.rb
@@ -23,10 +23,6 @@ class Claim::InterimClaimPresenter < Claim::BaseClaimPresenter
     false
   end
 
-  def can_have_expenses?
-    false
-  end
-
   def disbursement_only?
     claim.interim_fee&.is_disbursement?
   end

--- a/spec/presenters/claim/interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/interim_claim_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Claim::InterimClaimPresenter, type: :presenter do
 
   specify { expect(presenter.requires_trial_dates?).to be_falsey }
   specify { expect(presenter.requires_retrial_dates?).to be_falsey }
-  specify { expect(presenter.can_have_expenses?).to be_falsey }
+  specify { expect(presenter.can_have_expenses?).to be_truthy }
   specify { expect(presenter.pretty_type).to eq('LGFS Interim') }
   specify { expect(presenter.type_identifier).to eq('lgfs_interim') }
 

--- a/spec/presenters/interim_claim_presenter_spec.rb
+++ b/spec/presenters/interim_claim_presenter_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Claim::InterimClaimPresenter do
 
   it { expect(subject).to be_kind_of(Claim::BaseClaimPresenter) }
 
-  it 'should not have expenses' do
-    expect(subject.can_have_expenses?).to eq(false)
-  end
-
   it 'should have disbursements' do
     expect(subject.can_have_disbursements?).to eq(true)
   end


### PR DESCRIPTION
#### What
Expenses are not being displayed on the interim warrant path

#### Ticket

CBO-413

#### How
Removing the conditional check on the presenter

