### PR TITLE
Fix evidence coversheet link

### DIFF
--- a/app/views/shared/_disk_evidence_info.html.haml
+++ b/app/views/shared/_disk_evidence_info.html.haml
@@ -6,6 +6,6 @@
   = t('disk_evidence.hint')
 
 %p
-  = t('disk_evidence.hint_html')
+  = t('disk_evidence.hint_html', link: disc_evidence_external_users_claim_path(@claim))
 
 = render partial: 'external_users/claims/supporting_documents/laa_address', locals: { f: f }


### PR DESCRIPTION
#### What
pass disc evidence coversheet pdf link to locales 

#### Why
bug fix for previous commit 0f78182453b48e9bbea9d89f21434aa77ebbdbff
which inadvertently broke the link while refactoring.
