### PR TITLE
CBO-454 : Restoring archived claims

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -127,14 +127,14 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def unarchive
-    if @claim.archived_pending_delete?
-      @claim = PreviousVersionOfClaim.new(@claim).call
-      @claim.zeroise_nil_totals!
-      @claim.save!
-      redirect_to external_users_claims_url, notice: 'Claim unarchived'
-    else
-      redirect_to external_users_claim_url(@claim), alert: 'This claim cannot be unarchived'
-    end
+    claim_url = external_users_claim_url(@claim)
+    return redirect_to claim_url, alert: t('.not_archived') unless @claim.archived_pending_delete?
+    @claim = PreviousVersionOfClaim.new(@claim).call
+    @claim.zeroise_nil_totals!
+    @claim.save!
+    redirect_to external_users_claims_url, notice: 'Claim unarchived'
+  rescue StandardError
+    redirect_to claim_url, alert: t('.unarchivable')
   end
 
   def new

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -131,7 +131,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
     return redirect_to claim_url, alert: t('.not_archived') unless @claim.archived_pending_delete?
     @claim = PreviousVersionOfClaim.new(@claim).call
     @claim.zeroise_nil_totals!
-    @claim.save!
+    @claim.save!(validate: false)
     redirect_to external_users_claims_url, notice: 'Claim unarchived'
   rescue StandardError
     redirect_to claim_url, alert: t('.unarchivable')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -505,6 +505,9 @@ en:
       errors:
         not_editable: 'Can only edit "draft" claims'
         dependencies_missing: Claim section cannot be edited. Please fill its dependencies
+      unarchive:
+        not_archived: 'This claim is not in the archive'
+        unarchivable: 'This claim cannot be unarchived'
       hints:
         fees_header_prompt_text_html: &fees_vat_prompt All fees should be entered exclusive of VAT.
       redraft:

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -781,6 +781,29 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
         expect(response).to redirect_to(external_users_claim_url(subject))
       end
     end
+
+    context 'when the claim is archived with assessed values' do
+      subject(:claim) { create(:advocate_claim, external_user: advocate) }
+      before do
+        claim.submit!
+        claim.allocate!
+        claim.assessment.update(fees: 123.00, expenses: 23.45)
+        claim.authorise_part!
+        claim.redetermine!
+        claim.allocate!
+        claim.refuse!
+        claim.archive_pending_delete!
+        patch :unarchive, params: { id: claim }
+      end
+
+      it 'unarchives the claim and restores to state prior to archiving' do
+        expect(claim.reload).to be_refused
+      end
+
+      it 'redirects to external users root url' do
+        expect(response).to redirect_to(external_users_claims_url)
+      end
+    end
   end
 
   describe 'GET #show_message_controls' do


### PR DESCRIPTION
#### What
Allow providers to unarchive claims

#### Ticket
[Allow claims to be restored](https://dsdmoj.atlassian.net/browse/CBO-454)

#### Why
Following changes made to the system earlier in the year, some claims could be archived in a state where they could not be un-archived.  This removes validation on restore... after all, how could data be in the DB if it's not valid!

All subsequent changes should progress as normal

#### How
Remove validation from the save on unarchiving
