### PR TITLE
Update JSON uploader claim endpoint use

### DIFF
--- a/app/assets/javascripts/json_document_importer.js
+++ b/app/assets/javascripts/json_document_importer.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/helpers/json_document_importer_helper.rb
+++ b/app/helpers/json_document_importer_helper.rb
@@ -1,2 +1,0 @@
-module JsonDocumentImporterHelper
-end

--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -10,7 +10,7 @@ class JsonDocumentImporter
   validate :file_conforms_to_basic_json_schema, if: :json_data
 
   BASE_URL                      = GrapeSwaggerRails.options.app_url
-  CLAIM_CREATION                = RestClient::Resource.new BASE_URL + '/api/external_users/claims'
+  CLAIM_CREATION                = RestClient::Resource.new BASE_URL + '/api/external_users/advocates/final'
   DEFENDANT_CREATION            = RestClient::Resource.new BASE_URL + '/api/external_users/defendants'
   REPRESENTATION_ORDER_CREATION = RestClient::Resource.new BASE_URL + '/api/external_users/representation_orders'
   FEE_CREATION                  = RestClient::Resource.new BASE_URL + '/api/external_users/fees'


### PR DESCRIPTION
#### What
Change the JSON uploader to use the new advocates/final API claim endpoint
and remove a couple of uploader code files that were empty.

#### Why
The api/external_user/claims endpoint has been deprecated in
favour of api/external_users/advocates/final