### PR TITLE
New interim fee calc

### DIFF
--- a/app/services/claims/fee_calculator/graduated_price.rb
+++ b/app/services/claims/fee_calculator/graduated_price.rb
@@ -20,9 +20,13 @@ module Claims
         raise 'incomplete'
       end
 
+      # TODO: this should return a failed response until
+      # - fee calculator amended to have codes for warrant fee scenarios
+      # - CCCD is able to apply the sub category of warrant fee scenario logic
+      #
       def exclude_invalid_fee_calc
-        return unless %w[INRST INTDT INWAR].include?(fee_type.unique_code)
-        raise StandardError, 'temporary exclusion of interim fee calc for trial start, retrial start and warrant types'
+        return unless %w[INWAR].include?(fee_type.unique_code)
+        raise StandardError, 'temporary exclusion of interim fee calc warrant fee types'
       end
 
       def amount
@@ -33,9 +37,14 @@ module Claims
           options[:fee_type_code] = fee_type_code_for(fee_type)
 
           options[:day] = days.to_i
+          options[:trial_length] = days.to_i if trial_length_required?
           options[:ppe] = ppe.to_i
           options[:number_of_defendants] = defendants.size if lgfs?
         end
+      end
+
+      def trial_length_required?
+        %w[INTDT INRST].include?(fee_type.unique_code)
       end
     end
   end

--- a/features/fee_calculator/litigator/interim_fee_calculator.feature
+++ b/features/fee_calculator/litigator/interim_fee_calculator.feature
@@ -71,24 +71,24 @@ Feature: litigator completes interim fee page using calculator
     And I goto claim form step 'interim fees'
     And the interim fee amount should be populated with '715.75'
 
-    # Remove temporarily as fee calculator is returning wrong values
-    # # Trial start scenario, 2 defendants, class B offence
-    # Then I select an interim fee type of 'Trial start'
+    # Trial start scenario, 2 defendants, class B offence, 81 PPE
+    Then I select an interim fee type of 'Trial start'
+    And the interim fee amount should be populated with '0.00'
 
-    # # PPE impact
-    # And I enter 70 in the PPE total field
-    # And the interim fee amount should be populated with '1317.19'
-    # And I enter 71 in the PPE total field
-    # And the interim fee amount should be populated with '1332.56'
+    # Estimate trial length impact (10 days minimum required but fee represents 1 day only)
+    And I enter 9 in the estimated trial length field
+    And the interim fee amount should be populated with '0.00'
+    And I enter 10 in the estimated trial length field
+    And the interim fee amount should be populated with '1486.28'
+    And I enter 100 in the estimated trial length field
+    And the interim fee amount should be populated with '1486.28'
+    And I enter the trial start date '2018-04-01'
 
-    # # Estimate trial length impact (first two days incl. 10 days minimum required)
-    # And I enter 2 in the estimated trial length field
-    # And the interim fee amount should be populated with '1332.56'
-    # And I enter 3 in the estimated trial length field
-    # And the interim fee amount should be populated with '1860.65'
-    # And I enter 10 in the estimated trial length field
-    # And the interim fee amount should be populated with '5204.77'
-    # And I enter the trial start date '2018-04-01'
+    # PPE impact
+    And I enter 70 in the PPE total field
+    And the interim fee amount should be populated with '1317.19'
+    And I enter 71 in the PPE total field
+    And the interim fee amount should be populated with '1332.56'
 
     Then I click "Continue" in the claim form
     And I should be in the 'Evidence supplied on disk' form page
@@ -165,23 +165,23 @@ Feature: litigator completes interim fee page using calculator
     And I goto claim form step 'interim fees'
     And the interim fee amount should be populated with '477.17'
 
-    # # Retrial start scenario, 2 defendants, class B offence
-    # Then I select an interim fee type of 'Retrial start'
+    # Retrial start scenario, 2 defendants, class B offence, 81 PPE
+    Then I select an interim fee type of 'Retrial start'
 
-    # # PPE impact
-    # And I enter 70 in the PPE total field
-    # And the interim fee amount should be populated with '1317.19'
-    # And I enter 71 in the PPE total field
-    # And the interim fee amount should be populated with '1332.56'
+    # Estimated length of retrial impact (10 days minimum required but fee represents 1 day only)
+    And I enter 9 in the estimated retrial length field
+    And the interim fee amount should be populated with '0.00'
+    And I enter 10 in the estimated retrial length field
+    And the interim fee amount should be populated with '1486.28'
+    And I enter 100 in the estimated retrial length field
+    And the interim fee amount should be populated with '1486.28'
+    And I enter the retrial start date '2018-04-01'
 
