### PR TITLE
Use unpresented fee amount for field value

### DIFF
--- a/app/views/external_users/claims/graduated_fees/_fields.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_fields.html.haml
@@ -27,7 +27,7 @@
             error_key: "graduated_fee.quantity"
 
         .js-fee-calculator-success
-          = ff.hidden_field :price_calculated, value: fee.price_calculated?
+          = ff.hidden_field :price_calculated, value: ff.object.price_calculated?
 
         .js-fee-calculator-effectee
           .calculated-grad-fee
@@ -35,7 +35,7 @@
             label: t('.amount'),
             input_classes:"total fee-amount form-input-denote__input form-control-1-4",
             input_type: "currency",
-            value: number_with_precision(fee.amount, precision: 2),
+            value: number_with_precision(ff.object.amount, precision: 2),
             error_key: "graduated_fee.amount",
             errors: @error_presenter
 


### PR DESCRIPTION
This field was using a presented fee amount that
resulted in, for example, £20.00 in the
value attribute of the tag. Does not
have an impact on value saved when it is
changed but if fee calc is deactivated
(if we need too, by commenting `.calculated-grad-fee`
css class out in the view) it will not render the
presented amount as the input value.
