### PR TITLE
Append to any settings references to gamma

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -170,7 +170,7 @@ govuk_notify:
     new_external_litigator_admin: 'new_external_litigator_admin_template_uuid'
     unlock_instructions: 'unlock_instructions_template_uuid'
 
-notify_report_errors: <%= ENV["ENV"].in?(%w[api-sandbox demo disaster gamma]) %>
+notify_report_errors: <%= ENV["ENV"].in?(%w[api-sandbox demo disaster gamma production]) %>
 
 postcode_regexp: !ruby/regexp '/\A([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})\z/'
 

--- a/lib/rails_host.rb
+++ b/lib/rails_host.rb
@@ -1,5 +1,5 @@
 class RailsHost
-  VALID_ENVS = %w[dev demo staging api-sandbox gamma].freeze
+  VALID_ENVS = %w[dev demo staging api-sandbox gamma production].freeze
 
   def self.env
     ENV['ENV']

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 module GoogleAnalytics
-
   describe DataTracking do
-    context '#enabled?' do
+    describe '#enabled?' do
+      subject { described_class.enabled? }
       before do
         allow(Rails).to receive(:env).and_return('production'.inquiry)
       end
@@ -13,7 +13,7 @@ module GoogleAnalytics
           allow(described_class).to receive(:adapter).and_return('Adapter')
         end
 
-        %w(staging gamma).each do |host|
+        %w(staging gamma production).each do |host|
           it "returns true when host is #{host}" do
             allow(RailsHost).to receive(:env).and_return(host)
             expect(described_class.enabled?).to be_truthy


### PR DESCRIPTION
#### What
Check and append to any references to `gamma`
in the code base to add `production`

#### Why
`production` is the `ENV['ENV']` value in live-1
production, but is `gamma` in TD prod environments

- Ensure statistics error notification in
  live-1 production
- ensure GA datatracking enabled in live-1
  production (RailsHost is not actually
  used so this is simply and tidy in this
  respect)