### PR TITLE
CBO-710: Implement provider manager role spike

### DIFF
--- a/app/controllers/provider_management/external_users_controller.rb
+++ b/app/controllers/provider_management/external_users_controller.rb
@@ -23,7 +23,7 @@ class ProviderManagement::ExternalUsersController < ApplicationController
 
     if @external_user.save
       deliver_reset_password_instructions(@external_user.user)
-      redirect_to super_admins_provider_external_user_path(@provider, @external_user),
+      redirect_to provider_management_provider_external_user_path(@provider, @external_user),
                   notice: 'User successfully created'
     else
       render :new
@@ -36,15 +36,15 @@ class ProviderManagement::ExternalUsersController < ApplicationController
 
   def search
     if @external_user&.is_a?(ExternalUser)
-      redirect_to super_admins_provider_external_user_path(@external_user.provider, @external_user)
+      redirect_to provider_management_provider_external_user_path(@external_user.provider, @external_user)
     else
-      redirect_to super_admins_external_users_find_path, alert: 'No provider found with that email'
+      redirect_to provider_management_external_users_find_path, alert: 'No provider found with that email'
     end
   end
 
   def update
     if @external_user.update(external_user_params)
-      redirect_to super_admins_provider_external_user_path(@provider, @external_user),
+      redirect_to provider_management_provider_external_user_path(@provider, @external_user),
                   notice: 'User successfully updated'
     else
       render :edit
@@ -60,7 +60,7 @@ class ProviderManagement::ExternalUsersController < ApplicationController
     user = @external_user.user
 
     if user.update(password_params[:user_attributes])
-      redirect_to super_admins_provider_external_user_path(@provider, @external_user),
+      redirect_to provider_management_provider_external_user_path(@provider, @external_user),
                   notice: 'User password successfully updated'
     else
       render :change_password

--- a/app/controllers/provider_management/external_users_controller.rb
+++ b/app/controllers/provider_management/external_users_controller.rb
@@ -1,0 +1,92 @@
+class ProviderManagement::ExternalUsersController < ApplicationController
+  include PasswordHelpers
+
+  before_action :set_provider, except: %i[find search]
+  before_action :set_external_user, only: %i[show edit update change_password update_password]
+  before_action :external_user_by_email, only: %i[search]
+
+  def show; end
+
+  def index
+    @external_users = ExternalUser.where(provider: @provider)
+  end
+
+  def new
+    @external_user = ExternalUser.new(provider: @provider)
+    @external_user.build_user
+  end
+
+  def create
+    # downcase email_confirmation - devise will downcase the email
+    params[:external_user][:user_attributes][:email_confirmation].downcase!
+    @external_user = ExternalUser.new(params_with_temporary_password.merge(provider: @provider))
+
+    if @external_user.save
+      deliver_reset_password_instructions(@external_user.user)
+      redirect_to super_admins_provider_external_user_path(@provider, @external_user),
+                  notice: 'User successfully created'
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def find; end
+
+  def search
+    if @external_user&.is_a?(ExternalUser)
+      redirect_to super_admins_provider_external_user_path(@external_user.provider, @external_user)
+    else
+      redirect_to super_admins_external_users_find_path, alert: 'No provider found with that email'
+    end
+  end
+
+  def update
+    if @external_user.update(external_user_params)
+      redirect_to super_admins_provider_external_user_path(@provider, @external_user),
+                  notice: 'User successfully updated'
+    else
+      render :edit
+    end
+  end
+
+  def change_password; end
+
+  # NOTE: do NOT use update_password in PasswordHelper as it will
+  #       require current password and then sign in as user whose
+  #       password was changed and redirect to their user profile path
+  def update_password
+    user = @external_user.user
+
+    if user.update(password_params[:user_attributes])
+      redirect_to super_admins_provider_external_user_path(@provider, @external_user),
+                  notice: 'User password successfully updated'
+    else
+      render :change_password
+    end
+  end
+
+  private
+
+  def external_user_params
+    params.require(:external_user).permit(
+      :vat_registered,
+      :supplier_number,
+      roles: [],
+      user_attributes: %i[id email email_confirmation password password_confirmation first_name last_name]
+    )
+  end
+
+  def set_external_user
+    @external_user = ExternalUser.active.find(params[:id])
+  end
+
+  def external_user_by_email
+    @external_user = User.active.find_by(email: params[:external_user][:email])&.persona
+  end
+
+  def set_provider
+    @provider = Provider.find(params[:provider_id])
+  end
+end

--- a/app/controllers/provider_management/providers_controller.rb
+++ b/app/controllers/provider_management/providers_controller.rb
@@ -16,7 +16,7 @@ class ProviderManagement::ProvidersController < ApplicationController
 
   def update
     if @provider.update(provider_params.except(*filtered_params))
-      redirect_to super_admins_provider_path(@provider), notice: 'Provider successfully updated'
+      redirect_to provider_management_provider_path(@provider), notice: 'Provider successfully updated'
     else
       render 'shared/providers/edit'
     end
@@ -25,7 +25,7 @@ class ProviderManagement::ProvidersController < ApplicationController
   def create
     @provider = Provider.new(provider_params)
     if @provider.save
-      redirect_to super_admins_root_path, notice: 'Provider successfully created'
+      redirect_to provider_management_root_path, notice: 'Provider successfully created'
     else
       render 'shared/providers/new'
     end

--- a/app/controllers/provider_management/providers_controller.rb
+++ b/app/controllers/provider_management/providers_controller.rb
@@ -1,0 +1,43 @@
+class ProviderManagement::ProvidersController < ApplicationController
+  include ProviderAdminConcern
+
+  def index
+    @providers = Provider.order(name: :asc)
+  end
+
+  def new
+    @provider = Provider.new
+    render 'shared/providers/new'
+  end
+
+  def edit
+    render 'shared/providers/edit'
+  end
+
+  def update
+    if @provider.update(provider_params.except(*filtered_params))
+      redirect_to super_admins_provider_path(@provider), notice: 'Provider successfully updated'
+    else
+      render 'shared/providers/edit'
+    end
+  end
+
+  def create
+    @provider = Provider.new(provider_params)
+    if @provider.save
+      redirect_to super_admins_root_path, notice: 'Provider successfully created'
+    else
+      render 'shared/providers/new'
+    end
+  end
+
+  private
+
+  def set_provider
+    @provider = Provider.find(params[:id])
+  end
+
+  def filtered_params
+    []
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -40,7 +40,7 @@ class Ability
     can_manage_self(persona)
   end
 
-  def case_worker_admin(_persona)
+  def case_worker_admin(persona)
     can %i[index show update archived], Claim::BaseClaim
     can %i[show download], Document
     can %i[index new create], CaseWorker
@@ -48,6 +48,7 @@ class Ability
     can %i[new create], Allocation
     can :view, :management_information
     can %i[dismiss], InjectionAttempt
+    can %i[show index new create edit update], Provider if persona.roles.include?('provider_management')
   end
 
   def case_worker(persona)
@@ -55,6 +56,7 @@ class Ability
     can [:update], Claim::BaseClaim do |claim|
       claim.case_workers.include?(persona)
     end
+    can %i[show index new create edit update], Provider if persona.roles.include?('provider_management')
     can %i[show download], Document
     can_manage_own_password(persona)
     can %i[dismiss], InjectionAttempt

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -48,7 +48,7 @@ class Ability
     can %i[new create], Allocation
     can :view, :management_information
     can %i[dismiss], InjectionAttempt
-    can %i[show index new create edit update], Provider if persona.roles.include?('provider_management')
+    provider_management if persona.roles.include?('provider_management')
   end
 
   def case_worker(persona)
@@ -56,10 +56,15 @@ class Ability
     can [:update], Claim::BaseClaim do |claim|
       claim.case_workers.include?(persona)
     end
-    can %i[show index new create edit update], Provider if persona.roles.include?('provider_management')
+    provider_management if persona.roles.include?('provider_management')
     can %i[show download], Document
     can_manage_own_password(persona)
     can %i[dismiss], InjectionAttempt
+  end
+
+  def provider_management
+    can %i[show index new create edit update change_password update_password find search], ExternalUser
+    can %i[show index new create edit update], Provider
   end
 
   def persona_type(persona)

--- a/app/models/case_worker.rb
+++ b/app/models/case_worker.rb
@@ -14,7 +14,7 @@
 class CaseWorker < ApplicationRecord
   auto_strip_attributes squish: true, nullify: true
 
-  ROLES = %w[admin case_worker].freeze
+  ROLES = %w[admin case_worker provider_management].freeze
 
   include Roles
   include SoftlyDeletable

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -9,8 +9,6 @@
         %li
           = link_to t('.add_a_provider'), new_super_admins_provider_path, class: cp(new_super_admins_provider_path)
         %li
