### PR TITLE
Add release notes following addition of missing offences

### DIFF
--- a/app/assets/stylesheets/v1/application.css.scss
+++ b/app/assets/stylesheets/v1/application.css.scss
@@ -33,6 +33,7 @@
 @import "moj/spinner";
 @import 'moj/warnings';
 @import "moj/autocomplete";
+@import "api-documentation";
 
 
 // /////////////////////////////// TODO: KILL THIS ASAP

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -11,6 +11,28 @@
 
 %section.api-documentation
   %hr
+  %h2 6th March 2019
+  %ul.list-bullet
+    %li
+      Additional fee scheme 10 and 11 offence codes added
+    %br/
+    The following additional specific offence has been added to both fee scheme 10 and 11:
+    .panel
+      'Aiding, abetting, causing or permitting dangerous driving' in band 17.1
+    %br/
+    The following additional catchall offences have been added to both fee scheme 10 and 11 in every band
+    %br
+    .panel
+      'Other offences' in bands 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3, 6.4, 6.5, 7.1, 7.2, 7.3, 8.1, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 10.1, 11.1, 11.2, 12.1, 12.2, 12.3, 13.1, 14.1, 15.1, 15.2, 15.3, 16.1, 16.2, 16.3, 17.1
+    %br/
+    You can query all offences on the
+    %a{ href: '/api/documentation?v=1#!/api/getApiOffences', target: '_blank' } api/offences
+    endpoint - note that you will need to provide a
+    %code.code='rep_order_date'
+    parameter that falls within the scheme 10/11 scheme start and end date - start dates are 2018-04-01 and 2018-12-31 respectively
+
+%section.api-documentation
+  %hr
   %h2 28th February 2019
   %ul.list-bullet
     %li


### PR DESCRIPTION
#### What
Add release notes section to inform vendors
of the addition of more offences.

#### Ticket

extension of [CBO-597](https://dsdmoj.atlassian.net/browse/CBO-597)


#### Why
To inform vendors they may need to update
their stores of offences.

Also importing api-documentation css in
v1/manifest as was not before. This has
some documentation specifc styling.