### PR TITLE
Improve indexes

### DIFF
--- a/db/migrate/20181123101017_add_index_to_claims_on_uuid.rb
+++ b/db/migrate/20181123101017_add_index_to_claims_on_uuid.rb
@@ -1,0 +1,7 @@
+class AddIndexToClaimsOnUuid < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def change
+    add_index :claims, :uuid, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20181123101919_add_deleted_at_index_to_claims.rb
+++ b/db/migrate/20181123101919_add_deleted_at_index_to_claims.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtIndexToClaims < ActiveRecord::Migration[5.0]
+  def change
+    add_index :claims, :deleted_at
+  end
+end

--- a/db/migrate/20181123101919_add_deleted_at_index_to_claims.rb
+++ b/db/migrate/20181123101919_add_deleted_at_index_to_claims.rb
@@ -1,5 +1,7 @@
 class AddDeletedAtIndexToClaims < ActiveRecord::Migration[5.0]
+  self.disable_ddl_transaction!
+
   def change
-    add_index :claims, :deleted_at
+    add_index :claims, :deleted_at, algorithm: :concurrently
   end
 end

--- a/db/migrate/20181123102020_add_claim_id_index_to_determinations.rb
+++ b/db/migrate/20181123102020_add_claim_id_index_to_determinations.rb
@@ -1,0 +1,5 @@
+class AddClaimIdIndexToDeterminations < ActiveRecord::Migration[5.0]
+  def change
+    add_index :determinations, :claim_id
+  end
+end

--- a/db/migrate/20181123102020_add_claim_id_index_to_determinations.rb
+++ b/db/migrate/20181123102020_add_claim_id_index_to_determinations.rb
@@ -1,5 +1,7 @@
 class AddClaimIdIndexToDeterminations < ActiveRecord::Migration[5.0]
+  self.disable_ddl_transaction!
+
   def change
-    add_index :determinations, :claim_id
+    add_index :determinations, :claim_id, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 20181115121652) do
     t.index ["cms_number"], name: "index_claims_on_cms_number", using: :btree
     t.index ["court_id"], name: "index_claims_on_court_id", using: :btree
     t.index ["creator_id"], name: "index_claims_on_creator_id", using: :btree
+    t.index ["deleted_at"], name: "index_claims_on_deleted_at", using: :btree
     t.index ["external_user_id"], name: "index_claims_on_external_user_id", using: :btree
     t.index ["form_id"], name: "index_claims_on_form_id", using: :btree
     t.index ["offence_id"], name: "index_claims_on_offence_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181115121652) do
+ActiveRecord::Schema.define(version: 20181123102020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -207,6 +207,7 @@ ActiveRecord::Schema.define(version: 20181115121652) do
     t.datetime "updated_at"
     t.float    "vat_amount",    default: 0.0
     t.decimal  "disbursements", default: "0.0"
+    t.index ["claim_id"], name: "index_determinations_on_claim_id", using: :btree
   end
 
   create_table "disbursement_types", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 20181115121652) do
     t.index ["offence_id"], name: "index_claims_on_offence_id", using: :btree
     t.index ["state"], name: "index_claims_on_state", using: :btree
     t.index ["transfer_case_number"], name: "index_claims_on_transfer_case_number", using: :btree
+    t.index ["uuid"], name: "index_claims_on_uuid", unique: true, using: :btree
     t.index ["valid_until"], name: "index_claims_on_valid_until", using: :btree
   end
 


### PR DESCRIPTION
#### What
Add indexes as detailed in the original PRs #2323, #2394 and #2402 
but updating to make the last one run concurrently and without  a transaction

#### Why
Again, see commit messages.

#### How
This will be deployed out of hours to prevent any table locking to a minimum