### PR TITLE
CBO-458 : MAAT number validation

### DIFF
--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -66,7 +66,7 @@ class RepresentationOrderValidator < BaseValidator
     case_type = claim.try(:case_type)
     return unless case_type&.requires_maat_reference?
     validate_presence(:maat_reference, 'invalid')
-    validate_pattern(:maat_reference, /^[4-9][0-9]{6,9}$/, 'invalid')
+    validate_pattern(:maat_reference, /^[4-9][0-9]{6}$/, 'invalid')
     validate_matt_reference_uniqueness(:maat_reference, 'unique')
   end
 

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -66,7 +66,7 @@ class RepresentationOrderValidator < BaseValidator
     case_type = claim.try(:case_type)
     return unless case_type&.requires_maat_reference?
     validate_presence(:maat_reference, 'invalid')
-    validate_pattern(:maat_reference, /^[0-9]{7,10}$/, 'invalid')
+    validate_pattern(:maat_reference, /^[4-9][0-9]{6,9}$/, 'invalid')
     validate_matt_reference_uniqueness(:maat_reference, 'unique')
   end
 

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -66,7 +66,7 @@ class RepresentationOrderValidator < BaseValidator
     case_type = claim.try(:case_type)
     return unless case_type&.requires_maat_reference?
     validate_presence(:maat_reference, 'invalid')
-    validate_pattern(:maat_reference, /^[4-9][0-9]{6}$/, 'invalid')
+    validate_pattern(:maat_reference, Settings.maat_regexp, 'invalid')
     validate_matt_reference_uniqueness(:maat_reference, 'unique')
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -770,7 +770,7 @@ en:
           date: Representation order date
           representation_order: Representation order details
           maat_reference_number: MAAT reference
-          maat_reference_number_eg: 'for example 1234567, this can be found on the Representation Order'
+          maat_reference_number_eg: 'this should be 7 digits long, starting with at least a 4'
         summary:
           caption: 'Defendants: This section contains details about each defendant.'
           header: Defendant details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,7 +235,7 @@ en:
     form:
       upload: 'Choose file to upload'
   maat_reference_number: 'MAAT reference'
-  maat_reference_number_eg: 'for example 1234567890'
+  maat_reference_number_eg: 'for example 1234567'
 
   page_headings:
     edit_lgfs_claim: Edit litigator claim
@@ -770,7 +770,7 @@ en:
           date: Representation order date
           representation_order: Representation order details
           maat_reference_number: MAAT reference
-          maat_reference_number_eg: 'for example 1234567890'
+          maat_reference_number_eg: 'for example 1234567, this can be found on the Representation Order'
         summary:
           caption: 'Defendants: This section contains details about each defendant.'
           header: Defendant details

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -142,3 +142,5 @@ govuk_notify:
 notify_report_errors: <%= ENV["ENV"].in?(%w[api-sandbox demo disaster gamma]) %>
 
 postcode_regexp: !ruby/regexp '/\A([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})\z/'
+
+maat_regexp: !ruby/regexp <%= ENV['MAAT_REGEXP'] || '/^[2-9][0-9]{6}$/' %>

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -30,7 +30,7 @@ When(/^I enter defendant, (.*?)representation order and MAAT reference$/) do |sc
       @claim_form_page.defendants.first.last_name.set "Billiards"
       @claim_form_page.defendants.first.dob.set_date "1955-01-01"
       @claim_form_page.defendants.last.representation_orders.first.date.set_date date
-      @claim_form_page.defendants.last.representation_orders.first.maat_reference.set "1234567890"
+      @claim_form_page.defendants.last.representation_orders.first.maat_reference.set "4567890"
     end
 end
 
@@ -47,7 +47,7 @@ When(/^I add another defendant, (.*?)representation order and MAAT reference$/) 
     # do it again if the first click failed
     @claim_form_page.defendants.last.add_another_representation_order.click if @claim_form_page.defendants.last.representation_orders.first.nil?
     @claim_form_page.defendants.last.representation_orders.first.date.set_date date
-    @claim_form_page.defendants.last.representation_orders.first.maat_reference.set Random.rand(1000000...9999999)
+    @claim_form_page.defendants.last.representation_orders.first.maat_reference.set Random.rand(4000000...9999999)
   end
 end
 

