### PR TITLE
Use renamed SQS secret key

### DIFF
--- a/kubectl_deploy/dev/deployment.yaml
+++ b/kubectl_deploy/dev/deployment.yaml
@@ -164,7 +164,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: cccd-messaging
-                  key: sqs_cccd_id
+                  key: sqs_cccd_url
             - name: SETTINGS__GOVUK_NOTIFY__API_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubectl_deploy/staging/deployment.yaml
+++ b/kubectl_deploy/staging/deployment.yaml
@@ -164,7 +164,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: cccd-messaging
-                  key: sqs_cccd_id
+                  key: sqs_cccd_url
             - name: SETTINGS__GOVUK_NOTIFY__API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
#### What
Use renamed SQS secret key.

Relies on this [PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/927)
going in, that syncs queues and names across dev and staging

#### Why
For parity between envs and clarity
in naming