### PR TITLE
Rename the Claims::FeeCalculator::Calculate superclass

### DIFF
--- a/app/services/claims/fee_calculator/calculate_price.rb
+++ b/app/services/claims/fee_calculator/calculate_price.rb
@@ -8,7 +8,7 @@ module Claims
     Response = Struct.new(:success?, :data, :errors, :message, keyword_init: true)
     Data = Struct.new(:amount, :unit, keyword_init: true)
 
-    class Calculate
+    class CalculatePrice
       delegate  :earliest_representation_order_date,
                 :agfs?,
                 :lgfs?,

--- a/app/services/claims/fee_calculator/graduated_price.rb
+++ b/app/services/claims/fee_calculator/graduated_price.rb
@@ -5,7 +5,7 @@
 #
 module Claims
   module FeeCalculator
-    class GraduatedPrice < Calculate
+    class GraduatedPrice < CalculatePrice
       attr_reader :ppe, :days
 
       private

--- a/app/services/claims/fee_calculator/unit_price.rb
+++ b/app/services/claims/fee_calculator/unit_price.rb
@@ -10,7 +10,7 @@
 #
 module Claims
   module FeeCalculator
-    class UnitPrice < Calculate
+    class UnitPrice < CalculatePrice
       private
 
       def unit_price(modifier = nil)

--- a/spec/services/claims/fee_calculator/calculate_price_spec.rb
+++ b/spec/services/claims/fee_calculator/calculate_price_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Claims::FeeCalculator::Calculate do
+RSpec.describe Claims::FeeCalculator::CalculatePrice do
   subject { described_class.new(claim, params) }
 
   # IMPORTANT: use specific case type, offence class, fee types and reporder


### PR DESCRIPTION
#### What 
Refactor - rename CCCD Calculate service object

#### Why
As a super class of Graduated/UnitPrice it should 
be named similarly IMO.

