### PR TITLE
Amend defunct reference to old bucket env var

### DIFF
--- a/config/aws.yml
+++ b/config/aws.yml
@@ -16,9 +16,9 @@ devunicorn:
   <<: *default
 
 test:
-  access_key_id:      xxxxxxxx
-  secret_access_key:  xxxxxxxxxxxxx
-  bucket: <%= ENV['adp_bucket_name'] || "moj-cbo-documents-#{Rails.env}" %>
+  access_key_id: xxxxxxxx
+  secret_access_key: xxxxxxxxxxxxx
+  bucket: <%= Settings.aws.s3.bucket || 'cccd-test-bucket' %>
 
 develop:
   <<: *default


### PR DESCRIPTION
#### What
Amend defunct reference to old bucket env var

#### Why
s3 bucket name should now stored in SETTINGS__AWS__S3__BUCKET
env var. In fact you cannot upload to s3 locally anyway because
access is controlled via a TD AWS cross-account which only
jenkins has access to, as far as I am aware. All local
paperclip storage is configure to store locally in the public
folder.