### PR TITLE
Add offence unique code filter to API

### DIFF
--- a/app/interfaces/api/entities/offence.rb
+++ b/app/interfaces/api/entities/offence.rb
@@ -9,6 +9,7 @@ module API
       expose :full_format, merge: true, unless: export_format? do
         expose :id
         expose :description
+        expose :unique_code
         expose :offence_class_id, if: ->(instance, _opts) { instance.scheme_nine? }
         expose :offence_class,
                if: ->(instance, _opts) { instance.scheme_nine? },

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -80,7 +80,8 @@ module API
                      desc: 'OPTIONAL: Filter by offence description'
             optional :rep_order_date,
                      type: String,
-                     desc: 'OPTIONAL: Filter by scheme date based on representation order - format YYYY-MM-DD',
+                     default: '2016-04-01',
+                     desc: I18n.t('api.v1.dropdown_data.offences.params.rep_order_date'),
                      standard_json_format: true
             optional :unique_code,
                      type: String,

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -75,17 +75,24 @@ module API
         resource :offences do
           desc 'Return all Offence-ids to be used in advocate claims (see OffenceClasses for Litigator claims).'
           params do
-            optional :offence_description, type: String, desc: 'Offences matching description'
+            optional :offence_description,
+                     type: String,
+                     desc: 'OPTIONAL: Filter by offence description'
             optional :rep_order_date,
                      type: String,
-                     desc: 'OPTIONAL: Date of representation order in YYYY-MM-DD',
+                     desc: 'OPTIONAL: Filter by scheme date based on representation order - format YYYY-MM-DD',
                      standard_json_format: true
+            optional :unique_code,
+                     type: String,
+                     desc: 'OPTIONAL: Filter by offence unique code'
           end
           get do
-            scheme_date = params[:rep_order_date] || '2018-01-01'
+            scheme_date = params[:rep_order_date]
             description = params[:offence_description]
-            offences = FeeScheme.agfs.for(scheme_date).last.offences
+            unique_code = params[:unique_code]
+            offences = scheme_date.present? ? FeeScheme.agfs.for(scheme_date).last.offences : Offence.all
             offences = offences.where(description: description) if description.present?
+            offences = offences.where(unique_code: unique_code) if unique_code.present?
 
             present offences, with: API::Entities::Offence
           end

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -87,7 +87,7 @@ module API
                      desc: 'OPTIONAL: Filter by offence unique code'
           end
           get do
-            scheme_date = params[:rep_order_date]
+            scheme_date = params[:rep_order_date] || '2016-04-01'
             description = params[:offence_description]
             unique_code = params[:unique_code]
             offences = scheme_date.present? ? FeeScheme.agfs.for(scheme_date).last.offences : Offence.all

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -77,7 +77,7 @@ module API
           params do
             optional :offence_description,
                      type: String,
-                     desc: 'OPTIONAL: Filter by offence description'
+                     desc: I18n.t('api.v1.dropdown_data.offences.params.description')
             optional :rep_order_date,
                      type: String,
                      default: '2016-04-01',
@@ -85,7 +85,7 @@ module API
                      standard_json_format: true
             optional :unique_code,
                      type: String,
-                     desc: 'OPTIONAL: Filter by offence unique code'
+                     desc: I18n.t('api.v1.dropdown_data.offences.params.unique_code')
           end
           get do
             scheme_date = params[:rep_order_date] || '2016-04-01'

--- a/app/models/offence_class.rb
+++ b/app/models/offence_class.rb
@@ -32,6 +32,6 @@ class OffenceClass < ApplicationRecord
   end
 
   def lgfs_offence_id
-    offences.miscellaneous.first.id
+    offences&.miscellaneous&.first&.id
   end
 end

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -11,6 +11,43 @@
 
 %section.api-documentation
   %hr
