### PR TITLE
K8s/add latest tags

### DIFF
--- a/bin/k8secret
+++ b/bin/k8secret
@@ -12,12 +12,12 @@
 #
 # Examples:
 # most basic example if current-context is the one you want
-#  ``
+# `bin/k8secret -e dev`
 #
-# output default secrets oject to STDOUT
-#  `bin/k8secret -c live-1 -e dev -d`
+# output base64 decoded cccd-secrets oject to STDOUT
+# `bin/k8secret -c live-1 -e dev -d`
 #
-# write output to default temp secret file location (is .gitignored)
+# write base64 decoded cccd-secrets oject to a .gitignored temp file
 # `bin/k8secret -c live-1 -e dev -dw`
 #
 # query the s3 bucket secrets
@@ -39,7 +39,7 @@ class K8SecretOptParser
     options.secret = 'cccd-secrets'
 
     k8secret_opt_parser = OptionParser.new do |opts|
-      opts.banner = "Usage: secret [options]"
+      opts.banner = "Usage: #{__FILE__} [options]"
       opts.separator ""
       opts.separator "Specific options:"
 

--- a/k8sdeploy.sh
+++ b/k8sdeploy.sh
@@ -22,17 +22,34 @@ function _k8sdeploy() {
   esac
 
   context='live-1'
-  version=$(git rev-parse $(git branch | grep \* | cut -d ' ' -f2))
+  component=app
+  current_branch=$(git branch | grep \* | cut -d ' ' -f2)
   docker_registry=754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd
-  docker_tag=app-${version}
-  docker_image_tag=${docker_registry}:${docker_tag}
 
-  echo "Deploying $docker_image_tag to $environment on cluster $context"
-  kubectl set image -f kubectl_deploy/${environment}/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -n cccd-${environment} --context ${context} -f -
-  echo "Applying service..."
-  kubectl apply -n cccd-${environment} --context ${context} -f kubectl_deploy/${environment}/service.yaml
-  echo "Applying ingress..."
-  kubectl apply -n cccd-${environment} --context ${context} -f kubectl_deploy/${environment}/ingress.yaml
+  # get latest tag for branch
+  case $current_branch in
+    master)
+      docker_image_tag=${docker_registry}:${component}-latest
+      ;;
+    *)
+      docker_image_tag=${docker_registry}:${component}-${current_branch}-latest
+      ;;
+  esac
+
+  kubectl config set-context ${context} --namespace=cccd-${environment}
+  kubectl config use-context ${context}
+
+  echo "--------------------------------------------------"
+  echo "Context: $context"
+  echo "Environment: $environment"
+  echo "Current branch: $current_branch"
+  echo "Docker image: $docker_image_tag"
+  echo "--------------------------------------------------"
+
+  kubectl set image -f kubectl_deploy/${environment}/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
+  kubectl apply \
+    -f kubectl_deploy/${environment}/service.yaml \
+    -f kubectl_deploy/${environment}/ingress.yaml
 
 }
 


### PR DESCRIPTION
Add and use `latest` tag to build and deploy

#### What
Add additional tag to builds
and have deploy use the latest
branch tag rather than the shah.


#### Ticket

kubernetes migration epic

#### Why
This prevents accidental deploy of an image for
the latet tag/commit-sha that has not yet been 
built. However it does not deal with situation when no
build of the branch has been done.

#### How
Add an additional tag to each build to mark as the latest for that branch.
i.e.
`app-<branch-name>-latest`
or for master branch
`app-latest`

Have deploy script use the latest branch tag during deploy.

Extension - provide a warning if no image with that tag exists
and abort.
Extension - have rolling update to prevent termination of pod
if replacement container creation fails
