### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -130,7 +130,6 @@ Style/ClassVars:
 # Offense count: 4
 Style/IfInsideElse:
   Exclude:
-    - 'app/helpers/application_helper.rb'
     - 'app/presenters/error_message_translator.rb'
     - 'app/services/vat_auditor.rb'
     - 'app/validators/claim/interim_claim_validator.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -127,11 +127,6 @@ Style/ClassVars:
     - 'app/models/timed_transitions/transitioner.rb'
     - 'app/services/remote/http_client.rb'
 
-# Offense count: 4
-Style/IfInsideElse:
-  Exclude:
-    - 'app/presenters/error_message_translator.rb'
-
 # Offense count: 2
 Style/OptionalArguments:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,7 +131,6 @@ Style/ClassVars:
 Style/IfInsideElse:
   Exclude:
     - 'app/presenters/error_message_translator.rb'
-    - 'app/services/vat_auditor.rb'
     - 'app/validators/claim/interim_claim_validator.rb'
 
 # Offense count: 2

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,7 +131,6 @@ Style/ClassVars:
 Style/IfInsideElse:
   Exclude:
     - 'app/presenters/error_message_translator.rb'
-    - 'app/validators/claim/interim_claim_validator.rb'
 
 # Offense count: 2
 Style/OptionalArguments:

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,12 +42,28 @@ module ApplicationHelper
   # Returns a "current" css class if the path = current_page
   # TODO: this will not work on those routes that are also rooted to for the namespace or which have js that interferes
   def cp(path)
-    tab = extract_uri_param(path, 'tab')
-    if tab.present?
-      'current' if request.path == strip_params(path) && request.GET[:tab] == tab
-    else
-      'current' if request.path == strip_params(path)
-    end
+    'current' if path_matches(path) && tab_check_passes?(path)
+  end
+
+  def path_matches(path)
+    request.path == strip_params(path)
+  end
+
+  def tab_check_passes?(path)
+    tab_can_be_ignored?(path) || tab_matches(path)
+  end
+
+  def tab_can_be_ignored?(path)
+    tab_present(path).blank?
+  end
+
+  def tab_present(path)
+    extract_uri_param(path, 'tab')
+  end
+
+  def tab_matches(path)
+    tab = tab_present(path)
+    request.GET[:tab] == tab
   end
 
   def number_with_precision_or_default(number, options = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,27 +45,6 @@ module ApplicationHelper
     'current' if path_matches(path) && tab_check_passes?(path)
   end
 
-  def path_matches(path)
-    request.path == strip_params(path)
-  end
-
-  def tab_check_passes?(path)
-    tab_can_be_ignored?(path) || tab_matches(path)
-  end
-
-  def tab_can_be_ignored?(path)
-    tab_present(path).blank?
-  end
-
-  def tab_present(path)
-    extract_uri_param(path, 'tab')
-  end
-
-  def tab_matches(path)
-    tab = tab_present(path)
-    request.GET[:tab] == tab
-  end
-
   def number_with_precision_or_default(number, options = {})
     default = options.delete(:default) || ''
     if options.key?(:precision)
@@ -162,5 +141,28 @@ module ApplicationHelper
 
   def yes_no_options
     [%w[Yes true], %w[No false]]
+  end
+
+  private
+
+  def path_matches(path)
+    request.path == strip_params(path)
+  end
+
+  def tab_check_passes?(path)
+    tab_can_be_ignored?(path) || tab_matches(path)
+  end
+
+  def tab_can_be_ignored?(path)
+    tab_present(path).blank?
+  end
+
+  def tab_present(path)
+    extract_uri_param(path, 'tab')
+  end
+
+  def tab_matches(path)
+    tab = tab_present(path)
+    request.GET[:tab] == tab
   end
 end

--- a/app/presenters/error_message_translator.rb
+++ b/app/presenters/error_message_translator.rb
@@ -57,12 +57,10 @@ class ErrorMessageTranslator
     elsif key_refers_to_unnumbered_submodel?(key)
       translation_subset, submodel_key = extract_submodel_attribute(translations, key)
       get_messages(translation_subset, submodel_key, error)
-    else
-      if translation_exists?(translations, key, error)
-        @long_message  = translations[key][error]['long']
-        @short_message = translations[key][error]['short']
-        @api_message   = translations[key][error]['api']
-      end
+    elsif translation_exists?(translations, key, error)
+      @long_message  = translations[key][error]['long']
+      @short_message = translations[key][error]['short']
+      @api_message   = translations[key][error]['api']
     end
   end
 

--- a/app/services/vat_auditor.rb
+++ b/app/services/vat_auditor.rb
@@ -10,17 +10,9 @@ class VatAuditor
   def run
     print_claim_totals
     if @claim.agfs?
-      if @claim.vat_registered?
-        audit_agfs_vat_registered
-      else
-        audit_agfs_vat_free
-      end
+      @claim.vat_registered? ? audit_agfs_vat_registered : audit_agfs_vat_free
     else
-      if @claim.vat_registered?
-        audit_lgfs_vat_registered
-      else
-        audit_lgfs_vat_fee
-      end
+      @claim.vat_registered? ? audit_lgfs_vat_registered : audit_lgfs_vat_fee
     end
     puts @result_string if @verbose
     @result

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -48,8 +48,8 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
 
     if @record.interim_fee.is_trial_start?
       validate_presence(:first_day_of_trial, 'blank')
-    else
-      validate_absence(:first_day_of_trial, 'present') if @record.errors[:first_day_of_trial].empty?
+    elsif @record.errors[:first_day_of_trial].empty?
+      validate_absence(:first_day_of_trial, 'present')
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -94,4 +94,38 @@ describe ApplicationHelper do
 
   end
 
+  describe '#cp' do
+    subject(:cp) { helper.cp(path_with_params) }
+
+    let(:path) { 'test' }
+    let(:path_with_params) { path }
+
+    context 'when the current request path matches that passed in' do
+      before { controller.request.path = path }
+
+      it { is_expected.to eql 'current' }
+
+      context 'when then the tab param is set' do
+        before { controller.request.GET[:tab] = 'also_test' }
+
+        context 'and matches' do
+          let(:path_with_params) { 'test?tab=also_test' }
+
+          it { is_expected.to eql 'current' }
+        end
+
+        context 'and does not match' do
+          let(:path_with_params) { 'test?tab=still_not_a_test' }
+
+          it { is_expected.to eql nil }
+        end
+      end
+    end
+
+    context 'when the current request path does not match the one passed in' do
+      before { controller.request.path = 'not_a_test' }
+
+      it { is_expected.to eql nil }
+    end
+  end
 end


### PR DESCRIPTION
#### What
Address the `Style/IfInsideElse` cops

#### Why
Reduce the tech debt in the rubocop_todo file

#### How
Remove instances of nested if statements

#### Also
* extend tests of the ApplicationHelper to cover the `cp` method
* re-namespace a cop to remove a warning when running rubocop