### PR TITLE
Add app branch to ping output

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -10,7 +10,8 @@ class HeartbeatController < ApplicationController
       'version_number' => ENV['VERSION_NUMBER'] || 'Not Available',
       'build_date' => ENV['BUILD_DATE'] || 'Not Available',
       'commit_id' => ENV['COMMIT_ID'] || 'Not Available',
-      'build_tag' => ENV['BUILD_TAG'] || 'Not Available'
+      'build_tag' => ENV['BUILD_TAG'] || 'Not Available',
+      'app_branch' => ENV['APP_BRANCH'] || 'Not Available'
     }.to_json
 
     render json: json

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -27,12 +27,13 @@ RSpec.describe HeartbeatController, type: :controller do
         ENV['BUILD_DATE']       = nil
         ENV['COMMIT_ID']        = nil
         ENV['BUILD_TAG']        = nil
+        ENV['APP_BRANCH']       = nil
 
         get :ping
       end
 
       it 'returns "Not Available"' do
-        expect(JSON.parse(response.body).values).to eq( ["Not Available", "Not Available", "Not Available", "Not Available"])
+        expect(JSON.parse(response.body).values).to be_all("Not Available")
       end
     end
 
@@ -42,7 +43,8 @@ RSpec.describe HeartbeatController, type: :controller do
           'version_number'  => '123',
           'build_date'      => '20150721',
           'commit_id'       => 'afb12cb3',
-          'build_tag'       => 'test'
+          'build_tag'       => 'test',
+          'app_branch'      => 'test_branch'
         }
       end
 
@@ -51,6 +53,7 @@ RSpec.describe HeartbeatController, type: :controller do
         ENV['BUILD_DATE']       = '20150721'
         ENV['COMMIT_ID']        = 'afb12cb3'
         ENV['BUILD_TAG']        = 'test'
+        ENV['APP_BRANCH']       = 'test_branch'
 
         get :ping
       end


### PR DESCRIPTION
#### What
Add the name of the current branch
on which the build is based to ping output

#### Why
To easily identify which branch
is on what environment.

With the move to CirclCI for deployment
we are losing build version numbers and other
information that Jenkis build and deploy
provides for free. This is therefore to replace
some of that lost info.

#### How
docker build scripts already supply this info
and DockerFile already passes this information
and argument on to the environment. We just need
to output it.