### PR TITLE
Fix styling on transfer claim disbursements

### DIFF
--- a/app/views/external_users/litigators/transfer_claims/_disbursements_form_step.html.haml
+++ b/app/views/external_users/litigators/transfer_claims/_disbursements_form_step.html.haml
@@ -1,1 +1,10 @@
+- locale_scope = 'external_users.claims.disbursements.disbursement_fields'
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+#disbursements-header.form-group
+  %h2.heading-large
+    = t('.disbursements', scope: locale_scope)
+
 = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }


### PR DESCRIPTION
#### What
Fix styling on transfer claim disbursements - see screenshot


#### Ticket

none

#### Why
**before:** 
[
![screen shot 2018-12-11 at 16 35 15](https://user-images.githubusercontent.com/7016425/49815325-6e5d5480-fd63-11e8-825c-d74fab4e9577.png)
](url)
Noticed that following the FE design changes
for interim fee calc, including for disbursements
the transfer claims disbursements form step
was not using the new stylesheets, causing the above.

#### How
**after:** 
![screen shot 2018-12-11 at 16 40 54](https://user-images.githubusercontent.com/7016425/49815406-9e0c5c80-fd63-11e8-94c1-1019f0cf5005.png)

modify disbursement form step for transfer claims to use
the new stylesheets.

#### TODO:

shouls really be sharing this at a lower level but relative paths using a dynamic
current_step means this would make this fix more involved
