### PR TITLE
FIX: Restrict travel expense statuses to LGFS claims

### DIFF
--- a/app/views/shared/summary/expenses/_details.html.haml
+++ b/app/views/shared/summary/expenses/_details.html.haml
@@ -38,7 +38,7 @@
             = t('.distance')
         = "#{expense.distance} miles"
 
-    %li{ class: ('error' if current_user_is_caseworker? && expense.mileage_rate_id.eql?(2)) }
+    %li{ class: ('error' if current_user_is_caseworker? && claim.lgfs? && expense.mileage_rate_id.eql?(2)) }
       %span.bold
         = succeed ':' do
           = t('.cost')

--- a/app/views/shared/summary/expenses/show.html.haml
+++ b/app/views/shared/summary/expenses/show.html.haml
@@ -2,7 +2,7 @@
   %td{scope: 'row', style: 'width: 20%'}
     %span.bold-normal
       = expense.name
-    - if current_user_is_caseworker?
+    - if current_user_is_caseworker?  && @claim.lgfs?
       %span.state{ class: "state-#{expense.state.downcase}" }
         = expense.state
   %td{scope: 'row', style: 'width: 12%'}

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -138,75 +138,151 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
   end
 
   context 'calculated travel expense' do
-    subject { rendered }
+    context 'for litigator claims' do
+      subject { rendered }
 
-    let(:claim) { build(:litigator_claim, :with_fixed_fee_case, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) }
-    let!(:establishment) { create(:establishment, :crown_court, name: 'Basildon', postcode: 'SS14 2EW') }
+      let(:claim) { build(:litigator_claim, :with_fixed_fee_case, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) }
+      let!(:establishment) { create(:establishment, :crown_court, name: 'Basildon', postcode: 'SS14 2EW') }
 
-    before do
-      allow(view).to receive(:current_user_persona_is?).with(CaseWorker).and_return(true)
+      before do
+        allow(view).to receive(:current_user_persona_is?).with(CaseWorker).and_return(true)
 
-      claim.save
-      expense.save
-      assign(:claim, claim.reload)
-      render
-    end
+        claim.save
+        expense.save
+        assign(:claim, claim.reload)
+        render
+      end
 
-    context 'with a lower rate, non increased calculated distance' do
-      let(:expense) { build(:expense, :with_calculated_distance, mileage_rate_id: 1, location: 'Basildon', date: 3.days.ago, claim: claim) }
+      context 'with a lower rate, non increased calculated distance' do
+        let(:expense) { build(:expense, :with_calculated_distance, mileage_rate_id: 1, location: 'Basildon', date: 3.days.ago, claim: claim) }
 
-      it 'does not render a map link' do
-        expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
-        expect(rendered).to have_content('Accepted')
+        it 'does not render a map link' do
+          expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to have_content('Accepted')
+        end
+      end
+
+      context 'with a lower rate and a calculated and reduced distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_decreased, mileage_rate_id: 1,location: 'Basildon',date: 3.days.ago, claim: claim) }
+
+        it 'does not render a map link' do
+          expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to have_content('Accepted')
+        end
+      end
+
+      context 'with a lower rate and a calculated but increased distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_increased, mileage_rate_id: 1, location: 'Basildon',date: 3.days.ago, claim: claim) }
+
+        it 'renders a map link' do
+          expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to have_link('View car journey')
+          expect(rendered).to have_content('Unverified')
+        end
+      end
+
+      context 'with a higher rate, non increased calculated distance' do
+        let(:expense) { build(:expense, :with_calculated_distance, mileage_rate_id: 2, location: 'Basildon', date: 3.days.ago, claim: claim) }
+
+        it 'renders a map link' do
+          expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to have_link('View public transport journey')
+          expect(rendered).to have_content('Unverified')
+        end
+      end
+
+      context 'with a higher rate and a calculated and reduced distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_decreased, mileage_rate_id: 2,location: 'Basildon',date: 3.days.ago, claim: claim) }
+
+        it 'renders a map link' do
+          expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to have_link('View public transport journey')
+          expect(rendered).to have_content('Unverified')
+        end
+      end
+
+      context 'with a higher rate and a calculated but increased distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_increased, mileage_rate_id: 2, location: 'Basildon',date: 3.days.ago, claim: claim) }
+
+        it 'renders a map link' do
+          expect(rendered).to have_link_to(/www.google.co.uk\/maps/)
+          expect(rendered).to have_link('View public transport journey')
+          expect(rendered).to have_content('Unverified')
+        end
       end
     end
 
-    context 'with a lower rate and a calculated and reduced distance' do
-      let(:expense) { build(:expense, :with_calculated_distance_decreased, mileage_rate_id: 1,location: 'Basildon',date: 3.days.ago, claim: claim) }
+    context 'for advocate claims' do
+      subject { rendered }
 