--- a/spec/api/entities/ccr/defendant_spec.rb
+++ b/spec/api/entities/ccr/defendant_spec.rb
@@ -4,7 +4,7 @@ describe API::Entities::CCR::Defendant do
   subject(:response) { JSON.parse(described_class.represent(defendant).to_json).deep_symbolize_keys }
 
   let(:claim) { create(:advocate_claim) }
-  let(:rep_orders) { create_list(:representation_order, 1, uuid: 'uuid', maat_reference: '1234567890', representation_order_date: Date.new(2016, 1, 10)) }
+  let(:rep_orders) { create_list(:representation_order, 1, uuid: 'uuid', maat_reference: '2345678', representation_order_date: Date.new(2016, 1, 10)) }
 
   let(:defendant) do
     create(:defendant,
@@ -33,14 +33,14 @@ describe API::Entities::CCR::Defendant do
   end
 
   it 'returns representation order' do
-    expect(response[:representation_orders].first).to include(maat_reference: '1234567890', representation_order_date: '2016-01-10')
+    expect(response[:representation_orders].first).to include(maat_reference: '2345678', representation_order_date: '2016-01-10')
   end
 
   context 'when the defendant has more than one rep_order' do
     let(:rep_orders) do
       [
-        create(:representation_order, maat_reference: '1234567890', representation_order_date: Date.new(2016, 1, 10)),
-        create(:representation_order, maat_reference: '0987654321', representation_order_date: Date.new(2016, 1, 11))
+        create(:representation_order, maat_reference: '2345678', representation_order_date: Date.new(2016, 1, 10)),
+        create(:representation_order, maat_reference: '8765432', representation_order_date: Date.new(2016, 1, 11))
       ]
     end
 
@@ -49,7 +49,7 @@ describe API::Entities::CCR::Defendant do
     end
 
     it 'returns the first representation order entered' do
-      expect(response[:representation_orders].first).to include(maat_reference: '1234567890', representation_order_date: '2016-01-10')
+      expect(response[:representation_orders].first).to include(maat_reference: '2345678', representation_order_date: '2016-01-10')
     end
 
   end

--- a/spec/api/entities/ccr/representation_order_spec.rb
+++ b/spec/api/entities/ccr/representation_order_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe API::Entities::CCR::RepresentationOrder do
   subject(:response) { JSON.parse(described_class.represent(representation_order).to_json).deep_symbolize_keys }
 
-  let(:representation_order) { build(:representation_order, uuid: 'uuid', maat_reference: '1234567890', representation_order_date: Date.new(2016, 1, 10)) }
+  let(:representation_order) { build(:representation_order, uuid: 'uuid', maat_reference: '2345678', representation_order_date: Date.new(2016, 1, 10)) }
 
   it 'has expected json key-value pairs' do
-    expect(response).to include(maat_reference: '1234567890', representation_order_date: '2016-01-10')
+    expect(response).to include(maat_reference: '2345678', representation_order_date: '2016-01-10')
   end
 
   it 'returns representation_order_date in UTC format' do

--- a/spec/api/entities/defendant_spec.rb
+++ b/spec/api/entities/defendant_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 describe API::Entities::Defendant do
 
-  let(:rep_orders) { build_list(:representation_order, 1, uuid: 'uuid', maat_reference: '1234567890', representation_order_date: Date.new(2016, 1, 10)) }
+  let(:rep_orders) { build_list(:representation_order, 1, uuid: 'uuid', maat_reference: '2345678', representation_order_date: Date.new(2016, 1, 10)) }
   let(:defendant) { build(:defendant, uuid: 'uuid', first_name: 'Kaia', last_name: 'Casper', date_of_birth: Date.new(1995, 6, 20), representation_orders: rep_orders) }
 
   it 'represents the defendant entity' do
     result = described_class.represent(defendant)
-    expect(result.to_json).to eq '{"id":null,"uuid":null,"first_name":"Kaia","last_name":"Casper","date_of_birth":"1995-06-20","representation_orders":[{"id":null,"uuid":null,"maat_reference":"1234567890","date":"2016-01-10"}]}'
+    expect(result.to_json).to eq '{"id":null,"uuid":null,"first_name":"Kaia","last_name":"Casper","date_of_birth":"1995-06-20","representation_orders":[{"id":null,"uuid":null,"maat_reference":"2345678","date":"2016-01-10"}]}'
   end
 end

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
         api_key: provider.api_key,
         defendant_id: defendant.uuid,
         representation_order_date: representation_order_date.as_json,
-        maat_reference: '0123456789'
+        maat_reference: '4567890'
     }
   }
 

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
                               representation_order_date_dd: Time.now.day.to_s,
                               representation_order_date_mm: Time.now.month.to_s,
                               representation_order_date_yyyy: Time.now.year.to_s,
