### PR TITLE
Remove parallel_tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,6 @@ group :development, :devunicorn, :test do
   gem 'rspec-rails'
   gem 'rspec-collection_matchers'
   gem 'puma'
-  gem 'parallel_tests'
   gem 'site_prism', '~> 3.0'
   gem 'jasmine', '~> 3.4'
   gem 'guard-jasmine', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,8 +444,6 @@ GEM
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
     parallel (1.17.0)
-    parallel_tests (2.28.0)
-      parallel
     parser (2.6.3.0)
       ast (~> 2.4.0)
     pdf-forms (1.2.0)
@@ -761,7 +759,6 @@ DEPENDENCIES
   nokogiri (~> 1.10)
   paper_trail (~> 10.3.0)
   paperclip (~> 5.3.0)
-  parallel_tests
   pdf-forms
   pg (~> 0.18.2)
   posix-spawn (~> 0.3.13)

--- a/README.md
+++ b/README.md
@@ -226,11 +226,6 @@ To ping all environments
 alias ping.adp='for i in dev-adp.dsd.io staging-adp.dsd.io demo-adp.dsd.io api-sandbox-adp.dsd.io claim-crown-court-defence.service.gov.uk ; do a="https://${i}/ping.json" ; echo $a; b=`curl --silent $a` ; echo $b; echo; done'
 ```
 
-To run unit and integration tests in parallel
-```
-alias rake.fast='rake parallel:spec; rake parallel:features'
-```
-
 ## Sidekiq Console
 
 To run Sidekiq

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ devunicorn:
 
 test: &test
   <<: *default
-  database: <%= ENV['CBO_BASE_DATABASE_DATABASE'] || 'cbo_test' %><%= ENV['TEST_ENV_NUMBER'] %>
+  database: <%= ENV['CBO_BASE_DATABASE_DATABASE'] || 'cbo_test' %>
 
 develop:
   <<: *default


### PR DESCRIPTION
#### What
Remove parallel_tests gem

#### Why
This test suite dependency is not being
used and is not configured to play well
with current test suite in any event
due to before hooks in both rspec
and cucumber.
