### PR TITLE
Add fix for missing calculated distance

### DIFF
--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -70,7 +70,7 @@ class ExpensePresenter < BasePresenter
   end
 
   def show_map_link?
-    if expense.mileage_rate_id.eql?(1) && expense.distance <= expense.calculated_distance
+    if expense.mileage_rate_id&.eql?(1) && expense.distance <= (expense.calculated_distance ||= expense.distance)
       false
     else
       true

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -257,6 +257,12 @@ RSpec.describe ExpensePresenter do
 
         it { is_expected.to be true }
       end
+
+      context 'and the calculated_distance is nil' do
+        let(:calculated_distance) { nil }
+
+        it { is_expected.to be false }
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
Expenses without a calculated distance failed the presenter

#### Why
Examples were missed during testing

#### How
Add an override to compare `distance` with itself if the `calculated_distance` is missing