### PR TITLE
Add seeding for ccr cclf application case worker accounts

### DIFF
--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -18,7 +18,7 @@ module SeedHelper
         last_name: attrs[:last_name],
         email: attrs[:email].downcase,
         password: ENV.fetch(attrs[:password_env_var]),
-        password_confirmation: ENV[attrs[:password_env_var]]
+        password_confirmation: ENV.fetch(attrs[:password_env_var])
       )
       case_worker = CaseWorker.new(roles: attrs[:roles])
       case_worker.user = user

--- a/db/seeds/case_workers.rb
+++ b/db/seeds/case_workers.rb
@@ -14,5 +14,38 @@ data.each_with_index do |row, index|
     email: email,
     location: location,
     roles: [role],
-    password_env_var: 'CASE_WORKER_PASSWORD')
+    password_env_var: 'CASE_WORKER_PASSWORD'
+  )
+end
+
+# create an application user CCR
+SeedHelper.find_or_create_caseworker!(
+  first_name: 'CCR Injection',
+  last_name: 'DO NOT DELETE',
+  email: 'ccr@example.com',
+  location: 'Nottingham',
+  roles: %w[admin case_worker],
+  password_env_var: 'CASE_WORKER_PASSWORD'
+)
+
+ccr_caseworker_api_key = ENV.fetch('CCR_CASEWORKER_API_KEY')
+if ccr_caseworker_api_key
+  usr = User.find_by(email: 'ccr@example.com')
+  usr.update(api_key: ccr_caseworker_api_key) if !usr.api_key.eql?(ccr_caseworker_api_key)
+end
+
+# create an application user CCLF
+SeedHelper.find_or_create_caseworker!(
+  first_name: 'CCLF Injection',
+  last_name: 'DO NOT DELETE',
+  email: 'cclf@example.com',
+  location: 'Nottingham',
+  roles: %w[admin case_worker],
+  password_env_var: 'CASE_WORKER_PASSWORD'
+)
+
+cclf_caseworker_api_key = ENV.fetch('CCLF_CASEWORKER_API_KEY')
+if cclf_caseworker_api_key
+  usr = User.find_by(email: 'cclf@example.com')
+  usr.update(api_key: cclf_caseworker_api_key) if !usr.api_key.eql?(cclf_caseworker_api_key)
 end


### PR DESCRIPTION
#### What
Adds seeds for CCR and CCLF case worker application users

#### Why
So `db:reseed` and `db:reload` rake tasks
do not break Data injection.

relates to: https://github.com/ministryofjustice/advocate-defence-payments-deploy/pull/167