### PR TITLE
Put live-1 production into maintenance

### DIFF
--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: GA_TRACKER_ID
               value: 'UA-37377084-37'
             - name: MAINTENANCE_MODE
-              value: 'false'
+              value: 'true'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON


### PR DESCRIPTION
#### What
Put live-1 production into maintenance mode

#### Why
Prevents people using new production app
until we are ready for cutover.

More specifically this will help
to ensure any errors in DNS
delegation from GDS tomorrow do not
impact data - in the event of DNS delegation
going awry, if users are directed to the wrong
load balancer (unlikely), this will
direct them to a site in maintenance
mode and prevent any data being entered (which 
would subsequently be lost).

#### How
see [kubernetes-maintenance-mode](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence#kubernetes-maintenance-mode)