-    # # Estimated length of retrial impact (first two days incl. 10 days minimum required)
-    # And I enter 2 in the estimated retrial length field
-    # And the interim fee amount should be populated with '1332.56'
-    # And I enter 3 in the estimated retrial length field
-    # And the interim fee amount should be populated with '1860.65'
-    # And I enter 10 in the estimated retrial length field
-    # And the interim fee amount should be populated with '5204.77'
-    # And I enter the retrial start date '2018-04-01'
+    # PPE impact
+    And I enter 70 in the PPE total field
+    And the interim fee amount should be populated with '1317.19'
+    And I enter 71 in the PPE total field
+    And the interim fee amount should be populated with '1332.56'
 
     Then I click "Continue" in the claim form
     And I should be in the 'Evidence supplied on disk' form page

--- a/spec/services/claims/fee_calculator/graduated_price_spec.rb
+++ b/spec/services/claims/fee_calculator/graduated_price_spec.rb
@@ -139,7 +139,10 @@ RSpec.describe Claims::FeeCalculator::GraduatedPrice, :fee_calc_vcr do
           it_returns 'a successful fee calculator response', amount: 457.64
         end
 
-        # TODO: for now this should return a failed response as warrants need special handling
+        # TODO: this should return a failed response until
+        # - fee calculator amended to have codes for warrant fee scenarios
+        # - CCCD is able to apply the sub category of warrant fee scenario logic
+        #
         context 'warrant' do
           before { claim.retrial_estimated_length = 3 }
           let(:fee) { create(:interim_fee, :warrant, claim: claim) }

--- a/spec/services/claims/fee_calculator/graduated_price_spec.rb
+++ b/spec/services/claims/fee_calculator/graduated_price_spec.rb
@@ -109,27 +109,40 @@ RSpec.describe Claims::FeeCalculator::GraduatedPrice, :fee_calc_vcr do
           it_returns 'a successful fee calculator response', amount: 838.94
         end
 
-        context 'trial start', skip: 'temporary skip until error in fee calc api can be sorted out' do
-          before { claim.estimated_trial_length = 3 }
-          let(:fee) { create(:interim_fee, :trial_start, claim: claim, quantity: 100) }
-          let(:params) { { fee_type_id: fee.fee_type.id, days: claim.estimated_trial_length, ppe: fee.quantity } }
+        context 'trial start' do
+          let(:fee) { create(:interim_fee, :trial_start, claim: claim) }
+          let(:params) { { fee_type_id: fee.fee_type.id, days: length, ppe: 80 } }
 
-          it_returns 'a successful fee calculator response', amount: 1799.18
+          TRIAL_LENGTH_BOUNDARIES = { 9 => 0.00, 10 => 1467.58, 11 => 1467.58 }
+
+          TRIAL_LENGTH_BOUNDARIES.each_pair do |length, amount|
+            context "with an estimated length of #{length}" do
+              let(:length){ length }
+              it_returns 'a successful fee calculator response', amount: amount
+            end
+          end
 
           context 'when 2 defendants' do
+            let(:length) { 10 }
             it_returns 'a successful fee calculator response',
                         number_of_defendants: 2,
                         scheme: 'lgfs',
-                        amount: 2159.02
+                        amount: 1761.10
           end
         end
 
-        context 'retrial start', skip: 'temporary skip until error in fee calc api can be sorted out' do
-          before { claim.retrial_estimated_length = 3 }
-          let(:fee) { create(:interim_fee, :retrial_start, claim: claim, quantity: 96) }
-          let(:params) { { fee_type_id: fee.fee_type.id, days: claim.retrial_estimated_length, ppe: fee.quantity } }
+        context 'retrial start' do
+          let(:fee) { create(:interim_fee, :retrial_start, claim: claim) }
+          let(:params) { { fee_type_id: fee.fee_type.id, days: length, ppe: 80 } }
 
