### PR TITLE
Remove debug statement from archive task

### DIFF
--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -125,7 +125,6 @@ namespace :claims do
       raise ArgumentError.new "Only valid parameter is 'dummy'"
     end
 
-    puts "Running TimedTransitions::BatchTransitioner with dummy mode: #{@dummy}"
     TimedTransitions::BatchTransitioner.new(limit: 10000, dummy: @dummy).run
   end
 end


### PR DESCRIPTION
#### What
Remove debug statement from archive task

#### Why
Seems to be interfering with kibana ability to collect logs from the
cronjob that calls this.