### PR TITLE
CBO 686 - Implement Google tag manager

### DIFF
--- a/app/models/google_analytics/data_tracking.rb
+++ b/app/models/google_analytics/data_tracking.rb
@@ -7,6 +7,14 @@ module GoogleAnalytics
         adapter.present? && Rails.env.production?
       end
 
+      def tag_manager?
+        enabled? && adapter_name.eql?(:gtm)
+      end
+
+      def analytics?
+        enabled? && adapter_name.eql?(:ga)
+      end
+
       def track(*args)
         return unless enabled?
         raise ArgumentError, 'Uninitialized adapter' unless adapter

--- a/app/views/layouts/_analytics.js.haml
+++ b/app/views/layouts/_analytics.js.haml
@@ -4,7 +4,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-KCWHDK');
+    })(window,document,'script','dataLayer','#{ENV['GTM_TRACKER_ID']}');
 
 - if adapter == :ga
   :javascript

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,8 +15,9 @@
 
   - if GoogleAnalytics::DataTracking.enabled?
     = render partial: 'layouts/analytics', :formats => [:js], locals: { adapter: GoogleAnalytics::DataTracking.adapter_name }
-    %script
-      != ga_outlet
+    - if GoogleAnalytics::DataTracking.analytics?
+      %script
+        != ga_outlet
 
 - content_for :body_classes do
   = "controller-" + controller.controller_name
@@ -25,7 +26,7 @@
   = "with-proposition"
 
 - content_for :body_start do
-  - if GoogleAnalytics::DataTracking.adapter == :gtm
+  - if GoogleAnalytics::DataTracking.tag_manager?
     %noscript
       %iframe{ :src => "https://www.googletagmanager.com/ns.html?id=#{ENV['GTM_TRACKED_ID']}", :style => "display:none;visibility:hidden",:height => "0", :width => "0"}
 
@@ -66,7 +67,7 @@
 
 - content_for :body_end do
   = javascript_include_tag Rails.env.test? ? 'application.test' : 'application'
-  - if GoogleAnalytics::DataTracking.enabled?
+  - if GoogleAnalytics::DataTracking.analytics?
     :javascript
       ga(function(tracker) {
         var clientId = tracker.get('clientId');

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,6 +24,11 @@
 - content_for :header_class do
   = "with-proposition"
 
+- content_for :body_start do
+  - if GoogleAnalytics::DataTracking.adapter == :gtm
+    %noscript
+      %iframe{ :src => "https://www.googletagmanager.com/ns.html?id=#{ENV['GTM_TRACKED_ID']}", :style => "display:none;visibility:hidden",:height => "0", :width => "0"}
+
 - content_for :proposition_header do
   .header-proposition
     .content

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -3,4 +3,4 @@
 #   :ga  -> Google Analytics
 #   :gtm -> Google Tag Manager
 #
-GoogleAnalytics::DataTracking.adapter = :ga
+GoogleAnalytics::DataTracking.adapter = ENV['GTM_TRACKER_ID'].present? ? :gtm : :ga

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -39,5 +39,49 @@ module GoogleAnalytics
         end
       end
     end
+
+    context '#tag_manager?' do
+      subject(:tag_manager) { described_class.tag_manager? }
+
+      context 'when the adapter is google_tag_manager' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the adapter is google_analytics' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the adapter is nil' do
+        before { allow(described_class).to receive(:adapter).and_return(nil) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context '#analytics?' do
+      subject(:analytics) { described_class.analytics? }
+
+      context 'when the adapter is google_tag_manager' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when the adapter is google_analytics' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the adapter is nil' do
+        before { allow(described_class).to receive(:adapter).and_return(nil) }
+
+        it { is_expected.to be false }
+      end
+    end
   end
 end

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -41,7 +41,6 @@ module GoogleAnalytics
     end
 
     describe 'type methods' do
-
       before do
         allow(described_class).to receive(:adapter).and_return('Adapter')
         allow(Rails).to receive(:env).and_return('production'.inquiry)

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -40,47 +40,54 @@ module GoogleAnalytics
       end
     end
 
-    context '#tag_manager?' do
-      subject(:tag_manager) { described_class.tag_manager? }
+    describe 'type methods' do
 
-      context 'when the adapter is google_tag_manager' do
-        before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
-
-        it { is_expected.to be true }
+      before do
+        allow(described_class).to receive(:adapter).and_return('Adapter')
+        allow(Rails).to receive(:env).and_return('production'.inquiry)
       end
 
-      context 'when the adapter is google_analytics' do
-        before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
+      context '#tag_manager?' do
+        subject(:tag_manager) { described_class.tag_manager? }
+        context 'when the adapter is google_tag_manager' do
+          before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
 
-        it { is_expected.to be false }
+          it { is_expected.to be true }
+        end
+
+        context 'when the adapter is google_analytics' do
+          before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
+
+          it { is_expected.to be false }
+        end
+
+        context 'when the adapter is nil' do
+          before { allow(described_class).to receive(:adapter).and_return(nil) }
+
+          it { is_expected.to be false }
+        end
       end
 
-      context 'when the adapter is nil' do
-        before { allow(described_class).to receive(:adapter).and_return(nil) }
+      context '#analytics?' do
+        subject(:analytics) { described_class.analytics? }
 
-        it { is_expected.to be false }
-      end
-    end
+        context 'when the adapter is google_tag_manager' do
+          before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
 
-    context '#analytics?' do
-      subject(:analytics) { described_class.analytics? }
+          it { is_expected.to be false }
+        end
 
-      context 'when the adapter is google_tag_manager' do
-        before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
+        context 'when the adapter is google_analytics' do
+          before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
 
-        it { is_expected.to be false }
-      end
+          it { is_expected.to be true }
+        end
 
-      context 'when the adapter is google_analytics' do
-        before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
+        context 'when the adapter is nil' do
+          before { allow(described_class).to receive(:adapter).and_return(nil) }
 
-        it { is_expected.to be true }
-      end
-
-      context 'when the adapter is nil' do
-        before { allow(described_class).to receive(:adapter).and_return(nil) }
-
-        it { is_expected.to be false }
+          it { is_expected.to be false }
+        end
       end
     end
   end


### PR DESCRIPTION
#### What
Implement Google Tag Manager in CCCD

#### Ticket
[CCCD – Implement Google Tag Manager](https://dsdmoj.atlassian.net/browse/CBO-686)

#### Why
GTM allows a more granular approach to GA event tracking 

#### How
* Update the Javascript to allow passing in GTM container IDs per environment
* Allow the container to start in GTM mode if the environment variable is set, otherwise fall back to the original, plain, Google Analytics version.
* Add a non-JS compatible GTM script to be called if invoking GTM and JS is turned off

--------

#### TODO (wip)

 - [x] create a GTM account and add a demo container
 - [x] test on the demo environment to ensure it works as expected
