### PR TITLE
Fix Net::ReadTimeout at the end of all feature scenarios

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -54,6 +54,17 @@ end
 After do |scenario|
   name = scenario.location.file.gsub('features/','').gsub(/\.|\//, '-')
   screenshot_image(name) if scenario.failed?
+
+  # Following a local ruby and various dependecy updates cucumber no longer
+  # appears to have been shutting down the chromedriver automatically.
+  # This explicit quit patches the issue for chromedriver, ignoring
+  # Capybara::Rack::Test::Drivers, but hopefully a chromedriver
+  # or selenium webdriver update will make this unecessary in the near
+  # future
+  #
+  Capybara.current_session.driver.tap do |driver|
+    driver.quit if driver.respond_to?(:quit)
+  end
 end
 
 at_exit do


### PR DESCRIPTION
#### What
Fix Net::Timeout errors on master running cukes locally

#### Why
Following a local ruby and various dependecy updates cucumber no longer
appears to have been shutting down the chromedriver automatically.
This explicit close patches the isse but hopefully a chromedriver
or selenium webdrivers update will make this unnecessary in the near
future.
