### PR TITLE
Add maintenance page feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,28 +207,40 @@ You should now commit the cassette to the repo to ensure it is not unneccessaril
 
 ## Maintenance mode
 
-A Conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To active the conditional
-routes start the server with MAINTENANCE_MODE=true. Note that dotenv files cannot be used to set maintenance mode locally as the config gem (settings file) is loaded before them.
+A Conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To activate the conditional route you must provide the app server with either MAINTENANCE_MODE=true (kubernetes) or DOCKER_STATE=maintenance (template-deploy). Note that dotenv files cannot be used to set these envvars locally as the config gem (`settings.yml` file) is loaded before dotenv files.
 
 ```bash
 # activate maintenance mode locally
-DOCKER_STATE=maintenance rails s
+MAINTENANCE_MODE=true rails s
 ```
 
-To deploy the app with maintenance mode enabled works for template-deploy orchestrated environments and kubernetes orchestrated environments:
+You can deploy the app in maintenance mode for both template-deploy orchestrated environments and kubernetes orchestrated environments:
 
-### template-deploy maintenance mode
+### Template-deploy maintenance mode
 - build the app using Jenkins as normal.
-- deploy the app to an environment specifying the task 'maitenance'
+- deploy the app to an environment selecting `maintenance` for the task option (jenkins string parameter)
 
-Note that this is a quick fix method that leverages templates-deploy preexisting environment variable `DOCKER_STATE` for purposes it was not intended for.
+Note that this is a quick fix method that leverages templates-deploy pre-existing environment variable `DOCKER_STATE` for purposes it was not intended for.
 
-### kuberentes maintenance mode
-todo
+### kubernetes maintenance mode
+You can switch on maintenance mode by deploying either from your local machine or via circleCI. Either
+method requires you to amend the `deployment.yaml` file for the relevant environment, adding `MAINTENANCE_MODE=true`. e.g. `./kubernetes_deploy/dev/deployment.yaml`
 
+To apply via circleCI:
 
-To build and deploy an image with maintenance mode enabled you will need to pass
-this environment variable to the container.
+- commit the above change and push to github
+- run through circleCI and deploy to the relevant environment
+- For production environment you will need to merge to master and use its workflow
+
+To apply via local machine:
+
+- you will need all relevant aws credentials and git-crypted secrets access
+- use the deploy script
+
+```bash
+ # put dev into maintenance mode
+ kubernetes_deploy/scripts/deploy.sh dev latest
+```
 
 ## Javascript Unit Testing
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ You should now commit the cassette to the repo to ensure it is not unneccessaril
 
 ## Maintenance mode
 
-A Conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To activate the conditional route you must provide the app server with either MAINTENANCE_MODE=true (kubernetes) or DOCKER_STATE=maintenance (template-deploy). Note that dotenv files cannot be used to set these envvars locally as the config gem (`settings.yml` file) is loaded before dotenv files.
+A conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To activate the conditional route you must provide the app server with either MAINTENANCE_MODE=true (kubernetes) or DOCKER_STATE=maintenance (template-deploy). Note that dotenv files cannot be used to set these envvars locally as the config gem (`settings.yml` file) is loaded before dotenv files.
 
 ```bash
 # activate maintenance mode locally
@@ -218,28 +218,38 @@ You can deploy the app in maintenance mode for both template-deploy orchestrated
 
 ### Template-deploy maintenance mode
 - build the app using Jenkins as normal.
-- deploy the app to an environment selecting `maintenance` for the task option (jenkins string parameter)
+- deploy the app (same/any build) to an environment selecting `maintenance` for the task option (jenkins string parameter)
+- to take site out of maintenance redeploy (same/any build) with `none` for the task
 
 Note that this is a quick fix method that leverages templates-deploy pre-existing environment variable `DOCKER_STATE` for purposes it was not intended for.
 
 ### kubernetes maintenance mode
-You can switch on maintenance mode by deploying either from your local machine or via circleCI. Either
-method requires you to amend the `deployment.yaml` file for the relevant environment, adding `MAINTENANCE_MODE=true`. e.g. `./kubernetes_deploy/dev/deployment.yaml`
+You can switch on maintenance mode by deploying either from your local machine or via circleCI. Either method requires you to amend the `deployment.yaml` file for the relevant environment to add the env var `MAINTENANCE_MODE` with a value `'true'`.
+
+example `deployment.yaml` config:
+```yaml
+env:
+  - name: MAINTENANCE_MODE
+    value: 'true'
+```
 
 To apply via circleCI:
 
 - commit the above change and push to github
 - run through circleCI and deploy to the relevant environment
 - For production environment you will need to merge to master and use its workflow
+- to take site out of maintenance you would have to commit the reverse and redeploy via circleCI
+
 
 To apply via local machine:
 
 - you will need all relevant aws credentials and git-crypted secrets access
-- use the deploy script
+- amend `deployment.yaml`, as above, and run the deploy script, as below.
+- to take site out of maintenance amend `MAINTENANCE_MODE` to `'false'` and run the deploy script again.
 
 ```bash
