### PR TITLE
Default grad fee quantity to one.

### DIFF
--- a/app/interfaces/api/entities/cclf/adapted_graduated_fee.rb
+++ b/app/interfaces/api/entities/cclf/adapted_graduated_fee.rb
@@ -11,6 +11,10 @@ module API
         def adapter
           @adapter ||= ::CCLF::Fee::GraduatedFeeAdapter.new(object)
         end
+
+        def quantity
+          [object.quantity, 1].compact.max
+        end
       end
     end
   end

--- a/app/services/cclf/case_type_adapter.rb
+++ b/app/services/cclf/case_type_adapter.rb
@@ -1,7 +1,5 @@
 module CCLF
   class CaseTypeAdapter
-    # TODO: transfer claims only
-    #
     # NOTE: on the missing interim fee types:
     # - Interim "Warrant" (INWAR) fees are handled as "final" warrant fees, using the case_type.fee_type_code.
     # - Interim "Disbursement only" (INDIS) fee is merely a flag to indicate only disbursements are

--- a/spec/api/entities/cclf/adapted_graduated_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_graduated_fee_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe API::Entities::CCLF::AdaptedGraduatedFee, type: :adapter do
       quantity: '999',
     )
   end
+
+  # CCLF returns error response for 0 quantity on LIT_FEE
+  context 'when zero quantity on grad fee' do
+    let(:graduated_fee) { instance_double('graduated_fee', claim: claim, fee_type: fee_type, quantity: 0) }
+
+    it 'defaults quantity to 1' do
+      expect(response).to include(quantity: '1')
+    end
+  end
 end


### PR DESCRIPTION
#### What
Fix CCLF data injection bug

#### Ticket

[CBO-466](https://dsdmoj.atlassian.net/browse/CBO-466)

#### Why

CCLF does not accept a quantity of zero
for litigator fees, `LIT_FEE`, but CCCD grad
fees do. This was a bug identified in production.

The ideal fix should be in CCLF but we are blocked
on such changes at the moment.

#### How

return 1 if quantity is `0` or `nil`