### PR TITLE
Validate retrial start dates being on or after trial end dates

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -234,6 +234,7 @@ class Claim::BaseClaimValidator < BaseValidator
   # cannot be before earliest rep order date
   # cannot be more than 5 years in the past
   def validate_retrial_started_at
+    validate_on_or_after(@record.trial_concluded_at, :retrial_started_at, 'check_not_earlier_than_trial_concluded')
     validate_retrial_start_and_end(:retrial_started_at, :retrial_concluded_at, false)
   end
 

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -273,17 +273,17 @@ retrial_started_at:
     short: *date_not_allowed
     api: Date for retrial concluded at is not allowed
   check_other_date:
-    long: 'Check the date for "First day of retrial"'
+    long: Check the date for "First day of retrial"
     short: Can't be after the date "Retrial concluded"
-    api: 'Check the date for "First day of retrial"'
+    api: Check the date for "First day of retrial"
   check_not_too_far_in_past:
-    long: 'Check the date for First day of retrial"'
+    long: Check the date for First day of retrial"
     short: *too_far_in_past
-    api: 'Check the date for "First day of retrial"'
+    api: Check the date for "First day of retrial"
   check_not_earlier_than_rep_order:
-    long: 'Check the date for "First day of retrial"'
+    long: Check the date for "First day of retrial"
     short: *before_rep_order
-    api: 'Check the date for "First day of retrial"'
+    api: Check the date for "First day of retrial"
   invalid_date:
     long: Enter a valid date for the first day of retrial
     short: *enter_valid_date
@@ -292,6 +292,10 @@ retrial_started_at:
     long: First day of retrial cannot be in future
     short: *enter_valid_date
     api: First day of retrial cannot be in future
+  check_not_earlier_than_trial_concluded:
+    long: Check the date for "First day of retrial"
+    short: Can't be before the "Trial concluded on"
+    api: Check the date for "First day of retrial"
 
 retrial_estimated_length:
   _seq: 120

--- a/spec/support/matchers/validation_matchers.rb
+++ b/spec/support/matchers/validation_matchers.rb
@@ -3,31 +3,69 @@ require 'rspec/expectations'
 RSpec::Matchers.define :include_field_error_when do |options|
   options.assert_valid_keys :field, :other_field, :field_value, :other_field_value, :message, :translated_message, :translated_message_type
   match do |record|
-    record.send("#{options[:field]}=", options[:field_value])
-    record.send("#{options[:other_field]}=", options[:other_field_value])
+    set_options(options)
+    record.send("#{field}=", options[:field_value])
+    record.send("#{other_field}=", options[:other_field_value])
     record.valid?
-    result = record.errors[options[:field]].include?(options[:message]) if options.fetch(:message, nil).present?
-    result = translation_match?(options) if result && options.fetch(:translated_message, nil).present?
+    result = record.errors[field].include?(message) if message.present?
+    result = translation_match? if result && translated_message.present?
     result
   end
 
-  def translation_match?(options)
-    @translations ||= YAML.load_file("#{Rails.root}/config/locales/error_messages.en.yml") # lazy load translations
-    message_type = options[:translated_message_type] || 'short'
-    field = options[:field].to_s
+  def set_options(options)
+    @options = options
+  end
+
+  def options
+    @options
+  end
+
+  def translation_match?
     [
-      @translations.has_key?(field),
-      @translations[field].has_key?(options[:message]),
-      @translations[field][options[:message]][message_type].eql?(options[:translated_message])
+      translations.has_key?(field),
+      translations[field].has_key?(message),
+      actual_translated_message.eql?(translated_message)
     ].all?
   end
 
+  def actual_translated_message
+    translations.fetch(field, nil)&.fetch(message, nil)&.fetch(translated_message_type, nil)
+  end
+
+  def translations
+    @translations ||= YAML.load_file("#{Rails.root}/config/locales/error_messages.en.yml") # lazy load translations
+  end
+
+  def translated_message_type
+    @message_type ||= options[:translated_message_type] || 'short'
+  end
+
+  def field
+    @field ||= options[:field].to_s
+  end
+
+  def other_field
+    @other_field ||= options[:other_field].to_s
+  end
+
+  def message
+    @message ||= options.fetch(:message, nil)
+  end
+
+  def translated_message
+    @translated_message ||= options.fetch(:translated_message, nil)
+  end
+
   description do
