### PR TITLE
CBO-377:  From controls, translations & page semantics

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/assets/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -138,10 +138,12 @@
     },
 
     setHint: function(data, context) {
+
       var self = this;
       var $label = $(context).closest('.fx-fee-group').find('.form-group.quantity_wrapper').find('.form-hint');
       var $newLabel = self.setHintLabel(data);
       $label.text($newLabel);
+
       data ? $label.show() : $label.hide();
     },
 

--- a/app/assets/javascripts/plugins/jquery.numbered.elements.js
+++ b/app/assets/javascripts/plugins/jquery.numbered.elements.js
@@ -47,8 +47,8 @@
     updateNumbers: function() {
       var self = this;
       $(this.settings.wrapper).find(this.settings.item+':visible').each(function(idx, el) {
-        $(el).find(self.settings.number).text(idx+1)
-      })
+        $(el).find(self.settings.number).text(idx+1);
+      });
     }
   });
 

--- a/app/assets/stylesheets/v1/moj/_tables.scss
+++ b/app/assets/stylesheets/v1/moj/_tables.scss
@@ -249,7 +249,7 @@ table.report{
     }
 
     td:before {
-      content: attr(aria-label);
+      content: attr(data-label);
       float: left;
       font-weight: bold;
       text-transform: uppercase;

--- a/app/assets/stylesheets/v2/_buttons.scss
+++ b/app/assets/stylesheets/v2/_buttons.scss
@@ -98,3 +98,15 @@ form .form-buttons * {
     background-image: file-url("icon-pointer-2x.png");
   }
 }
+
+a.link-delete {
+  color: #b10e1e;
+  position: relative;
+  padding: .526315em 0em .263157em;
+  border: none;
+}
+
+.form-buttons * {
+  margin-right: 10px;
+  display: inline-block;
+}

--- a/app/assets/stylesheets/v2/_callout.scss
+++ b/app/assets/stylesheets/v2/_callout.scss
@@ -1,0 +1,14 @@
+.js-callout-banner {
+  border: 1px solid #2E2F30;
+  padding: 20px;
+  padding-bottom: 10px;
+  margin-bottom: 50px;
+  margin-right: 20px;
+}
+
+
+.js-callout-banner{
+  ul.list{
+    margin-top: 30px;
+  }
+}

--- a/app/assets/stylesheets/v2/_links.scss
+++ b/app/assets/stylesheets/v2/_links.scss
@@ -35,12 +35,3 @@ a.link-change, a.link-remove {
     line-height: 1.25;
   }
 }
-
-a[target="_blank"]:after
-/*a.link-open-window:after
-
-a:not( [href*='herokuapp.com'] ):not( [href^='#'] ):not( [href^='/'] ):after  */
-{
-  content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
-  margin: 0 0 0 5px;
-}

--- a/app/assets/stylesheets/v2/application.scss
+++ b/app/assets/stylesheets/v2/application.scss
@@ -57,7 +57,8 @@
 @import 'links';
 @import 'panels';
 @import 'breadcrumbs';
-@import "accessible-autocomplete";
+@import 'callout';
+@import 'accessible-autocomplete';
 
 .panel-margin-fix{
   margin-bottom: $gutter !important;

--- a/app/views/case_workers/admin/allocations/_orig_scheme_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_orig_scheme_filters.html.haml
@@ -1,7 +1,8 @@
-%fieldset.inline.allocation-filter-form
-  .column-half.form-group
+.form-group
+  %fieldset.inline.allocation-filter-form{"aria-describedby": "radio-control-hint"}
     %legend
-      = t('.scheme_types')
+      %span#radio-control-hint.form-label-bold
+        = t('.scheme_types')
     - allocation_scheme_filters.each do | filter_scheme |
       .multiple-choice
         = radio_button_tag :scheme, filter_scheme, params[:scheme].blank? ? filter_scheme == 'agfs' : params[:scheme] == filter_scheme

--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -1,36 +1,39 @@
 = form_for [:case_workers, :admin, @case_worker], builder: AdpFormBuilder do |f|
   = f.fields_for :user do |user_fields|
-    %fieldset
-      %legend.heading-medium
-        = t('.case_worker_details')
+    %h2.heading-medium
+      = t('.case_worker_details')
 
-      = user_fields.adp_text_field :first_name, label: t('.first_name')
+    = user_fields.adp_text_field :first_name, label: t('.first_name')
 
-      = user_fields.adp_text_field :last_name, label: t('.last_name')
+    = user_fields.adp_text_field :last_name, label: t('.last_name')
 
-      = user_fields.adp_text_field :email, label: t('.email')
+    = user_fields.adp_text_field :email, label: t('.email')
 
-      = user_fields.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
+    = user_fields.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
 
-      - if @case_worker.new_record?
-        = user_fields.adp_text_field :email_confirmation, label: t('.email_confirmation')
+    - if @case_worker.new_record?
+      = user_fields.adp_text_field :email_confirmation, label: t('.email_confirmation')
 
-      %fieldset.inline
-        %legend
-          = t('.location')
-        .form-group
-          = f.collection_radio_buttons(:location_id, Location.all, :id, :name) do |b|
-            .multiple-choice
-              = b.radio_button
-              = b.label { b.object.name }
+    .form-group
+      %fieldset.inline{'aria-describedby': 'radio-control-legend-location'}
+        %legend#radio-control-legend-location
+          %span.form-label-bold
+            = t('.location')
+        = f.collection_radio_buttons(:location_id, Location.all, :id, :name) do |b|
+          .multiple-choice
+            = b.radio_button("aria-labelledby": "radio-control-legend-location #{b.text.to_css_class}")
+            = b.label(id: b.text.to_css_class)  { b.object.name }
 
-      %fieldset.inline
-        %legend
-          = t('.roles')
-        .form-group
-          = f.collection_check_boxes(:roles, CaseWorker::ROLES, :to_s, :to_s) do |b|
-            .multiple-choice
-              = b.check_box
-              = b.label { b.value.humanize }
 
-    = f.submit t('.save'), class: "button"
+    .form-group
+      %fieldset.inline{'aria-describedby': 'checkbox-control-legend-roles'}
+        %legend#checkbox-control-legend-roles
+          %span.form-label-bold
+            = t('.roles')
+
+        = f.collection_check_boxes(:roles, CaseWorker::ROLES, :to_s, :to_s) do |b|
+          .multiple-choice
+            = b.check_box("aria-labelledby": "checkbox-control-legend-roles #{b.text.to_css_class}")
+            = b.label(id: b.text.to_css_class)  { b.value.humanize }
+
+    = f.submit t('.save'), class: 'button'

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -3,7 +3,7 @@
 
 = render partial: 'errors/error_summary', locals:{ ep: @case_worker, error_summary: t('.prohibited_save')}
 
-= render partial: 'layouts/header', locals: {page_heading: 'Change password'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 .main-section.container
   .body-content
@@ -11,7 +11,8 @@
       = f.fields_for :user do |user_fields|
         .form-fields
           %fieldset
-            %legend.visually-hidden Change Password
+            %legend.visually-hidden
+              = t('.change_password')
             .form-group
               .form-group.input
                 = user_fields.label :current_password, t(".current_password"), class: "form-label"

--- a/app/views/case_workers/admin/case_workers/edit.html.haml
+++ b/app/views/case_workers/admin/case_workers/edit.html.haml
@@ -1,9 +1,9 @@
 = content_for :page_title, flush: true do
   = t('.page_title', caseworker: @case_worker.name)
 
-= render partial: 'errors/error_summary', locals:{ ep: @case_worker, error_summary: 'This case worker has '}
+= render partial: 'errors/error_summary', locals:{ ep: @case_worker, error_summary: t('.error_summary')}
 
-= render partial: 'layouts/header', locals: {page_heading: 'Edit case worker details'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 .main-section.container
   .body-content

--- a/app/views/case_workers/admin/case_workers/edit.html.haml
+++ b/app/views/case_workers/admin/case_workers/edit.html.haml
@@ -1,6 +1,9 @@
 = content_for :page_title, flush: true do
   = t('.page_title', caseworker: @case_worker.name)
 
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
 = render partial: 'errors/error_summary', locals:{ ep: @case_worker, error_summary: t('.error_summary')}
 
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}

--- a/app/views/case_workers/admin/case_workers/new.html.haml
+++ b/app/views/case_workers/admin/case_workers/new.html.haml
@@ -1,8 +1,8 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'errors/error_summary', locals:{ ep: @case_worker, error_summary: 'This case worker has '}
+= render partial: 'errors/error_summary', locals:{ ep: @case_worker, error_summary: t('.error_summary')}
 
-= render partial: 'layouts/header', locals: {page_heading: 'New case worker details'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = render 'form'

--- a/app/views/case_workers/admin/case_workers/show.html.haml
+++ b/app/views/case_workers/admin/case_workers/show.html.haml
@@ -1,20 +1,21 @@
 = content_for :page_title, flush: true do
   = t('.page_title', caseworker: @case_worker.name)
 
-= render partial: 'layouts/header', locals: {page_heading: 'Your account'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 %table
-  %caption Your account
+  %caption
+    = t('.page_heading')
   %tbody
     %tr
       %th{scope:'row'}
-        = 'Roles:'
+        = t('.roles')
       %td
         = @case_worker.roles.map(&:humanize).join(', ')
 
 - if can? :edit, @case_worker
   .form-group
-    = link_to 'Edit', edit_case_workers_admin_case_worker_path(@case_worker), class: 'button'
+    = link_to t('.edit'), edit_case_workers_admin_case_worker_path(@case_worker), class: 'button'
 
 - if can? :change_password, @case_worker
   .form-group
-    = link_to 'Change password', change_password_case_workers_admin_case_worker_path(@case_worker)
+    = link_to t('.change_password'), change_password_case_workers_admin_case_worker_path(@case_worker)

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -1,7 +1,7 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: { page_heading: t('.h1_managment_info') }
+= render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
 - @available_report_types.each do |report_type, report|
   - report_name = t(".report_types.#{report_type}")

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -55,7 +55,7 @@
               = claim.unique_id
             - if claim.disk_evidence == true
               %span.disk-evidence
-                = "Disk evidence"
+                = t('.disk_evidence')
 
           %td
             = claim.external_user.name

--- a/app/views/case_workers/claims/_claims_sidebar.html.haml
+++ b/app/views/case_workers/claims/_claims_sidebar.html.haml
@@ -4,13 +4,13 @@
       .sidebar-nav.well
         %h3 Menu
         %ul.nav.nav-list
-          %li.selected 
-            = link_to "Dashboard", "/path1"
+          %li.selected
+            = link_to t('.dashboard'), "/path1"
             %ul
               %li{class: ('active' if params[:tab] == 'current' || params[:tab].blank?)}
-                = link_to 'Current claims', case_workers_claims_path(params.merge(tab: 'current'))
+                = link_to t('.current_claims'), case_workers_claims_path(params.merge(tab: 'current'))
               %li{class: ('active' if params[:tab] == 'completed')}
-                = link_to 'Completed claims', case_workers_claims_path(params.merge(tab: 'completed'))
-          %li= link_to "Payments", "/path1"
-          %li= link_to "Advocate details", "/path2"
-          %li= link_to "Reporting tool", "/path3"
+                = link_to t('.completed_claims'), case_workers_claims_path(params.merge(tab: 'completed'))
+          %li= link_to t('.payments'), "/path1"
+          %li= link_to t('.advocate_details'), "/path2"
+          %li= link_to t('.reporting_tool'), "/path3"

--- a/app/views/case_workers/claims/archived.html.haml
+++ b/app/views/case_workers/claims/archived.html.haml
@@ -1,7 +1,7 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: t('.archived_claims')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 = render partial: 'search_form', locals: { archived: true }
 = render partial: 'claims_list', locals: { claims: @claims }
 = paginate @claims

--- a/app/views/case_workers/claims/index.html.haml
+++ b/app/views/case_workers/claims/index.html.haml
@@ -1,7 +1,7 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: t('.your_claims')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 = render partial: 'search_form', locals: { archived: false }
 = render partial: 'claims_list', locals: { claims: @claims }
 = paginate @claims

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,9 +1,12 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'errors/error_summary', locals:{ ep: resource, error_summary: t('.prohibited_save')}
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
 
-= render partial: 'layouts/header', locals: {page_heading: 'Change your password'}
+= render partial: 'errors/error_summary', locals:{ ep: resource, error_summary: t('.error_summary')}
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
   %div.form-group
@@ -12,14 +15,14 @@
 
   .form-group
     %a{name: 'password'}
-    = f.label :password, 'New password', class: 'form-label'
+    = f.label :password, t('.new_password'), class: 'form-label-bold'
     = f.input_field :password, autofocus: true, class: 'form-control'
   .form-group
     %a{name: 'password_confirmation'}
-    = f.label :password_confirmation, 'Confirm your password', class: 'form-label'
+    = f.label :password_confirmation, t('.confirm_your_password'), class: 'form-label-bold'
     = f.input_field :password_confirmation, class: 'form-control'
 
   .form-group
-    = f.button :submit, 'Change password', class: 'button'
+    = f.button :submit, t('.change_password'), class: 'button'
 
 = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,22 +1,26 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: 'Forgot your password?'}
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
   - if resource.errors.any?
     .validation-summary
-      %h2.heading-small= "This #{resource_name} has #{pluralize(resource.errors.count, 'error')}"
+      %h2.heading-small
+        = "This #{resource_name} has #{pluralize(resource.errors.count, 'error')}"
       %ul
         - resource.errors.each do |attribute, message|
           %li
             = "#{attribute.to_s.humanize} #{message}"
 
   %div.form-group
-    = f.label :email, class: "form-label"
+    = f.label :email, class: "form-label-bold"
     = f.input_field :email, autofocus: true, autocomplete: 'off', class: "form-control"
 
   %div.form-group
-    = f.button :submit, "Send me password reset instructions", class: "button"
+    = f.button :submit, t('.send_button'), class: "button"
 
 = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,16 +1,19 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: "Sign in"}
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }) do |f|
   .form-group
-    = f.label :email, class: "form-label"
+    = f.label :email, class: "form-label-bold"
     = f.input_field :email, autofocus: true, class: "form-control"
   .form-group
-    = f.label :password, class: "form-label"
+    = f.label :password, class: "form-label-bold"
     = f.input_field :password, autocomplete: 'off', class: "form-control"
 
   .form-group
-    = f.button :submit, "Sign in", class: "button"
+    = f.button :submit, t('.sign_in'), class: "button"
   = render "devise/shared/links"

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,7 +1,10 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: 'Resend unlock instructions'}
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
   - if resource.errors.any?
@@ -12,10 +15,10 @@
             = "#{attribute.to_s.humanize} #{message}"
 
   %div.form-group
-    = f.label :email, class: 'form-label'
+    = f.label :email, class: 'form-label-bold'
     = f.input_field :email, autofocus: true, autocomplete: 'off', class: 'form-control'
 
   %div.form-group
-    = f.button :submit, 'Resend unlock instructions', class: 'button'
+    = f.button :submit, t('.submit'), class: 'button'
 
 = render 'devise/shared/links'

--- a/app/views/errors/internal_server_error.html.haml
+++ b/app/views/errors/internal_server_error.html.haml
@@ -1,1 +1,1 @@
-= render partial: 'layouts/header', locals: {page_heading: '500 - internal server error'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}

--- a/app/views/errors/not_found.html.haml
+++ b/app/views/errors/not_found.html.haml
@@ -1,1 +1,1 @@
-= render partial: 'layouts/header', locals: {page_heading: '404 - not found'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}

--- a/app/views/external_users/admin/external_users/_form.html.haml
+++ b/app/views/external_users/admin/external_users/_form.html.haml
@@ -21,39 +21,43 @@
         = user_fields.email_field :email_confirmation, class: "form-control"
 
     - if Settings.email_notification_enabled?
-      .form-section
-        %fieldset.inline
-          %legend
-            = 'Get email notifications of caseworker messages on claims you created?'
+      .form-group
+        %fieldset.inline{"aria-describedby": "radio-control-legend-email"}
+          %legend#radio-control-legend-email
+            %span.heading-medium
+              = t('.email_notification')
+
           = user_fields.collection_radio_buttons(:email_notification_of_message, [true, false], :to_s, :to_s) do |b|
             .multiple-choice
-              = b.radio_button
-              = b.label { (b.value.to_s == 'true' ? 'Yes' : 'No') }
+              = b.radio_button("aria-labelledby": "radio-control-legend-email #{b.text.to_css_class}")
+              = b.label(id: b.text.to_css_class) { (b.value.to_s == 'true' ? t('.answer_yes') : t('.answer_no')) }
 
     - if current_user.persona.admin?
-      .form-section
-        %fieldset.inline.js-advocate-roles.form-section
-          %legend.heading-medium
-            = 'Roles'
+      .form-group
+        %fieldset.inline.js-advocate-roles{"aria-describedby": "checkbox-control-legend-roles"}
+          %legend#checkbox-control-legend-roles
+            %span.heading-medium
+              = t('.roles')
 
           = f.collection_check_boxes(:roles, @external_user.available_roles, :to_s, :to_s) do |b|
             .multiple-choice
-              = b.check_box
-              = b.label { b.value.humanize }
+              = b.check_box("aria-labelledby": "checkbox-control-legend-roles #{b.text.to_css_class}")
+              = b.label(id: b.text.to_css_class) { b.value.humanize }
 
-        - if current_user.persona.provider.chamber?
-          .js-chamber-advocates-only
-            %fieldset.inline.form-section
-              %legend.heading-medium
-                = "Vat registered"
+    - if current_user.persona.provider.chamber?
+      .form-group.js-chamber-advocates-only
+        %fieldset.inline{"aria-describedby": "checkbox-control-legend-vat"}
+          %legend#checkbox-control-legend-vat
+            = t('.vat_registered')
 
-              = f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
-                .multiple-choice
-                  = b.radio_button
-                  = b.label { (b.value.to_s == 'true' ? 'Yes' : 'No') }
+          = f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
+            .multiple-choice
+              = b.radio_button("aria-labelledby": "checkbox-control-legend-vat #{b.text.to_css_class}")
+              = b.label(id: b.text.to_css_class) { (b.value.to_s == 'true' ? t('.answer_yes') : t('.answer_no')) }
 
-            = f.label :supplier_number, t(".supplier_number"), class: "form-label"
-            = f.text_field :supplier_number, class: "form-control"
+      .form-group
+        = f.label :supplier_number, t('.supplier_number'), class: 'form-label-bold'
+        = f.text_field :supplier_number, class: 'form-control'
 
   .form-group
-    = f.submit 'Save', class: "button"
+    = f.submit t('.save'), class: 'button'

--- a/app/views/external_users/admin/external_users/change_password.html.haml
+++ b/app/views/external_users/admin/external_users/change_password.html.haml
@@ -1,9 +1,9 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.prohibited_save')}
+= render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.error_summary')}
 
-= render partial: 'layouts/header', locals: {page_heading: t('.change_password')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 
 = form_for [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path do |f|

--- a/app/views/external_users/admin/external_users/edit.html.haml
+++ b/app/views/external_users/admin/external_users/edit.html.haml
@@ -1,6 +1,9 @@
 = content_for :page_title, flush: true do
   = t('.page_title', external_user: @external_user.user.name)
 
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag 'v2/application', media: 'all'
+
 = render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.error_summary')}
 
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading', external_user: @external_user.user.name)}

--- a/app/views/external_users/admin/external_users/edit.html.haml
+++ b/app/views/external_users/admin/external_users/edit.html.haml
@@ -1,8 +1,8 @@
 = content_for :page_title, flush: true do
   = t('.page_title', external_user: @external_user.user.name)
 
-= render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.prohibited_save')}
+= render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.error_summary')}
 
-= render partial: 'layouts/header', locals: {page_heading: t('.edit_advocate')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading', external_user: @external_user.user.name)}
 
 = render 'form'

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -1,14 +1,13 @@
 = content_for :page_title, flush: true do
   = t(".page_title_#{current_user.provider.provider_type}")
 
-= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading', provider_name: "#{current_user.provider.name}")}
 
 = content_for :search_html_block do
   .form-group
     = link_to t('.new_user'), new_external_users_admin_external_user_path
 
 = render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'listanchor'), hint_text: t('hint.search_users'), button_text: t('search.users') }
-
 %table.report
   %thead
     %th
@@ -27,18 +26,18 @@
   %tbody
     - @external_users.each do |advocate|
       %tr
-        %td
+        %td{'data-label': t('.last_name')}
           = advocate.last_name
-        %td
+        %td{'data-label': t('.first_name')}
           = advocate.first_name
-        %td
+        %td{'data-label': t('.supplier_number')}
           = advocate.supplier_number ? advocate.supplier_number : '-'
-        %td
+        %td{'data-label': t('.email')}
           = mail_to advocate.email, advocate.email, {title: t('.email_title', external_user: advocate.name)}
         - if Settings.email_notification_enabled?
-          %td
+          %td{'data-label': t('.email_confirmation')}
             = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
-        %td.user-controls
+        %td.user-controls{'data-label': t('.actions')}
           - if advocate.active?
             = link_to t('.edit'),  edit_external_users_admin_external_user_path(advocate)
             = " | "

--- a/app/views/external_users/admin/external_users/new.html.haml
+++ b/app/views/external_users/admin/external_users/new.html.haml
@@ -1,8 +1,8 @@
 = content_for :page_title, flush: true do
   = t(".page_title_#{@current_provider.provider_type}")
 
-= render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.prohibited_save')}
+= render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.error_summary')}
 
-= render partial: 'layouts/header', locals: {page_heading: t('.new_advocate')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading', provider_name: "#{current_user.provider.name}")}
 
 = render 'form'

--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -1,7 +1,7 @@
 = content_for :page_title, flush: true do
   = t(".page_title", provider_name: @provider.name)
 
-= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading', provider_name: @provider.name)}
 
 .table-container.container
   %table

--- a/app/views/external_users/advocates/_advocate_category.html.haml
+++ b/app/views/external_users/advocates/_advocate_category.html.haml
@@ -1,13 +1,14 @@
-.form-section
-  .form-group
-    %fieldset
-      = f.anchored_without_label t('shared.claim.advocate_category')
-      %legend.form-label-bold{:for => "advocate-category-1"}
+.form-group
+  %fieldset{"aria-describedby": "radio-control-legend-category"}
+    = f.anchored_without_label t('shared.claim.advocate_category')
+    %legend{:for => "advocate-category-1"}
+      %h3#radio-control-legend-category.heading-medium
         = t('shared.claim.advocate_category')
-      .advocate-categories{class: error_class?(@error_presenter, :advocate_category)}
-        = f.collection_radio_buttons(:advocate_category, f.object.eligible_advocate_categories.sort, :to_s, :to_s) do |b|
-          .multiple-choice.js-fee-calculator-advocate-type
-            = b.radio_button
-            = b.label { b.value.to_s }
+    .advocate-categories{class: error_class?(@error_presenter, :advocate_category)}
+      = f.collection_radio_buttons(:advocate_category, f.object.eligible_advocate_categories.sort, :to_s, :to_s) do |b|
+        .multiple-choice.js-fee-calculator-advocate-type
+          = b.radio_button("aria-labelledby": "radio-control-legend-category #{b.text.to_css_class}")
+          = b.label(id: b.text.to_css_class) { b.value.to_s }
 
-        = validation_error_message(@error_presenter, :advocate_category)
+      = validation_error_message(@error_presenter, :advocate_category)
+

--- a/app/views/external_users/advocates/claims/_basic_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/claims/_basic_fees_form_step.html.haml
@@ -6,7 +6,7 @@
 = content_for :v2_stylesheets do
   = stylesheet_link_tag "v2/application", media: "all"
 
-= render partial: 'external_users/claims/fees_shared_header'
+= render partial: 'external_users/claims/fees_shared_header', locals: {	page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope)}
 
 = render partial: 'external_users/advocates/advocate_category', locals: { f: f }
 

--- a/app/views/external_users/advocates/supplementary_claims/_defendants_form_step.html.haml
+++ b/app/views/external_users/advocates/supplementary_claims/_defendants_form_step.html.haml
@@ -1,4 +1,7 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
 = render partial: 'external_users/claims/defendants/fields', locals: { f: f }

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -1,9 +1,9 @@
 = content_for :page_title, flush: true do
   = t(".page_title.#{present(@claim).type_identifier}")
 
-= render partial: 'errors/error_summary', locals:{ ep: @certification, error_summary: t('.prohibited_save')}
+= render partial: 'errors/error_summary', locals:{ ep: @certification, error_summary: t('.error_summary')}
 
-= render partial: 'layouts/header', locals: {page_heading: 'Certification'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = form_for @certification, builder: AdpFormBuilder, url: external_users_claim_certification_path(@claim) do |f|
   %div.certification.normal
@@ -111,5 +111,5 @@
       .column-third
         &nbsp;
     .button-holder
-      = f.submit "Certify and submit claim", class: "button left btn-spacer-20"
-      = link_to 'Return to claim', edit_polymorphic_path(@claim), class: 'button-gray-3 left'
+      = f.submit t('.submit'), class: "button left btn-spacer-20"
+      = link_to t('.return'), edit_polymorphic_path(@claim), class: 'button-gray-3 left'

--- a/app/views/external_users/claim_types/selection.html.haml
+++ b/app/views/external_users/claim_types/selection.html.haml
@@ -1,13 +1,15 @@
 = content_for :page_title, flush: true do
   = claim_type_page_header(current_user)
 
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
 = render partial: 'layouts/header', locals: { page_heading: claim_type_prompt_heading_for(current_user) }
 
 %h2.heading-large
   = t('.claim_type_prompt_section_heading')
 
-
-= form_tag(types_external_users_claims_path, method: "post") do
+= form_tag(types_external_users_claims_path, method: 'post') do
   .form-section
     .form-group
       %fieldset
@@ -27,5 +29,5 @@
 
   .form-section
     .form-group.form-buttons
-      = submit_tag "Continue", class: "button"
-      = link_to 'Cancel', external_users_root_path, class: 'link-secondary'
+      = submit_tag t('.continue'), class: 'button'
+      = link_to t('.cancel'), external_users_root_path, role: 'button', class: 'link-secondary'

--- a/app/views/external_users/claims/_main_claims_list.html.haml
+++ b/app/views/external_users/claims/_main_claims_list.html.haml
@@ -54,40 +54,40 @@
         %tr{id: dom_id(claim), class: claim.state}
 
           - if user_requires_scheme_column?
-            %td
+            %td{'data-label' => t(".type")}
               = claim.pretty_type
 
-          %td
+          %td{'data-label' => t(".case_number")}
             = link_to claim.case_number,
                       external_users_claim_path_for_state(claim),
                       class: "js-test-case-number-link",
-                      'aria-label': t('.case_number_label', claim_state: claim.state.humanize, case_number: claim.case_number)
+                      'data-label': t('.case_number_label', claim_state: claim.state.humanize, case_number: claim.case_number)
             %div.unique-id-small
               = claim.unique_id
             %div.providers-ref
               = claim.providers_ref
 
           - if current_user.persona.admin?
-            %td
+            %td{'data-label' => t(".advocate_litigator")}
               = claim.external_user.name
 
-          %td
+          %td{'data-label' => t(".defendants")}
             = claim.defendant_names
 
-          %td.numeric.claimed-amount
+          %td.numeric.claimed-amount{'data-label' => t(".total")}
             = claim.total_inc_vat
 
-          %td.numeric
+          %td.numeric{'data-label' => t(".assessed")}
             = claim.amount_assessed
 
-          %td
+          %td{'data-label' => t(".status")}
             %span.state{class: 'state-' << claim.state.dasherize}
               = claim.state.humanize
 
-          %td.numeric
+          %td.numeric{'data-label' => t(".submission_date")}
             = claim.submitted_at.blank? ? "-" : claim.submitted_at
 
-          %td.messages
+          %td.messages{'data-label' => t(".messages")}
             - if claim.messages.any?
               = link_to claim.has_unread_messages_for?(current_user) ? t('.view_with_messages', message_count: claim.unread_messages_for(current_user).count) : t('.view') , "#{external_users_claim_path(claim, messages: true)}#messages", 'aria-label': t('.view_messages_label', case_number: claim.case_number)
             - else

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -19,6 +19,9 @@
   - else
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]
       = render partial: 'external_users/claims/summary/section_status', locals: { claim: claim, section: section, step: step }
+    - else
+      %p
+        = t("shared.summary.no_values.#{section}")
 - else
   - collection = local_assigns.has_key?(:collection) ? collection : claim.fees.select(&:present?)
   - section = local_assigns.has_key?(:section) ? section : :fees

--- a/app/views/external_users/claims/additional_information/_fields.html.haml
+++ b/app/views/external_users/claims/additional_information/_fields.html.haml
@@ -1,6 +1,6 @@
-%h2.bold-medium
+%h2#additional-information.heading-large
   = f.label :additional_information, t('.additional_information')
-#additional-info-hint.form-hint.xsmall
+#additional-info-hint.xsmall
   = t('.additional_information_prompt_text')
 #additional-info-area
   = f.text_area :additional_information, rows: 5, 'aria-describedby': 'additional-info-hint'

--- a/app/views/external_users/claims/additional_information/_fields.html.haml
+++ b/app/views/external_users/claims/additional_information/_fields.html.haml
@@ -3,4 +3,4 @@
 #additional-info-hint.xsmall
   = t('.additional_information_prompt_text')
 #additional-info-area
-  = f.text_area :additional_information, rows: 5, 'aria-describedby': 'additional-info-hint'
+  = f.text_area :additional_information, rows: 5, class: 'form-control', 'aria-describedby': 'additional-info-hint'

--- a/app/views/external_users/claims/archived.html.haml
+++ b/app/views/external_users/claims/archived.html.haml
@@ -1,7 +1,7 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: t('.archived_claims')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 = render partial: 'external_users/shared/timed_retention_banner'
 
 .container.search-wrapper#listanchor

--- a/app/views/external_users/claims/authorised.html.haml
+++ b/app/views/external_users/claims/authorised.html.haml
@@ -1,7 +1,7 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: t('.authorised_claims')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 .container.sub-header
   .hgroup

--- a/app/views/external_users/claims/basic_fees/_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_fields.html.haml
@@ -2,9 +2,9 @@
   #basic-fees.mod-fees
     - present(f.object.basic_fees, BasicFeesPresenter) do | basic_fees |
       // Present the primary fee
-      .form-section
-        %h3.heading-medium
-          = "Basic fees"
+
+      %h3.heading-medium
+        = t(".heading")
       = f.fields_for :basic_fees, basic_fees.primary_fee do |basic_fee_fields|
         - @basic_fee_count += 1
         - if present(basic_fee_fields.object).should_be_displayed?

--- a/app/views/external_users/claims/case_details/_advocate_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_advocate_fields.html.haml
@@ -1,23 +1,26 @@
-.form-group.js-typeahead{class: error_class?(@error_presenter, :external_user)}
+.form-section.js-typeahead{class: error_class?(@error_presenter, :external_user)}
   %a{id: :external_user}
-  %label.form-label-bold{for: 'claim_external_user_id_input'}
-    = t('.advocate')
+  %fieldset{"aria-describedby": "radio-control-legend-advocate"}
+    %legend{for: 'claim_external_user_id_input', id: "radio-control-legend-advocate"}
+      %span.form-label-bold
+        = t('.advocate')
 
   - provider_advocates = @provider.advocates.sort_by(&:name_and_number)
   - if provider_advocates.length >= 6
     = f.collection_select :external_user_id, provider_advocates, :id, :name_and_number, { include_blank: ''.html_safe }, { class: 'form-control typeahead' }
 
   - else
-    - options = provider_advocates.length == 1 ? { checked: provider_advocates.first.id } : {}
-    = f.collection_radio_buttons(:external_user_id, provider_advocates, :id, :name_and_number, options) do |b|
-      .multiple-choice
-        = b.radio_button
-        - if provider_advocates.length == 1
-          = b.label(class: 'selected') { b.text }
-        - else
-          = b.label { b.text }
+    .form-group
+      - options = provider_advocates.length == 1 ? { checked: provider_advocates.first.id } : {}
+      = f.collection_radio_buttons(:external_user_id, provider_advocates, :id, :name_and_number, options) do |b|
+        .multiple-choice
+          = b.radio_button("aria-labelledby": "radio-control-legend-advocate #{b.text.to_css_class}")
+          - if provider_advocates.length == 1
+            = b.label(class: 'selected', id: b.text.to_css_class) { b.text }
+          - else
+            = b.label(id: b.text.to_css_class) { b.text }
 
-  = validation_error_message(@error_presenter, :external_user)
+    = validation_error_message(@error_presenter, :external_user)
 
 .form-group
   %details

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -9,13 +9,13 @@
   = f.gov_uk_date_field(:trial_cracked_at, legend_text: t('.trial_cracked_at'), legend_class: 'govuk-legend', form_hint_text: t('.date_hint'), id: "trial_cracked_at", error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_cracked_at))
 
   .form-group
-    %fieldset{'aria-describedby': 'trial-cracked-hint'}
-      %legend#trial-cracked-hint.form-label-bold
+    %fieldset{"aria-describedby": "radio-control-legend-cracked-trial"}
+      %legend#radio-control-legend-cracked-trial.form-label-bold
         = t('.trial_cracked_at_third')
 
       = f.collection_radio_buttons(:trial_cracked_at_third, Settings.trial_cracked_at_third, :to_s, :humanize) do |b|
         .multiple-choice
-          = b.radio_button
-          = b.label { b.text }
+          = b.radio_button("aria-labelledby": "radio-control-legend-cracked-trial #{b.text.to_css_class}")
+          = b.label(id: b.text.to_css_class) { b.text }
 
   = validation_error_message(@error_presenter, :trial_cracked_at_third)

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -37,13 +37,16 @@
     hint_text: t('.case_number_hint'),
     errors: @error_presenter
 
-  .form-row
-    %fieldset
-      = f.anchored_label t('.case_transferred_from_another_court'), 'case_transferred_from_another_court', label_attributes: { class: 'form-label-bold' }
+  .form-group
+    %fieldset{"aria-describedby": "radio-control-legend-transfer"}
+      %legend#radio-control-legend-transfer
+        %h2.heading-medium
+          = t('.case_transferred_from_another_court')
+
       = f.collection_radio_buttons(:case_transferred_from_another_court, yes_no_options.reverse, :last, :first ) do |b|
         .multiple-choice{ 'data-target' => b.value.to_bool ? 'transfer-court-details' : nil }
-          = b.radio_button
-          = b.label { b.text }
+          = b.radio_button("aria-labelledby": "radio-control-legend-transfer #{b.text.to_css_class}")
+          = b.label(id: b.text.to_css_class) { b.text }
 
         - if b.value.to_bool
           #transfer-court-details.panel.panel-border-narrow.js-hidden

--- a/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
@@ -9,16 +9,16 @@
   = f.adp_text_field :retrial_estimated_length, label: t('.retrial_estimated_length'), hint_text: t('.retrial_estimated_length_hint'), input_classes:'form-control-1-8', input_type: 'number', errors: @error_presenter
 
   = f.adp_text_field :retrial_actual_length, label: t('.retrial_actual_length'), hint_text: t('.retrial_actual_length_hint'), input_classes:'form-control-1-8', input_type: 'number', errors: @error_presenter
+  .form-group.inline
+    %fieldset{"aria-describedby": "radio-control-legend-retrial"}
+      %legend#radio-control-legend-retrial.form-label-bold
+        %h3.heading-medium
+          = t('.retrial_reduction')
 
-  .form-group
-    %fieldset{'aria-describedby': 'trial-cracked-hint'}
-      %legend#trial-cracked-hint.form-label-bold
-        = t('.retrial_reduction')
-      .form-group.inline
-        = f.collection_radio_buttons(:retrial_reduction, [['Yes','true'],['No','false']], :last, :first ) do |b|
-          .multiple-choice
-            = b.radio_button
-            = b.label { b.text }
+      = f.collection_radio_buttons(:retrial_reduction, [['Yes','true'],['No','false']], :last, :first ) do |b|
+        .multiple-choice
+          = b.radio_button("aria-labelledby": "radio-control-legend-retrial #{b.text.to_css_class}")
+          = b.label(id: b.text.to_css_class) { b.text }
 
   = validation_error_message(@error_presenter, :retrial_reduction)
 

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -1,40 +1,42 @@
-.nested-fields.resource-details.defendant-details
-  %h2.heading-large
-    = t('.defendant')
-  .form-group.first-name
-    - @representation_order_count = 0
-    = f.adp_text_field :first_name, label: t('.first_name'), errors: @error_presenter
+%fieldset
+  .nested-fields.resource-details.defendant-details.fx-numberedList-item
+    %h2.heading-medium
+      = t('.defendant')
+      %span.fx-numberedList-number
+    .form-group.first-name
+      - @representation_order_count = 0
+      = f.adp_text_field :first_name, label: t('.first_name'), errors: @error_presenter
 
-  .form-group.last-name
-    = f.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
+    .form-group.last-name
+      = f.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
 
-  .form-group.dob
-    %a{:id => "defendant_#{@defendant_count+1}_date_of_birth"}
-    = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
+    .form-group.dob
+      %a{:id => "defendant_#{@defendant_count+1}_date_of_birth"}
+      = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
 
