### PR TITLE
Update shoulda-matchers from 3.1.2 to 4.0.0.rc1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ group :test do
   gem 'poltergeist'
   gem 'rails-controller-testing'
   gem 'rspec-mocks'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', '>= 4.0.0.rc1'
   gem 'selenium-webdriver'
   gem 'simplecov',                  require: false
   gem 'simplecov-csv',              require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     config (1.7.0)
       activesupport (>= 3.0)
       deep_merge (~> 1.2.1)
@@ -320,7 +320,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
-    i18n (1.1.1)
+    i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.20)
       activesupport (>= 4.0.2)
@@ -576,8 +576,8 @@ GEM
     shell-spinner (1.0.4)
       colorize
     shellany (0.0.1)
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.0.0)
+    shoulda-matchers (4.0.0.rc1)
+      activesupport (>= 4.2.0)
     sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -772,7 +772,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven (~> 1.2.2)
   shell-spinner (~> 1.0, >= 1.0.4)
-  shoulda-matchers
+  shoulda-matchers (>= 4.0.0.rc1)
   sidekiq (~> 4.2.9)
   simple_form (~> 4.0.0)
   simplecov

--- a/app/validators/certification_validator.rb
+++ b/app/validators/certification_validator.rb
@@ -13,7 +13,7 @@ class CertificationValidator < BaseValidator
 
   def validate_certification_date
     validate_presence(:certification_date, :blank)
-    validate_on_or_after(@record.claim.created_at, :certification_date, :after_claim_creation)
+    validate_on_or_after(@record.claim&.created_at, :certification_date, :after_claim_creation)
     validate_on_or_before(Date.today, :certification_date, :not_in_the_future)
   end
 end

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -14,22 +14,21 @@
 require 'rails_helper'
 
 RSpec.describe Certification, type: :model do
-  it { should belong_to(:claim) }
-  it { should belong_to(:certification_type) }
-
-  it { should validate_presence_of(:certified_by) }
-  it { should validate_presence_of(:certification_date) }
-
+  subject(:certification) { build(:certification, certification_type: certification_type, claim: claim) }
   let!(:certification_type) { create(:certification_type) }
   let(:claim) { build(:claim) }
 
-  subject(:certification) { build(:certification, certification_type: certification_type, claim: claim) }
+  it { is_expected.to belong_to(:claim) }
+  it { is_expected.to belong_to(:certification_type) }
+
+  it { is_expected.to validate_presence_of(:certified_by) }
+  it { is_expected.to validate_presence_of(:certification_date) }
 
   context 'validations' do
     it 'should be invalid without certification type' do
-      subject.certification_type_id = nil
-      expect(subject).not_to be_valid
-      expect(subject.errors.full_messages).to eq( ['You must select one option on this form'] )
+      certification.certification_type_id = nil
+      expect(certification).to be_invalid
+      expect(certification.errors.full_messages).to include('You must select one option on this form')
     end
 
     context 'certification date' do
@@ -41,9 +40,8 @@ RSpec.describe Certification, type: :model do
         end
 
         it 'should be invalid' do
-          expect(certification).not_to be_valid
-          error_message = 'Certification date must be same day or after claim submission day'
-          expect(certification.errors.full_messages).to eq( [error_message] )
+          expect(certification).to be_invalid
+          expect(certification.errors.full_messages).to include('Certification date must be same day or after claim submission day')
         end
       end
 
@@ -53,9 +51,8 @@ RSpec.describe Certification, type: :model do
         end
 
         it 'should be invalid' do
-          expect(certification).not_to be_valid
-          error_message = "Certification date can't be in the future"
-          expect(certification.errors.full_messages).to eq( [error_message] )
+          expect(certification).to be_invalid
+          expect(certification.errors.full_messages).to include("Certification date can't be in the future")
         end
       end
     end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Feedback, type: :model do
     }
   end
 
-  it { should validate_inclusion_of(:type).in_array(%w( feedback bug_report )) }
+  it { is_expected.to validate_inclusion_of(:type).in_array(%w( feedback bug_report )) }
 
   context 'feedback' do
     let(:feedback_params) do
@@ -18,7 +18,7 @@ RSpec.describe Feedback, type: :model do
 
     subject { Feedback.new(feedback_params) }
 
-    it { should validate_inclusion_of(:rating).in_array(('1'..'5').to_a) }
+    it { is_expected.to validate_inclusion_of(:rating).in_array(('1'..'5').to_a) }
 
     describe '#initialize' do
       it 'sets the email' do
@@ -107,10 +107,10 @@ RSpec.describe Feedback, type: :model do
 
     subject { Feedback.new(bug_report_params) }
 
-    it { should_not validate_inclusion_of(:rating).in_array(('1'..'5').to_a) }
-    it { should validate_presence_of(:event) }
-    it { should validate_presence_of(:outcome) }
-    it { should_not validate_presence_of(:case_number) }
+    it { is_expected.to_not validate_inclusion_of(:rating).in_array(('1'..'5').to_a) }
+    it { is_expected.to validate_presence_of(:event) }
+    it { is_expected.to validate_presence_of(:outcome) }
+    it { is_expected.to_not validate_presence_of(:case_number) }
 
     describe '#initialize' do
       it 'sets the email' do


### PR DESCRIPTION
#### What
Fix deprecation warning on unit test dependency library

#### Why

Handles the following deprecation warnings:

```
gems/shoulda-matchers-3.1.2/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb:551: warning: constant ::Fixnum is deprecated
```

#### How
update to version 4 release candidate 1.
