### PR TITLE
CBO-494: Performance Platform integration

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -119,6 +119,7 @@ Performance/UnneededSort:
 # Offense count: 2
 Security/Open:
   Exclude:
+    - 'app/interfaces/api/v2/performance_platform/quarterly_volume.rb'
     - 'app/controllers/case_workers/admin/management_information_controller.rb'
     - 'lib/id_sequence_resettable.rb'
 

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -21,6 +21,9 @@ module API
                        desc: I18n.t('api.v2.performance_platform.quarterly_volume.value', month: 'third')
             end
             get do
+              # create stats_report record then display it
+              # this can be deleted by a successful post
+              # or replaced by a re-generation of this end point
               results = { key: 'value' }
               present JSON.parse(results.to_json, object_class: OpenStruct)
             end

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -21,30 +21,14 @@ module API
                        desc: I18n.t('api.v2.performance_platform.quarterly_volume.value', month: 'third')
             end
             get do
-              # create stats_report record then display it
-              # this can be deleted by a successful post
-              # or replaced by a re-generation of this end point
-              results = {
-                month_one: {
-                  date: params[:start_date],
-                  usd_value: params[:month_1_usd_value],
-                  gbp_value: '00.00'
-                },
-                month_two: {
-                  date: params[:start_date].to_date + 1.month,
-                  usd_value: params[:month_2_usd_value],
-                  gbp_value: '00.00'
-                },
-                month_three: {
-                  date: Date.parse(params[:start_date]) + 2.months,
-                  usd_value: params[:month_3_usd_value],
-                  gbp_value: '00.00'
-                },
-                total_quarter_cost: '00.00',
-                claim_count: '0000',
-                cost_per_transaction_quarter: '00.00'
+              options = {
+                quarter_start: params[:start_date],
+                month_1: params[:month_1_usd_value],
+                month_2: params[:month_2_usd_value],
+                month_3: params[:month_3_usd_value]
               }
-              present JSON.parse(results.to_json)
+              results = Stats::QuarterlyVolumeGenerator.call(options)
+              present JSON.parse(results.to_json)['content']
             end
           end
         end

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -1,0 +1,32 @@
+module API
+  module V2
+    module PerformancePlatform
+      class QuarterlyVolume < Grape::API
+        resource :performance_platform, desc: 'Performance Platform' do
+          resource :quarterly_volume do
+            desc 'Calculate totals for quarterly volume performance platform report'
+            params do
+              optional :api_key, type: String, desc: I18n.t('api.v2.generic.params.api_key')
+              optional :start_date,
+                       type: String,
+                       desc: I18n.t('api.v2.performance_platform.quarterly_volume.start_date')
+              optional :month_1_usd_value,
+                       type: String,
+                       desc: I18n.t('api.v2.performance_platform.quarterly_volume.value', month: 'first')
+              optional :month_2_usd_value,
+                       type: String,
+                       desc: I18n.t('api.v2.performance_platform.quarterly_volume.value', month: 'second')
+              optional :month_3_usd_value,
+                       type: String,
+                       desc: I18n.t('api.v2.performance_platform.quarterly_volume.value', month: 'third')
+            end
+            get do
+              results = { key: 'value' }
+              present JSON.parse(results.to_json, object_class: OpenStruct)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -4,7 +4,6 @@ module API
       class QuarterlyVolume < Grape::API
         resource :performance_platform, desc: 'Performance Platform' do
           resource :quarterly_volume do
-            desc 'Calculate totals for quarterly volume performance platform report'
             params do
               optional :api_key, type: String, desc: I18n.t('api.v2.generic.params.api_key')
               optional :start_date,
@@ -20,6 +19,8 @@ module API
                        type: String,
                        desc: I18n.t('api.v2.performance_platform.quarterly_volume.value', month: 'third')
             end
+
+            desc 'Calculate totals for quarterly volume performance platform report'
             get do
               options = {
                 quarter_start: params[:start_date],
@@ -29,6 +30,24 @@ module API
               }
               results = Stats::QuarterlyVolumeGenerator.call(options)
               present JSON.parse(results.content.gsub(/=>/, ':').gsub(':nil,', ':null,'))
+            end
+          end
+
+          resource :quarterly_volume do
+            params do
+              optional :api_key, type: String, desc: I18n.t('api.v2.generic.params.api_key')
+              optional :start_date,
+                       type: String,
+                       desc: I18n.t('api.v2.performance_platform.quarterly_volume.start_date')
+            end
+            desc 'Submit calculated totals for quarterly volume performance platform report'
+            post do
+              # load results from tmp/s3
+              # error if previously generated files have not been saved
+              # parse results
+              # send results
+              result = { successful_upload: true }
+              present result.as_json
             end
           end
         end

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -60,7 +60,7 @@ module API
               results = quarterly_report
               start_of_quarter = Date.parse(results[:month_one][:date]).beginning_of_month
               qvr = Reports::PerformancePlatform::QuarterlyVolume.new(start_of_quarter)
-              qvr.populate_data(results[:total_quarter_cost])
+              qvr.populate_data(results[:total_quarter_cost], results[:claim_count])
               published = qvr.publish!
               result = { successful_upload: JSON.parse(published)['status'] }
               report.destroy

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -10,6 +10,8 @@ module API
           def quarterly_report
             data = open(report.document_url).read
             JSON.parse(data.gsub(/=>/, ':').gsub(':nil,', ':null,')).deep_symbolize_keys
+          rescue StandardError
+            error!('No report exists', 400)
           end
         end
 
@@ -52,6 +54,7 @@ module API
                        type: String,
                        desc: I18n.t('api.v2.performance_platform.quarterly_volume.start_date')
             end
+
             desc 'Submit calculated totals for quarterly volume performance platform report'
             post do
               results = quarterly_report

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -2,6 +2,17 @@ module API
   module V2
     module PerformancePlatform
       class QuarterlyVolume < Grape::API
+        helpers do
+          def report
+            Stats::StatsReport.most_recent_by_type('quarterly_volume')
+          end
+
+          def quarterly_report
+            data = open(report.document_url).read
+            JSON.parse(data.gsub(/=>/, ':').gsub(':nil,', ':null,')).deep_symbolize_keys
+          end
+        end
+
         resource :performance_platform, desc: 'Performance Platform' do
           resource :quarterly_volume do
             params do
@@ -28,8 +39,9 @@ module API
                 month_2: params[:month_2_usd_value],
                 month_3: params[:month_3_usd_value]
               }
-              results = Stats::QuarterlyVolumeGenerator.call(options)
-              present JSON.parse(results.content.gsub(/=>/, ':').gsub(':nil,', ':null,'))
+              Stats::StatsReportGenerator.call('quarterly_volume', options)
+
+              present quarterly_report
             end
           end
 
@@ -42,11 +54,13 @@ module API
             end
             desc 'Submit calculated totals for quarterly volume performance platform report'
             post do
-              # load results from tmp/s3
-              # error if previously generated files have not been saved
-              # parse results
-              # send results
-              result = { successful_upload: true }
+              results = quarterly_report
+              start_of_quarter = Date.parse(results[:month_one][:date]).beginning_of_month
+              qvr = Reports::PerformancePlatform::QuarterlyVolume.new(start_of_quarter)
+              qvr.populate_data(results[:total_quarter_cost])
+              published = qvr.publish!
+              result = { successful_upload: JSON.parse(published)['status'] }
+              report.destroy
               present result.as_json
             end
           end

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -28,7 +28,7 @@ module API
                 month_3: params[:month_3_usd_value]
               }
               results = Stats::QuarterlyVolumeGenerator.call(options)
-              present JSON.parse(results.to_json)['content']
+              present JSON.parse(results.content.gsub(/=>/, ':').gsub(':nil,', ':null,'))
             end
           end
         end

--- a/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
+++ b/app/interfaces/api/v2/performance_platform/quarterly_volume.rb
@@ -24,8 +24,27 @@ module API
               # create stats_report record then display it
               # this can be deleted by a successful post
               # or replaced by a re-generation of this end point
-              results = { key: 'value' }
-              present JSON.parse(results.to_json, object_class: OpenStruct)
+              results = {
+                month_one: {
+                  date: params[:start_date],
+                  usd_value: params[:month_1_usd_value],
+                  gbp_value: '00.00'
+                },
+                month_two: {
+                  date: params[:start_date].to_date + 1.month,
+                  usd_value: params[:month_2_usd_value],
+                  gbp_value: '00.00'
+                },
+                month_three: {
+                  date: Date.parse(params[:start_date]) + 2.months,
+                  usd_value: params[:month_3_usd_value],
+                  gbp_value: '00.00'
+                },
+                total_quarter_cost: '00.00',
+                claim_count: '0000',
+                cost_per_transaction_quarter: '00.00'
+              }
+              present JSON.parse(results.to_json)
             end
           end
         end

--- a/app/interfaces/api/v2/root.rb
+++ b/app/interfaces/api/v2/root.rb
@@ -20,6 +20,7 @@ module API
           mount API::V2::MI::InjectionErrors
           mount API::V2::MI::ProvisionalAssessments
           mount API::V2::MI::AdditionalInformationExpenses
