### PR TITLE
Correct path to new advocate final claim endpoint

### DIFF
--- a/app/models/json_document_importer.rb
+++ b/app/models/json_document_importer.rb
@@ -10,7 +10,7 @@ class JsonDocumentImporter
   validate :file_conforms_to_basic_json_schema, if: :json_data
 
   BASE_URL                      = GrapeSwaggerRails.options.app_url
-  CLAIM_CREATION                = RestClient::Resource.new BASE_URL + '/api/external_users/advocates/final'
+  CLAIM_CREATION                = RestClient::Resource.new BASE_URL + '/api/external_users/claims/advocates/final'
   DEFENDANT_CREATION            = RestClient::Resource.new BASE_URL + '/api/external_users/defendants'
   REPRESENTATION_ORDER_CREATION = RestClient::Resource.new BASE_URL + '/api/external_users/representation_orders'
   FEE_CREATION                  = RestClient::Resource.new BASE_URL + '/api/external_users/fees'


### PR DESCRIPTION
#### What
Fix the name of the endpoint used by the JSON uploader

#### Why
Following addition of new advocate final claim endpoint
and deprecating of old, the json uploader was pointed
to use the new endpoint, but namespacing was missed.