### PR TITLE
Add codeclimate-rubocop back using channel 0-71

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,6 +23,11 @@ plugins:
         ruby:
           filters:
             - "(call _ expose ___)" # exlude expose methods
+  rubocop:
+    enabled: true
+    channel: rubocop-0-71
+    config:
+      file: .rubocop.yml
   brakeman:
     enabled: true
   bundler-audit:


### PR DESCRIPTION
#### What
Add codeclimate-rubocop back using channel 0-71
instead of 0-70.

#### Why
previously removed due to problem
with `require: rubocop-performance`

Because codeclimate runs a diff against
the master branch and the master branches
codeclimate-rubocop was always failing due
to a problem with codeclimate-rubocop it had
be removed temporarily.