### PR TITLE
CBO-570 Accessibility: Offence details page review

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/assets/javascripts/modules/external_users/claims/NewClaim.js
@@ -1,32 +1,8 @@
 moj.Modules.NewClaim = {
   init: function() {
-
-    //Claim basic section
-    this.initBasicClaim();
-
     //Attach on submit claim validation
     this.initSubmitValidation();
   },
-
-  initBasicClaim: function() {
-    var self = this;
-
-    self.$offenceCategorySelect = $('#claim_offence_category_description');
-
-    self.$offenceCategorySelect.change(function() {
-      var param = $.param({
-        description: $(this).find(':selected').text()
-      });
-      $.getScript('/offences?' + param);
-    });
-
-    if (!$('#claim_offence_id').val()) {
-      $('.offence-class-select').hide();
-    }
-
-    self.attachToOffenceClassSelect();
-  },
-
   initSubmitValidation: function() {
     //
     // Warn the user if 'A copy of the indictment' is not selected in the
@@ -34,23 +10,12 @@ moj.Modules.NewClaim = {
     // Tests in /spec/javascripts/supporting-evidence_spec.js
     //
     $('input[name="commit_submit_claim"]').on('click', function(e) {
-        if ($('#claim_evidence_checklist_ids_4').exists() && !$('#claim_evidence_checklist_ids_4').prop('checked') && !$('[data-mute-indictment]').data('mute-indictment')) {
-          return confirm(
-            "The evidence checklist suggests that no indictment has been attached.\n" +
-            "This can lead to your claim being rejected.\n\n" +
-            "Do you wish to proceed without attaching an indictment?"
-          );
-        }
-    });
-  },
-
-  attachToOffenceClassSelect: function() {
-    $('#offence_class_description').on('change', function() {
-      $('#claim_offence_id').val($(this).val());
-
-      if (!$(this).val()) {
-        $('.offence-class-select').hide();
-        $('#claim_offence_id').val('');
+      if ($('#claim_evidence_checklist_ids_4').exists() && !$('#claim_evidence_checklist_ids_4').prop('checked') && !$('[data-mute-indictment]').data('mute-indictment')) {
+        return confirm(
+          "The evidence checklist suggests that no indictment has been attached.\n" +
+          "This can lead to your claim being rejected.\n\n" +
+          "Do you wish to proceed without attaching an indictment?"
+        );
       }
     });
   }

--- a/app/assets/javascripts/modules/external_users/claims/OffenceCtrl.js
+++ b/app/assets/javascripts/modules/external_users/claims/OffenceCtrl.js
@@ -1,0 +1,39 @@
+moj.Modules.OffenceCtrl = {
+  init: function() {
+
+    //Claim basic section
+    this.initBasicClaim();
+  },
+  initBasicClaim: function() {
+    var self = this;
+    if ($('#claim_offence_category_description').length) {
+      moj.Helpers.Autocomplete.new('#claim_offence_category_description', {
+        showAllValues: true,
+        autoselect: false
+      });
+    }
+
+    $.subscribe('/onConfirm/claim_offence_category_description-select/', function(e, data) {
+      var param = $.param({
+        description: data.query
+      });
+      $.getScript('/offences?' + param);
+    });
+
+
+    if (!$('#claim_offence_id').val()) {
+      $('.offence-class-select').hide();
+    }
+    self.attachToOffenceClassSelect();
+  },
+  attachToOffenceClassSelect: function() {
+    $('#offence_class_description').on('change', function() {
+      $('#claim_offence_id').val($(this).val());
+
+      if (!$(this).val()) {
+        $('.offence-class-select').hide();
+        $('#claim_offence_id').val('');
+      }
+    });
+  }
+};

--- a/app/assets/javascripts/modules/external_users/claims/OffenceCtrl.js
+++ b/app/assets/javascripts/modules/external_users/claims/OffenceCtrl.js
@@ -1,38 +1,55 @@
 moj.Modules.OffenceCtrl = {
-  init: function() {
-
-    //Claim basic section
-    this.initBasicClaim();
+  els: {
+    offenceClassSelectWrapper: '.offence-class-select',
+    offenceClassSelect: '#offence_class_description',
+    offenceID: '#claim_offence_id',
+    offenceCategoryDesc: '#claim_offence_category_description'
   },
-  initBasicClaim: function() {
-    var self = this;
-    if ($('#claim_offence_category_description').length) {
-      moj.Helpers.Autocomplete.new('#claim_offence_category_description', {
+  init: function() {
+    // init the auto complete
+    this.autocomplete();
+
+    // check the load state
+    // binding events to the dynamic select
+    this.checkState();
+
+    // bind general page events
+    this.bindEvents();
+  },
+
+  checkState: function() {
+    if (!$(this.els.offenceID).val()) {
+      $(this.els.offenceClassSelectWrapper).hide();
+    }
+    this.attachToOffenceClassSelect();
+  },
+
+  autocomplete: function() {
+    if ($(this.els.offenceCategoryDesc).length) {
+      moj.Helpers.Autocomplete.new(this.els.offenceCategoryDesc, {
         showAllValues: true,
         autoselect: false
       });
     }
+  },
 
+  bindEvents: function() {
+    var self = this;
     $.subscribe('/onConfirm/claim_offence_category_description-select/', function(e, data) {
       var param = $.param({
         description: data.query
       });
       $.getScript('/offences?' + param);
     });
-
-
-    if (!$('#claim_offence_id').val()) {
-      $('.offence-class-select').hide();
-    }
-    self.attachToOffenceClassSelect();
   },
-  attachToOffenceClassSelect: function() {
-    $('#offence_class_description').on('change', function() {
-      $('#claim_offence_id').val($(this).val());
 
+  attachToOffenceClassSelect: function() {
+    var self = this;
+    $(this.els.offenceClassSelect).on('change', function() {
+      $(self.els.offenceID).val($(this).val());
       if (!$(this).val()) {
-        $('.offence-class-select').hide();
-        $('#claim_offence_id').val('');
+        $(self.els.offenceClassSelectWrapper).hide();
+        $(self.els.offenceID).val('');
       }
     });
   }

--- a/app/views/external_users/claims/offence_details/_default_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_default_fields.html.haml
@@ -1,27 +1,30 @@
 - locale_scope = 'external_users.claims.offence_details.fields'
 
-%fieldset
-  #offence
-    .form-row.js-typeahead
-      .form-col.form-col-one-half{class: error_class?(@error_presenter, :offence)}
-        = f.anchored_label t('offence_category', scope: locale_scope), 'offence_category_description_input', { label_attributes: { class: 'form-label' } }
-        .form-hint.xsmall.zero-vert-margin
-          = t('offence_category_hint', scope: locale_scope)
-        - if @claim.new_record?
-          - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
-        - else
-          - selected_offence_category = @claim.offence.description rescue nil
+//
+// Offences PRE fee reform
+//
 
-        = collection_select :offence_category,
-                              :description,
-                              @offence_descriptions,
-                              :description, :description,
-                              { include_blank: ''.html_safe, selected: selected_offence_category },
-                              { class: 'form-control typeahead', id: 'claim_offence_category_description' }
-        = validation_error_message(@error_presenter, :offence)
+- locale_scope = 'external_users.claims.offence_details.fields'
 
-    .form-row
-      .form-col.form-col-one-half
-        .offence-class-select
-          = render partial: 'external_users/claims/offence_details/offence_select', locals: { offences: @offences }
-        = f.hidden_field :offence_id
+#cc-offence.form-group{class: error_class?(@error_presenter, :offence_category)}
+  %a{:id => "offence_category"}
+  %label.form-label-bold{:for => "claim_offence_category_description"}
+    = t('offence_category', scope: locale_scope)
+  .form-hint.xsmall.zero-vert-margin
+    = t('offence_category_hint', scope: locale_scope)
+
+  - if @claim.new_record?
+    - selected_offence_category = params[:offence_category].present? ? params[:offence_category][:description] : nil
+  - else
+    - selected_offence_category = @claim.offence.description rescue nil
+
+  = collection_select :offence_category,
+                        :description,
+                        @offence_descriptions,
+                        :description, :description,
+                        { include_blank: ''.html_safe, selected: selected_offence_category },
+                        { class: 'form-control fx-autocomplete', id: 'claim_offence_category_description' }
+
+.offence-class-select.form-group
+  = render partial: 'external_users/claims/offence_details/offence_select', locals: { offences: @offences }
+= f.hidden_field :offence_id

--- a/app/views/external_users/claims/offence_details/_default_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_default_fields.html.haml
@@ -1,11 +1,7 @@
-- locale_scope = 'external_users.claims.offence_details.fields'
-
 //
 // Offences PRE fee reform
 //
-
 - locale_scope = 'external_users.claims.offence_details.fields'
-
 #cc-offence.form-group{class: error_class?(@error_presenter, :offence_category)}
   %a{:id => "offence_category"}
   %label.form-label-bold{:for => "claim_offence_category_description"}

--- a/app/views/offences/index.js.erb
+++ b/app/views/offences/index.js.erb
@@ -4,6 +4,6 @@
 <% else %>
   $('.offence-class-select').html('<%=j render partial: "external_users/claims/offence_details/offence_select", locals: { offences: @offences } %>');
   $('.offence-class-select').slideDown();
-  moj.Modules.NewClaim.attachToOffenceClassSelect();
+  moj.Modules.OffenceCtrl.attachToOffenceClassSelect();
   $('#offence_class_description').change();
 <% end %>

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -25,6 +25,8 @@ class ClaimFormPage < SitePrism::Page
   element :providers_ref, "#claim_providers_ref"
   section :auto_case_type, CommonAutocomplete, "#cc-case-type"
   section :auto_court, CommonAutocomplete, "#cc-court"
+  section :auto_offence, CommonAutocomplete, "#cc-offence"
+
   element :case_number, "#claim_case_number"
 
   section :trial_details, "#trial-dates" do

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -58,7 +58,8 @@ When(/^I select the supplier number '(.*)'$/) do |number|
 end
 
 When(/^I select the offence category '(.*?)'$/) do |offence_cat|
-  @claim_form_page.select_offence_category offence_cat
+  @claim_form_page.auto_offence.choose_autocomplete_option(offence_cat)
+  wait_for_ajax
 end
 
 And(/^I sleep for '(.*?)' second$/) do |num_seconds|

--- a/spec/javascripts/Modules.OffenceCtrl_spec.js
+++ b/spec/javascripts/Modules.OffenceCtrl_spec.js
@@ -1,0 +1,76 @@
+describe("Modules.OffenceCtrl.js", function() {
+  var module = moj.Modules.OffenceCtrl;
+
+  var view = function(data) {
+
+    data = $.extend({}, data, {
+      value: '',
+      fee_scheme: 'AGFS 10'
+    });
+    return $([
+      '<div id="offence-view">',
+      '<div id="cc-offence">',
+      '  <select class="fx-autocomplete" id="claim_offence_category_description">',
+      '    <option value=""></option>',
+      '    <option value="Abandonment of children under two">Abandonment of children under two</option>',
+      '    <option value="Abduction of defective from parent">Abduction of defective from parent</option>',
+      '    <option value="Abduction of unmarried girl under 16 from parent">Abduction of unmarried girl under 16 from parent</option>',
+      '  </select>',
+      '</div>',
+      '<div class="offence-class-select"></div>',
+      '<input type="hidden" value="" id="claim_offence_id">',
+      '</div>'
+    ].join(''));
+  };
+
+
+  beforeEach(function() {
+    $('body').append(view());
+  });
+
+  afterEach(function() {
+    $('body #offence-view').remove();
+  });
+
+  describe('...defaults', function() {
+    it('should behave `els` selectors defined', function() {
+      expect(module.els.offenceClassSelectWrapper).toEqual('.offence-class-select');
+      expect(module.els.offenceClassSelect).toEqual('#offence_class_description');
+      expect(module.els.offenceID).toEqual('#claim_offence_id');
+      expect(module.els.offenceCategoryDesc).toEqual('#claim_offence_category_description');
+
+    });
+  });
+
+
+  describe('...Methods', function() {
+    describe('...init', function() {
+      it('should call `this.autocomplete`...', function() {
+        spyOn(module, 'autocomplete');
+
+        module.init();
+        expect(module.autocomplete).toHaveBeenCalledWith();
+      });
+      it('should call `this.checkState`...', function() {
+        spyOn(module, 'checkState');
+
+        module.init();
+        expect(module.checkState).toHaveBeenCalledWith();
+      });
+      it('should call `this.bindEvents`...', function() {
+        spyOn(module, 'bindEvents');
+
+        module.init();
+        expect(module.bindEvents).toHaveBeenCalledWith();
+      });
+    });
+    describe('...checkState', function() {
+      it('should call `this.attachToOffenceClassSelect`...', function() {
+        spyOn(module, 'attachToOffenceClassSelect');
+
+        module.checkState();
+        expect(module.attachToOffenceClassSelect).toHaveBeenCalledWith();
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### What
Implementing the new autocomplete on the offence page in aid of the accessibility review

#### Ticket

[CBO-570](https://dsdmoj.atlassian.net/browse/CBO-570)

#### Why
DAC report recommendations

#### How
- Moved the offence code to a controller
- activated the new autocomplete on offence page
- bound events as required to the offence class select
- view refactors in aid of cucumber
- updated features

--------

#### TODO (wip)

 - [x] JS specs

