### PR TITLE
Increase batch size for nightly transition

### DIFF
--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -126,6 +126,6 @@ namespace :claims do
     end
 
     puts "Running TimedTransitions::BatchTransitioner with dummy mode: #{@dummy}"
-    TimedTransitions::BatchTransitioner.new(limit: 5000, dummy: @dummy).run
+    TimedTransitions::BatchTransitioner.new(limit: 10000, dummy: @dummy).run
   end
 end


### PR DESCRIPTION
#### What
Increase batch size for nightly transition

#### Why
To catch up with achiving and deleting of
stale claims following failure over the last few
months.