-                              maat_reference: '4561237895'
+                              maat_reference: '4561237'
                           }
                       ]
                     }

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
                     representation_order_date_dd: Time.now.day.to_s,
                     representation_order_date_mm: Time.now.month.to_s,
                     representation_order_date_yyyy: Time.now.year.to_s,
-                    maat_reference: '4561237895'
+                    maat_reference: '4561237'
                   }
                 ]
               }
@@ -169,7 +169,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller, f
                           representation_order_date_dd: representation_order_date.day.to_s,
                           representation_order_date_mm: representation_order_date.month.to_s,
                           representation_order_date_yyyy: representation_order_date.year.to_s,
-                          maat_reference: '4561237895'
+                          maat_reference: '4561237'
                         }
                     ]
                   }

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
                     representation_order_date_dd: Time.now.day.to_s,
                     representation_order_date_mm: Time.now.month.to_s,
                     representation_order_date_yyyy: Time.now.year.to_s,
-                    maat_reference: '4561237895'
+                    maat_reference: '4561237'
                   }
                 ]
               }
@@ -140,7 +140,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
                               representation_order_date_dd: Time.now.day.to_s,
                               representation_order_date_mm: Time.now.month.to_s,
                               representation_order_date_yyyy: Time.now.year.to_s,
-                              maat_reference: '4561237895'
+                              maat_reference: '4561237'
                           }
                       ]
                     }

--- a/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
                     'representation_order_date_dd' => '2',
                     'representation_order_date_mm' => '7',
                     'representation_order_date_yyyy' => '2015',
-                    'maat_reference' => '1234567890',
+                    'maat_reference' => '2345678',
                     '_destroy' => 'false',
                     'id' => '115'
                   }

--- a/spec/examples/exported_claim.json
+++ b/spec/examples/exported_claim.json
@@ -26,7 +26,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567891",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/exported_claim_with_basic_error.json
+++ b/spec/examples/exported_claim_with_basic_error.json
@@ -26,7 +26,7 @@
         "order_for_judicial_apportionment": true,
         "representation_orders": [
           {
-            "maat_reference": "1234567890",
+            "maat_reference": "2345678",
             "representation_order_date": "2015-05-01"
           }
         ]

--- a/spec/examples/exported_claim_with_errors.json
+++ b/spec/examples/exported_claim_with_errors.json
@@ -27,7 +27,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567890",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/exported_claim_with_nulls.json
+++ b/spec/examples/exported_claim_with_nulls.json
@@ -26,7 +26,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567891",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/exported_claim_with_schema_error.json
+++ b/spec/examples/exported_claim_with_schema_error.json
@@ -27,7 +27,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567891",
+              "maat_reference": "234567",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/exported_claims.json
+++ b/spec/examples/exported_claims.json
@@ -26,7 +26,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567892",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]
@@ -85,7 +85,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567893",
+              "maat_reference": "2345679",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/exported_claims_with_errors.json
+++ b/spec/examples/exported_claims_with_errors.json
@@ -26,7 +26,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567894",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]
@@ -90,7 +90,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567895",
+              "maat_reference": "2345679",
               "representation_order_date": "2015-05-01"
             }
           ]
@@ -154,7 +154,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567896",
+              "maat_reference": "2345670",
               "representation_order_date": "2015-05-01"
             }
           ]
@@ -218,7 +218,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567893",
+              "maat_reference": "2345671",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/exported_claims_with_errors_2.json
+++ b/spec/examples/exported_claims_with_errors_2.json
@@ -29,7 +29,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567894",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]
@@ -91,7 +91,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567895",
+              "maat_reference": "2345679",
               "representation_order_date": "2015-05-01"
             }
           ]
@@ -154,7 +154,7 @@
         "order_for_judicial_apportionment": true,
         "representation_orders": [
           {
-            "maat_reference": "1234567896",
+            "maat_reference": "2345671",
             "representation_order_date": "2015-05-01"
           }
         ]
@@ -217,7 +217,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567893",
+              "maat_reference": "2345672",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/invalid_fee_type_id.json
+++ b/spec/examples/invalid_fee_type_id.json
@@ -26,7 +26,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567892",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]
@@ -90,7 +90,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567893",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/examples/invalid_utf8.json
+++ b/spec/examples/invalid_utf8.json
@@ -26,7 +26,7 @@
           "order_for_judicial_apportionment": true,
           "representation_orders": [
             {
-              "maat_reference": "1234567891",
+              "maat_reference": "2345678",
               "representation_order_date": "2015-05-01"
             }
           ]

--- a/spec/factories/claim/deterministic_claim.rb
+++ b/spec/factories/claim/deterministic_claim.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
 
     defendants do |env|
       build_list(:defendant, 1, first_name: 'Kaia', last_name: 'Casper', date_of_birth: Date.new(1995, 6, 20),
-                 representation_orders: build_list(:representation_order, 1, maat_reference: '1234567890', representation_order_date: env.rep_order_date))
+                 representation_orders: build_list(:representation_order, 1, maat_reference: '4567890', representation_order_date: env.rep_order_date))
     end
 
     fees do

--- a/spec/factories/representation_orders.rb
+++ b/spec/factories/representation_orders.rb
@@ -14,6 +14,6 @@
 FactoryBot.define do
   factory :representation_order do
     representation_order_date           { Date.today }
-    maat_reference                      { Faker::Number.number(10) }
+    maat_reference                      { Faker::Number.between(from = 4000000, to = 9999999999) }
   end
 end

--- a/spec/factories/representation_orders.rb
+++ b/spec/factories/representation_orders.rb
@@ -14,6 +14,6 @@
 FactoryBot.define do
   factory :representation_order do
     representation_order_date           { Date.today }
-    maat_reference                      { Faker::Number.between(from = 4000000, to = 9999999999) }
+    maat_reference                      { Faker::Number.between(from = 4000000, to = 9999999) }
   end
 end

--- a/spec/models/json_document_importer_spec.rb
+++ b/spec/models/json_document_importer_spec.rb
@@ -13,7 +13,7 @@ describe JsonDocumentImporter do
 
   let(:claim_params)                        { {:source=>'json_import', 'creator_email'=>'advocateadmin@example.com', 'advocate_email'=>'advocate@example.com', 'case_number'=>'A20161234', 'case_type_id'=>1, 'first_day_of_trial'=>'2015-06-01', 'estimated_trial_length'=>3, 'actual_trial_length'=>3, 'trial_concluded_at'=>'2015-06-03', 'advocate_category'=>'QC', 'offence_id'=>1, 'court_id'=>1, 'cms_number'=>'12345678', 'additional_information'=>'string', 'apply_vat'=>true, 'trial_fixed_notice_at'=>'2015-06-01', 'trial_fixed_at'=>'2015-06-01', 'trial_cracked_at'=>'2015-06-01', 'api_key'=>'test_key'} }
   let(:defendant_params)                    { {'first_name'=>'Angela', 'last_name'=>'Merkel', 'date_of_birth'=>'1979-12-10', 'order_for_judicial_apportionment'=>true, 'claim_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', 'api_key'=>'test_key'} }
