### PR TITLE
Add missing LGFS API integration tests

### DIFF
--- a/spec/factories/offences.rb
+++ b/spec/factories/offences.rb
@@ -20,9 +20,18 @@ FactoryBot.define do
       description 'Miscellaneous/other'
     end
 
+    transient do
+      lgfs_fee_scheme false
+    end
+
     trait :with_fee_scheme do
-      after(:build) do |offence|
-        offence.fee_schemes << (FeeScheme.find_by(name: 'AGFS', version: 9) || build(:fee_scheme, :agfs_nine))
+      after(:build) do |offence, evaluator|
+        if evaluator.lgfs_fee_scheme
+          fee_scheme = FeeScheme.find_by(name: 'LGFS', version: 9) || build(:fee_scheme, :lgfs_nine)
+        else
+          fee_scheme = FeeScheme.find_by(name: 'AGFS', version: 9) || build(:fee_scheme, :agfs_nine)
+        end
+        offence.fee_schemes << fee_scheme
       end
     end
 


### PR DESCRIPTION
#### What
Adds the missing graduated fee, interim fee
and transfer fee claim API integration tests.

#### Ticket

[CBO-468](https://dsdmoj.atlassian.net/browse/CBO-468)

#### Why

These are currently only tested via the smoke test
but are valuable as a more immediate form of feedback/test
to ensure we do not break the API and to assist in debugging
bug/issue reports from API consumers.

#### How
extend existing API integration test suite