### PR TITLE
Update the quarterly claim counter

### DIFF
--- a/app/services/claims/count.rb
+++ b/app/services/claims/count.rb
@@ -2,7 +2,7 @@ module Claims
   class Count
     class << self
       def quarter(date)
-        new(date, :quarter).call
+        new(date, :quarter).call_transitions
       end
 
       def month(date)
@@ -22,6 +22,10 @@ module Claims
 
     def call
       Claim::BaseClaim.where(original_submission_date: @start..@end).count
+    end
+
+    def call_transitions
+      ClaimStateTransition.where(created_at: @start..@end, to: %w[submitted redetermination]).count
     end
   end
 end

--- a/spec/services/claims/count_spec.rb
+++ b/spec/services/claims/count_spec.rb
@@ -7,7 +7,8 @@ describe Claims::Count do
   let(:period) { :month }
 
   before do
-    travel_to(Date.new(2017, 12, 17)) { create_list(:archived_pending_delete_claim, 3) }
+    travel_to(Date.new(2017, 12, 17)) { create_list(:archived_pending_delete_claim, 2) }
+    travel_to(Date.new(2017, 12, 17)) { create(:redetermination_claim) }
     travel_to(Date.new(2018, 01, 17)) { create_list(:archived_pending_delete_claim, 3) }
     travel_to(Date.new(2018, 02, 17)) { create_list(:archived_pending_delete_claim, 3) }
   end
@@ -19,6 +20,14 @@ describe Claims::Count do
       subject(:call) { claims_count.call }
 
       it { is_expected.to eql 3 }
+    end
+  end
+
+  describe '#call_transitions' do
+    context 'when period and date are set manually' do
+      subject(:call) { claims_count.call_transitions }
+
+      it { is_expected.to eql 3  }
     end
   end
 


### PR DESCRIPTION



#### What
This has been amended to count claim_state_transitions between the
required dates instead of just the claim submissions
#### Why
This should be counting submissions of redeterminations as well as
original submissions.
#### How
Switched the `#quarter` method to count the different type