### PR TITLE
MIGRATION DAY: Amend env var inline with eventual live-1 domain name

### DIFF
--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: RAILS_ENV
               value: 'production'
             - name: GRAPE_SWAGGER_ROOT_URL
-              value: 'https://cccd-production.apps.live-1.cloud-platform.service.justice.gov.uk'
+              value: 'https://claim-crown-court-defence.service.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-37'
             - name: MAINTENANCE_MODE


### PR DESCRIPTION
#### What
Amend env var inline with eventual live-1 domain name

IMPORTANT: needs merging after DNS changes applied and ingress
modifed for live-1 production

The GRAPE_SWAGGER_ROOT_URL is used for
1. internal api calls
2. use in email templates
3. api documenation