### PR TITLE
CCLF geckoboard reporting fix

### DIFF
--- a/lib/geckoboard_publisher/injection_record.rb
+++ b/lib/geckoboard_publisher/injection_record.rb
@@ -67,7 +67,10 @@ module GeckoboardPublisher
     end
 
     def total_cclf
-      cclf_injections.where(created_at: date_range).count
+      cclf_injections
+        .where(created_at: date_range)
+        .exclude_error('%already exist%')
+        .count
     end
 
     def total


### PR DESCRIPTION
#### What
Ensure the geckoboard report for CCLF injections _also_ ignores "Duplicate case" warnings
This had been implemented on CCR and should have been done for both fee schemes
