### PR TITLE
Change fee scheme specs to use seed helper

### DIFF
--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -66,7 +66,6 @@
 require 'rails_helper'
 
 RSpec.describe Claim::AdvocateClaim, type: :model do
-
   it { should belong_to(:external_user) }
   it { should belong_to(:creator).class_name('ExternalUser').with_foreign_key('creator_id') }
   it { should delegate_method(:provider_id).to(:creator) }
@@ -88,10 +87,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   it { should delegate_method(:requires_trial_dates?).to(:case_type) }
   it { should delegate_method(:requires_retrial_dates?).to(:case_type) }
   it { should delegate_method(:requires_cracked_dates?).to(:case_type) }
-
-  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
-  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
-  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
 
   describe 'validates external user and creator with same provider' do
     let(:provider) { create(:provider) }
@@ -186,6 +181,8 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       end
 
       context 'when claim has fee reform scheme' do
+        before { seed_fee_schemes }
+
         let(:claim) { create(:claim, :agfs_scheme_10) }
 
         it 'returns only basic fee types for AGFS excluding the ones that are not part of the fee reform' do

--- a/spec/services/ccr/daily_attendance_adapter_spec.rb
+++ b/spec/services/ccr/daily_attendance_adapter_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
   let(:retrial) { create(:case_type, :retrial) }
 
   before do
-    FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine)
-    FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine)
-    FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme)
+    seed_fee_schemes
   end
 
   describe '#attendances' do

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
-  let!(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) || create(:fee_scheme, :lgfs_nine) }
-  let!(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) || create(:fee_scheme, :agfs_nine) }
-  let!(:agfs_scheme_ten) { FeeScheme.find_by(name: 'AGFS', version: 10) || create(:fee_scheme) }
+  # before { seed_fee_schemes }
 
   before do
     @case_worker = create(:case_worker)


### PR DESCRIPTION
#### What
Attempting to resolve flakey tests relating
to fee schemes.

#### Why
Specs that rely on fee schemes directly or indirectly
are occasionally failing.

#### How
Using seed helper only to create fee schemes rather than rely
on factories. Also remove any before(:all) hooks as these may 
not get cleaned up successfully and result in fee schemes persisting
between specs.
