### PR TITLE
Bump Devise from 4.4.3 --> 4.6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'aws-sdk',                '~> 2'
 gem 'awesome_print'
 gem 'cancancan',              '~> 1.15'
 gem 'cocoon',                 '~> 1.2.6'
-gem 'devise',                 '~> 4.4.3'
+gem "devise",                 ">= 4.6.0"
 gem 'dry-monads',             '~> 1.0.0'
 gem 'dropzonejs-rails',       '~> 0.8.2'
 gem 'factory_bot_rails',      '~> 4.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     deep_merge (1.2.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.4.3)
+    devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -719,7 +719,7 @@ DEPENDENCIES
   config (~> 1.2)
   cucumber-rails (~> 1.6.0)
   database_cleaner
-  devise (~> 4.4.3)
+  devise (>= 4.6.0)
   dotenv-rails
   dropzonejs-rails (~> 0.8.2)
   dry-monads (~> 1.0.0)


### PR DESCRIPTION
#### What
Upgrade devise

#### Why
Handle [CVE security warning](https://github.com/plataformatec/devise/issues/4981)