### PR TITLE
Amend Dockerfile bundler config to exclude all but production gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 ruby '2.6.3'
-gem 'dotenv-rails', groups: [:development, :test]
 gem 'active_model_serializers', '~> 0.10.10'
 gem 'amoeba',                 '~> 3.1.0'
 gem 'auto_strip_attributes',  '~> 2.5.0'
@@ -77,6 +76,7 @@ group :development, :devunicorn, :test do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'byebug'
+  gem 'dotenv-rails'
   gem 'guard-cucumber'
   gem 'guard-jasmine', '~> 3.1'
   gem 'guard-livereload', '>= 2.5.2'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ COPY Gemfile* ./
 # note: installs bundler version used in Gemfile.lock
 #
 RUN gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ") \
-&& bundle config --global without test:development \
+&& bundle config --global without test development devunicorn \
 && bundle config build.nokogiri --use-system-libraries \
 && bundle install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,8 @@ RUN set -ex
 # - file: for paperclip file type spoofing check
 # - nodejs: for ExecJS and asset compilation
 # - runit for process management (because we have multiple services)
-# - libreoffice/pdftk: for pdf generation
+# - libreoffice/pdftk: for pdf conversion
+# - ttf-ubuntu-font-family: required for libreoffice pdf conversion
 # - redis: for backend key-value store
 #
 RUN apk --no-cache add --virtual build-dependencies \


### PR DESCRIPTION
#### What
Amend Dockerfile bundler config to exclude all but production gems

#### Why
Dockerfile was previously using faulty config setting resulting
in all gems being installed.