### PR TITLE
CBO-517: Enhance private milage travel validation

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -146,6 +146,15 @@ class Expense < ApplicationRecord
     distance > calculated_distance
   end
 
+  def establishment
+    return unless expense_type.car_travel?
+    Establishment.find_by(name: location)
+  end
+
+  def establishment_category
+    establishment&.category
+  end
+
   private
 
   # we only calculate VAT for AGFS claims for vatable providers.  On LGFS claims, the VAT amount is entered in the form.

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -151,10 +151,6 @@ class Expense < ApplicationRecord
     Establishment.find_by(name: location)
   end
 
-  def establishment_category
-    establishment&.category
-  end
-
   private
 
   # we only calculate VAT for AGFS claims for vatable providers.  On LGFS claims, the VAT amount is entered in the form.

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -359,7 +359,7 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def has_higher_rate_mileage?
     destinations = %w[magistrates_court prison]
-    @record.expenses.find { |x| x.mileage_rate_id.eql?(2) && destinations.exclude?(x.establishment_category) }
+    @record.expenses.find { |x| x.mileage_rate_id.eql?(2) && destinations.exclude?(x&.establishment&.category) }
   end
 
   def increased_travel?

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -358,7 +358,8 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def has_higher_rate_mileage?
-    @record.expenses.find { |x| x.mileage_rate_id.eql?(2) }
+    exclude_types = %w[magistrates_court prison]
+    @record.expenses.find { |x| x.mileage_rate_id.eql?(2) && exclude_types.exclude?(x.establishment_category) }
   end
 
   def increased_travel?

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -358,8 +358,8 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   def has_higher_rate_mileage?
-    exclude_types = %w[magistrates_court prison]
-    @record.expenses.find { |x| x.mileage_rate_id.eql?(2) && exclude_types.exclude?(x.establishment_category) }
+    destinations = %w[magistrates_court prison]
+    @record.expenses.find { |x| x.mileage_rate_id.eql?(2) && destinations.exclude?(x.establishment_category) }
   end
 
   def increased_travel?

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -194,37 +194,4 @@ RSpec.describe Expense, type: :model do
       it { is_expected.to be nil }
     end
   end
-
-  describe 'establishment_category' do
-    subject { expense.establishment_category }
-
-    context 'when the expense is car travel' do
-      let(:expense) do
-        build(:expense, :car_travel, calculated_distance: calculated_distance, location: location, date: 3.days.ago)
-      end
-
-      context 'when the expense has calculated_distance' do
-        let(:distance) { 235 }
-        let(:calculated_distance) { 235 }
-        let(:establishment) { create(:establishment, :prison) }
-        let(:location) { establishment.name }
-
-        it { is_expected.to eql establishment.category }
-      end
-
-      context 'when the expense does not have calculated_distance' do
-        let(:distance) { 235 }
-        let(:calculated_distance) { nil }
-        let(:location) { 'HMP test prison' }
-
-        it { is_expected.to be nil }
-      end
-    end
-
-    context 'when the expense is not car travel' do
-      let(:expense) { build(:expense, :parking, date: 3.days.ago) }
-
-      it { is_expected.to be nil }
-    end
-  end
 end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -161,4 +161,70 @@ RSpec.describe Expense, type: :model do
       end
     end
   end
+
+  describe 'establishment' do
+    subject { expense.establishment }
+
+    context 'when the expense is car travel' do
+      let(:expense) do
+        build(:expense, :car_travel, calculated_distance: calculated_distance, location: location, date: 3.days.ago)
+      end
+
+      context 'when the expense has calculated_distance' do
+        let(:distance) { 235 }
+        let(:calculated_distance) { 235 }
+        let(:establishment) { create(:establishment, :prison) }
+        let(:location) { establishment.name }
+
+        it { is_expected.to eql establishment }
+      end
+
+      context 'when the expense does not have calculated_distance' do
+        let(:distance) { 235 }
+        let(:calculated_distance) { nil }
+        let(:location) { 'HMP test prison' }
+
+        it { is_expected.to be nil }
+      end
+    end
+
+    context 'when the expense is not car travel' do
+      let(:expense) { build(:expense, :parking, date: 3.days.ago) }
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe 'establishment_category' do
+    subject { expense.establishment_category }
+
+    context 'when the expense is car travel' do
+      let(:expense) do
+        build(:expense, :car_travel, calculated_distance: calculated_distance, location: location, date: 3.days.ago)
+      end
+
+      context 'when the expense has calculated_distance' do
+        let(:distance) { 235 }
+        let(:calculated_distance) { 235 }
+        let(:establishment) { create(:establishment, :prison) }
+        let(:location) { establishment.name }
+
+        it { is_expected.to eql establishment.category }
+      end
+
+      context 'when the expense does not have calculated_distance' do
+        let(:distance) { 235 }
+        let(:calculated_distance) { nil }
+        let(:location) { 'HMP test prison' }
+
+        it { is_expected.to be nil }
+      end
+    end
+
+    context 'when the expense is not car travel' do
+      let(:expense) { build(:expense, :parking, date: 3.days.ago) }
+
+      it { is_expected.to be nil }
+    end
+  end
 end


### PR DESCRIPTION
#### What
When visiting magistrates courts and prisons, providers should not have to provide reasons for claiming higher rate mileage

#### Ticket
[CCCD: Additional travel information - iteration 2](https://dsdmoj.atlassian.net/browse/CBO-517)

#### Why
This is a known exemption to the higher rate milage rules that was missed from the original validation ticket

#### How
Add new methods to the `Expense` model to get the, optionally, linked `Establishment` and it's `Category` and allow the validation to check the values while looping through the, about to be created, expenses