### PR TITLE
Add Actual trial length to caseworker view

### DIFF
--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -16,17 +16,14 @@
               = t('.fee_category')
             %th{ scope: 'col' }
               = t('.fee_type')
-            - if claim.transfer? # could be applied to graduated too
+            - if claim.transfer? || (claim.final? && !claim.fixed_fee_case?) # could be applied to graduated too
               %th.numeric{ scope: 'col' }
-                = t('.days_claimed')
+                = claim.transfer? ? t('.days_claimed') : t('.actual_trial_length')
             %th.numeric{ scope: 'col' }
               = claim.fixed_fee_case? ? t('.quantity') : 'PPE'
             - if claim.fixed_fee_case?
               %th.numeric{ scope: 'col' }
                 = t('.rate')
-            - unless claim.interim? || claim.fixed_fee_case?
-              %th.numeric{ scope: 'col' }
-                = t('.actual_trial_length')
             %th.numeric{ scope: 'col' }
               = t('.amount')
         %tbody
@@ -50,17 +47,14 @@
                 - if fee.case_uplift?
                   %br
                   = "(#{t('.case_numbers')}: #{fee.case_numbers})"
-              - if claim.transfer?
+              - if claim.transfer? || (claim.final? && !claim.fixed_fee_case?)
                 %td.numeric{ scope: 'col' }
                   = fee.days_claimed
               %td.numeric
                 = fee.quantity
               - if claim.fixed_fee_case?
                 %td.numeric
-                  = fee.rate
-              - unless claim.interim? || claim.fixed_fee_case?
-                %td.numeric
-                  = claim&.actual_trial_length
+                  = fee.rate         
               %td.numeric
                 = fee.amount
 

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -24,6 +24,9 @@
             - if claim.fixed_fee_case?
               %th.numeric{ scope: 'col' }
                 = t('.rate')
+            - unless claim.interim? || claim.fixed_fee_case?
+              %th.numeric{ scope: 'col' }
+                = t('.actual_trial_length')
             %th.numeric{ scope: 'col' }
               = t('.amount')
         %tbody
@@ -55,6 +58,9 @@
               - if claim.fixed_fee_case?
                 %td.numeric
                   = fee.rate
+              - unless claim.interim? || claim.fixed_fee_case?
+                %td.numeric
+                  = claim&.actual_trial_length
               %td.numeric
                 = fee.amount
 

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -16,7 +16,7 @@
               = t('.fee_category')
             %th{ scope: 'col' }
               = t('.fee_type')
-            - if claim.transfer? || (claim.final? && !claim.fixed_fee_case?) # could be applied to graduated too
+            - if claim.transfer? || (claim.final? && !claim.fixed_fee_case?)
               %th.numeric{ scope: 'col' }
                 = claim.transfer? ? t('.days_claimed') : t('.actual_trial_length')
             %th.numeric{ scope: 'col' }
@@ -54,7 +54,7 @@
                 = fee.quantity
               - if claim.fixed_fee_case?
                 %td.numeric
-                  = fee.rate         
+                  = fee.rate
               %td.numeric
                 = fee.amount
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1715,6 +1715,7 @@ en:
       distance: Distance
       fee_category: Fee category
       fee_type: Fee type
+      actual_trial_length: Actual trial length
       fee_subtype: Fee subtype
       case_numbers: *case_numbers
       days_claimed: Days

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
         middle_name: &middle_name 'Middle name'
         last_name: &last_name 'Last name'
       fees:
+        actual_trial_length: &actual_trial_length Actual trial length
         case_numbers: &case_numbers 'Additional case numbers'
     not_provided: &not_provided 'Not provided'
     not_applicable: &not_applicable 'n/a'
@@ -803,7 +804,7 @@ en:
           transfer_court: Court
           transfer_court_hint: For example Cardiff
         trial_detail_fields:
