### PR TITLE
Use commandline for brakeman

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -4,7 +4,7 @@ namespace :ci do
     raise 'The test suite should only be run in development and test environments!' unless Rails.env.in? %w(development test)
     puts 'Info: Running Test Suite'.green
     Rake::Task['rubocop'].invoke
-    # Rake::Task['brakeman:run'].invoke
+    Rake::Task['brakeman:run'].invoke
     Rake::Task['jasmine:ci'].invoke
     Rake::Task['spec'].invoke
     puts 'Info: Sleeping for five seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren''t populated fast enough.'.green


### PR DESCRIPTION
#### What
Fix brakeman run for local and CI test suite runs

#### Why
Brakeman rake task has been broken following a
gem update. This changes to use the commandline
instead as [recommended](https://brakemanscanner.org/docs/rake/).