### PR TITLE
Update InjectionResponseService

### DIFF
--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -10,8 +10,8 @@ class InjectionResponseService
     slack.build_injection_payload(@response)
     return failure(action: 'run!', uuid: @response['uuid']) unless @claim
 
-    create_injection_attempt
-    slack.send_message!
+    injection_attempt = create_injection_attempt
+    slack.send_message! unless injection_attempt.succeeded?
     true
   end
 

--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -46,6 +46,11 @@ end
         run!
         expect(injection_attempt.succeeded).to be_truthy
       end
+
+      it 'does not send a slack message' do
+        run!
+        expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).not_to have_been_made
+      end
     end
 
     context 'when injection failed' do
@@ -55,6 +60,11 @@ end
       it 'marks injection as failed' do
         run!
         expect(injection_attempt.succeeded).to be_falsey
+      end
+
+      it 'sends a slack message' do
+        run!
+        expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made.times(1)
       end
 
       it 'adds error messages from the response' do


### PR DESCRIPTION
#### What
Only send slack notification when injection fails

#### Ticket
[Remove success from the injection channels](https://dsdmoj.atlassian.net/browse/CBO-508)

#### Why
As a product manager, or any other team member with access to the Slack channels, I want:
1. to enter the CCR and CCLF data injection slack channels and see only Katy Perry.

#### How
Add an `unless successful` check to the slack notification call