### PR TITLE
Remove phantomJS

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,4 @@
 brew "postgresql", restart_service: true
 brew "redis", restart_service: true
-cask "phantomjs"
 cask "chromedriver"
 cask "libreoffice"


### PR DESCRIPTION
#### What
remove cask for phantomJS from brewfile, used for dev setup

#### Why
Using chromedriver alone now. phantomJS
is EOL.