-  - unless @claim.lgfs? && @claim.interim?
-    .form-group
-      %fieldset
-        .multiple-choice
-          = f.check_box :order_for_judicial_apportionment
-          = f.label :order_for_judicial_apportionment, t('.order_for_judicial_apportionment'), class: 'judicial-apportionment-notice'
-          = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
+    - unless @claim.lgfs? && @claim.interim?
+      .form-group
+        %fieldset
+          .multiple-choice
+            = f.check_box :order_for_judicial_apportionment
+            = f.label :order_for_judicial_apportionment, t('.order_for_judicial_apportionment'), class: 'judicial-apportionment-notice'
+            = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
 
-    .form-group
-      %details
-        %summary
-          %span.summary Help with judicial apportionment
-        .panel.panel-border-narrow
-          %p
-            = t('.order_for_judicial_apportionment_help')
+      .form-group
+        %details
+          %summary
+            %span.summary Help with judicial apportionment
+          .panel.panel-border-narrow
+            %p
+              = t('.order_for_judicial_apportionment_help')
 
-  .documents
-    = f.fields_for :representation_orders do |repo_form|
-      = render partial: 'external_users/claims/defendants/representation_order_fields', locals: { f: repo_form }
-  .links
-    = link_to_add_association t('.add_another_rep_order'), f, :representation_orders, partial: 'external_users/claims/defendants/representation_order_fields'
+    .documents
+      = f.fields_for :representation_orders do |repo_form|
+        = render partial: 'external_users/claims/defendants/representation_order_fields', locals: { f: repo_form }
+    .links
+      = link_to_add_association t('.add_another_rep_order'), f, :representation_orders, partial: 'external_users/claims/defendants/representation_order_fields'
 
-  %p
-    = link_to_remove_association t('.remove_defendant'), f if @defendant_count > 0
+    %p
+      = link_to_remove_association t('.remove_defendant'), f if @defendant_count > 0
 
-- @defendant_count += 1
+  - @defendant_count += 1

--- a/app/views/external_users/claims/defendants/_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_fields.html.haml
@@ -1,7 +1,9 @@
-.form-section.defendants
-  %fieldset
-    = f.fields_for :defendants do |defendant|
-      = render partial: 'external_users/claims/defendants/defendant_fields', locals: { f: defendant }
+.form-section.defendants.fx-numberedList-wrapper
+  %h2.heading-large
+    = t('.page_heading')
+
+  = f.fields_for :defendants do |defendant|
+    = render partial: 'external_users/claims/defendants/defendant_fields', locals: { f: defendant }
 .form-section.form-actions.defendants-actions
   %hr
-  = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields', class: 'button button-secondary blue'
+  = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields', class: 'button button-secondary blue', render_options: { }, data: {'association-insertion-method' => 'append', 'association-insertion-node' => '.fx-numberedList-wrapper'}

--- a/app/views/external_users/claims/fixed_fees/advocates/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/advocates/_fields.html.haml
@@ -5,7 +5,6 @@
         %fieldset
           %legend.form-label-bold
             = t('.type_of_fee')
-            / <span class="form-hint"></span>
           = f.fields_for :fixed_fees do |fixed_fee_fields|
             - @fixed_fee_count += 1
             = render 'external_users/claims/fixed_fees/advocates/fixed_fee_fields', f: fixed_fee_fields

--- a/app/views/external_users/claims/fixed_fees/advocates/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/advocates/_fields.html.haml
@@ -1,12 +1,10 @@
 - if @claim.allows_fixed_fees?
   #fixed-fees.mod-fees.form-section
     .fixed-fee-group-wrapper
-      %h3.heading-medium
-        Fixed fee
       .form-group
         %fieldset
           %legend.form-label-bold
-            Type of fee
+            = t('.type_of_fee')
             / <span class="form-hint"></span>
           = f.fields_for :fixed_fees do |fixed_fee_fields|
             - @fixed_fee_count += 1

--- a/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
@@ -1,8 +1,5 @@
 - if @claim.allows_fixed_fees?
   .form-section.fx-fee-group.fixed-fee-group.js-block.fx-do-init{data:{"type": "fixedFees", autovat: @claim.apply_vat? ? "true" : "false", "block-type": "FeeBlockCalculator"}}
-    %h2.bold-medium
-      = t('.fixed_fees')
-
     = f.fields_for :fixed_fee do |ff|
       - fee = present(ff.object)
 

--- a/app/views/external_users/claims/interim_claim_info/_fields.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_fields.html.haml
@@ -1,34 +1,37 @@
 - if claim.requires_interim_claim_info?
   #interim-claim-info
-    %h2.bold-medium
+    %h2.heading-medium
       = t('.warrant_fee')
 
     = f.fields_for :interim_claim_info do |ff|
-      .form-row
-        %fieldset
-          = ff.anchored_label t('.warrant_fee_paid'), 'warrant_fee_paid', label_attributes: { class: 'form-label' }
-          = ff.collection_radio_buttons(:warrant_fee_paid, yes_no_options, :last, :first, { include_hidden: false, checked: ff.object.warrant_fee_paid ? 'true' : 'false' }) do |b|
-            .multiple-choice{ 'data-target' => b.value.to_bool ? 'interim-claim-info-details' : nil }
-              = b.radio_button
-              = b.label { b.text }
+      .form-section
+        %fieldset{"aria-describedby": "radio-control-legend-warrant"}
+          %legend#radio-control-legend-warrant
+            %span.form-label-bold
+              = t('.warrant_fee_paid')
+          .form-group
+            = ff.collection_radio_buttons(:warrant_fee_paid, yes_no_options, :last, :first, { include_hidden: false, checked: ff.object.warrant_fee_paid ? 'true' : 'false' }) do |b|
+              .multiple-choice{ 'data-target' => b.value.to_bool ? 'interim-claim-info-details' : nil }
+                = b.radio_button("aria-labelledby": "radio-control-legend-warrant #{b.text.to_css_class}")
+                = b.label(id: b.text.to_css_class) { b.text }
 
-            - if b.value.to_bool
-              #interim-claim-info-details.panel.panel-border-narrow.js-hidden
-                .form-group
-                  %fieldset
-                    %legend.visuallyhidden
-                      = t('.warrant_fee')
-                    .warrant-fee-issued-date-group
-                      = ff.gov_uk_date_field :warrant_issued_date,
-                                              legend_text: t('.date_issued'),
-                                              legend_class: 'form-label-bold',
-                                              id: 'interim_claim_info.warrant_issued_date',
-                                              error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_issued_date')
+              - if b.value.to_bool
+                #interim-claim-info-details.panel.panel-border-narrow.js-hidden
+                  .form-group
+                    %fieldset
+                      %legend.visuallyhidden
+                        = t('.warrant_fee')
+                      .warrant-fee-issued-date-group
+                        = ff.gov_uk_date_field :warrant_issued_date,
+                                                legend_text: t('.date_issued'),
+                                                legend_class: 'form-label-bold',
+                                                id: 'interim_claim_info.warrant_issued_date',
+                                                error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_issued_date')
 
-                .form-group
-                  .warrant-fee-executed-date-group
-                    = ff.gov_uk_date_field :warrant_executed_date,
-                                            legend_text: t('.date_executed'),
-                                            legend_class: 'govuk-legend',
-                                            id: 'interim_claim_info.warrant_executed_date',
-                                            error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_executed_date')
+                  .form-group
+                    .warrant-fee-executed-date-group
+                      = ff.gov_uk_date_field :warrant_executed_date,
+                                              legend_text: t('.date_executed'),
+                                              legend_class: 'govuk-legend',
+                                              id: 'interim_claim_info.warrant_executed_date',
+                                              error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_executed_date')

--- a/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
@@ -2,7 +2,7 @@
   = t('.page_intro_html')
 
 #misc-fees.mod-fees
-  .misc-fee-group-wrapper
+  .misc-fee-group-wrapper.fx-numberedList-wrapper
     = f.fields_for :misc_fees do |misc_fee_fields|
       - @misc_fee_count += 1
       = render partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', locals: { f: misc_fee_fields }

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -1,22 +1,26 @@
-.form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group{data:{"type": "miscFees", autovat: @claim.apply_vat? ? "true" : "false"}}
+.form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{data:{"type": "miscFees", autovat: @claim.apply_vat? ? "true" : "false"}}
   %h2.bold-medium
-    = t('.misc_fee')
+    %span#fx-numberedList-heading
+      = t('.misc_fee')
+      %span.fx-numberedList-number
     = link_to_remove_association t('.remove'), f, { wrapper_class: 'misc-fee-group', class: "header-action" }
 
   .form-group
     .fee-type.js-typeahead{class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")}
-      %label.form-label-bold
-        = t('.fee_type')
-      %a{id: "misc_fee_#{@misc_fee_count}_fee_type"}
-      - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
-      - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
-      = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
-        .multiple-choice
-          = b.radio_button
-          - if misc_fee_types_collection.length == 1
-            = b.label(class: 'selected') { b.text }
-          - else
-            = b.label { b.text }
+      %fieldset{"aria-describedby": "radio-control-legend"}
+        %legend#radio-control-legend
+          %span.form-label-bold
+            = t('.fee_type')
+        %a{id: "misc_fee_#{@misc_fee_count}_fee_type"}
+        - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
+        - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
+        = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
+          .multiple-choice
+            = b.radio_button("aria-labelledby": "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend #{b.text.to_css_class}")
+            - if misc_fee_types_collection.length == 1
+              = b.label(id: b.text.to_css_class, class: 'selected') { b.text }
+            - else
+              = b.label(id: b.text.to_css_class) { b.text }
 
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 

--- a/app/views/external_users/claims/outstanding.html.haml
+++ b/app/views/external_users/claims/outstanding.html.haml
@@ -1,7 +1,7 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: t('.heading')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 .container.sub-header
   .hgroup

--- a/app/views/external_users/claims/show.html.haml
+++ b/app/views/external_users/claims/show.html.haml
@@ -1,4 +1,5 @@
-- title 'Claim details'
+= content_for :page_title, flush: true do
+  = t('.page_title')
 
 - present(@claim) do |claim|
   = render partial: 'shared/claim_header', locals: {  claim: claim }

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -1,7 +1,13 @@
 = content_for :page_title, flush: true do
   = t(".#{@claim.agfs? ? 'agfs' : 'lgfs'}.#{@claim.type.underscore.gsub(/claim\//, '')}.page_title")
 
-= render partial: 'layouts/header', locals: { page_heading: t('.heading') }
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: { page_heading: t(".#{@claim.agfs? ? 'agfs' : 'lgfs'}.#{@claim.type.underscore.gsub(/claim\//, '')}.page_heading") }
+
+%h2.heading-large
+  = t('.page_heading')
 
 - present(@claim) do |claim|
   .grid-row.grid-sidebar
@@ -14,6 +20,6 @@
 
   .form-section
     .form-group.form-buttons
-      = link_to t('buttons.continue'), new_external_users_claim_certification_path(claim), { class: 'button button-continue', role: 'button', 'aria-label': t('.button_label') }
-      = link_to t('buttons.save_a_draft'), external_users_root_path, { class: 'button button-gray-3', role: 'button' }
+      = link_to t('buttons.continue'), new_external_users_claim_certification_path(claim), { class: 'button left btn-spacer-20', role: 'button', 'aria-label': t('.button_label') }
+      = link_to t('buttons.save_a_draft'), external_users_root_path, { class: 'button-gray-3 left', role: 'button' }
       = link_to t('buttons.delete_draft'), external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'link-delete'

--- a/app/views/external_users/claims/supplier_number/_fields.html.haml
+++ b/app/views/external_users/claims/supplier_number/_fields.html.haml
@@ -1,5 +1,5 @@
-.form-group.lgfs-supplier-numbers.has-select{class: error_class?(@error_presenter, :supplier_number)}
-  = f.anchored_label(t('.lgfs_supplier_number'), 'supplier_number', { label_attributes: {class: 'form-label'} })
+.form-group.lgfs-supplier-numbers.has-select{class: error_class?(@error_presenter, :supplier_number), "aria-describedby": "radio-control-legend-supplier"}
+  = f.anchored_label(t('.lgfs_supplier_number'), 'supplier_number', { label_attributes: {class: 'form-label', id: "radio-control-legend-supplier"} })
   %div.form-hint
     = supplier_number_hint
 
@@ -9,13 +9,14 @@
     = f.collection_select :supplier_number, supplier_numbers, :supplier_number, :supplier_label, {prompt: true}, {class: 'form-control'}
 
   - else
-    -# Radio element
-    = f.collection_radio_buttons(:supplier_number, supplier_numbers, :supplier_number, :supplier_label) do |b|
-      .multiple-choice
-        = b.radio_button
-        - if(current_user.persona.provider.lgfs_supplier_numbers.length == 1)
-          = b.label(class: "selected") { b.text }
-        - else
-          = b.label { b.text }
+    .form-group
+      -# Radio element
+      = f.collection_radio_buttons(:supplier_number, supplier_numbers, :supplier_number, :supplier_label) do |b|
+        .multiple-choice
+          = b.radio_button("aria-labelledby": "radio-control-legend-supplier #{b.text.to_css_class}")
+          - if(current_user.persona.provider.lgfs_supplier_numbers.length == 1)
+            = b.label(class: "selected", id: b.text.to_css_class) { b.text }
+          - else
+            = b.label(id: b.text.to_css_class) { b.text }
 
-  = validation_error_message(@error_presenter, :supplier_number)
+    = validation_error_message(@error_presenter, :supplier_number)

--- a/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
@@ -1,9 +1,8 @@
-.form-row{class: error_class?(@error_presenter, :disk_evidence)}
-  %h2.bold-medium
-    = f.anchored_label t('disk_evidence.header'), 'evidence_upload'
-
+.form-section{class: error_class?(@error_presenter, :disk_evidence)}
   %fieldset
-    = f.anchored_label t('disk_evidence.question'), 'disk_evidence'
+    %legend
+      %span.form-label-bold
+        = t('disk_evidence.question')
     = f.collection_radio_buttons(:disk_evidence, [['Yes','true'],['No','false']], :last, :first ) do |b|
       .multiple-choice{"data-target" => b.text == 'Yes' ? 'evidence-info' : nil}
         = b.radio_button

--- a/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
@@ -1,12 +1,14 @@
-.form-section{class: error_class?(@error_presenter, :disk_evidence)}
-  %fieldset
-    %legend
+.form-row{class: error_class?(@error_presenter, :disk_evidence)}
+  %h2.bold-medium
+    = f.anchored_label t('disk_evidence.header'), 'evidence_upload'
+  %fieldset{"aria-describedby": "radio-control-legend-evidence"}
+    %legend#radio-control-legend-evidence
       %span.form-label-bold
         = t('disk_evidence.question')
     = f.collection_radio_buttons(:disk_evidence, [['Yes','true'],['No','false']], :last, :first ) do |b|
       .multiple-choice{"data-target" => b.text == 'Yes' ? 'evidence-info' : nil}
-        = b.radio_button
-        = b.label { b.text }
+        = b.radio_button("aria-labelledby": "radio-control-legend-evidence #{b.text.to_css_class}")
+        = b.label(id: b.text.to_css_class) { b.text }
       - if (b.text == 'Yes')
         #evidence-info.panel.panel-border-narrow.js-hidden
           = render partial: 'shared/disk_evidence_info', locals: { f: f }

--- a/app/views/external_users/claims/supporting_documents/_new.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_new.html.haml
@@ -1,22 +1,27 @@
 - unless @claim.agfs? && @claim.interim?
-  = render partial: 'external_users/claims/supporting_documents/disk_evidence', locals: { f: f }
+  %h2.heading-large
+    = t(".supporting_evidence")
 
-%h3.heading-medium
-  = t('.supporting_evidence_docs')
+  = render partial: 'external_users/claims/supporting_documents/disk_evidence', locals: { f: f }
 
 .document-ids
   - @claim.documents.each do |document|
     = f.hidden_field :document_ids, multiple: true, value: document.id, id: "claim_document_ids_#{document.id}"
 
-.dropzone{data: {'dz-template' => "#{render('shared/dropzone_js').html_safe}" }}
-  .dz-default.dz-message.grid-row
-    .column-one-third.arrow-icon
-      %p
+.form-group
+  %fieldset
+    %legend.form-label-bold
+      = t(".legend")
+    .dropzone{data: {'dz-template' => "#{render('shared/dropzone_js').html_safe}" }}
+      .dz-default.dz-message.grid-row
+        .column-one-third.arrow-icon
+          %p
+        .column-one-half
+          %span.normal
+            = t(".file_upload_message" )
+          %br
+          %span.bold-normal= t(".or")
+          %br
+          .button-grey-3
+            = t('.choose_file')
 
-    .column-one-half
-      %span.normal="Drag and drop files here"
-      %br
-      %span.bold-normal= "or"
-      %br
-      .button-grey-3
-        = t('.choose_file')

--- a/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
@@ -1,6 +1,7 @@
 %fieldset.evidence-checklist{"data-mute-indictment": @claim.allows_fixed_fees? ? "true" : "false"}
-  %legend
-    %h3.heading-medium
-      = t('.supporting_evidence_checklist')
+  %legend.form-label-bold
+    = t('.supporting_evidence_checklist')
+    %span.form-hint
+      = t(".supporting_evidence_checklist_hint")
 
   = render partial: 'external_users/claims/supporting_evidence_checklist/evidence_checklist', locals: { f: f, collection: f.object.eligible_document_types }

--- a/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
@@ -8,22 +8,28 @@
 
     .js-case-conclusion-effectors
       .form-group{class: error_class?(@error_presenter, :litigator_type)}
-        %fieldset.inline
-          = f.anchored_label t('.litigator_type'), 'litigator_type', { label_attributes: { class: 'form-label-bold' } }
-          = f.collection_radio_buttons(:litigator_type, ['original','new'], :to_s, :humanize) do |b|
-            .multiple-choice
-              = b.radio_button(class: 'js-litigator-type')
-              = b.label { b.text }
+        %fieldset.inline{"aria-describedby": "radio-control-legend-type"}
+          %legend#radio-control-legend-type
+            %span.form-label-bold
+              = t('.litigator_type')
+          .form-group
+            = f.collection_radio_buttons(:litigator_type, ['original','new'], :to_s, :humanize) do |b|
+              .multiple-choice
+                = b.radio_button(class: "js-litigator-type", "aria-labelledby": "radio-control-legend-type #{b.text.to_css_class}")
+                = b.label(id: b.text.to_css_class) { b.text }
 
         = validation_error_message(@error_presenter, :litigator_type)
 
       .form-group{class: error_class?(@error_presenter, :elected_case)}
-        %fieldset.inline
-          = f.anchored_label t('.elected_case'), 'elected_case', { label_attributes: { class: 'form-label-bold' } }
-          = f.collection_radio_buttons(:elected_case, [['Yes','true'],['No','false']], :last, :first ) do |b|
-            .multiple-choice
-              = b.radio_button(class: 'js-elected-case')
-              = b.label { b.text }
+        %fieldset.inline{"aria-describedby": "radio-control-legend-elected"}
+          %legend#radio-control-legend-elected
+            %span.form-label-bold
+              = t('.elected_case')
+          .form-group
+            = f.collection_radio_buttons(:elected_case, [['Yes','true'],['No','false']], :last, :first ) do |b|
+              .multiple-choice
+                = b.radio_button(class: 'js-elected-case', "aria-labelledby": "radio-control-legend-elected #{b.text.to_css_class}")
+                = b.label(id: b.text.to_css_class) { b.text }
 
         = validation_error_message(@error_presenter, :elected_case)
 

--- a/app/views/external_users/claims/transfer_fee/_summary.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_summary.html.haml
@@ -1,2 +1,2 @@
-.form-section
+#transfer-fees-section.form-section
   = render partial: 'summary_fees', locals: { claim: claim, header: t('external_users.claims.transfer_fee.summary.header'), fee: claim.transfer_fee, editable: editable, section: section, step: :transfer_fees }

--- a/app/views/external_users/claims/warrant_fee/_summary.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_summary.html.haml
@@ -7,9 +7,6 @@
   - if claim.agfs?
     = render partial: 'external_users/claims/advocate_category_summary', locals: { claim: claim }
 
-    %p
-      &nbsp;
-
   - if claim.warrant_fee.nil?
     %p
       There is no warrant fee for this claim

--- a/app/views/external_users/litigators/claims/_fixed_fees_form_step.html.haml
+++ b/app/views/external_users/litigators/claims/_fixed_fees_form_step.html.haml
@@ -4,6 +4,6 @@
 = content_for :v2_stylesheets do
   = stylesheet_link_tag "v2/application", media: "all"
 
-= render partial: 'external_users/claims/fees_shared_header'
+= render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('.page_header')}
 
 = render partial: 'external_users/claims/fixed_fees/litigators/fields', locals: { f: f }

