### PR TITLE
Add api release notes for retrial validation

### DIFF
--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -11,6 +11,20 @@
 
 %section.api-documentation
   %hr
+  %h2 30th January 2019
+  %ul.list-bullet
+    %li
+      Validation of retrial and trial dates
+      %br/
+      %br/
+      The `retrial_started_at` date attribute must now contain a date on or after the `trial_concluded_at` date. This impacts advocate final claims for retrials.
+      %br/
+      %br/
+      This is neccessary to prevent "negative retrial intervals" as part of the implementation of fee calculation
+      for AGFS retrial fees.
+
+%section.api-documentation
+  %hr
   %h2 20th December 2018
   %ul.list-bullet
     %li


### PR DESCRIPTION
#### What
Add api release notes for retrial validation

#### Why
Missed from previous worked. One vendor has
discovered their app has a bug/feature which
falls foul of this validation.