### PR TITLE
Update vcr chromedriver handling

### DIFF
--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -19,7 +19,7 @@ VCR.configure do |c|
   # TODO: Set this port explicitly for chrome/selenium so we have control
   c.ignore_request do |request|
     uri = URI(request.uri)
-    [uri.host.eql?('127.0.0.1'), uri.port.eql?(9515)].all?
+    [uri.host.eql?('127.0.0.1'), (9515..9525).include?(uri.port)].all?
   end
 end
 


### PR DESCRIPTION
#### What
Add additional ports to the vcr ignore range

#### Why
If the chromedriver is cancelled or crashes, it can be left running as a background thread.  The next time features are started it increments the port number by one.

#### How
Check for a 10 sequential ports and ignore them.  After this users should probably be killing the zombie processes anyway!