### PR TITLE
Amend factory default rep order date

### DIFF
--- a/features/support/date_helper.rb
+++ b/features/support/date_helper.rb
@@ -11,7 +11,7 @@ module DateHelper
   end
 
   def scheme_date_for(text)
-    case text.downcase.strip
+    case text&.downcase&.strip
       when 'scheme 11' then
         Settings.agfs_scheme_11_release_date.strftime
       when 'scheme 10' || 'post agfs reform' then

--- a/spec/api/v1/external_users/expense_spec.rb
+++ b/spec/api/v1/external_users/expense_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe API::V1::ExternalUsers::Expense do
         reason_id: 5,
         reason_text: "Foo",
         mileage_rate_id: 1,
-        date: "2018-04-01T12:30:00"
+        date: scheme_date_for('scheme 10')
       }
     end
 

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
       end
 
       context 'valid certification params for submission' do
-        let(:frozen_time) { Time.new(2015, 8, 20, 13, 54, 22) }
+        let(:frozen_time) { Time.new(2018, 8, 20, 13, 54, 22) }
 
         it 'should be a redirect to confirmation' do
           post :create, params: valid_certification_params(claim, certification_type)
@@ -93,7 +93,7 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller, focus
         end
 
         it 'should set the submitted at date' do
-          Timecop.freeze(frozen_time) do
+          travel_to(frozen_time) do
             post :create, params: valid_certification_params(claim, certification_type)
           end
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -257,8 +257,8 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
   subject { create(:advocate_claim) }
 
   describe '.earliest_representation_order' do
-    let(:claim)         { FactoryBot.build :unpersisted_claim }
-    let(:early_date)    { 2.years.ago.to_date }
+    let(:claim) { FactoryBot.build :unpersisted_claim }
+    let(:early_date) { scheme_date_for(nil).to_date - 10.days }
 
     before(:each) do
       # add a second defendant

--- a/spec/models/stats/collector/claim_creation_source_collector_spec.rb
+++ b/spec/models/stats/collector/claim_creation_source_collector_spec.rb
@@ -49,11 +49,11 @@ module Stats
       end
 
       def report_day
-        Timecop.freeze(Time.new(2016, 3, 10, 11, 44, 55)) { 5.days.ago }
+        Timecop.freeze(Time.new(2018, 3, 10, 11, 44, 55)) { 5.days.ago }
       end
 
       def create_claim(state, date, attributes = {})
-        Timecop.freeze(date) do
+        travel_to(date) do
           FactoryBot.create(factory_name(state), attributes)
         end
       end

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -7,7 +7,7 @@ module FactoryHelpers
                 end
     create(:representation_order,
             defendant: defendant,
-            representation_order_date: representation_order_date || 380.days.ago)
+            representation_order_date: representation_order_date&.to_date || 380.days.ago)
     claim.reload
   end
 

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -72,9 +72,7 @@ module FactoryHelpers
   end
 
   def scheme_date_for(text)
-    return 400.days.ago unless text
-
-    case text.downcase.strip
+    case text&.downcase&.strip
       when 'scheme 11' then
         Settings.agfs_scheme_11_release_date.strftime
       when 'scheme 10' || 'post agfs reform' then

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -47,7 +47,7 @@ module TestHelpers
   end
 
   def scheme_date_for(text)
-    case text.downcase.strip
+    case text&.downcase&.strip
       when 'scheme 11' then
         Settings.agfs_scheme_11_release_date.strftime
       when 'scheme 10' || 'post agfs reform' then


### PR DESCRIPTION
#### What
Amend factory default rep order date

#### Why
The default `400.days.ago` was hitting
conflicts with tests as of today.
