### PR TITLE
Cbo 471 lgfs blank fields

### DIFF
--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -56,4 +56,8 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
   def requires_interim_claim_info?
     true
   end
+
+  def requires_trial_dates?
+    false
+  end
 end

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -98,28 +98,27 @@
             %td
               = claim&.trial_cracked_at_third&.humanize
 
-        - unless claim.lgfs? && claim.interim?
-          - if claim&.requires_trial_dates?
-            %tr
-              %th{ scope: 'row', class: 'bold' }
-                = t("first_day_of_trial", scope: trial_detail_fields)
-              %td
-                = claim&.first_day_of_trial&.strftime(Settings.date_format)
-            %tr
-              %th{ scope: 'row', class: 'bold' }
-                = t("estimated_trial_length", scope: trial_detail_fields)
-              %td
-                = claim&.estimated_trial_length
-            %tr
-              %th{ scope: 'row', class: 'bold' }
-                = t("actual_trial_length", scope: trial_detail_fields)
-              %td
-                = claim&.actual_trial_length
-            %tr
-              %th{ scope: 'row', class: 'bold' }
-                = t("trial_concluded_at", scope: trial_detail_fields)
-              %td
-                = claim&.trial_concluded_at&.strftime(Settings.date_format)
+        - if claim&.requires_trial_dates?
+          %tr
+            %th{ scope: 'row', class: 'bold' }
+              = t("first_day_of_trial", scope: trial_detail_fields)
+            %td
+              = claim&.first_day_of_trial&.strftime(Settings.date_format)
+          %tr
+            %th{ scope: 'row', class: 'bold' }
+              = t("estimated_trial_length", scope: trial_detail_fields)
+            %td
+              = claim&.estimated_trial_length
+          %tr
+            %th{ scope: 'row', class: 'bold' }
+              = t("actual_trial_length", scope: trial_detail_fields)
+            %td
+              = claim&.actual_trial_length
+          %tr
+            %th{ scope: 'row', class: 'bold' }
+              = t("trial_concluded_at", scope: trial_detail_fields)
+            %td
+              = claim&.trial_concluded_at&.strftime(Settings.date_format)
 
           - if claim&.requires_retrial_dates?
             %tr

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -74,9 +74,9 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I click Submit to LAA
     Then I should be on the check your claim page
-    And I should see the field 'Crown court' with value 'Blackfriars'
-    And I should see the field 'Case type' with value 'Contempt'
-    And I should see the field 'Date case concluded' with value '01/04/2016'
+    And I should see the field 'Crown court' with value 'Blackfriars' in 'Case details'
+    And I should see the field 'Case type' with value 'Contempt' in 'Case details'
+    And I should see the field 'Date case concluded' with value '01/04/2016' in 'Case details'
     And I should not see 'First day of trial'
     And I should not see 'Estimated trial length'
     And I should not see 'Actual trial length'

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -74,6 +74,13 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I click Submit to LAA
     Then I should be on the check your claim page
+    And I should see the field 'Crown court' with value 'Blackfriars'
+    And I should see the field 'Case type' with value 'Contempt'
+    And I should see the field 'Date case concluded' with value '01/04/2016'
+    And I should not see 'First day of trial'
+    And I should not see 'Estimated trial length'
+    And I should not see 'Actual trial length'
+    And I should not see 'Trial concluded on'
 
     When I click "Continue"
     Then I should be on the certification page

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -66,6 +66,15 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     Then I click "Continue" in the claim form
 
     And I should be on the check your claim page
+    Then I should be on the check your claim page
+    And I should see the field 'Crown court' with value 'Blackfriars'
+    And I should see the field 'Case type' with value 'Contempt'
+    And I should see the field 'Date case concluded' with value '01/04/2018'
+    And I should not see 'First day of trial'
+    And I should not see 'Estimated trial length'
+    And I should not see 'Actual trial length'
+    And I should not see 'Trial concluded on'
+
     When I click "Continue"
     Then I should be on the certification page
     And I click Certify and submit claim

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -66,15 +66,6 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     Then I click "Continue" in the claim form
 
     And I should be on the check your claim page