--- a/app/views/feedback/_anonymous_email_prompt.html.haml
+++ b/app/views/feedback/_anonymous_email_prompt.html.haml
@@ -1,8 +1,8 @@
 .form-group
   %fieldset.inline
     %legend
-      = f.label :email
-    %p.form-hint
+      = f.label :email, class: 'form-label-bold'
+    %span.form-hint
       = t('activemodel.attributes.feedback.email_hint')
 
     = f.text_field :email, class: 'form-control'

--- a/app/views/feedback/bug_report.html.haml
+++ b/app/views/feedback/bug_report.html.haml
@@ -1,41 +1,44 @@
-- title 'Bug report'
+= content_for :page_title, flush: true do
+  = t('.page_title')
 
-= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: 'The form you submitted has '}
-= render partial: 'layouts/header', locals: {page_heading: 'Help us improve this service'}
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
 
-.body-content
-  .panel.panel-border-wide
-    %p
-      Tell us about your experience of using this service today. Your answers to the following questions will help us improve the service.
-      = render partial: 'feedback/claim_edit_alert' if referrer_is_claim?(@feedback.referrer)
+= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: t('.error_summary')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
-  = form_for @feedback, builder: AdpFormBuilder, url: feedback_index_path, html: { novalidate: 'novalidate', class: 'normal'} do |f|
-    = f.hidden_field :type
-    = f.hidden_field :referrer
+.grid-row
+  .column-two-thirds
+    .panel.panel-border-wide
+      %p
+        = t('.intro')
+        = render partial: 'feedback/claim_edit_alert' if referrer_is_claim?(@feedback.referrer)
 
-    .form-group
-      %fieldset.inline
-        %legend
-          = f.anchored_label 'Case number / Unique ID', :case_number
-        .form-hint.xsmall.zero-vert-margin
-          = 'If your issue is related to a particular claim, provide the case number along with the unique ID you will find next to it (starts with #)'
-        = f.text_field :case_number, class: 'form-control'
-    .form-group
-      %fieldset.inline
-        %legend
-          = f.anchored_label 'What you were doing when the fault occurred?', :event
-        .form-hint.xsmall.zero-vert-margin
-          = 'Include as much information as possible, including the fee scheme (Advocate, Litigator final, Litigator interim or Litigator transfer) and case type'
-        = f.text_area :event, rows: 6, class: 'form-control'
-    .form-group
-      %fieldset.inline
-        %legend
-          = f.anchored_label 'What went wrong?', :outcome
-        .form-hint.xsmall.zero-vert-margin
-          = ''
-        = f.text_area :outcome, rows: 6, class: 'form-control'
+    = form_for @feedback, builder: AdpFormBuilder, url: feedback_index_path, html: { novalidate: 'novalidate', class: 'normal'} do |f|
+      = f.hidden_field :type
+      = f.hidden_field :referrer
 
-    = render partial: 'feedback/anonymous_email_prompt', locals: { f: f } if cannot_identify_user?
+      .form-group
+        %fieldset.inline
+          %legend
+            = f.anchored_label t('.case_number_label'), :case_number, label_attributes: { class: 'form-label-bold' }
+          .form-hint.xsmall.zero-vert-margin
+            = t('.case_number_hint')
+          = f.text_field :case_number, class: 'form-control'
+      .form-group
+        %fieldset.inline
+          %legend
+            = f.anchored_label t('.event_label'), :event, label_attributes: { class: 'form-label-bold' }
+          .form-hint.xsmall.zero-vert-margin
+            = t('.event_hint')
+          = f.text_area :event, rows: 6, class: 'form-control'
+      .form-group
+        %fieldset.inline
+          %legend
+            = f.anchored_label t('.outcome_label'), :outcome, label_attributes: { class: 'form-label-bold' }
+          = f.text_area :outcome, rows: 6, class: 'form-control'
 
-    .button-holder
-      = f.submit 'Send', class: 'button button-primary', id: 'submit-button'
+      = render partial: 'feedback/anonymous_email_prompt', locals: { f: f } if cannot_identify_user?
+
+      .button-holder
+        = f.submit 'Send', class: 'button button-primary', id: 'submit-button'

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -1,6 +1,9 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
 = render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: t('.error_summary')}
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
@@ -17,25 +20,27 @@
     - if params[:user_id].present?
       = hidden_field_tag :user_id, params[:user_id]
 
+
     .form-group
-      %fieldset.inline
-        %legend
-          = f.label :comment, t('.comment')
-        %p.form-hint
+      %label.form-label-bold{:for => "textarea-e"}
+        = t('.comment')
+        %span.form-hint
           = t('.comment_hint')
-        = f.text_area :comment, rows: 5, class: "form-control"
+      = f.text_area :comment, rows: 5, class: "form-control"
 
     = render partial: 'feedback/anonymous_email_prompt', locals: { f: f } if cannot_identify_user?
 
     .form-group
-      %fieldset
-        %legend
-          = f.label :rating
+      %fieldset{"aria-describedby": "radio-control-legend"}
+        %legend#radio-control-legend
+          %span.form-label-bold
+            = t('.rating')
 
         = f.collection_radio_buttons(:rating, Feedback::RATINGS.map {|k,v| [v,k]}, :last, :first) do |b|
           .multiple-choice
-            = b.radio_button
-            = b.label { b.object.first }
+            = b.radio_button("aria-labelledby": "radio-control-legend #{b.text.to_css_class}")
+            = b.label(id: b.text.to_css_class) { b.object.first }
 
     .button-holder
       = f.submit t('.send'), class: 'button button-primary', id: 'submit-button'
+

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -1,13 +1,13 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: 'This feedback has '}
-= render partial: 'layouts/header', locals: {page_heading: t('activemodel.attributes.feedback.heading')}
+= render partial: 'errors/error_summary', locals:{ ep: @feedback, error_summary: t('.error_summary')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 .body-content
   .panel.panel-border-wide
     %p
-      = t('activemodel.attributes.feedback.callout')
+      = t('.callout')
       = render partial: 'feedback/claim_edit_alert' if referrer_is_claim?(@feedback.referrer)
 
   = form_for @feedback, url: feedback_index_path(email: params[:email]), html: { novalidate: 'novalidate', class: 'normal'} do |f|
@@ -20,9 +20,9 @@
     .form-group
       %fieldset.inline
         %legend
-          = f.label :comment
+          = f.label :comment, t('.comment')
         %p.form-hint
-          = t('activemodel.attributes.feedback.comment_hint')
+          = t('.comment_hint')
         = f.text_area :comment, rows: 5, class: "form-control"
 
     = render partial: 'feedback/anonymous_email_prompt', locals: { f: f } if cannot_identify_user?
@@ -38,4 +38,4 @@
             = b.label { b.object.first }
 
     .button-holder
-      = f.submit 'Send', class: 'button button-primary', id: 'submit-button'
+      = f.submit t('.send'), class: 'button button-primary', id: 'submit-button'

--- a/app/views/json_template/index.html.haml
+++ b/app/views/json_template/index.html.haml
@@ -1,4 +1,5 @@
-= render partial: 'layouts/header', locals: {page_heading: 'Our current JSON schema'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+-# = render partial: 'layouts/header', locals: {page_heading: 'Our current JSON schema'}
 %h3 Given below is the JSON schema that can be used to validate your JSON documents.
 
 Note: JSON files must be UTF-8 encoded.

--- a/app/views/pages/api_landing.html.haml
+++ b/app/views/pages/api_landing.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'layouts/header', locals: {page_heading: 'Claim for crown court defence API'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 .grid-row
   .column-two-thirds

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'layouts/header', locals: {page_heading: 'API release notes'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 %section.api-github-issue
   Any development issues? aside from our

--- a/app/views/pages/contact_us.html.haml
+++ b/app/views/pages/contact_us.html.haml
@@ -1,4 +1,10 @@
-= render partial: 'layouts/header', locals: {page_heading: 'Contact us'}
+= content_for :page_title, flush: true do
+  = t('.page_title')
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 %section.contact-us
   = render partial: 'contact_details'

--- a/app/views/pages/servicedown.html.haml
+++ b/app/views/pages/servicedown.html.haml
@@ -1,5 +1,5 @@
 %section
-	= render partial: 'layouts/header', locals: {page_heading: 'The service is unavailable'}
+	= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 	%p This service is not available right now, but we're working hard to get things up and running again.
 	%p

--- a/app/views/pages/tandcs.haml
+++ b/app/views/pages/tandcs.haml
@@ -1,11 +1,14 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'layouts/header', locals: {page_heading: 'THE “CLAIM FOR CROWN COURT DEFENCE” APPLICATION TERMS OF USE'}
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 %section.tandcs
   %p
-    %h3.section-title
+    %h3.heading-medium
       1. Introduction
   %p
     These Terms of Use (“Terms”) apply to you when you use the ‘Claim
@@ -29,25 +32,25 @@
     bound by these Terms. Please read these Terms carefully and do not use the
     Application if you do not agree with them.
   %p
-    %h3.section-title
+    %h3.heading-medium
       2. Definitions
   %p
     In these terms:
   %p
-    %b Advocate
+    %h4.heading-small Advocate
     means either a person who is an “authorised person” or an “exempt person”,
     for the purposes of exercising a “right of audience”, as defined by the
     provisions of the Legal Services Act 2007 who is instructed by an Authorising
     Organisation;
 
   %p
-    %b Application
+    %h4.heading-small Application
     means the CCCD application, available at   
     = link_to 'https://claim-crown-court-defence.service.gov.uk/', 'https://claim-crown-court-defence.service.gov.uk/'
     \.
 
   %p
-    %b
+    %h4.heading-small
       Authorised representative
     means:
     %ul
@@ -64,25 +67,25 @@
         a Litigator.
 
   %p
-    %b Authorised Signatory
+    %h4.heading-small Authorised Signatory
     means an Authorised Representative of an Authorising Organisation who meets
     our signatory requirements as set out in the AGFS and, as applicable, LGFS bill
     submission screens;
 
   %p
-    %b
+    %h4.heading-small
       Authorising Organisation
     means an organisation or person making claims under the Standard Terms, or any
     other organisation or person who has written authority from us to use the
     Application in accordance with the Terms;
 
   %p
-    %b Claim
+    %h4.heading-small Claim
     means an AGFS or LGFS claim for payment, correctly made in accordance with the
     Criminal Legal Aid (Remuneration) Regulations 2013 (as amended);
 
   %p
-    %b
+    %h4.heading-small
       Controller
     means, where Personal Data is being processed for Law Enforcement Purposes,
     as it is defined in the Law Enforcement Directive (Directive (EU) 2016/680) (LED);
@@ -90,14 +93,14 @@
     General Data Protection Regulation (Regulation (EU) 2016/679) (GDPR);
 
   %p
-    %b
+    %h4.heading-small
       Data Loss Event
     means any event that results, or may result, in unauthorised access to Personal
     Data held by you, and/or actual or potential loss and/or destruction of Personal
     Data in breach of these Terms, including any Personal Data Breach;
 
   %p
-    %b
+    %h4.heading-small
       Data Protection Legislation
     means:
   %ul
@@ -122,18 +125,18 @@
       code of good practice.
 
   %p
-    %b
+    %h4.heading-small
       Data Security Requirements
     means our data security requirements (which can be located on our website)
     as may be amended by us from time to time;
 
   %p
-    %b
+    %h4.heading-small
       GDPR
     means the General Data Protection Regulation (Regulation (EU) 2016/679);
 
   %p
-    %b
+    %h4.heading-small
       LAA Data 
     means:
   %ul
@@ -151,53 +154,53 @@
       the Shared Data)
 
   %p
-    %b
+    %h4.heading-small
       Law Enforcement Purposes
     means as it is defined in the Data Protection Act 2018;
 
   %p
-    %b
+    %h4.heading-small
       LED
     means the Law Enforcement Directive (Directive (EU) 2016/680);
 
   %p
-    %b
+    %h4.heading-small
       Legal Aid Legislation
     means the Legal Aid, Sentencing and Punishment of Offenders Act 2012 and
     statutory instruments made under that act that are relevant to the AGFS or LGFS;
 
   %p
-    %b
+    %h4.heading-small
       Litigator
     means a solicitor, firm of solicitors or other appropriately qualified
     person referred to in a representation order as representing an assisted
     person;
 
   %p
-    %b
+    %h4.heading-small
       Personal Data 
     has the same meaning as the definition in the Data Protection Act 2018 and
     the GDPR;
 
   %p
-    %b
+    %h4.heading-small
       Personal Data Breach
     means as it is defined in the Data Protection Act 2018 and the GDPR;
 
   %p
-    %b Process
+    %h4.heading-small Process
     has the same meaning as the definition in the Data Protection Legislation but,
     for the purposes of these Terms, it shall include both manual and automatic
     processing;
 
   %p
-    %b Processor
+    %h4.heading-small Processor
     means, where Personal Data is being Processed for Law Enforcement Purposes, as
     it is defined in the LED; and in all other circumstances, as it is defined in
     the Data Protection Act 2018 and the GDPR;
 
   %p
-    %b Protective Measures
+    %h4.heading-small Protective Measures
     means the appropriate technical and organisational measures which may include:
     pseudonymising and encrypting Personal Data, ensuring confidentiality, integrity,
     availability and resilience of systems and services, ensuring that availability of
@@ -206,13 +209,13 @@
     adopted by it;
 
   %p
-    %b
+    %h4.heading-small
       Shared Data
     means data (including Personal Data) on the Application for which you are the
     Controller, either alone or jointly with us;
 
   %p
-    %b
+    %h4.heading-small
       Standard Terms
     means, as applicable:
   %ul
@@ -245,17 +248,17 @@
     subordinate legislation made under it and includes any new legal aid
     legislation in force on or after the date of these Terms.
   %p
-    %b
+    %h4.heading-small
       We, us, our 
     means the Lord Chancellor acting through the LAA.
   %p
-    %b
+    %h4.heading-small
       You, your 
     refers to (unless expressly indicated otherwise) you as an Authorised
     Representative, whom an Authorising Organisation has authorised to
     use the Application, an Advocate or a Litigator.
   %p
-    %h3.section-title
+    %h3.heading-medium
       3. Authorising Organisation and Instructed Counsel
   %p
     To use the application, you must be:
@@ -276,37 +279,37 @@
     If you are an Authorised Representative, Advocate or Litigator, you
     shall comply with these Terms when using the application.
   %p
-    %h3.section-title
+    %h3.heading-medium
       4. Licence to use the Application
   %p
-    %b
+    %h4.heading-small
       Authorised representatives
   %p
     Subject to section 13 below, we grant you a non-exclusive, non-transferable
     and revocable licence to use the Application in accordance with the purposes
     set out in the Standard Terms.
   %p
-    %b Advocates
+    %h4.heading-small Advocates
   %p
     Subject to section 13 below, we grant you a non-exclusive, non-transferable
     and revocable licence to use the Application to help us fulfil our statutory
     obligations under Part 1 of the Legal Aid, Sentencing and Punishment of Offenders
     Act 2012 relating to the legal aid scheme.
   %p
-    %b
+    %h4.heading-small
       Litigators
   %p
     Subject to section 13 below, we grant you a non-exclusive, non-transferable and
     revocable licence to use the Application in accordance with the purposes set out
     in the Standard Terms.
   %p
-    %h3.section-title
+    %h3.heading-medium
       5. Information on the Application
   %p
     You acknowledge that any information and other materials posted on the Application
     are not intended to amount to advice on which reliance should be placed.
   %p
-    %h3.section-title
+    %h3.heading-medium
       6. Availability of the Application
   %p
     We will use reasonable endeavours to make sure that the Application is
@@ -323,7 +326,7 @@
     %li
       make changes to the Application and any material on it
   %p
-    %h3.section-title
+    %h3.heading-medium
       7. Information Submitted Through the Application
   %p
     As an authorising organisation, you will make sure that:
@@ -359,7 +362,7 @@
     your Claims and submissions in accordance with the Legal Aid Legislation, and
     the Standard Terms where appropriate.
   %p
-    %h3.section-title
+    %h3.heading-medium
       8. Data Protection
 
   %p
@@ -438,17 +441,17 @@
     continue to apply for a period of six years following termination (howsoever
     caused) of your licence.
   %p
-    %h3.section-title
+    %h3.heading-medium
       9. Users and Passwords
   %p
-    %b
+    %h4.heading-small
       Advocate user 
   %p
     The Advocate user can create, edit, submit, view, manage and delete bills.
     However, the Advocate user can only create, edit, submit, view, manage
     and delete their own bills.
   %p
-    %b
+    %h4.heading-small
       Advocate administrator user
   %p
     The Advocate administrator user can create, edit, submit, view, manage
@@ -484,7 +487,7 @@
     you shall only use each username and password in accordance with the permissions
     and purposes authorised by the issuing Authorising Organisation.
   %p
-    %h3.section-title
+    %h3.heading-medium
       10. Intellectual Property Rights
   %p
     We are the owner or the licensee of all intellectual property rights in the
@@ -509,7 +512,7 @@
     you have made of any materials from the Application and we shall have the
     right to take action in accordance with section 13.
   %p
-    %h3.section-title
+    %h3.heading-medium
       11. Prohibited Uses
   %p
     You may not use the application:
@@ -556,7 +559,7 @@
     authorities by disclosing your identity. In the event of such a
     breach, your right to use the application will cease immediately.
   %p
-    %h3.section-title
+    %h3.heading-medium
       12. Links from the Application
   %p
     Where the Application contains links to other websites and resources
@@ -565,7 +568,7 @@
     websites or resources, and accept no responsibility for them or for
     any loss or damage that may arise from your use of them.
   %p
-    %h3.section-title
+    %h3.heading-medium
       13. Suspension and Termination
   %p
     We may revoke the licence granted to you in section 4 and terminate
@@ -600,7 +603,7 @@
     these Terms. The responses described in these Terms are not limited,
     and we may take any other action we reasonably consider appropriate.
   %p
-    %h3.section-title
+    %h3.heading-medium
       14. Liability
   %p
     In accordance with the Terms, the Authorising Organisation shall be
@@ -632,7 +635,7 @@
     or to your downloading of any content on it, or on any website linked
     to it.
   %p
-    %h3.section-title
+    %h3.heading-medium
       15. Changes to these Terms
   %p
     We may amend these Terms from time to time and we will notify you of
@@ -640,17 +643,17 @@
     are notified. Your continued use of the Application after this date shows
     your acceptance of such changes.
   %p
-    %h3.section-title
+    %h3.heading-medium
       16. Information About You and Your Visits to Our Site
   %p
-    %b
+    %h4.heading-small
       Your information
   %p
     We collect and process your Personal Data (such as your contact details
     and your IP address) in accordance with these Terms. By using the Application,
     you consent to this.
   %p
-    %b Cookies
+    %h4.heading-small Cookies
   %p
     We may use information obtained about you from cookies (files that your
     computer or other device sends to us) which we can access when you
@@ -659,7 +662,7 @@
   %p
     There are different kinds of cookies with different functions:
   %p
-    %b
+    %h4.heading-small
       Session cookies: 
     these cookies are only stored on your computer during your web session.
     They are automatically deleted when the browser is closed. They
@@ -667,7 +670,7 @@
     website without having to log in to each page. They do not collect
     any information from your computer.
   %p
-    %b
+    %h4.heading-small
       Persistent cookies: 
     a persistent cookie is stored as a file on your computer, and it
     remains there when you close your web browser. The cookie can be read
@@ -675,7 +678,7 @@
     do not use persistent cookies other than for Google Analytics (please
     see below for information on Google Analytics).
   %p
-    %b
+    %h4.heading-small
       Google Analytics: 
     The Application uses Google Analytics, a web analytics service provided
     by Google. Google Analytics uses cookies to analyse how the Application
@@ -690,7 +693,7 @@
     to Google processing your Personal Data in the manner and for the purposes
     set out above.
   %p
-    %b
+    %h4.heading-small
       Deleting cookies: 
     If you want to delete any cookies that are already on your computer,
     please read the instructions for your file management software to
@@ -706,7 +709,7 @@
     Application.
 
   %p
-    %h3.section-title
+    %h3.heading-medium
       17. Jurisdiction and Applicable Law
   %p
     These
@@ -721,7 +724,7 @@
     formation (including non-contractual disputes or claims).
 
   %p
-    %b
+    %h4.heading-small
       Contact Us
   %p
     You can write to us at: The Legal Aid Agency, 102 Petty France, London,

--- a/app/views/pages/timed_retention.html.haml
+++ b/app/views/pages/timed_retention.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'layouts/header', locals: {page_heading: 'Time-limited retention of claims'}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 - stale_weeks    = Settings.timed_transition_stale_weeks
 - archived_weeks = Settings.timed_transition_pending_weeks

--- a/app/views/shared/_claim_history.html.haml
+++ b/app/views/shared/_claim_history.html.haml
@@ -11,9 +11,10 @@
   .messages-print-link
     = link_to t('.print_messages'), open_messages_url, target: '_blank'
   .message-status
-    = "Status:"
+    = t('.status')
     %span.message-success
     %span.message-error
+
   - if show_message_controls?(claim)
     .js-controls.message-controls{"data-auth-url" => message_controls_url }
       = render partial: "shared/message_controls", locals: {message: @message }

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -2,18 +2,19 @@
   = hidden_field_tag :messages, 'true'
   .fx-assesment-hook
     #claim-status
-      %h3.heading-medium
-        = 'Assessment summary'
+      %h3#radio-control-heading.heading-medium{"aria-describedby": "radio-control-heading radio-control-legend"}
+        = t('.assessment_summary')
+
 
       - if current_user_is_caseworker?
         .js-cw-claim-action
-          %fieldset.form-group.inline.spacer{class: error_class?(@error_presenter, :determinations)}
-            %legend.bold-normal.form-label
-              = "Update the claim status"
+          %fieldset.form-group.inline.spacer{class: error_class?(@error_presenter, :determinations), "aria-describedby": "radio-control-legend"}
+            %legend#radio-control-legend.bold-normal.form-label
+              = t('.update_the_claim_status')
             = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last ) do |b|
               .multiple-choice
-                = b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state]&.to_sym))
-                = b.label { b.text }
+                = b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state]&.to_sym), "aria-labelledby": "radio-control-legend #{b.text.to_css_class}")
+                = b.label(id: b.text.to_css_class) { b.text }
             %div
               = validation_error_message(@error_presenter, :determinations)
 
