### PR TITLE
Fix count of claims in claim list

### DIFF
--- a/app/views/external_users/claims/_main_claims_list.html.haml
+++ b/app/views/external_users/claims/_main_claims_list.html.haml
@@ -8,7 +8,7 @@
           = t("shared.no_claims_found")
         - else
           = "Showing "
-          #{pluralize(@claims.size, 'claim')} of #{@claims.total_count}
+          #{pluralize(@claims.unscope(:order).size, 'claim')} of #{@claims.total_count}
           - if params[:search].present?
             matching "#{params[:search]}"
     %thead


### PR DESCRIPTION
#### What
Fix count of claims in claim list

#### Ticket
support and maintenance

#### Why
Seems to have been caused by rails 5.1 upgrade
where the alias used in the order by clause is
stripped when applying a count/size activerecord
operation on the statement.

#### How
Still looking for reason it has failed now but
by unscoping the order (which is irrelevant) on
the count operation it fixes it.