-          it_returns 'a successful fee calculator response', amount: 1732.86
+          RETRIAL_LENGTH_BOUNDARIES = { 9 => 0.00, 10 => 1467.58, 11 => 1467.58 }
+
+          RETRIAL_LENGTH_BOUNDARIES.each_pair do |length, amount|
+            context "with an estimated length of #{length}" do
+              let(:length) { length }
+              it_returns 'a successful fee calculator response', amount: amount
+            end
+          end
         end
 
         context 'retrial (new solicitor)' do

--- a/spec/support/shared_examples/services/shared_examples_for_fee_calculators.rb
+++ b/spec/support/shared_examples/services/shared_examples_for_fee_calculators.rb
@@ -28,7 +28,7 @@ RSpec.shared_examples 'a successful fee calculator response' do |options|
   end
 
   if options&.fetch(:amount, nil)
-    it 'includes expected amount' do
+    it "includes expected amount #{options&.fetch(:amount)}" do
       amount = options&.fetch(:amount)
       expect(response.data.amount).to eq amount
     end

--- a/vcr/cassettes/features/fee_calculator/litigator/interim_fee_calculator.yml
+++ b/vcr/cassettes/features/fee_calculator/litigator/interim_fee_calculator.yml
@@ -23,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:49 GMT
+      - Wed, 02 Jan 2019 11:31:08 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -39,7 +39,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:49 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:49 GMT
+      - Wed, 02 Jan 2019 11:31:08 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -122,7 +122,7 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 14:13:31 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=A&ppe=0&scenario=43
@@ -146,7 +146,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:50 GMT
+      - Wed, 02 Jan 2019 11:31:08 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -161,8 +161,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":678.44}'
     http_version: 
-
-  recorded_at: Fri, 07 Dec 2018 17:22:50 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
@@ -186,7 +185,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:50 GMT
+      - Wed, 02 Jan 2019 11:31:08 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -202,7 +201,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:50 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -226,7 +225,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:50 GMT
+      - Wed, 02 Jan 2019 11:31:08 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -285,7 +284,7 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:50 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=A&ppe=80&scenario=43
@@ -309,7 +308,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:50 GMT
+      - Wed, 02 Jan 2019 11:31:09 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -324,7 +323,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":678.44}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:50 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
@@ -348,7 +347,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:51 GMT
+      - Wed, 02 Jan 2019 11:31:09 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -364,7 +363,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:51 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -388,7 +387,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:51 GMT
+      - Wed, 02 Jan 2019 11:31:09 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -447,7 +446,7 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:51 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=A&ppe=81&scenario=43
@@ -471,7 +470,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:51 GMT
+      - Wed, 02 Jan 2019 11:31:09 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -486,7 +485,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":686.46}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:51 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:09 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
@@ -510,7 +509,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:59 GMT
+      - Wed, 02 Jan 2019 11:31:16 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -526,7 +525,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:59 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -550,7 +549,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:59 GMT
+      - Wed, 02 Jan 2019 11:31:16 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -609,7 +608,7 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:59 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:16 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=B&ppe=81&scenario=43
@@ -633,7 +632,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:22:59 GMT
+      - Wed, 02 Jan 2019 11:31:17 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -648,7 +647,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":596.46}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:22:59 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:17 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
@@ -672,7 +671,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:08 GMT
+      - Wed, 02 Jan 2019 11:31:25 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -688,7 +687,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:08 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:25 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -712,7 +711,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:08 GMT
+      - Wed, 02 Jan 2019 11:31:25 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -771,7 +770,7 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:08 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:25 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=43
@@ -795,7 +794,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:09 GMT
+      - Wed, 02 Jan 2019 11:31:26 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -810,7 +809,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":715.75}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:09 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:26 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
@@ -834,7 +833,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:09 GMT
+      - Wed, 02 Jan 2019 11:31:26 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -850,7 +849,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:09 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:26 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -874,7 +873,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:09 GMT
+      - Wed, 02 Jan 2019 11:31:26 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -933,10 +932,10 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:09 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:26 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=44
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=44&trial_length=0
     body:
       encoding: US-ASCII
       string: ''
