### PR TITLE
Add kubernetes custom domain ingress config

### DIFF
--- a/kubernetes_deploy/dev/ingress.yaml
+++ b/kubernetes_deploy/dev/ingress.yaml
@@ -12,6 +12,16 @@ spec:
             backend:
               serviceName: cccd-app-service
               servicePort: 80
+    - host: dev.claim-crown-court-defence.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: cccd-app-service
+              servicePort: 80
   tls:
     - hosts:
       - cccd-dev.apps.live-1.cloud-platform.service.justice.gov.uk
+    - hosts:
+      - dev.claim-crown-court-defence.service.justice.gov.uk
+      secretName: cccd-dev-cert


### PR DESCRIPTION
#### What
Add kubernetes custom domain ingress config

#### Why
This is to provide a custom domain name
for dev inline with cloud platforms changes:

route53 changes: https://github.com/ministryofjustice/cloud-platform-environments/pull/997
cert config: https://github.com/ministryofjustice/cloud-platform-environments/pull/1011

..and to provide template for customizing
staging and api-sandbox (and prod) custom domains

#### Ticket

[CBO-827](https://dsdmoj.atlassian.net/browse/CBO-827)


#### How
add route53 terraform and certificate generation to
[cloud-plaforms-environment](https://github.com/ministryofjustice/cloud-platform-environments) and modify ingress to access the newly created domains