### PR TITLE
Add fonts to Dockerfile to enable Evidence attachments to render properly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN apk --no-cache add --virtual build-dependencies \
                   linux-headers \
                   runit \
                   pdftk \
+                  ttf-ubuntu-font-family \
                   libreoffice \
                   redis
 


### PR DESCRIPTION
#### What
Adds fonts to the version of Alpine Linux used with docker to enable pdf previews of `.docx` documents to render correctly.

[See this Stack Overflow post](https://stackoverflow.com/questions/8626594/wicked-pdf-error-pdf-could-not-be-generated/58095049#58095049) for more information.

#### Ticket

[CBO-896: Evidence attachments not rendering properly](https://dsdmoj.atlassian.net/browse/CBO-886)