@@ -957,7 +956,331 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:09 GMT
+      - Wed, 02 Jan 2019 11:31:27 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '14'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":0.0}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:27 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:27 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
+        Fee Scheme 2016-04"}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:27 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:28 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '835'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
+        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
+        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
+        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
+        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
+        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
+        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
+        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
+        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
+        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
+        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
+        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
+        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
+        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
+        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
+        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
+        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
+        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
+        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
+        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
+        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
+        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
+        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
+        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
+        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
+        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
+        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
+        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
+        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
+        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
+        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
+        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
+        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
+        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
+        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
+        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
+        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
+        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
+        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
+        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
+        issued - retrial (after trial start)","code":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:28 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=9&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=44&trial_length=9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:28 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '14'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":0.0}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:28 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:28 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
+        Fee Scheme 2016-04"}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:28 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:28 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '835'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
+        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
+        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
+        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
+        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
+        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
+        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
+        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
+        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
+        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
+        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
+        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
+        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
+        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
+        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
+        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
+        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
+        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
+        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
+        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
+        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
+        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
+        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
+        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
+        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
+        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
+        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
+        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
+        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
+        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
+        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
+        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
+        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
+        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
+        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
+        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
+        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
+        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
+        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
+        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
+        issued - retrial (after trial start)","code":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:28 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=44&trial_length=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:28 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -972,7 +1295,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1486.28}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:09 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:29 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
@@ -996,7 +1319,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:10 GMT
+      - Wed, 02 Jan 2019 11:31:29 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1012,7 +1335,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:10 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:29 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -1036,7 +1359,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:10 GMT
+      - Wed, 02 Jan 2019 11:31:29 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1095,10 +1418,10 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:10 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:29 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=70&scenario=44
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=100&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=44&trial_length=100
     body:
       encoding: US-ASCII
       string: ''
@@ -1119,7 +1442,169 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:10 GMT
+      - Wed, 02 Jan 2019 11:31:29 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '18'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":1486.28}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:29 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:29 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '156'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
+        Fee Scheme 2016-04"}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:29 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:29 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '835'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
+        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
+        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
+        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
+        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
+        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
+        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
+        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
+        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
+        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
+        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
+        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
+        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
+        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
+        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
+        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
+        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
+        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
+        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
+        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
+        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
+        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
+        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
+        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
+        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
+        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
+        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
+        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
+        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
+        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
+        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
+        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
+        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
+        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
+        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
+        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
+        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
+        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
+        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
+        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
+        issued - retrial (after trial start)","code":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:31:29 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=100&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=70&scenario=44&trial_length=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:31:29 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1134,7 +1619,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1317.19}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:10 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:29 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
@@ -1158,7 +1643,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:10 GMT
+      - Wed, 02 Jan 2019 11:31:30 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1174,7 +1659,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:10 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:30 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -1198,7 +1683,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:10 GMT
+      - Wed, 02 Jan 2019 11:31:30 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1207,7 +1692,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '835'
+      - '825'
       Connection:
       - keep-alive
     body:
@@ -1257,10 +1742,10 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:10 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:30 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=44
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=100&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=44&trial_length=100
     body:
       encoding: US-ASCII
       string: ''
