### PR TITLE
Cbo 455 allow draft deletion

### DIFF
--- a/app/models/concerns/softly_deletable.rb
+++ b/app/models/concerns/softly_deletable.rb
@@ -13,7 +13,11 @@ module SoftlyDeletable
     def soft_delete
       transaction do
         before_soft_delete if respond_to?(:before_soft_delete)
-        result = update(deleted_at: Time.zone.now)
+        result = if is_a?(Claim::BaseClaim)
+                   update_attribute(:deleted_at, Time.zone.now)
+                 else
+                   update(deleted_at: Time.zone.now)
+                 end
         after_soft_delete if respond_to?(:after_soft_delete)
         result
       end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -7,8 +7,8 @@ namespace :ci do
     Rake::Task['brakeman:run'].invoke
     Rake::Task['jasmine:ci'].invoke
     Rake::Task['spec'].invoke
-    puts 'Info: Sleeping for five seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren''t populated fast enough.'.green
-    sleep 5
+    puts 'Info: Sleeping for ten seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren''t populated fast enough.'.green
+    sleep 10
     Rake::Task['cucumber'].invoke
   end
 end


### PR DESCRIPTION
#### What
Allow providers to delete _all_ draft claims

#### Ticket
[Unable to delete cases from draft](https://dsdmoj.atlassian.net/browse/CBO-455)

#### Why
Providers can save draft claims in any state, the code required to 'delete' them, actually a logical delete rather than a physical delete, still applied validation

#### How
Change the soft delete code to update the delete_at attribute of the claim.  This does not trigger validation and will allow 'invalid' claims to be removed from provider's claim lists

Bonus: updated the controller code to show better errors if the delete or archive methods fail
