### PR TITLE
Refactor the S3 handling

### DIFF
--- a/app/models/concerns/document_attachment.rb
+++ b/app/models/concerns/document_attachment.rb
@@ -1,24 +1,13 @@
 module DocumentAttachment
   extend ActiveSupport::Concern
+  include S3Headers
 
   included do
     attr_accessor :pdf_tmpfile
 
-    has_attached_file :converted_preview_document,
-                      { s3_headers: {
-                        'x-amz-meta-Cache-Control' => 'no-cache',
-                        'Expires' => 3.months.from_now.httpdate
-                      },
-                        s3_permissions: :private,
-                        s3_region: Settings.aws.s3.region }.merge(PAPERCLIP_STORAGE_OPTIONS)
+    has_attached_file :converted_preview_document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
 
-    has_attached_file :document,
-                      { s3_headers: {
-                        'x-amz-meta-Cache-Control' => 'no-cache',
-                        'Expires' => 3.months.from_now.httpdate
-                      },
-                        s3_permissions: :private,
-                        s3_region: Settings.aws.s3.region }.merge(PAPERCLIP_STORAGE_OPTIONS)
+    has_attached_file :document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
 
     validates_attachment_content_type :converted_preview_document, content_type: 'application/pdf'
   end

--- a/app/models/concerns/s3_headers.rb
+++ b/app/models/concerns/s3_headers.rb
@@ -1,7 +1,7 @@
 module S3Headers
   extend ActiveSupport::Concern
 
-  module ClassMethods
+  class_methods do
     def s3_headers
       {
         s3_headers: {

--- a/app/models/concerns/s3_headers.rb
+++ b/app/models/concerns/s3_headers.rb
@@ -1,0 +1,14 @@
+module S3Headers
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def s3_headers
+      { s3_headers: {
+          'x-amz-meta-Cache-Control' => 'no-cache',
+          'Expires' => 3.months.from_now.httpdate
+      },
+        s3_permissions: :private,
+        s3_region: Settings.aws.s3.region }
+    end
+  end
+end

--- a/app/models/concerns/s3_headers.rb
+++ b/app/models/concerns/s3_headers.rb
@@ -4,8 +4,8 @@ module S3Headers
   module ClassMethods
     def s3_headers
       { s3_headers: {
-          'x-amz-meta-Cache-Control' => 'no-cache',
-          'Expires' => 3.months.from_now.httpdate
+        'x-amz-meta-Cache-Control' => 'no-cache',
+        'Expires' => 3.months.from_now.httpdate
       },
         s3_permissions: :private,
         s3_region: Settings.aws.s3.region }

--- a/app/models/concerns/s3_headers.rb
+++ b/app/models/concerns/s3_headers.rb
@@ -3,12 +3,14 @@ module S3Headers
 
   module ClassMethods
     def s3_headers
-      { s3_headers: {
-        'x-amz-meta-Cache-Control' => 'no-cache',
-        'Expires' => 3.months.from_now.httpdate
-      },
+      {
+        s3_headers: {
+          'x-amz-meta-Cache-Control' => 'no-cache',
+          'Expires' => 3.months.from_now.httpdate
+        },
         s3_permissions: :private,
-        s3_region: Settings.aws.s3.region }
+        s3_region: Settings.aws.s3.region
+      }
     end
   end
 end

--- a/app/models/concerns/s3_headers.rb
+++ b/app/models/concerns/s3_headers.rb
@@ -9,8 +9,14 @@ module S3Headers
           'Expires' => 3.months.from_now.httpdate
         },
         s3_permissions: :private,
-        s3_region: Settings.aws.s3.region
+        s3_region: region
       }
+    end
+
+    private
+
+    def region
+      Settings.aws.region || 'eu-west-1'
     end
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -21,13 +21,7 @@ class Message < ApplicationRecord
 
   attr_accessor :claim_action, :written_reasons_submitted
 
-  has_attached_file :attachment,
-                    { s3_headers: {
-                      'x-amz-meta-Cache-Control' => 'no-cache',
-                      'Expires' => 3.months.from_now.httpdate
-                    },
-                      s3_permissions: :private,
-                      s3_region: Settings.aws.s3.region }.merge(PAPERCLIP_STORAGE_OPTIONS)
+  has_attached_file :attachment, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
 
   validates_attachment :attachment,
                        size: { in: 0.megabytes..20.megabytes },

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -15,6 +15,8 @@
 #
 
 class Message < ApplicationRecord
+  include S3Headers
+
   belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
   belongs_to :sender, foreign_key: :sender_id, class_name: 'User', inverse_of: :messages_sent
   has_many :user_message_statuses, dependent: :destroy

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -12,6 +12,8 @@
 
 module Stats
   class StatsReport < ApplicationRecord
