### PR TITLE
Bugfix: allow discontinuance? to return false if no case_type set

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -230,7 +230,7 @@ module Claim
     end
 
     def discontinuance?
-      case_type.fee_type_code.eql?('GRDIS')
+      case_type&.fee_type_code.eql?('GRDIS')
     end
 
     private

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1589,7 +1589,13 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
             expect(claim_10.discontinuance?).to be false
           end
         end
-      end  
+      end
+
+      context 'when the claim has been saved as draft before the case type is set' do
+        let(:claim) { build :advocate_claim, case_type: nil }
+
+        it { expect(claim.discontinuance?). to be false }
+      end
     end
   end
 


### PR DESCRIPTION
#### What: 

Add Safe Navigation Operator to case_type in the `discontinuance?` method of claims

#### Why: 
If a provider saved a draft before setting the case type, the `discontinuance?` check would fail as there was no case type to validate against
