### PR TITLE
Remove reason_text from expenses

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -64,6 +64,7 @@ class Expense < ApplicationRecord
 
   before_validation do
     self.schema_version ||= 2
+    remove_reason_text_unless_other
     round_quantity
     calculate_vat
   end
@@ -149,6 +150,10 @@ class Expense < ApplicationRecord
   def establishment
     return unless expense_type.car_travel?
     Establishment.find_by(name: location)
+  end
+
+  def remove_reason_text_unless_other
+    self.reason_text = nil unless expense_reason_other?
   end
 
   private

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -194,4 +194,12 @@ RSpec.describe Expense, type: :model do
       it { is_expected.to be nil }
     end
   end
+
+  describe '#remove_reason_text_unless_other' do
+    subject(:remove_reason_text_unless_other) { expense.remove_reason_text_unless_other }
+
+    let(:expense) { build :expense, reason_id: 4, reason_text: 'My unique reason' }
+
+    it { expect { remove_reason_text_unless_other }.to change { expense.reason_text }.to nil }
+  end
 end

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -311,20 +311,23 @@ RSpec.describe 'ExpenseValidator', type: :validator do
     end
 
     context 'validates absence when reason ID is other than 5 regardless of the reason set' do
+      subject { expense.valid? }
+
       before do
         expense.reason_id = 3
       end
 
-      it 'reason text is present' do
-        expense.reason_text = 'blah'
-        expense.valid?
-        expect(expense).not_to be_valid
-        expect(expense.errors[:reason_text]).to include('invalid')
+      context 'reason text is present' do
+        before { expense.reason_text = 'blah' }
+
+        it 'removes the reason text before validation' do
+          expect(subject).to be true
+          expect(expense.reason_text).to be nil
+        end
       end
 
-      it 'reason text is not present' do
-        expense.valid?
-        expect(expense).to be_valid
+      context 'reason text is not present' do
+        it { is_expected.to be true }
       end
     end
   end


### PR DESCRIPTION
#### What
Add a clear reason text method and call it before validation

#### Why
This reduces the errors caused by duplicating expenses with other
text reasons that don't get removed when the type of the duplicated
expense is changed

#### How
The method removes data from the `reason_text` field after being called from the `before_validation` block