+  %h2 7th March 2019
+  %ul.list-bullet
+    %li
+      Expose offence
+      %code.code='unique_code'
+      and optional filter on the
+      %a{ href: '/api/documentation?v=1#!/api/getApiOffences', target: '_blank' } api/offences
+      endpoint
+      %br/
+      %br/
+      To facilitate the lookup of offences the unique identifiers that
+      can be relied on not to change (i.e.
+      %code.code='unique_code'
+      ) have been exposed.
+      %br
+      %br
+      .panel
+        Note that an offence's
+        %code.code='id'
+        should not be persisted in consumers and relied on to add a specific offence to a claim. The reason for this is that internal id's could change unexpectedly. We will, however, endeavour to not change these for historical reasons. Instead an offence should be queried on this endpoint using the
+        %code.code='unique_code'
+        identifier (or description, but this too is not ideal) to retrieve its id.
+        %br/
+        %br/
+        An
+        %code.code='id'
+        retrieved by these means can be used to reliably create a claim with that offence.
+
+      In addition a
+      %code.code='unique_code'
+      filter has been added to enable consumers to retrieve a single offence's data.
+      %br/
+      %br/
+
+
+%section.api-documentation
+  %hr
   %h2 6th March 2019
   %ul.list-bullet
     %li

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -30,7 +30,10 @@
       .panel
         Note that an offence's
         %code.code='id'
-        should not be persisted in consumers and relied on to add a specific offence to a claim. The reason for this is that internal id's could change unexpectedly. We will, however, endeavour to not change these for historical reasons. Instead an offence should be queried on this endpoint using the
+        should not be persisted in consumers and relied on to add a specific offence to a claim.
+        The reason for this is that internal id's could change unexpectedly. We will, however,
+        endeavour to not change these for historical reasons. Instead an offence should be queried
+        on this endpoint using the
         %code.code='unique_code'
         identifier (or description, but this too is not ideal) to retrieve its id.
         %br/

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2223,6 +2223,9 @@ en:
         user_email: 'REQUIRED: The ADP account email address that uniquely identifies the advocate/litigator to whom this claim belongs.'
         travel_expense_additional_information: 'OPTIONAL: Any additional information regarding travel expenses, e.g. private mileage rate reasons'
       dropdown_data:
+        offences:
+          params:
+            rep_order_date: 'OPTIONAL: Filter by scheme date based on representation order - format YYYY-MM-DD - defaults to date for oldest available AGFS and LGFS fee schemes'
         params:
           role_filter: 'OPTIONAL: The role to filter the results. If not provided, all results are returned.'
       external_users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -931,7 +931,7 @@ en:
           offence_class_hint: "for example Burglary"
           select_offence_class: "Please select"
         scheme_xor:
-          one_not_both: 'Specify an Offence or an OffenceBand, not both'
+          one_not_both: 'Specify an OffenceClass or an OffenceBand, not both'
         summary:
           caption: 'Offence Details: This section contains information about the offence details.'
           header: Offence details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2225,7 +2225,9 @@ en:
       dropdown_data:
         offences:
           params:
-            rep_order_date: 'OPTIONAL: Filter by scheme date based on representation order - format YYYY-MM-DD - defaults to date for oldest available AGFS and LGFS fee schemes'
+            description: 'OPTIONAL: Filter by offence description'
+            rep_order_date: 'OPTIONAL: Filter by scheme date based on representation order - format YYYY-MM-DD. Default: date suitable for oldest available AGFS and LGFS fee schemes'
+            unique_code: 'OPTIONAL: Filter by offence unique code'
         params:
           role_filter: 'OPTIONAL: The role to filter the results. If not provided, all results are returned.'
       external_users:

--- a/lib/tasks/ccr_claims.rake
+++ b/lib/tasks/ccr_claims.rake
@@ -12,7 +12,7 @@ namespace :ccr_claims do
           response = RestClient.get(uri)
           memo << JSON.parse(response)
         rescue => e
-          warn "Error: #{e} for claim #{claim.uuid} on ap #{uri}"
+          warn "Error: #{e} for claim #{claim.uuid} on uri #{uri}"
         end
       end
       puts JSON.pretty_generate(claims_json)

--- a/spec/api/entities/offence_class_spec.rb
+++ b/spec/api/entities/offence_class_spec.rb
@@ -1,0 +1,10 @@
+describe API::Entities::OffenceClass do
+  subject(:response) { JSON.parse(described_class.represent(offence_class).to_json).deep_symbolize_keys }
+
+  let(:offence_class) { build(:offence_class) }
+  let(:expected_keys) { %i[id class_letter description lgfs_offence_id] }
+  
+  it 'has expected json keys' do
+    expect(response.keys).to include(*expected_keys)
+  end
+end

