### PR TITLE
Add or_one method to NilClass

### DIFF
--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -45,3 +45,7 @@ end
 class Integer
   include IntegerExtension
 end
+
+class NilClass
+  include NilExtension
+end

--- a/lib/extensions/nil_extension.rb
+++ b/lib/extensions/nil_extension.rb
@@ -1,0 +1,5 @@
+module NilExtension
+  def or_one
+    1
+  end
+end


### PR DESCRIPTION

#### What
Fixes sentry error related to calling an integer extension on nil

#### Why
Some actual trial lengths and other similar field values
are getting away with nil values which are then raising
NilClass errors on when CCR/CCLF calls the api endpoint
for DI.

[example sentry error](https://sentry.service.dsd.io/mojds/private-beta/issues/34897/)

#### How
default nil to 1 as well using an extension of nilClass itself
