### PR TITLE
Fix VAT on assessments and redeterminations

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -46,11 +46,15 @@ class Assessment < Determination
     save!
   end
 
+  # TODO: this appears to only be used by update_amount_assessed
+  # which is only used in tests, or tests directly??!
   def update_values(*args)
-    raise 'Cannot update a non-blank assessment' unless blank?
+    raise 'Cannot update an assessment that has values' if present?
     update_values!(*args)
   end
 
+  # TODO: this appears to only be used by update_amount_assessed
+  # which is only used in tests, or tests directly??!
   def update_values!(fees, expenses, disbursements, time = Time.now)
     self.fees = fees unless fees.nil?
     self.expenses = expenses unless expenses.nil?

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -278,6 +278,7 @@ module Claim
       end
     end
 
+    # TODO: this appears to only be used by tests
     def update_amount_assessed(options)
       assessment.update_values(options[:fees], options[:expenses], options[:disbursements])
     end

--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -36,7 +36,7 @@ class Determination < ApplicationRecord
   end
 
   def calculate_vat
-    return unless claim.is_a? Claim::AdvocateClaim
+    return unless claim.agfs?
     self.vat_amount = VatRate.vat_amount(total, claim.vat_date, calculate: claim.apply_vat?).round(2)
   end
 

--- a/app/models/vat_rate.rb
+++ b/app/models/vat_rate.rb
@@ -23,7 +23,7 @@ class VatRate < ApplicationRecord
       rate_for_date(date)
     end
 
-    # Calculate VAT amount for amount_excluding_vat on a given date
+    # Apply past, present or 0% VAT rates
     def vat_amount(amount_excluding_vat, date, calculate: true)
       rate = calculate ? VatRate.for_date(date) : 0
       (amount_excluding_vat * rate / 10_000.0).round(2)


### PR DESCRIPTION
#### What
Fixes the calculation and persisting of VAT amounts
on assessments and redeterminations for advocate
supplementary and interim claims.

#### Ticket

[CBO-752](https://dsdmoj.atlassian.net/browse/CBO-752)

#### Why
VAT was not being calculated and persisted on
assessments and redeterminations for advocate
supplementary and interim claims.

#### How
Use `.agfs?` method to filter those claims
requiring vat calculation, rather than check
the specific class type. This centralizes
the logic in the `agfs_claim_types` scope.