### PR TITLE
CBO-483: enhance additional travel information

### DIFF
--- a/app/interfaces/api/v1/claim_params_helper.rb
+++ b/app/interfaces/api/v1/claim_params_helper.rb
@@ -16,6 +16,9 @@ module API
         optional :providers_ref, type: String, desc: 'OPTIONAL: Providers reference number'
         optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
         optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
+        optional :travel_expense_additional_information,
+                 type: String,
+                 desc: I18n.t('api.v1.common_params.travel_expense_additional_information')
         optional :apply_vat, type: Boolean, desc: 'OPTIONAL: Include VAT (JSON Boolean data type: true or false)'
       end
 

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -31,7 +31,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         advocate_category defendant_uplifts_fixed_fees
       ],
       miscellaneous_fees: %i[defendant_uplifts_misc_fees],
-      travel_expenses: [],
+      travel_expenses: %i[travel_expense_additional_information],
       supporting_evidence: []
     }
   end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -358,10 +358,10 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def has_higher_rate_mileage?
-    @record.expenses.map { |s| s.mileage_rate_id.eql?(2) }.any?
+    @record.expenses.where(mileage_rate_id: 2).any?
   end
 
   def increased_travel?
-    @record.expenses.map { |x| x.calculated_distance && (x.distance > x.calculated_distance) }.any?
+    @record.expenses.where('calculated_distance IS NOT NULL AND (distance > calculated_distance)').any?
   end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -362,6 +362,6 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def increased_travel?
-    @record.expenses.where('calculated_distance IS NOT NULL AND (distance > calculated_distance)').any?
+    @record.expenses.where('distance > calculated_distance').any?
   end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -291,6 +291,13 @@ class Claim::BaseClaimValidator < BaseValidator
     add_error(:retrial_actual_length, 'too_long')
   end
 
+  def validate_travel_expense_additional_information
+    return if @record.from_api?
+    return unless @record.expenses.any?
+    validate_presence(:travel_expense_additional_information, 'higher_rate_travel_claimed') if has_higher_rate_mileage?
+    validate_presence(:travel_expense_additional_information, 'calculated_travel_increased') if increased_travel?
+  end
+
   def actual_length_consistent?(requires_dates, actual_length, start_date, end_date)
     requires_dates &&
       actual_length.present? &&
@@ -348,5 +355,13 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def validate_too_far_in_past(start_attribute)
     validate_on_or_after(Settings.earliest_permitted_date, start_attribute, 'check_not_too_far_in_past')
+  end
+
+  def has_higher_rate_mileage?
+    @record.expenses.map { |s| s.mileage_rate_id.eql?(2) }.any?
+  end
+
+  def increased_travel?
+    @record.expenses.map { |x| x.calculated_distance && (x.distance > x.calculated_distance) }.any?
   end
 end

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -23,6 +23,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
         legal_aid_transfer_date
         total
       ],
+      travel_expenses: %i[travel_expense_additional_information],
       supporting_evidence: []
     }
   end

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -16,6 +16,7 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
       offence_details: %i[offence],
       graduated_fees: %i[actual_trial_length total],
       miscellaneous_fees: %i[defendant_uplifts],
+      travel_expenses: %i[travel_expense_additional_information],
       supporting_evidence: []
     }
   end

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -33,6 +33,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
       defendants: [],
       offence_details: %i[offence],
       transfer_fees: %i[transfer_fee total],
+      travel_expenses: %i[travel_expense_additional_information],
       supporting_evidence: []
     }
   end

--- a/app/views/external_users/claims/expenses/_textarea_additional_info.html.haml
+++ b/app/views/external_users/claims/expenses/_textarea_additional_info.html.haml
@@ -1,7 +1,7 @@
 %h2.heading-medium
   = t('.additional_info_heading')
-.form-group
-  %label.form-label{:for => "travel-expenses-additional-information"}
-    = t('.additional_info_label')
-
-  = f.text_area :travel_expense_additional_information, class: 'form-control form-control-full-textarea', id: 'travel-expenses-additional-information', rows: 5, 'aria-describedby': 'additional-info-hint'
+.form-group{ class: ('field_with_errors form-group-error' if validation_error_message(@error_presenter, 'travel_expense_additional_information').present?) }
+  %label.form-hint{:for => "travel_expense_additional_information"}
+    = t(".#{@claim.agfs? ? 'agfs' : 'lgfs'}_additional_info_label")
+    = validation_error_message(@error_presenter, 'travel_expense_additional_information')
+  = f.text_area :travel_expense_additional_information, class: 'form-control form-control-full-textarea', id: 'travel_expense_additional_information', rows: 5, 'aria-describedby': 'additional-info-hint'

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -11,6 +11,35 @@
 
 %section.api-documentation
   %hr