-          = link_to t('.find_provider_by_email'), super_admins_external_users_find_path, class: cp(new_super_admins_provider_path)
-        %li
           = link_to t('.sidekiq_console'), sidekiq_web_path
       - elsif current_user.persona.is_a?(ExternalUser)
         %li

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -31,11 +31,11 @@
           %li
             = link_to t('.manage_your_settings'), edit_external_users_admin_external_user_path(current_user.persona), 'aria-label': t('.manage_your_settings'), class: cp(edit_external_users_admin_external_user_path(current_user.persona))
       - elsif current_user.persona.is_a?(CaseWorker)
+        %li
+          = link_to t('.your_claims'), case_workers_claims_path({ tab: :current }), 'aria-label': t('.your_claims'), class: cp(case_workers_claims_path)
+        %li
+          = link_to t('.archive'), archived_case_workers_claims_path({ tab: :archived }), 'aria-label': t('.archive'), class: cp(archived_case_workers_claims_path)
         - if current_user.persona.admin?
-          %li
-            = link_to t('.your_claims'), case_workers_claims_path({ tab: :current }), 'aria-label': t('.your_claims'), class: cp(case_workers_claims_path)
-          %li
-            = link_to t('.archive'), archived_case_workers_claims_path({ tab: :archived }), 'aria-label': t('.archive'), class: cp(archived_case_workers_claims_path)
           %li
             = link_to t('.allocation'), case_workers_admin_allocations_path, 'aria-label': t('.allocation'), class: cp(case_workers_admin_allocations_path({ tab: :unallocated }))
           %li
@@ -44,11 +44,12 @@
             = link_to t('.manage_case_workers'), case_workers_admin_case_workers_path, 'aria-label': t('.manage_case_workers'), class: cp(case_workers_admin_case_workers_path)
           %li
             = link_to t('.management_information'), case_workers_admin_management_information_path, 'aria-label': t('.management_information'), class: cp(case_workers_admin_management_information_path)
-        - else
+        - if current_user.persona.provider_management?
           %li
-            = link_to t('.your_claims'), case_workers_claims_path({ tab: :current }), 'aria-label': t('.your_claims'), class: cp(case_workers_claims_path)
+            = link_to t('.manage_providers'), provider_management_providers_path, class: cp(super_admins_providers_path)
           %li
-            = link_to t('.archive'), archived_case_workers_claims_path({ tab: :archived }), 'aria-label': t('.archive'), class: cp(archived_case_workers_claims_path)
+            = link_to t('.find_provider_by_email'), super_admins_external_users_find_path, class: cp(new_super_admins_provider_path)
+
       - else
         %li
           = t('.error')

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -42,13 +42,12 @@
             = link_to t('.re_allocation'), case_workers_admin_allocations_path({ tab: :allocated }), 'aria-label': t('.re_allocation'), class: cp(case_workers_admin_allocations_path({ tab: :allocated }))
           %li
             = link_to t('.manage_case_workers'), case_workers_admin_case_workers_path, 'aria-label': t('.manage_case_workers'), class: cp(case_workers_admin_case_workers_path)
-          %li
-            = link_to t('.management_information'), case_workers_admin_management_information_path, 'aria-label': t('.management_information'), class: cp(case_workers_admin_management_information_path)
         - if current_user.persona.provider_management?
           %li
-            = link_to t('.manage_providers'), provider_management_providers_path, class: cp(super_admins_providers_path)
+            = link_to t('.manage_providers'), provider_management_providers_path, 'aria-label': t('.manage_providers'), class: cp(provider_management_providers_path)
+        - if current_user.persona.admin?
           %li
-            = link_to t('.find_provider_by_email'), provider_management_external_users_find_path, class: cp(new_super_admins_provider_path)
+            = link_to t('.management_information'), case_workers_admin_management_information_path, 'aria-label': t('.management_information'), class: cp(case_workers_admin_management_information_path)
 
       - else
         %li

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -48,7 +48,7 @@
           %li
             = link_to t('.manage_providers'), provider_management_providers_path, class: cp(super_admins_providers_path)
           %li
-            = link_to t('.find_provider_by_email'), super_admins_external_users_find_path, class: cp(new_super_admins_provider_path)
+            = link_to t('.find_provider_by_email'), provider_management_external_users_find_path, class: cp(new_super_admins_provider_path)
 
       - else
         %li

--- a/app/views/provider_management/external_users/_form.html.haml
+++ b/app/views/provider_management/external_users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for [:super_admins, @provider, @external_user] do |f|
+= form_for [:provider_management, @provider, @external_user] do |f|
   - if @external_user.errors.any?
     .error-summary{"aria-labelledby" => "error-summary-heading", :role => "alert", :tabindex => "-1"}
       %h2#error-summary-heading.heading-medium.error-summary-heading

--- a/app/views/provider_management/external_users/_form.html.haml
+++ b/app/views/provider_management/external_users/_form.html.haml
@@ -1,0 +1,57 @@
+= form_for [:super_admins, @provider, @external_user] do |f|
+  - if @external_user.errors.any?
+    .error-summary{"aria-labelledby" => "error-summary-heading", :role => "alert", :tabindex => "-1"}
+      %h2#error-summary-heading.heading-medium.error-summary-heading
+        = "#{t('.prohibited_save')} #{pluralize(@external_user.errors.count, t('.error'))}"
+      %ul.error-summary-list
+        - @external_user.errors.full_messages.each do |msg|
+          %li
+            = msg
+
+  = f.fields_for :user do |user_fields|
+    %fieldset.user-form
+
+      .form-group
+        = user_fields.label t(".first_name"), class: "form-label-bold", for: "external_user_user_attributes_first_name"
+        = user_fields.text_field :first_name, class: "form-control"
+
+      .form-group
+        = user_fields.label t(".last_name"), class: "form-label-bold", for: "external_user_user_attributes_last_name"
+        = user_fields.text_field :last_name, class: "form-control"
+
+      .form-group
+        = user_fields.label t(".email"), class: "form-label-bold", for: "external_user_user_attributes_email"
+        = user_fields.email_field :email, class: "form-control"
+
+      .form-group
+        = user_fields.label t(".email_confirmation"), class: "form-label-bold", for: "external_user_user_attributes_email_confirmation"
+        = user_fields.email_field :email_confirmation, class: "form-control"
+
+    %fieldset.inline{"aria-describedby": "checkbox-control-legend-roles"}
+      %legend#checkbox-control-legend-roles
+        %span.form-label-bold
+          = t('.roles')
+
+      .form-group.inline.js-advocate-roles
+        = f.collection_check_boxes(:roles, @external_user.available_roles, :to_s, :to_s) do |b|
+          .multiple-choice
+            = b.check_box("aria-labelledby": "checkbox-control-legend-roles #{b.text.to_css_class}")
+            = b.label(id: b.value.to_css_class) { b.value.humanize }
+
+
+    - if @provider.chamber?
+      .form-group{"aria-describedby": "radio-control-legend"}
+        %fieldset.inline
+          %legend#radio-control-legend
+            %span.form-label-bold
+              = t('.apply_vat')
+            = f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
+              .multiple-choice
+                = b.radio_button("aria-labelledby": "radio-control-legend #{b.text.to_css_class}")
+                = b.label(id: b.value.to_css_class) { (b.value.to_s == 'true' ? 'Yes' : 'No') }
+
+      .form-group
+        = f.label t(".supplier_number"), class: "form-label", for: "external_user_supplier_number"
+        = f.text_field :supplier_number, class: "form-control"
+
+    = f.submit t('.submit'), class: "button"

--- a/app/views/provider_management/external_users/_form.html.haml
+++ b/app/views/provider_management/external_users/_form.html.haml
@@ -54,4 +54,4 @@
         = f.label t(".supplier_number"), class: "form-label", for: "external_user_supplier_number"
         = f.text_field :supplier_number, class: "form-control"
 
-    = f.submit t('.submit'), class: "button"
+    = f.submit t(".submit.#{action_name}"), class: "button"

--- a/app/views/provider_management/external_users/change_password.html.haml
+++ b/app/views/provider_management/external_users/change_password.html.haml
@@ -5,7 +5,7 @@
   = stylesheet_link_tag "v2/application", media: "all"
 
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
-= form_for [:super_admins, @external_user], url: update_password_super_admins_provider_external_user_path(@provider, @external_user) do |f|
+= form_for [:provider_management, @external_user], url: update_password_provider_management_provider_external_user_path(@provider, @external_user) do |f|
   - if @external_user.user.errors.any?
     .error-summary{"aria-labelledby" => "error-summary-heading-example-1", :role => "alert", :tabindex => "-1"}
       %h2#error-summary-heading-example-1.heading-medium.error-summary-heading