-      it 'does not render a map link' do
-        expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
-        expect(rendered).to have_content('Accepted')
+      let(:claim) { build(:advocate_claim, :with_fixed_fee_case, :submitted, travel_expense_additional_information: Faker::Lorem.paragraph(1)) }
+      let!(:establishment) { create(:establishment, :crown_court, name: 'Basildon', postcode: 'SS14 2EW') }
+
+      before do
+        allow(view).to receive(:current_user_persona_is?).with(CaseWorker).and_return(true)
+
+        claim.save
+        expense.save
+        assign(:claim, claim.reload)
+        render
       end
-    end
 
-    context 'with a lower rate and a calculated but increased distance' do
-      let(:expense) { build(:expense, :with_calculated_distance_increased, mileage_rate_id: 1, location: 'Basildon',date: 3.days.ago, claim: claim) }
+      context 'with a lower rate, non increased calculated distance' do
+        let(:expense) { build(:expense, :with_calculated_distance, mileage_rate_id: 1, location: 'Basildon', date: 3.days.ago, claim: claim) }
 
-      it 'renders a map link' do
-        expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
-        expect(rendered).to have_link('View car journey')
-        expect(rendered).to have_content('Unverified')
+        it 'does not render a map link' do
+          expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to_not have_content('Unverified')
+        end
       end
-    end
 
-    context 'with a higher rate, non increased calculated distance' do
-      let(:expense) { build(:expense, :with_calculated_distance, mileage_rate_id: 2, location: 'Basildon', date: 3.days.ago, claim: claim) }
+      context 'with a lower rate and a calculated and reduced distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_decreased, mileage_rate_id: 1,location: 'Basildon',date: 3.days.ago, claim: claim) }
 
-      it 'renders a map link' do
-        expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
-        expect(rendered).to have_link('View public transport journey')
-        expect(rendered).to have_content('Unverified')
+        it 'does not render a map link' do
+          expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to_not have_content('Unverified')
+        end
       end
-    end
 
-    context 'with a higher rate and a calculated and reduced distance' do
-      let(:expense) { build(:expense, :with_calculated_distance_decreased, mileage_rate_id: 2,location: 'Basildon',date: 3.days.ago, claim: claim) }
+      context 'with a lower rate and a calculated but increased distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_increased, mileage_rate_id: 1, location: 'Basildon',date: 3.days.ago, claim: claim) }
 
-      it 'renders a map link' do
-        expect(rendered).to have_link_to(/google.*maps.*origin=.*destination=.*/)
-        expect(rendered).to have_link('View public transport journey')
-        expect(rendered).to have_content('Unverified')
+        it 'renders a map link' do
+          expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to_not have_link('View car journey')
+          expect(rendered).to_not have_content('Unverified')
+        end
       end
-    end
 
-    context 'with a higher rate and a calculated but increased distance' do
-      let(:expense) { build(:expense, :with_calculated_distance_increased, mileage_rate_id: 2, location: 'Basildon',date: 3.days.ago, claim: claim) }
+      context 'with a higher rate, non increased calculated distance' do
+        let(:expense) { build(:expense, :with_calculated_distance, mileage_rate_id: 2, location: 'Basildon', date: 3.days.ago, claim: claim) }
 
-      it 'renders a map link' do
-        expect(rendered).to have_link_to(/www.google.co.uk\/maps/)
-        expect(rendered).to have_link('View public transport journey')
-        expect(rendered).to have_content('Unverified')
+        it 'renders a map link' do
+          expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to_not have_link('View public transport journey')
+          expect(rendered).to_not have_content('Unverified')
+        end
+      end
+
+      context 'with a higher rate and a calculated and reduced distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_decreased, mileage_rate_id: 2,location: 'Basildon',date: 3.days.ago, claim: claim) }
+
+        it 'renders a map link' do
+          expect(rendered).to_not have_link_to(/google.*maps.*origin=.*destination=.*/)
+          expect(rendered).to_not have_link('View public transport journey')
+          expect(rendered).to_not have_content('Unverified')
+        end
+      end
+
+      context 'with a higher rate and a calculated but increased distance' do
+        let(:expense) { build(:expense, :with_calculated_distance_increased, mileage_rate_id: 2, location: 'Basildon',date: 3.days.ago, claim: claim) }
+
+        it 'renders a map link' do
+          expect(rendered).to_not have_link_to(/www.google.co.uk\/maps/)
+          expect(rendered).to_not have_link('View public transport journey')
+          expect(rendered).to_not have_content('Unverified')
+        end
       end
     end
   end


### PR DESCRIPTION
#### What
Restrict travel expense statuses to LGFS claims

#### Ticket
N/A

#### Why
The travel automation change only apply to LGFS currently.  Adding status flags to AGFS expenses is causing confusion for case workers

#### How
Restrict the display in the view by checking the claim type using `claim.lgfs?`