### PR TITLE
Kubernetes - CCCD staging response queue (rebased version)

### DIFF
--- a/app/models/concerns/s3_headers.rb
+++ b/app/models/concerns/s3_headers.rb
@@ -16,7 +16,7 @@ module S3Headers
     private
 
     def region
-      Settings.aws.region || 'eu-west-1'
+      Settings.aws.region
     end
   end
 end

--- a/app/services/claims/injection_channel.rb
+++ b/app/services/claims/injection_channel.rb
@@ -2,6 +2,7 @@ module Claims
   class InjectionChannel
     def self.for(claim)
       return 'cccd_development' if claim.nil?
+      return 'cccd-k8s-injection' if Settings.aws&.sqs&.response_queue_url
       claim.agfs? ? 'cccd_ccr_injection' : 'cccd_cclf_injection'
     end
   end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -11,7 +11,11 @@ class InjectionResponseService
     return failure(action: 'run!', uuid: @response['uuid']) unless @claim
 
     injection_attempt = create_injection_attempt
-    slack.send_message! unless injection_attempt.succeeded?
+    if Settings.aws&.sqs&.response_queue_url
+      slack.send_message!
+    else
+      slack.send_message! unless injection_attempt.succeeded?
+    end
     true
   end
 

--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -1,7 +1,11 @@
 module MessageQueue
   class AwsClient
     def initialize(queue)
-      @sqs = Aws::SQS::Client.new(access_key_id: Settings.aws.access, secret_access_key: Settings.aws.secret)
+      @sqs = Aws::SQS::Client.new(
+        access_key_id: Settings.aws.sns.access,
+        secret_access_key: Settings.aws.sns.secret,
+        region: Settings.aws.region
+      )
       begin
         @queue_url = queue_url(queue)
       rescue Aws::SQS::Errors::NonExistentQueue

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -115,7 +115,7 @@ advocate_phone_contact: '03002002020'
 litigator_phone_contact: '03002002020'
 
 aws:
