### PR TITLE
Ignore kubernetes `yml` and `yaml` secret file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tags
 .personal/*
 
 vcr/cassettes/*.log
+
+# kubernetes secrets
+kube*/**/*secret*.y*ml


### PR DESCRIPTION
#### What
Ignore kubernetes `yml` and `yaml` secret file

#### Why
Putting this in just to make sure cross
branch work does not leak secrets.