### PR TITLE
Kubernetes apply archive stale

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,11 +174,11 @@ references:
       command: |
         docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/dev/secrets.yaml
-        kubectl apply -f kubernetes_deploy/cron_jobs/archive_stale.yaml
         kubectl set image -f kubernetes_deploy/dev/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/dev/service.yaml \
-        -f kubernetes_deploy/dev/ingress.yaml
+        -f kubernetes_deploy/dev/ingress.yaml \
+        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-api-sandbox: &setup-api-sandbox
@@ -198,7 +198,8 @@ references:
         kubectl set image -f kubernetes_deploy/api-sandbox/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/api-sandbox/service.yaml \
-        -f kubernetes_deploy/api-sandbox/ingress.yaml
+        -f kubernetes_deploy/api-sandbox/ingress.yaml \
+        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-staging: &setup-staging
@@ -218,7 +219,8 @@ references:
         kubectl set image -f kubernetes_deploy/staging/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/staging/service.yaml \
-        -f kubernetes_deploy/staging/ingress.yaml
+        -f kubernetes_deploy/staging/ingress.yaml \
+        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-prod: &setup-prod
@@ -238,7 +240,8 @@ references:
         kubectl set image -f kubernetes_deploy/production/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/production/service.yaml \
-        -f kubernetes_deploy/production/ingress.yaml
+        -f kubernetes_deploy/production/ingress.yaml \
+        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ references:
       command: |
         docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/dev/secrets.yaml
+        kubectl apply -f kubernetes_deploy/cron_jobs/archive_stale.yaml
         kubectl set image -f kubernetes_deploy/dev/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/dev/service.yaml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,10 +175,11 @@ references:
         docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/dev/secrets.yaml
         kubectl set image -f kubernetes_deploy/dev/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
+        kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/dev/service.yaml \
         -f kubernetes_deploy/dev/ingress.yaml \
-        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
+        -f kubernetes_deploy/cron_jobs/clean_ecr.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-api-sandbox: &setup-api-sandbox
@@ -196,10 +197,11 @@ references:
         docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/api-sandbox/secrets.yaml
         kubectl set image -f kubernetes_deploy/api-sandbox/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
+        kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/api-sandbox/service.yaml \
         -f kubernetes_deploy/api-sandbox/ingress.yaml \
-        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
+        -f kubernetes_deploy/cron_jobs/clean_ecr.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-staging: &setup-staging
@@ -217,10 +219,11 @@ references:
         docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/staging/secrets.yaml
         kubectl set image -f kubernetes_deploy/staging/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
+        kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/staging/service.yaml \
         -f kubernetes_deploy/staging/ingress.yaml \
-        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
+        -f kubernetes_deploy/cron_jobs/clean_ecr.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-prod: &setup-prod
@@ -238,10 +241,11 @@ references:
         docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
         kubectl apply -f kubernetes_deploy/production/secrets.yaml
         kubectl set image -f kubernetes_deploy/production/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
+        kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/production/service.yaml \
         -f kubernetes_deploy/production/ingress.yaml \
-        -f kubernetes_deploy/cron_jobs/archive_stale.yaml
+        -f kubernetes_deploy/cron_jobs/clean_ecr.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,8 +200,7 @@ references:
         kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/api-sandbox/service.yaml \
-        -f kubernetes_deploy/api-sandbox/ingress.yaml \
-        -f kubernetes_deploy/cron_jobs/clean_ecr.yaml
+        -f kubernetes_deploy/api-sandbox/ingress.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-staging: &setup-staging
@@ -222,8 +221,7 @@ references:
         kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/staging/service.yaml \
-        -f kubernetes_deploy/staging/ingress.yaml \
-        -f kubernetes_deploy/cron_jobs/clean_ecr.yaml
+        -f kubernetes_deploy/staging/ingress.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
   _setup-prod: &setup-prod
@@ -244,8 +242,7 @@ references:
         kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
         kubectl apply \
         -f kubernetes_deploy/production/service.yaml \
-        -f kubernetes_deploy/production/ingress.yaml \
-        -f kubernetes_deploy/cron_jobs/clean_ecr.yaml
+        -f kubernetes_deploy/production/ingress.yaml
         kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag"
 
 jobs:

--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: cccd-archive-stale
 spec:
-  schedule: "5 10 * * *"
+  schedule: "5 0 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 7
   failedJobsHistoryLimit: 3

--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: cccd-archive-stale
 spec:
-  schedule: "5 0 * * *"
+  schedule: "5 10 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 7
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
#### What

Gives the ability to apply updates/changes to the archive_stale cronjob in live-1.

#### Ticket

https://dsdmoj.atlassian.net/browse/CBO-985

#### Why

We will need to be able to deploy updates and changes to this job when we move to live-1

#### How

See https://github.com/ministryofjustice/cloud-platform-environments/pull/1548

This was tested by amending the schedule for archive_stale to run at 10.05 and then reverting this change out.

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
