### PR TITLE
Cbo 560 redetermination last caseworker

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ alias rake.fast='rake parallel:spec; rake parallel:features'
 
 ## Sidekiq Console
 
+To run Sidekiq
+
+```
+bundle exec sidekiq
+```
+
 To display the current state of the Sidekiq queues, as a logged in superadmin browse to `/sidekiq`
 
 ## Mailer previewing

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -124,13 +124,13 @@ class ClaimCsvPresenter < BasePresenter
     @journey.last.reason_text
   end
 
-  def previous (next_step)
+  def previous(next_step)
     complete_journeys.select { |step| step.to == next_step.from && step.created_at < next_step.created_at }
   end
 
   def pre_redetermination_user
     redetermination_steps = @journey.select { |step| step.to == 'redetermination' }
-    redetermination_steps.present? ? previous_steps = previous( redetermination_steps.last ) : previous_steps = nil
+    previous_steps = redetermination_steps.present? ? previous(redetermination_steps.last) : nil
     previous_steps.present? ? previous_steps.last.author_name : ''
   end
 end

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -128,7 +128,7 @@ class ClaimCsvPresenter < BasePresenter
     complete_journeys.select { |step| step.to == next_step.from && step.created_at < next_step.created_at }
   end
 
-  def pre_redetermination_user
+  def af1_lf1_processed_by
     redetermination_steps = @journey.select { |step| step.to == 'redetermination' }
     previous_steps = redetermination_steps.present? ? previous(redetermination_steps.last) : nil
     previous_steps.present? ? previous_steps.last.author_name : ''

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -12,10 +12,6 @@ class ClaimCsvPresenter < BasePresenter
     sorted_and_filtered_state_transitions.slice_after { |transition| COMPLETED_STATES.include?(transition.to) }
   end
 
-  def long_journeys
-    sorted_and_filtered_state_transitions
-  end
-
   def sorted_and_filtered_state_transitions
     claim_state_transitions.sort.reject do |transition|
       %w[draft archived_pending_delete].include?(transition.to) ||
@@ -124,12 +120,14 @@ class ClaimCsvPresenter < BasePresenter
     @journey.last.reason_text
   end
 
+  def previous(next_step)
+    complete_journeys = sorted_and_filtered_state_transitions
+    complete_journeys.select { |step| step.to == next_step.from && step.created_at < next_step.created_at }
+  end
+
   def af1_lf1_processed_by
-    redeterminations = @journey.select { |step| step.to == 'redetermination' }
-    if redeterminations.present?
-      redetermination = redeterminations.last
-      previous = long_journeys.select { |s| s.to == redetermination.from && s.created_at < redetermination.created_at }
-    end
-    previous.present? ? previous.last.author_name : ''
+    redetermination_steps = @journey.select { |step| step.to == 'redetermination' }
+    previous_steps = redetermination_steps.present? ? previous(redetermination_steps.last) : nil
+    previous_steps.present? ? previous_steps.last.author_name : ''
   end
 end

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -12,7 +12,7 @@ class ClaimCsvPresenter < BasePresenter
     sorted_and_filtered_state_transitions.slice_after { |transition| COMPLETED_STATES.include?(transition.to) }
   end
 
-  def complete_journeys
+  def long_journeys
     sorted_and_filtered_state_transitions
   end
 
@@ -124,13 +124,12 @@ class ClaimCsvPresenter < BasePresenter
     @journey.last.reason_text
   end
 
-  def previous(next_step)
-    complete_journeys.select { |step| step.to == next_step.from && step.created_at < next_step.created_at }
-  end
-
   def af1_lf1_processed_by
-    redetermination_steps = @journey.select { |step| step.to == 'redetermination' }
-    previous_steps = redetermination_steps.present? ? previous(redetermination_steps.last) : nil
-    previous_steps.present? ? previous_steps.last.author_name : ''
+    redeterminations = @journey.select { |step| step.to == 'redetermination' }
+    if redeterminations.present?
+      redetermination = redeterminations.last
+      previous = long_journeys.select { |s| s.to == redetermination.from && s.created_at < redetermination.created_at }
+    end
+    previous.present? ? previous.last.author_name : ''
   end
 end

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -12,6 +12,10 @@ class ClaimCsvPresenter < BasePresenter
     sorted_and_filtered_state_transitions.slice_after { |transition| COMPLETED_STATES.include?(transition.to) }
   end
 
+  def complete_journeys
+    sorted_and_filtered_state_transitions
+  end
+
   def sorted_and_filtered_state_transitions
     claim_state_transitions.sort.reject do |transition|
       %w[draft archived_pending_delete].include?(transition.to) ||
@@ -118,5 +122,15 @@ class ClaimCsvPresenter < BasePresenter
 
   def rejection_reason
     @journey.last.reason_text
+  end
+
+  def previous (next_step)
+    complete_journeys.select { |step| step.to == next_step.from && step.created_at < next_step.created_at }
+  end
+
+  def pre_redetermination_user
+    redetermination_steps = @journey.select { |step| step.to == 'redetermination' }
+    redetermination_steps.present? ? previous_steps = previous( redetermination_steps.last ) : previous_steps = nil
+    previous_steps.present? ? previous_steps.last.author_name : ''
   end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,9 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular 'date_attended', 'dates_attended'
   inflect.irregular 'claim was', 'claims were'
   inflect.acronym 'CPS'