- # put dev into maintenance mode
- kubernetes_deploy/scripts/deploy.sh dev latest
+# deploying to dev from local machine
+kubernetes_deploy/scripts/deploy.sh dev latest
 ```
 
 ## Javascript Unit Testing

--- a/README.md
+++ b/README.md
@@ -205,6 +205,31 @@ You should now commit the cassette to the repo to ensure it is not unneccessaril
 ***When you change a feature test such that you need to re-record its cassette you should delete the existing cassette in the `vcr` folder and proceed as if creating a new cassette, above.***
 
 
+## Maintenance mode
+
+A Conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To active the conditional
+routes start the server with MAINTENANCE_MODE=true. Note that dotenv files cannot be used to set maintenance mode locally as the config gem (settings file) is loaded before them.
+
+```bash
+# activate maintenance mode locally
+DOCKER_STATE=maintenance rails s
+```
+
+To deploy the app with maintenance mode enabled works for template-deploy orchestrated environments and kubernetes orchestrated environments:
+
+### template-deploy maintenance mode
+- build the app using Jenkins as normal.
+- deploy the app to an environment specifying the task 'maitenance'
+
+Note that this is a quick fix method that leverages templates-deploy preexisting environment variable `DOCKER_STATE` for purposes it was not intended for.
+
+### kuberentes maintenance mode
+todo
+
+
+To build and deploy an image with maintenance mode enabled you will need to pass
+this environment variable to the container.
+
 ## Javascript Unit Testing
 
 Run it using the `guard` command. Jasmine output available here: [http://localhost:8888](http://localhost:8888)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,7 +10,12 @@ class PagesController < ApplicationController
 
   def api_release_notes; end
 
-  def servicedown; end
+  def servicedown
+    respond_to do |format|
+      format.html { render :servicedown, status: 503 }
+      format.json { render json: [{ error: 'Temporarily unavailable' }], status: 503 }
+    end
+  end
 
   def timed_retention; end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,7 +12,7 @@ class PagesController < ApplicationController
 
   def servicedown
     respond_to do |format|
-      format.html { render :servicedown, status: 503 }
+      format.html { render :servicedown }
       format.json { render json: [{ error: 'Temporarily unavailable' }], status: 503 }
     end
   end

--- a/bin/cucumber
+++ b/bin/cucumber
@@ -5,7 +5,6 @@
 # The application 'cucumber' is installed as part of a gem, and
 # this file is here to facilitate running it.
 #
-
 require 'pathname'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,8 +71,8 @@ en:
       page_heading: API release notes
     servicedown:
       page_heading: "The service is unavailable"
-      page_unavailable: "This service is not available right now, but we're working hard to get things up and running again."
-      page_unavailable_html: "You can try again later or email us on <a href='mailto:%{email}'>%{email}</a>"
+      page_unavailable: "This service is not available right now due to planned maintenance work."
+      page_unavailable_html: "Please try again later."
     timed_retention:
       page_heading: "Time-limited retention of claims"
       paragraph_1: "Starting from 19th September 2016, claims will only be retained on the system for a limited period, and not indefinitely."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
-
   get 'dummy_exception', to: 'errors#dummy_exception'
   get 'ping',           to: 'heartbeat#ping', format: :json
   get 'healthcheck',    to: 'heartbeat#healthcheck',  as: 'healthcheck', format: :json
+
+  match '(*any)', to: 'pages#servicedown', via: :all if Settings.maintenance_mode_enabled?
+
   get 'servicedown',    to: 'pages#servicedown',      as: :service_down_page
   get '/tandcs',        to: 'pages#tandcs',           as: :tandcs_page
   get '/contact_us',    to: 'pages#contact_us',       as: :contact_us_page

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,6 +87,11 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 # on their claim
 email_notification_enabled?: true
 
+# Feature flag to enable maintenance mode
+# If enabled all routes mapped to pages#servicedown on startup
+#
+maintenance_mode_enabled?: <%= ENV.fetch('DOCKER_STATE', nil)&.downcase&.eql?('maintenance') %>
+
 feature_flags_enabled?: true
 active_features: []
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -90,7 +90,7 @@ email_notification_enabled?: true
 # Feature flag to enable maintenance mode
 # If enabled all routes mapped to pages#servicedown on startup
 #
-maintenance_mode_enabled?: <%= ENV.fetch('DOCKER_STATE', nil)&.downcase&.eql?('maintenance') %>
+maintenance_mode_enabled?: <%= ENV.fetch('DOCKER_STATE', nil)&.downcase&.eql?('maintenance') || ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql?('true') %>
 
 feature_flags_enabled?: true
 active_features: []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ COPY . .
 RUN bundle exec rake assets:precompile SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here 2> /dev/null
 
 # tidy up installation
-RUN apk del build-dependencies
+RUN apk update && apk del build-dependencies
 
 # non-root/appuser should own only what they need to
 RUN chown -R appuser:appgroup log tmp db

--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: 'https://api-sandbox.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-48'
+            - name: MAINTENANCE_MODE
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: 'https://dev.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-48'
+            - name: MAINTENANCE_MODE
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: 'https://cccd-production.apps.live-1.cloud-platform.service.justice.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-48'
+            - name: MAINTENANCE_MODE
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID
               value: 'UA-37377084-48'
+            - name: MAINTENANCE_MODE
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/spec/requests/pages/servicedown_spec.rb
+++ b/spec/requests/pages/servicedown_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Servicedown mode', type: :request do
   end
 
   shared_examples 'maintenance page' do
-    it { expect(response).to have_http_status :service_unavailable }
+    it { expect(response).to have_http_status :ok }
     it { expect(response.body).to include('planned maintenance') }
   end
 

--- a/spec/requests/pages/servicedown_spec.rb
+++ b/spec/requests/pages/servicedown_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe 'Servicedown mode', type: :request do
+  before do
+    allow(Settings).to receive(:maintenance_mode_enabled?).and_return(true)
+    Rails.application.reload_routes!
+  end
+
+  after do
+    allow(Settings).to receive(:maintenance_mode_enabled?).and_return(false)
+    Rails.application.reload_routes!
+  end
+
+  shared_examples 'maintenance page' do
+    it { expect(response).to have_http_status :service_unavailable }
+    it { expect(response.body).to include('planned maintenance') }
+  end
+
+  context '/ping' do
+    before { get '/ping' }
+    it { expect(response).to be_ok }
+    it { expect(response.body).to be_json }
+  end
+
+  context '/healthcheck' do
+    before do
+      allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 1))
+      allow(Sidekiq::RetrySet).to receive(:new).and_return(instance_double(Sidekiq::RetrySet, size: 0))
+      allow(Sidekiq::DeadSet).to receive(:new).and_return(instance_double(Sidekiq::DeadSet, size: 0))
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_return(true)
+      connection = double('connection', info: {})
+      allow(Sidekiq).to receive(:redis).and_yield(connection)
+      get '/healthcheck'
+    end
+
+    it { expect(response).to be_ok }
+    it { expect(response.body).to be_json }
+  end
+
+  context 'web page requests (html)' do
+    context 'sign in' do
+      before { get '/users/sign_in' }
+      it_behaves_like 'maintenance page'
+    end
+
+    context 'caseworker' do
+      before do
+        sign_in(user)
+      end
+
+      let(:user) { create(:case_worker).user }
+        context '/case_workers/claims' do
+        before { get case_workers_home_path }
+        it_behaves_like 'maintenance page'
+      end
+    end
+
+    context 'advocate' do
+      before { sign_in user }
+      let(:user) { create(:external_user, :advocate).user }
+
+      context '/external_user/claims' do
+        before { get external_users_claims_path }
+        it_behaves_like 'maintenance page'
+      end
+
+      context '/advocates/claims/new' do
+        before { get new_advocates_claim_path }
+        it_behaves_like 'maintenance page'
+      end
+    end
+  end
+
+  context 'api requests (json)' do
+    let(:user) { create(:external_user, :advocate).user }
+
+    context '/api/case_types' do
+      before { get '/api/case_types', params: { api_key: user.persona.provider.api_key, format: :json } }
+
+      it { expect(response).to have_http_status :service_unavailable }
+      it { expect(response.body).to be_json }
+      it { expect(response.body).to include_json({error: "Temporarily unavailable"}.to_json) }
+    end
+  end
+end


### PR DESCRIPTION
#### What
Reroute all requests to maintenance page based on flag

#### Ticket

[CBO-996](https://dsdmoj.atlassian.net/browse/CBO-996)

#### Why
So we can control access to the TD production
and Kuberentes/live-1 production sites using the
app itself.

Previous incarnation involved changing DNS A records
to divert all traffic to a static web site hosted
in s3, using an AWS CloudFront distribution. This
method is onerous to setup and the migraiton to live-1
would require two such setups.

#### How
see Maintenance mode section of readme

copied here for conveninence:

## Maintenance mode

A Conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To activate the conditional route you must provide the app server with either MAINTENANCE_MODE=true (kubernetes) or DOCKER_STATE=maintenance (template-deploy). Note that dotenv files cannot be used to set these envvars locally as the config gem (`settings.yml` file) is loaded before dotenv files.

```bash
# activate maintenance mode locally
MAINTENANCE_MODE=true rails s
```

You can deploy the app in maintenance mode for both template-deploy orchestrated environments and kubernetes orchestrated environments:

### Template-deploy maintenance mode
- build the app using Jenkins as normal.
- deploy the app to an environment selecting `maintenance` for the task option (jenkins string parameter)

Note that this is a quick fix method that leverages templates-deploy pre-existing environment variable `DOCKER_STATE` for purposes it was not intended for.

### kubernetes maintenance mode
You can switch on maintenance mode by deploying either from your local machine or via circleCI. Either
method requires you to amend the `deployment.yaml` file for the relevant environment, adding `MAINTENANCE_MODE=true`. e.g. `./kubernetes_deploy/dev/deployment.yaml`

To apply via circleCI:

- commit the above change and push to github
- run through circleCI and deploy to the relevant environment
- For production environment you will need to merge to master and use its workflow

To apply via local machine:

- you will need all relevant aws credentials and git-crypted secrets access
- use the deploy script

```bash
 # put dev into maintenance mode
 kubernetes_deploy/scripts/deploy.sh dev latest
```