--- a/spec/api/entities/offence_spec.rb
+++ b/spec/api/entities/offence_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe API::Entities::Offence do
   context 'when scheme nine' do
     let(:offence) { create(:offence, :with_fee_scheme, offence_class: create(:offence_class, :with_lgfs_offence )) }
 
-    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description offence_class_id offence_class] }
+    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description unique_code offence_class_id offence_class] }
   end
 
   context 'when scheme ten' do
@@ -15,7 +15,7 @@ RSpec.describe API::Entities::Offence do
              offence_band: create(:offence_band,
                                   offence_category: create(:offence_category, number: 6))) }
 
-    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description act_of_law offence_band] }
+    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description unique_code act_of_law offence_band] }
   end
 
   context 'when scheme eleven' do
@@ -24,6 +24,6 @@ RSpec.describe API::Entities::Offence do
              offence_band: create(:offence_band,
                                   offence_category: create(:offence_category, number: 6))) }
 
-    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description act_of_law offence_band] }
+    it { expect(JSON.parse(subject.to_json).keys).to eq %w[id description unique_code act_of_law offence_band] }
   end
 end

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe API::V1::DropdownData do
 
     it "should return a JSON formatted list of the required information" do
       results.each do |endpoint, json|
+        ap "#{endpoint}"
         response = get endpoint, params, format: :json
         expect(response.status).to eq 200
         expect(response.body).to be_json_eql(json)
@@ -125,6 +126,10 @@ RSpec.describe API::V1::DropdownData do
     context 'filtering' do
       context 'by rep order date' do
         context 'using a scheme 9 date' do
+          it 'defaults to scheme 9 offences' do
+            is_expected.to match_array([exposed_offence[scheme_9_offence]])
+          end
+
           it 'returns scheme 9 offences' do
             params.merge!(rep_order_date: '2016-03-01')
             is_expected.to match_array([exposed_offence[scheme_9_offence]])
@@ -157,26 +162,28 @@ RSpec.describe API::V1::DropdownData do
 
       context 'by unique_code' do
         context 'scheme 9' do
+          let(:rep_order_date) { scheme_date_for('scheme 9') }
+
           it 'returns matching offence' do
-            params.merge!(unique_code: scheme_9_offence.unique_code)
+            params.merge!(rep_order_date: rep_order_date, unique_code: scheme_9_offence.unique_code)
             is_expected.to match_array([exposed_offence[scheme_9_offence]])
           end
         end
 
         context 'scheme 10' do
-          let!(:offence) { create(:offence, :with_fee_scheme_ten) }
+          let(:rep_order_date) { scheme_date_for('scheme 10') }
 
           it 'returns matching offence' do
-            params.merge!(unique_code: scheme_10_offence.unique_code)
+            params.merge!(rep_order_date: rep_order_date, unique_code: scheme_10_offence.unique_code)
             is_expected.to match_array([exposed_offence[scheme_10_offence]])
           end
         end
 
         context 'scheme 11' do
-          let!(:offence) { create(:offence, :with_fee_scheme_eleven) }
+          let(:rep_order_date) { scheme_date_for('scheme 11') }
 
           it 'returns matching offence' do
-            params.merge!(unique_code: scheme_11_offence.unique_code)
+            params.merge!(rep_order_date: rep_order_date, unique_code: scheme_11_offence.unique_code)
             is_expected.to match_array([exposed_offence[scheme_11_offence]])
           end
         end

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe API::V1::DropdownData do
 
     it "should return a JSON formatted list of the required information" do
       results.each do |endpoint, json|
-        ap "#{endpoint}"
         response = get endpoint, params, format: :json
         expect(response.status).to eq 200
         expect(response.body).to be_json_eql(json)


### PR DESCRIPTION
#### What
To expose and enable filtering offences using unique_code

#### Ticket

[CBO-624](https://dsdmoj.atlassian.net/browse/CBO-624)

#### Why
First step toward ensuring API consumers (software vendors) use 
offence.unique_code to specify the offences on a claim endpoint,
rather than the offence ID. We should not be exposing internal IDs
as they cannot be guaranteed to remain the same.

#### How
- expose unique code on `api/offences`
- add unique code filtering option on `api/offences`

#### Separate ticket
- add offence_unique_code param to all claim endpoints
- deprecate and eventually remove offence_id param on claim endpoints
