### PR TITLE
Kubernetes fix master tag fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ references:
         sudo pip3 install awscli
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}"      
-        if [ "${CIRCLE_BRANCH}" == "kubernetes-fix-master-tag-fail" ]; then
+        if [ "${CIRCLE_BRANCH}" == "master" ]; then
           docker tag "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}" "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
           docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
         fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,8 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}"      
         if [ "${CIRCLE_BRANCH}" == "master" ]; then
-          docker tag "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}" "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
-          docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
+          docker tag "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}" "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-latest"
+          docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-latest"
         fi
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,8 +150,8 @@ references:
         sudo pip3 install awscli
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}"      
-        if [ "${CIRCLE_BRANCH}" == "master" ]; then
-          docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
+        if [ "${CIRCLE_BRANCH}" == "kubernetes-fix-master-tag-fail" ]; then
+          docker tag "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}" "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
           docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
         fi
 


### PR DESCRIPTION
#### What

The push_docker_image job in config.yml was failng when the branch was master was failing with the following error "No such image: app:latest". This was because it was looking for an image tagged app that did not exist.

#### Ticket

https://dsdmoj.atlassian.net/browse/CBO-900

#### Why

To fix CircleCI workflow

#### How

Tag ${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1} with :latest instead of app

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