@@ -1281,7 +1766,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:11 GMT
+      - Wed, 02 Jan 2019 11:31:30 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1296,493 +1781,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1332.56}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:11 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:11 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '156'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
-        Fee Scheme 2016-04"}]}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:11 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:11 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      - Accept-Encoding
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '835'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
-        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
-        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
-        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
-        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
-        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
-        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
-        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
-        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
-        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
-        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
-        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
-        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
-        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
-        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
-        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
-        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
-        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
-        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
-        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
-        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
-        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
-        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
-        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
-        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
-        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
-        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
-        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
-        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
-        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
-        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
-        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
-        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
-        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
-        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
-        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
-        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
-        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
-        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
-        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
-        issued - retrial (after trial start)","code":null}]}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:11 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=2&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=44
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:11 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":1332.56}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:11 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:12 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '156'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
-        Fee Scheme 2016-04"}]}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:12 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:12 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      - Accept-Encoding
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '835'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
-        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
-        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
-        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
-        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
-        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
-        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
-        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
-        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
-        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
-        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
-        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
-        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
-        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
-        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
-        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
-        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
-        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
-        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
-        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
-        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
-        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
-        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
-        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
-        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
-        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
-        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
-        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
-        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
-        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
-        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
-        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
-        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
-        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
-        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
-        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
-        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
-        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
-        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
-        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
-        issued - retrial (after trial start)","code":null}]}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:12 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=3&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=44
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:12 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":1860.65}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:12 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2016-04-01&type=LGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:12 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '156'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
-        Fee Scheme 2016-04"}]}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:12 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:13 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      - Accept-Encoding
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '835'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
-        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
-        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
-        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
-        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
-        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
-        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
-        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
-        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
-        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
-        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
-        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
-        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
-        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
-        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
-        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
-        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
-        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
-        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
-        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
-        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
-        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
-        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
-        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
-        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
-        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
-        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
-        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
-        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
-        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
-        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
-        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
-        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
-        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
-        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
-        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
-        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
-        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
-        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
-        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
-        issued - retrial (after trial start)","code":null}]}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:13 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=44
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:13 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":5204.77}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:13 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:30 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=A&ppe=0&scenario=45
@@ -1806,7 +1805,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:32 GMT
+      - Wed, 02 Jan 2019 11:31:49 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1821,7 +1820,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":452.29}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:32 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:49 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=A&ppe=80&scenario=45
@@ -1845,7 +1844,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:32 GMT
+      - Wed, 02 Jan 2019 11:31:49 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1860,7 +1859,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":452.29}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:32 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:49 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=A&ppe=81&scenario=45
@@ -1884,7 +1883,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:32 GMT
+      - Wed, 02 Jan 2019 11:31:49 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1899,7 +1898,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":457.64}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:32 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:49 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=B&ppe=81&scenario=45
@@ -1923,7 +1922,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:40 GMT
+      - Wed, 02 Jan 2019 11:31:56 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1938,7 +1937,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":397.64}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:40 GMT
+  recorded_at: Wed, 02 Jan 2019 11:31:56 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=45
@@ -1962,7 +1961,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:45 GMT
+      - Wed, 02 Jan 2019 11:32:01 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -1977,10 +1976,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":477.17}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:45 GMT
+  recorded_at: Wed, 02 Jan 2019 11:32:01 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=46
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=46&trial_length=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2001,7 +2000,85 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:45 GMT
+      - Wed, 02 Jan 2019 11:32:02 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '14'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":0.0}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:32:02 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=9&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=46&trial_length=9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:32:02 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '14'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":0.0}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:32:02 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=46&trial_length=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:32:02 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -2016,10 +2093,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1486.28}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:45 GMT
+  recorded_at: Wed, 02 Jan 2019 11:32:02 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=70&scenario=46
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=100&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=81&scenario=46&trial_length=100
     body:
       encoding: US-ASCII
       string: ''
@@ -2040,7 +2117,46 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:46 GMT
+      - Wed, 02 Jan 2019 11:32:02 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '18'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":1486.28}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:32:02 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=100&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=70&scenario=46&trial_length=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:32:03 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -2055,10 +2171,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1317.19}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:46 GMT
+  recorded_at: Wed, 02 Jan 2019 11:32:03 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=46
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=100&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=46&trial_length=100
     body:
       encoding: US-ASCII
       string: ''
@@ -2079,7 +2195,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Dec 2018 17:23:46 GMT
+      - Wed, 02 Jan 2019 11:32:03 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -2094,122 +2210,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1332.56}'
     http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:46 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=2&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=46
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:46 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":1332.56}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:46 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=3&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=46
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:47 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":1860.65}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:47 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=B&ppe=71&scenario=46
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Dec 2018 17:23:48 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '18'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":5204.77}'
-    http_version: 
-  recorded_at: Fri, 07 Dec 2018 17:23:48 GMT
+  recorded_at: Wed, 02 Jan 2019 11:32:03 GMT
 recorded_with: VCR 3.0.3

--- a/vcr/cassettes/spec/controllers/external_users/fees/prices_controller_spec.yml
+++ b/vcr/cassettes/spec/controllers/external_users/fees/prices_controller_spec.yml
@@ -23,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 19 Dec 2018 00:13:11 GMT
+      - Wed, 02 Jan 2019 11:38:45 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -39,7 +39,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Wed, 19 Dec 2018 00:13:11 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:45 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 19 Dec 2018 00:13:11 GMT
+      - Wed, 02 Jan 2019 11:38:45 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -71,8 +71,8 @@ http_interactions:
       - Accept-Encoding
       X-Frame-Options:
       - SAMEORIGIN
