### PR TITLE
Increase sunset date for deprecated api endpoint

### DIFF
--- a/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
@@ -27,7 +27,7 @@ module API::V1::ExternalUsers
       namespace '/' do
         desc 'DEPRECATED: Create an Advocate final claim. see advocates/final endpoint'
         post do
-          deprecate(datetime: Time.new(2019, 8, 30), link: "#{request.base_url}/api/release_notes")
+          deprecate(datetime: Time.new(2020, 1, 31), link: "#{request.base_url}/api/release_notes")
           create_resource(::Claim::AdvocateClaim)
           status api_response.status
           api_response.body
@@ -35,7 +35,7 @@ module API::V1::ExternalUsers
 
         desc 'DEPRECATED: Validate an Advocate final claim. see advocates/final/validate endpoint'
         post '/validate' do
-          deprecate(datetime: Time.new(2019, 8, 30), link: "#{request.base_url}/api/release_notes")
+          deprecate(datetime: Time.new(2020, 1, 31), link: "#{request.base_url}/api/release_notes")
           validate_resource(::Claim::AdvocateClaim)
           status api_response.status
           api_response.body

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -173,7 +173,7 @@
       Responses from any deprecated endpoint will include a
       %code.code='Sunset'
       HEADER with a value of the http formatted date of the intended End of Life date. There will also be a related link in the header to point to the release notes. We will be providing 6 months grace period on deprecations so the old endpoint will be
-      %em='removed on or after 30/08/2019'
+      %em='removed on or after 30/08/2019 (this has been moved to 31/01/2020 due to poor uptake)'
       \.
       %br/
       %br/

--- a/spec/api/v1/external_users/claims/advocate_final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocate_final_claim_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::AdvocateClaim do
   it_behaves_like 'a claim endpoint', relative_endpoint: :advocate
   it_behaves_like 'a claim validate endpoint', relative_endpoint: :advocate
   it_behaves_like 'a claim create endpoint', relative_endpoint: :advocate
-  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :validate, deprecation_datetime: Time.new(2019, 8, 30)
-  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :create, deprecation_datetime: Time.new(2019, 8, 30)
+  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :validate, deprecation_datetime: Time.new(2020, 1, 31)
+  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :create, deprecation_datetime: Time.new(2020, 1, 31)
 
   # TODO: write a generic date error handling spec and share
   describe "POST #{ClaimApiEndpoints.for(:advocate).validate}" do


### PR DESCRIPTION
#### What
Increase sunset date for deprecated api endpoint


#### Why
Poor uptake of new endpoints means alot
of vendor software will cease to function
if we remove the `api/external_users/claims`
endpoint.