### PR TITLE
Bump codeclimate rubocop channel 0-70 to 0-71

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,7 +15,7 @@ checks:
   method-count:
     config:
       threshold: 24
-engines:
+plugins:
   duplication:
     enabled: true
     config:
@@ -23,11 +23,6 @@ engines:
         ruby:
           filters:
             - "(call _ expose ___)" # exlude expose methods
-  rubocop:
-    enabled: true
-    channel: rubocop-0-70
-    config:
-      file: .rubocop.yml
   brakeman:
     enabled: true
   bundler-audit:


### PR DESCRIPTION
#### What
Bump codeclimate rubocop channel 0-70 to 0-71

#### Why
Inline with rubcop version used. and to
attempt to handle a codeclimate build error.