### PR TITLE
Implement CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,20 @@ jobs:
       - run:
           name: Run jasmine tests
           command: bundle exec rake jasmine:ci
+  brakeman:
+    <<: *build_container_config
+    steps:
+      - checkout # special step to check out source code to working directory
+
+      - attach_workspace:
+          at: ~/repo/
+
+      - attach_workspace:
+          at: ~/repo/tmp
+
+      - run:
+          name: Run brakeman
+          command: bundle exec brakeman
   upload-coverage:
     <<: *build_container_config
     steps:
@@ -219,9 +233,13 @@ workflows:
       - jasmine-tests:
           requires:
             - build-test-container
+      - brakeman:
+          requires:
+            - build-test-container
       - upload-coverage:
           requires:
             - rspec-tests
             - cucumber-tests
             - jasmine-tests
             - rubocop
+            - brakeman

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ references:
   build_containers_config: &build_container_config
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.5.3-node-browsers
+      - image: circleci/ruby:2.5.3-node-browsers-legacy
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_PATH: vendor/bundle
@@ -19,15 +19,6 @@ references:
           POSTGRES_USER: postgres
           POSTGRES_DB: cccd_test
           POSTGRES_PASSWORD: ""
-
-  install_phantom_js: &install_phantom_js
-    run:
-      name: Install PhantomJS
-      command: |
-        if ! [ $(which phantomjs) ]; then
-          sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
-        fi
-        sudo chmod ugo+x /usr/local/bin/phantomjs
 
   install_pdftk: &install_pdftk
     run:
@@ -161,7 +152,6 @@ jobs:
       - attach_workspace:
           at: ~/repo/tmp
 
-      - *install_phantom_js
       - run:
           name: Run jasmine tests
           command: bundle exec rake jasmine:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ references:
         sudo apt-get install -y pdftk
 
 jobs:
-  build-test-container:
+  build-test-container: &build-test-container
     <<: *build_container_config
     steps:
       - checkout
@@ -158,7 +158,7 @@ jobs:
           name: Run jasmine tests
           command: bundle exec rake jasmine:ci
   brakeman:
-    <<: *build_container_config
+    <<: *build-test-container
     steps:
       - checkout # special step to check out source code to working directory
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,9 +168,11 @@ jobs:
       - attach_workspace:
           at: ~/repo/tmp
 
+      - run: ruby --version
+      - run:
       - run:
           name: Run brakeman
-          command: bundle exec brakeman
+          command: bundle exec rake brakeman:run
   upload-coverage:
     <<: *build_container_config
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,8 @@ jobs:
           root: tmp
           paths:
             - codeclimate.backend.json
