### PR TITLE
Add deleted_at to disbursement type seeding

### DIFF
--- a/config/initializers/laa_fee_calculator_client.rb
+++ b/config/initializers/laa_fee_calculator_client.rb
@@ -1,7 +1,7 @@
 # To run development against a local or other fee calculator
 # client define LAA_FEE_CALCULATOR_HOST in your environment
 # Not having an LAA_FEE_CALCULATOR_HOST envvar will result in use of the
-# clients default host, which is currently the dev version of the API.
+# clients default host, which is currently the production version of the API.
 LAA::FeeCalculator.configure do |config|
   config.host = ENV['LAA_FEE_CALCULATOR_HOST'] if ENV['LAA_FEE_CALCULATOR_HOST']
 end

--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -70,26 +70,21 @@ module SeedHelper
       raise "Unexpected name for ExpenseType #{expense_type.id}: Expected #{name}, got #{expense_type.name}"
     end
 
-    if expense_type.unique_code.blank?
-      expense_type.update(unique_code: code)
-    end
-
+    expense_type.update(unique_code: code) if expense_type.unique_code.blank?
     expense_type
   end
 
-  def self.find_or_create_disbursement_type!(record_id, code, name)
+  def self.find_or_create_disbursement_type!(record_id, code, name, deleted_at=nil)
     disbursement_type = DisbursementType.find_by(id: record_id)
 
     if disbursement_type.nil?
-      disbursement_type = DisbursementType.create!(id: record_id, unique_code: code, name: name)
+      disbursement_type = DisbursementType.create!(id: record_id, unique_code: code, name: name, deleted_at: deleted_at)
     elsif disbursement_type.name != name
       raise "Unexpected name for DisbursementType #{disbursement_type.id}: Expected #{name}, got #{disbursement_type.name}"
     end
 
-    if disbursement_type.unique_code.blank?
-      disbursement_type.update(unique_code: code)
-    end
-
+    disbursement_type.update(unique_code: code) if disbursement_type.unique_code.blank?
+    disbursement_type.update(deleted_at: deleted_at) if disbursement_type.deleted_at.blank? && deleted_at
     disbursement_type
   end
 

--- a/db/seeds/disbursement_types.rb
+++ b/db/seeds/disbursement_types.rb
@@ -5,8 +5,8 @@ disbursement_types = [
   [2, 'ACC', 'Accounts'],
   [3, 'SWX', 'Computer experts'],
   [4, 'CMR', 'Consultant medical reports'],
-  [5, 'CJA', 'Costs judge application fee'], # softly deleted as handled by misc fees
-  [6, 'CJP', 'Costs judge preparation award'], # softly deleted as handled misc fees
+  [5, 'CJA', 'Costs judge application fee', DateTime.new(2018,2,7)], # softly deleted as handled by misc fees
+  [6, 'CJP', 'Costs judge preparation award', DateTime.new(2018,2,7)], # softly deleted as handled misc fees
   [7, 'DNA', 'DNA testing'],
   [8, 'ENG', 'Engineer'],
   [9, 'ENQ', 'Enquiry agents'],
@@ -30,16 +30,16 @@ disbursement_types = [
   [27, 'ARC', 'Surveyor/architect'],
   [28, 'SCR', 'Transcripts'],
   [29, 'TRA', 'Translator'],
-  [30, 'TRV', 'Travel costs'], # softly deleted as handled by travel expenses
+  [30, 'TRV', 'Travel costs', DateTime.new(2016,9,2)], # softly deleted as handled by travel expenses
   [31, 'VET', 'Vet report'],
   [32, 'VOI', 'Voice recognition'],
 ]
 
 max_id = 0
 disbursement_types.each do |row|
-  record_id, unique_code, name = row
+  record_id, unique_code, name , deleted_at = row
   max_id = [max_id, record_id].max
-  SeedHelper.find_or_create_disbursement_type!(record_id, unique_code, name)
+  SeedHelper.find_or_create_disbursement_type!(record_id, unique_code, name, deleted_at)
 end
 
 # This is to ensure API Sandbox and Gamma are in sync regarding the IDs

--- a/db/seeds/establishments.rb
+++ b/db/seeds/establishments.rb
@@ -3,7 +3,7 @@ require Rails.root.join('db','seeds', 'establishments', 'hospital_seeder')
 require Rails.root.join('db','seeds', 'establishments', 'magistrates_court_seeder')
 require Rails.root.join('db','seeds', 'establishments', 'crown_court_seeder')
 
-options = { dry_run: ENV['SEEDS_DRY_MODE'] }
+options = { dry_run: ENV['SEEDS_DRY_MODE'], stdout: false }
 
 Seeds::Establishments::PrisonSeeder.call(options)
 Seeds::Establishments::HospitalSeeder.call(options)

--- a/db/seeds/establishments/crown_court_seeder.rb
+++ b/db/seeds/establishments/crown_court_seeder.rb
@@ -8,6 +8,7 @@ module Seeds
       def initialize(options = {})
         @seed_file = Rails.root.join('lib', 'assets', 'data', 'establishments', 'crown_courts.csv')
         @dry_run = options[:dry_run].to_s.downcase.strip == 'true'
+        @stdout = options.fetch(:stdout, false)
       end
 
       def call
@@ -15,7 +16,7 @@ module Seeds
         CSV.foreach(seed_file, headers: true) do |row|
           process_row(row)
         end
-        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: true)
+        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: @stdout)
       end
 
       protected

