### PR TITLE
Remove unused active storage routes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,11 @@ Bundler.require(*Rails.groups)
 
 module AdvocateDefencePayments
   class Application < Rails::Application
+    # remove active storage routes - not used (yet)
+    initializer(:remove_activestorage_routes, after: :add_routing_paths) do |app|
+      app.routes_reloader.paths.delete_if {|path| path =~ /activestorage/}
+    end
+
     config.middleware.use Rack::Deflater
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
#### What
Remove unused active storage routes

#### Why
Still using paperclip for now so not needed

#### How
see [stackoverflow thread](https://stackoverflow.com/questions/52497044/how-to-disable-auto-generated-routes-by-active-storage)