### PR TITLE
CBO-482: Update caseworker map links

### DIFF
--- a/app/helpers/case_workers/travel_helper.rb
+++ b/app/helpers/case_workers/travel_helper.rb
@@ -2,15 +2,28 @@
 # i.e. google map API
 #
 module CaseWorkers::TravelHelper
-  def link_to_map(body, options = {})
-    origin = options.delete(:origin)
-    destination = options.delete(:destination)
-    travelmode = options.delete(:travelmode) || 'driving'
+  def link_to_map(expense, options = {})
+    @expense = expense
+    @options = options
+    @origin = @options.delete(:origin)
+    @destination = @options.delete(:destination)
 
-    link_to(body, google_map_url(origin, destination, travelmode), options) if origin.present? && destination.present?
+    link_to(link_text, google_map_url(@origin, @destination, travel_mode), @options) if can_link?
   end
 
   private
+
+  def can_link?
+    @origin.present? && @destination.present?
+  end
+
+  def link_text
+    I18n.t(@expense.mileage_rate_id.eql?(2) ? 'view_public_transport_link' : 'view_car_journey_link')
+  end
+
+  def travel_mode
+    @expense.mileage_rate_id.eql?(2) ? 'transit' : @options.delete(:travelmode) || 'driving'
+  end
 
   def google_map_url(origin, destination, travelmode)
     "https://www.google.co.uk/maps/dir/?api=1&origin=#{origin}&destination=#{destination}&travelmode=#{travelmode}"

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -68,4 +68,12 @@ class ExpensePresenter < BasePresenter
   def mileage_rate
     expense.mileage_rate&.name || 'n/a'
   end
+
+  def show_map_link?
+    if expense.mileage_rate_id.eql?(1) && expense.distance <= expense.calculated_distance
+      false
+    else
+      true
+    end
+  end
 end

--- a/app/views/shared/summary/expenses/_details.html.haml
+++ b/app/views/shared/summary/expenses/_details.html.haml
@@ -27,8 +27,9 @@
               = t('.distance_calculated')
           = expense.pretty_calculated_distance
           %br/
-      %li
-        = link_to_map t('.view_map_link'), origin: claim.supplier_postcode, destination: expense.location_postcode, target: '_blank'
+      -if expense.show_map_link?
+        %li
+          = link_to_map expense, origin: claim.supplier_postcode, destination: expense.location_postcode, target: '_blank'
 
     - else
       - if expense.distance?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,8 @@ en:
       upload: 'Choose file to upload'
   maat_reference_number: 'MAAT reference'
   maat_reference_number_eg: 'for example 1234567'
+  view_car_journey_link: View car journey
+  view_public_transport_link: View public transport journey
 
   page_headings:
     edit_lgfs_claim: Edit litigator claim

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1278,7 +1278,7 @@ en:
       expense: Expense
       expenses:
         caption: &expenses_caption 'Expenses: A detailed list by Type including amount, distance and location where applicable'
-        travel_expense_additional_information: Additional expenses information
+        travel_expense_additional_information: Additional information
         travel_expenses: Travel expenses
         index:
           calculated_distance: Calculated distance

--- a/spec/helpers/case_workers/travel_helper_spec.rb
+++ b/spec/helpers/case_workers/travel_helper_spec.rb
@@ -4,27 +4,54 @@ RSpec.describe CaseWorkers::TravelHelper do
   it { is_expected.to respond_to :link_to_map }
 
   describe '#link_to_map' do
+    let(:expense) { create(:expense, :with_calculated_distance, mileage_rate_id: mileage_rate, location: 'Basildon', date: 3.days.ago) }
+
     subject(:link) do
-      Nokogiri::HTML.fragment(helper.link_to_map('Test my link', origin: 'SE9 2XX', destination: 'SE9 3XX', target: '_blank')).
+      Nokogiri::HTML.fragment(helper.link_to_map(expense, origin: 'SE9 2XX', destination: 'SE9 3XX', target: '_blank')).
         search('a').
         first
     end
 