--- a/app/views/provider_management/external_users/change_password.html.haml
+++ b/app/views/provider_management/external_users/change_password.html.haml
@@ -1,0 +1,33 @@
+= content_for :page_title, flush: true do
+  = t('.page_title', external_user: @external_user.name)
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+= form_for [:super_admins, @external_user], url: update_password_super_admins_provider_external_user_path(@provider, @external_user) do |f|
+  - if @external_user.user.errors.any?
+    .error-summary{"aria-labelledby" => "error-summary-heading-example-1", :role => "alert", :tabindex => "-1"}
+      %h2#error-summary-heading-example-1.heading-medium.error-summary-heading
+        = "#{t('.prohibited_save')} #{pluralize(@external_user.user.errors.count, 'error')}"
+      %ul.error-summary-list
+        - @external_user.user.errors.full_messages.each do |msg|
+          %li
+            = msg
+  %h2.heading-medium
+    = t('.heading', external_user: @external_user.name)
+
+  = f.fields_for :user do |user_fields|
+    .form-fields
+      %fieldset
+        %legend.visually-hidden Change Password
+        .form-group
+          .form-group.input
+            = user_fields.label t(".password"), class: "form-label-bold"
+            = user_fields.password_field :password, class: "form-control"
+          .form-group.input
+            = user_fields.label t(".password_confirmation"), class: "form-label-bold"
+            = user_fields.password_field :password_confirmation, class: "form-control"
+
+  .form-group
+    = f.submit t(".submit"), class: "button"

--- a/app/views/provider_management/external_users/edit.html.haml
+++ b/app/views/provider_management/external_users/edit.html.haml
@@ -1,0 +1,12 @@
+= content_for :page_title, flush: true do
+  = t('.page_title', external_user: @external_user.name)
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading:  t('.page_heading')}
+
+%h2.heading-medium
+  = t('.heading')
+
+= render 'form'

--- a/app/views/provider_management/external_users/find.html.haml
+++ b/app/views/provider_management/external_users/find.html.haml
@@ -9,6 +9,6 @@
 = form_for(:external_user, url: provider_management_external_users_find_path) do |f|
   .form-group
     = f.label t(".email"), class: "form-label-bold"
-    = f.email_field :email, class: "form-control"
+    = f.email_field :email, class: "form-control email"
 
   = f.submit t('.submit'), class: "button"

--- a/app/views/provider_management/external_users/find.html.haml
+++ b/app/views/provider_management/external_users/find.html.haml
@@ -6,7 +6,7 @@
 
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
-= form_for(:external_user, url: super_admins_external_users_find_path) do |f|
+= form_for(:external_user, url: provider_management_external_users_find_path) do |f|
   .form-group
     = f.label t(".email"), class: "form-label-bold"
     = f.email_field :email, class: "form-control"

--- a/app/views/provider_management/external_users/find.html.haml
+++ b/app/views/provider_management/external_users/find.html.haml
@@ -1,0 +1,14 @@
+= content_for :page_title, flush: true do
+  = t('.page_title')
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+
+= form_for(:external_user, url: super_admins_external_users_find_path) do |f|
+  .form-group
+    = f.label t(".email"), class: "form-label-bold"
+    = f.email_field :email, class: "form-control"
+
+  = f.submit t('.submit'), class: "button"

--- a/app/views/provider_management/external_users/index.html.haml
+++ b/app/views/provider_management/external_users/index.html.haml
@@ -7,7 +7,7 @@
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 .grid-row.clear-float
-  = link_to t('.add_provider'), new_super_admins_provider_external_user_path(@provider), class: 'button right'
+  = link_to t('.add_provider'), new_provider_management_provider_external_user_path(@provider), class: 'button right'
 
 %table{summary: t('.table_summary', provider_name: @provider.name)}
   %caption
@@ -26,7 +26,7 @@
     - @external_users.each do |advocate|
       %tr
         %td{scope: 'row'}
-          = advocate.active? ? link_to(advocate.name, super_admins_provider_external_user_path(@provider, advocate), title: t('.view_details', text: advocate.name )) : advocate.name
+          = advocate.active? ? link_to(advocate.name, provider_management_provider_external_user_path(@provider, advocate), title: t('.view_details', text: advocate.name )) : advocate.name
         %td
           = advocate.supplier_number
         %td

--- a/app/views/provider_management/external_users/index.html.haml
+++ b/app/views/provider_management/external_users/index.html.haml
@@ -1,0 +1,35 @@
+= content_for :page_title, flush: true do
+  = t('.page_title', provider_name: @provider.name)
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+
+.grid-row.clear-float
+  = link_to t('.add_provider'), new_super_admins_provider_external_user_path(@provider), class: 'button right'
+
+%table{summary: t('.table_summary', provider_name: @provider.name)}
+  %caption
+    %h2.heading-medium.left
+      = t('.caption', provider_name: @provider.name)
+  %thead
+    %th{scope: 'col'}
+      = t('.name')
+    %th{scope: 'col'}
+      = t('.supplier_number')
+    %th{scope: 'col'}
+      = t('.email')
+    %th{scope: 'col'}
+      = t('.state')
+  %tbody
+    - @external_users.each do |advocate|
+      %tr
+        %td{scope: 'row'}
+          = advocate.active? ? link_to(advocate.name, super_admins_provider_external_user_path(@provider, advocate), title: t('.view_details', text: advocate.name )) : advocate.name
+        %td
+          = advocate.supplier_number
+        %td
+          = mail_to advocate.email, advocate.email, {title: t('.title', provider: advocate.name)}
+        %td
+          = advocate.active? ? t('.live')  : t('.inactive')

--- a/app/views/provider_management/external_users/new.html.haml
+++ b/app/views/provider_management/external_users/new.html.haml
@@ -1,0 +1,13 @@
+= content_for :page_title, flush: true do
+  = t('.page_title', provider_name: @provider.name)
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+
+%h2.heading-medium
+  = t('.heading', provider_name: @provider.name)
+
+= render 'form'

--- a/app/views/provider_management/external_users/show.html.haml
+++ b/app/views/provider_management/external_users/show.html.haml
@@ -15,7 +15,7 @@
         %th{scope: 'row'}
           = t('.provider')
         %td
-          = link_to @external_user.provider.name, super_admins_provider_path(@provider), title: t('.edit_provider')
+          = link_to @external_user.provider.name, provider_management_provider_path(@provider), title: t('.edit_provider')
       %tr
         %th{scope: 'row'}
           = t('.email')
@@ -44,7 +44,7 @@
 
 .form-group
   - if can? :edit, @external_user
-    = link_to t('.edit'), edit_super_admins_provider_external_user_path(@provider, @external_user), class: 'button', role: 'button'
+    = link_to t('.edit'), edit_provider_management_provider_external_user_path(@provider, @external_user), class: 'button', role: 'button'
 
   - if can? :change_password, @external_user
-    = link_to t('.change_password'), change_password_super_admins_provider_external_user_path(@provider, @external_user), class: 'button', role: 'button'
+    = link_to t('.change_password'), change_password_provider_management_provider_external_user_path(@provider, @external_user), class: 'button', role: 'button'

--- a/app/views/provider_management/external_users/show.html.haml
+++ b/app/views/provider_management/external_users/show.html.haml
@@ -1,0 +1,50 @@
+= content_for :page_title, flush: true do
+  = t('.page_title', external_user: @external_user.name)
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+
+.form-group
+  %table{summary: t('.table_summary', external_user: @external_user.name)}
+    %caption.heading-medium
+      = t('.caption')
+    %tbody
+      %tr
+        %th{scope: 'row'}
+          = t('.provider')
+        %td
+          = link_to @external_user.provider.name, super_admins_provider_path(@provider), title: t('.edit_provider')
+      %tr
+        %th{scope: 'row'}
+          = t('.email')
+        %td
+          = @external_user.email
+      %tr
+        %th{scope: 'row'}
+          = t('.name')
+        %td
+          = @external_user.name
+      %tr
+        %th{scope: 'row'}
+          = t('.supplier_number')
+        %td
+          = @external_user.supplier_number
+      %tr
+        %th{scope: 'row'}
+          = t('.vat_registered')
+        %td
+          = @external_user.vat_registered? ? t('.answer_yes') : t('.answer_no')
+      %tr
+        %th{scope: 'row'}
+          = t('.role')
+        %td
+          = @external_user.roles.map(&:humanize).join(', ')
+
+.form-group
+  - if can? :edit, @external_user
+    = link_to t('.edit'), edit_super_admins_provider_external_user_path(@provider, @external_user), class: 'button', role: 'button'
+
+  - if can? :change_password, @external_user
+    = link_to t('.change_password'), change_password_super_admins_provider_external_user_path(@provider, @external_user), class: 'button', role: 'button'

--- a/app/views/provider_management/providers/_providers.html.haml
+++ b/app/views/provider_management/providers/_providers.html.haml
@@ -4,7 +4,7 @@
 - else
 
   %table{summary: t('.table_summary')}
-    %caption.heading-medium
+    %caption.heading-medium.visually-hidden
       = t('.caption')
     %thead
       %th{scope: 'col'}

