### PR TITLE
Travel Automation report Fix

### DIFF
--- a/lib/geckoboard_publisher/travel_automation_report.rb
+++ b/lib/geckoboard_publisher/travel_automation_report.rb
@@ -80,7 +80,7 @@ module GeckoboardPublisher
 
     def calculate_totals(expense)
       user_entered_total = expense.amount + expense.vat_amount
-      mileage_rate = Expense::CAR_MILEAGE_RATES[expense.mileage_rate_id].rate
+      mileage_rate = Expense::MILEAGE_RATES[expense.mileage_rate_id].rate
       calc_amount = (expense.calculated_distance * mileage_rate)
       calc_vat = VatRate.vat_amount(calc_amount, expense.claim.vat_date, calculate: expense.claim.apply_vat?)
       calculated_total = calc_amount + calc_vat


### PR DESCRIPTION
What:
Update the Travel Automation Report mileage_rate calculation

Why:
The overnight report was failing because someone claimed a bike journey
and the rates are not included in the car_mileage_rates!

How:
Change the mileage_rate calculation to use the combined mileage rate
