### PR TITLE
Correct codeclimate rubocop channel

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ engines:
             - "(call _ expose ___)" # exlude expose methods
   rubocop:
     enabled: true
-    channel: rubocop-0-6
+    channel: rubocop-0-60
     config:
       file: .rubocop.yml
   brakeman:


### PR DESCRIPTION
Was using a non-existent channel. Available channels here:
https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop