### PR TITLE
Prevent warrant fee calc of zero

### DIFF
--- a/app/services/claims/fee_calculator/graduated_price.rb
+++ b/app/services/claims/fee_calculator/graduated_price.rb
@@ -12,17 +12,17 @@ module Claims
 
       def setup(options)
         @fee_type = Fee::BaseFeeType.find(options[:fee_type_id])
-        exclude_invalid_fee_calc
         @advocate_category = options[:advocate_category] || claim.advocate_category
         @days = options[:days] || 0
         @ppe = options[:ppe] || 0
+        exclude_invalid_fee_calc
       rescue StandardError
         raise 'incomplete'
       end
 
       def exclude_invalid_fee_calc
-        return unless %w[INRST INTDT].include?(fee_type.unique_code)
-        raise StandardError, 'temporary exclusion of (re)trial start interim fee calc'
+        return unless %w[INRST INTDT INWAR].include?(fee_type.unique_code)
+        raise StandardError, 'temporary exclusion of interim fee calc for trial start, retrial start and warrant types'
       end
 
       def amount

--- a/features/claims/litigator/interim_trial_warrant_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_warrant_claim_draft_submit.feature
@@ -33,12 +33,18 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
+    Given I insert the VCR cassette 'features/claims/litigator/interim_warrant_fee_calculations'
+
     Then I click "Continue" in the claim form
 
+    And I should be in the 'Interim fee' form page
     And I select an interim fee type of 'Warrant'
+    And the interim fee amount should be populated with ''
     And I enter '2016-01-01' as the warrant issued date
     And I enter '2016-04-01' as the warrant executed date
     And I enter '680.39' in the interim fee total field
+
+    And I eject the VCR cassette
 
     Then I click "Continue" in the claim form
 

--- a/features/step_definitions/litigator_interim_claim_steps.rb
+++ b/features/step_definitions/litigator_interim_claim_steps.rb
@@ -64,9 +64,9 @@ Then(/^I should see interim fee types applicable to a '(.*?)'$/) do |name|
   expect(@litigator_interim_claim_form_page.interim_fee.fee_type_select_names).to include(*expected_interim_fees_for(name))
 end
 
-Then(/^the interim fee amount should be populated with '(\d+\.\d+)'$/) do |amount|
+Then(/^the interim fee amount should be populated with '(\d+\.\d+)?'$/) do |amount|
   expect(@litigator_interim_claim_form_page.interim_fee).to have_amount
-  expect(@litigator_interim_claim_form_page.interim_fee.amount.value).to eql amount
+  expect(@litigator_interim_claim_form_page.interim_fee.amount.value).to eql amount.to_s
 end
 
 Then(/^the interim fee should have its price_calculated value set to true$/) do

--- a/spec/services/claims/fee_calculator/graduated_price_spec.rb
+++ b/spec/services/claims/fee_calculator/graduated_price_spec.rb
@@ -132,8 +132,13 @@ RSpec.describe Claims::FeeCalculator::GraduatedPrice, :fee_calc_vcr do
           it_returns 'a successful fee calculator response', amount: 457.64
         end
 
-        # TODO: these need special handling
+        # TODO: for now this should return a failed response as warrants need special handling
         context 'warrant' do
+          before { claim.retrial_estimated_length = 3 }
+          let(:fee) { create(:interim_fee, :warrant, claim: claim) }
+          let(:params) { { fee_type_id: fee.fee_type.id } }
+
+          it_returns 'a failed fee calculator response', message: /incomplete/i
         end
       end
 

--- a/vcr/cassettes/spec/support/shared_examples/services/shared_examples_for_fee_calculators.yml
+++ b/vcr/cassettes/spec/support/shared_examples/services/shared_examples_for_fee_calculators.yml
@@ -729,4 +729,43 @@ http_interactions:
       string: '{"amount":5142.87}'
     http_version: 
   recorded_at: Wed, 05 Dec 2018 17:16:33 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=3&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=96&scenario=48
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Dec 2018 14:47:52 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '14'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":0.0}'
+    http_version: 
+  recorded_at: Thu, 20 Dec 2018 14:47:52 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### What
Prevent warrant fee calculation returning and populating amount with zero

#### Ticket

[CBO-528](https://dsdmoj.atlassian.net/browse/CBO-528)

#### Why
Fee calculation for warrant fees is submitted  but because the values
are not complete (separate ticket for this) the request is valid but
the response is zero.

This results in any return to an existing warrant fee via the form
page flow, recalculating the value to 0.

#### How
Explicitly exclude interim warrant fee types in the graduated price service
class.
