### PR TITLE
Remove retrial/trial start/end validation temporarily

### DIFF
--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -233,8 +233,11 @@ class Claim::BaseClaimValidator < BaseValidator
   # must be less than or equal to last day of retrial
   # cannot be before earliest rep order date
   # cannot be more than 5 years in the past
+  # TODO: temporary removal of this validation to give vendors time to amend their apps - remove by 1st March 2019
   def validate_retrial_started_at
-    validate_on_or_after(@record.trial_concluded_at, :retrial_started_at, 'check_not_earlier_than_trial_concluded')
+    # rubocop: disable Metrics/LineLength
+    validate_on_or_after(@record.trial_concluded_at, :retrial_started_at, 'check_not_earlier_than_trial_concluded') unless @record.from_api?
+    # rubocop: enable Metrics/LineLength
     validate_retrial_start_and_end(:retrial_started_at, :retrial_concluded_at, false)
   end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -699,6 +699,21 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
             translated_message: 'Can\'t be before the "Trial concluded on"'
           )
         }
+
+        # TODO: This is a temporary removal of this validation to give vendors time to amend their apps - remove by 1st March 2019
+        context 'from API' do
+          before { allow(claim).to receive(:from_api?).and_return true }
+
+          it {
+            is_expected.to_not include_field_error_when(
+              field: :retrial_started_at, other_field: :trial_concluded_at,
+              field_value: 7.days.ago.to_date, other_field_value: 6.days.ago.to_date,
+              message: 'check_not_earlier_than_trial_concluded',
+              translated_message: 'Can\'t be before the "Trial concluded on"'
+            )
+          }
+        end
+
       end
 
       it 'shoud NOT error if first day of trial is before the claims earliest rep order' do


### PR DESCRIPTION
#### What
Remove retrial/trial start/end validation temporarily

#### Why
To give vendors time to "fix" their systems
inline.


#### How
Disable the validation for claims submitted
from api

#### TODO (wip)

 - [X] conditionally remove validation
 - [ ] update API docs