### PR TITLE
Switch jasmine test suite to use headless chrome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,8 +92,10 @@ group :development, :devunicorn, :test do
   gem 'rspec-collection_matchers'
   gem 'puma'
   gem 'parallel_tests'
-  gem 'site_prism',         '~> 2.9'
-  gem 'guard-jasmine',      '~> 2.0'
+  gem 'site_prism', '~> 2.9'
+  gem 'jasmine', '~> 3.1'
+  gem 'guard-jasmine', '~> 3.0'
+  gem 'jasmine_selenium_runner', require: false
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'guard-cucumber'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,11 +284,11 @@ GEM
       cucumber (>= 1.3.0)
       guard-compat (~> 1.0)
       nenv (~> 0.1)
-    guard-jasmine (2.1.0)
+    guard-jasmine (3.0.0)
       childprocess (~> 0.5)
       guard (~> 2.14)
       guard-compat (~> 1.2)
-      jasmine (~> 2.4)
+      jasmine (~> 3.1)
       multi_json (~> 1.12)
       thor (~> 0.19)
       tilt
@@ -349,12 +349,15 @@ GEM
     inflection (1.0.0)
     io-like (0.3.0)
     jaro_winkler (1.5.2)
-    jasmine (2.99.0)
-      jasmine-core (>= 2.99.0, < 3.0.0)
+    jasmine (3.3.0)
+      jasmine-core (~> 3.3.0)
       phantomjs
       rack (>= 1.2.1)
       rake
-    jasmine-core (2.99.2)
+    jasmine-core (3.3.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     jmespath (1.4.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -736,7 +739,7 @@ DEPENDENCIES
   grape-swagger (~> 0.28.0)
   grape-swagger-rails (~> 0.3.0)
   guard-cucumber
-  guard-jasmine (~> 2.0)
+  guard-jasmine (~> 3.0)
   guard-livereload (>= 2.5.2)
   guard-rspec
   guard-rubocop
@@ -744,6 +747,8 @@ DEPENDENCIES
   hashdiff
   hashie-forbidden_attributes (>= 0.1.1)
   i18n-tasks
+  jasmine (~> 3.1)
+  jasmine_selenium_runner
   jquery-rails (~> 4.3.3)
   json-schema (~> 2.6.2)
   json_spec

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -8,11 +8,15 @@
 #   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
 #end
 #
-#Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
-# NOTE: travis has phantomjs pre-installed and on path so auto-install
-#       not needed (and can intermittently fail with travis success
-#       if install site not available)
+require "jasmine/runners/selenium"
+
 Jasmine.configure do |config|
-  config.prevent_phantom_js_auto_install = true
+  config.runner = lambda { |formatter, jasmine_server_url|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.headless!
+
+    webdriver = Selenium::WebDriver.for(:chrome, options: options)
+    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
+  }
 end
 


### PR DESCRIPTION
#### What
Configure jasmine javascript testing framework
to use headless chrome instead of PhantomJS

#### Why
PhantomJS is abandoned and has been removed
from the feature tests already.

#### How
See this [jasmine testing framework related](https://github.com/jasmine/jasmine-gem/issues/293) post