+  inflect.acronym 'AF1'
+  inflect.acronym 'LF1'
+  inflect.human(/af1_lf1_processed_by/, "af1/lf1 processed by")
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,6 +63,7 @@ claim_csv_headers:
   - :disk_evidence_case
   - :main_defendant
   - :maat_reference
+  - :pre_redetermination_user
 
 expense_schema_version: 2
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,7 +63,7 @@ claim_csv_headers:
   - :disk_evidence_case
   - :main_defendant
   - :maat_reference
-  - :pre_redetermination_user
+  - :af1_lf1_processed_by
 
 expense_schema_version: 2
 

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -113,12 +113,6 @@ RSpec.describe ClaimCsvPresenter do
         it { is_expected.to eq claim.earliest_representation_order.maat_reference }
       end
 
-      describe 'pre_redermination_user' do
-        presenter.present! do |claim_journeys|
-           #kat todo!!!
-        end
-      end
-
       describe 'caseworker name' do
         context 'decision transition doesnt exist' do
           it 'returns nil' do
@@ -157,6 +151,30 @@ RSpec.describe ClaimCsvPresenter do
           end
         end
 
+      end
+
+      describe 'af1_lf1_processed_by' do
+        context 'an allocated claim' do
+          it 'returns nil' do
+            claim = create :authorised_claim
+            presenter = ClaimCsvPresenter.new(claim, view)
+            presenter.present! do |claim_journeys|
+              expect(presenter.af1_lf1_processed_by).to eq ''
+            end
+          end
+        end
+
+        context 'a redetermined claim' do
+          it 'returns the name of the last caseworker to update before redetermination' do
+            claim = create :authorised_claim
+            case_worker_name = claim.case_workers.first.name
+            claim.redetermine!
+            presenter = ClaimCsvPresenter.new(claim, view)
+            presenter.present! do |claim_journeys|
+              expect(presenter.af1_lf1_processed_by).to eq case_worker_name
+            end
+          end
+        end
       end
 
       context 'and unique values for' do

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe ClaimCsvPresenter do
         it { is_expected.to eq claim.earliest_representation_order.maat_reference }
       end
 
+      describe 'pre_redermination_user' do
+        presenter.present! do |claim_journeys|
+           #kat todo!!!
+        end
+      end
+
       describe 'caseworker name' do
         context 'decision transition doesnt exist' do
           it 'returns nil' do

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe ClaimCsvPresenter do
 
   let(:claim)               { create(:redetermination_claim) }
   let(:presenter)             { ClaimCsvPresenter.new(claim, view) }
+  let(:previous_user) { create(:user, first_name: 'Thea', last_name: 'Conway') }
+  let(:another_user) { create(:user, first_name: 'Hilda', last_name: 'Rogers') }
+
 
   context '#present!' do
 
@@ -153,6 +156,9 @@ RSpec.describe ClaimCsvPresenter do
 
       end
 
+      # Case worker name isn't unique - might not be the user who was working on this case just before redetermination
+      # What about when case is marked as redetermination multiple times?
+
       describe 'af1_lf1_processed_by' do
         context 'an allocated claim' do
           it 'returns nil' do
@@ -167,11 +173,27 @@ RSpec.describe ClaimCsvPresenter do
         context 'a redetermined claim' do
           it 'returns the name of the last caseworker to update before redetermination' do
             claim = create :authorised_claim
-            case_worker_name = claim.case_workers.first.name
+            transition = claim.last_decision_transition
+            transition.update_author_id(previous_user.id)
             claim.redetermine!
             presenter = ClaimCsvPresenter.new(claim, view)
             presenter.present! do |claim_journeys|
-              expect(presenter.af1_lf1_processed_by).to eq case_worker_name
+              expect(presenter.af1_lf1_processed_by).to eq previous_user.name
+            end
+          end
+        end
+
+        context 'a claim that is redetermined twice' do
+          it 'returns the name of the last caseworker to update before redetermination' do
+            claim = create :redetermination_claim
+            claim.allocate!
+            claim.authorise!
+            transition = claim.last_decision_transition
+            transition.update_author_id(another_user.id)
+            claim.redetermine!
+            presenter = ClaimCsvPresenter.new(claim, view)
+            presenter.present! do |claim_journeys|
+              expect(presenter.af1_lf1_processed_by).to eq another_user.name
             end
           end
         end

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Stats::ManagementInformationGenerator do
       expect(contents.size).to eq(valid_claims.size + 1)
     end
 
-    it 'has 17 columns' do
-      expect(contents.first.split(',').count).to eql 17
+    it 'has 18 columns' do
+      expect(contents.first.split(',').count).to eql 18
     end
   end
 end


### PR DESCRIPTION
#### What
Add last caseworker who worked on a claim to MI report

#### Ticket
CBO-560 https://dsdmoj.atlassian.net/projects/CBO/issues/CBO-560

#### Why
So that managers can focus the training for caseworkers and ultimately drive down the reject rate

#### How
Added column 'AF1/LF1 processed by' to MI report
--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