-      Content-Length:
-      - '835'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -122,7 +122,7 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Wed, 19 Dec 2018 00:13:11 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:45 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=1&scenario=4
@@ -146,7 +146,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 19 Dec 2018 00:13:11 GMT
+      - Wed, 02 Jan 2019 11:38:46 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -161,7 +161,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":5142.87}'
     http_version: 
-  recorded_at: Wed, 19 Dec 2018 00:13:11 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:46 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2018-03-31&type=AGFS
@@ -185,7 +185,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 19 Dec 2018 00:13:12 GMT
+      - Wed, 02 Jan 2019 11:38:47 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -201,7 +201,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}]}'
     http_version: 
-  recorded_at: Wed, 19 Dec 2018 00:13:12 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:47 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/scenarios/
@@ -225,7 +225,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 19 Dec 2018 00:13:12 GMT
+      - Wed, 02 Jan 2019 11:38:47 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -246,7 +246,7 @@ http_interactions:
         of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":12,"name":"Elected
         case not proceeded","code":"AS000014"}]}'
     http_version: 
-  recorded_at: Wed, 19 Dec 2018 00:13:12 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:47 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_APPEAL_CON&limit_from=1&offence_class=K&scenario=5
@@ -270,7 +270,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 19 Dec 2018 00:13:13 GMT
+      - Wed, 02 Jan 2019 11:38:48 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -288,5 +288,5 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Wed, 19 Dec 2018 00:13:13 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:48 GMT
 recorded_with: VCR 3.0.3

--- a/vcr/cassettes/spec/services/claims/fee_calculator/price_spec.yml
+++ b/vcr/cassettes/spec/services/claims/fee_calculator/price_spec.yml
@@ -23,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Nov 2018 10:50:32 GMT
+      - Wed, 02 Jan 2019 11:39:06 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -39,7 +39,7 @@ http_interactions:
       string: '{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
         Fee Scheme 9"}'
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 10:50:32 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:06 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_APPEAL_CON&scenario=5&unit=DAY
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Nov 2018 10:50:32 GMT
+      - Wed, 02 Jan 2019 11:39:06 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -81,7 +81,48 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 10:50:32 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:06 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_DISC_FULL&scenario=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:07 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '321'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2368,"scenario":5,"advocate_type":"JRALONE","fee_type":19,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"238.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:07 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_FEE&scenario=12&unit=DAY
@@ -105,7 +146,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Nov 2018 10:50:33 GMT
+      - Wed, 02 Jan 2019 11:39:07 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -114,7 +155,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '480'
+      - '495'
       Connection:
       - keep-alive
     body:
@@ -143,46 +184,5 @@ http_interactions:
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 10:50:33 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_DISC_FULL&scenario=5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 16 Nov 2018 10:50:33 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      - Accept-Encoding
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '321'
-      Connection:
-      - keep-alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2368,"scenario":5,"advocate_type":"JRALONE","fee_type":19,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"238.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-    http_version: 
-  recorded_at: Fri, 16 Nov 2018 10:50:33 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:07 GMT
 recorded_with: VCR 3.0.3

--- a/vcr/cassettes/spec/support/shared_examples/services/shared_examples_for_fee_calculators.yml
+++ b/vcr/cassettes/spec/support/shared_examples/services/shared_examples_for_fee_calculators.yml
@@ -23,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:35 GMT
+      - Wed, 02 Jan 2019 11:38:50 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -39,7 +39,7 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":2,"start_date":"2016-04-01","end_date":null,"type":"LGFS","description":"LGFS
         Fee Scheme 2016-04"}]}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:35 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:50 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/scenarios/
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:35 GMT
+      - Wed, 02 Jan 2019 11:38:51 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -71,8 +71,8 @@ http_interactions:
       - Accept-Encoding
       X-Frame-Options:
       - SAMEORIGIN
-      Content-Length:
-      - '835'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -122,85 +122,7 @@ http_interactions:
         issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
         issued - retrial (after trial start)","code":null}]}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:35 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=81&scenario=45
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 21 Dec 2018 08:06:35 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":457.64}'
-    http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:36 GMT
-- request:
-    method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=100&scenario=43
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/0.2.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 21 Dec 2018 08:06:37 GMT
-      Server:
-      - nginx/1.15.5
-      Vary:
-      - Accept, Cookie
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '17'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"amount":838.94}'
-    http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:37 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:51 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=1&scenario=22
@@ -224,7 +146,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:38 GMT
+      - Wed, 02 Jan 2019 11:38:51 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -239,7 +161,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":904.58}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:38 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:51 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=J&ppe=1&scenario=22
@@ -263,7 +185,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:39 GMT
+      - Wed, 02 Jan 2019 11:38:52 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -278,7 +200,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":1085.5}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:39 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:52 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=J&ppe=1&scenario=4
@@ -302,7 +224,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:41 GMT
+      - Wed, 02 Jan 2019 11:38:53 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -317,7 +239,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":6171.44}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:41 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:53 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=1&scenario=4
@@ -341,7 +263,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:44 GMT
+      - Wed, 02 Jan 2019 11:38:56 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -356,10 +278,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":5142.87}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:44 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:56 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2018-03-31&type=AGFS
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=81&scenario=45
     body:
       encoding: US-ASCII
       string: ''
@@ -376,11 +298,11 @@ http_interactions:
       message: OK
     headers:
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:46 GMT
+      - Wed, 02 Jan 2019 11:38:57 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -388,18 +310,17 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '158'
+      - '17'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
-        Fee Scheme 9"}]}'
+      string: '{"amount":457.64}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:46 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:57 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/scenarios/
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=9&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=80&scenario=46&trial_length=9
     body:
       encoding: US-ASCII
       string: ''
@@ -416,35 +337,29 @@ http_interactions:
       message: OK
     headers:
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:46 GMT
+      - Wed, 02 Jan 2019 11:38:58 GMT
       Server:
       - nginx/1.15.5
       Vary:
       - Accept, Cookie
-      - Accept-Encoding
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '292'
+      - '14'
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: '{"count":12,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":12,"name":"Elected
-        case not proceeded","code":"AS000014"}]}'
+      encoding: UTF-8
+      string: '{"amount":0.0}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:46 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:58 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_APPEAL_CON&limit_from=1&offence_class=K&scenario=5
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=11&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=80&scenario=46&trial_length=11
     body:
       encoding: US-ASCII
       string: ''
@@ -461,32 +376,29 @@ http_interactions:
       message: OK
     headers:
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:46 GMT
+      - Wed, 02 Jan 2019 11:38:59 GMT
       Server:
       - nginx/1.15.5
       Vary:
       - Accept, Cookie
-      - Accept-Encoding
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '344'
+      - '18'
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2064,"scenario":5,"advocate_type":"JRALONE","fee_type":8,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+      encoding: UTF-8
+      string: '{"amount":1467.58}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:46 GMT
+  recorded_at: Wed, 02 Jan 2019 11:38:59 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_STD_APPRNC&limit_from=1&offence_class=K&scenario=5
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=80&scenario=46&trial_length=10
     body:
       encoding: US-ASCII
       string: ''
@@ -503,31 +415,29 @@ http_interactions:
       message: OK
     headers:
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:47 GMT
+      - Wed, 02 Jan 2019 11:39:00 GMT
       Server:
       - nginx/1.15.5
       Vary:
       - Accept, Cookie
-      - Accept-Encoding
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '319'
+      - '18'
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":3260,"scenario":5,"advocate_type":"JRALONE","fee_type":27,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"87.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+      encoding: UTF-8
+      string: '{"amount":1467.58}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:47 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:00 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_ABS_PRC_HF&limit_from=1&offence_class=K&scenario=5
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=2&offence_class=J&ppe=80&scenario=44&trial_length=10
     body:
       encoding: US-ASCII
       string: ''
@@ -544,31 +454,29 @@ http_interactions:
       message: OK
     headers:
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:49 GMT
+      - Wed, 02 Jan 2019 11:39:01 GMT
       Server:
       - nginx/1.15.5
       Vary:
       - Accept, Cookie
-      - Accept-Encoding
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '321'
+      - '17'
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1840,"scenario":5,"advocate_type":"JRALONE","fee_type":5,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+      encoding: UTF-8
+      string: '{"amount":1761.1}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:49 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:01 GMT
 - request:
     method: get
-    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_FEE&limit_from=1&offence_class=K&scenario=12
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=11&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=80&scenario=44&trial_length=11
     body:
       encoding: US-ASCII
       string: ''
