### PR TITLE
Add bullet gem to identify optimizations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development, :devunicorn, :test do
 end
 
 group :test do
+  gem 'bullet', '~> 6.0'
   gem 'capybara', '~> 3.0'
   gem 'capybara-selenium'
   gem 'webdrivers', '~> 3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
       debug_inspector (>= 0.0.1)
     brakeman (4.5.0)
     builder (3.2.3)
+    bullet (6.0.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     callsite (0.0.11)
     cancancan (1.17.0)
@@ -665,6 +668,7 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
+    uniform_notifier (1.12.1)
     utf8-cleaner (0.2.5)
       activesupport
     vcr (4.0.0)
@@ -708,6 +712,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   brakeman
+  bullet (~> 6.0)
   byebug
   cancancan (~> 1.15)
   capybara (~> 3.0)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -89,6 +89,15 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # log N+1 queries, unused eager loading, avoidable count queries
+  # see log/bullet.log
+  #
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    # Bullet.raise = true # raise an error if optimization possible
+  end
+
   # Disable CSS3, jQuery animations and JS popups in test mode for speed, consistency and to avoid timing issues.
   config.middleware.use Rack::NoAnimations
   config.middleware.insert_after(Rack::NoAnimations, Rack::NoPopups)


### PR DESCRIPTION
#### What
Add  [bullet gem](https://github.com/flyerhzm/bullet)

#### Why
The bullet gem has been added and configured to run against the
test suite only. It will log errors to `log/bullet.log` for manual 
review by a developer.

This can be used, like rubocop, to optimize the codebase
and address technical debt when we have time.
