### PR TITLE
CBO-803: Add filter to the injection_response_service

### DIFF
--- a/app/models/injection_attempt.rb
+++ b/app/models/injection_attempt.rb
@@ -29,4 +29,8 @@ class InjectionAttempt < ApplicationRecord
     messages = data&.fetch(:errors)&.map { |child| child[:error] }
     messages || []
   end
+
+  def notification_can_be_skipped?
+    succeeded? || error_messages.any? { |message| message.include?('already exist') }
+  end
 end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -10,11 +10,11 @@ class InjectionResponseService
     slack.build_injection_payload(@response)
     return failure(action: 'run!', uuid: @response['uuid']) unless @claim
 
-    injection_attempt = create_injection_attempt
+    injection_attempt
     if Settings.aws&.sqs&.response_queue_url
       slack.send_message!
     else
-      slack.send_message! unless injection_attempt.succeeded?
+      slack.send_message! unless ignorable?
     end
     true
   end
@@ -43,5 +43,17 @@ class InjectionResponseService
     InjectionAttempt.create(claim: @claim,
                             succeeded: injected?,
                             error_messages: error_messages)
+  end
+
+  def injection_attempt
+    @injection_attempt ||= create_injection_attempt
+  end
+
+  def ignorable?
+    injection_attempt.succeeded? || has_ignorable_error?
+  end
+
+  def has_ignorable_error?
+    error_messages['errors'].any? { |message| message[:error].include?('already exist') }
   end
 end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -14,7 +14,7 @@ class InjectionResponseService
     if Settings.aws&.sqs&.response_queue_url
       slack.send_message!
     else
-      slack.send_message! unless ignorable?
+      slack.send_message! unless injection_attempt.notification_can_be_skipped?
     end
     true
   end
@@ -47,13 +47,5 @@ class InjectionResponseService
 
   def injection_attempt
     @injection_attempt ||= create_injection_attempt
-  end
-
-  def ignorable?
-    injection_attempt.succeeded? || has_ignorable_error?
-  end
-
-  def has_ignorable_error?
-    error_messages['errors'].any? { |message| message[:error].include?('already exist') }
   end
 end

--- a/spec/models/injection_attempt_spec.rb
+++ b/spec/models/injection_attempt_spec.rb
@@ -77,5 +77,27 @@ RSpec.describe InjectionAttempt, type: :model do
       expect(subject[:errors]).to eql error_messages['errors']
     end
   end
+
+  describe '#notification_can_be_skipped?' do
+    subject(:notification_can_be_skipped?) { injection_attempt.notification_can_be_skipped? }
+
+    context 'when the injection succeeded' do
+      let(:injection_attempt) { build(:injection_attempt) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the injection failed' do
+      let(:injection_attempt) { build(:injection_attempt, :with_errors) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the injection failed with ignorable errors' do
+      let(:injection_attempt) { build(:injection_attempt, :with_stat_excluded_errors) }
+
+      it { is_expected.to be true }
+    end
+  end
 end
 

--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe InjectionResponseService, slack_bot: true do
   let(:invalid_json) { { "errors": [], 'claim_id': '1234567', "messages":[] } }
   let(:valid_json_with_invalid_uuid) { { "from":"external application", "errors":[], "uuid":'b08cfd61-9999-8888-7777-651477183efb', "messages":[{'message':'Claim injected successfully.'}]} }
   let(:valid_json_on_success) { { "from":"external application", "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
-  let(:valid_json_on_failure) { { "from":"external application", "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."}, {'error':"Another injection error."} ],"uuid":claim.uuid,"messages":[] } }
+  let(:valid_json_on_failure) { { "from":"external application", "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."}, {'error':error_message} ],"uuid":claim.uuid,"messages":[] } }
   let(:error_message) { "Another injection error." }
 
 shared_examples "creates injection attempts" do

--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe InjectionResponseService, slack_bot: true do
   let(:valid_json_with_invalid_uuid) { { "from":"external application", "errors":[], "uuid":'b08cfd61-9999-8888-7777-651477183efb', "messages":[{'message':'Claim injected successfully.'}]} }
   let(:valid_json_on_success) { { "from":"external application", "errors":[], "uuid":claim.uuid, "messages":[{'message':'Claim injected successfully.'}]} }
   let(:valid_json_on_failure) { { "from":"external application", "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."}, {'error':"Another injection error."} ],"uuid":claim.uuid,"messages":[] } }
+  let(:error_message) { "Another injection error." }
 
 shared_examples "creates injection attempts" do
   it 'returns true' do
@@ -114,6 +115,14 @@ end
           expect(injection_attempt.error_messages).to be_present
           expect(injection_attempt.error_messages).to be_an Array
           expect(injection_attempt.error_messages).to include("No defendant found for Rep Order Number: '123456432'.","Another injection error.")
+        end
+      end
+
+      context 'with a known, ignorable, error' do
+        let(:error_message) { 'A case already exists for these case details.' }
+
+        it 'does not send a slack message' do
+          expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).not_to have_been_made
         end
       end
     end

--- a/vcr/cassettes/spec/controllers/external_users/fees/prices_controller_spec.yml
+++ b/vcr/cassettes/spec/controllers/external_users/fees/prices_controller_spec.yml
@@ -330,4 +330,45 @@ http_interactions:
       string: '{"amount":5142.87}'
     http_version: 
   recorded_at: Tue, 02 Apr 2019 10:19:13 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator-production.apps.cloud-platform-live-0.k8s.integration.dsd.io/api/v1/fee-schemes/2/calculate/?day=10&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=J&pages_of_prosecuting_evidence=0&ppe=1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/0.2.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.15.8
+      Date:
+      - Tue, 16 Jul 2019 09:50:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '18'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Cookie
+      Allow:
+      - GET
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":5142.87}'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 09:50:19 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
#### What
Reduce the noise in the slack injection channels

#### Ticket
[CCCD: SPIKE: Investigate methods to improve injection reporting](https://dsdmoj.atlassian.net/browse/CBO-803)

#### Why
After the CCLF injection reporting incident, it was determined that the injection channels in slack are very noisy

#### How
Apply some login in the injection response service to only send a slack message when the injection fail is not ignorable

#### TODO (wip)

 - [x] move the `ignorable` logic to the injection_attempt model
 - [X] Create some `ignorable` rules to prevent messages being sent