### PR TITLE
Delete the previous td migrator pod within the specified namespace

### DIFF
--- a/kubernetes_deploy/scripts/deploy_migrator.sh
+++ b/kubernetes_deploy/scripts/deploy_migrator.sh
@@ -30,7 +30,7 @@ function _deploy_migrator() {
   docker_image_tag=${docker_registry}:${component}-latest
 
   echo "Deleting previous pod..."
-  kubectl delete pod template-deploy-migrator
+  kubectl --context ${context} -n cccd-${environment} delete pod template-deploy-migrator
 
   printf "\e[33m--------------------------------------------------\e[0m\n"
   printf "\e[33mJob: kubernetes_deploy/pods/template_deploy_migrator/pod.yaml\e[0m\n"


### PR DESCRIPTION
#### What

Delete the previous template-deploy migrator pod within the
specified namespace.

#### Why

Prior to this it was not explicitly specifying the namespace
from which to delete the pod. This could resulting in a pod
in a different namespace being deleted.