### PR TITLE
CBO-515: travel automation status designs

### DIFF
--- a/app/assets/stylesheets/v1/moj/_tables.scss
+++ b/app/assets/stylesheets/v1/moj/_tables.scss
@@ -105,7 +105,8 @@ span.state {
   border-width: 2px;
   border-style: solid;
   background: #fff;
-  &.state-authorised {
+  &.state-authorised,
+  &.state-accepted {
     color: #00602b;
     border-color: #00602b;
   }
@@ -118,7 +119,8 @@ span.state {
     border-color: #1d5780;
   }
   &.state-rejected,
-  &.state-refused {
+  &.state-refused,
+  &.state-unverified {
     color: #99181a;
     border-color: #99181a;
   }

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -76,4 +76,22 @@ class ExpensePresenter < BasePresenter
       true
     end
   end
+
+  def state
+    if expense.mileage_rate_id&.eql?(1) &&
+       expense.calculated_distance.present? &&
+       (expense.distance <= expense.calculated_distance)
+      'Accepted'
+    else
+      'Unverified'
+    end
+  end
+
+  def distance_label
+    if expense.calculated_distance.present? && (expense.distance <= expense.calculated_distance)
+      '.distance'
+    else
+      '.distance_claimed'
+    end
+  end
 end

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -70,7 +70,7 @@ class ExpensePresenter < BasePresenter
   end
 
   def show_map_link?
-    if expense.mileage_rate_id&.eql?(1) && expense.distance <= (expense.calculated_distance ||= expense.distance)
+    if expense.mileage_rate_id&.eql?(1) && distance_reduced_or_accepted?
       false
     else
       true
@@ -78,9 +78,7 @@ class ExpensePresenter < BasePresenter
   end
 
   def state
-    if expense.mileage_rate_id&.eql?(1) &&
-       expense.calculated_distance.present? &&
-       (expense.distance <= expense.calculated_distance)
+    if expense.mileage_rate_id&.eql?(1) && distance_acceptable?
       'Accepted'
     else
       'Unverified'
@@ -88,10 +86,20 @@ class ExpensePresenter < BasePresenter
   end
 
   def distance_label
-    if expense.calculated_distance.present? && (expense.distance <= expense.calculated_distance)
+    if distance_acceptable?
       '.distance'
     else
       '.distance_claimed'
     end
+  end
+
+  private
+
+  def distance_acceptable?
+    expense.calculated_distance.present? && distance_reduced_or_accepted?
+  end
+
+  def distance_reduced_or_accepted?
+    (expense.distance <= expense.calculated_distance ||= expense.distance)
   end
 end

--- a/app/views/shared/summary/expenses/_details.html.haml
+++ b/app/views/shared/summary/expenses/_details.html.haml
@@ -38,7 +38,7 @@
             = t('.distance')
         = "#{expense.distance} miles"
 
-    %li{ class: ('error' if expense.mileage_rate_id.eql?(2)) }
+    %li{ class: ('error' if current_user_is_caseworker? && expense.mileage_rate_id.eql?(2)) }
       %span.bold
         = succeed ':' do
           = t('.cost')

--- a/app/views/shared/summary/expenses/_details.html.haml
+++ b/app/views/shared/summary/expenses/_details.html.haml
@@ -18,7 +18,7 @@
       %li{ class: ('error' if expense.distance_gt_calculated?) }
         %span.bold
           = succeed ':' do
-            = expense.distance_gt_calculated? ? t('.distance_claimed') : t('.distance')
+            = t(expense.distance_label)
         = "#{expense.distance} miles"
       - if expense.distance_gt_calculated?
         %li{ class: ('error' if expense.distance_gt_calculated?) }
@@ -38,7 +38,7 @@
             = t('.distance')
         = "#{expense.distance} miles"
 
-    %li
+    %li{ class: ('error' if expense.mileage_rate_id.eql?(2)) }
       %span.bold
         = succeed ':' do
           = t('.cost')

--- a/app/views/shared/summary/expenses/show.html.haml
+++ b/app/views/shared/summary/expenses/show.html.haml
@@ -2,8 +2,9 @@
   %td{scope: 'row', style: 'width: 20%'}
     %span.bold-normal
       = expense.name
-    %span.state{ class: "state-#{expense.state.downcase}" }
-      = expense.state
+    - if current_user_is_caseworker?
+      %span.state{ class: "state-#{expense.state.downcase}" }
+        = expense.state
   %td{scope: 'row', style: 'width: 12%'}
     %span.bold-normal
       = expense.reason

--- a/app/views/shared/summary/expenses/show.html.haml
+++ b/app/views/shared/summary/expenses/show.html.haml
@@ -2,6 +2,8 @@
   %td{scope: 'row', style: 'width: 20%'}
     %span.bold-normal
       = expense.name
+    %span.state{ class: "state-#{expense.state.downcase}" }
+      = expense.state
   %td{scope: 'row', style: 'width: 12%'}
     %span.bold-normal
       = expense.reason

--- a/spec/presenters/expense_presenter_spec.rb
+++ b/spec/presenters/expense_presenter_spec.rb
@@ -265,4 +265,103 @@ RSpec.describe ExpensePresenter do
       end
     end
   end
+
+  describe '#state' do
+    subject { presenter.state }
+
+    let(:claim) { create(:litigator_claim, :with_fixed_fee_case, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) }
+    let(:expense) { create(:expense, :car_travel, calculated_distance: calculated_distance, mileage_rate_id: mileage_rate, location: 'Basildon', date: 3.days.ago, claim: claim) }
+    let(:mileage_rate) { 1 }
+
+    context 'when the expense has public standard mileage rate' do
+      { accepted: { accepted: 27, decreased: 28 }, unverified: { increased: 26, nil: nil } }.each do |expected, values|
+        values.each do |type, value|
+          context "it #{type.eql?('nil') ? 'has not' : 'has'} been calculated and the distance is #{type}" do
+            let(:calculated_distance) { value }
+
+            it { is_expected.to eql expected.to_s.humanize }
+          end
+        end
+      end
+    end
+
+    context 'when the expense has private mileage rate' do
+      let(:mileage_rate) { 2 }
+      { unverified: { accepted: 27, decreased: 28, increased: 26, nil: nil } }.each do |expected, values|
+        values.each do |type, value|
+          context "it #{type.eql?('nil') ? 'has not' : 'has'} been calculated and the distance is #{type}" do
+            let(:calculated_distance) { value }
+
+            it { is_expected.to eql expected.to_s.humanize }
+          end
+        end
+      end
+    end
+  end
+
+  describe '#distance_label' do
+    subject { presenter.distance_label }
+
+    let(:claim) { create(:litigator_claim, :with_fixed_fee_case, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) }
+    let(:expense) { create(:expense, :car_travel, calculated_distance: calculated_distance, mileage_rate_id: mileage_rate, location: 'Basildon', date: 3.days.ago, claim: claim) }
+    let(:mileage_rate) { 1 }
+
+    context 'when the expense has public standard mileage rate' do
+      context 'when the distance has been calculated' do
+        context 'and has been accepted' do
+          let(:calculated_distance) { 27 }
+
+          it { is_expected.to eql '.distance' }
+        end
+
+        context 'and has been reduced' do
+          let(:calculated_distance) { 28 }
+
+          it { is_expected.to eql '.distance' }
+        end
+
+        context 'and has been increased' do
+          let(:calculated_distance) { 26 }
+
+          it { is_expected.to eql '.distance_claimed' }
+        end
+      end
+      
+      context 'when the distance has not been calculated' do
+        let(:calculated_distance) { nil }
+
+        it { is_expected.to eql '.distance_claimed' }
+      end
+    end
+
+    context 'when the expense has private mileage rate' do
+      let(:mileage_rate) { 2 }
+
+      context 'when the distance has been calculated' do
+        context 'and has been accepted' do
+          let(:calculated_distance) { 27 }
+
+          it { is_expected.to eql '.distance' }
+        end
+
+        context 'and has been reduced' do
+          let(:calculated_distance) { 28 }
+
+          it { is_expected.to eql '.distance' }
+        end
+
+        context 'and has been increased' do
+          let(:calculated_distance) { 26 }
+
+          it { is_expected.to eql '.distance_claimed' }
+        end
+      end
+
+      context 'when the distance has not been calculated' do
+        let(:calculated_distance) { nil }
+
+        it { is_expected.to eql '.distance_claimed' }
+      end
+    end
+  end
 end

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -138,6 +138,8 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
   end
 
   context 'calculated travel expense' do
+    subject { rendered }
+
     let(:claim) { build(:litigator_claim, :with_fixed_fee_case, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) }
     let!(:establishment) { create(:establishment, :crown_court, name: 'Basildon', postcode: 'SS14 2EW') }
 
@@ -155,6 +157,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
 
       it 'does not render a map link' do
         expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+        expect(rendered).to have_content('Accepted')
       end
     end
 
@@ -163,6 +166,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
 
       it 'does not render a map link' do
         expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+        expect(rendered).to have_content('Accepted')
       end
     end
 
@@ -172,6 +176,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
       it 'renders a map link' do
         expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
         expect(rendered).to have_link('View car journey')
+        expect(rendered).to have_content('Unverified')
       end
     end
 
@@ -181,6 +186,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
       it 'renders a map link' do
         expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
         expect(rendered).to have_link('View public transport journey')
+        expect(rendered).to have_content('Unverified')
       end
     end
 
@@ -190,6 +196,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
       it 'renders a map link' do
         expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
         expect(rendered).to have_link('View public transport journey')
+        expect(rendered).to have_content('Unverified')
       end
     end
 
@@ -199,6 +206,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
       it 'renders a map link' do
         expect(rendered).to have_link_to(/www.google.co.uk\/maps/)
         expect(rendered).to have_link('View public transport journey')
+        expect(rendered).to have_content('Unverified')
       end
     end
   end

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe 'external_users/claims/show.html.haml', type: :view do
         expect(rendered).to have_selector('div', text: 'Litigator account number')
       end
     end
+
+    describe 'Fees, expenses and more information' do
+      context 'when travel expenses have been calculated' do
+        let!(:expense) { create(:expense, :with_calculated_distance_increased, mileage_rate_id: 2, location: 'Basildon',date: 3.days.ago, claim: claim) }
+
+        it 'should not render state labels' do
+          claim.reload
+          render
+          expect(rendered).to_not have_selector('span.state.state-unverified', text: 'Unverified')
+        end
+      end
+    end
   end
 
   context 'Interim claims' do


### PR DESCRIPTION
#### What
Provide better guidance for caseworkers on when to assess travel expenses

#### Ticket
[CCCD: Implement Travel automation design ticket](https://dsdmoj.atlassian.net/browse/CBO-515)


#### Why
There has been some confusion around the need to process all travel expenses, this implements the designs in ticket CBO-484 that have been designed to reduce the cognitive load of case workers.  It endeavours to highlight only those travel expenses that need caseworker assessment

#### TODO (wip)

 - [X] Implement the designs from [CCCD: Create design for travel item assessment status](https://dsdmoj.atlassian.net/browse/CBO-484)
 - [x] Check edge cases in testing to ensure coverage of expense duplication issues