### PR TITLE
Remove fuubar reference from guard file

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -14,7 +14,7 @@ guard :jasmine, all_on_start: false do
   end
 end
 
-guard :rspec, cmd: "bundle exec rspec --format Fuubar --color", all_on_start: false do
+guard :rspec, cmd: "bundle exec rspec --format documentation --color", all_on_start: false do
   watch(%r{^spec/(.+)_spec\.rb$})
   watch(%r{^app/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }


### PR DESCRIPTION
After the Fuubar gem was removed, guard had stopped working