-  region: 'eu-west-2'
+  region: <%= ENV['AWS_REGION'] %>
   access: <%= ENV['AWS_ACCESS_KEY'] %>
   secret: <%= ENV['SECRET_ACCESS_KEY'] %>
   submitted_queue: <%= ENV['AWS_QUEUE_NAME'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -121,21 +121,22 @@ aws:
   submitted_queue: <%= ENV['AWS_QUEUE_NAME'] %>
   response_queue: <%= ENV['AWS_RESPONSE_QUEUE_NAME'] %>
   s3:
-    access: 'actual value in .env file or setup'
-    secret: 'actual value in .env file or setup'
-    bucket: 'actual value in .env file or setup'
+    access: 'store actual value as SETTINGS__AWS__S3__ACCESS'
+    secret: 'store actual value as SETTINGS__AWS__S3__SECRET'
+    bucket: 'store actual value as SETTINGS__AWS__S3__BUCKET'
   sqs:
     # This is deliberately blank - add a SETTINGS__AWS__SQS__RESPONSE_QUEUE_URL
     # value to .env files or the deployment repo if needed. this allows the `response_queue`
     # value to override it until it is set in all hosting areas/technologies
     response_queue_url:
   billing:
-    access: 'store-actual-values-in-.env-file'
-    secret: 'store-actual-values-in-.env-file'
-    account: 'store-actual-values-in-.env-file'
+    access: 'store actual value as SETTINGS__AWS__BILLING__ACCESS'
+    secret: 'store actual value as SETTINGS__AWS__BILLING__SECRET'
+    account: 'store actual value as SETTINGS__AWS__BILLING__ACCOUNT'
   sns:
-    access: <%= ENV['AWS_ACCESS_KEY'] %>
-    secret: <%= ENV['SECRET_ACCESS_KEY'] %>
+    access: 'store actual value as SETTINGS__AWS__SNS__ACCESS'
+    secret: 'store actual value as SETTINGS__AWS__SNS__ACCESS'
+    submitted_topic_arn: 'store actual value as SETTINGS__AWS__SNS__SUBMITTED_TOPIC_ARN'
 slack:
   bot_url: 'slack_bot_url'
   bot_name: 'bot_name'

--- a/kubectl_deploy/api-sandbox/deployment.yaml
+++ b/kubectl_deploy/api-sandbox/deployment.yaml
@@ -24,6 +24,8 @@ spec:
           #              path: /healthcheck
           #              port: 4567
           env:
+            - name: ENV
+              value: 'api-sandbox'
             - name: RAILS_ENV
               value: 'production'
             - name: DB_PORT

--- a/kubectl_deploy/api-sandbox/deployment.yaml
+++ b/kubectl_deploy/api-sandbox/deployment.yaml
@@ -13,16 +13,6 @@ spec:
       containers:
         - name: cccd-app
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:latest
-          # add this to override 02-limitrange.yaml settings for the namespace
-          # - not needed if 02-limitrange.yaml specifies the same or more.
-          #
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 2Gi
-            requests:
-              cpu: 125m
-              memory: 250Mi
           ports:
             - containerPort: 4567
           #          livenessProbe:

--- a/kubectl_deploy/dev/deployment.yaml
+++ b/kubectl_deploy/dev/deployment.yaml
@@ -24,6 +24,8 @@ spec:
           #              path: /healthcheck
           #              port: 4567
           env:
+            - name: ENV
+              value: 'dev'
             - name: RAILS_ENV
               value: 'production'
             - name: DB_PORT

--- a/kubectl_deploy/dev/deployment.yaml
+++ b/kubectl_deploy/dev/deployment.yaml
@@ -158,6 +158,11 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: secret_access_key
+            - name: SETTINGS__AWS__SQS__RESPONSE_QUEUE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-messaging
+                  key: sqs_cccd_id
             - name: SETTINGS__GOVUK_NOTIFY__API_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubectl_deploy/staging/deployment.yaml
+++ b/kubectl_deploy/staging/deployment.yaml
@@ -24,6 +24,8 @@ spec:
 #              path: /healthcheck
 #              port: 4567
           env:
+            - name: ENV
+              value: 'staging'
             - name: RAILS_ENV
               value: 'production'
             - name: DB_PORT

--- a/kubectl_deploy/staging/deployment.yaml
+++ b/kubectl_deploy/staging/deployment.yaml
@@ -163,6 +163,11 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: secret_access_key
+            - name: SETTINGS__AWS__SQS__RESPONSE_QUEUE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-messaging
+                  key: sqs_cccd_id
             - name: SETTINGS__GOVUK_NOTIFY__API_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubectl_deploy/staging/deployment.yaml
+++ b/kubectl_deploy/staging/deployment.yaml
@@ -93,11 +93,6 @@ spec:
                 secretKeyRef:
                   name: cccd-secrets
                   key: SECRET_ACCESS_KEY
-            - name: AWS_RESPONSE_QUEUE_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: AWS_RESPONSE_QUEUE_NAME
             - name: AWS_REGION
               valueFrom:
                 secretKeyRef:

--- a/spec/services/claims/injection_channel_spec.rb
+++ b/spec/services/claims/injection_channel_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe Claims::InjectionChannel, type: :service do
   subject(:injection_channel) { described_class.for(claim) }
 
+  context 'when a response_queue_url setting exists' do
+    before { allow(Settings.aws.sqs).to receive(:response_queue_url).and_return('http://test.aws.queue') }
+    let(:claim) { create(:litigator_claim) }
+
+    it { is_expected.to eql('cccd-k8s-injection') }
+  end
+
   context 'when claim is for LGFS' do
     let(:claim) { create(:litigator_claim) }
 

--- a/spec/support/shared_examples/models/s3_headers.rb
+++ b/spec/support/shared_examples/models/s3_headers.rb
@@ -1,20 +1,39 @@
 RSpec.shared_examples 'an s3 bucket' do
   describe '.s3_headers' do
-    subject { described_class.s3_headers[:s3_region] }
+    subject { described_class.s3_headers }
 
-    context 'when an aws region has been explicitly recorded in the settings' do
-      let(:fake_aws_region) { 'eu-west-49'}
+    context ':s3_headers' do
+      subject(:s3_headers) { described_class.s3_headers[:s3_headers] }
 
-      before { allow(Settings.aws).to receive(:region).and_return(fake_aws_region) }
+      it 'includes no-cache directive' do
+        freeze_time do
+          expect(s3_headers.values).to include('no-cache')
+        end
+      end
 
-      it { is_expected.to eql fake_aws_region }
+      it 'includes 3 month expiry directive' do
+        freeze_time do
+          is_expected.to include('Expires' => 3.months.from_now.httpdate)
+        end
+      end
     end
 
-    context 'when an aws region has not been set' do
+    context ':s3_permissions' do
+      subject(:s3_permissions) { described_class.s3_headers[:s3_permissions] }
 
-      before { allow(Settings.aws).to receive(:region).and_return(nil) }
+      it 'includes private directive for s3' do
+        is_expected.to eql(:private)
+      end
+    end
 
-      it { is_expected.to eql 'eu-west-1' }
+    context ':s3_region' do
+      subject(:s3_region) { described_class.s3_headers[:s3_region] }
+      let(:fake_aws_region) { 'eu-west-49' }
+
+      it 'includes region value from settings' do
+        expect(Settings.aws).to receive(:region).and_return(fake_aws_region)
+        is_expected.to eql fake_aws_region
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
Update the CCCD response queue handling.  Allow for different actions if the K8s environment has set a response_queue URL, but not set a response_queue name

#### Why
This will allow us to track _all_ injection attempts while testing the Kubernetes stack, while still allowing the template deploy environments to function as they do now

#### How
- [x] replace the `aws.response_queue` env_var with an `aws.sqs.response_queue_url`
- [x] Allow an override to the slack channel if the `aws.sqs.response_queue_url` exists
- [x] Always send a slack notification if  the `aws.sqs.response_queue_url` exists
- [ ] Rename the `Settings.aws.sns.access` to be `Settings.aws.messgaging.access` etc  This has become necessary since the grouping of messaging objects in terraform 
 ^^ I like the separation of SNS config from SQS. Even if the secrets are stored in the `cccd-messaging` secret they can referred to via settings in a more descriptive way
