### PR TITLE
Update gemfile lock to reflect removal of sdoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rdoc (4.3.0)
     redis (3.3.5)
     regexp_parser (1.4.0)
     remotipart (1.4.2)
@@ -580,9 +579,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sdoc (0.4.2)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
     selenium-webdriver (3.142.0)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -790,7 +786,6 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 5.0.7)
   scheduler_daemon!
-  sdoc (~> 0.4.0)
   sentry-raven (~> 2.9.0)
   shell-spinner (~> 1.0, >= 1.0.4)
   shoulda-matchers (>= 4.0.0.rc1)


### PR DESCRIPTION
should have been a part of 8f2ed914e8e9ef5397f627528c3949cc3351b6bb to remove sdoc.