+  %h2 3rd December 2018
+  %ul.list-bullet
+    %li
+      Adding new travel expense additional information field to claim endpoints
+      %br/
+      %br/
+      An additional field,
+      %code.code
+        travel_expense_additional_information
+      , has been added to all of the claim endpoints in the
+      API.  It is currently optional, but at a future date we will start to enforce validation in line with the web
+      interface.
+      %br/
+      %br/
+      The validation rule that will come into effect on the API in the future is:
+      %br/
+      If any of the travel expenses have their
+      %code.code
+        mileage_rate_id
+      values set to
+      %code.code
+        2
+      then the associated claim must have been created with
+      %code.code
+        travel_expense_additional_information
+      set
+
+%section.api-documentation
+  %hr
   %h2 05 November 2018
   %ul.list-bullet
     %li

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -846,8 +846,9 @@ en:
           remove: "Remove disbursement"
       expenses:
         textarea_additional_info:
-          additional_info_heading: Additional information (optional)
-          additional_info_label: Provide any information that will help in the assessment of your expenses
+          additional_info_heading: Additional information
+          agfs_additional_info_label: 'Provide any information that will help in the assessment of your expenses. For example, if you claim the private mileage rate on travel expenses, we need to know why.'
+          lgfs_additional_info_label: 'Provide any information that will help in the assessment of your expenses. For example, if you claim the private mileage rate or increase the mileage on travel expenses, we need to know why.'
         expense_fields:
           summary_heading: "How we calculate the distance"
           summary_content: |
@@ -1276,7 +1277,7 @@ en:
       expense: Expense
       expenses:
         caption: &expenses_caption 'Expenses: A detailed list by Type including amount, distance and location where applicable'
-        travel_expense_additional_information: Additional expenses information
+        travel_expense_additional_information: Additional information
         travel_expenses: Travel expenses
         index:
           calculated_distance: Calculated distance

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -847,8 +847,13 @@ en:
       expenses:
         textarea_additional_info:
           additional_info_heading: Additional information
-          agfs_additional_info_label: 'Provide any information that will help in the assessment of your expenses. For example, if you claim the private mileage rate on travel expenses, we need to know why.'
-          lgfs_additional_info_label: 'Provide any information that will help in the assessment of your expenses. For example, if you claim the private mileage rate or increase the mileage on travel expenses, we need to know why.'
+          agfs_additional_info_label: |
+            Provide any information that will help in the assessment of your expenses.
+            For example, if you claim the private mileage rate on travel expenses, we need to know why.
+          lgfs_additional_info_label: |
+            Provide any information that will help in the assessment of your expenses.
+            For example, if you claim the private mileage rate or increase the mileage
+            on travel expenses, we need to know why.'
         expense_fields:
           summary_heading: "How we calculate the distance"
           summary_content: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1631,6 +1631,7 @@ en:
       common_params:
         creator_email: 'REQUIRED: The ADP administrator account email address that uniquely identifies the creator of the claim.'
         user_email: 'REQUIRED: The ADP account email address that uniquely identifies the advocate/litigator to whom this claim belongs.'
+        travel_expense_additional_information: 'OPTIONAL: Any additional information regarding travel expenses, e.g. private mileage rate reasons'
       dropdown_data:
         params:
           role_filter: 'OPTIONAL: The role to filter the results. If not provided, all results are returned.'

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -515,6 +515,17 @@ legal_aid_transfer_date:
     short: Date not allowed
     api: The date Legal Aid was transferred is not allowed
 
+travel_expense_additional_information:
+  _seq: 215
+  higher_rate_travel_claimed:
+    long: 'You should provide details of why you have claimed private mileage rate travel'
+    short: 'Provide details for private mileage rate'
+    api: 'Provide details for private mileage rate'
+  calculated_travel_increased:
+    long: 'You should provide details of why you have increased some of your travel distances'
+    short: 'Provide details for increased travel distance'
+    api: 'Provide details for increased travel distance'
+
 #################################################################################
 #                                                                               #
 #   TRANSFER DETAIL                                                             #

--- a/spec/api/entities/expense_spec.rb
+++ b/spec/api/entities/expense_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe API::Entities::Expense do
 
-  let(:expense) { build(:expense, :car_travel, date: Date.new(1995, 6, 20), location: 'Here', quantity: 148.0, rate: 0.25, amount: 37.0, vat_amount: 5.2) }
+  let(:expense) { build(:expense, :car_travel, date: Date.new(1995, 6, 20), mileage_rate_id: 2, location: 'Here', quantity: 148.0, rate: 0.25, amount: 37.0, vat_amount: 5.2) }
 
   it 'represents the expense entity' do
     result = described_class.represent(expense)