--- a/app/views/provider_management/providers/_providers.html.haml
+++ b/app/views/provider_management/providers/_providers.html.haml
@@ -1,0 +1,32 @@
+- if providers.none?
+  %p
+    No providers found
+- else
+
+  %table{summary: t('.table_summary')}
+    %caption.heading-medium
+      = t('.caption')
+    %thead
+      %th{scope: 'col'}
+        = t('.provider_name')
+      %th{scope: 'col'}
+        = t('.provider_type')
+      %th{scope: 'col'}
+        = t('.fee_schemes')
+      %th{scope: 'col'}
+        = t('.vat_registered')
+      %th{scope: 'col'}
+        Users
+    %tbody
+      - providers.each do |provider|
+        %tr{id: dom_id(provider) }
+          %th{ scope: 'row'}
+            = link_to provider.name, super_admins_provider_path(provider)
+          %td
+            = provider.provider_type.humanize
+          %td
+            = provider.roles.map(&:upcase) * ', '
+          %td
+            = provider.vat_registered == true ? 'Yes' : 'No'
+          %td
+            = link_to "Manage users in provider", super_admins_provider_external_users_path(provider)

--- a/app/views/provider_management/providers/_providers.html.haml
+++ b/app/views/provider_management/providers/_providers.html.haml
@@ -21,7 +21,7 @@
       - providers.each do |provider|
         %tr{id: dom_id(provider) }
           %th{ scope: 'row'}
-            = link_to provider.name, super_admins_provider_path(provider)
+            = link_to provider.name, provider_management_provider_path(provider)
           %td
             = provider.provider_type.humanize
           %td
@@ -29,4 +29,4 @@
           %td
             = provider.vat_registered == true ? 'Yes' : 'No'
           %td
-            = link_to "Manage users in provider", super_admins_provider_external_users_path(provider)
+            = link_to "Manage users in provider", provider_management_provider_external_users_path(provider)

--- a/app/views/provider_management/providers/index.html.haml
+++ b/app/views/provider_management/providers/index.html.haml
@@ -1,0 +1,12 @@
+= content_for :page_title, flush: true do
+  = t('.page_title')
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+
+%p
+  = link_to t('.add_a_provider'), new_super_admins_provider_path, class: 'button', role:'button'
+
+= render partial: 'providers', locals: { providers: @providers }

--- a/app/views/provider_management/providers/index.html.haml
+++ b/app/views/provider_management/providers/index.html.haml
@@ -7,6 +7,6 @@
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
 %p
-  = link_to t('.add_a_provider'), new_super_admins_provider_path, class: 'button', role:'button'
+  = link_to t('.add_a_provider'), new_provider_management_provider_path, class: 'button', role:'button'
 
 = render partial: 'providers', locals: { providers: @providers }

--- a/app/views/provider_management/providers/index.html.haml
+++ b/app/views/provider_management/providers/index.html.haml
@@ -6,7 +6,9 @@
 
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
-%p
-  = link_to t('.add_a_provider'), new_provider_management_provider_path, class: 'button', role:'button'
+.form-section
+  .form-group.form-buttons
+    = link_to t('.add_a_provider'), new_provider_management_provider_path, class: 'button', role:'button'
+    = link_to t('.find_provider_by_email'), provider_management_external_users_find_path, class: 'link-secondary'
 
 = render partial: 'providers', locals: { providers: @providers }

--- a/app/views/provider_management/providers/show.html.haml
+++ b/app/views/provider_management/providers/show.html.haml
@@ -43,4 +43,4 @@
 
 - if can? :edit, @provider
   .form-group
-    = link_to t('.edit'), edit_super_admins_provider_path(@provider), class: 'button'
+    = link_to t('.edit'), edit_provider_management_provider_path(@provider), class: 'button'

--- a/app/views/provider_management/providers/show.html.haml
+++ b/app/views/provider_management/providers/show.html.haml
@@ -1,0 +1,46 @@
+= content_for :page_title, flush: true do
+  = t('.page_title', provider_name: @provider.name)
+
+= content_for :v2_stylesheets do
+  = stylesheet_link_tag "v2/application", media: "all"
+
+= render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
+
+.form-group
+  %table{summary: t('.table_summary', provider_name: @provider.name)}
+    %caption
+      %h2.heading-medium
+        = @provider.name
+    %tbody
+      %tr
+        %th{scope: "row"}
+          = t('.provider_type')
+        %td
+          = @provider.provider_type.capitalize
+
+      %tr
+        %th{scope: "row"}
+          = t('.fee_schemes')
+        %td
+          = @provider.roles.map(&:upcase) * ', '
+
+      - if @provider.lgfs_supplier_numbers.any?
+        %th{scope: "row"}
+          = t('.lgfs_supplier_numbers')
+        %td
+          = @provider.lgfs_supplier_numbers.to_sentence
+
+      - if @provider.firm? && @provider.agfs?
+        %th{scope: "row"}
+          = t('.firm_agfs_supplier_number')
+        %td
+          = @provider.firm_agfs_supplier_number
+
+      %th{scope: "row"}
+        = t('.vat_registered')
+      %td
+        = @provider.vat_registered == true ? t('.answer_yes') : t('.answer_no')
+
+- if can? :edit, @provider
+  .form-group
+    = link_to t('.edit'), edit_super_admins_provider_path(@provider), class: 'button'

--- a/app/views/shared/providers/_form.html.haml
+++ b/app/views/shared/providers/_form.html.haml
@@ -5,7 +5,7 @@
     = render partial: 'errors/error_summary', locals: { ep: @provider, error_summary: t('.error_summary') }
 
     //Provider name
-    = f.adp_text_field :name, id: 'name', label: t('.provider_name'), hint_text: t('.provider_name_hint')
+    = f.adp_text_field :name, id: 'name', input_classes: 'name', label: t('.provider_name'), hint_text: t('.provider_name_hint')
 
     // Provider type
     .form-group#js-provider-type.jqr-delegate-hook{class: @provider.errors[:provider_type].any? ? "error" : ""}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -605,7 +605,9 @@ en:
         supplier_number: *supplier_number
         apply_vat: "VAT registered"
         roles: *roles
-        submit: 'Create user'
+        submit:
+          edit: Update user
+          new: Create user
       find:
         email: *email
         submit: 'Search'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
       api_documentation: API Documentation
       archive: Your archive
       error: There was an error
-      manage_provider: Provider
+      manage_provider: Manage provider
       manage_providers: Providers
       manage_users: Manage users
       manage_your_settings: Manage your settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -530,6 +530,7 @@ en:
         page_heading: Manage providers
         add_a_provider: Add a provider
         page_title: View providers in claim for Crown court defence
+        find_provider_by_email: Find provider by email
       providers:
         fee_schemes: Fee schemes
         provider_type: *provider_type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,17 +24,16 @@ en:
   layouts:
     primary_navigation:
       add_a_provider: Add a provider
-      allocation: Allocation list
+      allocation: Allocation
       api_documentation: API Documentation
-      archive: Your claim archive
+      archive: Your archive
       error: There was an error
-      find_provider_by_email: Find provider by email
-      manage_provider: Manage provider
-      manage_providers: Manage providers
+      manage_provider: Provider
+      manage_providers: Providers
       manage_users: Manage users
       manage_your_settings: Manage your settings
-      manage_case_workers: Manage case workers
-      management_information: Management information
+      manage_case_workers: Case workers
+      management_information: Reports
       your_claims: Your claims
       re_allocation: Re-allocation
       sidekiq_console: Sidekiq console

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,13 +521,13 @@ en:
         lgfs_supplier_numbers: 'LGFS supplier numbers'
         firm_agfs_supplier_number: 'AGFS supplier number'
         page_title: "View %{provider_name}'s details"
-        page_heading: Manage provider
+        page_heading: Providers
         edit: Edit
         answer_yes: "Yes"
         answer_no:  "No"
         table_summary: The provider type, fee scheme and VAT status for %{provider_name}
       index:
-        page_heading: Manage providers
+        page_heading: Providers
         add_a_provider: Add a provider
         page_title: View providers in claim for Crown court defence
         find_provider_by_email: Find provider by email
@@ -2109,7 +2109,7 @@ en:
           edit_link_label: "Edit case worker: %{case_worker}"
           caption: Case worker list
           create_case_worker: Create a new case worker
-          page_heading: Manage case workers
+          page_heading: Case workers
           summary: A list of case workers, ordered by surname. Edit and delete links in the last column.
           hint:
             search: for example case worker name
@@ -2257,7 +2257,7 @@ en:
           invalid_report_type: *invalid_report_type
         index:
           page_title: View management information
-          page_heading: Management information
+          page_heading: Reports
           all_claims_report: 'All claims report'
           report_generated_at: "The latest report was generated at %{time}"
           day: Day
@@ -2282,7 +2282,7 @@ en:
         job_scheduled: 'A background job has been scheduled to regenerate the report. Please refresh this page in a few minutes.'
     claims:
       archived:
-        page_heading: Archived claims
+        page_heading: Your archive
         page_title: View the claim archive
       determination_fields:
         disbursements: Disbursements

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -506,6 +506,122 @@ en:
         heading: Change password for %{external_user}
         page_heading: Manage users
 
+# en.provider_management
+  provider_management:
+    providers:
+      provider_type: &provider_type 'Provider type'
+      provider_name: &provider_name 'Provider name'
+      supplier_number: &supplier_number 'Supplier number'
+      vat_registered: &vat_registered 'VAT registered'
+      show:
+        fee_schemes: Fee schemes
+        provider_type: *provider_type
+        provider_name: *provider_name
+        supplier_number: *supplier_number
+        vat_registered: *vat_registered
+        lgfs_supplier_numbers: 'LGFS supplier numbers'
+        firm_agfs_supplier_number: 'AGFS supplier number'
+        page_title: "View %{provider_name}'s details"
+        page_heading: Manage provider
+        edit: Edit
+        answer_yes: "Yes"
+        answer_no:  "No"
+        table_summary: The provider type, fee scheme and VAT status for %{provider_name}
+      index:
+        page_heading: Manage providers
+        add_a_provider: Add a provider
+        page_title: View providers in claim for Crown court defence
+      providers:
+        fee_schemes: Fee schemes
+        provider_type: *provider_type
+        provider_name: *provider_name
+        supplier_number: *supplier_number
+        vat_registered: *vat_registered
+        caption: Provider list
+        table_summary: A list of providers. Includes links to the provider page and to manage users
+      form:
+        cancel_button: Cancel
+        error: 'error'
+        prohibited_save: 'This provider has'
+        provider_type: *provider_type
+        fee_schemes: Fee scheme
+        fee_schemes_hint: Please choose all relevant options
+        provider_name: *provider_name
+        provider_name_hint: The trading name of the Chamber or Firm
+        save_button: Save details
+        supplier_number: *supplier_number
+        vat_registered: *vat_registered
+        form_error_hint: 'Check below for more detail'
+        agfs_supplier_number: "AGFS Supplier Number"
+    external_users:
+      index:
+        name: 'Name'
+        supplier_number: *supplier_number
+        email: 'Email'
+        page_title: View users in %{provider_name}
+        caption: Users in %{provider_name}
+        state: Account state
+        add_provider: Add user to provider
+        page_heading: Manage Users
+        title: Click to email %{provider}
+        live: Live
+        inactive: Inactive
+        table_summary: A list of user details for %{provider_name}
+        view_details: View details for %{text}
+      show:
+        caption: User details
+        page_title: View %{external_user}'s details
+        provider: Provider
+        email: *email
+        name: Name
+        supplier_number: *supplier_number
+        vat_registered: VAT registered
+        role: Role
+        edit: Edit
+        change_password: *change_password
+        answer_yes: "Yes"
+        answer_no:  "No"
+        manage_user: Manage user
+        page_heading: Manage user
+        table_summary: A list of user details for %{external_user}
+        edit_provider: edit the provider
+      edit:
+        page_title: Edit %{external_user}'s details
+        heading: Edit user details
+        page_heading: Manage users
+      new:
+        page_title: Add a user to %{provider_name}
+        heading: New user details for %{provider_name}
+        page_heading: Manage users
+      form:
+        error: 'error'
+        prohibited_save: 'This user has'
+        email: *email
+        email_confirmation: *email_confirmation
+        password: *password
+        password_confirmation: *password_confirmation
+        first_name: *first_name
+        last_name: *last_name
+        supplier_number: *supplier_number
+        apply_vat: "VAT registered"
+        roles: *roles
+        submit: 'Create user'
+      find:
+        email: *email
+        submit: 'Search'
+        page_heading: Find provider by email
+        page_title: Find provider by email
+      change_password:
+        error: 'error'
+        prohibited_save: 'This user password change has'
+        current_password: Current password
+        password: *password
+        password_confirmation: *password_confirmation
+        submit: *change_password
+        page_title: Change %{external_user}'s password
+        heading: Change password for %{external_user}
+        page_heading: Manage users
+
 # en.external_users
   external_users:
     agfs_claim_heading: Claim for advocate fees

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,17 @@ Rails.application.routes.draw do
       get 'management_information/download', to: 'management_information#download', as: :management_information_download
       get 'management_information/generate', to: 'management_information#generate', as: :management_information_generate
     end
+
+  end
+
+  namespace :provider_management do
+    root to: 'provider_management/providers#index'
+    resources :providers, except: [:destroy] do
+      resources :external_users, except: [:destroy] do
+        get 'change_password', on: :member
+        patch 'update_password', on: :member
+      end
+    end
   end
 
   namespace :geckoboard_api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,6 @@ Rails.application.routes.draw do
 
   # shared by super_admin and case worker provider managers
   concern :provider_management_routes do
-    root to: 'providers#index'
     get 'external_users/find', to: 'external_users#find'
     post 'external_users/find', to: 'external_users#search'
 
@@ -84,6 +83,7 @@ Rails.application.routes.draw do
   end
 
   namespace :super_admins do
+    root to: 'providers#index'
     concerns :provider_management_routes
 
     namespace :admin do
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
   end
 
   namespace :provider_management do
+    root to: 'provider_management/providers#index'
     concerns :provider_management_routes
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,8 @@ Rails.application.routes.draw do
     put :settings, on: :member, action: :update_settings, format: :js
   end
 
-  namespace :super_admins do
+  # shared by super_admin and case worker provider managers
+  concern :provider_management_routes do
     root to: 'providers#index'
     get 'external_users/find', to: 'external_users#find'
     post 'external_users/find', to: 'external_users#search'
@@ -80,6 +81,10 @@ Rails.application.routes.draw do
         patch 'update_password', on: :member
       end
     end
+  end
+
+  namespace :super_admins do
+    concerns :provider_management_routes
 
     namespace :admin do
       root to: 'providers#index'
@@ -89,7 +94,10 @@ Rails.application.routes.draw do
         patch 'update_password', on: :member
       end
     end
+  end
 
+  namespace :provider_management do
+    concerns :provider_management_routes
   end
 
   scope module: 'external_users' do
@@ -179,18 +187,6 @@ Rails.application.routes.draw do
       get 'management_information/generate', to: 'management_information#generate', as: :management_information_generate
     end
 
-  end
-
-  namespace :provider_management do
-    root to: 'provider_management/providers#index'
-    get 'external_users/find', to: 'external_users#find'
-    post 'external_users/find', to: 'external_users#search'
-    resources :providers, except: [:destroy] do
-      resources :external_users, except: [:destroy] do
-        get 'change_password', on: :member
-        patch 'update_password', on: :member
-      end
-    end
   end
 
   namespace :geckoboard_api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,8 @@ Rails.application.routes.draw do
 
   namespace :provider_management do
     root to: 'provider_management/providers#index'
+    get 'external_users/find', to: 'external_users#find'
+    post 'external_users/find', to: 'external_users#search'
     resources :providers, except: [:destroy] do
       resources :external_users, except: [:destroy] do
         get 'change_password', on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,7 @@ Rails.application.routes.draw do
   end
 
   namespace :provider_management do
-    root to: 'provider_management/providers#index'
+    root to: 'providers#index'
     concerns :provider_management_routes
   end
 

--- a/features/page_objects/provider_index_page.rb
+++ b/features/page_objects/provider_index_page.rb
@@ -1,0 +1,3 @@
+class ProviderIndexPage < BasePage
+  set_url "/provider_management/providers"
+end

--- a/features/page_objects/provider_page.rb
+++ b/features/page_objects/provider_page.rb
@@ -1,4 +1,4 @@
-require_relative 'sections/checkbox_fee_section'
+require_relative 'sections/checklist_section'
 
 class ProviderPage < BasePage
   set_url "/provider_management/providers/new"
@@ -7,28 +7,11 @@ class ProviderPage < BasePage
 
   sections :radios, RadioSection, '.multiple-choice'
 
-  sections :checklist, '.multiple-choice' do
-    element :label, 'label'
-    element :checkbox, 'input[type="checkbox"]', visible: false
-  end
+  section :fee_schemes, ChecklistSection, "div#js-fee-schemes"
 
   element :save_details, "input.button"
 
   def choose(label)
     radios.find { |radio| radio.label.text.match?(label) }.click
-  end
-
-  def checklist_item_for(label)
-    checklist.find do |item|
-      item.label.text.match?(Regexp.new(Regexp.escape(label), true))
-    end
-  end
-
-  def check(label)
-    page.check checklist_item_for(label).checkbox['id'], visible: false
-  end
-
-  def uncheck(label)
-    page.uncheck checklist_item_for(label).checkbox['id'], visible: false
   end
 end

