### PR TITLE
CBO-462 : Ensure single rep order for injection

### DIFF
--- a/app/interfaces/api/entities/ccr/defendant.rb
+++ b/app/interfaces/api/entities/ccr/defendant.rb
@@ -6,7 +6,7 @@ module API
         expose :first_name
         expose :last_name
         expose :date_of_birth
-        expose :representation_orders_with_earliest_first,
+        expose :earliest_representation_order,
                using: API::Entities::CCR::RepresentationOrder,
                as: :representation_orders
 
@@ -16,7 +16,7 @@ module API
           object.claim.defendants.unscope(:order).order(created_at: :asc)&.first == object || false
         end
 
-        def representation_orders_with_earliest_first
+        def earliest_representation_order
           object.representation_orders.unscope(:order).order(representation_order_date: :asc).take(1)
         end
       end

--- a/app/interfaces/api/entities/ccr/defendant.rb
+++ b/app/interfaces/api/entities/ccr/defendant.rb
@@ -17,7 +17,7 @@ module API
         end
 
         def representation_orders_with_earliest_first
-          object.representation_orders.unscope(:order).order(representation_order_date: :asc)
+          object.representation_orders.unscope(:order).order(representation_order_date: :asc).take(1)
         end
       end
     end

--- a/spec/api/entities/ccr/defendant_spec.rb
+++ b/spec/api/entities/ccr/defendant_spec.rb
@@ -36,4 +36,21 @@ describe API::Entities::CCR::Defendant do
     expect(response[:representation_orders].first).to include(maat_reference: '1234567890', representation_order_date: '2016-01-10')
   end
 
+  context 'when the defendant has more than one rep_order' do
+    let(:rep_orders) do
+      [
+        create(:representation_order, maat_reference: '1234567890', representation_order_date: Date.new(2016, 1, 10)),
+        create(:representation_order, maat_reference: '0987654321', representation_order_date: Date.new(2016, 1, 11))
+      ]
+    end
+
+    it 'returns a single rep_order' do
+      expect(response[:representation_orders].count).to eql 1
+    end
+
+    it 'returns the first representation order entered' do
+      expect(response[:representation_orders].first).to include(maat_reference: '1234567890', representation_order_date: '2016-01-10')
+    end
+
+  end
 end

--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -215,8 +215,8 @@ RSpec.describe API::V2::CCLFClaim, feature: :injection do
           ]
         }
 
-        it 'returns multiple representation orders' do
-          is_expected.to have_json_size(2).at_path('defendants/0/representation_orders')
+        it 'returns the earliest of the representation orders' do
+          is_expected.to have_json_size(1).at_path('defendants/0/representation_orders')
         end
 
         it 'returns earliest rep order first (per defendant)' do

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -184,8 +184,8 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           ]
         }
 
-        it 'returns multiple representation orders' do
-          is_expected.to have_json_size(2).at_path('defendants/0/representation_orders')
+        it 'returns the earliest of the representation orders' do
+          is_expected.to have_json_size(1).at_path('defendants/0/representation_orders')
         end
 
         it 'returns earliest rep order first (per defendant)' do


### PR DESCRIPTION
#### What
Ensure that the CCR/LF endpoints only return a single rep-order.  If there are multiple, it should be the earliest dated one.

#### Ticket
[More than one rep order on a claim injection error](https://dsdmoj.atlassian.net/browse/CBO-462)

#### Why
CCR/LF will reject the injection if there are multiple rep-orders for a defendant