### PR TITLE
Cbo 626 fix dump script

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -275,7 +275,7 @@ namespace :db do
     open(file_name, 'a') do |file|
       yield ->(model) do
         type_caster = model.class.arel_table.send(:type_caster)
-        values = model.send(:arel_attributes_with_values_for_create, model.class.column_names)
+        values = model.send(:attributes_for_create, model.class.column_names)
         values.each do |attribute, value|
           values[attribute] = type_caster.type_cast_for_database(attribute.name, value)
         end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 namespace :db do
 
   namespace :static do
@@ -316,7 +314,7 @@ namespace :db do
     attr_accessor :model
     def initialize(file_name)
       @model = nil
-      @file_name = file_name || 'anonymised_data.sql' 
+      @file_name = file_name || 'anonymised_data.sql'
     end
 
     def model=(model)
@@ -345,7 +343,7 @@ namespace :db do
       column_names = model.class.column_names
       attribute_names = extract_attribute_names(column_names)
       add_values(attribute_names)
-    end 
+    end
 
     def add_values(attribute_names)
       attrs = {}
@@ -361,9 +359,9 @@ namespace :db do
 
     def extract_attribute_names(column_names)
       # note attributes_for_creater is a private method
-      # therefore not great to depend on
+      # therefore not great to depend on.
       # call to it extracted here for later refactor.
-      model.send(:attributes_for_create, column_names) 
+      model.send(:attributes_for_create, column_names)
     end
   end
 end


### PR DESCRIPTION
#### What
Fix database dump script

#### Ticket

[CBO-626 fix dump script](https://dsdmoj.atlassian.net/browse/CBO-626)

#### Why
It broke when we upgraded rails to 5.2.2

Issue was that the method `arel_attributes_with_values_for_create` had become deprecated

#### How
New class that should make it easier to maintain.

--------

#### TODO (wip)

- [] test it actually works for prod
- [] possible further refactors
