### PR TITLE
Cost Per Transaction report fix

### DIFF
--- a/app/services/reports/performance_platform/quarterly_volume.rb
+++ b/app/services/reports/performance_platform/quarterly_volume.rb
@@ -76,7 +76,7 @@ module Reports
       end
 
       def count_digital_claims
-        @count_digital_claims ||= Claims::Count.week(@start_date)
+        @count_digital_claims ||= Claims::Count.quarter(@start_date)
       end
 
       def client

--- a/scheduled_tasks/performance_platform_cost_per_transaction_task.rb
+++ b/scheduled_tasks/performance_platform_cost_per_transaction_task.rb
@@ -5,7 +5,7 @@ class PerformancePlatformCostPerTransactionTask < Scheduler::SchedulerTask
   def run
     raise ReportNotActivated unless ENV['PERF_PLAT_QV_TOKEN']
     log('Performance Platform - Cost Per Transaction Task started')
-    cpt = Reports::PerformancePlatform::QuarterlyVolume.new(Date.yesterday.beginning_of_quarter)
+    cpt = Reports::PerformancePlatform::QuarterlyVolume.new(Date.today.beginning_of_quarter - 3.months)
     cpt.populate_data
     cpt.publish!
   rescue ReportNotActivated

--- a/scheduled_tasks/performance_platform_cost_per_transaction_task.rb
+++ b/scheduled_tasks/performance_platform_cost_per_transaction_task.rb
@@ -1,6 +1,6 @@
 # https://github.com/ssoroka/scheduler_daemon for help
 class PerformancePlatformCostPerTransactionTask < Scheduler::SchedulerTask
-  cron '15 4 1 1/3 *' # 04:15 on the first of every quarter
+  cron '15 4 2,3 1,4,7,10 *' # 04:15 on the 2nd and third of every quarter
   class ReportNotActivated < RuntimeError; end
   def run
     raise ReportNotActivated unless ENV['PERF_PLAT_QV_TOKEN']


### PR DESCRIPTION
#### What
The Cost per transaction run on the first of April had a couple of issues, this seeks to address both

#### Why
1)The report did not run at the expected time.  As the scheduler cannot be queried for next run, the only way to test this is to update the cron definition and try again.

2) When the report was run manually, it miscalculated the count of transactions, leading to an elevated Cost Per Transaction figure

#### How
1) Change to cron format.  Each language/host OS seems to validate cron differently which makes it hard to 'validate' what will work.  The new version has been validated at [crontab.guru](https://crontab.guru/#15_4_2,3_1,4,7,10_*) and doesn't return any validation issues.  This can run for the next two days to see if it works, and then reverted to only run on the first of the month after that.
2) Change the count to run agains the whole quarter, not just the first week! 🤦‍♂️ 