### PR TITLE
Fix page title sentry error

### DIFF
--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -1,5 +1,5 @@
 = content_for :page_title, flush: true do
-  = t(".#{@claim.fee_scheme.name.underscore}.#{@claim.type.underscore.gsub(/claim\//, '')}.page_title")
+  = t(".#{@claim.fee_scheme&.name&.underscore}.#{@claim.type.underscore.gsub(/claim\//, '')}.page_title")
 
 = render partial: 'errors/error_summary', locals:{ ep: @certification, error_summary: t('.prohibited_save')}
 

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -1,5 +1,5 @@
 = content_for :page_title, flush: true do
-  = t(".#{@claim.fee_scheme&.name&.underscore}.#{@claim.type.underscore.gsub(/claim\//, '')}.page_title")
+  = t(".page_title.#{present(@claim).type_identifier}")
 
 = render partial: 'errors/error_summary', locals:{ ep: @certification, error_summary: t('.prohibited_save')}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -621,18 +621,12 @@ en:
         date: 'Date'
         page_title_transfer_claim: Certify and submit the litigator transfer fees claim
         page_title_advocate_claim: advocate claim
-        agfs:
-          advocate_claim:
-            page_title: Certify and submit the advocate final fees claim
-          advocate_interim_claim:
-            page_title: Certify and submit the advocate warrant fees claim
-        lgfs:
-          transfer_claim:
-            page_title: Certify and submit the litigator transfer fees claim
-          interim_claim:
-            page_title: Certify and submit the litigator interim fees claim
-          litigator_claim:
-            page_title: Certify and submit the litigator final fees claim
+        page_title:
+          agfs_final: Certify and submit the advocate final fees claim
+          agfs_interim: Certify and submit the advocate warrant fees claim
+          lgfs_final: Certify and submit the litigator final fees claim
+          lgfs_interim: Certify and submit the litigator interim fees claim
+          lgfs_transfer: Certify and submit the litigator transfer fees claim
     claim_types:
       chosen:
         errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -631,7 +631,7 @@ en:
             page_title: Certify and submit the litigator transfer fees claim
           interim_claim:
             page_title: Certify and submit the litigator interim fees claim
-          final_claim:
+          litigator_claim:
             page_title: Certify and submit the litigator final fees claim
     claim_types:
       chosen:


### PR DESCRIPTION
#### What
Fix page title sentry error

#### Why
- translation mappings incorrect for lit final claim
- LGFS claims with earliest rep order **before** scheme 8 start date
    have no fee scheme, making page title translation throw an error.

#### Fixes
 [example sentry error](https://sentry.service.dsd.io/mojds/private-beta/issues/34365/)
