### PR TITLE
Fix live-1 archive stale cronjob

### DIFF
--- a/app/services/transform/claim.rb
+++ b/app/services/transform/claim.rb
@@ -38,6 +38,7 @@ module Transform
     }.freeze
 
     CLAIM_TYPE_CONVERSIONS = {
+      'Claim::AdvocateSupplementaryClaim' => 'Advocate supplementary claim',
       'Claim::AdvocateInterimClaim' => 'Advocate interim claim',
       'Claim::AdvocateClaim' => 'Advocate final claim',
       'Claim::InterimClaim' => 'Litigator interim claim',

--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -27,13 +27,94 @@ spec:
               - rake
               - claims:archive_stale
             env:
-              - name: DATABASE_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: cccd-rds
-                    key: url
-              - name: SECRET_KEY_BASE
-                valueFrom:
-                  secretKeyRef:
-                    name: cccd-secrets
-                    key: SECRET_KEY_BASE
+            - name: ENV
+              value: 'cronjob-worker'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-rds
+                  key: url
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SECRET_KEY_BASE
+            - name: CASE_WORKER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: CASE_WORKER_PASSWORD
+            - name: ADVOCATE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: ADVOCATE_PASSWORD
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: AWS_REGION
+            - name: SETTINGS__AWS__S3__REGION
+              value: 'eu-west-2'
+            - name: SETTINGS__AWS__S3__ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: access_key_id
+            - name: SETTINGS__AWS__S3__SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: secret_access_key
+            - name: SETTINGS__AWS__S3__BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: bucket_name
+            - name: SETTINGS__SLACK__BOT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__SLACK__BOT_URL
+            - name: SETTINGS__GOVUK_NOTIFY__API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__GOVUK_NOTIFY__API_KEY
+            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__MESSAGE_ADDED_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__MESSAGE_ADDED_EMAIL
+            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_USER
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_USER
+            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_ADVOCATE_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_ADVOCATE_ADMIN
+            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_LITIGATOR_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_LITIGATOR_ADMIN
+            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__PASSWORD_RESET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__PASSWORD_RESET
+            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__UNLOCK_INSTRUCTIONS
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-secrets
+                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__UNLOCK_INSTRUCTIONS
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-elasticache-redis
+                  key: url

--- a/kubernetes_deploy/scripts/cronjob.sh
+++ b/kubernetes_deploy/scripts/cronjob.sh
@@ -4,7 +4,7 @@ function _cronjob() {
   Usage: cronjob job environment [branch]
   Where:
     job [archive_stale|clean_ecr]
-    environment [dev|staging|api-sandbox]
+    environment [dev|staging|api-sandbox|production]
     branch [<branchname>-latest|commit-sha]
 
   Example:
@@ -45,7 +45,7 @@ function _cronjob() {
   esac
 
   case "$2" in
-    dev | staging | api-sandbox)
+    dev | staging | api-sandbox | production)
       environment=$2
       ;;
     *)


### PR DESCRIPTION
#### What
Fix live-1 archive stale cronjob

#### Ticket

[CBO-979](https://dsdmoj.atlassian.net/browse/CBO-979)

#### Why
live-1 cronjob failing on placeholder
prod environment with live data.

The error received was
```
undefined methods `match` for nil:NilClass
```

This is can be raised by paperclip. Could
also be caused by MI data problems.

Better to provide all env vars that are available
in any environment to be confident the job can work
in any environment. Note that zendesk, google api
and other keys are not available to all environments
and so are excluded.

#### How
Add s3 and other secrets to archive stale cronjob