### PR TITLE
Update the MI transformation to export PPE correctly

### DIFF
--- a/spec/services/transform/claim_spec.rb
+++ b/spec/services/transform/claim_spec.rb
@@ -42,5 +42,23 @@ RSpec.describe Transform::Claim do
         expect(call[:claim_type]).to eq 'Advocate final claim'
       end
     end
+
+    describe '#ppe' do
+      subject(:ppe) { call[:ppe] }
+
+      context 'when the claim is agfs' do
+        let(:basic_fee) { create(:basic_fee, :ppe_fee, quantity: 1024, rate: 25) }
+        let(:claim) { create :archived_pending_delete_claim, basic_fees: [basic_fee] }
+
+        it { is_expected.to eq 1024 }
+      end
+
+      context 'when the claim is lgfs' do
+        let(:grad_fee) { create :graduated_fee, quantity: 2048 }
+        let(:claim) { create :litigator_claim, :archived_pending_delete, fees: [grad_fee] }
+
+        it { is_expected.to eq 2048 }
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What
Improve the MI data export prior to deletion

#### Why
Previously the code only looked at FeeTypes `BAPPE` that is used by AGFS claims only.  Therefore all 

#### How
This enhancement now extracts the quantity from the appropriate LGFS fee by type as well as still reading `BAPPE` from AGFS