--- a/spec/api/v1/external_users/claims/integration/litigator_claim_creation.rb
+++ b/spec/api/v1/external_users/claims/integration/litigator_claim_creation.rb
@@ -95,6 +95,7 @@ RSpec.describe 'API claim creation for LGFS' do
       offence_id: nil,
       actual_trial_length: nil,
       court_id: court.id,
+      travel_expense_additional_information: 'Rail works required private car',
       additional_information: 'Bish bosh bash'
     }
   end

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -34,8 +34,8 @@ FactoryBot.define do
     trait :car_travel do
       expense_type  { build :expense_type, :car_travel }
       distance 27
-      mileage_rate_id 2
-      amount "12.15"
+      mileage_rate_id 1
+      amount "6.75"
     end
 
     trait :with_calculated_distance do

--- a/spec/lib/geckoboard_publisher/travel_automation_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/travel_automation_report_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe GeckoboardPublisher::TravelAutomationReport, geckoboard: true do
         {
           date: "2017-03-19",
           accepted: 0,
-          cost_increased: 9,
+          cost_increased: 5,
           cost_reduction: 0,
           increased: 2,
           percent_accepted: 0,
@@ -59,7 +59,7 @@ RSpec.describe GeckoboardPublisher::TravelAutomationReport, geckoboard: true do
           date: "2017-03-21",
           accepted: 0,
           cost_increased: 0,
-          cost_reduction: 9,
+          cost_reduction: 5,
           increased: 0,
           percent_accepted: 0,
           percent_increased: 0,
@@ -72,8 +72,7 @@ RSpec.describe GeckoboardPublisher::TravelAutomationReport, geckoboard: true do
 
     before do
       travel_to(Date.parse('19-MAR-2017')) do
-        lgfs_claim = create(:litigator_claim, :submitted)
-
+        lgfs_claim = create(:litigator_claim, :submitted, travel_expense_additional_information: 'explanation')
         create_list(:expense, 2, :with_calculated_distance_increased, date: 3.days.ago, claim: lgfs_claim)
       end
 

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
     basic_fees: %i[total advocate_category defendant_uplifts_basic_fees],
     fixed_fees: %i[total advocate_category defendant_uplifts_fixed_fees],
     miscellaneous_fees: %i[defendant_uplifts_misc_fees],
-    travel_expenses: [],
+    travel_expenses: %i[travel_expense_additional_information],
     supporting_evidence: []
   }
 end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -701,4 +701,182 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       end
     end
   end
