### PR TITLE
Switch unicorn application server to use port 3000

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -92,4 +92,4 @@ echo "starting sidekiq daemon"
 bundle exec sidekiq -d
 
 echo "launching unicorn"
-bundle exec unicorn -p 80 -c config/unicorn.rb
+bundle exec unicorn -p 3000 -c config/unicorn.rb


### PR DESCRIPTION
Switch port on which unicorn listens

#### What
This MUST be combined with a change to the
host (nginx) to container port mapping, defined
in your deployment, such that the host forwards 
requests to this new port.

For Template-deploy this goes in [enviroment specific pillar file](https://github.com/ministryofjustice/template-deploy/blob/master/pillar/prod/prod.sls).

A CCCD Template-deploy specific example can be
[found on this line](https://github.com/ministryofjustice/advocate-defence-payments-deploy/blob/master/pillar/demo/demo.sls#L52)


#### Ticket
[relates to CBO-707](https://dsdmoj.atlassian.net/browse/CBO-707)

#### Why
Migration to kubernetes solution will necessitate not using
port 80 - because the app must be run as a non-root user
in alpine linux distro. non-root users are not permitted
to bind to port 80.

#### How
- Have unicorn 'listen' on port 3000 (default rails port) - is this good practice
- Update stack to map nginx http server port to that port see [advocate-defence-payments-deploy](https://github.com/ministryofjustice/advocate-defence-payments-deploy)

--------

#### TODO (wip)

 - [X] Start unicorn on port 3000
 - [x]  map nginx http server port to that port - [separate PR](https://github.com/ministryofjustice/advocate-defence-payments-deploy/pull/180)
