### PR TITLE
Add REDIS_URL secret envvar to all live-1 namespaces

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ -z ${REDIS_URL+x} ]; then
   printf '\e[33mINFO: Starting redis-server daemon\e[0m\n'
   redis-server --daemonize yes
 else
-  printf '\e[33mINFO: Using remote redis-server\e[0m\n'
+  printf '\e[33mINFO: Using remote redis-server specified in REDIS_URL\e[0m\n'
 fi
 
 printf '\e[33mINFO: Starting sidekiq daemon\e[0m\n'

--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: RAILS_ENV
               value: 'production'
             - name: GRAPE_SWAGGER_ROOT_URL
-              value: 'https://cccd-api-sandbox.apps.live-1.cloud-platform.service.justice.gov.uk'
+              value: 'https://api-sandbox.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-48'
             - name: PDFTK_PATH
@@ -186,3 +186,8 @@ spec:
                 secretKeyRef:
                   name: cccd-secrets
                   key: TEST_CHAMBER_API_KEY
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-elasticache-redis
+                  key: url

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: RAILS_ENV
               value: 'production'
             - name: GRAPE_SWAGGER_ROOT_URL
-              value: 'https://cccd-dev.apps.live-1.cloud-platform.service.justice.gov.uk'
+              value: 'https://dev.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-48'
             - name: PDFTK_PATH
@@ -216,3 +216,9 @@ spec:
                 secretKeyRef:
                   name: cccd-secrets
                   key: TEST_CHAMBER_API_KEY
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-elasticache-redis
+                  key: url
+

--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -256,3 +256,8 @@ spec:
                 secretKeyRef:
                   name: cccd-secrets
                   key: PERF_PLAT_QV_TOKEN
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-elasticache-redis
+                  key: url

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: RAILS_ENV
               value: 'production'
             - name: GRAPE_SWAGGER_ROOT_URL
-              value: 'https://cccd-staging.apps.live-1.cloud-platform.service.justice.gov.uk'
+              value: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-48'
             - name: PDFTK_PATH
@@ -256,3 +256,8 @@ spec:
                 secretKeyRef:
                   name: cccd-secrets
                   key: PERF_PLAT_QV_TOKEN
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-elasticache-redis
+                  key: url


### PR DESCRIPTION
#### What
Enable remote redis usage (AWS elasticache)
for background job queues and internal API
call caching.

#### Why
For sidekiq to access/use elasticache redis servers
on dev, staging, api-sandbox and production.

live-1 instances have been using local
redis servers inside their containers up until
now. They should, however be using a remote, shared
redis cluster across all instances/pods.

*Also*:
 Amend grape swagger root url env var

  This is a poorly named reference to the
  domain URI of the app and as such is used
  for several purposes, include creation
  of links to password resets (etc) in emails.
  The problem only came to light when testing
  email queuing during the redis work.

  As such it should reflect the desired ingress
  for a given environment.

#### Ticket

[CBO-903](https://dsdmoj.atlassian.net/browse/CBO-903)

#### How
Setup elasticache redis clusters for dev, staging, api-sandbox
and production live-1 namespaces, outputting the secret url to be
be used to connect to those clusters. see [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/1216).

Once created, put the secret url into the default env var that `sidekiq`
uses to connect to redis, namely `REDIS_URL`.

--------

#### TODO (wip)

 - [X] create elasticache clusters
 - [X] amend deployment.yaml to output REDIS_URL