### PR TITLE
Fix env key not found error

### DIFF
--- a/db/seeds/case_workers.rb
+++ b/db/seeds/case_workers.rb
@@ -28,7 +28,7 @@ SeedHelper.find_or_create_caseworker!(
   password_env_var: 'CASE_WORKER_PASSWORD'
 )
 
-ccr_caseworker_api_key = ENV.fetch('CCR_CASEWORKER_API_KEY')
+ccr_caseworker_api_key = ENV.fetch('CCR_CASEWORKER_API_KEY', nil)
 if ccr_caseworker_api_key
   usr = User.find_by(email: 'ccr@example.com')
   usr.update(api_key: ccr_caseworker_api_key) if !usr.api_key.eql?(ccr_caseworker_api_key)
@@ -44,7 +44,7 @@ SeedHelper.find_or_create_caseworker!(
   password_env_var: 'CASE_WORKER_PASSWORD'
 )
 
-cclf_caseworker_api_key = ENV.fetch('CCLF_CASEWORKER_API_KEY')
+cclf_caseworker_api_key = ENV.fetch('CCLF_CASEWORKER_API_KEY', nil)
 if cclf_caseworker_api_key
   usr = User.find_by(email: 'cclf@example.com')
   usr.update(api_key: cclf_caseworker_api_key) if !usr.api_key.eql?(cclf_caseworker_api_key)


### PR DESCRIPTION
#### What
Fix env key not found error

#### Why
The case worker seeds for application
users (ccr/cclf) rely on an envar api
key that is not present on all environments.

Lack of an env key breaks the jenkins build
job since it seeds.