-          actual_trial_length: 'Actual trial length'
+          actual_trial_length: *actual_trial_length
           actual_trial_length_hint: 'Number of days'
           estimated_trial_length: 'Estimated trial length'
           estimated_trial_length_hint: 'Number of days'
@@ -1145,7 +1146,7 @@ en:
         fields:
           page_header: Graduated fee
           page_hint: *fees_vat_prompt
-          actual_trial_length: Actual trial length
+          actual_trial_length: *actual_trial_length
           actual_trial_length_hint: Number of days
           rate: *rate
           quantity: *ppe_quantity
@@ -1556,7 +1557,7 @@ en:
         dates_attended: Dates attended
         retrial_started_at: Retrial started at
         first_day_of_trial: First day of trial
-      actual_trial_length: Actual trial length
+      actual_trial_length: *actual_trial_length
       mileage_rate: Cost per mile
       expense: Expense
       expenses:
@@ -1715,7 +1716,7 @@ en:
       distance: Distance
       fee_category: Fee category
       fee_type: Fee type
-      actual_trial_length: Actual trial length
+      actual_trial_length: *actual_trial_length
       fee_subtype: Fee subtype
       case_numbers: *case_numbers
       days_claimed: Days

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
         it 'displays expected table headers' do
           within '.fees-summary' do |summary|
             expect(summary).to include_table_headers('Fee category', 'Fee type', 'Days', 'PPE', 'Amount')
+            expect(summary).to_not include_table_headers('Actual trial length')
           end
         end
       end

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
 
         it 'displays expected table headers' do
           within '.fees-summary' do |summary|
-            expect(summary).to include_table_headers('Fee category', 'Fee type', 'Days', 'PPE', 'Actual trial length', 'Amount')
+            expect(summary).to include_table_headers('Fee category', 'Fee type', 'Days', 'PPE', 'Amount')
           end
         end
       end

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
 
         it 'displays expected table headers' do
           within '.fees-summary' do |summary|
-            expect(summary).to include_table_headers('Fee category', 'Fee type', 'PPE', 'Amount')
+            expect(summary).to include_table_headers('Fee category', 'Fee type', 'PPE',  'Actual trial length', 'Amount')
           end
         end
       end
@@ -92,6 +92,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
         it 'displays expected table headers' do
           within '.fees-summary' do |summary|
             expect(summary).to include_table_headers('Fee category', 'Fee type', 'Quantity', 'Rate', 'Amount')
+            expect(summary).to_not include_table_headers('Actual trial length')
           end
         end
       end
@@ -102,6 +103,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
         it 'displays expected table headers' do
           within '.fees-summary' do |summary|
             expect(summary).to include_table_headers('Fee category', 'Fee type', 'Amount')
+            expect(summary).to_not include_table_headers('Actual trial length')
           end
         end
       end
@@ -111,7 +113,7 @@ RSpec.describe 'case_workers/claims/show.html.haml', type: :view do
 
         it 'displays expected table headers' do
           within '.fees-summary' do |summary|
-            expect(summary).to include_table_headers('Fee category', 'Fee type', 'Days', 'PPE', 'Amount')
+            expect(summary).to include_table_headers('Fee category', 'Fee type', 'Days', 'PPE', 'Actual trial length', 'Amount')
           end
         end
       end


### PR DESCRIPTION
#### What
Fix bug resulting from CBO-471 where Actual Trial Length was no longer being displayed to caseworkers for litigator claims on the case summary screen

#### Ticket
CBO-542 LGFS actual trial length caseworker view (https://dsdmoj.atlassian.net/projects/CBO/issues/CBO-542)

#### Why
Caseworkers need to see this field for lgfs graduated fees in order to process claims.

#### How
This value was originally displayed in the Case Details section, I have moved it to the Fees section on the caseworker view in order to be more consistent with the litigator check your claim page and also reflect that the actual trial length is entered as part of the litigator graduated fee page.

