### PR TITLE
Update messaging aws client

### DIFF
--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -3,7 +3,7 @@ module MessageQueue
     def initialize(queue)
       @sqs = Aws::SQS::Client.new(access_key_id: Settings.aws.access, secret_access_key: Settings.aws.secret)
       begin
-        @queue_url = @sqs.get_queue_url(queue_name: queue).queue_url
+        @queue_url = queue_url(queue)
       rescue Aws::SQS::Errors::NonExistentQueue
         raise StandardError.new, "Non existing queue: #{queue}."
       end
@@ -26,6 +26,11 @@ module MessageQueue
     end
 
     private
+
+    def queue_url(queue)
+      return queue if queue =~ /\A#{URI::regexp(%w[http https])}\z/
+      @sqs.get_queue_url(queue_name: queue).queue_url
+    end
 
     def messages
       @sqs.receive_message(

--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -28,7 +28,7 @@ module MessageQueue
     private
 
     def queue_url(queue)
-      return queue if queue =~ /\A#{URI::regexp(%w[http https])}\z/
+      return queue if queue =~ /\A#{URI.regexp(%w[http https])}\z/
       @sqs.get_queue_url(queue_name: queue).queue_url
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -120,8 +120,10 @@ aws:
   submitted_queue: <%= ENV['AWS_QUEUE_NAME'] %>
   response_queue: <%= ENV['AWS_RESPONSE_QUEUE_NAME'] %>
   sqs:
-    submitted_queue_url: 'store-actual-values-in-.env-file'
-    response_queue_url: 'store-actual-values-in-.env-file'
+    # This is deliberately blank - add a SETTINGS__AWS__SQS__RESPONSE_QUEUE_URL
+    # value to .env files or the deployment repo if needed. this allows the `response_queue`
+    # value to override it until it is set in all hosting areas/technologies
+    response_queue_url:
   billing:
     access: 'store-actual-values-in-.env-file'
     secret: 'store-actual-values-in-.env-file'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -119,6 +119,9 @@ aws:
   secret: <%= ENV['SECRET_ACCESS_KEY'] %>
   submitted_queue: <%= ENV['AWS_QUEUE_NAME'] %>
   response_queue: <%= ENV['AWS_RESPONSE_QUEUE_NAME'] %>
+  sqs:
+    submitted_queue_url: 'store-actual-values-in-.env-file'
+    response_queue_url: 'store-actual-values-in-.env-file'
   billing:
     access: 'store-actual-values-in-.env-file'
     secret: 'store-actual-values-in-.env-file'

--- a/scheduled_tasks/poll_injection_responses_task.rb
+++ b/scheduled_tasks/poll_injection_responses_task.rb
@@ -6,7 +6,7 @@ class PollInjectionResponsesTask < Scheduler::SchedulerTask
   every '1m'
 
   def run
-    queue = Settings.aws.response_queue
+    queue = Settings.aws.sqs.response_queue_url || Settings.aws.response_queue
     return unless queue
     log("Checking for messages on #{queue}")
     MessageQueue::AwsClient.new(queue).poll!

--- a/spec/services/message_queue/aws_client_spec.rb
+++ b/spec/services/message_queue/aws_client_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module MessageQueue
   describe AwsClient, slack_bot: true do
-    subject(:aws_client) { described_class.new(aws_queue_name) }
+    subject(:aws_client) { described_class.new(aws_queue_id) }
 
     let(:client) do
       Aws::SQS::Client.new(
@@ -18,7 +18,7 @@ module MessageQueue
       )
     end
     let(:claim) { create(:advocate_claim) }
-    let(:aws_queue_name) { 'valid_queue_name' }
+    let(:aws_queue_id) { 'valid_queue_name' }
     let(:stub_queue_response) { stub_queue_response_success }
     let(:stub_send_response) {}
     let(:stub_poll_response) {}
@@ -59,12 +59,18 @@ module MessageQueue
     end
 
     context 'when passed a non-existant queue' do
-      let(:aws_queue_name) { 'no_such_queue' }
+      let(:aws_queue_id) { 'no_such_queue' }
       let(:stub_queue_response) { stub_queue_response_failure }
 
       it 'raises an appropriate error' do
         expect{aws_client}.to raise_error(StandardError, 'Non existing queue: no_such_queue.')
       end
+    end
+
+    context 'when passed a valid queue_url' do
+      let(:aws_queue_id) { 'https://aws.queue/name'}
+
+      it { is_expected.to be_a AwsClient }
     end
 
     describe '#send!' do


### PR DESCRIPTION
#### What
Amend the way that the AWS SQS messaging client can be called

#### Why
As part of the Kubernetes work, queues will no longer have a statically defined name, but the queue_url will be generated and inserted into the environment variables

#### How
By adding an environment variable for the queue_url this can be loaded, if present.  If the value is not present the code falls back to the previous version and loads the queue_name and requests the URL from AWS.

A bonus of this is that a single call will be made to the AWS API now, `receive_message`, instead of two, `get_queue_url` *and* `receive_message`
