### PR TITLE
Update bundler version 2.0.1 --> 2.0.2 used by Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ aliases:
     run:
       name: Install dependencies
       command: |
-        gem install bundler -v 2.0.1
-        bundle check || bundle _2.0.1_ install --jobs=4 --retry=3 --path vendor/bundle
+        bundler_version=$(cat Gemfile.lock | tail -1 | tr -d " ")
+        gem install bundler -v $bundler_version
+        bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
 
   _save-cache: &save-cache
     save_cache:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,9 @@ COPY Gemfile* ./
 
 # only install production dependencies,
 # build nokogiri using libxml2-dev, libxslt-dev
-RUN gem install bundler -v 2.0.1 \
+# note: installs bundler version used in Gemfile.lock
+#
+RUN gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ") \
 && bundle config --global without test:development \
 && bundle config build.nokogiri --use-system-libraries \
 && bundle install


### PR DESCRIPTION
#### What
Update bundler version based on `Gemfile.lock`

#### Why
Updates 2.0.1 --> 2.0.2 and will keep inline
with latest `Gemfile.lock`. It will also prevent warnings
such as:
```
Warning: the running version of Bundler (2.0.1) is older than the version that created the lockfile (2.0.2). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
```