--- a/features/page_objects/provider_page.rb
+++ b/features/page_objects/provider_page.rb
@@ -1,0 +1,34 @@
+require_relative 'sections/checkbox_fee_section'
+
+class ProviderPage < BasePage
+  set_url "/provider_management/providers/new"
+
+  element :name, "input.name"
+
+  sections :radios, RadioSection, '.multiple-choice'
+
+  sections :checklist, '.multiple-choice' do
+    element :label, 'label'
+    element :checkbox, 'input[type="checkbox"]', visible: false
+  end
+
+  element :save_details, "input.button"
+
+  def choose(label)
+    radios.find { |radio| radio.label.text.match?(label) }.click
+  end
+
+  def checklist_item_for(label)
+    checklist.find do |item|
+      item.label.text.match?(Regexp.new(Regexp.escape(label), true))
+    end
+  end
+
+  def check(label)
+    page.check checklist_item_for(label).checkbox['id'], visible: false
+  end
+
+  def uncheck(label)
+    page.uncheck checklist_item_for(label).checkbox['id'], visible: false
+  end
+end

--- a/features/page_objects/provider_search_page.rb
+++ b/features/page_objects/provider_search_page.rb
@@ -1,0 +1,7 @@
+class ProviderSearchPage < BasePage
+  set_url "/provider_management/external_users/find"
+
+  element :email, "input.email"
+
+  element :search, "input.button"
+end

--- a/features/page_objects/sections/checkbox_fee_section.rb
+++ b/features/page_objects/sections/checkbox_fee_section.rb
@@ -1,27 +1,5 @@
-class CheckboxFeeSection < SitePrism::Section
-  sections :checklist, '.multiple-choice' do
-    element :label, 'label'
-    element :checkbox, 'input[type="checkbox"]', visible: false
-  end
-
-  def checklist_labels
-    checklist.map { |item| item.label.text if item.has_label? }
-  end
-
-  def checklist_item_for(label)
-    checklist.find do |item|
-      item.label.text.match?(Regexp.new(Regexp.escape(label), true))
-    end
-  end
-
-  def check(label)
-    page.check checklist_item_for(label).checkbox['id'], visible: false
-  end
-
-  def uncheck(label)
-    page.uncheck checklist_item_for(label).checkbox['id'], visible: false
-  end
-
+require_relative 'checklist_section'
+class CheckboxFeeSection < ChecklistSection
   def set_quantity(label, value = 1)
     fee_block = fee_block_for(label)
     fee_block.quantity.set value

--- a/features/page_objects/sections/checklist_section.rb
+++ b/features/page_objects/sections/checklist_section.rb
@@ -1,0 +1,24 @@
+class ChecklistSection < SitePrism::Section
+  sections :checklist, '.multiple-choice' do
+    element :label, 'label'
+    element :checkbox, 'input[type="checkbox"]', visible: false
+  end
+
+  def checklist_labels
+    checklist.map { |item| item.label.text if item.has_label? }
+  end
+
+  def checklist_item_for(label)
+    checklist.find do |item|
+      item.label.text.match?(Regexp.new(Regexp.escape(label), true))
+    end
+  end
+
+  def check(label)
+    page.check checklist_item_for(label).checkbox['id'], visible: false
+  end
+
+  def uncheck(label)
+    page.uncheck checklist_item_for(label).checkbox['id'], visible: false
+  end
+end

--- a/features/provider_management.feature
+++ b/features/provider_management.feature
@@ -1,0 +1,38 @@
+@javascript
+Feature: Case worker can manage providers
+
+  Scenario: A provider Manager can create a new chamber
+    When I insert the VCR cassette 'features/provider_management'
+    Given I am a signed in case worker provider manager
+    When I click the link 'Providers'
+    Then I should be on the provider index page
+
+    When I click the link 'Add a provider'
+    Then I should be on the new provider page
+
+    When I set the provider name to 'Test Chambers'
+    And I set the provider type to 'Firm'
+    Then I should see 'LGFS'
+    Then I should see 'AGFS'
+    When I set the provider type to 'Chamber'
+    Then I should not see 'LGFS'
+    When I select the 'AGFS' fee scheme
+    When I click the Save details button
+    Then I should see 'Provider successfully created'
+
+    And I eject the VCR cassette
+
+  Scenario: A provider Manager can search for providers
+    When I insert the VCR cassette 'features/provider_management'
+    Given I am a signed in case worker provider manager
+    And an external provider exists
+
+    When I click the link 'Providers'
+    And I click the link 'Find provider by email'
+    Then I should be on the provider search page
+
+    When I enter 'test.user@chambers.com' in the email field
+    And I click the search button
+    Then I should see 'Manage user'
+
+    And I eject the VCR cassette

--- a/features/step_definitions/provider_management_steps.rb
+++ b/features/step_definitions/provider_management_steps.rb
@@ -1,0 +1,40 @@
+When('an external provider exists') do
+  user = create(:user, email: 'test.user@chambers.com')
+  create(:external_user, :advocate_and_admin, user: user)
+end
+
+When("I set the provider name to {string}") do |name|
+  @new_provider_page.name.set name
+end
+
+When("I set the provider type to {string}") do |type|
+  @new_provider_page.choose(type)
+end
+
+When('I select the {string} fee scheme') do |fee_scheme|
+  @new_provider_page.check(fee_scheme)
+end
+
+When("I click the Save details button") do
+  @new_provider_page.save_details.click
+end
+
+When('I enter {string} in the email field') do |email|
+  @provider_search_page.email.set email
+end
+
+When("I click the search button") do
+  @provider_search_page.search.click
+end
+
+Then(/^I should be on the provider index page$/) do
+  expect(@provider_index_page).to be_displayed
+end
+
+Then(/^I should be on the new provider page$/) do
+  expect(@new_provider_page).to be_displayed
+end
+
+Then(/^I should be on the provider search page$/) do
+  expect(@provider_search_page).to be_displayed
+end

--- a/features/step_definitions/provider_management_steps.rb
+++ b/features/step_definitions/provider_management_steps.rb
@@ -12,7 +12,7 @@ When("I set the provider type to {string}") do |type|
 end
 
 When('I select the {string} fee scheme') do |fee_scheme|
-  @new_provider_page.check(fee_scheme)
+  @new_provider_page.fee_schemes.check(fee_scheme)
 end
 
 When("I click the Save details button") do

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -90,6 +90,11 @@ Given(/^I am a signed in case worker admin$/) do
   sign_in(@case_worker.user, 'password')
 end
 
+Given(/^I am a signed in case worker provider manager$/) do
+  @case_worker = create(:case_worker, :provider_manager)
+  sign_in(@case_worker.user, 'password')
+end
+
 Given(/^I am a signed in super admin$/) do
   make_accounts('super admin')
   visit new_user_session_path

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -21,6 +21,9 @@ Before('not @no-site-prism') do
   @certification_page = CertificationPage.new
   @confirmation_page = ConfirmationPage.new
   @allocation_page = AllocationPage.new
+  @provider_index_page = ProviderIndexPage.new
+  @new_provider_page = ProviderPage.new
+  @provider_search_page = ProviderSearchPage.new
 end
 
 Before do

--- a/lib/demo_data/demo_seeds/case_workers.rb
+++ b/lib/demo_data/demo_seeds/case_workers.rb
@@ -15,6 +15,6 @@ SeedHelper.find_or_create_caseworker!(
   last_name: 'Worker-Admin',
   email: 'caseworkeradmin@example.com',
   location: 'Nottingham',
-  roles: ['admin'],
+  roles: ['admin','provider_management'],
   password_env_var: 'ADMIN_PASSWORD'
 )

--- a/spec/controllers/provider_management/external_users_controller_spec.rb
+++ b/spec/controllers/provider_management/external_users_controller_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 require 'json'
 
 RSpec.describe ProviderManagement::ExternalUsersController, type: :controller do
-  let(:case_worker_manager)   { create(:case_worker, :provider_manager) }
-  let(:provider)      { create(:provider) }
-  let(:frozen_time)  { 6.months.ago }
-  let(:external_user)   do
+  let(:case_worker_manager) { create(:case_worker, :provider_manager) }
+  let(:provider) { create(:provider) }
+  let(:frozen_time) { 6.months.ago }
+  let(:external_user) do
     Timecop.freeze(frozen_time) { create(:external_user, :admin, provider: provider) }
   end
 
@@ -100,11 +100,9 @@ RSpec.describe ProviderManagement::ExternalUsersController, type: :controller do
     it 'renders the new template' do
       expect(response).to render_template(:new)
     end
-
   end
 
   describe "POST #create" do
