### PR TITLE
Move logic around displaying days and Actual trial length to presenter

### DIFF
--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -349,6 +349,10 @@ class Claim::BaseClaimPresenter < BasePresenter
     claim.fees.select { |f| f.fee_type.unique_code.eql?('BACAV') }.any? { |x| x.amount&.nonzero? }
   end
 
+  def display_days?
+    false
+  end
+
   private
 
   # a blank assessment is created when the claim is created,

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -60,4 +60,8 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
   def requires_trial_dates?
     false
   end
+
+  def display_days?
+    !claim.fixed_fee_case?
+  end
 end

--- a/app/presenters/claim/transfer_claim_presenter.rb
+++ b/app/presenters/claim/transfer_claim_presenter.rb
@@ -77,4 +77,8 @@ class Claim::TransferClaimPresenter < Claim::BaseClaimPresenter
   def mandatory_case_details?
     claim.court && claim.case_number && claim.supplier_number
   end
+
+  def display_days?
+    true
+  end
 end

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -16,7 +16,7 @@
               = t('.fee_category')
             %th{ scope: 'col' }
               = t('.fee_type')
-            - if claim.transfer? || (claim.final? && !claim.fixed_fee_case?)
+            - if claim.display_days?
               %th.numeric{ scope: 'col' }
                 = claim.transfer? ? t('.days_claimed') : t('.actual_trial_length')
             %th.numeric{ scope: 'col' }
@@ -47,7 +47,7 @@
                 - if fee.case_uplift?
                   %br
                   = "(#{t('.case_numbers')}: #{fee.case_numbers})"
-              - if claim.transfer? || (claim.final? && !claim.fixed_fee_case?)
+              - if claim.display_days?
                 %td.numeric{ scope: 'col' }
                   = fee.days_claimed
               %td.numeric

--- a/spec/presenters/claim/interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/interim_claim_presenter_spec.rb
@@ -62,10 +62,10 @@ RSpec.describe Claim::InterimClaimPresenter, type: :presenter do
     end
   end
 
-  describe '#display_days' do
+  describe '#display_days?' do
     subject { presenter.display_days? }
 
-    context 'for transfer case' do
+    context 'for interim case' do
       let(:claim) { build(:interim_claim, interim_fee: nil) }
       it { is_expected.to be false }
     end

--- a/spec/presenters/claim/interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/interim_claim_presenter_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Claim::InterimClaimPresenter, type: :presenter do
         let(:interim_fee) { build(:interim_fee, :disbursement) }
 
         specify { expect(presenter.disbursement_only?).to be_truthy }
+        specify { expect(presenter.display_days?).to be false }
       end
     end
   end

--- a/spec/presenters/claim/interim_claim_presenter_spec.rb
+++ b/spec/presenters/claim/interim_claim_presenter_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe Claim::InterimClaimPresenter, type: :presenter do
     end
   end
 
+  describe '#display_days' do
+    subject { presenter.display_days? }
+
+    context 'for transfer case' do
+      let(:claim) { build(:interim_claim, interim_fee: nil) }
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#summary_sections' do
     specify {
       expect(presenter.summary_sections).to eq({

--- a/spec/presenters/claim/litigator_claim_presenter_spec.rb
+++ b/spec/presenters/claim/litigator_claim_presenter_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Claim::LitigatorClaimPresenter, type: :presenter do
     end
   end
 
-  describe '#display_days' do
+  describe '#display_days?' do
     subject { presenter.display_days? }
 
     context 'for a fixed fee case' do

--- a/spec/presenters/claim/litigator_claim_presenter_spec.rb
+++ b/spec/presenters/claim/litigator_claim_presenter_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Claim::LitigatorClaimPresenter, type: :presenter do
         let(:fixed_fee) { build(:fixed_fee, amount: 42.5) }
 
         specify { expect(presenter.raw_fixed_fees_total).to eq(42.5) }
+        specify { expect(presenter.display_days?).to be false }
       end
     end
   end
@@ -67,6 +68,7 @@ RSpec.describe Claim::LitigatorClaimPresenter, type: :presenter do
         let(:graduated_fee) { build(:graduated_fee, amount: 42.5) }
 
         specify { expect(presenter.raw_grad_fees_total).to eq(42.5) }
+        specify { expect(presenter.display_days?).to be true }
       end
     end
   end

--- a/spec/presenters/claim/litigator_claim_presenter_spec.rb
+++ b/spec/presenters/claim/litigator_claim_presenter_spec.rb
@@ -43,8 +43,21 @@ RSpec.describe Claim::LitigatorClaimPresenter, type: :presenter do
         let(:fixed_fee) { build(:fixed_fee, amount: 42.5) }
 
         specify { expect(presenter.raw_fixed_fees_total).to eq(42.5) }
-        specify { expect(presenter.display_days?).to be false }
       end
+    end
+  end
+
+  describe '#display_days' do
+    subject { presenter.display_days? }
+
+    context 'for a fixed fee case' do
+      let(:claim) { build(:litigator_claim, :with_fixed_fee_case) }
+      it { is_expected.to be false }
+    end
+
+    context 'for non-fixed fee case' do
+      let(:claim) { build(:litigator_claim, :with_graduated_fee_case) }
+      it { is_expected.to be true }
     end
   end
 

--- a/spec/presenters/claim/transfer_claim_presenter_spec.rb
+++ b/spec/presenters/claim/transfer_claim_presenter_spec.rb
@@ -30,8 +30,16 @@ RSpec.describe Claim::TransferClaimPresenter, type: :presenter do
         let(:transfer_fee) { build(:transfer_fee, amount: 42.5) }
 
         specify { expect(presenter.raw_transfer_fees_total).to eq(42.5) }
-        specify { expect(presenter.display_days?).to be true }
       end
+    end
+  end
+
+  describe '#display_days' do
+    subject { presenter.display_days? }
+
+    context 'for transfer case' do
+      let(:claim) { build(:transfer_claim, transfer_fee: nil) }
+      it { is_expected.to be true }
     end
   end
 

--- a/spec/presenters/claim/transfer_claim_presenter_spec.rb
+++ b/spec/presenters/claim/transfer_claim_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Claim::TransferClaimPresenter, type: :presenter do
     end
   end
 
-  describe '#display_days' do
+  describe '#display_days?' do
     subject { presenter.display_days? }
 
     context 'for transfer case' do

--- a/spec/presenters/claim/transfer_claim_presenter_spec.rb
+++ b/spec/presenters/claim/transfer_claim_presenter_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Claim::TransferClaimPresenter, type: :presenter do
         let(:transfer_fee) { build(:transfer_fee, amount: 42.5) }
 
         specify { expect(presenter.raw_transfer_fees_total).to eq(42.5) }
+        specify { expect(presenter.display_days?).to be true }
       end
     end
   end


### PR DESCRIPTION
Created display_days? to determine whether Days or Actual trial length is displayed in caseworker view.

#### What

Added display_days? to presenter classes to determine whether Actual trial length or days is displayed in claim summary caseworker view for lgfs claims

#### Ticket

n/a (residual tech debt from 542)
