### PR TITLE
Bump bundler from 1.17.3 to 2.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ aliases:
     run:
       name: Install dependencies
       command: |
-        gem install bundler -v 1.17.3
-        bundle check || bundle _1.17.3_ install --jobs=4 --retry=3 --path vendor/bundle
+        gem install bundler -v 2.0.1
+        bundle check || bundle _2.0.1_ install --jobs=4 --retry=3 --path vendor/bundle
 
   _save-cache: &save-cache
     save_cache:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -808,4 +808,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ COPY Gemfile* ./
 
 # only install production dependencies,
 # build nokogiri using libxml2-dev, libxslt-dev
-RUN gem install bundler -v 1.17.3 \
+RUN gem install bundler -v 2.0.1 \
 && bundle config --global without test:development \
 && bundle config build.nokogiri --use-system-libraries \
 && bundle install


### PR DESCRIPTION
#### What
Bump bundler from 1.17.3 to 2.0.1

Local development update instructions
```
gem install bundler
bundle update --bundler
```

#### Why
This has been out for a while now, and we should use
latest for stability.