### PR TITLE
Fix for travel automation fix

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -362,6 +362,6 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def increased_travel?
-    @record.expenses.find { |x| x.calculated_distance && (x.distance > x.calculated_distance) }
+    @record.expenses.find { |x| x.calculated_distance && x.distance && (x.distance > x.calculated_distance) }
   end
 end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -703,8 +703,8 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
   end
 
   context 'travel expense additional information' do
-      subject { claim.valid? }
-
+    subject { claim.valid? }
+    context 'for car travel' do
       before do
         claim.expenses.delete_all
         create(:expense, :car_travel, calculated_distance: calculated_distance, mileage_rate_id: mileage_rate, location: 'Basildon', date: 3.days.ago, claim: claim)
@@ -879,4 +879,5 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         end
       end
     end
+  end
 end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -879,5 +879,16 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         end
       end
     end
+
+    context 'with simulation of duplicated car_travel > parking' do
+      before do
+        claim.expenses.delete_all
+        create(:expense, :parking, calculated_distance: 27, distance: nil, date: 3.days.ago, claim: claim)
+        claim.reload
+        claim.form_step = :travel_expenses
+      end
+
+      it { is_expected.to be true  }
+    end
   end
 end


### PR DESCRIPTION
#### What
Fix for the previous fix for validating additional travel information introduced a regression failure

#### Why
Users were creating a car_travel expense, duplicating it, and changing it to parking.

#### How
This requires checking for the presence of both `distance` and `calculated_distance`.  Using safe navigation operators with numeric comparisons is blocked, so 
```
x&.distance > x&.calculated_distance
``` 
will generate new and exciting errors :(
