### PR TITLE
Afix chromdriver version feature tests

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,8 +22,16 @@ require_relative '../../spec/support/factory_helpers'
 # loss of signed in user
 ActionController::Base.allow_forgery_protection = true
 
-# Activate to view driver detailed output
+# Activate to view chromedriver detailed output
 # Webdrivers.logger.level = :DEBUG
+
+# pin version to 2.46 of chromedriver as latest
+# version (75.0.3770.80) is not running headless.
+# see https://chromedriver.storage.googleapis.com/index.html
+# for usable version numbers and review later.
+#
+Webdrivers::Chromedriver.required_version = '2.46'
+
 # The `webdriver` gem's requests to download drivers is being blocked by Webmock
 # without this.
 # see https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock


### PR DESCRIPTION
#### What
Pin chromdriver version for webdrivers gem

#### Why
Latest version (75) is not running headless
locally. Possible chromedriver bug?!

Version 74 latest (see https://chromedriver.storage.googleapis.com/index.html)
is available and does run headless but have decided to use 2.46
which covers versions 71 to 73 in discussion with FE dev.