### PR TITLE
Remove simplecov console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,6 @@ group :test do
   gem 'rspec-mocks'
   gem 'shoulda-matchers', '>= 4.0.0.rc1'
   gem 'simplecov', require: false
-  gem 'simplecov-console', require: false
   gem 'simplecov-csv', require: false
   gem 'simplecov-multi', require: false
   gem 'i18n-tasks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,6 @@ GEM
     annotate (2.7.5)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 13.0)
-    ansi (1.5.0)
     arel (9.0.0)
     ast (2.4.0)
     auto_strip_attributes (2.5.0)
@@ -317,7 +316,6 @@ GEM
     hashie-forbidden_attributes (0.1.1)
       hashie (>= 3.0)
     highline (2.0.2)
-    hirb (0.7.3)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -600,10 +598,6 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-console (0.4.2)
-      ansi
-      hirb
-      simplecov
     simplecov-csv (0.1.3)
       simplecov
     simplecov-html (0.10.2)
@@ -792,7 +786,6 @@ DEPENDENCIES
   sidekiq (~> 5.2.7)
   simple_form (~> 4.1.0)
   simplecov
-  simplecov-console
   simplecov-csv
   simplecov-multi
   site_prism (~> 3.2)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,9 +12,6 @@ SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 # require 'simplecov-csv'
 # SimpleCov.formatter = SimpleCov::Formatter::CSVFormatter
 
-# require 'simplecov-console'
-# SimpleCov.formatter = SimpleCov::Formatter::Console
-
 SimpleCov.configure do
   add_filter '_spec.rb'
   add_filter 'spec/'


### PR DESCRIPTION
#### What
Remove simplecov-console gem

#### Ticket
support and maintenance - depedency updates

#### Why
We do not use and it adds a lot of dependencies.
The latest bump also requires a json bump which
could have unintended side-effects.