+
+  context 'travel expense additional information' do
+      subject { claim.valid? }
+
+      before do
+        claim.expenses.delete_all
+        create(:expense, :car_travel, calculated_distance: calculated_distance, mileage_rate_id: mileage_rate, location: 'Basildon', date: 3.days.ago, claim: claim)
+        claim.reload
+        claim.form_step = :travel_expenses
+      end
+
+      context 'from the web' do
+        context 'when the claim has no additional travel information' do
+          let(:additional_travel_info) { nil }
+
+          context 'when the mileage rate is lower' do
+            let(:mileage_rate) { 1 }
+
+            context 'and the calculated distance is accepted' do
+              let(:calculated_distance) { 27 }
+
+              it { is_expected.to be true }
+            end
+
+            context 'and the calculated distance is reduced' do
+              let(:calculated_distance) { 28 }
+
+              it { is_expected.to be true }
+            end
+
+            context 'and the calculated distance is increased' do
+              let(:calculated_distance) { 26 }
+
+              it { is_expected.to be false }
+            end
+
+            context 'and the calculated distance is nil' do
+              let(:calculated_distance) { nil }
+
+              it { is_expected.to be true  }
+            end
+          end
+
+          context 'when the mileage rate is higher' do
+            let(:mileage_rate) { 2 }
+
+            context 'and the calculated distance is accepted' do
+              let(:calculated_distance) { 27 }
+
+              it { is_expected.to be false }
+            end
+
+            context 'and the calculated distance is reduced' do
+              let(:calculated_distance) { 28 }
+
+              it { is_expected.to be false }
+            end
+
+            context 'and the calculated distance is increased' do
+              let(:calculated_distance) { 26 }
+
+              it { is_expected.to be false }
+            end
+
+            context 'and the calculated distance is nil' do
+              let(:calculated_distance) { nil }
+
+              it { is_expected.to be false }
+            end
+          end
+        end
+        context 'when the claim has additional travel information' do
+          before { claim.travel_expense_additional_information = 'this is info' }
+
+          context 'when the mileage rate is lower' do
+            let(:mileage_rate) { 1 }
+
+            context 'and the calculated distance is accepted' do
+              let(:calculated_distance) { 27 }
+
+              it { is_expected.to be true }
+            end
+
+            context 'and the calculated distance is reduced' do
+              let(:calculated_distance) { 28 }
+
+              it { is_expected.to be true }
+            end
+
+            context 'and the calculated distance is increased' do
+              let(:calculated_distance) { 26 }
+
+              it { is_expected.to be true }
+            end
+
+            context 'and the calculated distance is nil' do
+              let(:calculated_distance) { nil }
+
+              it { is_expected.to be true  }
+            end
+          end
+
+          context 'when the mileage rate is higher' do
+            let(:mileage_rate) { 2 }
+
+            context 'and the calculated distance is accepted' do
+              let(:calculated_distance) { 27 }
+
+              it { is_expected.to be true }
+            end
+
+            context 'and the calculated distance is reduced' do
+              let(:calculated_distance) { 28 }
+
+              it { is_expected.to be true }
+            end
+
+            context 'and the calculated distance is increased' do
+              let(:calculated_distance) { 26 }
+
+              it { is_expected.to be true }
+            end
+          end
+        end
+      end
+
+      context 'from the API' do
+        before { claim.source = 'api' }
+
+        context 'when the claim has no additional travel information' do
+          let(:additional_travel_info) { nil }
+
+          context 'when the mileage rate is lower' do
+            let(:mileage_rate) { 1 }
+
+            context 'and the calculated distance is nil' do
+              let(:calculated_distance) { nil }
+
+              it { is_expected.to be true }
+            end
+          end
+
+          context 'when the mileage rate is higher' do
+            let(:mileage_rate) { 2 }
+
+            context 'and the calculated distance is nil' do
+              let(:calculated_distance) { nil }
+
+              it { is_expected.to be true  }
+            end
+          end
+        end
+
+        context 'when the claim has additional travel information' do
+          before { claim.travel_expense_additional_information = 'this is info' }
+
+          context 'when the mileage rate is lower' do
+            let(:mileage_rate) { 1 }
+
+            context 'and the calculated distance is nil' do
+              let(:calculated_distance) { nil }
+
+              it { is_expected.to be true }
+            end
+          end
+
+          context 'when the mileage rate is higher' do
+            let(:mileage_rate) { 2 }
+
+            context 'and the calculated distance is nil' do
+              let(:calculated_distance) { nil }
+
+              it { is_expected.to be true  }
+            end
+          end
+        end
+      end
+    end
 end

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
       legal_aid_transfer_date
       total
     ],
+    travel_expenses: %i[travel_expense_additional_information],
     supporting_evidence: []
   }
 

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
     offence_details: %i[offence],
     graduated_fees: %i[actual_trial_length total],
     miscellaneous_fees: %i[defendant_uplifts],
+    travel_expenses: %i[travel_expense_additional_information],
     supporting_evidence: []
   }
 

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
     defendants: [],
     offence_details: %i[offence],
     transfer_fees: %i[transfer_fee total],
+    travel_expenses: %i[travel_expense_additional_information],
     supporting_evidence: []
   }
 


### PR DESCRIPTION
#### What
Acceptance Criteria
* Remove "(optional)" from the additional information input label on the travel information page
* Add validation to the additional information, if a car travel distance has changed; or, a 45p rate has been chosen on any expense
  - Display an error message if additional information is not provided when a user has claimed mileage at 45p
    > tell  us why at least one of your expenses has been claimed at 45p
  - display an error message if additional information is not provided when a user has increased the automatically calculated distance
    > tell us why you have increased the distance travelled for at least one of your expenses
* Update the form hint: "Provide any information that will help in the assessment of your expenses. For example, if you increase mileage on travel expenses, we need to know why."

#### Ticket
[Update additional information feature on travel expenses page](https://dsdmoj.atlassian.net/browse/CBO-483)

#### Why
The provision of the additional information will, more frequently, allow case workers to assess the claim during the initial assessment.  If they have to message and ask for the data, the assessments are delayed and it takes longer for the providers to receive their payments.

#### How
* Update the hint text and labelling
* Increase the validation
* Update the API to allow submission of additional information (but not yet validate)

#### TODO (wip)
- [x] Update the label (remove optional)
- [x] Update the hint text
- [x] Validate presence of info if provider has claimed higher rate mileage (web)
- [X] Validate presence of info if provider has increased calculated distance (web)
- [x] Add `travel_expense_additional_information` to claim endpoints on the API
- [x] Update release notes to alert Software vendors 