### PR TITLE
Fix price calculated for grad fee calc bug

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -367,6 +367,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
         :fee_type_id,
         :quantity,
         :amount,
+        :price_calculated,
         date_attributes_for(:date)
       ],
       interim_fee_attributes: [

--- a/app/views/external_users/claims/graduated_fees/_fields.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_fields.html.haml
@@ -26,9 +26,6 @@
             errors: @error_presenter,
             error_key: "graduated_fee.quantity"
 
-        .js-fee-calculator-success
-          = ff.hidden_field :price_calculated, value: ff.object.price_calculated?
-
         .js-fee-calculator-effectee
           .calculated-grad-fee
           = ff.adp_text_field :amount,
@@ -38,6 +35,9 @@
             value: number_with_precision(ff.object.amount, precision: 2),
             error_key: "graduated_fee.amount",
             errors: @error_presenter
+
+        .js-fee-calculator-success
+          = ff.hidden_field :price_calculated, value: ff.object.price_calculated?
 
         .help-wrapper.form-group{ style: 'display: none;' }
           %details

--- a/features/fee_calculator/advocate/fixed_fee_calculator.feature
+++ b/features/fee_calculator/advocate/fixed_fee_calculator.feature
@@ -96,3 +96,5 @@ Feature: Advocate completes fixed fee page using calculator
 
   Then I click "Continue" in the claim form
   And I am on the miscellaneous fees page
+
+  And all the fixed fees should have their price_calculated values set to true

--- a/features/fee_calculator/advocate/misc_fee_calculator.feature
+++ b/features/fee_calculator/advocate/misc_fee_calculator.feature
@@ -40,6 +40,9 @@ Feature: Advocate completes misc fee page using calculator
     And I eject the VCR cassette
 
     Then I click "Continue" in the claim form
+    And I should be in the 'Travel expenses' form page
+    And all the misc fees should have their price_calculated values set to true
+
     And I save as draft
     Then I should see 'Draft claim saved'
     And Claim 'A20174321' should be listed with a status of 'Draft' and a claimed amount of '£2,070.72'

--- a/features/fee_calculator/litigator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/litigator/fixed_fee_calculator.feature
@@ -59,3 +59,5 @@ Feature: litigator completes fixed fee page using calculator
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
+
+    And the fixed fee should have its price_calculated value set to true

--- a/features/fee_calculator/litigator/graduated_fee_calculator.feature
+++ b/features/fee_calculator/litigator/graduated_fee_calculator.feature
@@ -83,3 +83,5 @@ Feature: litigator completes graduated fee page using calculator
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
+
+    And the graduated fee should have its price_calculated value set to true

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -81,6 +81,10 @@ class ClaimFormPage < SitePrism::Page
   section :lgfs_supplier_number_radios, SupplierNumberRadioSection, '.lgfs-supplier-numbers'
   element :lgfs_supplier_number_select, 'select#claim_supplier_number'
 
+  def claim_id
+    find('#claim-form')['data-claim-id']
+  end
+
   def select_advocate(name)
     select name, from: "claim_external_user_id"
   end

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -199,6 +199,16 @@ Then(/^I should see the (.*) applicable basic fees$/) do |scheme_text|
   expect(@claim_form_page.basic_fees.checklist_labels).to match_array(additional_fees)
 end
 
+Then(/^all the fixed fees should have their price_calculated values set to true$/) do
+  claim = Claim::BaseClaim.find(@claim_form_page.claim_id)
+  expect(claim.fixed_fees.pluck(:price_calculated).all?).to eql true
+end
+
+Then(/^all the misc fees should have their price_calculated values set to true$/) do
+  claim = Claim::BaseClaim.find(@claim_form_page.claim_id)
+  expect(claim.misc_fees.pluck(:price_calculated).all?).to eql true
+end
+
 def scheme_9_additional_fees
   [
     'Daily attendance fee (3 to 40)',

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -158,3 +158,13 @@ end
 Then(/^I should see the additional info area$/) do
   expect(@claim_form_page.additional_information_expenses).to be_visible
 end
+
+Then(/^the graduated fee should have its price_calculated value set to true$/) do
+  claim = Claim::BaseClaim.find(@claim_form_page.claim_id)
+  expect(claim.graduated_fee.price_calculated).to eql true
+end
+
+Then(/^the fixed fee should have its price_calculated value set to true$/) do
+  claim = Claim::BaseClaim.find(@claim_form_page.claim_id)
+  expect(claim.fixed_fee.price_calculated).to eql true
+end


### PR DESCRIPTION
#### What
Fix bug whereby graduated fee calculation was not persisting `price_calculated` flag

#### Ticket

relates to [CBO-299](https://dsdmoj.atlassian.net/browse/CBO-299)

#### Why
bug fix, the flag was i believe primarily to prevent form navigation and saving as
draft resulting in a form state in which the fee cannot be calculated but is readonly
but need to check as the `pageLoad` js function may render this unnecessary now.

Is useful for stats in any event to determine how many fees have been "price calculated".
