### PR TITLE
Ignore hold and deploy dev on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context dev
-      
+
   _apply-dev: &apply-dev
     deploy:
       name: Deploy cccd docker image to cccd-dev
@@ -182,7 +182,7 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context sandbox
-      
+
   _apply-api-sandbox: &apply-api-sandbox
     deploy:
       name: Deploy cccd docker image to cccd-api-sandbox
@@ -202,7 +202,7 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context staging
-      
+
   _apply-staging: &apply-staging
     deploy:
       name: Deploy cccd docker image to cccd-staging
@@ -222,7 +222,7 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context production
-      
+
   _apply-prod: &apply-prod
     deploy:
       name: Deploy cccd docker image to cccd-prod
@@ -338,7 +338,7 @@ jobs:
       - *setup-staging
       - *decrypt_secrets
       - *apply-staging
- 
+
   deploy-production:
     <<: *cloud_platform_container_config
     steps:
@@ -356,7 +356,7 @@ jobs:
       - *setup-dev
       - *decrypt_secrets
       - *apply-dev
-  
+
   # TODO: once merged with new alpine build try this out
   #
   # build-prod-container:
@@ -415,13 +415,28 @@ workflows:
       - build-and-push-docker:
           requires:
             - upload-coverage
+      - auto-deploy-dev:
+          requires:
+            - build-and-push-docker
+          filters:
+            branches:
+              only:
+                - master
       - hold-dev:
           type: approval
           requires:
             - build-and-push-docker
+          filters:
+            branches:
+              ignore:
+                - master
       - deploy-dev:
           requires:
             - hold-dev
+          filters:
+            branches:
+              ignore:
+                - master
       - hold-api-sandbox:
           type: approval
           requires:
@@ -442,15 +457,8 @@ workflows:
             - build-and-push-docker
           filters:
             branches:
-              only: 
+              only:
                 - master
       - deploy-production:
           requires:
             - hold-production
-      - auto-deploy-dev:
-          requires:
-            - build-and-push-docker
-          filters:
-            branches:
-              only: 
-                - master


### PR DESCRIPTION
#### What
remove hold and deploy to dev on master

#### Why
we auto deploy to dev on master

#### How
add 
```
filters: 
  branches:
    ignore:
      - master
```

to relevant workflow steps