-    "include error on #{options[:field]} when #{options[:field]}: #{options[:field_value]} and #{options[:other_field]}: #{options[:other_field_value]}"
+    "include error #{message} on #{field}"
   end
 
   failure_message do |record|
-    "expected #{record.errors.messages}} to include errors for #{options[:field]}"
+    msg = ""
+    msg += "expected valid: false\n got: true\n " if record.valid?
+    msg += "expected error: #{message} on #{field}\n got: #{record.errors[field]}\n" if message.present? && !record.errors[field].include?(message)
+    msg += "expected #{translated_message_type + ' '}translation: \"#{translated_message}\"\n got: \"#{actual_translated_message}\"" if translated_message.present? && !actual_translated_message.eql?(translated_message)
+    msg
   end
 
   failure_message_when_negated do |record|

--- a/spec/support/validation_helpers.rb
+++ b/spec/support/validation_helpers.rb
@@ -46,7 +46,7 @@ module ValidationHelpers
   end
 
   # checks the translation exists and has expected message
-  def with_expected_error_translation(field, message, options)
+  def with_expected_error_translation(field, message, options = {})
     @translations ||= YAML.load_file("#{Rails.root}/config/locales/error_messages.en.yml") # lazy load translations
     message_type = options[:translated_message_type] || 'short'
     expect(@translations.has_key?(field.to_s)).to eql true
@@ -84,7 +84,7 @@ module ValidationHelpers
     with_expected_error_translation(field, message, options) if options[:translated_message]
   end
 
-  def should_error_if_earlier_than_other_date(record, field, other_field, message, options={})
+  def should_error_if_earlier_than_other_date(record, field, other_field, message, options = {})
     date1 = 365.days.ago
     date2 = date1 + options.fetch(:by, 1.day)
     record.send("#{field}=", date1)

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -678,6 +678,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       it { should_errror_if_later_than_other_date(claim, :retrial_started_at, :retrial_concluded_at, 'check_other_date', translated_message: 'Can\'t be after the date "Retrial concluded"') }
       it { should_error_if_earlier_than_earliest_repo_date(claim, :retrial_started_at, 'check_not_earlier_than_rep_order', translated_message: 'Can\'t be before the earliest rep. order') }
       it { should_error_if_too_far_in_the_past(claim, :retrial_started_at, 'check_not_too_far_in_past', translated_message: 'Can\'t be too far in the past') }
+      it { should_error_if_earlier_than_other_date(claim, :retrial_started_at, :trial_concluded_at, 'check_not_earlier_than_trial_concluded', translated_message: 'Can\'t be before the "Trial concluded on"') }
 
       it 'shoud NOT error if first day of trial is before the claims earliest rep order' do
         stub_earliest_rep_order(claim, 1.month.ago)


### PR DESCRIPTION
#### What
Validate retrial start dates being on or after trial end dates

#### Ticket

[CBO-547](https://dsdmoj.atlassian.net/browse/CBO-547)

#### Why
As part of retrial fee calculation it was found that
alot of `retrial_started_at` dates were being entered with
a date earlier than the `trial_concluded_at`. This leads
to a negative retrial interval, which in turn, causes the
fee calculator to return a basic fee amount ("Advocate fee")
equivalent to the trial (as if the user was not claiming
a reduction on the retrial).

- the "negative retrial interval" could be a result of
  user error, or attempting to claim no reduction.
- in any event the data should be accurate and it should
  not be possible for a retrial to start before a trial ends

This validation has been put in place to enforce the
business/legislative rules AND to enable accurate
calculation of retrial reductions based on retrial
intervals


TODO: 
- write use an RSpec custom matcher for the validation spec(s) [tech debt]