### PR TITLE
Remove codeclimate rubocop plugin

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,7 +15,7 @@ checks:
   method-count:
     config:
       threshold: 24
-engines:
+plugins:
   duplication:
     enabled: true
     config:
@@ -23,11 +23,6 @@ engines:
         ruby:
           filters:
             - "(call _ expose ___)" # exlude expose methods
-  rubocop:
-    enabled: true
-    channel: rubocop-0-70
-    config:
-      file: .rubocop.yml
   brakeman:
     enabled: true
   bundler-audit:


### PR DESCRIPTION
#### What
Remove rubocop plugin use from codeclimate

#### Why
Until some codeclimate-rubocop issues are resolved
I am removing codeclimates rubocop plugin.

[rubocop-perfromance](https://github.com/codeclimate/codeclimate-rubocop/issues/187)

In any event we are running rubocop as part
of the test suite CI run.