-    it 'sets text of link' do
-      expect(link.text).to eql 'Test my link'
+    context 'when on the higher mileage rate' do
+      let(:mileage_rate) { 2 }
+
+      it 'sets text of link' do
+        expect(link.text).to eql 'View public transport journey'
+      end
+
+      it 'sets href attribute to google api with matching params' do
+        expect(link.attributes['href'].value).to match(/google.*origin=SE9 2XX.*destination=SE9 3XX.*travelmode=transit/)
+      end
+
+      it 'sets target of link' do
+        expect(link.attributes['target'].value).to match(/_blank/)
+      end
+
+      it 'passes other html options to link_to' do
+        expect(helper).to receive(:link_to).with('View public transport journey', link.attributes['href'].value, { target: '_not_a_real_value', class: 'not-a-class' })
+        helper.link_to_map(expense, origin: 'SE9 2XX', destination: 'SE9 3XX', target: '_not_a_real_value', class: 'not-a-class')
+      end
     end
 
-    it 'sets href attribute to google api with matching params' do
-      expect(link.attributes['href'].value).to match(/google.*origin=SE9 2XX.*destination=SE9 3XX.*travelmode=driving/)
-    end
+    context 'when on the lower mileage rate' do
+      let(:mileage_rate) { 1 }
 
-    it 'sets target of link' do
-      expect(link.attributes['target'].value).to match(/_blank/)
-    end
+      it 'sets text of link' do
+        expect(link.text).to eql 'View car journey'
+      end
 
-    it 'passes other html options to link_to' do
-      expect(helper).to receive(:link_to).with('Test message sending', link.attributes['href'].value, { target: '_not_a_real_value', class: 'not-a-class' })
-      helper.link_to_map('Test message sending', origin: 'SE9 2XX', destination: 'SE9 3XX', target: '_not_a_real_value', class: 'not-a-class')
+      it 'sets href attribute to google api with matching params' do
+        expect(link.attributes['href'].value).to match(/google.*origin=SE9 2XX.*destination=SE9 3XX.*travelmode=driving/)
+      end
+
+      it 'sets target of link' do
+        expect(link.attributes['target'].value).to match(/_blank/)
+      end
+
+      it 'passes other html options to link_to' do
+        expect(helper).to receive(:link_to).with('View car journey', link.attributes['href'].value, { target: '_not_a_real_value', class: 'not-a-class' })
+        helper.link_to_map(expense, origin: 'SE9 2XX', destination: 'SE9 3XX', target: '_not_a_real_value', class: 'not-a-class')
+      end
     end
   end
 end

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -223,4 +223,40 @@ RSpec.describe ExpensePresenter do
       it { is_expected.to eql 'Timbuktu' }
     end
   end
+
+  describe '#show_map_link?' do
+    subject { presenter.show_map_link? }
+
+    let(:claim) { create(:litigator_claim, :with_fixed_fee_case, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) }
+    let(:expense) { create(:expense, :car_travel, calculated_distance: calculated_distance, mileage_rate_id: mileage_rate, location: 'Basildon', date: 3.days.ago, claim: claim) }
+    let(:mileage_rate) { 1 }
+
+    context 'when the mileage rate is 45p' do
+      let(:mileage_rate) { 2 }
+
+      { accepted: 27, decreased: 28, increased: 26 }.each do |type, value|
+        context "and the distance is #{type}" do
+          let(:calculated_distance) { value }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when the mileage rate is 25p' do
+      { accepted: 27, decreased: 28 }.each do |type, value|
+        context "and the distance is #{type}" do
+          let(:calculated_distance) { value }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'and the distance is increased' do
+        let(:calculated_distance) { 26 }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
 end

--- a/spec/support/matchers/have_link_to.rb
+++ b/spec/support/matchers/have_link_to.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :have_link_to do |expected = nil|
+  match do |actual|
+    actual =~ /#{expected}/
+  end
+
+  failure_message do |actual|
+    "expected #{actual.inspect} to include a url of #{expected.inspect}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected #{actual.inspect} not to include a url of #{expected}"
+  end
+end


### PR DESCRIPTION
#### What
Refine the handling of the View map link on the caseworker claim view

#### Ticket
[CCCD: "View map" link on caseworker view](https://dsdmoj.atlassian.net/browse/CBO-482)

#### Why
Users were reporting confusion about when they needed to click on the link and what they needed to review

#### How
Update the helpers and presenters to refine the circumstances under which the link should be shown, where it should point and what the text should display
