### PR TITLE
Fix flickering features

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -58,6 +58,7 @@ ActionController::Base.allow_rescue = false
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin
+  DatabaseCleaner.clean_with(:deletion)
   DatabaseCleaner.strategy = :transaction
 rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -25,6 +25,7 @@ end
 Before do
   unless ($seed_done ||= false)
 
+    ActiveRecord::Base.connection.reset_pk_sequence!('offences')
     load "#{Rails.root}/db/seeds/courts.rb"
     load "#{Rails.root}/db/seeds/offence_classes.rb"
     load "#{Rails.root}/db/seeds/offences.rb"


### PR DESCRIPTION
#### What
After the introduction of scheme 11 offences the features were flickering during test runs

#### Why
The seeds for scheme 11+ offences can be fragile and expect the
database to have been created from an empty start.

#### How
Ensure the database is deleted prior to a cucumber run by running a `DatabaseCleaner.clean_with(:deletion)` before cucumber starts and ensuring the `Offence` primary key has been reset before creating the required seed data