### PR TITLE
Exclude unmappable transfer claim miscs fees

### DIFF
--- a/app/interfaces/api/entities/cclf/transfer_claim.rb
+++ b/app/interfaces/api/entities/cclf/transfer_claim.rb
@@ -8,7 +8,7 @@ module API
           data.push AdaptedMiscFee.represent(object.misc_fees)
           data.push AdaptedDisbursement.represent(object.disbursements)
           data.push AdaptedExpense.represent(object.expenses)
-          data.flatten.as_json
+          data.as_json.flat_select { |bill| bill[:bill_type].present? }
         end
       end
     end

--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe API::V2::CCLFClaim, feature: :injection do
 
           it { is_valid_cclf_json(response) }
 
-          it 'returns array NOT containing misc fee bill' do
+          it 'returns array NOT containing misc fee bills' do
             is_expected.to have_json_size(1).at_path("bills")
             is_expected.to be_json_eql('LIT_FEE'.to_json).at_path("bills/0/bill_type")
           end

--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -500,6 +500,22 @@ RSpec.describe API::V2::CCLFClaim, feature: :injection do
             is_expected.to be_json_eql('SPECIAL_PREP'.to_json).at_path("bills/1/bill_subtype")
           end
         end
+
+        context 'when unmappable miscellaneous fees exists' do
+          let(:miupl) { create(:misc_fee_type, :lgfs, :miupl) }
+          let(:claim) do
+            create(:transfer_claim, :with_transfer_detail, :submitted).tap do |claim|
+              create(:misc_fee, :lgfs, fee_type: miupl, claim: claim)
+            end
+          end
+
+          it { is_valid_cclf_json(response) }
+
+          it 'returns array NOT containing misc fee bill' do
+            is_expected.to have_json_size(1).at_path("bills")
+            is_expected.to be_json_eql('LIT_FEE'.to_json).at_path("bills/0/bill_type")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### What
Ensure nil bill types on transfer claims are not injected

#### Why
To fix Transfer claim defendant uplifts injection error

#### How
This Just in time logic/method of excluding any unmappable 
bills based on bill_type presence is used by litigator final
and interim already. Applying it to transfers too as fix.
