### PR TITLE
Set kubernetes image pull policy to always

### DIFF
--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       containers:
         - name: cccd-app
+          imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:latest
           ports:
             - containerPort: 3000

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       containers:
         - name: cccd-app
+          imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:latest
           ports:
             - containerPort: 3000

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       containers:
         - name: cccd-app
+          imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-snsv9
           ports:
             - containerPort: 3000


### PR DESCRIPTION
#### What
Always pull the specified docker image

#### Why
In order to honor the use of latest tags.

#### How
set kubernetes deployment config for app container images
to always pull - default is IfNotPresent, which only pulls
the image if does not already exist, which means `app-latest`
tags will never work as it does already exist.