### PR TITLE
Fix count of claims in outstanding/authorised claims lists

### DIFF
--- a/app/views/external_users/claims/authorised.html.haml
+++ b/app/views/external_users/claims/authorised.html.haml
@@ -3,7 +3,7 @@
 .container.sub-header
   .hgroup
     %h2
-      = "#{@claims.size} of #{@claims.total_count}"
+      = "#{@claims.unscope(:order).size} of #{@claims.total_count}"
       = t('.with_total_assessed_value_of')
       %span.numerical-value
         = number_to_currency(@total_value)

--- a/app/views/external_users/claims/outstanding.html.haml
+++ b/app/views/external_users/claims/outstanding.html.haml
@@ -3,7 +3,7 @@
 .container.sub-header
   .hgroup
     %h2
-      = "#{@claims.size} of #{@claims.total_count}"
+      = "#{@claims.unscope(:order).size} of #{@claims.total_count}"
       = t('.claims_value')
       %span.numerical-value
         = number_to_currency(@total_value)


### PR DESCRIPTION
#### What
Fixes [Sentry error](https://sentry.service.dsd.io/mojds/private-beta/issues/34132/)

#### Ticket
support and maintenance

#### Why
Seems to have been cause by rails 5.1 upgrade
where the alias used in the order by clause is
stripped when applying a count/size activerecord
operation on the statement.

Still looking for reason it has failed now but
by unscoping the order (which is irrelevant) to
a count operation anyway, it fixes it.


#### TODO: 

- write spec to cover the index ordering functionality.
