### PR TITLE
Fix seed data bug with evidence checklist

### DIFF
--- a/lib/demo_data/document_generator.rb
+++ b/lib/demo_data/document_generator.rb
@@ -7,7 +7,6 @@ module DemoData
       'repo_order_1.pdf'                      => 1,
       'repo_order_2.pdf'                      => 1,
       'repo_order_3.pdf'                      => 1,
-      'LAC_1.pdf'                             => 3,
       'committal_bundle.pdf'                   => 3,
       'indictment.pdf'                        => 4,
       'judicial_appointment_order.pdf'        => 5,

--- a/lib/demo_data/document_generator.rb
+++ b/lib/demo_data/document_generator.rb
@@ -7,7 +7,7 @@ module DemoData
       'repo_order_1.pdf'                      => 1,
       'repo_order_2.pdf'                      => 1,
       'repo_order_3.pdf'                      => 1,
-      'LAC_1.pdf'                             => 2,
+      'LAC_1.pdf'                             => 3,
       'committal_bundle.pdf'                   => 3,
       'indictment.pdf'                        => 4,
       'judicial_appointment_order.pdf'        => 5,


### PR DESCRIPTION
`ERROR: StateMachines::InvalidTransition :: Cannot transition state via :submit from :draft (Reason(s): Evidence checklist ids Evidence checklist id 2 is invalid, please use valid evidence checklist ids)`

Change id of evidence to `2` to avoid this. This is because the DocType with this id was deleted from `/app/models/doc_type.rb` in the last PR as it was an old evidence type. 
