### PR TITLE
Remove explicit rvm call to see if travis is working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 cache: bundler
-rvm:
-  - 2.5.1
 addons:
   postgresql: '9.6'
   code_climate:


### PR DESCRIPTION
#### What
Remove explicit rvm call in `.travis.yml`

#### Why
Travis suddenly stopped reading the ruby-version, now it has started again, this should not be needed