+      - store_artifacts:
+          path: ./tmp/codeclimate.backend.json
   cucumber-tests:
     <<: *build_container_config
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,235 @@
+version: 2
+references:
+  build_containers_config: &build_container_config
+    working_directory: ~/repo
+    docker:
+      - image: circleci/ruby:2.5.3-node-browsers
+        environment:
+          BUNDLE_JOBS: 3
+          BUNDLE_PATH: vendor/bundle
+          BUNDLE_RETRY: 3
+          CBO_BASE_DATABASE_DATABASE: cccd_test
+          PDFTK_PATH: /usr/bin/pdftk
+          PGHOST: 127.0.0.1
+          PGUSER: postgres
+          RAILS_ENV: test
+          TZ: Europe/London
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: cccd_test
+          POSTGRES_PASSWORD: ""
+
+  install_phantom_js: &install_phantom_js
+    run:
+      name: Install PhantomJS
+      command: |
+        if ! [ $(which phantomjs) ]; then
+          sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
+        fi
+        sudo chmod ugo+x /usr/local/bin/phantomjs
+
+  install_pdftk: &install_pdftk
+    run:
+      name: Install PDFTK
+      command: |
+        sudo apt-get install -y pdftk
+
+jobs:
+  build-test-container:
+    <<: *build_container_config
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            mkdir -p tmp/
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
+            chmod +x ./tmp/cc-test-reporter
+
+      - persist_to_workspace:
+          root: tmp
+          paths:
+            - cc-test-reporter
+
+      # Which version of bundler?
+      - run:
+          name: Which bundler?
+          command: bundle -v
+
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+            - cccd-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      # Store bundle cache
+      - save_cache:
+          key: cccd-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - vendor/bundle
+
+  rubocop:
+    <<: *build_container_config
+    steps:
+      - checkout # special step to check out source code to working directory
+
+      - attach_workspace:
+          at: ~/repo/
+
+      - attach_workspace:
+          at: ~/repo/tmp
+
+      - run:
+          name: Run Rubocop
+          command: bundle exec rubocop
+  rspec-tests:
+    <<: *build_container_config
+    parallelism: 2
+    steps:
+      - checkout # special step to check out source code to working directory
+
+      - attach_workspace:
+          at: ~/repo/
+
+      - attach_workspace:
+          at: ~/repo/tmp
+
+      - *install_pdftk
+
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+      - run:
+          name: Database setup
+          command: bin/rails db:schema:load --trace
+      - run:
+          name: Run rspec tests
+          command: |
+            bundle exec rspec $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.backend.json
+      - persist_to_workspace:
+          root: tmp
+          paths:
+            - codeclimate.backend.json
+  cucumber-tests:
+    <<: *build_container_config
+    steps:
+      - checkout # special step to check out source code to working directory
+
+      - attach_workspace:
+          at: ~/repo/
+
+      - attach_workspace:
+          at: ~/repo/tmp
+
+      - *install_pdftk
+
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+      - run:
+          name: Database setup
+          command: bin/rails db:schema:load --trace
+
+      - run:
+          name: Run cucumber tests
+          command: bundle exec cucumber
+
+      - store_artifacts:
+          path: ./tmp/capybara
+  jasmine-tests:
+    <<: *build_container_config
+    steps:
+      - checkout # special step to check out source code to working directory
+
+      - attach_workspace:
+          at: ~/repo/
+
+      - attach_workspace:
+          at: ~/repo/tmp
+
+      - *install_phantom_js
+      - run:
+          name: Run jasmine tests
+          command: bundle exec rake jasmine:ci
+  upload-coverage:
+    <<: *build_container_config
+    steps:
+      - attach_workspace:
+          at: ~/repo/tmp
+
+      - run:
+          name: Upload coverage results to Code Climate
+          command: |
+            ./tmp/cc-test-reporter upload-coverage -i tmp/codeclimate.backend.json
+
+  build-prod-container:
+    docker:
+      - image: docker:17.03-git
+        environment:
+          DSD_APP_NAME: "advocatedefencepayments"
+          ECR_APP_NAME: "claim-for-crown-court-defence"
+          ECR_DOCKER_IMAGE: "laa-get-paid/claim-crown-court-defence"
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 17.03.0-ce
+          docker_layer_caching: true
+      - run:
+          name: Login to the DSD Docker registry
+          command: |
+            docker login \
+              --username $DOCKER_USER \
+              --password $DOCKER_PASS \
+              --email $DOCKER_EMAIL \
+              $DOCKER_REGISTRY
+      - run:
+          name: Login to the ECR Docker registry
+          command: |
+            apk add --no-cache --no-progress py2-pip
+            pip install awscli
+            ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            ${ecr_login}
+      - run:
+          name: Build docker image
+          command: |
+            docker build --pull -t $ECR_ENDPOINT/$ECR_APP_NAME -f docker/Dockerfile .
+            docker tag $ECR_ENDPOINT/$ECR_APP_NAME $ECR_ENDPOINT/$ECR_APP_NAME:$CIRCLE_BUILD_NUM
+            docker push $ECR_ENDPOINT/$ECR_APP_NAME:$CIRCLE_BUILD_NUM
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build-test-container
+      - rubocop:
+          requires:
+            - build-test-container
+      - rspec-tests:
+          requires:
+            - build-test-container
+      - cucumber-tests:
+          requires:
+            - build-test-container
+      - jasmine-tests:
+          requires:
+            - build-test-container
+      - upload-coverage:
+          requires:
+            - rspec-tests
+            - cucumber-tests
+            - jasmine-tests
+            - rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,6 @@ jobs:
 
       - run: ruby --version
       - run:
