### PR TITLE
Cbo 398 case number uplift validation

### DIFF
--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -46,8 +46,9 @@ module Fee
         return if case_numbers.blank?
 
         case_numbers.split(',').each do |case_number|
-          add_error(:case_numbers, 'invalid') unless case_number.strip.match?(CASE_NUMBER_PATTERN)
-          add_error(:case_numbers, 'adtnl_case_num_eqls_main_case_num') if case_number.strip.eql?(claim.case_number)
+          case_number = case_number.strip
+          add_error(:case_numbers, 'invalid') unless case_number.match?(CASE_NUMBER_PATTERN)
+          add_error(:case_numbers, 'adtnl_case_num_eqls_main_case_num') if case_number.eql?(claim.case_number)
         end
       end
     end

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -47,9 +47,13 @@ module Fee
 
         case_numbers.split(',').each do |case_number|
           case_number = case_number.strip
-          add_error(:case_numbers, 'invalid') unless case_number.match?(CASE_NUMBER_PATTERN)
-          add_error(:case_numbers, 'adtnl_case_num_eqls_main_case_num') if case_number.eql?(claim.case_number)
+          validate_case_number(case_number)
         end
+      end
+
+      def validate_case_number(case_number)
+        add_error(:case_numbers, 'invalid') unless case_number.match?(CASE_NUMBER_PATTERN)
+        add_error(:case_numbers, 'adtnl_case_num_eqls_main_case_num') if case_number.eql?(claim.case_number)
       end
     end
   end

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -53,7 +53,7 @@ module Fee
 
       def validate_case_number(case_number)
         add_error(:case_numbers, 'invalid') unless case_number.match?(CASE_NUMBER_PATTERN)
-        add_error(:case_numbers, 'adtnl_case_num_eqls_main_case_num') if case_number.eql?(claim.case_number)
+        add_error(:case_numbers, 'eqls_claim_case_number') if case_number.eql?(claim.case_number)
       end
     end
   end

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -53,7 +53,7 @@ module Fee
 
       def validate_case_number(case_number)
         add_error(:case_numbers, 'invalid') unless case_number.match?(CASE_NUMBER_PATTERN)
-        add_error(:case_numbers, 'eqls_claim_case_number') if case_number.eql?(claim.case_number)
+        add_error(:case_numbers, 'eqls_claim_case_number') if case_number.casecmp?(claim.case_number)
       end
     end
   end

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -46,10 +46,8 @@ module Fee
         return if case_numbers.blank?
 
         case_numbers.split(',').each do |case_number|
-          unless case_number.strip.match?(CASE_NUMBER_PATTERN)
-            add_error(:case_numbers, 'invalid')
-            break
-          end
+          add_error(:case_numbers, 'invalid') unless case_number.strip.match?(CASE_NUMBER_PATTERN)
+          add_error(:case_numbers, 'adtnl_case_num_eqls_main_case_num') if case_number.strip.eql?(claim.case_number)
         end
       end
     end

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -939,7 +939,7 @@ basic_fee:
     adtnl_case_num_eqls_main_case_num:
       long: The additional case number must be different to the main case number
       short: Enter valid case numbers
-      api: The number of case uplifts does not match the additional case numbers
+      api: Enter valid case numbers for the Number of cases uplift
 
 #################################################################################
 #                                                                               #

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -25,6 +25,8 @@ dictionary:
     claim_max_amount: &claim_max_amount 'Amount claimed exceeds limit'
     max_length: &max_length 'Length exceeds limit'
     expense_before_rep_order: &expense_before_rep_order "Date of expense must be on or after the date of the earliest representation order"
+    eqls_claim_case_number: &eqls_claim_case_number 'The additional case number must be different to the main case number'
+
 
 # applies to defendant, fee, expense
 claim:
@@ -937,7 +939,7 @@ basic_fee:
       short: Enter case numbers for each uplift
       api: The number of case uplifts does not match the additional case numbers
     eqls_claim_case_number:
-      long: The additional case number must be different to the main case number
+      long: *eqls_claim_case_number
       short: Enter valid case numbers
       api: Enter valid case numbers for the Number of cases uplift
 
@@ -1110,6 +1112,10 @@ fixed_fee:
         long: The number of case uplifts does not match the additional case numbers
         short: Enter case numbers for each uplift
         api: The number of case uplifts does not match the additional case numbers
+      eqls_claim_case_number:
+        long: *eqls_claim_case_number
+        short: Enter valid case numbers
+        api: Enter valid case numbers for the Number of cases uplift
 
 #################################################################################
 #                                                                               #

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -936,7 +936,7 @@ basic_fee:
       long: The number of case uplifts does not match the additional case numbers
       short: Enter case numbers for each uplift
       api: The number of case uplifts does not match the additional case numbers
-    adtnl_case_num_eqls_main_case_num:
+    eqls_claim_case_number:
       long: The additional case number must be different to the main case number
       short: Enter valid case numbers
       api: Enter valid case numbers for the Number of cases uplift

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -936,6 +936,10 @@ basic_fee:
       long: The number of case uplifts does not match the additional case numbers
       short: Enter case numbers for each uplift
       api: The number of case uplifts does not match the additional case numbers
+    adtnl_case_num_eqls_main_case_num:
+      long: The additional case number must be different to the main case number
+      short: Enter valid case numbers
+      api: The number of case uplifts does not match the additional case numbers
 
 #################################################################################
 #                                                                               #

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -75,7 +75,7 @@ shared_examples 'common AGFS number of cases uplift validations' do
       noc_fee.case_numbers = 'A20161234,T20171234'
       should_not_error(noc_fee, :case_numbers)
     end
-   end
+  end
 
   context 'case numbers list invalid' do
     it 'when case_numbers is blank and quantity is not zero' do
@@ -104,7 +104,7 @@ shared_examples 'common AGFS number of cases uplift validations' do
       should_error_with(noc_fee, :case_numbers, 'noc_qty_mismatch')
     end
 
-    it 'when case number is not equal to main case number' do
+    it 'when case number is equal to main case number' do
       noc_fee.case_numbers = claim.case_number
       should_error_with(noc_fee, :case_numbers, 'adtnl_case_num_eqls_main_case_num')
     end

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -106,7 +106,7 @@ shared_examples 'common AGFS number of cases uplift validations' do
 
     it 'when case number is equal to main case number' do
       noc_fee.case_numbers = claim.case_number
-      should_error_with(noc_fee, :case_numbers, 'adtnl_case_num_eqls_main_case_num')
+      should_error_with(noc_fee, :case_numbers, 'eqls_claim_case_number')
     end
   end
 

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -75,7 +75,7 @@ shared_examples 'common AGFS number of cases uplift validations' do
       noc_fee.case_numbers = 'A20161234,T20171234'
       should_not_error(noc_fee, :case_numbers)
     end
-  end
+   end
 
   context 'case numbers list invalid' do
     it 'when case_numbers is blank and quantity is not zero' do
@@ -102,6 +102,11 @@ shared_examples 'common AGFS number of cases uplift validations' do
     it 'when quantity and number of additional cases do not match' do
       noc_fee.case_numbers = 'A20161234 , A20158888'
       should_error_with(noc_fee, :case_numbers, 'noc_qty_mismatch')
+    end
+
+    it 'when case number is not equal to main case number' do
+      noc_fee.case_numbers = claim.case_number
+      should_error_with(noc_fee, :case_numbers, 'adtnl_case_num_eqls_main_case_num')
     end
   end
 


### PR DESCRIPTION
#### What
Validate that claim with a case uplift with the same case number as main claim in CCCD

#### Ticket
CBO-398 https://dsdmoj.atlassian.net/projects/CBO/issues/CBO-398?filter=allopenissues

#### Why
We are getting some CCR data injection errors due to AGFS providers claiming a case uplift using the same case number as the main claim. CCR does not allow this, but CCCD currently does.

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
