### PR TITLE
Deactivate fee calculation for [re]trial start interim fee

### DIFF
--- a/app/services/claims/fee_calculator/graduated_price.rb
+++ b/app/services/claims/fee_calculator/graduated_price.rb
@@ -12,11 +12,17 @@ module Claims
 
       def setup(options)
         @fee_type = Fee::BaseFeeType.find(options[:fee_type_id])
+        exclude_invalid_fee_calc
         @advocate_category = options[:advocate_category] || claim.advocate_category
         @days = options[:days] || 0
         @ppe = options[:ppe] || 0
       rescue StandardError
         raise 'incomplete'
+      end
+
+      def exclude_invalid_fee_calc
+        return unless %w[INRST INTDT].include?(fee_type.unique_code)
+        raise StandardError, 'temporary exclusion of (re)trial start interim fee calc'
       end
 
       def amount

--- a/features/fee_calculator/litigator/interim_fee_calculator.feature
+++ b/features/fee_calculator/litigator/interim_fee_calculator.feature
@@ -71,23 +71,24 @@ Feature: litigator completes interim fee page using calculator
     And I goto claim form step 'interim fees'
     And the interim fee amount should be populated with '715.75'
 
-    # Trial start scenario, 2 defendants, class B offence
-    Then I select an interim fee type of 'Trial start'
+    # Remove temporarily as fee calculator is returning wrong values
+    # # Trial start scenario, 2 defendants, class B offence
+    # Then I select an interim fee type of 'Trial start'
 
-    # PPE impact
-    And I enter 70 in the PPE total field
-    And the interim fee amount should be populated with '1317.19'
-    And I enter 71 in the PPE total field
-    And the interim fee amount should be populated with '1332.56'
+    # # PPE impact
+    # And I enter 70 in the PPE total field
+    # And the interim fee amount should be populated with '1317.19'
+    # And I enter 71 in the PPE total field
+    # And the interim fee amount should be populated with '1332.56'
 
-    # Estimate trial length impact (first two days incl. 10 days minimum required)
-    And I enter 2 in the estimated trial length field
-    And the interim fee amount should be populated with '1332.56'
-    And I enter 3 in the estimated trial length field
-    And the interim fee amount should be populated with '1860.65'
-    And I enter 10 in the estimated trial length field
-    And the interim fee amount should be populated with '5204.77'
-    And I enter the trial start date '2018-04-01'
+    # # Estimate trial length impact (first two days incl. 10 days minimum required)
+    # And I enter 2 in the estimated trial length field
+    # And the interim fee amount should be populated with '1332.56'
+    # And I enter 3 in the estimated trial length field
+    # And the interim fee amount should be populated with '1860.65'
+    # And I enter 10 in the estimated trial length field
+    # And the interim fee amount should be populated with '5204.77'
+    # And I enter the trial start date '2018-04-01'
 
     Then I click "Continue" in the claim form
     And I should be in the 'Evidence supplied on disk' form page
@@ -164,23 +165,23 @@ Feature: litigator completes interim fee page using calculator
     And I goto claim form step 'interim fees'
     And the interim fee amount should be populated with '477.17'
 
-    # Retrial start scenario, 2 defendants, class B offence
-    Then I select an interim fee type of 'Retrial start'
+    # # Retrial start scenario, 2 defendants, class B offence
+    # Then I select an interim fee type of 'Retrial start'
 
-    # PPE impact
-    And I enter 70 in the PPE total field
-    And the interim fee amount should be populated with '1317.19'
-    And I enter 71 in the PPE total field
-    And the interim fee amount should be populated with '1332.56'
+    # # PPE impact
+    # And I enter 70 in the PPE total field
+    # And the interim fee amount should be populated with '1317.19'
+    # And I enter 71 in the PPE total field
+    # And the interim fee amount should be populated with '1332.56'
 
-    # Estimated length of retrial impact (first two days incl. 10 days minimum required)
-    And I enter 2 in the estimated retrial length field
-    And the interim fee amount should be populated with '1332.56'
-    And I enter 3 in the estimated retrial length field
-    And the interim fee amount should be populated with '1860.65'
-    And I enter 10 in the estimated retrial length field
-    And the interim fee amount should be populated with '5204.77'
-    And I enter the retrial start date '2018-04-01'
+    # # Estimated length of retrial impact (first two days incl. 10 days minimum required)
+    # And I enter 2 in the estimated retrial length field
+    # And the interim fee amount should be populated with '1332.56'
+    # And I enter 3 in the estimated retrial length field
+    # And the interim fee amount should be populated with '1860.65'
+    # And I enter 10 in the estimated retrial length field
+    # And the interim fee amount should be populated with '5204.77'
+    # And I enter the retrial start date '2018-04-01'
 
     Then I click "Continue" in the claim form
     And I should be in the 'Evidence supplied on disk' form page

--- a/spec/services/claims/fee_calculator/graduated_price_spec.rb
+++ b/spec/services/claims/fee_calculator/graduated_price_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Claims::FeeCalculator::GraduatedPrice, :fee_calc_vcr do
           it_returns 'a successful fee calculator response', amount: 838.94
         end
 
-        context 'trial start' do
+        context 'trial start', skip: 'temporary skip until error in fee calc api can be sorted out' do
           before { claim.estimated_trial_length = 3 }
           let(:fee) { create(:interim_fee, :trial_start, claim: claim, quantity: 100) }
           let(:params) { { fee_type_id: fee.fee_type.id, days: claim.estimated_trial_length, ppe: fee.quantity } }
@@ -117,7 +117,7 @@ RSpec.describe Claims::FeeCalculator::GraduatedPrice, :fee_calc_vcr do
           it_returns 'a successful fee calculator response', amount: 1799.18
         end
 
-        context 'retrial start' do
+        context 'retrial start', skip: 'temporary skip until error in fee calc api can be sorted out' do
           before { claim.retrial_estimated_length = 3 }
           let(:fee) { create(:interim_fee, :retrial_start, claim: claim, quantity: 96) }
           let(:params) { { fee_type_id: fee.fee_type.id, days: claim.retrial_estimated_length, ppe: fee.quantity } }


### PR DESCRIPTION
#### What
Deactivate fee calculation for [re]trial start interim fee

#### Why
The fee calculator api is returning the wrong amounts
for these fee types

see [laa-fee-calculator github issue](https://github.com/ministryofjustice/laa-fee-calculator/issues/79)

#### How
explicitly raise standard error for these fee types in the
graduated price service object. This will stop an api request
and raise incomplete to the JS, preventing any further processing
on back and front ends
