### PR TITLE
MIGRATION DAY: servicedown page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,8 +68,8 @@ en:
       page_heading: API release notes
     servicedown:
       page_heading: "The service is unavailable"
-      page_unavailable: "This service is not available right now, but we're working hard to get things up and running again."
-      page_unavailable_html: "You can try again later or email us on <a href='mailto:%{email}'>%{email}</a>"
+      page_unavailable: "This service is not available right now due to planned maintenance work."
+      page_unavailable_html: "Please try again later."
     timed_retention:
       page_heading: "Time-limited retention of claims"
       paragraph_1: "Starting from 19th September 2016, claims will only be retained on the system for a limited period, and not indefinitely."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  match '(*any)', to: 'pages#servicedown', via: :all
 
   get 'dummy_exception', to: 'errors#dummy_exception'
   get 'ping',           to: 'heartbeat#ping', format: :json


### PR DESCRIPTION
#### What
reroute all app traffic to servicedown page

#### Why
As an additional method for preventing
user access to the app (in addition to
DNS change for maintenance page).


#### Ticket

[CBO-984](https://dsdmoj.atlassian.net/browse/CBO-984)

#### Why
d-day migration to live-1

#### How
wildcard match on all routes including `'/'`

`'(*any)'` - matches all routes and none/root. the `any` is merely
needed for rails to bind url parameters to a variable.