### PR TITLE
TEST - Modify the way claim state is handled in factories

### DIFF
--- a/features/step_definitions/caseworker_claim_steps.rb
+++ b/features/step_definitions/caseworker_claim_steps.rb
@@ -1,24 +1,10 @@
 Given(/^there is a claim allocated to the case worker with case number '(.*?)'$/) do |case_number|
-  # TODO: this does not create a valid submitted claim
-  # creates some sort of claim with some information that happens
-  # to be in the submitted state
-  # To go around this I'm preserving old functionality for the factory by
-  # setting the form_step.
-  # Going forward this should be properly fixed with an actual factory that is valid
-  # for a submitted claim
-  @claim = create(:allocated_claim, external_user: @advocate, case_number: case_number, form_step: :case_details)
+  @claim = create(:allocated_claim, external_user: @advocate, case_number: case_number)
   @case_worker.claims << @claim
 end
 
 Given(/^there is a redetermination claim allocated to the case worker with case number '(.*?)'$/) do |case_number|
-  # TODO: this does not create a valid redetermination claim
-  # creates some sort of claim with some information that happens
-  # to be in the redetermination state
-  # To go around this I'm preserving old functionality for the factory by
-  # setting the form_step.
-  # Going forward this should be properly fixed with an actual factory that is valid
-  # for a redetermination claim
-  @claim = create(:redetermination_claim, external_user: @advocate, case_number: case_number, form_step: :case_details)
+  @claim = create(:redetermination_claim, external_user: @advocate, case_number: case_number)
   @case_worker.claims << @claim
 end
 


### PR DESCRIPTION
Modify the way claim state is handled in factories

Advocate claim factories for claims in a particular
state are simply altering the state without ensuring the
claim is valid. This can result in invalid claims in
a (post) submitted - which should never be possible and
can result in specs and features throwing invalid transition
errors unexpectedly.
