### PR TITLE
CBO-463: Improve sandbox provider creation

### DIFF
--- a/app/services/external_users/create_user.rb
+++ b/app/services/external_users/create_user.rb
@@ -42,7 +42,7 @@ module ExternalUsers
     def generate_lgfs_supplier_number
       last_record = SupplierNumber.where("supplier_number LIKE '9X%'").reorder(:supplier_number).last
       return 1 unless last_record
-      /^9X(?<highest_number>^.*)X$/ =~ last_record.supplier_number
+      /^9X(?<highest_number>\d{3})X$/ =~ last_record.supplier_number
       highest_number.to_i + 1
     end
 

--- a/spec/services/external_users/create_user_spec.rb
+++ b/spec/services/external_users/create_user_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe ExternalUsers::CreateUser do
       expect(new_external_user.provider).to eq(new_provider)
     end
 
+    context 'when a previous supplier exists' do
+      before do
+        service.call!
+        #simulate calling the service twice
+        service.call!
+      end
+
+      it 'allocates sequential lgfs_supplier_numbers numbers for sandbox users' do
+        second_provider = Provider.order('created_at').last
+        expect(second_provider.lgfs_supplier_numbers.first.supplier_number).to eql '9X002X'
+      end
+    end
+
     context 'when the provider is not created due to some error' do
       before do
         expect(Provider)


### PR DESCRIPTION
#### What
Update the create_user regex

#### Ticket
[raise error for non-unique provider reference - api-sandbox](https://dsdmoj.atlassian.net/browse/CBO-463)

#### Why
The previous version was failing because of the caret(^)

#### How
This explicitly looks for the 3 digit numbers used by software vendors
on the api sandbox.  As the next line expects an integer, this seems
a safe proposal
