### PR TITLE
CBO-973: transfer grad fee issue

### DIFF
--- a/app/validators/fee/graduated_fee_validator.rb
+++ b/app/validators/fee/graduated_fee_validator.rb
@@ -14,6 +14,7 @@ class Fee::GraduatedFeeValidator < Fee::BaseFeeValidator
 
   def validate_claim
     super
+    add_error(:claim, :incompatible_claim_type) if @record.claim&.transfer?
     return unless @record.claim&.final?
     add_error(:claim, :incompatible_case_type) if @record.claim.case_type&.is_fixed_fee?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,6 +253,7 @@ en:
           attributes:
             claim:
               incompatible_case_type: Fixed fee invalid on non-fixed fee case types
+              incompatible_claim_type: cannot be a transfer claim
         supplier_number:
           attributes:
             supplier_number:

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -393,6 +393,15 @@ RSpec.describe API::V1::ExternalUsers::Fee do
             expect(last_response.status).to eq 400
             expect_error_response("Enter a valid amount for the transfer fee",0)
           end
+
+          it 'raises an error when graduated fees are added' do
+            valid_params[:fee_type_id] = graduated_fee_type.id
+            post_to_create_endpoint
+            expect(last_response.status).to eq 400
+
+            binding.pry
+            expect_error_response("Graduated fee 5 claim cannot be a transfer claim",0)
+          end
         end
       end
     end

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe API::V1::ExternalUsers::Fee do
             valid_params[:fee_type_id] = graduated_fee_type.id
             post_to_create_endpoint
             expect(last_response.status).to eq 400
-            expect_error_response("Graduated fee 5 claim cannot be a transfer claim",0)
+            expect(last_response.body).to include("Graduated fee 1 claim cannot be a transfer claim")
           end
         end
       end

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -398,8 +398,6 @@ RSpec.describe API::V1::ExternalUsers::Fee do
             valid_params[:fee_type_id] = graduated_fee_type.id
             post_to_create_endpoint
             expect(last_response.status).to eq 400
-
-            binding.pry
             expect_error_response("Graduated fee 5 claim cannot be a transfer claim",0)
           end
         end

--- a/spec/validators/fee/graduated_fee_validator_spec.rb
+++ b/spec/validators/fee/graduated_fee_validator_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe Fee::GraduatedFeeValidator, type: :validator do
       end
     end
 
+    context 'when the fee is for a transfer claim' do
+      let(:claim) { build(:transfer_claim) }
+      let(:fee) { build(:graduated_fee, claim: claim) }
+
+      it { expect(fee.valid?).to eql false }
+    end
+
     context 'when the associated claim has no case type defined' do
       let(:claim) { build(:litigator_claim, case_type: nil) }
       let(:fee) { build(:graduated_fee, claim: claim) }


### PR DESCRIPTION
#### What
Prevent API users from submitting grad fees to a transfer claim

#### Ticket
[Provider able to claim 2 graduated fees on single bill](https://dsdmoj.atlassian.net/browse/CBO-973)

#### Why
Caseworkers reported this claim in CCCD which shows both a cracked trial and a transfer fee on the same bill.  this should not be possible for 2 reasons  - 1 it should not be possible to claim 2 graduated fees on the same bill in any scenario. Secondly, a transfer fee is an entirely separate bill type to a regular grad fee and it shouldn’t have been possible to select both a transfer and final fee LGFS bill within a single claim, transfer and final bills have different journeys within the app that cant be combined!
 
#### How
Traditionally we did not validate fee types against claim types, because the web app filters the correct fee pages to the user.  One of the CMS's was submitting grad fees to Transfer cases (at least Trial and Cracked Trial have been seen).  This validation will prevent that happening.

--------

#### TODO (wip)

 - [ ] Alert the software vendors via slack that this change will affect fee submission.  This will potentially break at least one CMS as it is, incorrectly, sending these fee types
