### PR TITLE
Replace Travel information validation

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -358,10 +358,10 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def has_higher_rate_mileage?
-    @record.expenses.where(mileage_rate_id: 2).any?
+    @record.expenses.find { |x| x.mileage_rate_id.eql?(2) }
   end
 
   def increased_travel?
-    @record.expenses.where('distance > calculated_distance').any?
+    @record.expenses.find { |x| x.calculated_distance && (x.distance > x.calculated_distance) }
   end
 end


### PR DESCRIPTION
#### What
Make the new additional-travel-information validation work

#### Why
The map methods were swapped out for `where` queries that failed
because the objects hadn't been persisted to the database yet.

#### How
Restoring to find queries that are quicker than map, but work on the
objects in memory