-      - run:
           name: Run brakeman
           command: bundle exec rake brakeman:run
   upload-coverage:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - 'features/**/*'
     - 'old_features/**/*'
     - 'spec/**/*'
+    - 'tmp/**/*'
     - 'vendor/**/*'
 
 Documentation:

--- a/features/support/dropzone_helper.rb
+++ b/features/support/dropzone_helper.rb
@@ -1,19 +1,20 @@
 module DropzoneHelper
   def drag_and_drop_file(selector, file)
+    id = SecureRandom.uuid
     page.execute_script <<-JS
       tempFileInput = window.$('<input/>').attr(
-        {id: 'temp-file-input', name: 'temp-file-input', type:'file'}
+        {id: 'temp-file-input-#{id}', name: 'temp-file-input', type: 'file'}
       ).appendTo('body');
     JS
 
-    attach_file('temp-file-input', file)
+    attach_file("temp-file-input-#{id}", file)
 
     page.execute_script('fileList = [tempFileInput.get(0).files[0]];')
 
     page.execute_script <<-JS
       e = jQuery.Event('drop', { dataTransfer : { files : fileList } });
       $('.#{selector}')[0].dropzone.listeners[0].events.drop(e);
-      $('#temp-file-input').remove();
+      $('#temp-file-input-#{id}').remove();
     JS
   end
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -51,6 +51,11 @@ AfterConfiguration do
   Cucumber::Rails::Database.javascript_strategy = :truncation, { except: NON_TRUNCATED_TABLES }
 end
 
+After do |scenario|
+  name = scenario.location.file.gsub('features/','').gsub(/\.|\//, '-')
+  screenshot_image(name) if scenario.failed?
+end
+
 at_exit do
   #
   # NOTE: ActiveRecord may be interfering with exit codes

--- a/features/support/screenshot_helper.rb
+++ b/features/support/screenshot_helper.rb
@@ -1,11 +1,17 @@
 module ScreenshotHelper
    # selenium headless chrome solution for full screenshot
   def screenshot_and_open_image
+    file_path = screenshot_image
+    Launchy.open file_path
+  end
+
+  def screenshot_image(name = 'capybara-screenshot')
     window = Capybara.current_session.driver.browser.manage.window
     window.resize_to(*dimensions)
-    file_path = Rails.root.join("tmp/capybara/capybara-screenshot-#{Time.now.utc.iso8601.gsub('-', '').gsub(':', '')}.png").to_s
+    screenshot_name = "#{name}-#{Time.now.utc.iso8601.gsub('-', '').gsub(':', '')}.png"
+    file_path = Rails.root.join("tmp/capybara/#{screenshot_name}").to_s
     save_screenshot(file_path)
-    Launchy.open file_path
+    file_path
   end
 
   def dimensions


### PR DESCRIPTION
#### What
Implement CircleCI
- Add an after hook to cucumber to take a screenshot if it fails

#### Ticket
[CCCD : Spike investigate kubernetes](https://dsdmoj.atlassian.net/browse/CBO-520)

#### Why
The cloud platform team are implementing kubernetes as a hosting solution and most teams are using CircleCI as their CI/CD tool.  Doing so for CCCD has the following advantages:
- Parallel running of tests, Circle can be configured to run different tests simultaneously, whereas Travis runs them in sequence, this will reduce our CI runs from ~30 minutes to ~15.
- Circle will also replace Jenkins when the full switch to kubernetes is undertaken
- Circle can store screenshots of failing cucumber tests for review after the run has finished
