### PR TITLE
hotfix for disc evidence coversheet

### DIFF
--- a/app/models/disc_evidence_coversheet.rb
+++ b/app/models/disc_evidence_coversheet.rb
@@ -34,7 +34,7 @@ class DiscEvidenceCoversheet
   end
 
   def fee_scheme
-    @fee_scheme || claim.fee_scheme.name.upcase
+    @fee_scheme || defined?(claim.fee_scheme.name)
   end
 
   def agfs?


### PR DESCRIPTION
#### What
Fix for disc evidence NoMethodError

#### Why
Sentry highlighted the issue, if claim is empty, then `name` method will be undefined

#### How
Check if method is defined.