### PR TITLE
CBO-943: email notifications refused rejected

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -21,7 +21,6 @@ class MessagesController < ApplicationController
     @message = Message.new(message_params.merge(sender_id: current_user.id))
 
     if @message.save
-      send_email_if_required
       @notification = { notice: 'Message successfully sent' }
     else
       @notification = { alert: 'Message not sent: ' + @message.errors.full_messages.join(', ') }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -20,11 +20,11 @@ class MessagesController < ApplicationController
   def create
     @message = Message.new(message_params.merge(sender_id: current_user.id))
 
-    if @message.save
-      @notification = { notice: 'Message successfully sent' }
-    else
-      @notification = { alert: 'Message not sent: ' + @message.errors.full_messages.join(', ') }
-    end
+    @notification = if @message.save
+                      { notice: 'Message successfully sent' }
+                    else
+                      { alert: 'Message not sent: ' + @message.errors.full_messages.join(', ') }
+                    end
 
     respond_to do |format|
       format.js
@@ -43,14 +43,7 @@ class MessagesController < ApplicationController
   private
 
   def message
-    @message ||=  Message.find(params[:id])
-  end
-
-  def send_email_if_required
-    return unless current_user.persona.is_a?(CaseWorker)
-    return unless @message.claim.creator.send_email_notification_of_message?
-    return if @message.claim.creator.softly_deleted?
-    NotifyMailer.message_added_email(@message.claim).deliver_later
+    @message ||= Message.find(params[:id])
   end
 
   def redirect_to_url

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -66,10 +66,15 @@ class Message < ApplicationRecord
   private
 
   def send_email_if_required
-    return unless sender.persona.is_a?(CaseWorker)
-    return unless claim.creator.send_email_notification_of_message?
-    return if claim.creator.softly_deleted?
-    NotifyMailer.message_added_email(claim).deliver_later
+    NotifyMailer.message_added_email(claim).deliver_later if send_email?
+  end
+
+  def send_email?
+    [
+      sender.persona.is_a?(CaseWorker),
+      claim.creator.send_email_notification_of_message?,
+      claim.creator.active?
+    ].all?
   end
 
   def generate_statuses

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -49,7 +49,7 @@ class Message < ApplicationRecord
 
   scope :most_recent_last, -> { includes(:user_message_statuses).order(created_at: :asc) }
 
-  after_create :generate_statuses, :process_claim_action, :process_written_reasons
+  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
 
   class << self
     def for(object)
@@ -64,6 +64,13 @@ class Message < ApplicationRecord
   end
 
   private
+
+  def send_email_if_required
+    return unless sender.persona.is_a?(CaseWorker)
+    return unless claim.creator.send_email_notification_of_message?
+    return if claim.creator.softly_deleted?
+    NotifyMailer.message_added_email(claim).deliver_later
+  end
 
   def generate_statuses
     users_for_statuses.each do |user|

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Message, type: :model do
     end
   end
 
-  context 'send_message_if_required' do
+  context 'send_email_if_required' do
     let(:claim) { create :allocated_claim  }
     # let(:creator) { create :external_user }
     let(:creator) { claim.creator }

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -129,7 +129,6 @@ RSpec.describe Message, type: :model do
 
   context 'send_email_if_required' do
     let(:claim) { create :allocated_claim  }
-    # let(:creator) { create :external_user }
     let(:creator) { claim.creator }
     let(:case_worker) { claim.case_workers.first }
 


### PR DESCRIPTION
#### What
We've had provider feedback to say even though they are signed up to receive an email notification on a case, they are not doing so for rejected or refused claims.
#### Ticket
[Email notifications for refused/rejected claims - fix issue](https://dsdmoj.atlassian.net/browse/CBO-943)

#### Why
Providers should be receiving email notifications when a caseworker sends them a message on any case.

#### How
MOve the logic for sending emails into the message itself.  As a message is created, if it was sent by a caseworker, and the provider has opted-in to receive emails and is still active, an email will be sent