@@ -22,7 +23,7 @@
           %tr{:style => "vertical-align: top;"}
             %th &nbsp;
             %th
-              = t('shared.assessment.claimed_by', type: claim.external_user_description)
+              = t('.claimed_by', type: claim.external_user_description)
             %th
               Total authorised by LAA
               - if claim.opened_for_redetermination?
@@ -50,47 +51,48 @@
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
       .js-cw-claim-rejection-reasons{style: 'display:none', class: error_class?(@error_presenter, :rejected_reason)}
-        %fieldset.form-group.nested-fields.indent-fieldset.spacer
+        %fieldset.form-group.nested-fields.indent-fieldset.spacer{"aria-describedby": "checkbox-control-legend-1"}
           %div
             = validation_error_message(@error_presenter, :rejected_reason)
           %a#rejected_reason
-          %legend.bold-normal.form-label
-            = "Choose reason for rejection"
+          %legend.bold-normal.form-label#checkbox-control-legend-1
+            = t('.reason_for_rejection')
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
             .multiple-choice
-              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value))
-              = b.label { b.text }
+              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), "aria-labelledby": "checkbox-control-legend-1 #{b.text.to_css_class}")
+              = b.label(id: b.text.to_css_class) { b.text }
 
           %fieldset.form-group.nested-fields.fieldset.spacer.js-reject-reason-text{style: 'display:none; padding-top:10px;', class: error_class?(@error_presenter, :rejected_reason_other)}
             %div
               %a#rejected_reason_other
-              = f.label :reject_reason_text, 'Reason text'
-              .form-hint.xsmall These reasons will be displayed to providers
+              = f.label :reject_reason_text, t('.reason_text')
+              .form-hint.xsmall
+                = t('.reason_hint')
               = f.text_field :reject_reason_text, {class: 'form-control'}
               %div
                 = validation_error_message(@error_presenter, :rejected_reason_other)
 
       .js-cw-claim-refuse-reasons{style: 'display:none', class: error_class?(@error_presenter, :refused_reason)}
-        %fieldset.form-group.nested-fields.indent-fieldset.spacer
+        %fieldset.form-group.nested-fields.indent-fieldset.spacer{"aria-describedby": "checkbox-control-legend-2"}
           %div
             = validation_error_message(@error_presenter, :refused_reason)
           %a#refused_reason
-          %legend.bold-normal.form-label
-            = "Choose reason for refusal"
+          %legend.bold-normal.form-label#checkbox-control-legend-2
+            = t('.reason_for_refusal')
 
           = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
             .multiple-choice
-              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value))
-              = b.label { b.text }
+              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), "aria-labelledby": "checkbox-control-legend-2 #{b.text.to_css_class}")
+              = b.label(id: b.text.to_css_class) { b.text }
 
           %fieldset.form-group.nested-fields.fieldset.spacer.js-refuse-reason-text{style: 'display:none; padding-top:10px;', class: error_class?(@error_presenter, :refused_reason_other)}
             %div
               %a#refused_reason_other
-              = f.label :refuse_reason_text, 'Reason text'
+              = f.label :refuse_reason_text, t('.reason_text')
               .form-hint.xsmall These reasons will be displayed to providers
               = f.text_field :refuse_reason_text, {class: 'form-control'}
               %div
                 = validation_error_message(@error_presenter, :refused_reason_other)
 
       %p
-        = f.submit 'Update', class: 'button', id: 'button'
+        = f.submit t('.update'), class: 'button', id: 'button'

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -3,12 +3,16 @@
 
   - if current_user_persona_is?(ExternalUser) && @claim.redeterminable?
     .js-hide-status
-      = f.label t('.update_claim_status'), class: "form-label bold-normal"
-      .form-group.inline.js-test-claim-action
-        = f.collection_radio_buttons(:claim_action, Claims::ExternalUserActions.available_for(@claim), :to_s, :to_s) do |b|
-          .multiple-choice
-            = b.radio_button
-            = b.label { b.value.humanize }
+      %fieldset.inline{"aria-describedby": "radio-control-legend-1"}
+        %legend#radio-control-legend-1
+          %span.form-label-bold
+            = t('.update_claim_status')
+
+        .form-group.inline.js-test-claim-action
+          = f.collection_radio_buttons(:claim_action, Claims::ExternalUserActions.available_for(@claim), :to_s, :to_s) do |b|
+            .multiple-choice
+              = b.radio_button("aria-labelledby": "radio-control-legend-1 #{b.text.to_css_class}")
+              = b.label(id: b.value.to_css_class) { b.value.humanize }
 
   - if messaging_permitted?(message) || current_user_is_caseworker?
     .grid-row.js-test-send-buttons

--- a/app/views/shared/_scheme_filters.html.haml
+++ b/app/views/shared/_scheme_filters.html.haml
@@ -1,15 +1,13 @@
 - if show_claim_list_scheme_filters?(available_schemes)
   .column-half.form-group
-    %fieldset.inline.js-claim-scheme-filter
+    %fieldset.inline.js-claim-scheme-filter{"aria-describedby": "radio-control-hint"}
       %legend
-        = t('.scheme_filter')
-      .form-hint.xsmall.zero-vert-margin
-        = t('.scheme_filter_hint')
+        %span.form-label-bold
+          = t('.scheme_filter')
+        %span#radio-control-hint.form-hint.xsmall.zero-vert-margin
+          = t('.scheme_filter_hint')
       - [:all].concat(available_schemes).each do |filter_scheme|
         .multiple-choice
           = radio_button_tag :scheme, filter_scheme, scheme.blank? ? filter_scheme == :all : scheme == filter_scheme
           = label_tag "scheme_#{filter_scheme}", nil, class: "block-label" do
             = filter_scheme == :all ? t('.scheme_filter_all') : filter_scheme.upcase
-
-
-

--- a/app/views/shared/providers/_form.html.haml
+++ b/app/views/shared/providers/_form.html.haml
@@ -9,19 +9,19 @@
 
     // Provider type
     .form-group#js-provider-type.jqr-delegate-hook{class: @provider.errors[:provider_type].any? ? "error" : ""}
-      %fieldset.inline#provider_provider_type
-        %legend.form-label-bold
-          = t('.provider_type')
-
-        = f.collection_radio_buttons(:provider_type, Provider::PROVIDER_TYPES, :to_s, :to_s, include_hidden: false) do |b|
-          .multiple-choice
-            = b.radio_button(class: "jqr-publisher",  "data-jqr-publish-events": "/provider/type/")
-            = b.label { b.value.capitalize }
-
+      %fieldset.inline#provider_provider_type{"aria-describedby": "radio-control-legend"}
+        %legend#radio-control-legend
+          %span.form-label-bold
+            = t('.provider_type')
+        .form-group
+          = f.collection_radio_buttons(:provider_type, Provider::PROVIDER_TYPES, :to_s, :to_s, include_hidden: false) do |b|
+            .multiple-choice
+              = b.radio_button(class: "jqr-publisher",  "data-jqr-publish-events": "/provider/type/", "aria-labelledby": "radio-control-legend #{b.text.to_css_class}")
+              = b.label(id: b.value.to_css_class) { b.value.capitalize }
 
     #js-fee-schemes.form-group.jqr-delegate-hook.jqr-subscriber{style: "display: none;", "data-jqr-subscribe-events": "/provider/type/", "data-jqr-subscribe-values": "chamber|firm", class: @provider.errors[:roles].any? ? "error" : ""}
-      %fieldset.inline#provider_roles
-        %legend
+      %fieldset.inline#provider_roles{"aria-describedby": "checkbox-control-legend-provider"}
+        %legend#checkbox-control-legend-provider
           %h1.heading-medium
             = t('.fee_schemes')
           %span.form-hint
@@ -33,8 +33,8 @@
           - jqr_publish_events = "/scheme/type/" + b.value + "/"
 
           .multiple-choice
-            = b.check_box(class: "jqr-publisher", "data-jqr-publish-events": jqr_publish_events)
-            = b.label(class: 'block-label jqr-subscriber', "data-jqr-subscribe-events": "/provider/type/", "data-jqr-subscribe-values": jqr_subscribe_values) { b.value.upcase }
+            = b.check_box(class: "jqr-publisher", "data-jqr-publish-events": jqr_publish_events, "aria-labelledby": "checkbox-control-legend-provider #{b.text.to_css_class}")
+            = b.label(class: 'block-label jqr-subscriber', "data-jqr-subscribe-events": "/provider/type/", "data-jqr-subscribe-values": jqr_subscribe_values, id: b.value.to_css_class) { b.value.upcase }
 
     #js-agfs-supplier-number.jqr-subscriber{style: "display: none;", "data-jqr-subscribe-events": "/scheme/type/agfs/custom/", "data-jqr-subscribe-values": "show-agfs-supplier" }
       = f.adp_text_field :firm_agfs_supplier_number, id: 'firm_agfs_supplier_number', label: t('.agfs_supplier_number'), error_key: 'firm_agfs_supplier_number'
@@ -44,17 +44,18 @@
 
     #js-vat.form-group.jqr-subscriber{style: "display: none;", "data-jqr-subscribe-events": "/scheme/type/lgfs/custom/", "data-jqr-subscribe-values": "show-lgfs-supplier", class: @provider.errors[:vat_registered].any? ? "form-group-error" : "" }
       %a#vat_registered
-      %fieldset.inline
+
+      %fieldset.inline#provider_vat_status{"aria-describedby": "radio-control-legend-1"}
         %legend
-          %h1.heading-medium
+          %h1#radio-control-legend-1.heading-medium
             = t('.vat_registered')
-          %span.form-hint
+          %span.form-label-bold
             = t('.vat_registered_hint')
 
         = f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s, include_hidden: false) do |b|
           %div.multiple-choice
-            = b.radio_button
-            = b.label { (b.value.to_s == 'true' ? 'Yes' : 'No') }
+            = b.radio_button("aria-labelledby": "radio-control-legend-1 #{b.text.to_css_class}")
+            = b.label(id: b.value.to_css_class) { (b.value.to_s == 'true' ? 'Yes' : 'No') }
 
         = validation_error_message(@provider, :vat_registered)
 

--- a/app/views/shared/providers/_form.html.haml
+++ b/app/views/shared/providers/_form.html.haml
@@ -2,7 +2,7 @@
   = form_for @provider, url: form_url, builder: AdpFormBuilder, html: { novalidate: true } do |f|
 
     // Error summary
-    = render partial: 'errors/error_summary', locals: { ep: @provider, error_summary: t('.prohibited_save') }
+    = render partial: 'errors/error_summary', locals: { ep: @provider, error_summary: t('.error_summary') }
 
     //Provider name
     = f.adp_text_field :name, id: 'name', label: t('.provider_name'), hint_text: t('.provider_name_hint')

--- a/app/views/shared/providers/edit.html.haml
+++ b/app/views/shared/providers/edit.html.haml
@@ -4,7 +4,7 @@
 = content_for :v2_stylesheets do
   = stylesheet_link_tag "v2/application", media: "all"
 
-= render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading', provider_name: @provider.name)}
 
 .grid-row
   .column-full

--- a/app/views/super_admins/admin/super_admins/change_password.html.haml
+++ b/app/views/super_admins/admin/super_admins/change_password.html.haml
@@ -4,7 +4,7 @@
 = content_for :v2_stylesheets do
   = stylesheet_link_tag "v2/application", media: "all"
 
