### PR TITLE
Prevent supplmenetary claims with no miscellaneous fees

### DIFF
--- a/app/models/claim/advocate_supplementary_claim.rb
+++ b/app/models/claim/advocate_supplementary_claim.rb
@@ -8,6 +8,7 @@ module Claim
 
     before_validation do
       set_supplier_number
+      assign_total_attrs
     end
 
     SUBMISSION_STAGES = [
@@ -39,6 +40,23 @@ module Claim
       },
       { name: :supporting_evidence }
     ].freeze
+
+    def assign_total_attrs
+      return if from_api?
+      assign_fees_total(%i[misc_fees]) if fees_changed?
+      assign_expenses_total if expenses_changed?
+      return unless total_changes_required?
+      assign_total
+      assign_vat
+    end
+
+    def total_changes_required?
+      fees_changed? || expenses_changed?
+    end
+
+    def fees_changed?
+      misc_fees_changed?
+    end
 
     def external_user_type
       :advocate

--- a/app/validators/claim/advocate_supplementary_claim_validator.rb
+++ b/app/validators/claim/advocate_supplementary_claim_validator.rb
@@ -14,7 +14,7 @@ class Claim::AdvocateSupplementaryClaimValidator < Claim::BaseClaimValidator
         supplier_number
       ],
       defendants: [],
-      miscellaneous_fees: %i[advocate_category defendant_uplifts_misc_fees],
+      miscellaneous_fees: %i[advocate_category defendant_uplifts_misc_fees total],
       travel_expenses: %i[travel_expense_additional_information],
       supporting_evidence: []
     }

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -91,38 +91,38 @@ RSpec.describe ClaimStateTransitionReason, type: :model do
     subject(:refuse_reasons_for) { described_class.refuse_reasons_for(claim).map(&:code) }
 
     context 'for a litigator final claim' do
-      let(:claim) { create(:litigator_claim, :fixed_fee, fixed_fee: create(:fixed_fee, :lgfs), state: 'refused') }
+      let(:claim) { create(:litigator_claim, :fixed_fee, fixed_fee: create(:fixed_fee, :lgfs)) }
 
       it { is_expected.to match_array %w[duplicate_claim other_refuse] }
     end
 
     context 'for a litigator transfer claim' do
-      let(:claim) { create(:transfer_claim, transfer_fee: build(:transfer_fee), state: 'refused') }
+      let(:claim) { create(:transfer_claim, transfer_fee: build(:transfer_fee)) }
 
       it { is_expected.to match_array %w[duplicate_claim other_refuse] }
     end
 
     context 'for a litigator interim claim' do
-      let(:claim) { create(:interim_claim, interim_fee: build(:interim_fee), state: 'refused') }
+      let(:claim) { create(:interim_claim, interim_fee: build(:interim_fee)) }
 
       it { is_expected.to match_array %w[duplicate_claim no_effective_pcmh no_effective_trial short_trial other_refuse] }
     end
 
     context 'for an advocate final claim' do
       let(:basic_fee) { build(:basic_fee, :baf_fee, quantity: 1, amount: 21.01) }
-      let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee], state: 'refused') }
+      let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee]) }
 
       it { is_expected.to match_array %w[wrong_ia duplicate_claim other_refuse] }
     end
 
     context 'for an advocate interim claim' do
-      let(:claim) { create(:advocate_interim_claim, state: 'refused') }
+      let(:claim) { create(:advocate_interim_claim) }
 
       it { is_expected.to match_array %w[duplicate_claim no_effective_pcmh no_effective_trial short_trial other_refuse] }
     end
 
     context 'for an advocate supplementary claim' do
-      let(:claim) { create(:advocate_supplementary_claim, state: 'refused') }
+      let(:claim) { create(:advocate_supplementary_claim) }
 
       it { is_expected.to match_array %w[wrong_ia duplicate_claim other_refuse] }
     end

--- a/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Claim::AdvocateSupplementaryClaimValidator, type: :validator do
       supplier_number
     ],
     defendants: [],
-    miscellaneous_fees: %i[advocate_category defendant_uplifts_misc_fees],
+    miscellaneous_fees: %i[advocate_category defendant_uplifts_misc_fees total],
     travel_expenses: %i[travel_expense_additional_information],
     supporting_evidence: []
   }


### PR DESCRIPTION
#### What
Prevent supplementary claims with no miscellaneous fees
and calculate totals for such fees on the backend too


#### Ticket

[CBO-595](https://dsdmoj.atlassian.net/browse/CBO-595)

#### Why
Backend totals calculation required for API submissions in any
event. Plus a supplementary claim should(??) have a miscellaneous
fee value