-
     def post_to_create_external_user_action(options={})
       post :create, params: {
         provider_id: provider,

--- a/spec/controllers/provider_management/external_users_controller_spec.rb
+++ b/spec/controllers/provider_management/external_users_controller_spec.rb
@@ -1,0 +1,245 @@
+require 'rails_helper'
+require 'json'
+
+RSpec.describe ProviderManagement::ExternalUsersController, type: :controller do
+  let(:case_worker_manager)   { create(:case_worker, :provider_manager) }
+  let(:provider)      { create(:provider) }
+  let(:frozen_time)  { 6.months.ago }
+  let(:external_user)   do
+    Timecop.freeze(frozen_time) { create(:external_user, :admin, provider: provider) }
+  end
+
+  before { sign_in case_worker_manager.user }
+
+  describe "GET #show" do
+    before { get :show, params: { provider_id: provider, id: external_user } }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+    it 'assigns @provider and @external_user' do
+      expect(assigns(:provider)).to eq(provider)
+      expect(assigns(:external_user)).to eq(external_user)
+    end
+  end
+
+  describe "GET #index" do
+    before { get :index, params: { provider_id: provider } }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+    it 'assigns @provider' do
+      expect(assigns(:provider)).to eq(provider)
+    end
+
+    it 'assigns @external_users' do
+      expect(assigns(:external_users)).to include(external_user)
+    end
+  end
+
+  describe 'GET #find' do
+    before { get :find }
+
+    it 'returns http success' do
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST #search' do
+    subject { response }
+
+    before { post :search, params: { external_user: { email: email } } }
+
+    context 'when the email is for a provider' do
+      let(:email) { external_user.email }
+
+      it { is_expected.to redirect_to(provider_management_provider_external_user_path(external_user.provider, external_user)) }
+    end
+
+    context 'when the email is for a non-provider' do
+      let(:email) { case_worker_manager.email }
+
+      it { is_expected.to redirect_to(provider_management_external_users_find_path) }
+    end
+
+    context 'when the email does not exist' do
+      let(:email) { 'vail.email@does.not.exist.com' }
+
+      it { is_expected.to redirect_to(provider_management_external_users_find_path) }
+    end
+  end
+
+  describe "GET #new" do
+    let(:external_user) do
+     a = ExternalUser.new(provider: provider)
+     a.build_user
+     a
+    end
+
+    before { get :new, params: { provider_id: provider } }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+    # NOTE: use json comparison because we are not interested in
+    #       whether the object is the same just that it creates a
+    #       new one and builds its user
+    it 'assigns @provider and @external_user' do
+      expect(assigns(:provider)).to eq(provider)
+      expect(assigns(:external_user).to_json).to eq(external_user.to_json)
+    end
+
+    it 'builds user for @external_user' do
+      expect(assigns(:external_user).user.to_json).to eq(external_user.user.to_json)
+    end
+
+    it 'renders the new template' do
+      expect(response).to render_template(:new)
+    end
+
+  end
+
+  describe "POST #create" do
+
+    def post_to_create_external_user_action(options={})
+      post :create, params: {
+        provider_id: provider,
+        external_user: {
+          user_attributes: {
+            email: 'foo@foobar.com',
+            email_confirmation: 'foo@foobar.com',
+            first_name: options[:valid]==false ? '' : 'john',
+            last_name: 'Smith'
+          },
+          roles: ['advocate'],
+          supplier_number: 'AB124'
+        }
+      }
+    end
+
+    context 'when valid' do
+      it 'creates an external_user' do
+        expect{ post_to_create_external_user_action }.to change(User, :count).by(1)
+      end
+
+      it 'redirects to external_users show view' do
+        post_to_create_external_user_action
+        expect(response).to redirect_to(provider_management_provider_external_user_path(provider, ExternalUser.last))
+      end
+    end
+
+    context 'when invalid' do
+      it 'does not create an external_user' do
+        expect{ post_to_create_external_user_action(valid: false) }.to_not change(User, :count)
+      end
+
+      it 'renders the new template' do
+        post_to_create_external_user_action(valid: false)
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe "GET #edit" do
+    before { get :edit, params: { provider_id: provider, id: external_user } }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+   it 'assigns @provider and @external_user' do
+      expect(assigns(:provider)).to eq(provider)
+      expect(assigns(:external_user)).to eq(external_user)
+    end
+
+    it 'renders the template' do
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe "PUT #update" do
+
+    context 'when valid' do
+      before(:each) { put :update, params: { provider_id: provider, id: external_user, external_user: { supplier_number: 'XX100', roles: ['advocate'] } } }
+
+      it 'updates an external_user' do
+        external_user.reload
+        expect(external_user.reload.roles).to eq(['advocate'])
+      end
+
+      it 'redirects to external_users index' do
+        expect(response).to redirect_to(provider_management_provider_external_user_path(provider, external_user))
+      end
+    end
+
+    context 'when invalid' do
+      before(:each) { put :update, params: { provider_id: provider, id: external_user, external_user: { roles: ['foo'] } } }
+
+      it 'does not update external_user' do
+        external_user.reload
+        expect(external_user.roles).to eq(['admin'])
+      end
+
+      it 'renders the edit template' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  describe "GET #change_password" do
+    before { get :change_password, params: { provider_id: provider, id: external_user } }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+    it 'assigns @provider and @external_user' do
+      expect(assigns(:external_user)).to eq(external_user)
+      expect(assigns(:provider)).to eq(provider)
+    end
+
+    it 'renders the change password template' do
+      expect(response).to render_template(:change_password)
+    end
+  end
+
+  describe "PUT #update_password" do
+
+    context 'when valid' do
+
+      before(:each) do
+        put :update_password, params: { provider_id: provider, id: external_user, external_user: { user_attributes: { password: 'password123', password_confirmation: 'password123' } } }
+        external_user.reload
+      end
+
+      it 'does not require current password to be successful in updating the user record ' do
+        expect(external_user.user.updated_at).to_not eql frozen_time
+      end
+
+      it 'redirects to external_user show action' do
+        expect(response).to redirect_to(provider_management_provider_external_user_path(provider, external_user))
+      end
+    end
+
+    context 'when invalid' do
+
+      before(:each) do
+        put :update_password, params: { provider_id: provider, id: external_user, external_user: { user_attributes: { password: 'password123', password_confirmation: 'passwordxxx' } } }
+      end
+
+      it 'does not update the user record' do
+        expect(external_user.user.updated_at).to eql frozen_time
+      end
+
+      it 'renders the change password template' do
+        expect(response).to render_template(:change_password)
+      end
+    end
+
+  end
+
+end

--- a/spec/controllers/provider_management/external_users_controller_spec.rb
+++ b/spec/controllers/provider_management/external_users_controller_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe ProviderManagement::ExternalUsersController, type: :controller do
 
   describe "GET #new" do
     let(:external_user) do
-     a = ExternalUser.new(provider: provider)
-     a.build_user
-     a
+      ExternalUser.new(provider: provider).tap do |eu|
+        eu.build_user
+      end
     end
 
     before { get :new, params: { provider_id: provider } }

--- a/spec/controllers/provider_management/providers_controller_spec.rb
+++ b/spec/controllers/provider_management/providers_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ProviderManagement::ProvidersController, type: :controller do
-  let(:case_worker_manager)   { create(:case_worker, :provider_manager) }
-  let(:providers)   { create_list(:provider, 5) }
-  let(:provider)    { create(:provider, :lgfs, name: 'test 123') }
+  let(:case_worker_manager) { create(:case_worker, :provider_manager) }
+  let(:providers) { create_list(:provider, 5) }
+  let(:provider) { create(:provider, :lgfs, name: 'test 123') }
 
   subject { provider }
 

--- a/spec/controllers/provider_management/providers_controller_spec.rb
+++ b/spec/controllers/provider_management/providers_controller_spec.rb
@@ -1,0 +1,192 @@
+require 'rails_helper'
+
+RSpec.describe ProviderManagement::ProvidersController, type: :controller do
+  let(:super_admin) { create(:super_admin) }
+  let(:providers)   { create_list(:provider, 5) }
+  let(:provider)    { create(:provider, :lgfs, name: 'test 123') }
+
+  subject { provider }
+
+  before { sign_in super_admin.user }
+
+  describe "GET #show" do
+    before { get :show, params: { id: subject } }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+    it 'assigns @provider' do
+      expect(assigns(:provider)).to eql(subject)
+    end
+  end
+
+  describe "GET #index" do
+    before { get :index }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+    it 'assigns @providers to ALL providers' do
+      providers.each do |provider|
+        expect(assigns(:providers)).to include(provider)
+      end
+    end
+  end
+
+  describe "GET #edit" do
+    before { get :edit, params: { id: subject } }
+
+    it "returns http success" do
+      expect(response).to be_successful
+    end
+
+    it 'assigns @provider' do
+      expect(assigns(:provider)).to eql(subject)
+    end
+  end
+
+  describe "PUT #update" do
+
+    context 'when changing from firm to chamber' do
+
+      it 'changes from chamber to firm and removes LGFS supplier numbers' do
+        firm = create :provider, :firm, :with_lgfs_supplier_numbers
+        expect(firm.lgfs_supplier_numbers).to have(4).items
+
+        patch :update, params: { id: firm, provider: { name: firm.name, provider_type: 'chamber', roles: ['agfs', ''], firm_agfs_supplier_number: '', vat_registered: 'true'} }
+        expect(response).to redirect_to(super_admins_provider_path(firm))
+        firm.reload
+        expect(firm.roles).to eq(['agfs'])
+        expect(firm.firm_agfs_supplier_number).to be_nil
+        expect(firm.lgfs_supplier_numbers).to be_empty
+      end
+
+    end
+
+    context 'when valid' do
+      before(:each) { put :update, params: { id: subject, provider: {name: 'test firm'} } }
+
+      it 'updates successfully' do
+        expect(subject.reload.name).to eq('test firm')
+      end
+
+      it 'redirects to providers show page' do
+        expect(response).to redirect_to(super_admins_provider_path(subject))
+      end
+    end
+
+    context 'when invalid' do
+      before(:each) { put :update, params: { id: subject, provider: {name: ''} } }
+
+      it 'does not update provider' do
+        expect(subject.reload.name).to eq('test 123')
+      end
+
+      it 'renders the edit template' do
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe 'multiple supplier numbers' do
+      let(:provider) { create(:provider, :lgfs) }
+      subject { provider }
+
+      before(:each) { subject.lgfs_supplier_numbers.delete_all }
+
+      context 'when invalid' do
+        before(:each) do
+          put :update, params: { id: subject, provider: {
+              supplier_numbers_attributes: [
+                  {supplier_number: 'XY123'},
+                  {supplier_number: ''}
+              ]
+          } }
+        end
+
+        it 'does not update provider' do
+          expect(subject.reload.lgfs_supplier_numbers).to be_empty
+        end
+
+        it 'renders the edit template' do
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context 'when valid' do
+        before(:each) do
+          put :update, params: { id: subject, provider: {
+              lgfs_supplier_numbers_attributes: [
+                  {supplier_number: '1B222Z'},
+                  {supplier_number: '2B555Z'}
+              ]
+          } }
+        end
+
+        it 'updates the provider' do
+          expect(subject.reload.lgfs_supplier_numbers.map(&:supplier_number).sort).to eq(%w(1B222Z 2B555Z))
+        end
+
+        it 'redirects to providers show page' do
+          expect(response).to redirect_to(super_admins_provider_path(subject))
+        end
+      end
+    end
+  end
+
+  describe "GET #new" do
+    before { get :new }
+
+    it 'returns http succes' do
+      expect(response).to be_successful
+    end
+
+    it "assigns a new provider to @provider" do
+      expect(assigns(:provider)).to be_a_new(Provider)
+    end
+  end
+
+  describe "POST #create" do
+    before(:each) do
+      post :create, params: { provider: params }
+    end
+
+    context 'when valid' do
+      let(:params) do
+        {
+          provider_type: 'firm',
+          name: 'St Johns',
+          firm_agfs_supplier_number: '2M462',
+          roles: ['lgfs', 'agfs'],
+          vat_registered: false,
+          lgfs_supplier_numbers_attributes: {
+            '0'=>{'supplier_number' => '2E481W', '_destroy' => 'false'}
+          }
+        }
+      end
+
+      it "creates a new provider" do
+        expect(flash[:notice]).to eq 'Provider successfully created'
+      end
+
+      it 'redirects to index' do
+        expect(response).to redirect_to(super_admins_root_path)
+      end
+    end
+
+    context 'when invalid' do
+      let(:params) do
+        {name: 'St Johns', supplier_number: '4321'}
+      end
+
+      it "does not create a provider" do
+        expect(Provider.count).to eq(0)
+      end
+
+      it 'renders new action' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/controllers/provider_management/providers_controller_spec.rb
+++ b/spec/controllers/provider_management/providers_controller_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ProviderManagement::ProvidersController, type: :controller do
-  let(:super_admin) { create(:super_admin) }
+  let(:case_worker_manager)   { create(:case_worker, :provider_manager) }
   let(:providers)   { create_list(:provider, 5) }
   let(:provider)    { create(:provider, :lgfs, name: 'test 123') }
 
   subject { provider }
 
-  before { sign_in super_admin.user }
+  before { sign_in case_worker_manager.user }
 
   describe "GET #show" do
     before { get :show, params: { id: subject } }
@@ -56,7 +56,7 @@ RSpec.describe ProviderManagement::ProvidersController, type: :controller do
         expect(firm.lgfs_supplier_numbers).to have(4).items
 
         patch :update, params: { id: firm, provider: { name: firm.name, provider_type: 'chamber', roles: ['agfs', ''], firm_agfs_supplier_number: '', vat_registered: 'true'} }
-        expect(response).to redirect_to(super_admins_provider_path(firm))
+        expect(response).to redirect_to(provider_management_provider_path(firm))
         firm.reload
         expect(firm.roles).to eq(['agfs'])
         expect(firm.firm_agfs_supplier_number).to be_nil
@@ -73,7 +73,7 @@ RSpec.describe ProviderManagement::ProvidersController, type: :controller do
       end
 
       it 'redirects to providers show page' do
-        expect(response).to redirect_to(super_admins_provider_path(subject))
+        expect(response).to redirect_to(provider_management_provider_path(subject))
       end
     end
 
@@ -129,7 +129,7 @@ RSpec.describe ProviderManagement::ProvidersController, type: :controller do
         end
 
         it 'redirects to providers show page' do
-          expect(response).to redirect_to(super_admins_provider_path(subject))
+          expect(response).to redirect_to(provider_management_provider_path(subject))
         end
       end
     end
@@ -171,7 +171,7 @@ RSpec.describe ProviderManagement::ProvidersController, type: :controller do
       end
 
       it 'redirects to index' do
-        expect(response).to redirect_to(super_admins_root_path)
+        expect(response).to redirect_to(provider_management_root_path)
       end
     end
 

--- a/spec/controllers/super_admins/external_users_controller_spec.rb
+++ b/spec/controllers/super_admins/external_users_controller_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe SuperAdmins::ExternalUsersController, type: :controller do
 
   describe "GET #new" do
     let(:external_user) do
-     a = ExternalUser.new(provider: provider)
-     a.build_user
-     a
+      ExternalUser.new(provider: provider).tap do |eu|
+        eu.build_user
+      end
     end
 
     before { get :new, params: { provider_id: provider } }

--- a/spec/factories/case_workers.rb
+++ b/spec/factories/case_workers.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       roles { ['admin'] }
     end
 
+    trait :provider_manager do
+      roles { ['provider_management'] }
+    end
+
     trait :softly_deleted do
       deleted_at { 10.minutes.ago }
     end

--- a/spec/models/case_worker_spec.rb
+++ b/spec/models/case_worker_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe CaseWorker, type: :model do
   it { should validate_presence_of(:user).with_message('User cannot be blank') }
 
   describe 'ROLES' do
-    it 'should have "admin" and "case_worker"' do
-      expect(CaseWorker::ROLES).to match_array(%w( admin case_worker ))
+    it 'should have "admin", "case_worker" and "provider_management"' do
+      expect(CaseWorker::ROLES).to match_array(%w( admin case_worker provider_management ))
     end
   end
 

--- a/vcr/cassettes/features/provider_management.yml
+++ b/vcr/cassettes/features/provider_management.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3001/api/case_workers/claims?api_key=a83bd8aa-2df9-4d4f-8ddf-04e213b2a00b&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      Host:
+      - localhost:3001
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"67ef371da077dc4bb41ecaad1d2c6bc5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bd5bec20-ad21-4793-b49a-5e25bc0363af
+      X-Runtime:
+      - '0.015250'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAF0z9VwAA6pWKkhMz8xLLMnMz1OyqlZKLi0qSs0riQeKpipZGeooleSXJOaAucVKVgYwfnJ+aV4JmJ+TmZtZEl+WmFMKUm9Qq6OUWZKaC1QbHVsLAAAA//8DAGCLOJhdAAAA
+    http_version: 
+  recorded_at: Mon, 03 Jun 2019 14:49:01 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
#### What
The spike was to investigate the work required to move the provider management function to role based.

#### Ticket
[SPIKE: CCCD: investigate moving the manage provider functionality to a role](https://dsdmoj.atlassian.net/browse/CBO-710)

#### Why
There is a single SuperAdmin user that has access to maintain the providers.  Adding an additional role that can be allocated, to case_workers only, means that users of the system can manage providers without logging out and in again. 
It also means that we no longer have to change the Super Admin password when a user with access leaves the department

#### How
Add an additional CaseWorker Role that can be implemented on a per-user basis.  This means that a user can have their permissions revoked by another admin and that, if they leave and their account is deleted we do not have to cycle the Super Admin password

#### Todo
- [x] Discuss the need for a single Super Admin login going forward
- [x] Agree on how to handle sidekiq monitoring if Super Admin is removed
- [x] Refactor the duplicated code if it is decided to retain both versions

These will all be discussed as part of this [jira ticket](https://dsdmoj.atlassian.net/browse/CBO-757)