-= render partial: 'layouts/header', locals: {page_heading: t('.heading')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = form_for [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path do |f|
   - if @super_admin.user.errors.any?

--- a/app/views/super_admins/external_users/_form.html.haml
+++ b/app/views/super_admins/external_users/_form.html.haml
@@ -27,25 +27,31 @@
         = user_fields.label t(".email_confirmation"), class: "form-label-bold", for: "external_user_user_attributes_email_confirmation"
         = user_fields.email_field :email_confirmation, class: "form-control"
 
-    %fieldset.user-form
-      = f.label :roles, class: "form-label"
+    %fieldset.inline{"aria-describedby": "checkbox-control-legend-roles"}
+      %legend#checkbox-control-legend-roles
+        %span.form-label-bold
+          = t('.roles')
+
       .form-group.inline.js-advocate-roles
         = f.collection_check_boxes(:roles, @external_user.available_roles, :to_s, :to_s) do |b|
           .multiple-choice
-            = b.check_box
-            = b.label { b.value.humanize }
+            = b.check_box("aria-labelledby": "checkbox-control-legend-roles #{b.text.to_css_class}")
+            = b.label(id: b.value.to_css_class) { b.value.humanize }
+
 
     - if @provider.chamber?
-      .js-chamber-advocates-only
-        = f.label(:vat_registered, t('.apply_vat'), class: "form-label")
-        .form-group.inline
-          = f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
-            .multiple-choice
-              = b.radio_button
-              = b.label { (b.value.to_s == 'true' ? 'Yes' : 'No') }
+      .form-group{"aria-describedby": "radio-control-legend"}
+        %fieldset.inline
+          %legend#radio-control-legend
+            %span.form-label-bold
+              = t('.apply_vat')
+            = f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
+              .multiple-choice
+                = b.radio_button("aria-labelledby": "radio-control-legend #{b.text.to_css_class}")
+                = b.label(id: b.value.to_css_class) { (b.value.to_s == 'true' ? 'Yes' : 'No') }
 
-        .form-group
-          = f.label t(".supplier_number"), class: "form-label", for: "external_user_supplier_number"
-          = f.text_field :supplier_number, class: "form-control"
+      .form-group
+        = f.label t(".supplier_number"), class: "form-label", for: "external_user_supplier_number"
+        = f.text_field :supplier_number, class: "form-control"
 
     = f.submit t('.submit'), class: "button"

--- a/app/views/super_admins/external_users/edit.html.haml
+++ b/app/views/super_admins/external_users/edit.html.haml
@@ -1,6 +1,9 @@
 = content_for :page_title, flush: true do
   = t('.page_title', external_user: @external_user.name)
 
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
 = render partial: 'layouts/header', locals: {page_heading:  t('.page_heading')}
 
 %h2.heading-medium

--- a/app/views/super_admins/external_users/find.html.haml
+++ b/app/views/super_admins/external_users/find.html.haml
@@ -4,7 +4,7 @@
 = content_for :v2_stylesheets do
   = stylesheet_link_tag "v2/application", media: "all"
 
-= render partial: 'layouts/header', locals: {page_heading: t('.page_title')}
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 = form_for(:external_user, url: super_admins_external_users_find_path) do |f|
   .form-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
       add_a_provider: Add a provider
       allocation: Allocation list
       api_documentation: API Documentation
-      archive: Archive list
+      archive: Your claim archive
       error: There was an error
       find_provider_by_email: Find provider by email
       manage_provider: Manage provider
@@ -37,12 +37,31 @@ en:
       your_claims: Your claims
       re_allocation: Re-allocation
       sidekiq_console: Sidekiq console
-      all_claims: All claims list
+      all_claims: Your claims
       sub_navigation: Sub navigation
+  json_template:
+    index:
+      page_heading: Claim for crown court defence API
   pages:
+    api_landing:
+      page_heading: Claim for crown court defence API
+    api_release_notes:
+      page_heading: API release notes
+    servicedown:
+      page_heading: The service is unavailable
+    timed_retention:
+      page_heading: Time-limited retention of claims
     tandcs:
       page_title: Terms and conditions for claim for Crown court defence
-
+      page_heading: Terms and conditions
+    contact_us:
+      page_title: Contact us
+      page_heading: Contact us
+  errors:
+    internal_server_error:
+      page_heading: 500 - internal server error
+    not_found:
+      page_heading: 404 - not found
   date: Date
   distance:
     unit:
@@ -129,8 +148,6 @@ en:
     how_is_this_calculated_help: &how_is_this_calculated_help How is this calculated?
     miscellaneous_fees: &miscellaneous_fees Miscellaneous fees
     miscellaneous_fee: &miscellaneous_fee Miscellaneous fee
-
-
   activemodel:
     attributes:
       feedback:
@@ -251,7 +268,6 @@ en:
             rate:
               blank: Rate cannot be blank
               numericality: Rate must be greater than or equal to 0
-
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'
@@ -339,7 +355,6 @@ en:
     calculate:
       amount_unavailable: The calculated rate is unavailable, please enter manually.
 
-
 # en.super_admins
   super_admins:
     admin:
@@ -349,7 +364,7 @@ en:
           add_super_admin: 'Add Super administrator'
           edit: Edit
           page_heading: Your account
-          change_password: Change password
+          change_password: &change_password Change password
         edit:
           page_heading: Edit super administrator details
           edit_super_admin: 'Edit user'
@@ -372,9 +387,9 @@ en:
           current_password: Current password
           password: *password
           password_confirmation: *password_confirmation
-          submit: 'Change password'
+          submit: *change_password
           page_title: Change %{super_admin}'s password
-          heading: Change password
+          page_heading: Change password
     providers:
       provider_type: &provider_type 'Provider type'
       provider_name: &provider_name 'Provider name'
@@ -445,7 +460,7 @@ en:
         vat_registered: VAT registered
         role: Role
         edit: Edit
-        change_password: Change password
+        change_password: *change_password
         answer_yes: "Yes"
         answer_no:  "No"
         manage_user: Manage user
@@ -476,6 +491,7 @@ en:
       find:
         email: *email
         submit: 'Search'
+        page_heading: Find provider by email
         page_title: Find provider by email
       change_password:
         error: 'error'
@@ -483,25 +499,27 @@ en:
         current_password: Current password
         password: *password
         password_confirmation: *password_confirmation
-        submit: 'Change password'
+        submit: *change_password
         page_title: Change %{external_user}'s password
         heading: Change password for %{external_user}
         page_heading: Manage users
 
 # en.external_users
   external_users:
+    agfs_claim_heading: Claim for advocate fees
+    lgfs_claim_heading: Claim for litigator fees
+    claim_heading: Claim for Crown court fees
     claim_types_helper:
       claim_type_page_header:
         page_title_advocate: Choose a bill type for advocate claim
         page_title_litigator: Choose a bill type for litigator claim
         page_title_generic: Choose a bill type for Crown court claim
-
     admin:
       external_users:
         advocates:
         index:
           title: 'Manage users'
-          page_heading: 'Manage users'
+          page_heading: Manage %{provider_name}'s users
           actions: Manage details
           advocates: 'Users'
           add_advocate: 'Add User'
@@ -523,14 +541,14 @@ en:
           confirmation: Are you sure?
         new:
           error: 'error'
-          new_advocate: 'New user'
-          prohibited_save: 'This user has'
+          page_heading: Add a new user to %{provider_name}
+          error_summary: This user has
           page_title_firm: Add a user to your firm's account
           page_title_chamber: Add a user to your chambers' account
         edit:
-          edit_advocate: 'Edit user'
+          page_heading: Edit %{external_user}'s details
           error: 'error'
-          prohibited_save: 'This user has'
+          error_summary: This user has
           page_title: Edit user account details for %{external_user}
         form:
           email: *email
@@ -544,13 +562,14 @@ en:
           submit: 'Create user'
         change_password:
           error: 'error'
-          prohibited_save: This user password change has
+          error_summary: This user password change has
           current_password: Current password
           password: *password
           password_confirmation: *password_confirmation
-          submit: Change password
+          submit: *change_password
           page_title: Change your password
-          change_password: Change password
+          page_heading: *change_password
+          change_password: *change_password
         show:
           page_title: View your account details
           table_caption: Your account details
@@ -559,7 +578,7 @@ en:
           roles: 'Roles:'
           supplier_number: 'Supplier number:'
           edit: Edit
-          change_password: Change password
+          change_password: *change_password
           page_heading: Your account
 
 
@@ -576,7 +595,7 @@ en:
           supplier_number: *supplier_number
           vat_registered: *vat_registered
           api_key: *api_key
-          page_heading: Manage provider
+          page_heading: Manage %{provider_name}
           page_title: "View %{provider_name}'s details"
           lgfs_supplier_numbers: "LGFS supplier numbers"
           firm_agfs_supplier_number: "AGFS supplier number"
@@ -600,23 +619,26 @@ en:
           form_error_hint: 'Check below for more detail'
           page_title_firm: Edit your firm's account
           page_title_chamber: Edit your chambers' account
-    all_claims: All claims list
-    your_claims: Your claims list
+    all_claims: Your claims
+    your_claims: Your claims
     claim_heading: Claim for Crown Court fees
-    agfs_claim_heading: Claim for advocate fees
-    lgfs_claim_heading: Claim for litigator fees
+
     certifications:
       new:
-        prohibited_save: This claim certification has
+        submit: Certify and submit claim
+        return: Return to claim
+        error_summary: This claim certification has
         certified_by: 'Name of person certifying'
         certified_by_prompt_text: 'Enter full name'
         certification_date: 'Date'
         date: 'Date'
         page_title_transfer_claim: Certify and submit the litigator transfer fees claim
         page_title_advocate_claim: advocate claim
+        page_heading: Certification
         page_title:
           agfs_final: Certify and submit the advocate final fees claim
           agfs_interim: Certify and submit the advocate warrant fees claim
+          agfs_supplementary: Certify and submit the advocate supplementary fees claim
           lgfs_final: Certify and submit the litigator final fees claim
           lgfs_interim: Certify and submit the litigator interim fees claim
           lgfs_transfer: Certify and submit the litigator transfer fees claim
@@ -629,6 +651,7 @@ en:
         page_title_advocate: Choose a bill type for advocate claim
         page_title_litigator: Choose a bill type for litigator claim
         page_title_generic: Choose a bill type for Crown court claim
+        page_title_advocate: Claim for advocate fees
         agfs_rb: Advocate final fee
         agfs_supplementary_rb: Advocate supplementary fee
         agfs_supplementary_hint: For miscellaneous fees claimed without a graduated or fixed fee
@@ -659,18 +682,18 @@ en:
       additional_information:
         fields:
           additional_information: 'Additional information'
-          additional_information_prompt_text: 'for example any other information that will help us process your claim'
+          additional_information_prompt_text: Provide any information that will help in the assessment of your claim
         summary:
           header: Additional information
           not_available: No additional information has been provided
           change: Change
           change_link_label: Change additional information
       archived:
-        archived_claims: 'Archived claims'
-        archived_claim: 'archived claim'
+        page_heading: Your claim archive
+        archived_claim: Your claim archive
         page_title: View your claims archive
       authorised:
-        authorised_claims: 'Authorised claims for last week'
+        page_heading: Your authorised claims
         with_total_assessed_value_of: 'claims with a total assessed value of'
         page_title: View your authorised claims
       basic_fees:
@@ -809,8 +832,11 @@ en:
           npw_section_hint: Total number of prosecution witnesses
           total: Total
         fields:
+          page_header: Graduated fees
+          page_hint: All fees should be entered exclusive of VAT.
           amount: 'Amount'
           basic_fees: 'Initial fees'
+          heading: Basic fees
           fee_prompt_text: |
             You must enter a quantity and rate.  Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a>
             for help.
@@ -941,7 +967,6 @@ en:
           change: Change
           change_link_label: Change offence details
         selected_offence_header: 'You have chosen the following offence details:'
-
       defendants:
         defendant_fields:
           first_name: *first_name
@@ -953,10 +978,11 @@ en:
           order_for_judicial_apportionment_help: Judicial apportionment is when the defendant has applied for and received an order confirming they are not required to pay the full amount of their defence costs. If applicable, please ensure you upload a copy of the order to your claim.
           add_another_rep_order: 'Add another representation order'
           remove_defendant: 'Remove defendant'
-          defendant: Defendant details
+          defendant: Defendant
         fields:
           defendants: 'Defendants'
           add_another_defendant: 'Add another defendant'
+          page_heading: Defendant details
         representation_order_fields:
           date: Representation order date
           representation_order: Representation order details
@@ -973,7 +999,6 @@ en:
           common:
             defendant_index: Defendant %{index}
             defendant_reporder: Defendant %{index} representation order %{index}
-
       main_claims_list:
         amount_assessed_sort_label: 'Sort by: Amount assessed'
         last_submitted_at_sort_label: 'Sort by: Last submitted at date'
@@ -1115,7 +1140,7 @@ en:
           transfer_date_default_label_text: Date stopped/started acting
           case_conclusions: How did the case conclude?
         summary:
-          header: Transfer fee
+          header: Transfer fees
           litigator_type: Litigator type
           elected_case: Was the case elected?
           transfer_stage_new: When did you start acting?
@@ -1131,26 +1156,34 @@ en:
         prohibited_save: This claim has
         error: 'error'
         form_error_hint: 'Check below for more detail'
+
       summary:
         button_label: *continue_to_certification_button
-        heading: Check your claim
+        page_heading: Check your claim
         case_details: Case details
         agfs:
           advocate_claim:
             page_title: View claim summary for advocate final fees claim
+            page_heading: Claim for advocate final fee
           advocate_supplementary_claim:
             page_title: View claim summary for advocate supplementary fee claim
+            page_heading: Claim for advocate supplementary fee
           advocate_interim_claim:
             page_title: View claim summary for advocate warrant fees claim
+            page_heading: Claim for advocate interim fee
         lgfs:
           final_claim:
             page_title: View claim summary for litigator final fees claim
+            page_heading: Claim for litigator final fee
           litigator_claim:
             page_title: View claim summary for litigator final fees claim
+            page_heading: Claim for litigator final fee
           interim_claim:
             page_title: View claim summary for litigator interim fees claim
+            page_heading: Claim for litigator interim fee
           transfer_claim:
             page_title: View claim summary for litigator transfer fees claim
+            page_heading: Claim for litigator transfer fee
         page_title: View claim summary for litigator transfer fees claim
       fee_fields:
         add_date_attended: 'Add dates'
@@ -1158,6 +1191,7 @@ en:
       fixed_fees:
         advocates:
           fields:
+            type_of_fee: Type of fee
             add_fixed_fee: 'Add another fee'
             amount: 'Amount'
             fixed_fees: 'Fixed fees'
@@ -1185,7 +1219,7 @@ en:
             fixed_fees: "Fixed fees"
             fee_type: *fee_type
             quantity: *quantity
-            quantity_hint: 'Enter a quantity'
+            quantity_hint: Enter a quantity
             rate: *rate
             amount: Total
             prompt_text_html: *graduated_fee_calculators_help
@@ -1256,7 +1290,7 @@ en:
         authorised_claim_details_label: View authorised claims details
       graduated_fees:
         fields:
-          page_header: Graduated fee
+          page_header: Graduated fees
           page_hint: *fees_vat_prompt
           actual_trial_length: *actual_trial_length
           actual_trial_length_hint: Number of days
@@ -1266,7 +1300,7 @@ en:
           help_how_we_calculate_amount_title: *how_is_this_calculated_help
           help_how_we_calculate_amount_body: We calculate the amount based upon the fee scheme, case type, offence class, trial length, the total pages of evidence, and number of defendants
         summary:
-          header: Graduated fee
+          header: Graduated fees
           actual_trial_length:
             one: 1 day
             other: "%{count} days"
@@ -1278,7 +1312,7 @@ en:
         rejected: Rejected
         submitted: Submitted to LAA
         show_count: 'Showing %{page_count} of %{total} claims'
-        page_title: View your claims list
+        page_title: View your claims
       interim_claim_info:
         fields: &interim_claim_info_fields
           warrant_fee: Warrant fees
@@ -1291,7 +1325,7 @@ en:
       json_document_importer:
         import_claim: Or upload your claims in JSON format
       outstanding:
-        heading: Outstanding claims
+        page_heading: Your outstanding claims
         claims_value: claims with a total value of
         page_title: View your outstanding claims
       supporting_documents:
@@ -1310,6 +1344,10 @@ en:
           choose_file: 'Choose a file'
           file_name: "File name"
           supporting_evidence_docs: 'Upload supporting evidence'
+          supporting_evidence: Supporting evidence
+          file_upload_message: Drag and drop files here
+          legend: Upload supporting evidence
+          or: or
       supporting_evidence:
         summary:
           header: Supporting evidence
@@ -1324,7 +1362,8 @@ en:
           caption: 'Supporting evidence: This section contains a list of all the documents that you have told us have been uploaded.'
           header: Supporting evidence
         fields:
-          supporting_evidence_checklist: 'Supporting evidence checklist'
+          supporting_evidence_checklist: Supporting evidence checklist
+          supporting_evidence_checklist_hint: Select all that apply
       warrant_fee:
         summary:
           caption: 'Warrant Fees: This section contains details of any warrant fees that have been claimed.'
@@ -1399,6 +1438,8 @@ en:
         total: 'Total'
         no_fees: 'No fees for this claim'
         no_disbursements: 'No disbursements for this claim'
+      show:
+        page_title: Case details
     expenses:
       distances:
         create:
@@ -1485,6 +1526,7 @@ en:
 
         defendants_form_step:
           page_title: Enter defendant details for advocate supplementary fee claim
+          page_heading: Defendant details
 
         miscellaneous_fees_form_step:
           page_title: Enter miscellaneous fees for advocate supplementary fee claim
@@ -1496,6 +1538,7 @@ en:
           page_title: Upload supporting evidence for advocate msupplementary fee claim
 
     litigators:
+
       interim_claims:
         new:
           page_title: &lgfs_interim_claims_title Enter case details for litigator interim fees claim
@@ -1577,6 +1620,7 @@ en:
 
         fixed_fees_form_step:
           page_title: Enter fixed fees for litigator final fees claim
+          page_header: Fixed fees
 
         offence_details_form_step:
           page_title: Enter offence details for litigator final fees claim
@@ -1598,7 +1642,6 @@ en:
 
         warrant_fees_form_step:
           page_title: Enter warrant fees for litigator final fees claim
-
   shared:
     claim_header:
       case_number: 'Case number:'
@@ -1682,7 +1725,7 @@ en:
         section_heading: Add provider details
         page_title: Add a provider to claim for Crown court defence
       edit:
-        page_heading: Settings
+        page_heading: Edit %{provider_name}'s details
         section_heading: Edit provider details
         page_title: "Edit %{provider_name}'s details"
       form:
@@ -1702,7 +1745,7 @@ en:
             supplier_name: For example, the city or street name
             postcode: For example, SW11 1AA
             supplier_number: For example, 1A234B
-        prohibited_save: 'This provider has'
+        error_summary: 'This provider has'
         provider_name: *provider_name
         provider_name_hint: The trading name of the Chamber or Firm
         provider_type: *provider_type
@@ -1817,6 +1860,7 @@ en:
         defendants: "There are no defendants for this claim"
         disbursements: "There are no disbursements for this claim"
         fixed_fees: "There are no fixed fees for this claim"
+        transfer_fee: "There are no transfer fee for this claim"
         graduated_fees: "There are no graduated fees for this claim"
         interim_fee: "There is no interim fee for this claim"
         misc_fees: "There are no miscellaneous fees for this claim"
@@ -1956,7 +2000,6 @@ en:
       scheme_filter_hint: 'Configure list below by AGFS and LGFS claims'
       scheme_filter: 'Filter list by:'
       scheme_filter_all: 'All'
-
   case_workers:
     table_headings:
       your_claims: Your claims
@@ -1989,8 +2032,10 @@ en:
           roles: Roles
           save: Save
         change_password:
+          change_password: Change password
+          page_heading: Change password
           error: 'error'
-          prohibited_save: 'This case worker password change has'
+          prohibited_save: This case worker password change has
           current_password: Current password
           password: *password
           password_confirmation: *password_confirmation
@@ -1998,10 +2043,18 @@ en:
           page_title: Change your password
         new:
           page_title: Add a caseworker
+          error_summary: 'This case worker has '
+          page_heading: New case worker details
         edit:
           page_title: Edit %{caseworker}'s details
+          error_summary: 'This case worker has '
+          page_heading: Edit case worker details
         show:
           page_title: View %{caseworker}'s details
+          change_password: *change_password
+          edit: Edit
+          page_heading: Your account
+          roles: Roles
       allocations:
         filter_value_bands:
           all: All
@@ -2113,7 +2166,7 @@ en:
           invalid_report_type: *invalid_report_type
         index:
           page_title: View management information
-          h1_managment_info: Management information
+          page_heading: Management information
           all_claims_report: 'All claims report'
           report_generated_at: "The latest report was generated at %{time}"
           day: Day
@@ -2138,7 +2191,7 @@ en:
         job_scheduled: 'A background job has been scheduled to regenerate the report. Please refresh this page in a few minutes.'
     claims:
       archived:
-        archived_claims: Archived claims
+        page_heading: Archived claims
         page_title: View the claim archive
       determination_fields:
         disbursements: Disbursements
@@ -2153,32 +2206,32 @@ en:
         vat_rate: "VAT (%{vat_rate})"
         vat_rate: "Total (including %{vat_rate} VAT)"
       index:
-        your_claims: Your claims
+        page_heading: Your claims
         page_title: View your allocated claims list
       claims_list:
-        type: Type
-        advocate_litigator: *advocate_litigator
-        case_number: Case number
         advocate: Advocate
-        defendants: Defendants
+        advocate_litigator: *advocate_litigator
+        advocate_sort_label: 'Sort by: Provider name'
+        case_number: Case number
+        case_number_sort_label: 'Sort by: Case number'
         case_type: Case type
-        total: Claimed
-        status: Status
-        submission_date: Date submitted
+        case_type_sort_label: 'Sort by: Case type'
+        defendants: Defendants
+        disk_evidence: Disk evidence
+        last_submitted_at_sort_label: 'Sort by: Last submitted at date'
         messages: Messages
         none: None
-        advocate_sort_label: 'Sort by: Provider name'
-        case_number_sort_label: 'Sort by: Case number'
-        case_type_sort_label: 'Sort by: Case type'
-        last_submitted_at_sort_label: 'Sort by: Last submitted at date'
-        state_sort_label: 'Sort by: Claim state'
-        total_inc_vat_sort_label: 'Sort by: Claimed amount'
-        type_sort_label: 'Sort by: Claim type'
         number_of_claims: 'Number of claims: '
+        state_sort_label: 'Sort by: Claim state'
+        status: Status
+        submission_date: Date submitted
+        total: Claimed
+        total_inc_vat_sort_label: 'Sort by: Claimed amount'
+        type: Type
+        type_sort_label: 'Sort by: Claim type'
         view: *view
         view_messages_label: "View Messages for Case number %{case_number}"
         view_with_messages: "View (%{message_count} new)"
-
       hint:
         search: for example case number, MAAT reference, defendant name, case worker name or email
       interim_claim_info:
@@ -2191,10 +2244,19 @@ en:
         completed_claims_count: Completed claims (%{completed_claims_count})
         current_claims_count: Allocated claims (%{current_claims_count})
         unallocated_claims_count: Allocated claims (%{unallocated_claims_count})
+      claims_sidebar:
+        advocate_details: Advocate details
+        completed_claims: Completed claims
+        current_claims: Current claims
+        dashboard: Dashboard
+        payments: Payments
+        reporting_tool: Reporting tool
   devise:
     sessions:
       new:
         page_title: Sign in to claim for Crown court defence
+        page_heading: Sign in
+        sign_in: Sign in
     shared:
       links:
         sign_in: Sign in
@@ -2207,12 +2269,20 @@ en:
     passwords:
       new:
         page_title: Retrieve your password for claim for Crown court defence
+        send_button: Send me password reset instructions
+        page_heading: Forgot your password?
       edit:
-        prohibited_save: This password change has
+        change_password: *change_password
+        confirm_your_password: Confirm your password
+        error_summary: 'This password change has '
+        page_heading: Change your password
         page_title: Change your password for claim for Crown court defence
+        new_password: New password
     unlocks:
       new:
+        page_heading: Resend password reset instructions
         page_title: Resend unlock instructions for claim for Crown court defence
+        submit: Resend unlock instructions
   validators:
     advocate:
       category: 'Advocate category must be one of those in the provided list'
@@ -2317,5 +2387,23 @@ en:
 
 # en.feedback
   feedback:
+    bug_report:
+      page_title: Bug report
+      page_heading: Help us improve this service
+      error_summary: 'The form you submitted has '
+      intro: |
+        Tell us about your experience of using this service today. Your answers to the following questions will help us improve the service.
+      case_number_label: Case number / Unique ID
+      case_number_hint: |
+        If your issue is related to a particular claim, provide the case number along with the unique ID you will find next to it (starts with #)
+      event_label: What you were doing when the fault occurred?
+      event_hint: Include as much information as possible, including the fee scheme (Advocate, Litigator final, Litigator interim or Litigator transfer) and case type
+      outcome_label: What went wrong?
     feedback:
       page_title: Help us improve this service
+      error_summary: 'This feedback has '
+      page_heading: 'Help us improve this service'
+      callout: 'We will use your answers to the questions below to help us build a better service.'
+      comment: 'Tell us about your experience of using this service today.'
+      comment_hint: "Don't include any personal or sensitive information."
+      send: Send

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,7 +18,6 @@
 #
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   layouts:
     primary_navigation:
@@ -144,7 +143,7 @@ en:
     not_provided: *not_provided
     not_applicable: *not_applicable
   content:
-    graduated_fee_calculators_help: &graduated_fee_calculators_help Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators init</a> for help.
+    graduated_fee_calculators_help: &graduated_fee_calculators_help Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fees Calculator">graduated fees calculators init</a> for help.
     how_is_this_calculated_help: &how_is_this_calculated_help How is this calculated?
     miscellaneous_fees: &miscellaneous_fees Miscellaneous fees
     miscellaneous_fee: &miscellaneous_fee Miscellaneous fee
@@ -153,7 +152,7 @@ en:
       feedback:
         heading: 'Help us improve this service'
         callout: 'We will use your answers to the questions below to help us build a better service.'
-        rating: 'Overall, how satisfied were you with this service?'
+
         comment: 'Tell us about your experience of using this service today.'
         comment_hint: "Don't include any personal or sensitive information."
         email: 'What is your email address? (Optional)'
@@ -552,6 +551,7 @@ en:
           page_title: Edit user account details for %{external_user}
         form:
           email: *email
+          email_notification: Get email notifications of caseworker messages on claims you created?
           email_confirmation: *email_confirmation
           password: *password
           password_confirmation: *password_confirmation
@@ -560,6 +560,10 @@ en:
           supplier_number: 'Supplier number'
           roles: *roles
           submit: 'Create user'
+          answer_yes: 'Yes'
+          answer_no: 'No'
+          save: Save
+          vat_registered: VAT registered
         change_password:
           error: 'error'
           error_summary: This user password change has
@@ -648,6 +652,8 @@ en:
           claim_type_choice_incomplete: 'AGFS/LGFS claim type choice incomplete'
           invalid_claim_types: 'Invalid bill type selected'
       selection:
+        continue: Continue
+        cancel: Cancel
         page_title_advocate: Choose a bill type for advocate claim
         page_title_litigator: Choose a bill type for litigator claim
         page_title_generic: Choose a bill type for Crown court claim
@@ -838,7 +844,7 @@ en:
           basic_fees: 'Initial fees'
           heading: Basic fees
           fee_prompt_text: |
-            You must enter a quantity and rate.  Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a>
+            You must enter a quantity and rate.  Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fees Calculator">graduated fees calculators</a>
             for help.
           fee_type: *fee_type
           quantity: *quantity
@@ -1164,26 +1170,26 @@ en:
         agfs:
           advocate_claim:
             page_title: View claim summary for advocate final fees claim
-            page_heading: Claim for advocate final fee
+            page_heading: Claim for advocate final fees
           advocate_supplementary_claim:
             page_title: View claim summary for advocate supplementary fee claim
-            page_heading: Claim for advocate supplementary fee
+            page_heading: Claim for advocate supplementary fees
           advocate_interim_claim:
             page_title: View claim summary for advocate warrant fees claim
-            page_heading: Claim for advocate interim fee
+            page_heading: Claim for advocate warrant fees
         lgfs:
           final_claim:
             page_title: View claim summary for litigator final fees claim
-            page_heading: Claim for litigator final fee
+            page_heading: Claim for litigator final fees
           litigator_claim:
             page_title: View claim summary for litigator final fees claim
-            page_heading: Claim for litigator final fee
+            page_heading: Claim for litigator final fees
           interim_claim:
             page_title: View claim summary for litigator interim fees claim
-            page_heading: Claim for litigator interim fee
+            page_heading: Claim for litigator interim fees
           transfer_claim:
             page_title: View claim summary for litigator transfer fees claim
-            page_heading: Claim for litigator transfer fee
+            page_heading: Claim for litigator transfer fees
         page_title: View claim summary for litigator transfer fees claim
       fee_fields:
         add_date_attended: 'Add dates'
@@ -1426,7 +1432,7 @@ en:
         fees: Fees
         fees_header_prompt_text_html: *fees_vat_prompt
         fees_calculator_html: |
-            Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fee Calculator">graduated fee calculators</a> for help.
+            Check the <a href="https://www.gov.uk/government/publications/graduated-fee-calculators" target="_blank" rel="external" title="Graduated Fees Calculator">graduated fees calculators</a> for help.
       summary_claims_sidebar:
         button_label: *continue_to_certification_button
         continue: 'Continue'
@@ -1536,7 +1542,6 @@ en:
 
         supporting_evidence_form_step:
           page_title: Upload supporting evidence for advocate msupplementary fee claim
-
     litigators:
 
       interim_claims:
@@ -1663,6 +1668,16 @@ en:
     determination:
       caption: 'Total of assessed amounts by category'
       summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows'
+    determinations_form:
+      update: Update
+      assessment_summary: Assessment summary
+      reason_for_refusal: Choose reason for refusal
+      reason_for_rejection: Choose reason for rejection
+      claimed_by: Claimed by
+      reason_text: Reason text
+      reason_hint: These reasons will be displayed to providers
+      update_the_claim_status: Update the claim status
+      reason_text: Reason text
     determinations_table:
       caption: 'This section contains a categorised list of amounts claimed and the amount authorised by the LAA'
       summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows.'
@@ -1994,6 +2009,7 @@ en:
       heading: Claim
     claim_history:
       print_messages: Print all messages
+      status: Status
     assessment:
       claimed_by: "Claimed by %{type}"
     scheme_filters:
@@ -2407,3 +2423,4 @@ en:
       comment: 'Tell us about your experience of using this service today.'
       comment_hint: "Don't include any personal or sensitive information."
       send: Send
+      rating: 'Overall, how satisfied were you with this service?'

--- a/features/000.feature
+++ b/features/000.feature
@@ -9,3 +9,4 @@ Feature: This feature runs first to sanitize the database.
   Scenario: Logged out I see the login page. Silly test will do the magic.
     Given I visit "/"
     Then I should see 'Sign in'
+    Then I should see a page title "Sign in to claim for Crown court defence"

--- a/features/allocation.feature
+++ b/features/allocation.feature
@@ -9,6 +9,7 @@ Feature: Case worker admin allocates claims
 
     And I am a signed in case worker admin
     When I visit the allocation page
+    Then I should see a page title "View the allocation queue"
     And I should see the AGFS filters
     And I select claims "T20160001, T20160002"
     And I select case worker "John Smith"
@@ -17,9 +18,10 @@ Feature: Case worker admin allocates claims
     And claims "T20160001, T20160002" should no longer be displayed
     And I should see '2 claims have been allocated to John Smith'
     And I sign out
-
+    Then I should see a page title "Help us improve this service"
     When I sign in as John Smith
     Then I should be on the 'Your claims' page
+    Then I should see a page title "View your allocated claims list"
     And claims "T20160001, T20160002" should appear on the page
     And I sign out
 

--- a/features/authorise_claim.feature
+++ b/features/authorise_claim.feature
@@ -11,6 +11,7 @@ Feature: Case worker fully authorises claim
 
     When I am signed in as the case worker
     And I select the claim
+    Then I should see a page title "View the claim details"
     And expand the messages section
     And fill out the Fees Total authorised by Laa with the amount of fees claimed
     And do the same with expenses

--- a/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
@@ -14,6 +14,7 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I select the court 'Caernarfon'
     And I enter a case number of 'A20191234'
 
+    And I should see a page title "Enter case details for advocate supplementary fee claim"
     Then I click "Continue" in the claim form
 
     And I enter defendant, scheme 11 representation order and MAAT reference
@@ -21,6 +22,7 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_eleven/supplementary_fee_calculations'
 
+    And I should see a page title "Enter defendant details for advocate supplementary fee claim"
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
     And I should see the advocate categories 'Junior,Leading junior,QC'
@@ -38,6 +40,7 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
 
     And I eject the VCR cassette
 
+    And I should see a page title "Enter miscellaneous fees for advocate supplementary fee claim"
     When I click "Continue" in the claim form
     Then I should be in the 'Travel expenses' form page
 
@@ -46,6 +49,7 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I add an expense date for scheme 11
     And I add an expense net amount for "34.56"
 
+    And I should see a page title "Enter travel expenses for advocate supplementary fee claim"
     Then I click "Continue" in the claim form
 
     When I upload the document 'judicial_appointment_order.pdf'
@@ -53,6 +57,7 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I check the evidence boxes for 'Order in respect of judicial apportionment'
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for advocate msupplementary fee claim"
     When I click "Continue" in the claim form
     And I should be on the check your claim page
     Then the following check your claim details should exist:
@@ -84,13 +89,17 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
       | supporting-evidence-section | Supporting evidence | judicial_appointment_order.pdf |
       | supporting-evidence-section | Supporting evidence checklist | Order in respect of judicial apportionment |
 
+    And I should see a page title "View claim summary for advocate supplementary fee claim"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
+
+    And I should see a page title "Certify and submit the advocate supplementary fees claim"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 
+    And I should see a page title "Thank you for submitting your claim"
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20191234' should be listed with a status of 'Submitted' and a claimed amount of '£466.02'

--- a/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
@@ -31,11 +31,13 @@ Feature: Advocate admin submits a claim for a Trial case
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
 
+    And I should see a page title "Enter defendant details for advocate final fees claim"
     Then I click "Continue" in the claim form
     And I select the offence category 'Activities relating to opium'
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_nine/trial_claim_edit'
 
+    And I should see a page title "Enter offence details for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I should see the advocate categories 'Junior alone,Led junior,Leading junior,QC'
@@ -46,6 +48,7 @@ Feature: Advocate admin submits a claim for a Trial case
     And the basic fee net amount should be populated with '1305.00'
     Then I add a number of cases uplift fee with additional case numbers
 
+    And I should see a page title "Enter graduated fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
@@ -55,6 +58,7 @@ Feature: Advocate admin submits a claim for a Trial case
 
     And I eject the VCR cassette
 
+    And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I select an expense type "Hotel accommodation"
@@ -63,12 +67,14 @@ Feature: Advocate admin submits a claim for a Trial case
     And I add an expense location
     And I add an expense date for scheme 9
 
+    And I should see a page title "Enter travel expenses for advocate final fees claim"
     Then I click "Continue" in the claim form
     And I upload the document 'judicial_appointment_order.pdf'
     And I should see 10 evidence check boxes
     And I check the evidence boxes for 'Order in respect of judicial apportionment'
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for advocate final fees claim"
     Then I click Submit to LAA
     And I should be on the check your claim page
 
@@ -91,10 +97,13 @@ Feature: Advocate admin submits a claim for a Trial case
     And I should see 'Order in respect of judicial apportionment'
     And I should see 'Bish bosh bash'
 
+    And I should see a page title "View claim summary for advocate final fees claim"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
+
+    And I should see a page title "Certify and submit the advocate final fees claim"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 

--- a/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
@@ -33,7 +33,7 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     Given I insert the VCR cassette 'features/claims/advocate/scheme_nine/claim_draft_edit'
 
     Then I click "Continue" in the claim form
-    And I should be in the 'Fees' form page
+    And I should be in the 'Graduated fees' form page
 
     And I should see "First day of trial"
     And the basic fee net amount should be populated with '0.00'

--- a/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
@@ -40,6 +40,8 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     Then the fixed fee 'Adjourned appeals, committals and breaches' should have a rate of '87.00' and a hint of 'Number of days'
     And I select the 'Number of cases uplift' fixed fee with case numbers
     Then the fixed fee 'Number of cases uplift' should have a rate of '26.00'
+
+    And I should see a page title "Enter fixed fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
@@ -47,6 +49,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
 
     And I eject the VCR cassette
 
+    And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I select an expense type "Parking"
@@ -54,15 +57,18 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     And I add an expense net amount for "34.56"
     And I add an expense date for scheme 9
 
+    And I should see a page title "Enter travel expenses for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I upload 3 documents
     And I check the boxes for the uploaded documents
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for advocate final fees claim"
     Then I click Submit to LAA
     And I should be on the check your claim page
 
+    And I should see a page title "View claim summary for advocate final fees claim"
     When I click "Continue"
     Then I should be on the certification page
 

--- a/features/claims/advocate/scheme_ten/advocate_expense_page.feature
+++ b/features/claims/advocate/scheme_ten/advocate_expense_page.feature
@@ -13,6 +13,7 @@ Feature: Advocate creates, saves, edits claims and expenses
     And I select a case type of 'Trial'
     And I enter scheme 10 trial start and end dates
 
+    And I should see a page title "Enter case details for advocate final fees claim"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft
@@ -49,6 +50,7 @@ Feature: Advocate creates, saves, edits claims and expenses
     Then I should see '20p per mile'
     Then I should see 'Other reason'
 
+    And I should see a page title "Enter travel expenses for advocate final fees claim"
     And I save as draft
 
     When I click the claim 'A20181234'

--- a/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
@@ -14,11 +14,13 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     And I select a case type of 'Appeal against conviction'
     And I enter a case number of 'A20181234'
 
+    And I should see a page title "Enter case details for advocate final fees claim"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, scheme 10 representation order and MAAT reference
     And I add another defendant, scheme 10 representation order and MAAT reference
 
+    And I should see a page title "Enter defendant details for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_ten/fixed_fee_calculations'
@@ -39,6 +41,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     Then I uncheck the fixed fee "Number of defendants uplift"
     Then the summary total should equal '£468.00'
 
+    And I should see a page title "Enter fixed fees for advocate final fees claim"
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
 
@@ -47,22 +50,25 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
 
     And I eject the VCR cassette
 
+    And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     Then I click "Continue" in the claim form
-    And I should be in the 'Travel expenses' form page
 
+    And I should be in the 'Travel expenses' form page
     And I select an expense type "Parking"
     And I select a travel reason "View of crime scene"
     And I add an expense net amount for "34.56"
     And I add an expense date for scheme 10
 
+    And I should see a page title "Enter travel expenses for advocate final fees claim"
     Then I click "Continue" in the claim form
-    And I should be in the 'Evidence supplied on disk' form page
 
+    And I should be in the 'Supporting evidence' form page
     And I upload the document 'indictment.pdf'
     And I should see 10 evidence check boxes
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for advocate final fees claim"
     Then I click Submit to LAA
 
     And I should be on the check your claim page
@@ -82,11 +88,16 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     And I should see 'A copy of the indictment'
     And I should see 'Bish bosh bash'
 
+    And I should see a page title "View claim summary for advocate final fees claim"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
+
+    And I should see a page title "Certify and submit the advocate final fees claim"
     And I click Certify and submit claim
+
+    And I should see a page title "Thank you for submitting your claim"
     Then I should be on the claim confirmation page
 
     When I click View your claims

--- a/features/claims/advocate/scheme_ten/advocate_interim_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_interim_claim_edit_submit.feature
@@ -12,6 +12,8 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20181234'
 
+    And I should see a page title "Enter case details for advocate warrant fees claim"
+
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
     And I save as draft
     Then I should see 'Draft claim saved'
@@ -23,6 +25,7 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     And I edit the claim's defendants
     And I enter defendant, scheme 10 representation order and MAAT reference
 
+    And I should see a page title "Enter defendant details for advocate warrant fees claim"
     Then I click "Continue" in the claim form
 
     And I search for the scheme 10 offence 'Absconding from lawful custody'
@@ -32,6 +35,7 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     And I fill in '2018-04-01' as the warrant issued date
     And I enter a Warrant net amount of '100'
 
+    And I should see a page title "Enter fees for advocate warrant fees claim"
     Then I click "Continue" in the claim form
 
     And I select an expense type "Parking"
@@ -39,19 +43,24 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     And I add an expense net amount for "34.56"
     And I add an expense date for scheme 10
 
+    And I should see a page title "Enter travel expenses for advocate warrant fees claim"
     Then I click "Continue" in the claim form
 
     And I upload 3 documents
     And I check the boxes for the uploaded documents
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for advocate warrant fees claim"
     And I click Submit to LAA
     Then I should be on the check your claim page
 
+    And I should see a page title "View claim summary for advocate warrant fees claim"
     When I click "Continue"
-    Then I should be on the certification page
 
+    Then I should be on the certification page
     When I check “I attended the main hearing”
+
+    And I should see a page title "Certify and submit the advocate warrant fees claim"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 

--- a/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
@@ -14,6 +14,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I select a case type of 'Trial'
     And I enter scheme 10 trial start and end dates
 
+    And I should see a page title "Enter case details for advocate final fees claim"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft
@@ -28,14 +29,14 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I enter defendant, scheme 10 representation order and MAAT reference
     And I add another defendant, scheme 10 representation order and MAAT reference
 
+    And I should see a page title "Enter defendant details for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I search for the scheme 10 offence 'Absconding from lawful custody'
-
     Given I insert the VCR cassette 'features/claims/advocate/scheme_ten/trial_claim_edit'
 
     When I select the first search result
-    Then I should be in the 'Fees' form page
+    Then I should be in the 'Graduated fees' form page
 
     And I should see the advocate categories 'Junior,Leading junior,QC'
     And I should see the scheme 10 applicable basic fees
@@ -46,6 +47,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And the basic fee net amount should be populated with '550.00'
     And I add a number of cases uplift fee with additional case numbers
 
+    And I should see a page title "Enter graduated fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended '2018-04-01'
@@ -55,6 +57,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
 
     And I eject the VCR cassette
 
+    And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I select an expense type "Hotel accommodation"
@@ -63,6 +66,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I add an expense location
     And I add an expense date for scheme 10
 
+    And I should see a page title "Enter travel expenses for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I upload the document 'judicial_appointment_order.pdf'
@@ -70,6 +74,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I check the evidence boxes for 'Order in respect of judicial apportionment,A copy of the indictment'
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for advocate final fees claim"
     Then I click Submit to LAA
 
     Then I should be on the check your claim page
@@ -92,12 +97,17 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I should see 'Order in respect of judicial apportionment'
     And I should see 'Bish bosh bash'
 
+    And I should see a page title "View claim summary for advocate final fees claim"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
+
+    And I should see a page title "Certify and submit the advocate final fees claim"
     And I click Certify and submit claim
+
     Then I should be on the claim confirmation page
+    And I should see a page title "Thank you for submitting your claim"
 
     When I click View your claims
     Then I should be on the your claims page

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -17,8 +17,10 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I select a case type of 'Trial'
     And I enter a case number of 'A20161234'
 
+    And I should see a page title "Enter case details for litigator interim fees claim"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
+    And I should see a page title "Enter defendant details for litigator interim fees claim"
     And I save as draft
     Then I should see 'Draft claim saved'
 
@@ -31,6 +33,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I enter defendant, LGFS representation order and MAAT reference
     And I add another defendant, LGFS representation order and MAAT reference
 
+    And I should see a page title "Enter defendant details for litigator interim fees claim"
     Then I click "Continue" in the claim form
 
     And I select the offence category 'Handling stolen goods'
@@ -38,7 +41,9 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     Given I insert the VCR cassette 'features/claims/litigator/interim_fee_calculations'
 
+    And I should see a page title "Enter offence details for litigator interim fees claim"
     When I click "Continue" in the claim form
+
     And I should be in the 'Interim fee' form page
     And I should see interim fee types applicable to a 'Trial'
 
@@ -56,12 +61,14 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     And I eject the VCR cassette
 
-    Then I click "Continue" in the claim form and move to the 'Evidence supplied on disk' form page
+    And I should see a page title "Enter fees for litigator interim fees claim"
+    Then I click "Continue" in the claim form and move to the 'Supporting evidence' form page
 
     And I upload the document 'indictment.pdf'
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for litigator interim fees claim"
     And I click Submit to LAA
     Then I should be on the check your claim page
     And I should see 'Blackfriars'
@@ -90,9 +97,11 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I should see 'A copy of the indictment'
     And I should see 'Bish bosh bash'
 
+    And I should see a page title "View claim summary for litigator interim fees claim"
     When I click "Continue"
     Then I should be on the certification page
 
+    And I should see a page title "Certify and submit the litigator interim fees claim"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -47,6 +47,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I eject the VCR cassette
 
+    And I should see a page title "Enter fixed fees for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And I should be in the 'Miscellaneous fees' form page
@@ -54,11 +55,13 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I add a litigator miscellaneous fee 'Costs judge application'
     And I add a litigator miscellaneous fee 'Defendant uplift'
 
+    And I should see a page title "Enter miscellaneous fees for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '25.08'
     And I add another disbursement 'Meteorologist' with net amount '58.22' and vat amount '0'
 
+    And I should see a page title "Enter disbursements for litigator final fees claim"
     Then I click "Continue" in the claim form and move to the 'Travel expenses' form page
 
     And I select an expense type "Parking"
@@ -66,6 +69,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I add an expense net amount for "34.56"
     And I add an expense date for LGFS
 
+    And I should see a page title "Enter travel expenses for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And I upload 1 document
@@ -82,9 +86,11 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should not see 'Actual trial length'
     And I should not see 'Trial concluded on'
 
+    And I should see a page title "View claim summary for litigator final fees claim"
     When I click "Continue"
     Then I should be on the certification page
 
+    And I should see a page title "Certify and submit the litigator final fees claim"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -61,7 +61,7 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     And I enter the date for the first expense '2016-04-02'
     Then I click "Continue" in the claim form
 
-    And I should be in the 'Evidence supplied on disk' form page
+    And I should be in the 'Supporting evidence' form page
 
     Then I click "Continue" in the claim form
 

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -20,8 +20,11 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     When I click "Continue" I should be on the 'Case details' page and see a "Choose a supplier number" error
 
     When I choose the supplier number '1A222Z'
+
+    And I should see a page title "Enter case details for litigator final fees claim"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
+    And I should see a page title "Enter defendant details for litigator final fees claim"
     And I save as draft
     Then I should see 'Draft claim saved'
 
@@ -33,11 +36,14 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I edit the claim's case details
 
     Then I should see a supplier number select list
+
+    And I should see a page title "Enter case details for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And I enter defendant, LGFS representation order and MAAT reference
     And I add another defendant, LGFS representation order and MAAT reference
 
+    And I should see a page title "Enter defendant details for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     When I select the offence category 'Abandonment of children under two'
@@ -56,6 +62,8 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     Given I insert the VCR cassette 'features/claims/litigator/graduated_fee_calculations'
+
+    And I should see a page title "Enter offence details for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And the graduated fee amount should be populated with '429.12'
@@ -66,6 +74,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I fill '51' as the ppe total
     Then the graduated fee amount should be populated with '437.89'
 
+    And I should see a page title "Enter graduated fees for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And I eject the VCR cassette
@@ -74,11 +83,13 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee'
     And I add a litigator miscellaneous fee 'Costs judge application'
 
+    And I should see a page title "Enter miscellaneous fees for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '25.08'
     And I add another disbursement 'Meteorologist' with net amount '58.22' and vat amount '0'
 
+    And I should see a page title "Enter disbursements for litigator final fees claim"
     Then I click "Continue" in the claim form and move to the 'Travel expenses' form page
 
     And I select an expense type "Parking"
@@ -86,6 +97,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I add an expense net amount for "34.56"
     And I add an expense date for scheme 10
 
+    And I should see a page title "Enter travel expenses for litigator final fees claim"
     Then I click "Continue" in the claim form
 
     And I upload 1 document
@@ -93,6 +105,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for litigator final fees claim"
     And I click Submit to LAA
     Then I should be on the check your claim page
     And I should see the field 'Crown court' with value 'Blackfriars' in 'Case details'
@@ -107,9 +120,11 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should not see 'Estimated trial length'
     And I should not see 'Trial concluded on'
 
+    And I should see a page title "View claim summary for litigator final fees claim"
     When I click "Continue"
     Then I should be on the certification page
 
+    And I should see a page title "Certify and submit the litigator final fees claim"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -18,6 +18,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I enter the transfer date '2015-05-21'
     And I select a case conclusion of 'Cracked'
 
+    And I should see a page title "Enter fees for litigator transfer fees claim"
     And I click "Continue" in the claim form
 
     When I choose the supplier number '1A222Z'
@@ -25,8 +26,10 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I enter a case number of 'A20161234'
     And I enter the case concluded date
 
+    And I should see a page title "Enter case details for litigator transfer fees claim"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
+    And I should see a page title "Enter defendant details for litigator transfer fees claim"
     And I save as draft
     Then I should see 'Draft claim saved'
 
@@ -39,12 +42,15 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I enter defendant, LGFS representation order and MAAT reference
     And I add another defendant, LGFS representation order and MAAT reference
 
+    And I should see a page title "Enter defendant details for litigator transfer fees claim"
     And I click "Continue" in the claim form
 
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     Given I insert the VCR cassette 'features/claims/litigator/transfer_fee_calculations'
+
+    And I should see a page title "Enter offence details for litigator transfer fees claim"
     And I click "Continue" in the claim form
 
     Then the transfer fee amount should be populated with '269.08'
@@ -55,6 +61,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I fill '51' as the ppe total
     Then the transfer fee amount should be populated with '274.37'
 
+    And I should see a page title "Enter fees for litigator transfer fees claim"
     Then I click "Continue" in the claim form
 
     And I eject the VCR cassette
@@ -63,11 +70,13 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee'
     And I add a litigator miscellaneous fee 'Costs judge application'
 
+    And I should see a page title "Enter miscellaneous fees for litigator transfer fees claim"
     Then I click "Continue" in the claim form
 
     And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '25.08'
     And I add another disbursement 'Meteorologist' with net amount '58.22' and vat amount '0'
 
+    And I should see a page title "Enter disbursements for litigator transfer fees claim"
     Then I click "Continue" in the claim form and move to the 'Travel expenses' form page
 
     And I select an expense type "Parking"
@@ -75,6 +84,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I add an expense net amount for "34.56"
     And I add an expense date for LGFS
 
+    And I should see a page title "Enter travel expenses for litigator transfer fees claim"
     Then I click "Continue" in the claim form
 
     And I upload 1 document
@@ -82,13 +92,16 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
 
+    And I should see a page title "Upload supporting evidence for litigator transfer fees claim"
     Then I click Submit to LAA
     And I should be on the check your claim page
     And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
 
+    And I should see a page title "View claim summary for litigator transfer fees claim"
     When I click "Continue"
     Then I should be on the certification page
 
+    And I should see a page title "Certify and submit the litigator transfer fees claim"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 

--- a/features/fee_calculator/advocate/graduated_fee_calculator.feature
+++ b/features/fee_calculator/advocate/graduated_fee_calculator.feature
@@ -26,7 +26,7 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     Given I insert the VCR cassette 'features/fee_calculator/advocate/graduated_fee_trial_calculator'
     When I select the offence category 'Murder'
     And I click "Continue" in the claim form
-    And I should be in the 'Fees' form page
+    And I should be in the 'Graduated fees' form page
     Then the basic fee net amount should be populated with '0.00'
 
     # advocate category impacts "basic" fee
@@ -78,7 +78,7 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
 
     When I select the offence category 'Murder'
     And I click "Continue" in the claim form
-    And I should be in the 'Fees' form page
+    And I should be in the 'Graduated fees' form page
     Then the basic fee net amount should be populated with '0.00'
 
     # advocate category impacts "basic" fee (retrial interval within a month, 30% reduction)

--- a/features/fee_calculator/litigator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/litigator/fixed_fee_calculator.feature
@@ -26,7 +26,7 @@ Feature: litigator completes fixed fee page using calculator
     Given I insert the VCR cassette 'features/fee_calculator/litigator/fixed_fee_calculator'
 
     Then I click "Continue" in the claim form
-    And I should be in the 'Fees' form page
+    And I should be in the 'Fixed fees' form page
 
     And the fixed fee rate should be populated with '349.47'
     And I fill '2018-11-01' as the fixed fee date

--- a/features/fee_calculator/litigator/interim_fee_calculator.feature
+++ b/features/fee_calculator/litigator/interim_fee_calculator.feature
@@ -46,7 +46,7 @@ Feature: litigator completes interim fee page using calculator
     And I enter the effective PCMH date '2018-04-01'
 
     Then I click "Continue" in the claim form
-    And I should be in the 'Evidence supplied on disk' form page
+    And I should be in the 'Supporting evidence' form page
 
     # offence impact
     And I goto claim form step 'offence details'
@@ -58,7 +58,7 @@ Feature: litigator completes interim fee page using calculator
     And the interim fee amount should be populated with '596.46'
 
     Then I click "Continue" in the claim form
-    And I should be in the 'Evidence supplied on disk' form page
+    And I should be in the 'Supporting evidence' form page
 
     # defendant uplift impact
     And I goto claim form step 'defendants'
@@ -90,7 +90,7 @@ Feature: litigator completes interim fee page using calculator
     And the interim fee amount should be populated with '1332.56'
 
     Then I click "Continue" in the claim form
-    And I should be in the 'Evidence supplied on disk' form page
+    And I should be in the 'Supporting evidence' form page
 
     And the interim fee should have its price_calculated value set to true
 
@@ -142,7 +142,7 @@ Feature: litigator completes interim fee page using calculator
     And I enter the first trial concluded date '2018-04-01'
 
     Then I click "Continue" in the claim form
-    And I should be in the 'Evidence supplied on disk' form page
+    And I should be in the 'Supporting evidence' form page
 
     # offence impact
     And I goto claim form step 'offence details'
@@ -182,7 +182,7 @@ Feature: litigator completes interim fee page using calculator
     And the interim fee amount should be populated with '1332.56'
 
     Then I click "Continue" in the claim form
-    And I should be in the 'Evidence supplied on disk' form page
+    And I should be in the 'Supporting evidence' form page
 
     And the interim fee should have its price_calculated value set to true
 

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -28,4 +28,4 @@ Feature: A user can provide feedback and report bugs
     Then I expect ZendeskSender to receive a description with an email
     And I see confirmation that my 'feedback' was received
     And I should be on the sign in page
- 
+

--- a/features/page_objects/claim_summary_page.rb
+++ b/features/page_objects/claim_summary_page.rb
@@ -1,7 +1,7 @@
 class ClaimSummaryPage < SitePrism::Page
   set_url "/external_users/claims/{claim_id}/summary"
 
-  element :continue, ".form-buttons > a.button-continue:nth-of-type(1)"
+  element :continue, ".form-buttons > a.button:nth-of-type(1)"
   element :change_case_details, "#case-details-section a.link-change:nth-of-type(1)"
   element :change_defendants, "#defendants-section a.link-change:nth-of-type(1)"
   element :change_expenses, "#expenses-section a.link-change:nth-of-type(1)"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -149,9 +149,13 @@ And(/^I should see in the sidebar vat total '(.*?)'$/) do |total|
   end
 end
 
-And(/^I should be in the '(.*?)' form page$/) do |page_title|
+Then(/^I should see a page title "([^"]*)"$/) do |page_title|
+  expect(page.title).to have_content(page_title)
+end
+
+And(/^I should be in the '(.*?)' form page$/) do |page_heading|
   within('#claim-form') do
-    expect(page.first('h2')).to have_content(page_title)
+    expect(page.first('h2')).to have_content(page_heading)
   end
 end
 

--- a/lib/extensions/string_extension.rb
+++ b/lib/extensions/string_extension.rb
@@ -39,6 +39,10 @@ module StringExtension
     acronym.upcase
   end
 
+  def to_css_class
+    downcase.strip.tr(' _', '--')
+  end
+
   private
 
   def clean_and_split_sentence

--- a/spec/lib/extensions/string_extension_spec.rb
+++ b/spec/lib/extensions/string_extension_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe String do
 
-  context '#zero?' do
+  describe '#zero?' do
     context 'for blank values' do
       it 'should be false' do
         expect(''.zero?).to eq(false)
@@ -26,7 +26,7 @@ describe String do
     end
   end
 
-  context 'to_bool' do
+  describe '#to_bool' do
     context 'for blank values' do
       it 'should be false for empty string' do
         expect(''.to_bool).to eq(false)
@@ -54,7 +54,7 @@ describe String do
     end
   end
 
-  context 'alpha?' do
+  describe '#alpha?' do
     context 'for blank values' do
       it 'should be false for empty string' do
         expect(''.alpha?).to eq(false)
@@ -82,7 +82,7 @@ describe String do
     end
   end
 
-  context 'digit?' do
+  describe '#digit?' do
     context 'for blank values' do
       it 'should be false for empty string' do
         expect(''.digit?).to eq(false)
@@ -107,6 +107,13 @@ describe String do
           expect(value.digit?).to eq(false)
         end
       end
+    end
+  end
+
+  describe '#to_css_class' do
+    it "should look right" do
+      expect('Part authorised'.to_css_class).to eq('part-authorised')
+      expect(' Pa_rt authori_s ed'.to_css_class).to eq('pa-rt-authori-s-ed')
     end
   end
 end


### PR DESCRIPTION
#### What
Adding aria markup to almost all the radio and check box instances across the site

Other changes include:
- translations moved to the `en.yml`
- semantic layouts to apply the correct html patterns

#### Ticket

[CBO-377](https://dsdmoj.atlassian.net/browse/CBO-377)

#### Why

DAC report

#### How

In most cases the `fieldset > legend` + the `radio|checkbox label`  are combined to create the `aria-label` 
--------