+          mount API::V2::PerformancePlatform::QuarterlyVolume
 
           namespace :ccr, desc: 'CCR injection specific claim format' do
             mount API::V2::CCRClaim

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -12,7 +12,7 @@
 
 module Stats
   class StatsReport < ApplicationRecord
-    TYPES = %w[management_information provisional_assessment rejections_refusals].freeze
+    TYPES = %w[management_information provisional_assessment rejections_refusals quarterly_volume].freeze
 
     validates :status, inclusion: { in: %w[started completed error] }
 
@@ -24,6 +24,7 @@ module Stats
 
     scope :management_information, -> { not_errored.where(report_name: 'management_information') }
     scope :provisional_assessment, -> { not_errored.where(report_name: 'provisional_assessment') }
+    scope :quarterly_volume, -> { not_errored.where(report_name: 'quarterly_volume') }
 
     has_attached_file :document,
                       { s3_headers: {

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -12,7 +12,7 @@
 
 module Stats
   class StatsReport < ApplicationRecord
-    TYPES = %w[management_information provisional_assessment rejections_refusals quarterly_volume].freeze
+    TYPES = %w[management_information provisional_assessment rejections_refusals].freeze
 
     validates :status, inclusion: { in: %w[started completed error] }
 
@@ -24,7 +24,6 @@ module Stats
 
     scope :management_information, -> { not_errored.where(report_name: 'management_information') }
     scope :provisional_assessment, -> { not_errored.where(report_name: 'provisional_assessment') }
-    scope :quarterly_volume, -> { not_errored.where(report_name: 'quarterly_volume') }
 
     has_attached_file :document,
                       { s3_headers: {

--- a/app/services/claims/count.rb
+++ b/app/services/claims/count.rb
@@ -1,0 +1,27 @@
+module Claims
+  class Count
+    class << self
+      def quarter(date)
+        new(date, :quarter).call
+      end
+
+      def month(date)
+        new(date, :month).call
+      end
+
+      def week(date)
+        new(date, :week).call
+      end
+    end
+
+    def initialize(date, period)
+      date = Date.parse(date.to_s || Date.today.to_s)
+      @start = date.send("beginning_of_#{period}").beginning_of_day.to_s(:db)
+      @end = date.send("end_of_#{period}").end_of_day.to_s(:db)
+    end
+
+    def call
+      Claim::BaseClaim.where(original_submission_date: @start..@end).count
+    end
+  end
+end

--- a/app/services/conversion/currency.rb
+++ b/app/services/conversion/currency.rb
@@ -1,0 +1,35 @@
+module Conversion
+  class Currency
+    def self.call(date, value)
+      new(date, value).call
+    end
+
+    def initialize(date, value)
+      @date = date
+      @value = value
+    end
+
+    def call
+      params = query_options
+      result = JSON.parse(RestClient.get('http://apilayer.net/api/historical', params: params)).deep_symbolize_keys
+      rate = result[:quotes][:USDGBP]
+      (rate * @value.to_f).round(2)
+    rescue StandardError => e
+      Rails.logger.error "Error converting currency #{e.message}"
+      nil
+    end
+
+    private
+
+    def query_options
+      default_options.merge(date: @date.to_s(:db))
+    end
+
+    def default_options
+      {
+        currencies: 'USD,GBP',
+        access_key: ENV['CURRENCY_API_KEY']
+      }
+    end
+  end
+end

--- a/app/services/conversion/currency.rb
+++ b/app/services/conversion/currency.rb
@@ -6,7 +6,7 @@ module Conversion
 
     def initialize(date, value)
       @date = date
-      @value = value.delete(',')
+      @value = value&.delete(',')
     end
 
     def call

--- a/app/services/conversion/currency.rb
+++ b/app/services/conversion/currency.rb
@@ -6,7 +6,7 @@ module Conversion
 
     def initialize(date, value)
       @date = date
-      @value = value
+      @value = value.delete(',')
     end
 
     def call

--- a/app/services/conversion/currency.rb
+++ b/app/services/conversion/currency.rb
@@ -28,7 +28,7 @@ module Conversion
     def default_options
       {
         currencies: 'USD,GBP',
-        access_key: ENV['CURRENCY_API_KEY']
+        access_key: Rails.application.secrets.currency_api_key
       }
     end
   end

--- a/app/services/reports/performance_platform/quarterly_volume.rb
+++ b/app/services/reports/performance_platform/quarterly_volume.rb
@@ -43,9 +43,7 @@ module Reports
       end
 
       def count_digital_claims
-        first = @start_date.beginning_of_day.to_s(:db)
-        last = @start_date.end_of_quarter.end_of_day.to_s(:db)
-        @count_digital_claims ||= Claim::BaseClaim.where(original_submission_date: first..last).count
+        @count_digital_claims ||= Claims::Count.quarter(@start_date)
       end
     end
   end

--- a/app/services/reports/performance_platform/quarterly_volume.rb
+++ b/app/services/reports/performance_platform/quarterly_volume.rb
@@ -23,6 +23,7 @@ module Reports
         }
         @pps.add_data_set(@start_date, data)
         @ready_to_send = true
+        @pps.data_sets
       rescue RuntimeError => e
         raise e
       rescue StandardError

--- a/app/services/reports/performance_platform/quarterly_volume.rb
+++ b/app/services/reports/performance_platform/quarterly_volume.rb
@@ -11,15 +11,16 @@ module Reports
         @ready_to_send = false
       end
 
-      def populate_data(total_cost)
+      def populate_data(total_cost, claim_count)
         @total_cost = total_cost
-        raise 'Total cost cannot be parsed as a numeric value' unless total_cost_is_numeric?
+        @claim_count = claim_count
+        raise 'Arguments should be numeric' unless inputs_numeric?
         data = {
-          cost_per_transaction_quarter: (@total_cost.to_f / count_digital_claims.to_f).round(2),
+          cost_per_transaction_quarter: (@total_cost.to_f / @claim_count.to_f).round(2),
           start_at: @start_date.beginning_of_day.to_s(:db),
           end_at: @start_date.end_of_quarter.end_of_day.to_s(:db),
           total_cost_quarter: @total_cost.to_f,
-          transactions_per_quarter: count_digital_claims
+          transactions_per_quarter: @claim_count
         }
         @pps.add_data_set(@start_date, data)
         @ready_to_send = true
@@ -36,14 +37,10 @@ module Reports
 
       private
 
-      def total_cost_is_numeric?
-        true if Float(@total_cost)
+      def inputs_numeric?
+        true if Float(@total_cost) && Integer(@claim_count)
       rescue StandardError
         false
-      end
-
-      def count_digital_claims
-        @count_digital_claims ||= Claims::Count.quarter(@start_date)
       end
     end
   end

--- a/app/services/reports/performance_platform/quarterly_volume.rb
+++ b/app/services/reports/performance_platform/quarterly_volume.rb
@@ -1,0 +1,51 @@
+module Reports
+  module PerformancePlatform
+    class QuarterlyVolume
+      attr_reader :ready_to_send
+
+      def initialize(start_date)
+        raise 'Report must start on a quarter' unless start_date.at_beginning_of_quarter.eql?(start_date)
+        raise 'Report cannot be in the future' unless start_date < Date.today
+        @pps = ::PerformancePlatform.report('quarterly_volumes')
+        @start_date = start_date
+        @ready_to_send = false
+      end
+
+      def populate_data(total_cost)
+        @total_cost = total_cost
+        raise 'Total cost cannot be parsed as a numeric value' unless total_cost_is_numeric?
+        data = {
+          cost_per_transaction_quarter: (@total_cost.to_f / count_digital_claims.to_f).round(2),
+          start_at: @start_date.beginning_of_day.to_s(:db),
+          end_at: @start_date.end_of_quarter.end_of_day.to_s(:db),
+          total_cost_quarter: @total_cost.to_f,
+          transactions_per_quarter: count_digital_claims
+        }
+        @pps.add_data_set(@start_date, data)
+        @ready_to_send = true
+      rescue RuntimeError => e
+        raise e
+      rescue StandardError
+        @ready_to_send = false
+      end
+
+      def publish!
+        @pps.send_data! if @ready_to_send
+      end
+
+      private
+
+      def total_cost_is_numeric?
+        true if Float(@total_cost)
+      rescue StandardError
+        false
+      end
+
+      def count_digital_claims
+        first = @start_date.beginning_of_day.to_s(:db)
+        last = @start_date.end_of_quarter.end_of_day.to_s(:db)
+        @count_digital_claims ||= Claim::BaseClaim.where(original_submission_date: first..last).count
+      end
+    end
+  end
+end

--- a/app/services/reports/performance_platform/transactions_by_channel.rb
+++ b/app/services/reports/performance_platform/transactions_by_channel.rb
@@ -30,9 +30,7 @@ module Reports
       private
 
       def count_digital_claims
-        first = @start_date.beginning_of_day.to_s(:db)
-        last = (@start_date + 6.days).end_of_day.to_s(:db)
-        Claim::BaseClaim.where(original_submission_date: first..last).count
+        @count_digital_claims ||= Claims::Count.week(@start_date)
       end
     end
   end

--- a/app/services/reports/performance_platform/transactions_by_channel.rb
+++ b/app/services/reports/performance_platform/transactions_by_channel.rb
@@ -1,0 +1,39 @@
+module Reports
+  module PerformancePlatform
+    class TransactionsByChannel
+      attr_reader :ready_to_send
+
+      def initialize(start_date)
+        raise 'Report must start on a Monday' unless start_date.monday?
+        raise 'Report cannot be in the current week' unless start_date.cweek != Date.today.cweek
+        raise 'Report cannot be in the future' unless start_date < Date.today
+        @pps = ::PerformancePlatform.report('transactions_by_channel')
+        @start_date = start_date
+        @ready_to_send = false
+      end
+
+      def populate_data
+        data = [{ count: 0, channel: 'paper' }]
+        data << { count: count_digital_claims, channel: 'digital' }
+        data.each do |hash|
+          @pps.add_data_set(@start_date, hash)
+        end
+        @ready_to_send = true
+      rescue StandardError
+        @ready_to_send = false
+      end
+
+      def publish!
+        @pps.send_data! if @ready_to_send
+      end
+
+      private
+
+      def count_digital_claims
+        first = @start_date.beginning_of_day.to_s(:db)
+        last = (@start_date + 6.days).end_of_day.to_s(:db)
+        Claim::BaseClaim.where(original_submission_date: first..last).count
+      end
+    end
+  end
+end

--- a/app/services/reports/performance_platform/transactions_by_channel.rb
+++ b/app/services/reports/performance_platform/transactions_by_channel.rb
@@ -4,11 +4,11 @@ module Reports
       attr_reader :ready_to_send
 
       def initialize(start_date)
-        raise 'Report must start on a Monday' unless start_date.monday?
-        raise 'Report cannot be in the current week' unless start_date.cweek != Date.today.cweek
-        raise 'Report cannot be in the future' unless start_date < Date.today
-        @pps = ::PerformancePlatform.report('transactions_by_channel')
         @start_date = start_date
+        raise 'Report must start on a Monday' unless @start_date.monday?
+        raise 'Report cannot be in the current week' if @start_date.cweek.eql?(Date.today.cweek)
+        raise 'Report cannot be in the future' if @start_date >= Date.today
+        @pps = ::PerformancePlatform.report('transactions_by_channel')
         @ready_to_send = false
       end
 

--- a/app/services/stats/quarterly_volume_generator.rb
+++ b/app/services/stats/quarterly_volume_generator.rb
@@ -63,9 +63,7 @@ module Stats
     end
 
     def count_digital_claims
-      first = @start_date.beginning_of_day.to_s(:db)
-      last = @start_date.end_of_quarter.end_of_day.to_s(:db)
-      @count_digital_claims ||= Claim::BaseClaim.where(original_submission_date: first..last).count
+      @count_digital_claims ||= Claims::Count.quarter(start_date)
     end
   end
 end

--- a/app/services/stats/quarterly_volume_generator.rb
+++ b/app/services/stats/quarterly_volume_generator.rb
@@ -27,9 +27,9 @@ module Stats
         result.merge!(calculate_gbp_for_(int))
       end
       totals = {
-        total_quarter_cost: @gbp_total,
+        total_quarter_cost: @gbp_total.to_f.round(2),
         claim_count: count_digital_claims,
-        cost_per_transaction_quarter: @gbp_total / count_digital_claims
+        cost_per_transaction_quarter: (@gbp_total / count_digital_claims).to_f.round(2)
       }
       result.merge!(totals)
       result

--- a/app/services/stats/quarterly_volume_generator.rb
+++ b/app/services/stats/quarterly_volume_generator.rb
@@ -8,6 +8,8 @@ module Stats
 
     def initialize(options = {})
       @format = options.fetch(:format, DEFAULT_FORMAT)
+      @options = options.except(:format)
+      @gbp_total = 0.0
     end
 
     def call
@@ -20,17 +22,50 @@ module Stats
     attr_reader :format
 
     def generate_new_report
-      {
-        _id: 'xxxxx',
-        _timestamp: '2017-04-01T00:00:00+00:00',
-        cost_per_transaction_quarter: '0.5',
-        end_at: '2017-07-01T00:00:00+00:00',
-        period: 'quarter',
-        service: 'Crown Court Defence',
-        start_at: '2017-04-01T00:00:00+00:00',
-        total_cost_quarter: '1276.9',
-        transactions_per_quarter: '0.18'
+      result = base_hash
+      3.times do |int|
+        result.merge!(calculate_gbp_for_(int))
+      end
+      totals = {
+        total_quarter_cost: @gbp_total,
+        claim_count: count_digital_claims,
+        cost_per_transaction_quarter: @gbp_total / count_digital_claims
       }
+      result.merge!(totals)
+      result
+    end
+
+    def base_hash
+      {
+        total_quarter_cost: nil,
+        claim_count: nil,
+        cost_per_transaction_quarter: nil,
+        month_one: { date: nil, usd_value: nil, gbp_value: nil },
+        month_two: { date: nil, usd_value: nil, gbp_value: nil },
+        month_three: { date: nil, usd_value: nil, gbp_value: nil }
+      }
+    end
+
+    def calculate_gbp_for_(month_offset)
+      date = (start_date + month_offset.months).end_of_month
+      usd_value = @options[:"month_#{month_offset + 1}"]
+      gbp_value = Conversion::Currency.call(date, usd_value)
+      @gbp_total += gbp_value
+      { "month_#{number_to_text(month_offset + 1)}": { date: date, usd_value: usd_value, gbp_value: gbp_value } }
+    end
+
+    def number_to_text(value)
+      { '1' => 'one', '2' => 'two', '3' => 'three' }[value.to_s]
+    end
+
+    def start_date
+      @start_date ||= Date.parse(@options[:quarter_start])
+    end
+
+    def count_digital_claims
+      first = @start_date.beginning_of_day.to_s(:db)
+      last = @start_date.end_of_quarter.end_of_day.to_s(:db)
+      @count_digital_claims ||= Claim::BaseClaim.where(original_submission_date: first..last).count
     end
   end
 end

--- a/app/services/stats/quarterly_volume_generator.rb
+++ b/app/services/stats/quarterly_volume_generator.rb
@@ -1,0 +1,36 @@
+module Stats
+  class QuarterlyVolumeGenerator
+    DEFAULT_FORMAT = 'json'.freeze
+
+    def self.call(options = {})
+      new(options).call
+    end
+
+    def initialize(options = {})
+      @format = options.fetch(:format, DEFAULT_FORMAT)
+    end
+
+    def call
+      output = generate_new_report
+      Stats::Result.new(output, format)
+    end
+
+    private
+
+    attr_reader :format
+
+    def generate_new_report
+      {
+        _id: 'xxxxx',
+        _timestamp: '2017-04-01T00:00:00+00:00',
+        cost_per_transaction_quarter: '0.5',
+        end_at: '2017-07-01T00:00:00+00:00',
+        period: 'quarter',
+        service: 'Crown Court Defence',
+        start_at: '2017-04-01T00:00:00+00:00',
+        total_cost_quarter: '1276.9',
+        transactions_per_quarter: '0.18'
+      }
+    end
+  end
+end

--- a/app/services/stats/quarterly_volume_generator.rb
+++ b/app/services/stats/quarterly_volume_generator.rb
@@ -1,6 +1,6 @@
 module Stats
   class QuarterlyVolumeGenerator
-    DEFAULT_FORMAT = 'json'.freeze
+    DEFAULT_FORMAT = 'csv'.freeze
 
     def self.call(options = {})
       new(options).call
@@ -14,7 +14,7 @@ module Stats
 
     def call
       output = generate_new_report
-      Stats::Result.new(output, format)
+      Stats::Result.new(output.as_json.to_s, format)
     end
 
     private

--- a/app/services/stats/quarterly_volume_generator.rb
+++ b/app/services/stats/quarterly_volume_generator.rb
@@ -14,7 +14,8 @@ module Stats
 
     def call
       output = generate_new_report
-      Stats::Result.new(output.as_json.to_s, format)
+      File.open(filename, 'w') { |file| file.write output.as_json }
+      output
     end
 
     private
@@ -56,6 +57,10 @@ module Stats
 
     def number_to_text(value)
       { '1' => 'one', '2' => 'two', '3' => 'three' }[value.to_s]
+    end
+
+    def filename
+      File.join(Rails.root, 'tmp', "#{@start_date.strftime('%Y_%m')}_qv_report.json")
     end
 
     def start_date

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -36,7 +36,8 @@ module Stats
       generator_klass = {
         management_information: ManagementInformationGenerator,
         provisional_assessment: ProvisionalAssessmentReportGenerator,
-        rejections_refusals: RejectionsRefusalsReportGenerator
+        rejections_refusals: RejectionsRefusalsReportGenerator,
+        quarterly_volume: QuarterlyVolumeGenerator
       }[report_type.to_sym]
       generator_klass.call(options)
     end

--- a/config/initializers/performance_platform.rb
+++ b/config/initializers/performance_platform.rb
@@ -1,5 +1,5 @@
 PerformancePlatform.configure do |config|
-  config.root_url = 'https://www.performance.service.gov.uk/data'
+  config.root_url = ENV['PERFORMANCE_PLATFORM_ENDPOINT'] if ENV['PERFORMANCE_PLATFORM_ENDPOINT']
   config.service = ENV['PERFORMANCE_PLATFORM_SERVICE']
   config.group = ENV['PERFORMANCE_PLATFORM_GROUP']
 end

--- a/config/initializers/performance_platform.rb
+++ b/config/initializers/performance_platform.rb
@@ -1,0 +1,5 @@
+PerformancePlatform.configure do |config|
+  config.root_url = 'https://www.performance.service.gov.uk/data'
+  config.service = ENV['PERFORMANCE_PLATFORM_SERVICE']
+  config.group = ENV['PERFORMANCE_PLATFORM_GROUP']
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2022,6 +2022,11 @@ en:
           date_to: "OPTIONAL/REQUIRED: Claims submitted on or before date (YYYY-MM-DD). Required if start date set"
         scheme_ten:
           format: 'OPTIONAL: the format to output the data. DEFAULT: json.  CSV will download automatically'
+      performance_platform:
+        quarterly_volume:
+          start_date: 'REQUIRED: First day of the quarter (YYYY-MM-DD)'
+          value: 'REQUIRED: The hosting cost for the %{month} month in the quarter'
+
   faker:
     address:
       postcode: /[A-PR-UWYZ]([A-HK-Y][0-9][ABEHMNPRVWXY0-9]?|[0-9][ABCDEFGHJKPSTUW0-9]?) [0-9][ABD-HJLNP-UW-Z]{2}/

--- a/config/performance_platform.yml
+++ b/config/performance_platform.yml
@@ -1,0 +1,16 @@
+reports:
+  transactions_by_channel:
+    type: 'test-transactions-by-channel'
+    period: 'weekly'
+    fields:
+      - :channel
+      - :count
+    token: <%= ENV['PERF_PLAT_TBC_TOKEN'] %>
+  digital_take_up:
+    type: 'test-digital-take-up'
+    period: 'weekly'
+    token: <%= ENV["PERF_PLAT_DTU_TOKEN"] %>
+  quarterly_volumes:
+    type: 'quarterly-volumes'
+    period: 'quarter'
+    token: <%= ENV["PERF_PLAT_QV_TOKEN"] %>

--- a/config/performance_platform.yml
+++ b/config/performance_platform.yml
@@ -6,11 +6,13 @@ reports:
       - :channel
       - :count
     token: <%= ENV['PERF_PLAT_TBC_TOKEN'] %>
-  digital_take_up:
-    type: 'test-digital-take-up'
-    period: 'weekly'
-    token: <%= ENV["PERF_PLAT_DTU_TOKEN"] %>
   quarterly_volumes:
-    type: 'quarterly-volumes'
+    type: 'test-quarterly-volumes'
     period: 'quarter'
+    fields:
+      - :cost_per_transaction_quarter
+      - :start_at
+      - :end_at
+      - :total_cost_quarter
+      - :transactions_per_quarter
     token: <%= ENV["PERF_PLAT_QV_TOKEN"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,17 +13,21 @@
 development:
   secret_key_base: ee63f015ce225c840bf33a4f40e4890398221b394ca5f93e7ca6d4a491acf2f35bedcca677f146b22a6fa212099af990a16a80c7e8c8a8ac28927daa84e091a3
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
+  currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>
 
 devunicorn:
   secret_key_base: ee63f015ce225c840bf33a4f40e4890398221b394ca5f93e7ca6d4a491acf2f35bedcca677f146b22a6fa212099af990a16a80c7e8c8a8ac28927daa84e091a3
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
+  currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>
 
 test:
   secret_key_base: 71bdb5d745e27e76e6df101da527598ae7586d2e9667e1a9a31111b3b71f7a63a23a6bab4e03b872a09fb3d26c9ade3006b7847825326148070a729317871add
   google_api_key: <%= ENV["GOOGLE_API_KEY"] || 'AIzaSyBCakM2PXzKf1mKC7Yw270DOw6o9Xsi7fP' %>
+  currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
+  currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,7 +23,8 @@ devunicorn:
 test:
   secret_key_base: 71bdb5d745e27e76e6df101da527598ae7586d2e9667e1a9a31111b3b71f7a63a23a6bab4e03b872a09fb3d26c9ade3006b7847825326148070a729317871add
   google_api_key: <%= ENV["GOOGLE_API_KEY"] || 'AIzaSyBCakM2PXzKf1mKC7Yw270DOw6o9Xsi7fP' %>
-  currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>
+  currency_api_key: <%= ENV["CURRENCY_API_KEY"] || '9a96505b072d357abd8291aaea203840' %>
+# the test currency_api_key value will work on the stored vcr cassette but is no longer valid for real use
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -25,4 +25,5 @@ end
 
 VCR.cucumber_tags do |t|
   t.tag '@fee_calc_vcr', match_requests_on: [:method, path_query_matcher]
+  t.tag '@currency_vcr', match_requests_on: [:method, path_query_matcher]
 end

--- a/lib/performance_platform.rb
+++ b/lib/performance_platform.rb
@@ -14,7 +14,7 @@ module PerformancePlatform
     def report(name)
       report = Reports.new.call(name)
       Submission.new(report)
-    rescue NoMethodError
+    rescue RuntimeError
       raise "#{name} is not present in config/performance_platform.yml"
     end
 

--- a/lib/performance_platform.rb
+++ b/lib/performance_platform.rb
@@ -1,0 +1,36 @@
+require 'performance_platform/data_set'
+require 'performance_platform/url_builder'
+require 'performance_platform/submission'
+require 'performance_platform/reports'
+require 'performance_platform/configuration'
+
+module PerformancePlatform
+  class << self
+    def root
+      # spec = Gem::Specification.find_by_name("performance-platform")
+      # spec.gem_dir
+    end
+
+    def report(name)
+      report = Reports.new.call(name)
+      Submission.new(report)
+    rescue NoMethodError
+      raise "#{name} is not present in config/performance_platform.yml"
+    end
+
+    attr_writer :configuration
+    def configuration
+      @configuration ||= Configuration.new
+    end
+    alias config configuration
+
+    def configure
+      yield(configuration) if block_given?
+      configuration
+    end
+
+    def reset
+      @configuration = Configuration.new
+    end
+  end
+end

--- a/lib/performance_platform/configuration.rb
+++ b/lib/performance_platform/configuration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PerformancePlatform
+  class Configuration
+    attr_accessor :root_url, :service, :group
+
+    def initialize
+      @root_url ||= root_url
+      @service ||= service
+      @group ||= group
+    end
+  end
+end

--- a/lib/performance_platform/configuration.rb
+++ b/lib/performance_platform/configuration.rb
@@ -2,10 +2,12 @@
 
 module PerformancePlatform
   class Configuration
+    PERFORMANCE_PLATFORM_ENDPOINT = 'https://www.performance.service.gov.uk/data'
+
     attr_accessor :root_url, :service, :group
 
     def initialize
-      @root_url ||= root_url
+      @root_url ||= root_url || PERFORMANCE_PLATFORM_ENDPOINT
       @service ||= service
       @group ||= group
     end

--- a/lib/performance_platform/data_set.rb
+++ b/lib/performance_platform/data_set.rb
@@ -24,7 +24,7 @@ module PerformancePlatform
     def required_keys
       default_keys = %i[_timestamp service period]
       default_keys << :channel if @values.key?(:channel)
-      @values.reject { |key| !default_keys.include?(key.to_sym) }
+      @values.select { |key| default_keys.include?(key.to_sym) }
     end
   end
 end

--- a/lib/performance_platform/data_set.rb
+++ b/lib/performance_platform/data_set.rb
@@ -18,15 +18,13 @@ module PerformancePlatform
     end
 
     def required_values
-      required_keys_as_hash.values
-    end
-
-    def required_keys_as_hash
-      required_keys.to_h
+      required_keys.values
     end
 
     def required_keys
-      @values.except(:count)
+      default_keys = %i[_timestamp service period]
+      default_keys << :channel if @values.key?(:channel)
+      @values.reject { |key| !default_keys.include?(key.to_sym) }
     end
   end
 end

--- a/lib/performance_platform/data_set.rb
+++ b/lib/performance_platform/data_set.rb
@@ -1,0 +1,32 @@
+module PerformancePlatform
+  class DataSet
+    def initialize(opts = {})
+      @values = opts
+    end
+
+    def payload
+      hash = { _id: build_id }
+      hash.merge(@values)
+    end
+
+    private
+
+    attr_accessor :values
+
+    def build_id
+      Base64.strict_encode64(required_values.join('.'))
+    end
+
+    def required_values
+      required_keys_as_hash.values
+    end
+
+    def required_keys_as_hash
+      required_keys.to_h
+    end
+
+    def required_keys
+      @values.except(:count)
+    end
+  end
+end

--- a/lib/performance_platform/reports.rb
+++ b/lib/performance_platform/reports.rb
@@ -1,0 +1,21 @@
+module PerformancePlatform
+  class Reports
+    def initialize
+      @reports = yaml_file['reports']
+    rescue NoMethodError
+      raise 'config/performance_platform.yml cannot be loaded'
+    end
+
+    def call(name)
+      @reports[name].symbolize_keys
+    rescue NoMethodError
+      raise "#{name} is not present in config/performance_platform.yml"
+    end
+
+    private
+
+    def yaml_file
+      YAML.safe_load(ERB.new(IO.read("#{Rails.root}/config/performance_platform.yml")).result, [Symbol])
+    end
+  end
+end

--- a/lib/performance_platform/submission.rb
+++ b/lib/performance_platform/submission.rb
@@ -1,0 +1,49 @@
+module PerformancePlatform
+  class Submission
+    def initialize(report)
+      @values = { service: PerformancePlatform.configuration.service }
+      @report_opts = report
+      @data_sets = []
+      @ready_to_send = false
+    end
+
+    def add_data_set(time_stamp, fields = {})
+      raise "Fields submitted do not match required fields for #{@report_opts[:type]}" unless report_matches?(fields)
+
+      params = {
+        _timestamp: time_stamp.strftime('%Y-%m-%dT00:00:00+00:00'),
+        service: @values[:service],
+        period: @report_opts[:period],
+        report: @report_opts[:type]
+      }
+      params.merge!(fields)
+      @data_sets << DataSet.new(params).payload
+      @ready_to_send = true
+    rescue StandardError => e
+      @ready_to_send = false
+      raise e
+    end
+
+    def send_data!
+      raise 'Unable to send without payload' unless @ready_to_send
+
+      RestClient.post(url, @data_sets.to_json, headers)
+    rescue RestClient::ExceptionWithResponse => e
+      e.response.body
+    end
+
+    private
+
+    def headers
+      { content_type: :json, authorization: "Bearer #{@report_opts[:token]}" }
+    end
+
+    def url
+      UrlBuilder.for_type(@report_opts[:type])
+    end
+
+    def report_matches?(fields)
+      @report_opts[:fields].sort == fields.keys.sort
+    end
+  end
+end

--- a/lib/performance_platform/submission.rb
+++ b/lib/performance_platform/submission.rb
@@ -1,5 +1,7 @@
 module PerformancePlatform
   class Submission
+    attr_reader :data_sets
+
     def initialize(report)
       @values = { service: PerformancePlatform.configuration.service }
       @report_opts = report

--- a/lib/performance_platform/url_builder.rb
+++ b/lib/performance_platform/url_builder.rb
@@ -1,0 +1,9 @@
+module PerformancePlatform
+  class UrlBuilder
+    class << self
+      def for_type(type)
+        [PerformancePlatform.configuration.root_url, PerformancePlatform.configuration.group, type].join('/')
+      end
+    end
+  end
+end

--- a/scheduled_tasks/performance_platform_channel_task.rb
+++ b/scheduled_tasks/performance_platform_channel_task.rb
@@ -1,11 +1,11 @@
 # https://github.com/ssoroka/scheduler_daemon for help
 class PerformancePlatformChannelTask < Scheduler::SchedulerTask
-  cron '40 3 * * 1' # 3:40 on Monday
+  cron '40 3 * * 1,2' # 3:40 on Monday
   class ReportNotActivated < RuntimeError; end
   def run
     raise ReportNotActivated unless ENV['PERF_PLAT_TBC_TOKEN']
     log('Performance Platform - Channel Task started')
-    tbc = Reports::PerformancePlatform::TransactionsByChannel.new(Date.today - 7.days)
+    tbc = Reports::PerformancePlatform::TransactionsByChannel.new(Date.today.beginning_of_week - 7.days)
     tbc.populate_data
     tbc.publish!
   rescue ReportNotActivated

--- a/scheduled_tasks/performance_platform_channel_task.rb
+++ b/scheduled_tasks/performance_platform_channel_task.rb
@@ -1,6 +1,6 @@
 # https://github.com/ssoroka/scheduler_daemon for help
 class PerformancePlatformChannelTask < Scheduler::SchedulerTask
-  cron '40 3 * * 1,2' # 3:40 on Monday
+  cron '40 3 * * 1,3' # 3:40 on Monday
   class ReportNotActivated < RuntimeError; end
   def run
     raise ReportNotActivated unless ENV['PERF_PLAT_TBC_TOKEN']

--- a/scheduled_tasks/performance_platform_channel_task.rb
+++ b/scheduled_tasks/performance_platform_channel_task.rb
@@ -1,0 +1,18 @@
+# https://github.com/ssoroka/scheduler_daemon for help
+class PerformancePlatformChannelTask < Scheduler::SchedulerTask
+  cron '40 3 * * 1' # 3:40 on Monday
+  class ReportNotActivated < RuntimeError; end
+  def run
+    raise ReportNotActivated unless ENV['PERF_PLAT_TBC_TOKEN']
+    log('Performance Platform - Channel Task started')
+    tbc = Reports::PerformancePlatform::TransactionsByChannel.new(Date.today - 7.days)
+    tbc.populate_data
+    tbc.publish!
+  rescue ReportNotActivated
+    'Performance Platform - Channel Task skipped as `PERF_PLAT_TBC_TOKEN` not found in ENV'
+  rescue StandardError => ex
+    log('There was an error: ' + ex.message)
+  ensure
+    log('Performance Platform - Channel Task finished')
+  end
+end

--- a/scheduled_tasks/performance_platform_channel_task.rb
+++ b/scheduled_tasks/performance_platform_channel_task.rb
@@ -1,6 +1,6 @@
 # https://github.com/ssoroka/scheduler_daemon for help
 class PerformancePlatformChannelTask < Scheduler::SchedulerTask
-  cron '40 3 * * 1,3' # 3:40 on Monday
+  cron '40 3 * * 1' # 3:40 on Monday
   class ReportNotActivated < RuntimeError; end
   def run
     raise ReportNotActivated unless ENV['PERF_PLAT_TBC_TOKEN']

--- a/scheduled_tasks/performance_platform_channel_task.rb
+++ b/scheduled_tasks/performance_platform_channel_task.rb
@@ -9,7 +9,7 @@ class PerformancePlatformChannelTask < Scheduler::SchedulerTask
     tbc.populate_data
     tbc.publish!
   rescue ReportNotActivated
-    'Performance Platform - Channel Task skipped as `PERF_PLAT_TBC_TOKEN` not found in ENV'
+    log('Performance Platform - Channel Task skipped as `PERF_PLAT_TBC_TOKEN` not found in ENV')
   rescue StandardError => ex
     log('There was an error: ' + ex.message)
   ensure

--- a/spec/api/v2/performance_platform/quarterly_volume_spec.rb
+++ b/spec/api/v2/performance_platform/quarterly_volume_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe API::V2::PerformancePlatform::QuarterlyVolume do
   let(:value_3) { 3000 }
 
   def do_request
-    get '/api/performance_platform/quarterly_volume', params, format: :json
+    get '/api/performance_platform/quarterly_volume', params
   end
 
   describe 'GET quarterly_volume' do

--- a/spec/api/v2/performance_platform/quarterly_volume_spec.rb
+++ b/spec/api/v2/performance_platform/quarterly_volume_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe API::V2::PerformancePlatform::QuarterlyVolume do
+  include Rack::Test::Methods
+  include ApiSpecHelper
+  include DatabaseHousekeeping
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:case_worker_admin) { create(:case_worker, :admin) }
+  let(:external_user) { create(:external_user) }
+  let(:params) { default_params }
+  let(:default_params) { { api_key: api_key, start_date: start_date, value_1: value_1, value_2: value_2, value_3: value_3 } }
+  let(:start_date) { Date.new(2018, 1, 1) }
+  let(:value_1) { 1000 }
+  let(:value_2) { 2000 }
+  let(:value_3) { 3000 }
+
+  def do_request
+    get '/api/performance_platform/quarterly_volume', params, format: :json
+  end
+
+  describe 'GET quarterly_volume' do
+
+    before { do_request }
+
+    context 'when accessed by a CaseWorker' do
+      let(:api_key) { case_worker_admin.user.api_key }
+
+      it 'returns success' do
+        expect(last_response).to be_ok
+      end
+    end
+
+    context 'when accessed by an user that has no permissions' do
+      let(:api_key) { external_user.user.api_key }
+
+      it 'returns unauthorised' do
+        expect(last_response).to be_unauthorized
+        expect(last_response.body).to include('Unauthorised')
+      end
+    end
+  end
+end

--- a/spec/api/v2/performance_platform/quarterly_volume_spec.rb
+++ b/spec/api/v2/performance_platform/quarterly_volume_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe API::V2::PerformancePlatform::QuarterlyVolume do
   let(:value_2) { 2000 }
   let(:value_3) { 3000 }
 
+  after { FileUtils.rm_rf(Dir["#{Rails.root}/tmp/[^.]*_qv_report.json"]) }
+
   def do_post_request
     post '/api/performance_platform/quarterly_volume', post_params
   end
@@ -49,7 +51,10 @@ RSpec.describe API::V2::PerformancePlatform::QuarterlyVolume do
 
   describe 'POST quarterly_volume' do
     context 'when report not previously generated' do
-      before { do_post_request }
+      before do
+        FileUtils.rm_rf(Dir["#{Rails.root}/tmp/[^.]*_qv_report.json"])
+        do_post_request
+      end
 
       let(:api_key) { case_worker_admin.user.api_key }
 

--- a/spec/api/v2/performance_platform/quarterly_volume_spec.rb
+++ b/spec/api/v2/performance_platform/quarterly_volume_spec.rb
@@ -8,23 +8,65 @@ RSpec.describe API::V2::PerformancePlatform::QuarterlyVolume do
 
   let(:case_worker_admin) { create(:case_worker, :admin) }
   let(:external_user) { create(:external_user) }
-  let(:params) { default_params }
-  let(:default_params) { { api_key: api_key, start_date: start_date, value_1: value_1, value_2: value_2, value_3: value_3 } }
   let(:start_date) { Date.new(2018, 1, 1) }
+  let(:get_params) { { api_key: api_key, start_date: start_date, value_1: value_1, value_2: value_2, value_3: value_3 } }
   let(:value_1) { 1000 }
   let(:value_2) { 2000 }
   let(:value_3) { 3000 }
 
-  def do_request
-    get '/api/performance_platform/quarterly_volume', params
+  def do_get_request
+    get '/api/performance_platform/quarterly_volume', get_params
   end
 
   describe 'GET quarterly_volume' do
+    before { do_get_request }
+
+    context 'when accessed by a CaseWorker' do
+      context 'when report not previously generated' do
+        let(:api_key) { case_worker_admin.user.api_key }
+
+        it 'returns success' do
+          expect(last_response).to be_ok
+        end
+      end
+    end
+
+
+    context 'when accessed by an user that has no permissions' do
+      let(:api_key) { external_user.user.api_key }
+
+      it 'returns unauthorised' do
+        expect(last_response).to be_unauthorized
+        expect(last_response.body).to include('Unauthorised')
+      end
+    end
+  end
+
+  describe 'POST quarterly_volume' do
+    let(:post_params) { { api_key: api_key, start_date: start_date } }
+
+    def do_request
+      post '/api/performance_platform/quarterly_volume', post_params
+    end
 
     before { do_request }
 
-    context 'when accessed by a CaseWorker' do
+    context 'when report not previously generated' do
       let(:api_key) { case_worker_admin.user.api_key }
+
+      it 'returns a 404 error' do
+        expect(last_response.status).to eq 400
+      end
+
+      it 'returns the correct error' do
+        expect(last_response.body).to include('No report exists')
+      end
+    end
+
+    context 'when report exists' do
+      let(:api_key) { case_worker_admin.user.api_key }
+
+      before { do_get_request }
 
       it 'returns success' do
         expect(last_response).to be_ok

--- a/spec/api/v2/performance_platform/quarterly_volume_spec.rb
+++ b/spec/api/v2/performance_platform/quarterly_volume_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe API::V2::PerformancePlatform::QuarterlyVolume do
 
       let(:api_key) { case_worker_admin.user.api_key }
 
-      it 'returns a 404 error' do
+      it 'returns a 400 error' do
         expect(last_response.status).to eq 400
       end
 

--- a/spec/lib/performance_platform/data_set_spec.rb
+++ b/spec/lib/performance_platform/data_set_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe PerformancePlatform::DataSet do
+  subject(:data_set) { described_class.new(params) }
+
+  let(:params) { { _timestamp: time_stamp, service: service, period: period, channel: channel, count: count } }
+  let(:time_stamp) { '2018-01-01T00:00:00+00:00' }
+  let(:channel) { 'Digital' }
+  let(:count) { 1234 }
+  let(:period) { 'week' }
+  let(:service)  { 'cccd'}
+
+
+  describe 'initialized' do
+    subject(:payload) { data_set.payload }
+    describe 'with a channel' do
+      let(:expected_result) do
+        {
+          _id: 'MjAxOC0wMS0wMVQwMDowMDowMCswMDowMC5jY2NkLndlZWsuRGlnaXRhbA==',
+          _timestamp: '2018-01-01T00:00:00+00:00',
+          service: 'cccd',
+          period: 'week',
+          channel: 'Digital',
+          count: 1234
+        }
+      end
+
+      it { is_expected.to eql(expected_result) }
+    end
+
+    describe 'without a channel' do
+      let(:params) { { _timestamp: time_stamp, service: service, period: period, count: count } }
+
+      let(:expected_result) do
+        {
+          _id: 'MjAxOC0wMS0wMVQwMDowMDowMCswMDowMC5jY2NkLndlZWs=',
+          _timestamp: '2018-01-01T00:00:00+00:00',
+          service: 'cccd',
+          period: 'week',
+          count: 1234
+        }
+      end
+
+      it { is_expected.to eql(expected_result) }
+    end
+
+    describe '_id' do
+      subject { payload[:_id] }
+
+      it 'can be decoded to match the values' do
+        expect(Base64.decode64(subject)).to eq '2018-01-01T00:00:00+00:00.cccd.week.Digital'
+      end
+    end
+  end
+
+end

--- a/spec/lib/performance_platform/reports_spec.rb
+++ b/spec/lib/performance_platform/reports_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe PerformancePlatform::Reports do
+  subject(:reports) { described_class.new }
+  let(:expected_yaml) { {"reports"=>{"transactions_by_channel"=>{"type"=>"test-transactions-by-channel", "period"=>"weekly", "fields"=>[:channel, :count], "token"=>nil}}} }
+
+  before do
+    allow_any_instance_of(described_class).to receive(:yaml_file).and_return(expected_yaml)
+  end
+
+  context 'when the reports file can be processed' do
+    it { is_expected.to be_a PerformancePlatform::Reports }
+  end
+
+  context 'when the reports file cannot be processed' do
+    let(:expected_yaml) { nil }
+    it { expect { reports }.to raise_error('config/performance_platform.yml cannot be loaded') }
+  end
+
+  describe '.call' do
+    subject(:call) { reports.call(report) }
+
+    context 'when passed a report name that is present in the yaml file' do
+      let(:report) { 'transactions_by_channel' }
+
+      it { is_expected.to be_a Hash }
+    end
+
+    context 'when passed a report name that is not present in the yaml file' do
+      let(:report) { 'non-existent-report' }
+
+      it { expect { call }.to raise_error('non-existent-report is not present in config/performance_platform.yml') }
+    end
+  end
+end

--- a/spec/lib/performance_platform/submission_spec.rb
+++ b/spec/lib/performance_platform/submission_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe PerformancePlatform::Submission do
+  subject(:submission) { described_class.new(report) }
+
+  let(:service) { 'cccd' }
+  let(:report) { { type: "test-transactions-by-channel", period: "weekly", fields: [:channel, :count], token: 'fake-token' } }
+
+  it { is_expected.to respond_to :add_data_set }
+  it { is_expected.to respond_to :send_data! }
+  before do
+    stub_request(:post, %r{\Ahttps://www.performance.service.gov.uk/data/.*\z}).to_return(status: 200, body: "", headers: {})
+  end
+  describe '#send_data!' do
+    subject(:send_data!) { submission.send_data! }
+
+    context 'when no data has been defined' do
+      it 'raises an error' do
+        expect{ subject }.to raise_error(RuntimeError, 'Unable to send without payload')
+      end
+    end
+
+    context 'when data_set has been filled' do
+      before do
+        submission.add_data_set(Date.new(2018,8,13), channel: 'Paper', count: 0)
+        subject
+      end
+
+      it 'hits the performance platform' do
+        expect(a_request(:post, /\Ahttps:\/\/www.performance.service.gov.uk\/data\/.*\z/)).to have_been_made.times(1)
+      end
+
+      it { is_expected.to be_truthy } 
+    end
+  end
+end

--- a/spec/lib/performance_platform/url_builder_spec.rb
+++ b/spec/lib/performance_platform/url_builder_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe PerformancePlatform::UrlBuilder do
+  subject(:url_builder) { described_class.for_type(type) }
+
+  describe 'when called with a group and type' do
+    before { allow(PerformancePlatform.configuration).to receive(:group).and_return('report_group')}
+    let(:type) { 'report_type' }
+
+    it { is_expected.to eql 'https://www.performance.service.gov.uk/data/report_group/report_type' }
+  end
+end

--- a/spec/lib/performance_platform_spec.rb
+++ b/spec/lib/performance_platform_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PerformancePlatform do
     context 'when passed a report name that is not present in the yaml file' do
       let(:report_name) { 'non-existent-report' }
 
-      it { expect { subject }.to raise_error('non-existent-report is not present in config/performance_platform.yml') }
+      it { expect { report }.to raise_error('non-existent-report is not present in config/performance_platform.yml') }
     end
   end
 

--- a/spec/lib/performance_platform_spec.rb
+++ b/spec/lib/performance_platform_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe PerformancePlatform do
+  subject(:perf_platform) { described_class }
+
+  describe '#report' do
+    subject(:report) { described_class.report(report_name) }
+
+    before do
+      expected_yaml = {"reports"=>{"transactions_by_channel"=>{"type"=>"test-transactions-by-channel", "period"=>"weekly", "fields"=>[:channel, :count], "token"=>nil}}}
+      allow_any_instance_of(PerformancePlatform::Reports).to receive(:yaml_file).and_return(expected_yaml)
+    end
+
+    context 'when passed a report name that is present in the yaml file' do
+      let(:report_name) { 'transactions_by_channel' }
+
+      it { is_expected.to be_a PerformancePlatform::Submission }
+    end
+
+    context 'when passed a report name that is not present in the yaml file' do
+      let(:report_name) { 'non-existent-report' }
+
+      it { expect { subject }.to raise_error('non-existent-report is not present in config/performance_platform.yml') }
+    end
+  end
+end

--- a/spec/lib/performance_platform_spec.rb
+++ b/spec/lib/performance_platform_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PerformancePlatform do
   subject(:perf_platform) { described_class }
 
-  describe '#report' do
+  describe '.report' do
     subject(:report) { described_class.report(report_name) }
 
     before do
@@ -21,6 +21,22 @@ RSpec.describe PerformancePlatform do
       let(:report_name) { 'non-existent-report' }
 
       it { expect { subject }.to raise_error('non-existent-report is not present in config/performance_platform.yml') }
+    end
+  end
+
+  describe '.reset' do
+    let(:root_url) { 'https://new.pi/endpoint' }
+
+    before do
+      described_class.configure do |config|
+        config.root_url = root_url
+      end
+    end
+
+    it 'resets the configured host' do
+      expect(described_class.configuration.root_url).to eql root_url
+      described_class.reset
+      expect(described_class.configuration.root_url).to eql 'https://www.performance.service.gov.uk/data'
     end
   end
 end

--- a/spec/services/claims/count_spec.rb
+++ b/spec/services/claims/count_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe Claims::Count do
+  subject(:claims_count) { described_class.new(date, period) }
+
+  let(:date) { Date.new(2018,1,20) }
+  let(:period) { :month }
+
+  before do
+    travel_to(Date.new(2017, 12, 17)) { create_list(:archived_pending_delete_claim, 3) }
+    travel_to(Date.new(2018, 01, 17)) { create_list(:archived_pending_delete_claim, 3) }
+    travel_to(Date.new(2018, 02, 17)) { create_list(:archived_pending_delete_claim, 3) }
+  end
+
+  it { expect(subject).to be_a Claims::Count }
+
+  describe '#call' do
+    context 'when period and date are set manually' do
+      subject(:call) { claims_count.call }
+
+      it { is_expected.to eql 3 }
+    end
+  end
+
+  context 'class methods' do
+    describe '.quarter' do
+      subject { described_class.quarter(date) }
+
+      it { is_expected.to eql 6 }
+    end
+
+    describe '.month' do
+      subject { described_class.month(date) }
+
+      it { is_expected.to eql 3 }
+    end
+
+    describe '.week' do
+      context 'when the week has data' do
+        subject { described_class.week(date) }
+
+        it { is_expected.to eql 3 }
+      end
+
+      context 'when the week has no data' do
+        subject { described_class.week(date + 7.days) }
+
+        it { is_expected.to eql 0 }
+      end
+    end
+  end
+end

--- a/spec/services/conversion/currency_spec.rb
+++ b/spec/services/conversion/currency_spec.rb
@@ -2,7 +2,17 @@ RSpec.describe Conversion::Currency, :currency_vcr do
   subject(:call) { described_class.call(date, usd_value) }
 
   let(:date) { Date.new(2018, 1, 30) }
-  let(:usd_value) { 1842.39 }
+  let(:usd_value) { '1842.39' }
 
-  it { is_expected.to eq 1301.5 }
+  it { is_expected.to be_a Float }
+
+  context 'when the usd_value has no formatting' do
+    it { is_expected.to eq 1301.5 }
+  end
+
+  context 'when the usd_value has commas as thousand separators' do
+    let(:usd_value) { '1,842.39' }
+
+    it { is_expected.to eq 1301.5 }
+  end
 end

--- a/spec/services/conversion/currency_spec.rb
+++ b/spec/services/conversion/currency_spec.rb
@@ -15,4 +15,16 @@ RSpec.describe Conversion::Currency, :currency_vcr do
 
     it { is_expected.to eq 1301.5 }
   end
+
+  context 'when the conversion fails' do
+    let(:date) { 'date' }
+    let(:usd_value) { 'dollars' }
+
+    it 'raises an error' do
+      expect(Rails.logger).to receive(:error).with(/Error converting currency.*/)
+      call
+    end
+
+    it { is_expected.to be nil }
+  end
 end

--- a/spec/services/conversion/currency_spec.rb
+++ b/spec/services/conversion/currency_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Conversion::Currency, :currency_vcr do
+  subject(:call) { described_class.call(date, usd_value) }
+
+  let(:date) { Date.new(2018, 1, 30) }
+  let(:usd_value) { 1842.39 }
+
+  it { is_expected.to eq 1301.5 }
+end

--- a/spec/services/reports/performance_platform/quarterly_volume_spec.rb
+++ b/spec/services/reports/performance_platform/quarterly_volume_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe Reports::PerformancePlatform::QuarterlyVolume do
+  subject(:report) { described_class.new(date) }
+
+  let(:valid_report_date) { Date.new(2018, 10, 1) }
+  let(:date) { valid_report_date }
+
+  describe 'initializing' do
+    context 'when the date is not the start of a quarter' do
+      let(:date) { Date.new(2018, 10, 2) }
+
+      it { expect { report }.to raise_error('Report must start on a quarter') }
+    end
+
+    context 'when the date is in the future' do
+      let(:date) { Date.new(2019, 1, 1) }
+
+      it do
+        travel_to(Date.new(2018, 12, 31)) do
+          expect { report }.to raise_error('Report cannot be in the future')
+        end
+      end
+    end
+
+    context 'when the date is valid' do
+      it { is_expected.to be_truthy }
+      it { expect(report.ready_to_send).to be false }
+    end
+  end
+
+  describe '#populate_data' do
+    subject(:populate_data) { report.populate_data(total_cost) }
+    let(:total_cost) { 1234.45 }
+
+    context 'when the total_cost submitted is valid' do
+      context 'when the data is fine' do
+        it { expect(populate_data).to be_truthy }
+        it { expect { populate_data }.to change { report.ready_to_send }.from(false).to(true) }
+      end
+
+      context 'when a collation error occurs' do
+        before { allow(report).to receive(:count_digital_claims).and_raise(StandardError)}
+
+        it { expect(report.ready_to_send).to be false }
+        it { expect { populate_data }.not_to change { report.ready_to_send }.from(false) }
+      end
+    end
+
+    context 'when the total_cost submitted is invalid' do
+      before { allow(report).to receive(:count_digital_claims).and_raise(StandardError)}
+      let(:total_cost) { '47 pounds' }
+
+      it { expect { populate_data }.to raise_error('Total cost cannot be parsed as a numeric value')}
+    end
+  end
+
+  describe '#publish!' do
+    subject(:publish) { report.publish! }
+
+    before do
+      report.populate_data(1234)
+      stub_request(:post, %r{\Ahttps://www.performance.service.gov.uk/data/.*\z}).to_return(status: 200, body: "", headers: {})
+    end
+
+    it { is_expected.to be_truthy }
+  end
+end

--- a/spec/services/reports/performance_platform/transactions_by_channel_spec.rb
+++ b/spec/services/reports/performance_platform/transactions_by_channel_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe Reports::PerformancePlatform::TransactionsByChannel do
+  subject(:report) { described_class.new(date) }
+
+  let(:monday) { Date.new(2018, 12, 24) }
+  let(:tuesday) { Date.new(2018, 12, 25) }
+
+  describe 'initializing' do
+    context 'when the date is not a Monday' do
+      let(:date) { Date.new(2018, 12, 25) }
+
+      it { expect { report }.to raise_error('Report must start on a Monday') }
+    end
+
+    context 'when the date is within the last 7 days' do
+      let(:date) { monday }
+
+      it do
+        travel_to(tuesday) do
+          expect { report }.to raise_error('Report cannot be in the current week')
+        end
+      end
+    end
+
+    context 'when the date is in the future' do
+      let(:date) { Date.new(2018, 12, 31)}
+
+      it do
+        travel_to(tuesday) do
+          expect { report }.to raise_error('Report cannot be in the future')
+        end
+      end
+    end
+
+    context 'when the date is valid' do
+      let(:date) { Date.new(2018, 12, 17)}
+
+      it { is_expected.to be_truthy }
+      it { expect(report.ready_to_send).to be false }
+    end
+  end
+
+  describe '#populate_data' do
+    subject(:populate_data) { report.populate_data }
+    let(:date) { Date.new(2018, 12, 17) }
+
+    context 'when the data is fine' do
+      it { expect(populate_data).to be_truthy }
+      it { expect { populate_data }.to change { report.ready_to_send }.from(false).to(true) }
+    end
+
+    context 'when a collation error occurs' do
+      before { allow(report).to receive(:count_digital_claims).and_raise(StandardError)}
+
+      it { expect(populate_data).to be_falsey }
+      it { expect { populate_data }.not_to change { report.ready_to_send }.from(false) }
+    end
+  end
+
+  describe '#publish!' do
+    subject(:publish) { report.publish! }
+    let(:date) { Date.new(2018, 12, 17) }
+
+    before do
+      report.populate_data
+      stub_request(:post, %r{\Ahttps://www.performance.service.gov.uk/data/.*\z}).to_return(status: 200, body: "", headers: {})
+    end
+
+    it { is_expected.to be_truthy }
+  end
+end

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -19,10 +19,12 @@ VCR.configure do |c|
   c.ignore_request do |request|
     URI(request.uri).path == "/__identify__" ||
     (!URI(request.uri).path.start_with?('/api/') &&
-      !URI(request.uri).path =~ /maps.googleapis.com/)
+      !URI(request.uri).path =~ /maps.googleapis.com/ &&
+      !URI(request.uri).path =~ /apilayer.net/)
   end
 
   c.filter_sensitive_data('<GOOGLE_API_KEY>') { Rails.application.secrets.google_api_key }
+  c.filter_sensitive_data('<CURRENCY_API_KEY>') { Rails.application.secrets.currency_api_key }
 end
 
 # use `VCR_OFF=true rspec` too turn off vcr
@@ -41,7 +43,7 @@ end
 # in the cassette library under a directory structure
 # mirroring the specs'.
 RSpec.configure do |config|
-  config.around(:each, :fee_calc_vcr) do |example|
+  config.around(:each, [:fee_calc_vcr, :currency_vcr]) do |example|
     if VCR.turned_on?
       cassette = Pathname.new(example.metadata[:file_path]).cleanpath.sub_ext('').to_s
       VCR.use_cassette(cassette, :record => :new_episodes, :match_requests_on => [:method, path_query_matcher]) do

--- a/vcr/cassettes/spec/api/v2/performance_platform/quarterly_volume_spec.yml
+++ b/vcr/cassettes/spec/api/v2/performance_platform/quarterly_volume_spec.yml
@@ -153,4 +153,60 @@ http_interactions:
       string: '{"success":true,"terms":"https:\/\/currencylayer.com\/terms","privacy":"https:\/\/currencylayer.com\/privacy","historical":true,"date":"2018-03-31","timestamp":1522540799,"source":"USD","quotes":{"USDUSD":1,"USDGBP":0.71347}}'
     http_version: 
   recorded_at: Tue, 08 Jan 2019 10:38:19 GMT
+- request:
+    method: post
+    uri: https://www.performance.service.gov.uk/data//test-quarterly-volumes
+    body:
+      encoding: UTF-8
+      string: '[{"_id":"MjAxOC0wMS0wMVQwMDowMDowMCswMDowMC4ucXVhcnRlcg==","_timestamp":"2018-01-01T00:00:00+00:00","service":null,"period":"quarter","report":"test-quarterly-volumes","cost_per_transaction_quarter":null,"start_at":"2018-01-01
+        00:00:00","end_at":"2018-03-31 22:59:59","total_cost_quarter":0.0,"transactions_per_quarter":0}]'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer
+      Content-Length:
+      - '323'
+      Host:
+      - www.performance.service.gov.uk
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 17 Jan 2019 15:48:48 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-lhr6321-LHR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1547740128.192387,VS0,VE58
+    body:
+      encoding: UTF-8
+      string: "{\n  \"message\": \"The requested URL was not found on the server.
+        \ If you entered the URL manually please check your spelling and try again.\",
+        \n  \"status\": \"error\"\n}"
+    http_version: 
+  recorded_at: Thu, 17 Jan 2019 15:48:48 GMT
 recorded_with: VCR 3.0.3

--- a/vcr/cassettes/spec/api/v2/performance_platform/quarterly_volume_spec.yml
+++ b/vcr/cassettes/spec/api/v2/performance_platform/quarterly_volume_spec.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://apilayer.net/api/historical?access_key=<CURRENCY_API_KEY>&currencies=USD,GBP&date=2018-01-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.5.1p57
+      Host:
+      - apilayer.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Via:
+      - 1.1 WFRW001
+      Connection:
+      - Keep-Alive
+      Proxy-Connection:
+      - Keep-Alive
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 08 Jan 2019 10:38:18 GMT
+      Content-Type:
+      - application/json; Charset=UTF-8
+      Etag:
+      - a794c569a513379eeb3285e9656a8922
+      Server:
+      - nginx
+      X-Apilayer-Transaction-Id:
+      - 79de0b8b-af66-4d17-95ec-68d61f65a8a4
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS
+      Last-Modified:
+      - Wed, 31 Jan 2018 23:59:59 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Time:
+      - '0.030'
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"terms":"https:\/\/currencylayer.com\/terms","privacy":"https:\/\/currencylayer.com\/privacy","historical":true,"date":"2018-01-31","timestamp":1517443199,"source":"USD","quotes":{"USDUSD":1,"USDGBP":0.70417}}'
+    http_version: 
+  recorded_at: Tue, 08 Jan 2019 10:38:18 GMT
+- request:
+    method: get
+    uri: http://apilayer.net/api/historical?access_key=<CURRENCY_API_KEY>&currencies=USD,GBP&date=2018-02-28
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.5.1p57
+      Host:
+      - apilayer.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Via:
+      - 1.1 WFRW001
+      Connection:
+      - Keep-Alive
+      Proxy-Connection:
+      - Keep-Alive
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 08 Jan 2019 10:38:18 GMT
+      Content-Type:
+      - application/json; Charset=UTF-8
+      Etag:
+      - 33913f9f8e169e478a1a74da318ae631
+      Server:
+      - nginx
+      X-Apilayer-Transaction-Id:
+      - b0208c6b-27b9-4be5-86bf-e840ec2fddb6
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS
+      Last-Modified:
+      - Wed, 28 Feb 2018 23:59:59 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Time:
+      - '0.041'
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"terms":"https:\/\/currencylayer.com\/terms","privacy":"https:\/\/currencylayer.com\/privacy","historical":true,"date":"2018-02-28","timestamp":1519862399,"source":"USD","quotes":{"USDUSD":1,"USDGBP":0.72721}}'
+    http_version: 
+  recorded_at: Tue, 08 Jan 2019 10:38:18 GMT
+- request:
+    method: get
+    uri: http://apilayer.net/api/historical?access_key=<CURRENCY_API_KEY>&currencies=USD,GBP&date=2018-03-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.5.1p57
+      Host:
+      - apilayer.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Via:
+      - 1.1 WFRW001
+      Connection:
+      - Keep-Alive
+      Proxy-Connection:
+      - Keep-Alive
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 08 Jan 2019 10:38:18 GMT
+      Content-Type:
+      - application/json; Charset=UTF-8
+      Etag:
+      - e8436ff1cb03cb1cea1b2deaa12aaca2
+      Server:
+      - nginx
+      X-Apilayer-Transaction-Id:
+      - cffbabcc-ff3c-4467-a9c8-293760fe3ab3
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS
+      Last-Modified:
+      - Sat, 31 Mar 2018 23:59:59 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Time:
+      - '0.040'
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"terms":"https:\/\/currencylayer.com\/terms","privacy":"https:\/\/currencylayer.com\/privacy","historical":true,"date":"2018-03-31","timestamp":1522540799,"source":"USD","quotes":{"USDUSD":1,"USDGBP":0.71347}}'
+    http_version: 
+  recorded_at: Tue, 08 Jan 2019 10:38:19 GMT
+recorded_with: VCR 3.0.3

--- a/vcr/cassettes/spec/services/conversion/currency_spec.yml
+++ b/vcr/cassettes/spec/services/conversion/currency_spec.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://apilayer.net/api/historical?access_key=<CURRENCY_API_KEY>&currencies=USD,GBP&date=2018-01-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Host:
+      - apilayer.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 05 Jan 2019 21:12:14 GMT
+      Content-Type:
+      - application/json; Charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      X-Apilayer-Transaction-Id:
+      - 36dfc3f7-12ce-4259-91cd-5b70d41067f8
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS
+      Last-Modified:
+      - Tue, 30 Jan 2018 23:59:59 GMT
+      Etag:
+      - ecb47cc21992c20d5c7831387e05493d
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Time:
+      - '0.028'
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"terms":"https:\/\/currencylayer.com\/terms","privacy":"https:\/\/currencylayer.com\/privacy","historical":true,"date":"2018-01-30","timestamp":1517356799,"source":"USD","quotes":{"USDUSD":1,"USDGBP":0.706419}}'
+    http_version: 
+  recorded_at: Sat, 05 Jan 2019 21:12:14 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### What
Allow the application to push Performance Platform data

#### Ticket
[investigate performance platform automation](https://dsdmoj.atlassian.net/browse/CBO-494)

#### Why
The methods for calculating and submitting Performance Platform data is currently manual and time consuming.  

#### How
##### Transactions by Channel
As the system is now 100% digital and we no longer have to manually calculate `paper` claims, the `Transactions by Channel` report (which also drives Digital take up on the PP) can be entirely automated.

##### Quarterly Volumes
This requires data from the AWS billing account that is currently locked down.  Therefore we have added API end-points that allow us to submit the AWS US Dollar values per month.  The report will then calculate the conversion to GBP, total and compile as needed and then submit them to the PP.

#### TODO (wip)

 - [x] Define Performance Platform objects for submitting data
 - [x] Define report objects for compiling our data prior to submission
 - [ ] Ensure standard naming and approach on both reports
 - [ ] Double check test coverage