@@ -585,29 +493,143 @@ http_interactions:
       message: OK
     headers:
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:54 GMT
+      - Wed, 02 Jan 2019 11:39:02 GMT
       Server:
       - nginx/1.15.5
       Vary:
       - Accept, Cookie
-      - Accept-Encoding
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '343'
+      - '18'
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":748,"scenario":12,"advocate_type":"JRALONE","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"194.00000","limit_from":1,"limit_to":null,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
-        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+      encoding: UTF-8
+      string: '{"amount":1467.58}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:54 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:02 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=10&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=80&scenario=44&trial_length=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:03 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '18'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":1467.58}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:03 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=9&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=80&scenario=44&trial_length=9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:04 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '14'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":0.0}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:04 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?advocate_type&day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&ppe=100&scenario=43
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:05 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '17'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"amount":838.94}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:05 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/prices/?advocate_type&fee_type_code=LIT_FEE&limit_from=0&offence_class=H&scenario=5
@@ -631,7 +653,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:56 GMT
+      - Wed, 02 Jan 2019 11:39:08 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -647,7 +669,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":58843,"scenario":5,"advocate_type":null,"fee_type":54,"offence_class":"H","scheme":2,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"349.47000","limit_from":0,"limit_to":null,"modifiers":[],"strict_range":false}]}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:56 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:08 GMT
 - request:
     method: get
     uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/prices/?advocate_type&fee_type_code=LIT_FEE&limit_from=0&offence_class=H&scenario=12
@@ -671,7 +693,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 Dec 2018 08:06:57 GMT
+      - Wed, 02 Jan 2019 11:39:09 GMT
       Server:
       - nginx/1.15.5
       Vary:
@@ -689,5 +711,256 @@ http_interactions:
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":true},{"limit_from":5,"limit_to":null,"fixed_percent":"30.00","percent_per_unit":"0.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":true}],"strict_range":false}]}'
     http_version: 
-  recorded_at: Fri, 21 Dec 2018 08:06:57 GMT
+  recorded_at: Wed, 02 Jan 2019 11:39:09 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/?case_date=2018-03-31&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:10 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '158'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"start_date":"2012-04-01","end_date":"2018-03-31","type":"AGFS","description":"AGFS
+        Fee Scheme 9"}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:10 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:10 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '292'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":12,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":12,"name":"Elected
+        case not proceeded","code":"AS000014"}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:10 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_ABS_PRC_HF&limit_from=1&offence_class=K&scenario=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:10 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '321'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1840,"scenario":5,"advocate_type":"JRALONE","fee_type":5,"offence_class":null,"scheme":1,"unit":"HALFDAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":60,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:11 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_APPEAL_CON&limit_from=1&offence_class=K&scenario=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:12 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '344'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":2064,"scenario":5,"advocate_type":"JRALONE","fee_type":8,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"130.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:12 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_STD_APPRNC&limit_from=1&offence_class=K&scenario=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:13 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '319'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":3260,"scenario":5,"advocate_type":"JRALONE","fee_type":27,"offence_class":null,"scheme":1,"unit":"DAY","fee_per_unit":"87.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:13 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/1/prices/?advocate_type=JRALONE&fee_type_code=AGFS_FEE&limit_from=1&offence_class=K&scenario=12
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Jan 2019 11:39:16 GMT
+      Server:
+      - nginx/1.15.5
+      Vary:
+      - Accept, Cookie
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":748,"scenario":12,"advocate_type":"JRALONE","fee_type":34,"offence_class":"K","scheme":1,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"194.00000","limit_from":1,"limit_to":null,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
+        of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 11:39:16 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### Warning
cannot be merged/deployed until [this laa-fee-calculator commit](https://github.com/ministryofjustice/laa-fee-calculator/commit/e5edd784dff98eef0c0a8851f0e491a623ac4461) is deployed to production

#### What
Reactivate interim fee calc, applying API call changes needed

#### Why
Fee calc API was [invalid for trial start and retrial start
interim fees](https://github.com/ministryofjustice/laa-fee-calculator/issues/79). This was corrected in [this laa-fee-calculator commit](https://github.com/ministryofjustice/laa-fee-calculator/commit/e5edd784dff98eef0c0a8851f0e491a623ac4461) 

#### How
default trial_length  modifier to value of days
for these two interim fees.

