### PR TITLE
Update validation for Litigator claim

### DIFF
--- a/app/models/claim/litigator_claim.rb
+++ b/app/models/claim/litigator_claim.rb
@@ -67,7 +67,7 @@ module Claim
     route_key_name 'litigators_claim'
 
     validates_with ::Claim::LitigatorClaimValidator, unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
-    validates_with ::Claim::LitigatorSupplierNumberValidator, on: :create
+    validates_with ::Claim::LitigatorSupplierNumberValidator, if: proc { |c| c.draft? }
     validates_with ::Claim::LitigatorClaimSubModelValidator
 
     has_one :fixed_fee,

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -17,7 +17,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2016-04-01'
-    Then I click "Continue" in the claim form and move to the 'Case details' form page
+    When I click "Continue" I should see a "Choose a supplier number" error
 
     When I choose the supplier number '1A222Z'
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -13,11 +13,13 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I should see 3 supplier number radios
 
-    When I choose the supplier number '1A222Z'
     And I select a case type of 'Trial'
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2016-04-01'
+    Then I click "Continue" in the claim form and move to the 'Case details' form page
+
+    When I choose the supplier number '1A222Z'
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -17,7 +17,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2016-04-01'
-    When I click "Continue" I should see a "Choose a supplier number" error
+    When I click "Continue" I should be on the 'Case details' page and see a "Choose a supplier number" error
 
     When I choose the supplier number '1A222Z'
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -106,11 +106,19 @@ When(/^I click "Continue" in the claim form$/) do
   wait_for_ajax
 end
 
-When(/^I click "Continue" I should see a "([^"]*)" error$/) do |error_message|
+When(/^I click "Continue" I should be on the 'Case details' page and see a "([^"]*)" error$/) do |error_message|
+  sleep 3
   @claim_form_page.continue_button.click
   wait_for_ajax
-  within('div.error-summary') do
-    expect(page).to have_content(error_message)
+  using_wait_time(6) do
+    if !page.has_content?(error_message)
+      #clicking again because the first one didn't work
+      @claim_form_page.continue_button.click
+      wait_for_ajax
+    end
+    within('div.error-summary') do
+      expect(page).to have_content(error_message)
+    end
   end
 end
 

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -106,6 +106,14 @@ When(/^I click "Continue" in the claim form$/) do
   wait_for_ajax
 end
 
+When(/^I click "Continue" I should see a "([^"]*)" error$/) do |error_message|
+  @claim_form_page.continue_button.click
+  wait_for_ajax
+  within('div.error-summary') do
+    expect(page).to have_content(error_message)
+  end
+end
+
 When(/^I click "Continue" in the claim form and move to the '(.*?)' form page$/) do |page_title|
   original_header = page.first('h2').text
   sleep 3

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
     before { SupplierNumber.find_by(supplier_number: claim.supplier_number).delete }
 
     describe 'on create' do
-      describe 'the claim is invalid' do
+      describe 'the claim is in draft' do
         let(:claim) { build(:litigator_claim, :fixed_fee, :forced_validation, fixed_fee: build(:fixed_fee, :lgfs)) }
 
         it { is_expected.to be false }
@@ -163,8 +163,8 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
     end
 
     describe 'on edit' do
-      describe 'the claim is valid' do
-        let(:claim) { create(:litigator_claim, :fixed_fee, :forced_validation, fixed_fee: build(:fixed_fee, :lgfs)) }
+      describe 'the claim is not in draft' do
+        let(:claim) { create(:litigator_claim, :fixed_fee, :forced_validation, fixed_fee: create(:fixed_fee, :lgfs), state: 'submitted') }
 
         it { is_expected.to be true }
       end


### PR DESCRIPTION
#### What
Validation on LGFS supplier number field on Claim for litigator fees page, meaning that providers were able to continue with their application without a supplier number being collected. 

#### Ticket
[CBO-569](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=222&projectKey=CBO&modal=detail&selectedIssue=CBO-569)

#### Why
Caseworkers were unable to assess claims 

#### How
Changed validation restriction so that it was called when a claim was in `draft?` rather than just when `LitigatorClaimsController#create` was called, as was the previous trigger.
