### PR TITLE
Cbo 582 caseworker allocation filter for Supplementary Claim

### DIFF
--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -36,6 +36,7 @@ module API
         expose :risk_based_bills
         expose :injection_errored
         expose :cav_warning
+        expose :supplementary
       end
 
       private
@@ -125,6 +126,10 @@ module API
 
       def cav_warning
         (last_injection_attempt_succeeded && contains_conference_and_view).to_i
+      end
+
+      def supplementary
+        object.case_type.eql?('Supplementary').to_i
       end
     end
   end

--- a/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
@@ -23,6 +23,8 @@
         = t('.injection_errors')
       %option{:value => "agfs_warrants"}
         = t('.warrants')
+      %option{:value => "supplementary"}
+        = t('.supplementary')
 
 
 .form-group#filter-tasks.dtFilter.dtFilterLGFS{data: {scheme: 'lgfs'}, style: 'display: none;'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2100,8 +2100,8 @@ en:
           redetermination: Redetermination
           risk_based_bills: Risk based bills
           case_types: Case types
-          trial: trial
-          warrants: warrants
+          trial: Trial
+          warrants: Warrants
       management_information:
         validate_report_type:
           invalid_report_type: &invalid_report_type The requested report type is not supported

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2102,6 +2102,7 @@ en:
           case_types: Case types
           trial: Trial
           warrants: Warrants
+          supplementary: Supplementary
       management_information:
         validate_report_type:
           invalid_report_type: &invalid_report_type The requested report type is not supported

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2024,7 +2024,7 @@ en:
           clear_filters: Clear filter
           allocate: Allocate
           allocation_queue: Allocation queue
-          defendents: Defedants
+          defendents: Defendants
           error_summary: 'This claim allocation has '
           filter_claims: Filter claims
           page_heading: Allocation

--- a/features/allocation.feature
+++ b/features/allocation.feature
@@ -9,6 +9,7 @@ Feature: Case worker admin allocates claims
 
     And I am a signed in case worker admin
     When I visit the allocation page
+    And I should see the AGFS filters
     And I select claims "T20160001, T20160002"
     And I select case worker "John Smith"
     And I click Allocate

--- a/features/step_definitions/caseworker_claim_allocation_steps.rb
+++ b/features/step_definitions/caseworker_claim_allocation_steps.rb
@@ -170,6 +170,13 @@ When(/^I click on a claims row cell$/) do
   page.find('tbody').all('tr')[0].all('td')[1].click()
 end
 
+When(/^I should see the AGFS filters$/) do
+  options = %w(All Fixed\ fee Cracked Trial Guilty\ Plea Redetermination
+               Awaiting\ written\ reasons Disk\ evidence Injection\ errors
+               Warrants Supplementary)
+  expect(page.find('#filter-tasks')).to have_select(options: options)
+end
+
 Then (/^I should see that claims checkbox (ticked|unticked)$/) do | checkbox_state|
   if checkbox_state == 'ticked'
     expect(page.find('tbody').all('tr')[0].all('input[type=checkbox]')[0]).to be_checked

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -65,7 +65,8 @@ describe API::Entities::SearchResult do
           interim_disbursements: 0,
           risk_based_bills: 0,
           injection_errored: 0,
-          cav_warning: 0
+          cav_warning: 0,
+          supplementary: 0
         }
       end
 
@@ -156,6 +157,12 @@ describe API::Entities::SearchResult do
       context 'when passed a advocate interim/warrant claim' do
         let(:claim) { OpenStruct.new('id' => '179818', 'uuid' => '887cbd94-3f48-4955-8646-918de4db3617', 'case_type' => 'Warrant', 'state'=>'submitted', 'total' => '667.33', 'fees' => "0.0~Warrant Fee~Fee::WarrantFeeType", 'last_submitted_at' => '07/12/2017  12:58:29', 'class_letter' => nil, 'is_fixed_fee' => nil, 'fee_type_code' => nil, 'graduated_fee_types' => "GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR") }
         before { result.merge!(agfs_warrants: 1) }
+        include_examples 'returns expected JSON filter values'
+      end
+
+      context 'when passed a advocate interim/warrant claim' do
+        let(:claim) { OpenStruct.new('id' => '179818', 'uuid' => '887cbd94-3f48-4955-8646-918de4db3617', 'case_type' => 'Supplementary', 'state'=>'submitted', 'total' => '667.33', 'fees' => "0.0~Warrant Fee~Fee::WarrantFeeType", 'last_submitted_at' => '07/12/2017  12:58:29', 'class_letter' => nil, 'is_fixed_fee' => nil, 'fee_type_code' => nil, 'graduated_fee_types' => "GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR") }
+        before { result.merge!(supplementary: 1) }
         include_examples 'returns expected JSON filter values'
       end
     end


### PR DESCRIPTION
#### What
Allows a CaseworkerAdmin user to filter the allocation queue by the new Supplementary Claim type.

#### Ticket


[CBO-582](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=222&projectKey=CBO&modal=detail&selectedIssue=CBO-582)

#### Why
Requested by user

#### How
Add an extra variable to allocation filter, and corresponding API code to allow filtering by this claim type.
