### PR TITLE
Fix undefined method call `strftim` (typo)

### DIFF
--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -148,7 +148,7 @@
               %th{ scope: 'row' }
                 = t('retrial_concluded_at', scope: retrial_detail_fields)
               %td
-                %time{ 'aria-label': claim&.retrial_concluded_at&.strftim(Settings.date_format_label), datetime: claim&.retrial_concluded_at&.strftime(Settings.datetime_attribute) }
+                %time{ 'aria-label': claim&.retrial_concluded_at&.strftime(Settings.date_format_label), datetime: claim&.retrial_concluded_at&.strftime(Settings.datetime_attribute) }
                 = claim&.retrial_concluded_at&.strftime(Settings.date_format)
             %tr
               %th{ scope: 'row' }


### PR DESCRIPTION
#### What
case details summary partial calling `strftim` (typo)

#### Why
Raise by [sentry alert] (https://sentry.service.dsd.io/mojds/private-beta/issues/36707/)