-    Then I should be on the check your claim page
-    And I should see the field 'Crown court' with value 'Blackfriars'
-    And I should see the field 'Case type' with value 'Contempt'
-    And I should see the field 'Date case concluded' with value '01/04/2018'
-    And I should not see 'First day of trial'
-    And I should not see 'Estimated trial length'
-    And I should not see 'Actual trial length'
-    And I should not see 'Trial concluded on'
-
     When I click "Continue"
     Then I should be on the certification page
     And I click Certify and submit claim

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -93,6 +93,13 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I click Submit to LAA
     Then I should be on the check your claim page
+    And I should see the field 'Crown court' with value 'Blackfriars'
+    And I should see the field 'Case type' with value 'Trial'
+    And I should see the field 'Date case concluded' with value '01/04/2016'
+    And I should see the field 'Actual trial length' with value '1'
+    And I should not see 'First day of trial'
+    And I should not see 'Estimated trial length'
+    And I should not see 'Trial concluded on'
 
     When I click "Continue"
     Then I should be on the certification page

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -93,10 +93,14 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I click Submit to LAA
     Then I should be on the check your claim page
-    And I should see the field 'Crown court' with value 'Blackfriars'
-    And I should see the field 'Case type' with value 'Trial'
-    And I should see the field 'Date case concluded' with value '01/04/2016'
-    And I should see the field 'Actual trial length' with value '1'
+    And I should see the field 'Crown court' with value 'Blackfriars' in 'Case details'
+    And I should see the field 'Case type' with value 'Trial' in 'Case details'
+    And I should see the field 'Date case concluded' with value '01/04/2016' in 'Case details'
+    And I should see the field 'Type of fee' with value 'Trial' in 'Graduated fee'
+    And I should see the field 'First day of hearing' with value '01/01/2018' in 'Graduated fee'
+    And I should see the field 'Actual trial length' with value '1' in 'Graduated fee'
+    And I should see the field 'Total pages of evidence' with value '51' in 'Graduated fee'
+    And I should see the field 'Net amount' with value '£437.89' in 'Graduated fee'
     And I should not see 'First day of trial'
     And I should not see 'Estimated trial length'
     And I should not see 'Trial concluded on'

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -158,8 +158,10 @@ Then(/^I should see "([^"]*)"$/) do |arg1|
   expect(page).to have_content(arg1)
 end
 
-And(/^I should see the field '(.*?)' with value '(.*?)'$/) do |field, value|
-  expect(page.find(:css, 'tr', text: field)).to have_content(value)
+And(/^I should see the field '(.*?)' with value '(.*?)' in '(.*?)'$/) do |field, value, section|
+  within(page.find(:css, 'div.form-section', text: section)) do
+    expect(page.find(:css, 'tr', text: field)).to have_content(value)
+  end
 end
 
 # Record modes can be: all, none, new_episodes or once. Default is 'none'.

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -158,6 +158,10 @@ Then(/^I should see "([^"]*)"$/) do |arg1|
   expect(page).to have_content(arg1)
 end
 
+And(/^I should see the field '(.*?)' with value '(.*?)'$/) do |field, value|
+  expect(page.find(:css, 'tr', text: field)).to have_content(value)
+end
+
 # Record modes can be: all, none, new_episodes or once. Default is 'none'.
 # When creating new tests that calls new endpoints, you will need to record the cassette.
 # NOTE: see the README section 'Recording new VCR cassettes' for assistance

--- a/spec/presenters/claim/litigator_claim_presenter_spec.rb
+++ b/spec/presenters/claim/litigator_claim_presenter_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe Claim::LitigatorClaimPresenter, type: :presenter do
     specify { expect(presenter.requires_interim_claim_info?).to be_truthy }
   end
 
+  describe '#requires_trial_dates?' do
+    specify { expect(presenter.requires_trial_dates?).to be false }
+  end
+
   describe '#summary_sections' do
     specify {
       expect(presenter.summary_sections).to eq({


### PR DESCRIPTION
#### What
As an LGFS provider
I do not want to be displayed 'first day of trial' and 'trial concluded on' on the case details summary
So that I am not shown unnecessary blank fields

#### Ticket
https://dsdmoj.atlassian.net/projects/CBO/issues/CBO-471?filter=allopenissues&orderby=priority%20DESC

#### Why
To avoid confusion?

#### How
Added a function hide_blank_litigator_fields? in presenter classes
