### PR TITLE
CAV warning hotfix

### DIFF
--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -346,7 +346,7 @@ class Claim::BaseClaimPresenter < BasePresenter
   end
 
   def has_conference_and_views?
-    claim.fees.select { |f| f.fee_type.unique_code.eql?('BACAV') }.any? { |x| x.amount.nonzero? }
+    claim.fees.select { |f| f.fee_type.unique_code.eql?('BACAV') }.any? { |x| x.amount&.nonzero? }
   end
 
   private


### PR DESCRIPTION
#### What
Sentry has flagged an issue with CAV where the amount is `nil`

#### How
Use a safe operator on amount for nonzero?
