### PR TITLE
Amend live-1 DI to use named SQS queues

### DIFF
--- a/app/services/claims/injection_channel.rb
+++ b/app/services/claims/injection_channel.rb
@@ -2,7 +2,7 @@ module Claims
   class InjectionChannel
     def self.for(claim)
       return 'cccd_development' if claim.nil?
-      return 'cccd-k8s-injection' if Settings.aws&.sqs&.response_queue_url
+      return 'cccd-k8s-injection' if Settings.aws&.response_queue&.match?('laa-get-paid')
       claim.agfs? ? 'cccd_ccr_injection' : 'cccd_cclf_injection'
     end
   end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -11,7 +11,8 @@ class InjectionResponseService
     return failure(action: 'run!', uuid: @response['uuid']) unless @claim
 
     injection_attempt
-    if Settings.aws&.sqs&.response_queue_url
+    # TEMP: always send slack message for live-1 SQS response queue
+    if Settings.aws&.response_queue&.match?('laa-get-paid')
       slack.send_message!
     else
       slack.send_message! unless injection_attempt.notification_can_be_skipped?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -142,10 +142,6 @@ aws:
   sqs:
     access: 'store actual value as SETTINGS__AWS__SQS__ACCESS'
     secret: 'store actual value as SETTINGS__AWS__SQS__SECRET'
-    # NOTE: This is deliberately blank - add a SETTINGS__AWS__SQS__RESPONSE_QUEUE_URL
-    # value to .env files or the deployment repo if needed. this allows the `response_queue`
-    # value to override it until it is set in all hosting areas/technologies
-    response_queue_url:
 
 slack:
   bot_url: 'slack_bot_url'

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -171,11 +171,11 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: secret_access_key
-            - name: SETTINGS__AWS__SQS__RESPONSE_QUEUE_URL
+            - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:
                   name: cccd-messaging
-                  key: sqs_cccd_url
+                  key: sqs_cccd_name
             - name: SETTINGS__GOVUK_NOTIFY__API_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -171,11 +171,11 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: secret_access_key
-            - name: SETTINGS__AWS__SQS__RESPONSE_QUEUE_URL
+            - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:
                   name: cccd-messaging
-                  key: sqs_cccd_url
+                  key: sqs_cccd_name
             - name: SETTINGS__GOVUK_NOTIFY__API_KEY
               valueFrom:
                 secretKeyRef:

--- a/scheduled_tasks/poll_injection_responses_task.rb
+++ b/scheduled_tasks/poll_injection_responses_task.rb
@@ -6,7 +6,7 @@ class PollInjectionResponsesTask < Scheduler::SchedulerTask
   every '1m'
 
   def run
-    queue = Settings.aws.sqs.response_queue_url || Settings.aws.response_queue
+    queue = Settings.aws.response_queue
     return unless queue
     log("Checking for messages on #{queue}")
     MessageQueue::AwsClient.new(queue).poll!

--- a/spec/services/claims/injection_channel_spec.rb
+++ b/spec/services/claims/injection_channel_spec.rb
@@ -3,8 +3,14 @@ require 'rails_helper'
 RSpec.describe Claims::InjectionChannel, type: :service do
   subject(:injection_channel) { described_class.for(claim) }
 
-  context 'when a response_queue_url setting exists' do
-    before { allow(Settings.aws.sqs).to receive(:response_queue_url).and_return('http://test.aws.queue') }
+  context 'when claim type can not be inferred' do
+    let(:claim) { nil }
+
+    it { is_expected.to eql('cccd_development') }
+  end
+
+  context 'when a response_queue name matches live-1 SQS name' do
+    before { allow(Settings.aws).to receive(:response_queue).and_return('laa-get-paid-test-responses-for-cccd') }
     let(:claim) { create(:litigator_claim) }
 
     it { is_expected.to eql('cccd-k8s-injection') }
@@ -20,11 +26,5 @@ RSpec.describe Claims::InjectionChannel, type: :service do
     let(:claim) { create(:claim) }
 
     it { is_expected.to eql('cccd_ccr_injection') }
-  end
-
-  context 'when claim type can not be inferred' do
-    let(:claim) { nil }
-
-    it { is_expected.to eql('cccd_development') }
   end
 end

--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe InjectionResponseService, slack_bot: true do
   let(:valid_json_on_failure) { { "from":"external application", "errors":[ {'error':"No defendant found for Rep Order Number: '123456432'."}, {'error':error_message} ],"uuid":claim.uuid,"messages":[] } }
   let(:error_message) { "Another injection error." }
 
-shared_examples "creates injection attempts" do
-  it 'returns true' do
-    is_expected.to be true
-  end
+  shared_examples "creates injection attempts" do
+    it 'returns true' do
+      is_expected.to be true
+    end
 
-  it 'creates an injection attempt' do
-    expect{ run! }.to change(InjectionAttempt, :count).by(1)
+    it 'creates an injection attempt' do
+      expect{ run! }.to change(InjectionAttempt, :count).by(1)
+    end
   end
-end
 
   context 'when initialized with' do
     describe 'valid json' do
@@ -79,7 +79,7 @@ end
     end
 
     context 'when testing kubernetes' do
-      before { allow(Settings.aws.sqs).to receive(:response_queue_url).and_return('http://test.aws.queue') }
+      before { allow(Settings.aws).to receive(:response_queue).and_return('laa-get-paid-test-responses-for-cccd') }
 
       context 'when injection succeeded' do
         let(:json) { valid_json_on_success }


### PR DESCRIPTION
#### What
Amend k8s/live-1 data injection to use new, named SQS queues

#### Ticket

[CBO-863](https://dsdmoj.atlassian.net/browse/CBO-863)

#### Why

Following cloud-platforms addition of the ability
to create named SQS queues, new queues have been
generated, with names. This enables the live-1
(kubernetes) version of CCCD to use the
same mechanism for receiving messages as current
(template-deploy) version. It also means that
in the event queues need to be recreated the
fixed name hides the new SQS queue URLs, making
the codebase more relient to infrastructure changes.

#### How
 - remove response_queue_url (previously used for k8s)
 - add response queue name secret to k8s config
 - consume named response queue from secret
 - adjust conditional slack message sending inline