-  let(:rep_order_params)                    { {'maat_reference'=>'1234567891', 'representation_order_date'=>'2015-05-01', 'defendant_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', 'api_key'=>'test_key'} }
+  let(:rep_order_params)                    { {'maat_reference'=>'2345678', 'representation_order_date'=>'2015-05-01', 'defendant_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', 'api_key'=>'test_key'} }
   let(:fee_params)                          { {'fee_type_id'=>2, 'quantity'=>1, 'rate'=>1.1, 'claim_id'=>'642ec639-5037-4d64-a3aa-27c377e51ea7', 'api_key'=>'test_key'} }
   let(:expense_params)                      { {
                                                 'expense_type_id' => 1,

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -61,14 +61,12 @@ describe RepresentationOrder do
       context 'our test MAAT reference' do
         before { representation_order.maat_reference = '2320006' }
 
-        context 'when on the live environment' do
+        context 'uses environment configured MAAT regex' do
           before do
-            allow(ENV).to receive(:[]).with('MAAT_REGEXP').and_return /^[4-9][0-9]{6}$/
-            allow(Settings).to receive(:maat_regexp).and_return ENV['MAAT_REGEXP']
+            allow(Settings).to receive(:maat_regexp).and_return /^[4-9][0-9]{6}$/
           end
 
           it 'should error' do
-            expect(Settings.maat_regexp).to eql /^[4-9][0-9]{6}$/
             expect(representation_order).not_to be_valid
           end
         end

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -64,7 +64,7 @@ describe RepresentationOrder do
       end
     end
 
-    context 'case type does not require maat refrence' do
+    context 'case type does not require maat reference' do
       before(:each)       { representation_order.defendant.claim.case_type = FactoryBot.build(:case_type, requires_maat_reference: false) }
       it 'should not error if present' do
         representation_order.maat_reference = '2078352232'

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -28,6 +28,7 @@ describe RepresentationOrder do
 
     context 'case type requires maat reference' do
       before(:each)       { representation_order.defendant.claim.case_type = FactoryBot.build(:case_type, :requires_maat_reference) }
+
       it 'should error if blank' do
         representation_order.maat_reference = nil
         expect(representation_order).not_to be_valid
@@ -53,8 +54,13 @@ describe RepresentationOrder do
       end
 
       it 'should not error if 7-10 numeric digits' do
-        representation_order.maat_reference = '2078352232'
+        representation_order.maat_reference = '5078352232'
         expect(representation_order).to be_valid
+      end
+
+      it 'should error if the first digit is below 4' do
+        representation_order.maat_reference = '2345678'
+        expect(representation_order).not_to be_valid
       end
     end
 

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -41,7 +41,7 @@ describe RepresentationOrder do
         expect(representation_order.errors[:maat_reference]).to eq( [ 'invalid'])
       end
 
-      it 'should error if greater than 10 numeric characters' do
+      it 'should error if greater than 7 numeric characters' do
         representation_order.maat_reference = '4562131111111'
         expect(representation_order).not_to be_valid
         expect(representation_order.errors[:maat_reference]).to eq( [ 'invalid'])
@@ -53,8 +53,8 @@ describe RepresentationOrder do
         expect(representation_order.errors[:maat_reference]).to eq( [ 'invalid'])
       end
 
-      it 'should not error if 7-10 numeric digits' do
-        representation_order.maat_reference = '5078352232'
+      it 'should not error if 7 numeric digits' do
+        representation_order.maat_reference = '5078332'
         expect(representation_order).to be_valid
       end
 

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -58,9 +58,26 @@ describe RepresentationOrder do
         expect(representation_order).to be_valid
       end
 
-      it 'should error if the first digit is below 4' do
-        representation_order.maat_reference = '2345678'
-        expect(representation_order).not_to be_valid
+      context 'our test MAAT reference' do
+        before { representation_order.maat_reference = '2320006' }
+
+        context 'when on the live environment' do
+          before do
+            allow(ENV).to receive(:[]).with('MAAT_REGEXP').and_return /^[4-9][0-9]{6}$/
+            allow(Settings).to receive(:maat_regexp).and_return ENV['MAAT_REGEXP']
+          end
+
+          it 'should error' do
+            expect(Settings.maat_regexp).to eql /^[4-9][0-9]{6}$/
+            expect(representation_order).not_to be_valid
+          end
+        end
+
+        context 'when on a non-live environment' do
+          it 'should be valid' do
+            expect(representation_order).to be_valid
+          end
+        end
       end
     end
 

--- a/spec/support/api/claims/base_claim_test.rb
+++ b/spec/support/api/claims/base_claim_test.rb
@@ -103,7 +103,7 @@ class BaseClaimTest
     {
       "api_key": api_key,
       "defendant_id": defendant_uuid,
-      "maat_reference": '4546963741',
+      "maat_reference": '4546963',
       "representation_order_date": '2015-05-21'
     }
   end


### PR DESCRIPTION
#### What
Refine the MAAT validation 

#### Ticket

[MAAT reference validation: take 2!](https://dsdmoj.atlassian.net/browse/CBO-458)

#### Why
To try and prevent providers submitting obviously fake MAAT references, we regularly see `00000000` and `123456789`

#### How
Create a `Settings.maat_regexp` entry that will still allow use of test data, but that can be overwritten by env variable on individual environments if we need to refine this further