+    include S3Headers
+
     TYPES = %w[management_information provisional_assessment rejections_refusals].freeze
 
     validates :status, inclusion: { in: %w[started completed error] }
@@ -25,13 +27,7 @@ module Stats
     scope :management_information, -> { not_errored.where(report_name: 'management_information') }
     scope :provisional_assessment, -> { not_errored.where(report_name: 'provisional_assessment') }
 
-    has_attached_file :document,
-                      { s3_headers: {
-                        'x-amz-meta-Cache-Control' => 'no-cache',
-                        'Expires' => 3.months.from_now.httpdate
-                      },
-                        s3_permissions: :private,
-                        s3_region: Settings.aws.s3.region }.merge(REPORTS_STORAGE_OPTIONS)
+    has_attached_file :document, s3_headers.merge(REPORTS_STORAGE_OPTIONS)
 
     validates_attachment_content_type :document, content_type: ['text/csv']
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Document, type: :model do
   it { should have_attached_file(:converted_preview_document) }
   it { should validate_attachment_content_type(:converted_preview_document).allowing('application/pdf') }
 
+  it_behaves_like 'an s3 bucket'
+
   it do
     should validate_attachment_content_type(:document).
       allowing('application/pdf',

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -124,4 +124,23 @@ RSpec.describe Message, type: :model do
       expect(claim.state).to eq 'part_authorised'
     end
   end
+
+  describe '.s3_headers' do
+    subject { described_class.s3_headers[:s3_region] }
+
+    context 'when an aws region has been explicitly recorded in the settings' do
+      let(:fake_aws_region) { 'eu-west-49'}
+
+      before { allow(Settings.aws).to receive(:region).and_return(fake_aws_region) }
+
+      it { is_expected.to eql fake_aws_region }
+    end
+
+    context 'when an aws region has not been set' do
+
+      before { allow(Settings.aws).to receive(:region).and_return(nil) }
+
+      it { is_expected.to eql 'eu-west-1' }
+    end
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Message, type: :model do
 
   it { should have_attached_file(:attachment) }
 
+  it_behaves_like 'an s3 bucket'
+
   it do
      should validate_attachment_content_type(:attachment).
        allowing('application/pdf',
@@ -122,25 +124,6 @@ RSpec.describe Message, type: :model do
       expect(claim.claim_state_transitions.reorder(created_at: :asc).map(&:event)).to eq( [ nil, 'submit', 'allocate', 'authorise_part', 'await_written_reasons', 'authorise_part' ] )
       expect(claim.last_state_transition.author_id).to eq(user.id)
       expect(claim.state).to eq 'part_authorised'
-    end
-  end
-
-  describe '.s3_headers' do
-    subject { described_class.s3_headers[:s3_region] }
-
-    context 'when an aws region has been explicitly recorded in the settings' do
-      let(:fake_aws_region) { 'eu-west-49'}
-
-      before { allow(Settings.aws).to receive(:region).and_return(fake_aws_region) }
-
-      it { is_expected.to eql fake_aws_region }
-    end
-
-    context 'when an aws region has not been set' do
-
-      before { allow(Settings.aws).to receive(:region).and_return(nil) }
-
-      it { is_expected.to eql 'eu-west-1' }
     end
   end
 end

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Stats::StatsReport do
+  it_behaves_like 'an s3 bucket'
+
   context 'management information reports' do
     before(:all) do
       @mi_old = create :stats_report, started_at: 10.days.ago

--- a/spec/support/shared_examples/models/s3_headers.rb
+++ b/spec/support/shared_examples/models/s3_headers.rb
@@ -1,0 +1,20 @@
+RSpec.shared_examples 'an s3 bucket' do
+  describe '.s3_headers' do
+    subject { described_class.s3_headers[:s3_region] }
+
+    context 'when an aws region has been explicitly recorded in the settings' do
+      let(:fake_aws_region) { 'eu-west-49'}
+
+      before { allow(Settings.aws).to receive(:region).and_return(fake_aws_region) }
+
+      it { is_expected.to eql fake_aws_region }
+    end
+
+    context 'when an aws region has not been set' do
+
+      before { allow(Settings.aws).to receive(:region).and_return(nil) }
+
+      it { is_expected.to eql 'eu-west-1' }
+    end
+  end
+end


### PR DESCRIPTION
#### What
Improve the S3 header generation to allow it to work with both Kubernetes _and_ template deploy

#### Why
As part of the Kubernetes work, we needed to update the methods used to upload files to s3.  This has left the code slightly fragile in that it will work for K8s but not for the existing template deploy methods.  This refactor aims to allow the code to be deployed to both environments

#### How
 - [X] Extract the s3 headers into shared code to allow updates to be made in a single place
 - [x] extend the code to allow template deploy to work too
