### PR TITLE
K8S staging - rename messaging secret filename

### DIFF
--- a/kubectl_deploy/staging/deployment.yaml
+++ b/kubectl_deploy/staging/deployment.yaml
@@ -151,17 +151,17 @@ spec:
             - name: SETTINGS__AWS__SNS__SUBMITTED_TOPIC_ARN
               valueFrom:
                 secretKeyRef:
-                  name: cccd-claims-submitted-sns
+                  name: cccd-messaging
                   key: topic_arn
             - name: SETTINGS__AWS__SNS__ACCESS
               valueFrom:
                 secretKeyRef:
-                  name: cccd-claims-submitted-sns
+                  name: cccd-messaging
                   key: access_key_id
             - name: SETTINGS__AWS__SNS__SECRET
               valueFrom:
                 secretKeyRef:
-                  name: cccd-claims-submitted-sns
+                  name: cccd-messaging
                   key: secret_access_key
             - name: SETTINGS__GOVUK_NOTIFY__API_KEY
               valueFrom:


### PR DESCRIPTION
#### What
Rename the values for SNS secret source

#### Why
As part of rationalising the messaging artefacts, the secret files were merged into a new secrets file

#### How
Rename the env var source file name in the staging deployment.yaml