### PR TITLE
Use unpresented fee rate for LGFS fixed fee rate

### DIFF
--- a/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
@@ -36,8 +36,8 @@
             input_classes:'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
             input_type: 'currency',
             errors: @error_presenter,
-            input_readonly: fee.price_calculated?,
-            value: number_with_precision(fee.rate, precision: 2)
+            input_readonly: ff.object.price_calculated?,
+            value: number_with_precision(ff.object.rate, precision: 2)
 
       .js-fee-calculator-success
         = ff.hidden_field :price_calculated, value: ff.object.price_calculated?


### PR DESCRIPTION
#### What
Change LGFS fixed fee rate input value to use unpresented fee object value

#### Why
This field was using a presented fee rate that
resulted in, for example, £20.00 in the
value attribute of the tag. Does not
have an impact on value saved as it is
recalculated but would have impact
if we need too deactivate fee calc, as the
presented value is ignored

#### TODO:
Note, quantity field uses presented value to apply "not a decimal"
`number_with_precision` logic but this leads to inconsistency and 
confusion.