--- a/db/seeds/establishments/hospital_seeder.rb
+++ b/db/seeds/establishments/hospital_seeder.rb
@@ -8,6 +8,7 @@ module Seeds
       def initialize(options = {})
         @seed_file = Rails.root.join('lib', 'assets', 'data', 'establishments', 'hospitals.csv')
         @dry_run = options[:dry_run].to_s.downcase.strip == 'true'
+        @stdout = options.fetch(:stdout, false)
       end
 
       def call
@@ -15,7 +16,7 @@ module Seeds
         CSV.foreach(seed_file, headers: true) do |row|
           process_row(row)
         end
-        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: true)
+        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: @stdout)
       end
 
       protected

--- a/db/seeds/establishments/magistrates_court_seeder.rb
+++ b/db/seeds/establishments/magistrates_court_seeder.rb
@@ -8,6 +8,7 @@ module Seeds
       def initialize(options = {})
         @seed_file = Rails.root.join('lib', 'assets', 'data', 'establishments', 'magistrates_courts.csv')
         @dry_run = options[:dry_run].to_s.downcase.strip == 'true'
+        @stdout = options.fetch(:stdout, false)
       end
 
       def call
@@ -15,7 +16,7 @@ module Seeds
         CSV.foreach(seed_file, headers: true) do |row|
           process_row(row)
         end
-        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: true)
+        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: @stdout)
       end
 
       protected

--- a/db/seeds/establishments/prison_seeder.rb
+++ b/db/seeds/establishments/prison_seeder.rb
@@ -8,6 +8,7 @@ module Seeds
       def initialize(options = {})
         @seed_file = Rails.root.join('lib', 'assets', 'data', 'establishments', 'prisons.csv')
         @dry_run = options[:dry_run].to_s.downcase.strip == 'true'
+        @stdout = options.fetch(:stdout, false)
       end
 
       def call
@@ -15,7 +16,7 @@ module Seeds
         CSV.foreach(seed_file, headers: true) do |row|
           process_row(row)
         end
-        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: true)
+        log("[OUTPUT] Total: #{total} | Created: #{total_created}| Updated: #{total_updated} | Error: #{total_with_error}", stdout: @stdout)
       end
 
       protected


### PR DESCRIPTION
#### What
Reflect softly deleted disbursements in seeds

#### Ticket

[CBO-447](https://dsdmoj.atlassian.net/browse/CBO-447)

#### Why
This is to ensure any disbursement types softly deleted
on production are reflected on other envs when/if reseeded.

Need to check all softley deleted records and their
respective seeding files too.
