### PR TITLE
Add filter to the injection_response_service

### DIFF
--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe InjectionResponseService, slack_bot: true do
   let(:valid_json_with_invalid_uuid) { { "from":"external application", "errors":[], "uuid":'b08cfd61-9999-8888-7777-651477183efb', "messages":[{'message':'Claim injected successfully.'}]} }
   let(:valid_json_on_success) { { "from":"external application", "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
   let(:valid_json_on_failure) { { "from":"external application", "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."}, {'error':"Another injection error."} ],"uuid":claim.uuid,"messages":[] } }
+  let(:error_message) { "Another injection error." }
 
 shared_examples "creates injection attempts" do
   it 'returns true' do
@@ -72,6 +73,14 @@ end
         expect(injection_attempt.error_messages).to be_present
         expect(injection_attempt.error_messages).to be_an Array
         expect(injection_attempt.error_messages).to include("No defendant found for Rep Order Number: '123456432'.","Another injection error.")
+      end
+
+      context 'with a known, ignorable, error' do
+        let(:error_message) { 'A case already exists for these case details.' }
+
+        it 'does not send a slack message' do
+          expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).not_to have_been_made
+        end
       end
     end
 


### PR DESCRIPTION
#### What
Reduce the noise in the slack injection channels

#### Ticket
[CCCD: SPIKE: Investigate methods to improve injection reporting](https://dsdmoj.atlassian.net/browse/CBO-803)

#### Why
After the CCLF injection reporting incident, it was determined that the injection channels in slack are very noisy

#### How
Apply some login in the injection response service to only send a slack message when the injection fail is not ignorable

#### TODO (wip)

 - [ ] move the `injectable` logic to the injection_attempt model
 - [X] Create some `ignorable` rules to prevent messages being sent
