### PR TITLE
Correct docker tag naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,12 +167,12 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context dev
-      
+
   _apply-dev: &apply-dev
     deploy:
       name: Deploy cccd docker image to cccd-dev
       command: |
-        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}
+        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/dev/secrets.yaml
         kubectl set image -f kubernetes_deploy/dev/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
@@ -187,12 +187,12 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context sandbox
-      
+
   _apply-api-sandbox: &apply-api-sandbox
     deploy:
       name: Deploy cccd docker image to cccd-api-sandbox
       command: |
-        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}
+        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/api-sandbox/secrets.yaml
         kubectl set image -f kubernetes_deploy/api-sandbox/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
@@ -207,12 +207,12 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context staging
-      
+
   _apply-staging: &apply-staging
     deploy:
       name: Deploy cccd docker image to cccd-staging
       command: |
-        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}
+        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/staging/secrets.yaml
         kubectl set image -f kubernetes_deploy/staging/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
@@ -227,12 +227,12 @@ references:
         $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
         setup-kube-auth
         kubectl config use-context production
-      
+
   _apply-prod: &apply-prod
     deploy:
       name: Deploy cccd docker image to cccd-prod
       command: |
-        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}
+        docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/production/secrets.yaml
         kubectl set image -f kubernetes_deploy/production/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
@@ -343,7 +343,7 @@ jobs:
       - *setup-staging
       - *decrypt_secrets
       - *apply-staging
- 
+
   deploy-production:
     <<: *cloud_platform_container_config
     steps:
@@ -361,7 +361,7 @@ jobs:
       - *setup-dev
       - *decrypt_secrets
       - *apply-dev
-  
+
   # TODO: once merged with new alpine build try this out
   #
   # build-prod-container:


### PR DESCRIPTION
#### What
correct tag name pushed and applied

#### Why
The tag from the build was not being used to
deploy. This meant deploys were not getting
deployed and instead the last good image
tag remained on the instances.

It would be nice if we could get this to
displayed as a deployment failure in circleCI.