### PR TITLE
CBO-992: Stylesheet refactoring, remove inline styles

### DIFF
--- a/app/assets/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/assets/javascripts/modules/Modules.AllocationDataTable.js
@@ -303,10 +303,10 @@ moj.Modules.AllocationDataTable = {
     $('.allocation-submit').on('click', function (e) {
 
       self.ui.$msgFail.find('span').html();
-      self.ui.$msgSuccess.hide();
+      self.ui.$msgSuccess.addClass('hidden');
 
       self.ui.$msgSuccess.find('span').html('Allocating.. please wait a moment..');
-      self.ui.$msgSuccess.show();
+      self.ui.$msgSuccess.removeClass('hidden');
 
       e.preventDefault();
       self.ui.$submit.prop('disabled', true);
@@ -353,16 +353,16 @@ moj.Modules.AllocationDataTable = {
           claim_ids: data
         }
       }).success(function (data) {
-        self.ui.$msgFail.hide();
+        self.ui.$msgFail.addClass('hidden');
         self.ui.$msgSuccess.find('span').html(data.allocated_claims.length + ' claims have been allocated to ' + $('#allocation_case_worker_id').val());
-        self.ui.$msgSuccess.show();
+        self.ui.$msgSuccess.removeClass('hidden');
         self.reloadScheme({
           scheme: self.searchConfig.scheme
         });
       }).error(function (data) {
-        self.ui.$msgSuccess.hide();
+        self.ui.$msgSuccess.addClass('hidden');
         self.ui.$msgFail.find('span').html(data.responseJSON.errors.join(''));
-        self.ui.$msgFail.show();
+        self.ui.$msgFail.removeClass('hidden');
       }).always(function () {
         self.ui.$submit.prop('disabled', false);
       });

--- a/app/assets/javascripts/modules/Modules.AmountAssessed.js
+++ b/app/assets/javascripts/modules/Modules.AmountAssessed.js
@@ -1,12 +1,12 @@
 moj.Modules.AmountAssessed = {
   blocks: [],
-  init: function() {
+  init: function () {
     this.blocks.push(new moj.Modules.AmountAssessedBlock());
   }
 };
 
 
-moj.Modules.AmountAssessedBlock = function(selector) {
+moj.Modules.AmountAssessedBlock = function (selector) {
   var self = this;
 
   this.config = {
@@ -47,7 +47,7 @@ moj.Modules.AmountAssessedBlock = function(selector) {
 
   this.el = this.config.hook;
 
-  this.init = function() {
+  this.init = function () {
     this.$el = $(this.el);
     this.$form = $(this.config.form);
     this.$actions = $(this.config.actions);
@@ -61,62 +61,62 @@ moj.Modules.AmountAssessedBlock = function(selector) {
     this.setInitState();
   };
 
-  this.slider = function(state, el) {
+  this.slider = function (state, el) {
     // open and close slider
     // true: open
     // false: close
-    return state ? $(el).slideDown(0) : $(el).slideUp(0);
+    return state ? $(el).removeClass('hidden') : $(el).addClass('hidden');
   };
 
-  this.bindEvents = function() {
+  this.bindEvents = function () {
     var self = this;
 
-    this.$actions.on('change', function(e) {
+    this.$actions.on('change', function (e) {
       var state = $(e.target).val();
       $.publish('claim.status.change', {
         state: state
       })
     });
 
-    this.$reasons.on('change', function(e) {
+    this.$reasons.on('change', function (e) {
       var reason = self.$otherCheckbox.is(':checked');
       $.publish('claim.reasons.change', {
         reason: reason
       });
     });
 
-    this.$refuseReasons.on('change', function(e) {
+    this.$refuseReasons.on('change', function (e) {
       var reason = self.$otherRefuseCheckbox.is(':checked');
       $.publish('claim.refuseReasons.change', {
         reason: reason
       })
     });
 
-    $.subscribe('claim.reasons.change', function(e, data) {
+    $.subscribe('claim.reasons.change', function (e, data) {
       data.reason ? self.slider(true, self.$otherinput) : self.slider(false, self.$otherinput)
     });
 
-    $.subscribe('claim.refuseReasons.change', function(e, data) {
+    $.subscribe('claim.refuseReasons.change', function (e, data) {
       data.reason ? self.slider(true, self.$otherRefuseInput) : self.slider(false, self.$otherRefuseInput)
     });
 
-    $.subscribe('claim.status.change', function(e, data) {
+    $.subscribe('claim.status.change', function (e, data) {
       var state = self.states[data.state]
-      self.$form.is(function(idx, el) {
+      self.$form.is(function (idx, el) {
         self.slider(state.form, el)
       });
 
-      self.$reasons.is(function(idx, el) {
+      self.$reasons.is(function (idx, el) {
         self.slider(state.reasons, el)
       });
 
-      self.$refuseReasons.is(function(idx, el) {
+      self.$refuseReasons.is(function (idx, el) {
         self.slider(state.refuseReasons, el)
       });
     });
   };
 
-  this.setInitState = function(){
+  this.setInitState = function () {
     this.$actions.find('input:checked').trigger('change');
     this.$reasons.find('input:checked').trigger('change');
     this.$refuseReasons.find('input:checked').trigger('change');

--- a/app/assets/javascripts/modules/Modules.OffenceSearchInput.js
+++ b/app/assets/javascripts/modules/Modules.OffenceSearchInput.js
@@ -40,7 +40,7 @@ moj.Modules.OffenceSearchInput = {
     filter: '/offence/search/filter/'
   },
 
-  init: function() {
+  init: function () {
     this.$el = $(this.el);
     if (this.$el.length > 0) {
       this.$input = $(this.input);
@@ -51,26 +51,26 @@ moj.Modules.OffenceSearchInput = {
     }
   },
 
-  bindEvents: function() {
+  bindEvents: function () {
     this.clearSearch();
     this.bindSubscribers();
     this.trackUserInput();
   },
 
   // binding subscribers and callbacks
-  bindSubscribers: function() {
+  bindSubscribers: function () {
     var self = this;
 
-    $.subscribe(this.subscribers.run, function() {
+    $.subscribe(this.subscribers.run, function () {
       self.runQuery();
     });
 
-    $.subscribe(this.subscribers.filter, function(e, options) {
+    $.subscribe(this.subscribers.filter, function (e, options) {
       self.runQuery(options);
     });
   },
 
-  runQuery: function(options) {
+  runQuery: function (options) {
     var self = this;
 
     // dataOptions for the api request
@@ -86,16 +86,16 @@ moj.Modules.OffenceSearchInput = {
       // filters are applied
       options);
 
-    this.query(dataOptions).then(function(data) {
+    this.query(dataOptions).then(function (data) {
       // showing the clear search button
-      self.$clear.show();
+      self.$clear.removeClass('hidden');
 
       // publish the response data
       $.publish(self.publishers.results, data);
     });
   },
 
-  query: function(options) {
+  query: function (options) {
     var _options = options;
     var self = this;
     var def = $.Deferred();
@@ -104,11 +104,11 @@ moj.Modules.OffenceSearchInput = {
       url: '/offences',
       data: _options,
       dataType: 'json',
-      success: function(results) {
+      success: function (results) {
         options.results = results || [];
         def.resolve(_options);
       },
-      error: function(req, status, err) {
+      error: function (req, status, err) {
         def.reject(status, err)
       }
     });
@@ -118,9 +118,9 @@ moj.Modules.OffenceSearchInput = {
 
   // Tracking the user inout and calling the API
   // when required. Uses $.debounce to limit calls
-  trackUserInput: function() {
+  trackUserInput: function () {
     var self = this;
-    this.$input.on('keyup', $.debounce(290, function(e) {
+    this.$input.on('keyup', $.debounce(290, function (e) {
       if (self.$input.val().length >= 3) {
         self.runQuery();
       }
@@ -128,11 +128,11 @@ moj.Modules.OffenceSearchInput = {
   },
 
   // clearSearch procedure
-  clearSearch: function() {
+  clearSearch: function () {
     var self = this;
-    this.$el.on('click', '.fx-clear-search', function(e) {
+    this.$el.on('click', '.fx-clear-search', function (e) {
       e.preventDefault();
-      self.$clear.hide();
+      self.$clear.addClass('hidden');
       self.$el.find('.fx-input').val('');
       self.$el.find('.fx-model').val('');
       $.publish('/offence/search/clear/');

--- a/app/assets/javascripts/modules/Modules.OffenceSearchView.js
+++ b/app/assets/javascripts/modules/Modules.OffenceSearchView.js
@@ -12,7 +12,7 @@ moj.Modules.OffenceSearchView = {
   pageControls: '.button-holder',
 
   // template for each result
-  template: function() {
+  template: function () {
     return ['<div class="grid-row offence-item fx-result-item">',
       '<div class="column-two-thirds">',
       '<span class="font-xsmall link-grey">',
@@ -38,7 +38,7 @@ moj.Modules.OffenceSearchView = {
   /**
    * init called my moj.init()
    */
-  init: function() {
+  init: function () {
     var self = this;
 
     // cache jQuery referances for each view
@@ -47,33 +47,33 @@ moj.Modules.OffenceSearchView = {
     this.$pageControls = $(this.pageControls);
 
     // Event: search results available to render
-    $.subscribe('/offence/search/results/', function(e, data) {
+    $.subscribe('/offence/search/results/', function (e, data) {
       self.render(data);
       self.$view.show();
       self.$pageControls.toggle(false);
     });
 
     // Event: page control state changes
-    $.subscribe('/office/search/pageControls/', function(e, state){
+    $.subscribe('/office/search/pageControls/', function (e, state) {
       self.$pageControls.toggle(state);
     })
 
     // Event: clear search + results
-    $.subscribe('/offence/search/clear/', function() {
+    $.subscribe('/offence/search/clear/', function () {
 
       self.$view.hide();
       self.$view.find('.fx-results').empty();
       self.$view.find('.fx-filters-display p').empty();
       self.$view.find('.fx-results-found p').empty();
 
-      if(!moj.Modules.OffenceSelectedView.isVisible()){
+      if (!moj.Modules.OffenceSelectedView.isVisible()) {
         self.$pageControls.toggle(true);
       }
 
     });
 
     // Event: create rails model / submit the form
-    $(document.body).on('click', '.set-selection', function(e) {
+    $(document.body).on('click', '.set-selection', function (e) {
       var $element = $(e.target);
       var data = $element.data();
       var field = $(data.field);
@@ -92,11 +92,11 @@ moj.Modules.OffenceSearchView = {
     });
 
     // Event: Apply filter(s)
-    $('.fx-view').on('click', '.fx-filter', function(e) {
+    $('.fx-view').on('click', '.fx-filter', function (e) {
       e.preventDefault();
       var $el = $(this);
       var filter = {};
-      $.each($el.data(), function(key, val) {
+      $.each($el.data(), function (key, val) {
         filter[key + '_id'] = val;
       });
 
@@ -104,7 +104,7 @@ moj.Modules.OffenceSearchView = {
     });
 
     // Event: Remove filters
-    $('.fx-view').on('click', '.fx-clear-filters', function(e) {
+    $('.fx-view').on('click', '.fx-clear-filters', function (e) {
       e.preventDefault()
       $.publish('/offence/search/filter/', {});
     });
@@ -115,7 +115,7 @@ moj.Modules.OffenceSearchView = {
    * @param  {object} options Data to render to the view
    * @return {string}         View content
    */
-  filterResults: function(options) {
+  filterResults: function (options) {
 
     var str = '';
 
@@ -136,7 +136,7 @@ moj.Modules.OffenceSearchView = {
    * render Render the view and attach to DOM
    * @param  {object} options results data
    */
-  render: function(options) {
+  render: function (options) {
 
 
     var tmpl = $.templates(this.template()); // Get compiled template
@@ -151,7 +151,7 @@ moj.Modules.OffenceSearchView = {
     this.$view.find('.fx-filters-display p').append(this.filterResults(options));
 
     this.$view.find('.fx-results-found p').empty();
-    this.$view.find('.fx-results-found p').append('Results found: ' + options.results.length + ' <a href="#noop" class="fx-clear-search">Clear search</a>');
+    this.$view.find('.fx-results-found p').append('Results found: ' + options.results.length + ' <a href="#noop" class="fx-clear-search hidden">Clear search</a>');
 
     this.$view.find('.fx-results').highlight(options.search_offence);
 

--- a/app/assets/javascripts/modules/Plugin.jqDataTable.filter.js
+++ b/app/assets/javascripts/modules/Plugin.jqDataTable.filter.js
@@ -1,5 +1,5 @@
 ;
-(function($, window, document, undefined) {
+(function ($, window, document, undefined) {
   var pluginName = "dtFilter",
     defaults = {};
 
@@ -19,35 +19,35 @@
      * Method called internally
      * @return {Object} Return `this` to maintain chaining (?)
      */
-    init: function() {
+    init: function () {
       this.bindEvents();
       return this;
     },
     /**
      * Rest this control's selected index to 0
      */
-    resetSelectIndex: function() {
+    resetSelectIndex: function () {
       $(this.element).find('select').prop('selectedIndex', 0);
     },
 
     /**
      * Bind all the events
      */
-    bindEvents: function() {
+    bindEvents: function () {
       var self = this;
 
       // Listen for clear event
-      $.subscribe('/general/clear-filters/', function() {
+      $.subscribe('/general/clear-filters/', function () {
         self.resetSelectIndex();
       });
 
       // Listen for scheme change and clear index
-      $.subscribe('/scheme/change/', function() {
+      $.subscribe('/scheme/change/', function () {
         self.resetSelectIndex();
       });
 
       // publish the events with filter specific data
-      $(this.element).on('change', 'select', function(e) {
+      $(this.element).on('change', 'select', function (e) {
         var filter = $(e.target).attr('name');
         $.publish('/general/change/', filter);
         $.publish('/filter/' + filter + '/', {
@@ -59,7 +59,7 @@
       // Listen for scheme change:
       //  - clear selected indexes
       //  - show / hide
-      $.subscribe('/scheme/change/', function(e, data) {
+      $.subscribe('/scheme/change/', function (e, data) {
         self.resetSelectIndex();
 
         var $el = $(self.element);
@@ -69,13 +69,13 @@
         }
 
         // The element will show / hide itself
-        schemeAttr === data.scheme ? $el.show() : $el.hide();
+        schemeAttr === data.scheme ? $el.removeClass('hidden') : $el.addClass('hidden');
       });
     }
   };
 
-  $.fn[pluginName] = function(options) {
-    return this.each(function() {
+  $.fn[pluginName] = function (options) {
+    return this.each(function () {
       if (!$.data(this, "plugin_" + pluginName)) {
         $.data(this, "plugin_" + pluginName,
           new Plugin(this, options));

--- a/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/assets/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -1,5 +1,5 @@
 moj.Helpers.Blocks = {
-  Base: function(options) {
+  Base: function (options) {
     var _options = {
       type: '_Base',
       vatfactor: 0.2,
@@ -11,7 +11,7 @@ moj.Helpers.Blocks = {
     this.$el = this.config.$el;
     this.el = this.config.el;
 
-    this.setState = function(selector, state) {
+    this.setState = function (selector, state) {
       if (this.$el.find(selector).length) {
         if (this.$el.find(selector).is(':visible') === state) {
           return;
@@ -21,7 +21,7 @@ moj.Helpers.Blocks = {
       throw new Error('Selector did not return an element: ' + selector);
     };
 
-    this.setVal = function(selector, val) {
+    this.setVal = function (selector, val) {
       if (this.$el.find(selector).length) {
         this.$el.find(selector).val(val).change();
         return;
@@ -29,7 +29,7 @@ moj.Helpers.Blocks = {
       throw new Error('Selector did not return an element: ' + selector);
     };
 
-    this.setNumber = function(selector, val, points) {
+    this.setNumber = function (selector, val, points) {
       points = points || '2';
       if (this.$el.find(selector).length) {
         this.$el.find(selector).val(parseFloat(val).toFixed(points)).change();
@@ -38,37 +38,37 @@ moj.Helpers.Blocks = {
       return;
     };
 
-    this.getConfig = function(key) {
+    this.getConfig = function (key) {
       return this.config[key] || undefined;
     };
 
-    this.updateTotals = function() {
+    this.updateTotals = function () {
       return 'This method needs an override';
     };
 
-    this.isVisible = function() {
+    this.isVisible = function () {
       return this.$el.find('.rate').is(':visible') || this.$el.find('.amount').is(':visible') || this.$el.find('.total').is(':visible');
     };
 
-    this.applyVat = function() {
+    this.applyVat = function () {
       if (this.config.autoVAT) {
         this.totals.vat = this.totals.total * this.config.vatfactor;
       }
     };
 
-    this.getVal = function(selector) {
+    this.getVal = function (selector) {
       return parseFloat(this.$el.find(selector + ':visible').val()) || 0;
     };
 
-    this.getDataVal = function(selector, key) {
+    this.getDataVal = function (selector, key) {
       return parseFloat(this.$el.find(selector).data(key)) || false;
     };
 
-    this.getMultipliedVal = function(val1, val2) {
+    this.getMultipliedVal = function (val1, val2) {
       return parseFloat((this.getVal(val1) * this.getVal(val2)).toFixed(2));
     };
   },
-  FeeBlock: function() {
+  FeeBlock: function () {
     var self = this;
     // copy methods over
     moj.Helpers.Blocks.Base.apply(this, arguments);
@@ -80,7 +80,7 @@ moj.Helpers.Blocks = {
       vat: 0
     };
 
-    this.init = function() {
+    this.init = function () {
       this.config.fn = 'FeeBlock';
       this.bindEvents();
       return this;
@@ -90,19 +90,19 @@ moj.Helpers.Blocks = {
       this.bindRecalculate();
     };
 
-    this.bindRecalculate = function() {
-      this.$el.on('change keyup', '.quantity, .rate, .amount, .vat, .total', function(e) {
+    this.bindRecalculate = function () {
+      this.$el.on('change keyup', '.quantity, .rate, .amount, .vat, .total', function (e) {
         self.$el.trigger('recalculate');
       });
     };
 
-    this.reload = function() {
+    this.reload = function () {
       this.updateTotals();
       this.applyVat();
       return this;
     };
 
-    this.setTotals = function() {
+    this.setTotals = function () {
       this.totals = {
         quantity: this.getVal('.quantity'),
         rate: this.getVal('.rate'),
@@ -115,30 +115,30 @@ moj.Helpers.Blocks = {
       return this.totals;
     };
 
-    this.updateTotals = function(a) {
+    this.updateTotals = function (a) {
       if (!this.isVisible()) {
         return this.totals;
       }
       return this.setTotals();
     };
 
-    this.render = function() {
+    this.render = function () {
       this.$el.find('.total').html('&pound;' + moj.Helpers.Blocks.addCommas(this.totals.total.toFixed(2)));
       this.$el.find('.total').data('total', this.totals.total);
     };
   },
-  FeeBlockCalculator: function() {
+  FeeBlockCalculator: function () {
     var self = this;
     moj.Helpers.Blocks.FeeBlock.apply(this, arguments);
 
-    this.init = function() {
+    this.init = function () {
       this.config.fn = 'FeeBlockCalculator';
       this.bindRecalculate();
       this.bindRender();
       return this;
     };
 
-    this.setTotals = function() {
+    this.setTotals = function () {
       this.totals = {
         quantity: this.getVal('.quantity'),
         rate: this.getVal('.rate'),
@@ -151,18 +151,18 @@ moj.Helpers.Blocks = {
       return this.totals;
     };
 
-    this.bindRender = function() {
-      this.$el.on('change keyup', '.quantity, .rate', function() {
+    this.bindRender = function () {
+      this.$el.on('change keyup', '.quantity, .rate', function () {
         self.updateTotals();
         self.render();
       });
     };
   },
-  FeeBlockManualAmounts: function() {
+  FeeBlockManualAmounts: function () {
     var self = this;
     moj.Helpers.Blocks.FeeBlock.apply(this, arguments);
 
-    this.init = function() {
+    this.init = function () {
       this.config.fn = 'FeeBlockManualAmounts';
 
       this.bindRecalculate();
@@ -171,7 +171,7 @@ moj.Helpers.Blocks = {
       return this;
     };
 
-    this.setTotals = function() {
+    this.setTotals = function () {
       this.totals = {
         quantity: this.getVal('.quantity'),
         rate: this.getVal('.rate'),
@@ -183,14 +183,14 @@ moj.Helpers.Blocks = {
       return this.totals;
     };
 
-    this.bindRender = function() {
-      this.$el.on('change keyup', '.amount, .vat', function() {
+    this.bindRender = function () {
+      this.$el.on('change keyup', '.amount, .vat', function () {
         self.updateTotals();
         self.render();
       });
     };
   },
-  PhantomBlock: function() {
+  PhantomBlock: function () {
     var self = this;
     moj.Helpers.Blocks.Base.apply(this, arguments);
     this.totals = {
@@ -201,11 +201,11 @@ moj.Helpers.Blocks = {
       vat: 0
     };
 
-    this.isVisible = function() {
+    this.isVisible = function () {
       return true;
     };
 
-    this.reload = function() {
+    this.reload = function () {
       this.totals.total = (parseFloat(this.$el.data('seed')) || 0);
       this.totals.typeTotal = this.totals.total;
 
@@ -217,7 +217,7 @@ moj.Helpers.Blocks = {
       return this;
     };
 
-    this.init = function() {
+    this.init = function () {
       return this;
     };
   },
@@ -229,7 +229,7 @@ moj.Helpers.Blocks = {
    * - manage the travel reason select
    * - manage the location select
    */
-  ExpenseBlock: function() {
+  ExpenseBlock: function () {
     var self = this;
     var staticdata = moj.Helpers.Blocks.staticdata.expenseBlock;
 
@@ -239,7 +239,7 @@ moj.Helpers.Blocks = {
     this.defaultstate = staticdata.defaultstate;
     this.expenseReasons = staticdata.expenseReasons;
 
-    this.init = function() {
+    this.init = function () {
       this.config.fn = 'ExpenseBlock';
       this.config.featureDistance = $('#expenses').data('featureDistance');
 
@@ -250,21 +250,21 @@ moj.Helpers.Blocks = {
       return this;
     };
 
-    this.bindEvents = function() {
+    this.bindEvents = function () {
       // Bind the core change listener
       this.bindRecalculate();
       // Bind events on the this.$el element
       this.bindListners();
     };
 
-    this.bindListners = function() {
+    this.bindListners = function () {
       var self = this;
 
       /**
        * Listen for the `expense type` change event and
        * pass the event object to the statemanager
        */
-      this.$el.on('change', '.fx-travel-expense-type select', function(e) {
+      this.$el.on('change', '.fx-travel-expense-type select', function (e) {
         e.stopPropagation();
         var $el = $(e.target);
 
@@ -281,7 +281,7 @@ moj.Helpers.Blocks = {
        *   this is used to reset to the correct line in the select box
        *   when the user returns to the page
        */
-      this.$el.on('change', '.fx-travel-reason select', function(e) {
+      this.$el.on('change', '.fx-travel-reason select', function (e) {
         e.stopPropagation();
 
         var $option, state, location_type;
@@ -306,7 +306,7 @@ moj.Helpers.Blocks = {
       // This is used to reset the correct block state and seleted values
       // when the page reloads
       // The change event will also trigger the distance lookup if required
-      this.$el.on('change', '.fx-establishment-select select', function(e) {
+      this.$el.on('change', '.fx-establishment-select select', function (e) {
         e.stopPropagation();
         var $option = $(e.target).find('option:selected');
 
@@ -316,9 +316,9 @@ moj.Helpers.Blocks = {
           self.getDistance({
             claimid: $('#claim-form').data('claimId'),
             destination: $option.data('postcode')
-          }).then(function(number, result) {
+          }).then(function (number, result) {
             self.updateMileageElements(number, false, result);
-          }, function(error) {
+          }, function (error) {
             self.viewErrorHandler(error);
           });
         }
@@ -326,30 +326,30 @@ moj.Helpers.Blocks = {
 
       // Binding to the mileage radio buttons (click and change)
       // to update calculations
-      this.$el.on('change, click', '.fx-travel-mileage input[type=radio]', function(e) {
+      this.$el.on('change, click', '.fx-travel-mileage input[type=radio]', function (e) {
         self.updateMileageElements(self.getRateId(), true);
       });
 
       // Binding to mileage input key up
       // when a user manually enters the distance to update the calculations
-      this.$el.on('keyup', '.fx-travel-distance input', function(e) {
+      this.$el.on('keyup', '.fx-travel-distance input', function (e) {
         var rateId = self.getRateId();
         self.updateMileageElements(rateId, rateId ? true : false);
       });
 
       // Binding to the net amount key up to update the VAT amount field
-      this.$el.on('keyup', '.fx-travel-net-amount input', function(e) {
+      this.$el.on('keyup', '.fx-travel-net-amount input', function (e) {
         self.setNumber('.fx-travel-vat-amount input', e.target.value * self.config.vatfactor);
       });
 
       return this;
     };
 
-    this.getRateId = function() {
+    this.getRateId = function () {
       return this.$el.find('.fx-travel-mileage input[type=radio]:visible:checked').val();
     };
 
-    this.updateMileageElements = function(rateId, calculate, result) {
+    this.updateMileageElements = function (rateId, calculate, result) {
       var factor = (rateId == '3') ? 0.20 : (rateId == '1') ? 0.25 : this.config.mileageFactor;
       if (!result) {
         result = {
@@ -366,10 +366,10 @@ moj.Helpers.Blocks = {
 
     // Call the Distance helper and return the
     // id for the checked ra
-    this.getDistance = function(ajaxConfig) {
+    this.getDistance = function (ajaxConfig) {
       var def = $.Deferred();
       var self = this;
-      moj.Helpers.API.Distance.query(ajaxConfig).then(function(result) {
+      moj.Helpers.API.Distance.query(ajaxConfig).then(function (result) {
         var number = self.$el.find('.fx-travel-mileage input[type=radio]:visible:checked').val();
 
         result.miles = Math.round((result.distance / self.config.metersPerMile));
@@ -377,14 +377,14 @@ moj.Helpers.Blocks = {
 
         def.resolve(number, result);
 
-      }, function(result) {
+      }, function (result) {
         def.reject(result.error);
       });
       return def.promise();
     };
 
     // Setting the view error state and message
-    this.viewErrorHandler = function(message) {
+    this.viewErrorHandler = function (message) {
       var el = this.$el.find('.fx-general-errors');
       el.find('span').text(message);
       el.css('display', 'inline-block');
@@ -392,7 +392,7 @@ moj.Helpers.Blocks = {
 
     // The location elment is an input or a select
     // This method will return the html to append to the dom
-    this.setLocationElement = function(obj) {
+    this.setLocationElement = function (obj) {
       if (!obj) throw new Error('Missing param: obj, cannot build element');
 
       // cache selected value
@@ -411,13 +411,13 @@ moj.Helpers.Blocks = {
     };
 
     // Display the input and hide the select
-    this.displayLocationInput = function() {
+    this.displayLocationInput = function () {
       this.$el.find('.location_wrapper').css('display', 'block');
       this.$el.find('.fx-establishment-select').css('display', 'none');
       return this;
     };
 
-    this.attachSelectWithOptions = function(locationType, selectedValue) {
+    this.attachSelectWithOptions = function (locationType, selectedValue) {
       var self = this;
       var $detachedSelect;
 
@@ -426,7 +426,7 @@ moj.Helpers.Blocks = {
       moj.Helpers.API.Establishments.getAsSelectWithOptions(locationType, {
         prop: 'name',
         value: selectedValue
-      }).then(function(els) {
+      }).then(function (els) {
 
         $detachedSelect = self.$el.find('.fx-establishment-select select').detach();
 
@@ -440,19 +440,19 @@ moj.Helpers.Blocks = {
         self.$el.find('.location_wrapper').css('display', 'none');
         self.$el.find('.fx-travel-location .has-select label').text(staticdata.locationLabel[locationType] || staticdata.locationLabel.default);
 
-      }, function() {
+      }, function () {
         throw new Error('Attach options failed:', arguments);
       });
     };
 
-    this.loadCurrentState = function() {
+    this.loadCurrentState = function () {
       var $select = this.$el.find('.fx-travel-expense-type select');
       if ($select.val()) {
         $select.trigger('change');
       }
     };
 
-    this.setTotals = function() {
+    this.setTotals = function () {
       this.totals = {
         quantity: this.getVal('.quantity'),
         rate: this.getVal('.rate'),
@@ -469,7 +469,7 @@ moj.Helpers.Blocks = {
      * @param  {object} e jQuery event object
      * @return this
      */
-    this.statemanager = function($el) {
+    this.statemanager = function ($el) {
       var self = this;
       var reasons = [];
       var state = {
@@ -489,12 +489,12 @@ moj.Helpers.Blocks = {
         'mileage',
         'reason',
         'vatAmount'
-      ].forEach(function(value, idx) {
+      ].forEach(function (value, idx) {
         $detached.find(self.stateLookup[value]).css('display', (state.config[value] ? 'block' : 'none'));
 
         // Clear out the value for this input
-        if(!state.config[value]){
-          $detached.find(self.stateLookup[value] +' input:not([type=radio])').val('');
+        if (!state.config[value]) {
+          $detached.find(self.stateLookup[value] + ' input:not([type=radio])').val('');
         }
       });
 
@@ -505,7 +505,7 @@ moj.Helpers.Blocks = {
       $detached.find(this.stateLookup.location).css('display', (state.config.location ? 'block' : 'none'));
 
       // remove the location data from the form
-      if(!state.config.location){
+      if (!state.config.location) {
         $detached.find('.fx-location-model').val('');
         $detached.find('.fx-travel-location > .location_wrapper:first input').val('');
         $detached.find('.fx-travel-location > .fx-establishment-select select').prop('selectedIndex', 0);
@@ -532,7 +532,7 @@ moj.Helpers.Blocks = {
       // Looping over the correct reasonset and
       // build the `<options data-attr="" .. />` elements
       // This will handled the selected option as well
-      this.expenseReasons[state.config.reasonSet].forEach(function(obj) {
+      this.expenseReasons[state.config.reasonSet].forEach(function (obj) {
         $option = $(new Option(obj.reason, obj.id));
         $option.attr('data-reason-text', obj.reason_text);
         $option.attr('data-location-type', obj.location_type);
@@ -556,7 +556,7 @@ moj.Helpers.Blocks = {
       // Loading the dynamic `location` data
       // wait for the data is loaded before
       // firing the change event
-      $.subscribe('/API/establishments/loaded/', function() {
+      $.subscribe('/API/establishments/loaded/', function () {
         $detached.find('.fx-travel-reason select').trigger('change');
       });
 
@@ -571,10 +571,10 @@ moj.Helpers.Blocks = {
      * @param state State config object
      * @return $dom return the $dom referance
      */
-    this.radioStateManager = function($dom, state) {
+    this.radioStateManager = function ($dom, state) {
 
       // Clearing the radio buttons if they are not required
-      if(!state.config.mileage){
+      if (!state.config.mileage) {
         $dom.find('.fx-travel-mileage input[type=radio]').is(function () {
           $(this).removeAttr('checked').prop('disabled', true);
         });
@@ -605,17 +605,17 @@ moj.Helpers.Blocks = {
       return $dom;
     };
 
-    this.setRadioState = function($dom, config) {
+    this.setRadioState = function ($dom, config) {
       // Car mileage visibility, radio checked & disabled values
       $dom.find('.fx-travel-mileage-car').css('display', config.car);
-      $dom.find('.fx-travel-mileage-car input').is(function() {
+      $dom.find('.fx-travel-mileage-car input').is(function () {
         $(this).prop('disabled', !config.carModel);
 
       });
 
       // Bike mileage visibility, radio checked & disabled values
       $dom.find('.fx-travel-mileage-bike').css('display', config.bike);
-      $dom.find('.fx-travel-mileage-bike input[type=radio]').is(function() {
+      $dom.find('.fx-travel-mileage-bike input[type=radio]').is(function () {
         $(this).prop('checked', config.bikeModel).prop('disabled', !config.bikeModel).change();
       });
       return $dom;
@@ -729,7 +729,7 @@ moj.Helpers.Blocks = {
       }
     }
   },
-  addCommas: function(nStr) {
+  addCommas: function (nStr) {
     nStr += '';
     var x = nStr.split('.');
     var x1 = x[0];

--- a/app/assets/javascripts/modules/external_users/claims/CaseTypeCtrl.js
+++ b/app/assets/javascripts/modules/external_users/claims/CaseTypeCtrl.js
@@ -1,5 +1,5 @@
 moj.Modules.CaseTypeCtrl = {
-  activate: function() {
+  activate: function () {
     return $('#claim_form_step').val() === 'case_details';
   },
   els: {
@@ -10,22 +10,22 @@ moj.Modules.CaseTypeCtrl = {
   },
 
   actions: {
-    requiresTrialDates: function(param, context) {
+    requiresTrialDates: function (param, context) {
       context.toggle(context.els.requiresTrialDates, param);
     },
-    requiresRetrialDates: function(param, context) {
+    requiresRetrialDates: function (param, context) {
       context.toggle(context.els.requiresRetrialDates, param);
     },
-    requiresCrackedDates: function(param, context) {
+    requiresCrackedDates: function (param, context) {
       context.toggle(context.els.requiresCrackedDates, param);
     }
   },
 
-  toggle: function(element, param) {
-    return $(element).css('display', param ? 'block' : 'none');
+  toggle: function (element, param) {
+    return param ? $(element).removeClass('hidden') : $(element).addClass('hidden');
   },
 
-  init: function() {
+  init: function () {
     if (this.activate()) {
 
       // bind events
@@ -39,10 +39,10 @@ moj.Modules.CaseTypeCtrl = {
   bindEvents: function () {
     var self = this;
 
-    $.subscribe('/onConfirm/claim_case_type_id-select/', function(e, data) {
+    $.subscribe('/onConfirm/claim_case_type_id-select/', function (e, data) {
       // Loop over the data object and fire the
       // methods as required, passing in the param
-      Object.keys(data).map(function(objectKey) {
+      Object.keys(data).map(function (objectKey) {
         if (typeof self.actions[objectKey] == 'function') {
           self.actions[objectKey](data[objectKey], self);
         }
@@ -50,8 +50,8 @@ moj.Modules.CaseTypeCtrl = {
     });
   },
 
-  initAutocomplete: function() {
-    $(this.els.fxAutocomplete).is(function(idx, el) {
+  initAutocomplete: function () {
+    $(this.els.fxAutocomplete).is(function (idx, el) {
       moj.Helpers.Autocomplete.new('#' + el.id, {
         showAllValues: true,
         autoselect: false

--- a/app/assets/javascripts/modules/external_users/claims/TransferDetailFieldsDisplay.js
+++ b/app/assets/javascripts/modules/external_users/claims/TransferDetailFieldsDisplay.js
@@ -9,7 +9,7 @@ moj.Modules.TransferDetailFieldsDisplay = {
   transferDateLabel: '.js-transfer-date-label .form-label-bold',
   params: {},
 
-  init: function() {
+  init: function () {
     if ($(this.tdWrapper).length > 0) {
       this.cacheEls();
       this.$tdWrapper = $(this.tdWrapper);
@@ -18,7 +18,7 @@ moj.Modules.TransferDetailFieldsDisplay = {
     }
   },
 
-  cacheEls: function() {
+  cacheEls: function () {
     this.params = {
       litigator_type: {
         el: this.litigatorTypeRadio,
@@ -35,43 +35,43 @@ moj.Modules.TransferDetailFieldsDisplay = {
     };
   },
 
-  addChangeEvent: function() {
+  addChangeEvent: function () {
     var self = this;
     var elements = [this.litigatorTypeRadio,
       this.electedCaseRadio,
       this.transferStageSelect
     ].join(',');
-    this.$tdWrapper.on('change', elements, function() {
+    this.$tdWrapper.on('change', elements, function () {
       self.callCaseConclusionController();
     });
   },
 
   // called by controller js view render
-  caseConclusionToggle: function(toggle) {
+  caseConclusionToggle: function (toggle) {
     if (toggle) {
-      $(this.caseConclusionSelect).show();
+      $(this.caseConclusionSelect).removeClass('hidden');
     } else {
       $(this.caseConclusionSelect + ' select.fx-autocomplete').prop('selectedIndex', 0); // reset actual select list value
       $('#claim_case_conclusion_id_input').val(''); // reset awesomplete displayed value
-      $(this.caseConclusionSelect).hide();
+      $(this.caseConclusionSelect).addClass('hidden');
     }
   },
 
   // called by controller js view render
-  labelTextToggle: function(transfer_stage_label_text, transfer_date_label_text) {
+  labelTextToggle: function (transfer_stage_label_text, transfer_date_label_text) {
     this.$tdWrapper.find(this.transferStageLabel).text(transfer_stage_label_text);
     this.$tdWrapper.find(this.transferDateLabel).text(transfer_date_label_text);
   },
 
-  getParamVal: function(param_key) {
+  getParamVal: function (param_key) {
     var selector = this.params[param_key].el + this.params[param_key].selector;
     return '&' + param_key + '=' + $(this.$tdWrapper.find(selector)).val();
   },
 
-  constructParams: function() {
+  constructParams: function () {
     var self = this;
     var params = '';
-    $.each(this.params, function(key) {
+    $.each(this.params, function (key) {
       params += self.getParamVal(key);
     });
 
@@ -79,7 +79,7 @@ moj.Modules.TransferDetailFieldsDisplay = {
     return params.substr(1);
   },
 
-  callCaseConclusionController: function() {
+  callCaseConclusionController: function () {
     var params = this.constructParams();
     $.getScript('/case_conclusions?' + params);
   }

--- a/app/assets/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.GraduatedPrice.js
+++ b/app/assets/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.GraduatedPrice.js
@@ -1,5 +1,5 @@
 // moj.Modules.FeeCalculator.GraduatedPrice
-(function(exports, $) {
+(function (exports, $) {
   var Modules = exports.Modules.FeeCalculator || {};
 
   Modules.GraduatedPrice = {
@@ -22,7 +22,7 @@
     advocateTypeChange: function () {
       var self = this;
       if ($('.calculated-grad-fee').exists()) {
-        $('.js-fee-calculator-advocate-type').change(function() {
+        $('.js-fee-calculator-advocate-type').change(function () {
           self.calculateAllGraduatedPrices();
         });
       }
@@ -31,7 +31,7 @@
     prosecutionEvidenceChange: function () {
       var self = this;
       if ($('.calculated-grad-fee').exists()) {
-        $('.js-fee-calculator-prosecution-evidence').change(function() {
+        $('.js-fee-calculator-prosecution-evidence').change(function () {
           self.calculateAllGraduatedPrices();
         });
       }
@@ -58,54 +58,54 @@
       this.bindCalculateEvents($els, this, 'keyup');
     },
 
-    bindCalculateEvents: function(els, self, eventType) {
+    bindCalculateEvents: function (els, self, eventType) {
       if ($('.calculated-grad-fee').exists()) {
-        els.on(eventType, $.debounce(290, function(e) {
+        els.on(eventType, $.debounce(290, function (e) {
           self.calculateGraduatedPrice(e.currentTarget);
         }));
       }
     },
 
-    claimId: function() {
+    claimId: function () {
       return $('#claim-form').data('claimId');
     },
 
-    advocateCategory: function() {
+    advocateCategory: function () {
       return this.getVal('input:radio[name="claim[advocate_category]"]:checked');
     },
 
-    feeTypeId: function(context) {
+    feeTypeId: function (context) {
       return this.getVal(context, '.js-fee-type');
     },
 
-    ppe: function(context) {
+    ppe: function (context) {
       return this.getVal(context, 'input.js-fee-calculator-ppe');
     },
 
-    pw: function(context) {
+    pw: function (context) {
       return this.getVal(context, 'input.js-fee-calculator-pw');
     },
 
-    days: function(context) {
+    days: function (context) {
       return this.getVal(context, 'input.js-fee-calculator-days:visible');
     },
-    
-    prosecutionEvidence: function() {
+
+    prosecutionEvidence: function () {
       return this.getVal('input:radio[name="claim[prosecution_evidence]"]:checked');
     },
 
-    getVal: function(context, selector){
-      if(selector) {
+    getVal: function (context, selector) {
+      if (selector) {
         return $(context).find(selector).val();
       }
       return $(context).val();
-    }, 
+    },
 
-    pagesOfProsecutingEvidence: function() {
+    pagesOfProsecutingEvidence: function () {
       return this.prosecutionEvidence() == 'true' ? 1 : 0;
     },
 
-    setAmount: function(data, context) {
+    setAmount: function (data, context) {
       var $amount = $(context).find('input.fee-amount');
       var $price_calculated = $(context).find('.js-fee-calculator-success > input');
 
@@ -115,11 +115,11 @@
       $amount.prop('readonly', data > 0);
     },
 
-    enableAmount: function(context) {
+    enableAmount: function (context) {
       $(context).find('input.fee-amount').prop('readonly', false);
     },
 
-    displayError: function(context, message) {
+    displayError: function (context, message) {
       this.clearErrors(context);
       var $label = $(context).find('.js-graduated-price-effectee > label');
       var $price_calculated = $(context).find('.js-fee-calculator-success > input');
@@ -132,16 +132,16 @@
       $label.html(new_label);
     },
 
-    clearErrors: function(context) {
+    clearErrors: function (context) {
       $(context).find('.js-calculate-grad-error').remove();
     },
 
-    displayHelp: function(context, show) {
+    displayHelp: function (context, show) {
       var $help = $(context).find('.fee-calc-help-wrapper');
-      show ? $help.show() : $help.hide();
+      show ? $help.removeClass('hidden') : $help.addClass('hidden');
     },
 
-    feeData: function(context) {
+    feeData: function (context) {
       var data = {};
       data.claim_id = this.claimId();
       data.price_type = this.priceType;
@@ -154,33 +154,33 @@
       return data;
     },
 
-    responseErrored: function(response) {
+    responseErrored: function (response) {
       return Boolean(
-                      response.hasOwnProperty('responseJSON') &&
-                      response.responseJSON.errors[0] != 'insufficient_data'
-                    );
+        response.hasOwnProperty('responseJSON') &&
+        response.responseJSON.errors[0] != 'insufficient_data'
+      );
     },
 
     graduatedPriceAjax: function (data, context) {
       var self = this;
       $.ajax({
-        type: 'POST',
-        url: '/external_users/claims/' + data.claim_id + '/fees/calculate_price.json',
-        data: data,
-        dataType: 'json'
-      })
-      .done(function(response) {
-        self.clearErrors(context);
-        self.setAmount(response.data.amount, context);
-        self.displayHelp(context, true);
-      })
-      .fail(function(response) {
-        if (self.responseErrored(response)) {
-          self.displayError(context, response.responseJSON.message);
-        }
-        self.displayHelp(context, false);
-        self.enableAmount(context);
-      });
+          type: 'POST',
+          url: '/external_users/claims/' + data.claim_id + '/fees/calculate_price.json',
+          data: data,
+          dataType: 'json'
+        })
+        .done(function (response) {
+          self.clearErrors(context);
+          self.setAmount(response.data.amount, context);
+          self.displayHelp(context, true);
+        })
+        .fail(function (response) {
+          if (self.responseErrored(response)) {
+            self.displayError(context, response.responseJSON.message);
+          }
+          self.displayHelp(context, false);
+          self.enableAmount(context);
+        });
     },
 
     calculateGraduatedPrice: function (target) {
@@ -191,15 +191,15 @@
 
     calculateAllGraduatedPrices: function () {
       var self = this;
-      $('.js-graduated-price-effectee').each( function() {
+      $('.js-graduated-price-effectee').each(function () {
         self.calculateGraduatedPrice(this);
       });
     },
 
     pageLoad: function () {
       var self = this;
-      $(document).ready( function() {
-        $('.calculated-grad-fee').each(function() {
+      $(document).ready(function () {
+        $('.calculated-grad-fee').each(function () {
           self.calculateAllGraduatedPrices(self);
         });
       });

--- a/app/assets/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/assets/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -1,13 +1,13 @@
 // moj.Modules.FeeCalculator.UnitPrice
-(function(exports, $) {
+(function (exports, $) {
   var Modules = exports.Modules.FeeCalculator || {};
 
   Modules.UnitPrice = {
-    init: function() {
+    init: function () {
       this.bindEvents();
     },
 
-    bindEvents: function() {
+    bindEvents: function () {
       this.advocateTypeChange();
       this.basicFeeTypeChange();
       this.fixedFeeTypeChange();
@@ -17,11 +17,11 @@
       this.pageLoad();
     },
 
-    advocateTypeChange: function() {
+    advocateTypeChange: function () {
       var self = this;
       // TODO: move this to a data-flag
       if ($('.calculated-unit-fee').exists()) {
-        $('.js-fee-calculator-advocate-type').change(function() {
+        $('.js-fee-calculator-advocate-type').change(function () {
           self.calculateUnitPrice();
         });
       }
@@ -42,14 +42,14 @@
       $(context + '-input').siblings('.destroy').val(bool);
     },
 
-    feeTypeCheckboxChange: function(elId) {
+    feeTypeCheckboxChange: function (elId) {
       var self = this;
 
-      $(elId).on('change', '.fx-checkbox-hook', function(e) {
+      $(elId).on('change', '.fx-checkbox-hook', function (e) {
         var $el = $(e.target);
         var parentEl = '#' + $el.closest('.multiple-choice').data('target');
 
-        if(!$el.is(':checked')){
+        if (!$el.is(':checked')) {
           // TODO: if we are going to destroy the fee do we need to clear it?
           self.clearFee(parentEl);
           self.markForDestruction(parentEl, true);
@@ -62,25 +62,25 @@
       });
     },
 
-    basicFeeTypeChange: function() {
+    basicFeeTypeChange: function () {
       this.feeTypeCheckboxChange('#basic-fees');
     },
 
-    fixedFeeTypeChange: function() {
+    fixedFeeTypeChange: function () {
       this.feeTypeCheckboxChange('#fixed-fees');
     },
 
-    miscFeeTypeCheckboxChange: function() {
+    miscFeeTypeCheckboxChange: function () {
       this.feeTypeCheckboxChange('#misc-fees');
     },
 
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
-    miscFeeTypesSelectChange: function($el) {
+    miscFeeTypesSelectChange: function ($el) {
       var self = this;
       var $els = $el || $('.fx-misc-fee-calculation');
 
       if ($('.fx-misc-fee-calculation').exists() && $('.calculated-unit-fee').exists()) {
-        $els.change(function() {
+        $els.change(function () {
           self.calculateUnitPrice();
         });
       }
@@ -89,17 +89,17 @@
     // needs to handle both select list and checboxes
     // for advocate final and supplementary claims respectively.
     //
-    miscFeeTypeChange: function() {
+    miscFeeTypeChange: function () {
       this.miscFeeTypesSelectChange();
       this.miscFeeTypeCheckboxChange();
     },
 
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
-    feeQuantityChange: function($el) {
+    feeQuantityChange: function ($el) {
       var self = this;
       var $els = $el || $('.js-fee-quantity');
       if ($('.calculated-unit-fee').exists()) {
-        $els.on('change keyup', $.debounce(290, function(e) {
+        $els.on('change keyup', $.debounce(290, function (e) {
           self.calculateUnitPrice();
           self.populateNetAmount(this);
         }));
@@ -107,15 +107,15 @@
     },
 
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
-    feeRateChange: function($el) {
+    feeRateChange: function ($el) {
       var self = this;
       var $els = $el || $('.js-fee-calculator-rate');
-      $els.change(function() {
+      $els.change(function () {
         self.populateNetAmount(this);
       });
     },
 
-    setRate: function(data, context) {
+    setRate: function (data, context) {
       var $input = $(context).find('input.fee-rate');
       var $price_calculated = $(context).siblings('.js-fee-calculator-success').find('input');
 
@@ -127,24 +127,24 @@
 
     // TODO: backend should tell front end what to present
     // in data attributes preferably
-    setHintLabel: function(data) {
+    setHintLabel: function (data) {
       var $result = '';
       switch (data) {
-      case 'HALFDAY':
-        $result = 'half day';
-        break;
-      case 'DEFENDANT':
-      case 'CASE':
-        $result = 'additional ' + data;
-        break;
-      default:
-        $result = data;
+        case 'HALFDAY':
+          $result = 'half day';
+          break;
+        case 'DEFENDANT':
+        case 'CASE':
+          $result = 'additional ' + data;
+          break;
+        default:
+          $result = data;
       }
 
       return (data ? 'Number of ' + $result.toLowerCase() + 's' : '');
     },
 
-    setHint: function(data, context) {
+    setHint: function (data, context) {
 
       var self = this;
       var $label = $(context).closest('.fx-fee-group').find('.form-group.quantity_wrapper').find('.form-hint');
@@ -154,11 +154,11 @@
       data ? $label.show() : $label.hide();
     },
 
-    enableRate: function(context) {
+    enableRate: function (context) {
       $(context).find('input.fee-rate').prop('readonly', false);
     },
 
-    populateNetAmount: function(context) {
+    populateNetAmount: function (context) {
       var $feeGroup = $(context).closest('.fx-fee-group');
       var $el = $feeGroup.find('.fee-net-amount');
       var rate = $feeGroup.find('input.fee-rate').val();
@@ -168,7 +168,7 @@
       $el.html(text);
     },
 
-    displayError: function(response, context) {
+    displayError: function (response, context) {
       // only some errors will have a JSON response
       this.clearErrors(context);
       var $label = $(context).find('label');
@@ -182,16 +182,16 @@
       $label.html(new_label);
     },
 
-    clearErrors: function(context) {
+    clearErrors: function (context) {
       $(context).find('.js-calculate-unit-error').remove();
     },
 
-    displayHelp: function(context, show) {
+    displayHelp: function (context, show) {
       var $help = $(context).closest('.fx-fee-group').find('.fee-calc-help-wrapper');
-      show ? $help.show() : $help.hide();
+      show ? $help.removeClass('hidden') : $help.addClass('hidden');
     },
 
-    unitPriceAjax: function(data, context) {
+    unitPriceAjax: function (data, context) {
       var self = this;
       var dataobject = {
         type: 'POST',
@@ -201,13 +201,13 @@
       };
 
       $.ajax(dataobject)
-        .done(function(response) {
+        .done(function (response) {
           self.clearErrors(context);
           self.setRate(response.data.amount, context);
           self.setHint(response.data.unit, context);
           self.displayHelp(context, true);
         })
-        .fail(function(response) {
+        .fail(function (response) {
           if (response.hasOwnProperty('responseJSON') && response.responseJSON.errors[0] != 'insufficient_data') {
             self.displayError(response, context);
             self.setHint(null, context);
@@ -218,7 +218,7 @@
         });
     },
 
-    buildFeeData: function(data) {
+    buildFeeData: function (data) {
       data.claim_id = $('#claim-form').data('claimId');
       data.price_type = 'UnitPrice';
       var advocate_category = $('input:radio[name="claim[advocate_category]"]:checked').val();
@@ -227,7 +227,7 @@
       }
 
       var fees = data.fees = [];
-      $('.fx-fee-group:visible').each(function() {
+      $('.fx-fee-group:visible').each(function () {
         fees.push({
           fee_type_id: $(this).find('.js-fee-type').first().val(),
           quantity: $(this).find('input.js-fee-quantity').val()
@@ -238,13 +238,13 @@
     // Calculates the "unit price" for a given fee,
     // including fixed fee case uplift fee types,
     // and misc fee defendant uplifts.
-    calculateUnitPrice: function() {
+    calculateUnitPrice: function () {
       var self = this;
       var data = {};
 
       this.buildFeeData(data);
 
-      $('.js-unit-price-effectee').each(function(idx, el) {
+      $('.js-unit-price-effectee').each(function (idx, el) {
         if ($(el).is(':visible')) {
           data.fee_type_id = $(this).closest('.fx-fee-group').find('.js-fee-type').first().val();
           self.unitPriceAjax(data, this);
@@ -252,17 +252,17 @@
       });
 
       // if everything is hidden - force sidebar recalculate
-      if($('.js-unit-price-effectee:visible').length === 0){
+      if ($('.js-unit-price-effectee:visible').length === 0) {
         $('#claim-form').trigger('recalculate');
       }
     },
 
-    pageLoad: function() {
+    pageLoad: function () {
       var self = this;
-      $(document).ready(function() {
+      $(document).ready(function () {
         // TODO: this loop is causing multiple init procedures
         // limiting it for now to at least one visible
-        $('.calculated-unit-fee:visible:first').each(function() {
+        $('.calculated-unit-fee:visible:first').each(function () {
           self.calculateUnitPrice();
         });
       });

--- a/app/assets/javascripts/plugins/jquery.numbered.elements.js
+++ b/app/assets/javascripts/plugins/jquery.numbered.elements.js
@@ -1,4 +1,4 @@
-(function(factory) {
+(function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['jquery'], factory);
@@ -9,7 +9,7 @@
     // Browser globals
     factory(jQuery);
   }
-}(function($, undefined) {
+}(function ($, undefined) {
   'use strict';
 
   var pluginName = 'numberedList';
@@ -29,35 +29,36 @@
 
   // Avoid Plugin.prototype conflicts
   $.extend(Plugin.prototype, {
-    init: function() {
+    init: function () {
       if ($(this.settings.wrapper).length >= 1) {
         this.bindListeners();
         this.updateNumbers();
       }
     },
-    bindListeners: function() {
+    bindListeners: function () {
       var self = this;
       var el = '#' + $(this.settings.wrapper).attr('id');
-      if(el === "#undefined"){
+      if (el === "#undefined") {
         throw Error('This is an error message');
       }
 
-      $(el).on('cocoon:after-insert', function(e) {
+      $(el).on('cocoon:after-insert', function (e) {
         self.updateNumbers();
       });
 
-      $(el).on('cocoon:after-remove', function(e) {
+      $(el).on('cocoon:after-remove', function (e) {
         self.updateNumbers();
       });
     },
-    updateNumbers: function() {
+    updateNumbers: function () {
       var self = this;
       var number = self.settings.number;
       var action = self.settings.action;
       var items = $(this.settings.wrapper).find(this.settings.item + ':visible');
 
-      items.each(function(idx, el) {
-        $(el).find(action).css('display', 'block');
+      items.each(function (idx, el) {
+        // $(el).find(action).css('display', 'block');
+        $(el).find(action).removeClass('hidden');
         $(el).find(number).text('');
         if (items.length > 1) {
           $(el).find(number).text(idx + 1);
@@ -71,7 +72,7 @@
   // multiple times
   if (typeof $[pluginName] === "undefined") {
 
-    $[pluginName] = function(options) {
+    $[pluginName] = function (options) {
 
       if (!activated) {
         new Plugin(options);

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -64,3 +64,7 @@ input.form-control:read-only {
     width: $full-width;
   }
 }
+
+.inline-form {
+  display: inline-block;
+}

--- a/app/assets/stylesheets/_links.scss
+++ b/app/assets/stylesheets/_links.scss
@@ -24,9 +24,6 @@ a.link-remove {
   }
 }
 
-
-/*--- Add new fields ---*/
-
 a.add_fields {
   display: none;
 }
@@ -35,9 +32,11 @@ a.add_fields {
   display: inline-block;
 }
 
-
-/*--- Ported from v1 stylesheets ---*/
-
 a.delete-draft {
   color: $red;
+}
+
+.download-all-link {
+  @extend .font-small;
+  float: right;
 }

--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -288,10 +288,6 @@ form {
   padding-bottom: 0;
 }
 
-.inline-form {
-  display: inline;
-}
-
 .indent-fieldset {
   border-left: 5px solid $border-colour;
   border-bottom: 0;

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -1,10 +1,10 @@
 = render partial: 'errors/error_summary', locals: { ep: @allocation, error_summary: t('.error_summary') }
 
-.notice-summary{ role: 'group', 'aria-labelledby': 'notice-summary-heading', tabindex: '-1', style: 'display: none;' }
+.notice-summary.hidden{ role: 'group', 'aria-labelledby': 'notice-summary-heading', tabindex: '-1' }
   %span.heading-medium.notice-summary-heading{ id: 'notice-summary-heading' }
     %span.msg
 
-.error-summary{ role: 'group', 'aria-labelledby': 'error-summary-heading', tabindex: '-1', style: 'display: none;' }
+.error-summary.hidden{ role: 'group', 'aria-labelledby': 'error-summary-heading', tabindex: '-1' }
   %span#error-summary-heading.heading-medium.error-summary-heading
     %span.msg
 
@@ -30,11 +30,11 @@
     .grid-row.js-typeahead
       .column-one-third.js-typeahead
         = label_tag :quantity_to_allocate, t('.no_of_claims'), class: 'form-label-bold'
-        = number_field_tag :quantity_to_allocate, nil, { style: 'width: 100%', min: 0, size: 5, class: 'form-control' }
+        = number_field_tag :quantity_to_allocate, nil, { min: 0, size: 5, class: 'form-control form-control-full' }
       .column-one-third
         #cc-caseworker
           = label_tag :allocation_case_worker_id, t('dictionary.models.case_worker'), class: 'form-label-bold'
-          = collection_select :allocation, :case_worker_id, @case_workers, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', style: 'width: 100%' }
+          = collection_select :allocation, :case_worker_id, @case_workers, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control form-control-full fx-autocomplete' }
       .column-one-third
         %br/
         = submit_tag t('.allocate'), class: 'button allocation-submit'

--- a/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
@@ -2,7 +2,7 @@
   %label.form-label-bold{ for: 'filterAGFS' }
     = t('.case_types')
 
-  %select#filterAGFS.form-control{ name: 'tasks', style: 'width: 100%' }
+  %select#filterAGFS.form-control.form-control-full{ name: 'tasks' }
     %option{ value: '' }
       = t('.all')
     %option{ value: 'fixed_fee' }
@@ -27,11 +27,11 @@
       = t('.supplementary')
 
 
-#filter-tasks-lgfs.form-group.dtFilter.dtFilterLGFS{ data: { scheme: 'lgfs' }, style: 'display: none;' }
+#filter-tasks-lgfs.form-group.dtFilter.dtFilterLGFS.hidden{ data: { scheme: 'lgfs' } }
   %label.form-label-bold{ for: 'filterLGFS' }
     = t('.case_types')
 
-  %select#filterLGFS.form-control{ name: 'tasks', style: 'width: 100%' }
+  %select#filterLGFS.form-control.form-control-full{ name: 'tasks' }
     %option{ value: '' }
       = t('.all')
     %option{ value: 'fixed_fee' }

--- a/app/views/case_workers/admin/allocations/_filter_value_bands.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_value_bands.html.haml
@@ -2,7 +2,7 @@
   %label.form-label-bold{ for: 'select-box-filter-value' }
     = t('.value')
 
-  %select#select-box-filter-value.form-control{ name: 'filter_value_bands', style: 'width: 100%;' }
+  %select#select-box-filter-value.form-control.form-control-full{ name: 'filter_value_bands' }
     %option{ value: '' }
       = t('.all')
     %option{ value: 'max:25000' }

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -40,7 +40,7 @@
       .case-worker-reallocation.grid-row.form-group.js-typeahead
         .column-one-quarter.js-case-worker-list
           = f.label :case_worker_id, class: 'form-label-bold', id: :case_worker_id
-          = f.collection_select :case_worker_id, @case_workers, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', style: 'width: 100%;', 'aria-label': t('case_workers.admin.allocations.re_allocation.case_worker') }
+          = f.collection_select :case_worker_id, @case_workers, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control form-control-full fx-autocomplete', 'aria-label': t('case_workers.admin.allocations.re_allocation.case_worker') }
         .column-one-half.margin-spacer-sm
           = f.submit t('.re_allocate'), class: 'button'
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -13,7 +13,7 @@
   .form-group
     = render 'terms_and_conditions'
 
-    = label_tag :terms_and_conditions_acceptance, required: true, class: 'form-label', style: 'font-weight: bold;' do
+    = label_tag :terms_and_conditions_acceptance, required: true, class: 'form-label-bold' do
       = check_box_tag :terms_and_conditions_acceptance
       Accept terms and conditions
 

--- a/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
@@ -43,7 +43,7 @@
     .js-fee-calculator-success
       = f.hidden_field :price_calculated, value: f.object.price_calculated?
 
-    .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+    .fee-calc-help-wrapper.form-group.hidden
       %details
         %summary
           %span.summary

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
@@ -35,7 +35,7 @@
             = t('.help_with_basic_fees.post_agfs_reform_html')
           - else
             = t('.help_with_basic_fees.pre_agfs_reform_html')
-          .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+          .fee-calc-help-wrapper.form-group.hidden
             = t('.help_with_basic_fees.how_is_this_rate_calculated_html')
 
     = render partial: 'external_users/claims/basic_fees/first_date_display', locals: { fee: fee }

--- a/app/views/external_users/claims/basic_fees/_extra_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_extra_fee_fields.html.haml
@@ -37,7 +37,7 @@
     .js-fee-calculator-success
       = f.hidden_field :price_calculated, value: f.object.price_calculated?
 
-    .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+    .fee-calc-help-wrapper.form-group.hidden
       %details
         %summary
           %span.summary

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -1,4 +1,4 @@
-#cracked-trial-dates.form-section{style: @claim&.case_type&.requires_cracked_dates? ? 'display: block;' : 'display: none;', 'aria-labelledby': 'cracked-trial-dates-heading'}
+#cracked-trial-dates.form-section{ class: @claim&.case_type&.requires_cracked_dates? ? '' : 'hidden', 'aria-labelledby': 'cracked-trial-dates-heading' }
   %h3#cracked-trial-dates-heading.heading-medium
     = t('.cracked_trial_details')
 

--- a/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
@@ -1,4 +1,4 @@
-#retrial-dates.form-section{style: @claim&.case_type&.requires_retrial_dates? ? 'display: block;' : 'display: none;', 'aria-labelledby': 'retrial-dates-heading'}
+#retrial-dates.form-section{ class: @claim&.case_type&.requires_retrial_dates? ? '' : 'hidden', 'aria-labelledby': 'retrial-dates-heading' }
   %h3#retrial-dates-heading.heading-medium
     = t('.retrial_detail')
 

--- a/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
@@ -1,4 +1,4 @@
-#trial-dates.form-section{style: @claim&.case_type&.requires_trial_dates? ? 'display: block;' : 'display: none;', 'aria-labelledby': 'trial-dates-heading'}
+#trial-dates.form-section{ class: @claim&.case_type&.requires_trial_dates? ? '' : 'hidden', 'aria-labelledby': 'trial-dates-heading' }
   %h3#trial-dates-heading.heading-medium
     = t('.trial_detail')
 

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -5,7 +5,7 @@
       %span.heading-medium
         = t('.defendant')
         %span.fx-numberedList-number
-        = link_to_remove_association f, class: 'header-action fx-numberedList-action', style: 'display: none;' do
+        = link_to_remove_association f, class: 'header-action fx-numberedList-action hidden' do
           = t('.remove')
           %span.visuallyhidden
             = t('.defendant')

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -6,7 +6,7 @@
       %span.heading-medium
         = t('.representation_order')
         %span.fx-numberedList-number
-        = link_to_remove_association f, class: 'header-action fx-numberedList-action', style: 'display: none;' do
+        = link_to_remove_association f, class: 'header-action fx-numberedList-action hidden' do
           = t('.remove')
           %span.visuallyhidden
             = t('.representation_order')

--- a/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
+++ b/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
@@ -2,7 +2,7 @@
   %h2.bold-medium
     = t('.disbursement')
     %span.fx-numberedList-number
-    = link_to_remove_association t('.remove'), f, wrapper_class: 'disbursement-group', class: "header-action fx-numberedList-action", style: "display: none;"
+    = link_to_remove_association t('.remove'), f, wrapper_class: 'disbursement-group', class: 'header-action fx-numberedList-action hidden'
 
   .form-group
     .disbursement-type.js-typeahead{ class: error_class?(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type") }
@@ -11,7 +11,7 @@
       = f.select :disbursement_type_id,
         DisbursementType.active.map{ |disbursement| [disbursement.name, disbursement.id] },
         { include_blank: ''.html_safe },
-        { class: 'form-control fx-autocomplete', style: 'width: 100%', 'aria-label': t('.disbursement_type') }
+        { class: 'form-control form-control-full fx-autocomplete', 'aria-label': t('.disbursement_type') }
 
       = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")
 

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -9,7 +9,7 @@
       = t('.expense')
       %span.fx-numberedList-number
       %span.fx-remove-link
-      = link_to_remove_association f, wrapper_class: 'expense-group', class: 'header-action fx-numberedList-action', style: 'display: none;' do
+      = link_to_remove_association f, wrapper_class: 'expense-group', class: 'header-action fx-numberedList-action hidden' do
         = t('.remove')
         %span.visuallyhidden
           = t('.expense')

--- a/app/views/external_users/claims/fixed_fees/advocates/_fixed_fee_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/advocates/_fixed_fee_fields.html.haml
@@ -46,7 +46,7 @@
     .js-fee-calculator-success
       = f.hidden_field :price_calculated, value: f.object.price_calculated?
 
-    .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+    .fee-calc-help-wrapper.form-group.hidden
       %details
         %summary
           %span.summary

--- a/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/litigators/_fields.html.haml
@@ -39,7 +39,7 @@
       .js-fee-calculator-success
         = ff.hidden_field :price_calculated, value: ff.object.price_calculated?
 
-      .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+      .fee-calc-help-wrapper.form-group.hidden
         %details
           %summary
             %span.summary

--- a/app/views/external_users/claims/graduated_fees/_fields.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_fields.html.haml
@@ -39,7 +39,7 @@
         .js-fee-calculator-success
           = ff.hidden_field :price_calculated, value: ff.object.price_calculated?
 
-        .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+        .fee-calc-help-wrapper.form-group.hidden
           %details
             %summary
               %span.summary

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -3,7 +3,7 @@
   %span.bold-medium
     = t('.misc_fee')
     %span.fx-numberedList-number
-    = link_to_remove_association t('.remove'), f, wrapper_class: 'misc-fee-group', class: 'header-action fx-numberedList-action', style: 'display: none;'
+    = link_to_remove_association t('.remove'), f, wrapper_class: 'misc-fee-group', class: 'header-action fx-numberedList-action hidden'
 
   .form-group
     .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") }
@@ -15,7 +15,7 @@
       = f.collection_select :fee_type_id,
        @claim.eligible_misc_fee_types, :id, :description,
        { include_blank: ''.html_safe },
-       { class: 'form-control js-misc-fee-type js-fee-type js-fee-calculator-fee-type typeahead fx-misc-fee-calculation', style: 'width:100%', 'aria-label': t('.fee_type') }
+       { class: 'form-control form-control-full js-misc-fee-type js-fee-type js-fee-calculator-fee-type typeahead fx-misc-fee-calculation', 'aria-label': t('.fee_type') }
 
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
@@ -41,7 +41,7 @@
   .js-fee-calculator-success
     = f.hidden_field :price_calculated, value: f.object.price_calculated?
 
-  .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+  .fee-calc-help-wrapper.form-group.hidden
     %details
       %summary
         %span.summary

--- a/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
@@ -37,7 +37,7 @@
     .js-fee-calculator-success
       = f.hidden_field :price_calculated, value: f.object.price_calculated?
 
-    .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+    .fee-calc-help-wrapper.form-group.hidden
       %details
         %summary
           %span.summary

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -3,7 +3,7 @@
     %span
       = t('.misc_fee')
       %span.fx-numberedList-number
-    = link_to_remove_association t('.remove'), f, wrapper_class: 'misc-fee-group', class: 'header-action fx-numberedList-action', style: 'display: none;'
+    = link_to_remove_association t('.remove'), f, wrapper_class: 'misc-fee-group', class: 'header-action fx-numberedList-action hidden'
 
   .form-group
     .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count+1}_fee_type") }

--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -24,7 +24,7 @@
     %span.form-hint
       = 'For example class, band, offence or act name'
 
-    %a.fx-clear-search{ style: 'display: none;', href: '#noop' } Clear search
+    %a.fx-clear-search.hidden{ href: '#noop' } Clear search
 
 
     %input#offence.form-control.fx-input{ name: 'offence-search-input', type: 'input', autocomplete: 'off' }

--- a/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_detail_fields.html.haml
@@ -42,7 +42,7 @@
         = f.gov_uk_date_field(:transfer_date, legend_text: t('.transfer_date_default_label_text'), legend_class: 'govuk-legend js-transfer-date-label', id: 'transfer_date', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'transfer_date'))
 
 
-    #cc-case-conclusion.form-group.js-typeahead.js-case-conclusions-select{ class: error_class?(@error_presenter, 'case_conclusion_id'), style: claim.conclusion_required? ? 'display: block;' : 'display: none;' }
+    #cc-case-conclusion.form-group.js-typeahead.js-case-conclusions-select{ class: error_class?(@error_presenter, 'case_conclusion_id'), class: claim.conclusion_required? ? '' : 'hidden' }
       = f.anchored_label t('.case_conclusions'), 'case_conclusion_id', { label_attributes: { class: 'form-label-bold' } }
       = f.collection_select :case_conclusion_id, claim.case_conclusions, :first, :last,{ include_blank: ''.html_safe },{ class: 'form-control fx-autocomplete medium-input', 'aria-label': t('.case_conclusions') }
       = validation_error_message(@error_presenter, 'case_conclusion_id')

--- a/app/views/external_users/claims/transfer_fee/_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_fields.html.haml
@@ -37,7 +37,7 @@
       .js-fee-calculator-success
         = tf.hidden_field :price_calculated, value: tf.object.price_calculated?
 
-      .fee-calc-help-wrapper.form-group{ style: 'display: none;' }
+      .fee-calc-help-wrapper.form-group.hidden
         %details
           %summary
             %span.summary

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -44,15 +44,15 @@
                 = f.hidden_field :form_step, value: 'offence_details'
                 = f.hidden_field :form_id, value: @claim.form_id
                 = f.submit t('buttons.add_evidence'), name: 'commit_continue', class: 'button left btn-spacer-20 button-secondary blue certify-claim'
-            = link_to t('buttons.delete_draft'), external_users_claim_path(claim), method: :delete, data: { confirm: t('.confirm_text') }, class: 'delete-draft'
+            = link_to t('buttons.delete_draft'), external_users_claim_path(claim), method: :delete, data: { confirm: t('.confirm_text') }, class: 'delete-draft', role: 'button'
 
         - if claim.archivable?
           = t('.actions')
           .action-wrapper
             - if claim.rejected?
-              = button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: 'patch', class: 'button resubmit-claim', form: { style: 'display: inline-block;' }
-            = link_to t('.archive'), external_users_claim_path(claim), method: :delete, data: { confirm: t('.confirm_text') }, class: 'button'
+              = button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: 'patch', class: 'button resubmit-claim', form_class: 'inline-form'
+            = link_to t('.archive'), external_users_claim_path(claim), method: :delete, data: { confirm: t('.confirm_text') }, class: 'button', role: 'button'
         - if claim.archived_pending_delete?
           = t('.actions')
           .action-wrapper
-            = button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: 'patch', class: 'button', form: { style: 'display: inline-block;' }
+            = button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: 'patch', class: 'button', form_class: 'inline-form'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -51,7 +51,7 @@
 
     // CASE WORKER ACTIONS
     - if current_user_is_caseworker?
-      .js-cw-claim-rejection-reasons{ style: 'display:none', class: error_class?(@error_presenter, :rejected_reason) }
+      .js-cw-claim-rejection-reasons.hidden{ class: error_class?(@error_presenter, :rejected_reason) }
         %fieldset.form-group.nested-fields.indent-fieldset.spacer{ 'aria-describedby': 'checkbox-control-legend-1' }
           %div
             = validation_error_message(@error_presenter, :rejected_reason)
@@ -63,7 +63,7 @@
               = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), 'aria-labelledby': "checkbox-control-legend-1 #{b.text.to_css_class}")
               = b.label { b.text }
 
-          .form-group.panel.nested-fields.fieldset.spacer.js-reject-reason-text{ style: 'display: none; padding-top: 10px;', class: error_class?(@error_presenter, :rejected_reason_other) }
+          .form-group.panel.nested-fields.fieldset.spacer.js-reject-reason-text.hidden{ class: error_class?(@error_presenter, :rejected_reason_other) }
             %div
               %a#rejected_reason_other
               = f.label :reject_reason_text, class: 'form-label' do
@@ -74,7 +74,7 @@
               %div
                 = validation_error_message(@error_presenter, :rejected_reason_other)
 
-      .js-cw-claim-refuse-reasons{ style: 'display:none', class: error_class?(@error_presenter, :refused_reason) }
+      .js-cw-claim-refuse-reasons.hidden{ class: error_class?(@error_presenter, :refused_reason) }
         %div
           = validation_error_message(@error_presenter, :refused_reason)
 
@@ -88,7 +88,7 @@
               = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), 'aria-labelledby': "checkbox-control-legend-2 #{b.text.to_css_class}")
               = b.label { b.text }
 
-          .form-group.panel.nested-fields.fieldset.spacer.js-refuse-reason-text{ style: 'display: none; padding-top: 10px;', class: error_class?(@error_presenter, :refused_reason_other) }
+          .form-group.panel.nested-fields.fieldset.spacer.js-refuse-reason-text.hidden{ class: error_class?(@error_presenter, :refused_reason_other) }
             %div
               %a#refused_reason_other
               = f.label :refuse_reason_text, class: 'form-label' do

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -3,7 +3,7 @@
 %h3.heading-medium
   = t('.existing_evidence')
   - if current_user_persona_is?(CaseWorker) && @claim.documents.any?
-    = link_to t('shared.download_all'), download_zip_case_workers_claim_path(@claim), class: 'font-small', style: 'float: right'
+    = link_to t('shared.download_all'), download_zip_case_workers_claim_path(@claim), class: 'download-all-link'
 
 - if @claim.documents.none?
   = t('.no_documents_uploaded')

--- a/app/views/shared/_supplier_number_fields.html.haml
+++ b/app/views/shared/_supplier_number_fields.html.haml
@@ -4,13 +4,13 @@
     %span.fx-numberedList-number
     - editable = f.object.new_record? || f.object.supplier_number.blank? || !f.object.valid?
     - if editable
-      = link_to_remove_association t('.remove'), f, wrapper_class: 'supplier-number-group', class: "header-action fx-numberedList-action", style: "display: none;"
+      = link_to_remove_association t('.remove'), f, wrapper_class: 'supplier-number-group', class: 'header-action fx-numberedList-action hidden'
     - else
       - if f.object.has_non_archived_claims?
         %span.form-hint
           Cannot remove supplier number while claims are still in progress
       - else
-        = link_to_remove_association t('.remove'), f, wrapper_class: 'supplier-number-group', class: "header-action fx-numberedList-action", style: "display: none;"
+        = link_to_remove_association t('.remove'), f, wrapper_class: 'supplier-number-group', class: 'header-action fx-numberedList-action hidden'
 
   -# adp_text_field does not allow to use rails defaults locales for model attributes :S
   - attributes_scope = 'activerecord.attributes.supplier_number'

--- a/spec/javascripts/Modules.OffenceSearchInput_spec.js
+++ b/spec/javascripts/Modules.OffenceSearchInput_spec.js
@@ -1,7 +1,7 @@
-describe("Modules.OffenceSearchInput.js", function() {
+describe("Modules.OffenceSearchInput.js", function () {
   var module = moj.Modules.OffenceSearchInput;
 
-  var view = function(data) {
+  var view = function (data) {
 
     data = $.extend({}, data, {
       value: '',
@@ -12,7 +12,7 @@ describe("Modules.OffenceSearchInput.js", function() {
       '  <label class="form-label" for="offence">',
       '    Search for the offence',
       '    <span class="form-hint">For example class, band, offence or act name</span>',
-      '    <a class="fx-clear-search" href="#noop">Clear search</a>',
+      '    <a class="fx-clear-search hidden" href="#noop">Clear search</a>',
       '    <input autocomplete="off" class="fx-input" id="offence" name="offence-search-input" type="input" value="' + data.value + '">',
       '  </label>',
       '  <input value="' + data.value + '" class="fx-model" type="hidden" name="claim[offence_id]" id="claim_offence_id" />',
@@ -22,38 +22,38 @@ describe("Modules.OffenceSearchInput.js", function() {
   }
 
 
-  beforeEach(function() {
+  beforeEach(function () {
     $('body .mod-search-input').remove();
     $('body').append(view());
   });
 
-  afterEach(function() {
+  afterEach(function () {
 
   });
 
-  describe('...defaults', function() {
-    it('`this.el`', function() {
+  describe('...defaults', function () {
+    it('`this.el`', function () {
       expect(module.el).toEqual('.mod-search-input')
     });
-    it('`this.input`', function() {
+    it('`this.input`', function () {
       expect(module.input).toEqual('.fx-input')
     });
-    it('`this.model`', function() {
+    it('`this.model`', function () {
       expect(module.model).toEqual('.fx-model')
     });
-    it('`this.feeScheme`', function() {
+    it('`this.feeScheme`', function () {
       expect(module.feeScheme).toEqual('.fx-fee-scheme')
     });
-    it('`this.debouce`', function() {
+    it('`this.debouce`', function () {
       expect(module.debouce).toEqual(500)
     });
-    it('`this.subscribers`', function() {
+    it('`this.subscribers`', function () {
       expect(module.subscribers).toEqual({
         run: '/offence/search/run/',
         filter: '/offence/search/filter/'
       })
     });
-    it('`this.publishers`', function() {
+    it('`this.publishers`', function () {
       expect(module.publishers).toEqual({
         results: '/offence/search/results/'
       })
@@ -61,9 +61,9 @@ describe("Modules.OffenceSearchInput.js", function() {
   });
 
 
-  describe('...Methods', function() {
-    describe('...init', function() {
-      it('should check the dom and `init` if required, caching a `$el` referance ', function() {
+  describe('...Methods', function () {
+    describe('...init', function () {
+      it('should check the dom and `init` if required, caching a `$el` referance ', function () {
         spyOn(module, 'bindEvents');
 
         module.init();
@@ -75,8 +75,8 @@ describe("Modules.OffenceSearchInput.js", function() {
       });
     });
 
-    describe('...bindEvents', function() {
-      it('should bind `clearSearch`', function() {
+    describe('...bindEvents', function () {
+      it('should bind `clearSearch`', function () {
         spyOn(module, 'clearSearch')
         spyOn(module, 'trackUserInput');
         module.init();
@@ -85,8 +85,8 @@ describe("Modules.OffenceSearchInput.js", function() {
       });
     });
 
-    describe('...bindSubscribers', function() {
-      it('should subscribe to the `this.subscribers.run` event', function() {
+    describe('...bindSubscribers', function () {
+      it('should subscribe to the `this.subscribers.run` event', function () {
         spyOn(module, 'runQuery');
         module.init();
 
@@ -96,8 +96,8 @@ describe("Modules.OffenceSearchInput.js", function() {
       });
     });
 
-    describe('...runQuery', function() {
-      it('should construct the `dataOptions` object correctly', function() {
+    describe('...runQuery', function () {
+      it('should construct the `dataOptions` object correctly', function () {
         var deferred = $.Deferred();
         var spy = spyOn(module, 'query').and.returnValue(deferred.promise());
         spyOn($, 'publish');
@@ -143,25 +143,25 @@ describe("Modules.OffenceSearchInput.js", function() {
         });
       });
 
-      it('should show the `clear search` link', function() {
+      it('should show the `clear search` link', function () {
         var deferred = $.Deferred();
         var spy = spyOn(module, 'query').and.returnValue(deferred.promise());
         spyOn($, 'publish');
 
         module.init();
 
-        spyOn(module.$clear, 'show').and.callThrough();
+        spyOn(module.$clear, 'removeClass').and.callThrough();
 
         module.runQuery();
 
-        module.query().then(function() {
-          expect(module.$clear.show).toHaveBeenCalled()
+        module.query().then(function () {
+          expect(module.$clear.removeClass).toHaveBeenCalled()
         });
 
         deferred.resolve({});
       });
 
-      it('should publish the search results', function() {
+      it('should publish the search results', function () {
         var deferred = $.Deferred();
         var spy = spyOn(module, 'query').and.returnValue(deferred.promise());
         var fixtureData = {
@@ -177,7 +177,7 @@ describe("Modules.OffenceSearchInput.js", function() {
 
         module.runQuery();
 
-        module.query().then(function() {
+        module.query().then(function () {
           expect($.publish).toHaveBeenCalledWith('/offence/search/results/', fixtureData)
         });
 
@@ -185,8 +185,8 @@ describe("Modules.OffenceSearchInput.js", function() {
       });
     });
 
-    describe('...trackUserInput', function() {
-      it('should use `$.debounce`', function() {
+    describe('...trackUserInput', function () {
+      it('should use `$.debounce`', function () {
         spyOn($, 'debounce');
         module.$input.val('mudr');
 
@@ -201,8 +201,8 @@ describe("Modules.OffenceSearchInput.js", function() {
       });
     });
 
-    describe('...clearSearch', function() {
-      it('should clear the `this.input` and `this.model` elements', function() {
+    describe('...clearSearch', function () {
+      it('should clear the `this.input` and `this.model` elements', function () {
         spyOn(module, 'clearSearch').and.callThrough();
         $('.fx-input').val('sample query');
         $('.fx-model').val('sample model');
@@ -219,7 +219,7 @@ describe("Modules.OffenceSearchInput.js", function() {
 
       });
 
-      it('should `$.publish` the clear event', function() {
+      it('should `$.publish` the clear event', function () {
         spyOn($, 'publish')
         module.init();
 

--- a/spec/javascripts/helpers-sidebar_spec.js
+++ b/spec/javascripts/helpers-sidebar_spec.js
@@ -1,14 +1,14 @@
-describe('Helpers.Blocks.js', function() {
-  it('should exist with expected constructors', function() {
+describe('Helpers.Blocks.js', function () {
+  it('should exist with expected constructors', function () {
     expect(moj.Helpers.Blocks).toBeDefined();
     expect(moj.Helpers.Blocks.Base).toBeDefined();
     expect(moj.Helpers.Blocks.FeeBlock).toBeDefined();
     expect(moj.Helpers.Blocks.FeeBlockCalculator).toBeDefined();
   });
 
-  describe('Methods', function() {
-    describe('...addCommas', function() {
-      it('should format the numbers correctly', function() {
+  describe('Methods', function () {
+    describe('...addCommas', function () {
+      it('should format the numbers correctly', function () {
         var expected = {
           0: '0.01',
           1: '0.11',
@@ -20,19 +20,19 @@ describe('Helpers.Blocks.js', function() {
           7: '111,111,111.11'
         };
 
-        ['0.01', '0.11', '1.11', '11.11', '111.11', '1111.11', '11111.11', '111111111.11'].forEach(function(val, idx) {
+        ['0.01', '0.11', '1.11', '11.11', '111.11', '1111.11', '11111.11', '111111111.11'].forEach(function (val, idx) {
           expect(expected[idx]).toBe(moj.Helpers.Blocks.addCommas(val));
         });
       });
     });
   });
 
-  describe('Instances', function() {
+  describe('Instances', function () {
     var instance;
-    beforeEach(function() {});
+    beforeEach(function () {});
 
-    describe('Base', function() {
-      it('should have defaults set', function() {
+    describe('Base', function () {
+      it('should have defaults set', function () {
         instance = new moj.Helpers.Blocks.Base();
         expect(instance.config).toEqual({
           type: '_Base',
@@ -43,7 +43,7 @@ describe('Helpers.Blocks.js', function() {
         });
       });
 
-      it('should take an `options` object and overide', function() {
+      it('should take an `options` object and overide', function () {
         instance = new moj.Helpers.Blocks.Base({
           type: 'TYPE',
           vatfactor: 99,
@@ -58,7 +58,7 @@ describe('Helpers.Blocks.js', function() {
         });
       });
 
-      it('should cache referances to the DOM element', function() {
+      it('should cache referances to the DOM element', function () {
         var fixtureDom = ['<div class="js-block fx-do-init">', '<span>hello</span>', '</div>'].join('');
         $('body').append(fixtureDom);
         instance = new moj.Helpers.Blocks.Base({
@@ -70,9 +70,9 @@ describe('Helpers.Blocks.js', function() {
         $('.js-block').remove();
       });
 
-      describe('Methods', function() {
-        describe('...getConfig', function() {
-          it('should return the correct `this.config` prop', function() {
+      describe('Methods', function () {
+        describe('...getConfig', function () {
+          it('should return the correct `this.config` prop', function () {
             instance = new moj.Helpers.Blocks.Base({
               some: 'thing'
             });
@@ -81,15 +81,15 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...updateTotals', function() {
-          it('should return a info message', function() {
+        describe('...updateTotals', function () {
+          it('should return a info message', function () {
             instance = new moj.Helpers.Blocks.Base();
             expect(instance.updateTotals()).toBe('This method needs an override');
           });
         });
 
-        describe('...isVisible', function() {
-          it('should correctly return the `isVisible` status', function() {
+        describe('...isVisible', function () {
+          it('should correctly return the `isVisible` status', function () {
             var fixtureDom = [
               '<div class="js-block fx-do-init">',
               '<span class="rate">rate</span>',
@@ -109,8 +109,8 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...applyVat', function() {
-          it('should not apply 20% VAT by default', function() {
+        describe('...applyVat', function () {
+          it('should not apply 20% VAT by default', function () {
             instance = new moj.Helpers.Blocks.Base();
             instance.totals = {
               vat: 0,
@@ -120,7 +120,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.totals.vat).toBe(0);
           });
 
-          it('should not apply VAT if `autoVAT` is false', function() {
+          it('should not apply VAT if `autoVAT` is false', function () {
             instance = new moj.Helpers.Blocks.Base({
               autoVAT: false
             });
@@ -132,7 +132,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.totals.vat).toBe(0);
           });
 
-          it('should use a configurable `config.vatfactor`', function() {
+          it('should use a configurable `config.vatfactor`', function () {
             instance = new moj.Helpers.Blocks.Base({
               vatfactor: 0.5,
               autoVAT: true
@@ -146,8 +146,8 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...getVal', function() {
-          beforeEach(function() {
+        describe('...getVal', function () {
+          beforeEach(function () {
             var fixtureDom = [
               '<div class="js-block fx-do-init">',
               '<input class="rate" value="22.22"/>',
@@ -161,23 +161,23 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          afterEach(function() {
+          afterEach(function () {
             $('.js-block').remove();
           });
 
-          it('should return the input value given a selector', function() {
+          it('should return the input value given a selector', function () {
             expect(instance.getVal('.rate')).toBe(22.22);
             expect(instance.getVal('.amount')).toBe(33.33);
           });
 
-          it('should return 0 if no value is found', function() {
+          it('should return 0 if no value is found', function () {
             $('.js-block').find('.amount').remove();
             expect(instance.getVal('.amount')).toBe(0);
           });
         });
 
-        describe('...getDataVal', function() {
-          beforeEach(function() {
+        describe('...getDataVal', function () {
+          beforeEach(function () {
             var fixtureDom = [
               '<div class="js-block fx-do-init">',
               '<input class="total" data-total="44.44" value="44.44"/>',
@@ -190,23 +190,23 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          afterEach(function() {
+          afterEach(function () {
             $('.js-block').remove();
           });
 
-          it('should return the input value given a selector', function() {
+          it('should return the input value given a selector', function () {
             expect(instance.getDataVal('.total', 'total')).toBe(44.44);
           });
 
-          it('should return `false` if no value is found', function() {
+          it('should return `false` if no value is found', function () {
             $('.js-block').find('.total').remove();
             expect(instance.getDataVal('.total', 'total')).toBe(false);
           });
         });
 
         // TO DO
-        describe('...setState', function() {
-          beforeEach(function() {
+        describe('...setState', function () {
+          beforeEach(function () {
             var fixtureDom = [
               '<div class="js-block fx-do-init">',
               '<input class="total" data-total="44.44" value="44.44"/>',
@@ -219,19 +219,19 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          afterEach(function() {
+          afterEach(function () {
             $('.js-block').remove();
           });
 
-          it('should throw an error if no element is found', function() {
+          it('should throw an error if no element is found', function () {
 
-            expect(function() {
+            expect(function () {
               instance.setState('.tal', true);
             }).toThrowError('Selector did not return an element: .tal');
 
           });
 
-          it('should set the visibility of the selector', function() {
+          it('should set the visibility of the selector', function () {
             instance.setState('.total', true);
             expect(instance.$el.find('.total:visible').length).toEqual(1);
 
@@ -240,8 +240,8 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...setVal', function() {
-          beforeEach(function() {
+        describe('...setVal', function () {
+          beforeEach(function () {
             var fixtureDom = [
               '<div class="js-block fx-do-init">',
               '<input class="total" data-total="44.44" value="44.44"/>',
@@ -254,26 +254,26 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          afterEach(function() {
+          afterEach(function () {
             $('.js-block').remove();
           });
 
-          it('should throw an error if no element is found', function() {
+          it('should throw an error if no element is found', function () {
 
-            expect(function() {
+            expect(function () {
               instance.setVal('.tal', 83.333339);
             }).toThrowError('Selector did not return an element: .tal');
 
           });
 
-          it('should set the value of the selector', function() {
+          it('should set the value of the selector', function () {
             instance.setVal('.total', 83.333339);
             expect(instance.$el.find('.total').val()).toEqual('83.333339');
           });
         });
 
-        describe('...setNumber', function() {
-          beforeEach(function() {
+        describe('...setNumber', function () {
+          beforeEach(function () {
             var fixtureDom = [
               '<div class="js-block fx-do-init">',
               '<input class="total" data-total="44.44" value="44.44"/>',
@@ -286,11 +286,11 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          afterEach(function() {
+          afterEach(function () {
             $('.js-block').remove();
           });
 
-          it('should set the value of the selector', function() {
+          it('should set the value of the selector', function () {
             instance.setNumber('.total', 83.333339);
             expect(instance.$el.find('.total').val()).toEqual('83.33');
           });
@@ -298,8 +298,8 @@ describe('Helpers.Blocks.js', function() {
       });
     });
 
-    describe('FeeBlock', function() {
-      it('should apply Base Methods and set config props on the instance', function() {
+    describe('FeeBlock', function () {
+      it('should apply Base Methods and set config props on the instance', function () {
         var fixtureDom = [
           '<div class="js-block fx-do-init">',
           '</div>'
@@ -315,9 +315,9 @@ describe('Helpers.Blocks.js', function() {
         $('.js-block').remove();
       });
 
-      describe('Methods', function() {
+      describe('Methods', function () {
         var fixtureDom;
-        beforeEach(function() {
+        beforeEach(function () {
           fixtureDom = [
             '<div class="js-block fx-do-init">',
             '<input class="quantity" value="11.11"/>',
@@ -334,40 +334,40 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        afterEach(function() {
+        afterEach(function () {
           $('.js-block').remove();
         });
 
-        describe('...init', function() {
-          it('should call `this.bindEvents`', function() {
+        describe('...init', function () {
+          it('should call `this.bindEvents`', function () {
             spyOn(instance, 'bindEvents');
             instance.init();
             expect(instance.bindEvents).toHaveBeenCalled();
           });
 
-          it('should call `this.bindRecalculate`', function() {
+          it('should call `this.bindRecalculate`', function () {
             spyOn(instance, 'bindRecalculate');
             instance.init();
             expect(instance.bindRecalculate).toHaveBeenCalled();
           });
         });
 
-        describe('...bindEvents', function() {
-          it('should call `this.bindRecalculate`', function() {
+        describe('...bindEvents', function () {
+          it('should call `this.bindRecalculate`', function () {
             spyOn(instance, 'bindRecalculate');
             instance.init();
             expect(instance.bindRecalculate).toHaveBeenCalled();
           });
         });
 
-        describe('...bindRecalculate', function() {
-          it('should bind a change event on specific elements', function() {
+        describe('...bindRecalculate', function () {
+          it('should bind a change event on specific elements', function () {
             spyOn(instance.$el, 'on');
             instance.bindRecalculate();
             expect(instance.$el.on).toHaveBeenCalledWith('change keyup', '.quantity, .rate, .amount, .vat, .total', jasmine.any(Function));
           });
 
-          it('should trigger the `recalculate` event when `change` is fired', function() {
+          it('should trigger the `recalculate` event when `change` is fired', function () {
             spyOn(instance.$el, 'trigger');
             instance.bindRecalculate();
             instance.$el.find('.rate').trigger('change');
@@ -375,15 +375,15 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...reload', function() {
-          it('should call `updateTotals`', function() {
+        describe('...reload', function () {
+          it('should call `updateTotals`', function () {
             spyOn(instance, 'updateTotals');
             instance.reload();
 
             expect(instance.updateTotals).toHaveBeenCalled();
           });
 
-          it('should call `applyVat`', function() {
+          it('should call `applyVat`', function () {
             spyOn(instance, 'applyVat');
             instance.reload();
 
@@ -391,9 +391,9 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...setTotals', function() {
+        describe('...setTotals', function () {
 
-          it('should return an updated `this.totals` object', function() {
+          it('should return an updated `this.totals` object', function () {
             instance.$el.find('.rate').val('222.22');
             instance.$el.find('.amount').val('333.33');
             instance.$el.find('.total').data('total', '444.44');
@@ -409,7 +409,7 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          it('should handle missing `data-total` on the element', function() {
+          it('should handle missing `data-total` on the element', function () {
             instance.$el.find('.rate').val('222.22');
             instance.$el.find('.amount').val('333.33');
             instance.$el.find('.total').remove();
@@ -428,18 +428,18 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...updateTotals', function() {
+        describe('...updateTotals', function () {
           var called = false;
 
-          it('should call `this.isVisible`', function() {
-            instance.isVisible = function() {
+          it('should call `this.isVisible`', function () {
+            instance.isVisible = function () {
               called = true;
             };
             instance.updateTotals();
             expect(called).toBe(true);
           });
 
-          it('should return the current `this.totals` when element is hidden', function() {
+          it('should return the current `this.totals` when element is hidden', function () {
             instance.totals = {
               current: 'total'
             };
@@ -449,7 +449,7 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          it('should call `this.setTotals` when `this.isVisible` returns true', function() {
+          it('should call `this.setTotals` when `this.isVisible` returns true', function () {
             instance.totals = {
               current: 'total'
             };
@@ -466,8 +466,8 @@ describe('Helpers.Blocks.js', function() {
       });
     });
 
-    describe('FeeBlockCalculator', function() {
-      it('should apply Base Methods and set config props on the instance', function() {
+    describe('FeeBlockCalculator', function () {
+      it('should apply Base Methods and set config props on the instance', function () {
         var fixtureDom = [
           '<div class="js-block fx-do-init">',
           '</div>'
@@ -485,9 +485,9 @@ describe('Helpers.Blocks.js', function() {
         $('.js-block').remove();
       });
 
-      describe('Methods', function() {
+      describe('Methods', function () {
         var fixtureDom;
-        beforeEach(function() {
+        beforeEach(function () {
           fixtureDom = [
             '<div class="js-block fx-do-init">',
             '<input class="quantity" value="11.11"/>',
@@ -504,28 +504,28 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        afterEach(function() {
+        afterEach(function () {
           $('.js-block').remove();
         });
 
-        describe('...init', function() {
-          it('should call `this.bindRender`', function() {
+        describe('...init', function () {
+          it('should call `this.bindRender`', function () {
             spyOn(instance, 'bindRender');
             instance.init();
             expect(instance.bindRender).toHaveBeenCalled();
           });
         });
 
-        describe('...render', function() {
-          it('should update the view correctly', function() {
+        describe('...render', function () {
+          it('should update the view correctly', function () {
             instance.totals.total = 1234567.89;
             instance.render();
             expect(instance.$el.find('.total').data('total')).toBe(1234567.89);
           });
         });
 
-        describe('...setTotals', function() {
-          it('should set `this.totals` correctly', function() {
+        describe('...setTotals', function () {
+          it('should set `this.totals` correctly', function () {
             instance.totals = {
               quantity: 'changeme',
               rate: 'changeme',
@@ -545,35 +545,35 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...bindRender', function() {
-          it('should bind a change event on specific elements', function() {
+        describe('...bindRender', function () {
+          it('should bind a change event on specific elements', function () {
             spyOn(instance.$el, 'on');
             instance.bindRender();
             expect(instance.$el.on).toHaveBeenCalledWith('change keyup', '.quantity, .rate', jasmine.any(Function));
           });
 
-          it('should call `this.updateTotals` when `change` is fired', function() {
+          it('should call `this.updateTotals` when `change` is fired', function () {
             spyOn(instance, 'updateTotals');
             instance.bindRender();
             instance.$el.find('.rate').trigger('change');
             expect(instance.updateTotals).toHaveBeenCalled();
           });
 
-          it('should call `this.updateTotals` when `keyup` is fired', function() {
+          it('should call `this.updateTotals` when `keyup` is fired', function () {
             spyOn(instance, 'updateTotals');
             instance.bindRender();
             instance.$el.find('.rate').trigger('keyup');
             expect(instance.updateTotals).toHaveBeenCalled();
           });
 
-          it('should call `this.render` when `change` is fired', function() {
+          it('should call `this.render` when `change` is fired', function () {
             spyOn(instance, 'render');
             instance.bindRender();
             instance.$el.find('.rate').trigger('change');
             expect(instance.render).toHaveBeenCalled();
           });
 
-          it('should call `this.render` when `keyup` is fired', function() {
+          it('should call `this.render` when `keyup` is fired', function () {
             spyOn(instance, 'render');
             instance.bindRender();
             instance.$el.find('.rate').trigger('keyup');
@@ -583,13 +583,13 @@ describe('Helpers.Blocks.js', function() {
       });
     });
 
-    describe('ExpenseBlock', function() {
+    describe('ExpenseBlock', function () {
 
-      describe('Defaults', function() {
+      describe('Defaults', function () {
         var fixtureDom;
         var instance;
 
-        beforeEach(function() {
+        beforeEach(function () {
           fixtureDom = [
             '<div class="js-block fx-do-init">',
             '</div>'
@@ -603,16 +603,16 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        afterEach(function() {
+        afterEach(function () {
           $('.js-block').remove();
         });
 
-        it('should apply Base Methods and set config props on the instance', function() {
+        it('should apply Base Methods and set config props on the instance', function () {
           expect(instance.getConfig).toBeDefined();
           expect(instance.getConfig('type')).toEqual('ExpenseBlock');
         });
 
-        it('should have `this.stateLookup` defined', function() {
+        it('should have `this.stateLookup` defined', function () {
           expect(instance.stateLookup).toEqual({
             "vatAmount": ".fx-travel-vat-amount",
             "reason": ".fx-travel-reason",
@@ -627,7 +627,7 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        it('should have `this.defaultstate` defined', function() {
+        it('should have `this.defaultstate` defined', function () {
           expect(instance.defaultstate).toEqual({
             "mileage": false,
             "date": false,
@@ -641,7 +641,7 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        it('should have `this.expenseReasons` defined', function() {
+        it('should have `this.expenseReasons` defined', function () {
           expect(instance.expenseReasons).toEqual({
             "A": [{
               "id": 1,
@@ -718,9 +718,9 @@ describe('Helpers.Blocks.js', function() {
         });
       });
 
-      describe('Methods', function() {
+      describe('Methods', function () {
         var fixtureDom;
-        beforeEach(function() {
+        beforeEach(function () {
           fixtureDom = [
             '<div class="js-block fx-do-init">',
             '<p class="fx-general-errors" style="display: none;"><span></span></p>',
@@ -773,22 +773,22 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        afterEach(function() {
+        afterEach(function () {
           $('#claim-form').remove();
         });
 
-        describe('...init', function() {
-          it('should call `this.bindEvents`', function() {
+        describe('...init', function () {
+          it('should call `this.bindEvents`', function () {
             spyOn(instance, 'bindEvents');
             instance.init();
             expect(instance.bindEvents).toHaveBeenCalled();
           });
-          it('should call `this.loadCurrentState`', function() {
+          it('should call `this.loadCurrentState`', function () {
             spyOn(instance, 'loadCurrentState');
             instance.init();
             expect(instance.loadCurrentState).toHaveBeenCalled();
           });
-          it('should update `this.config.fn`', function() {
+          it('should update `this.config.fn`', function () {
             spyOn(instance, 'bindEvents');
             spyOn(instance, 'loadCurrentState');
 
@@ -798,22 +798,22 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...bindEvents', function() {
-          it('should call `this.bindRecalculate`', function() {
+        describe('...bindEvents', function () {
+          it('should call `this.bindRecalculate`', function () {
             spyOn(instance, 'bindRecalculate');
             instance.init();
             expect(instance.bindRecalculate).toHaveBeenCalled();
           });
 
-          it('should call `this.bindListners`', function() {
+          it('should call `this.bindListners`', function () {
             spyOn(instance, 'bindListners');
             instance.init();
             expect(instance.bindListners).toHaveBeenCalled();
           });
         });
 
-        describe('...bindListners', function() {
-          it('expense type: should bind change listner', function() {
+        describe('...bindListners', function () {
+          it('expense type: should bind change listner', function () {
             var selector = '.fx-travel-expense-type select';
             var spyEvent = spyOnEvent(selector, 'change');
 
@@ -823,7 +823,7 @@ describe('Helpers.Blocks.js', function() {
             expect(spyEvent).toHaveBeenTriggered();
           });
 
-          it('expense type: should handle change event', function() {
+          it('expense type: should handle change event', function () {
             var selector = '.fx-travel-expense-type select';
             instance.bindListners();
             spyOn(instance, 'statemanager');
@@ -832,7 +832,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.statemanager).toHaveBeenCalledWith(selector);
           });
 
-          it('travel reason: should bind change listner', function() {
+          it('travel reason: should bind change listner', function () {
             var selector = '.fx-travel-reason select:last';
             var spyEvent = spyOnEvent(selector, 'change');
 
@@ -842,7 +842,7 @@ describe('Helpers.Blocks.js', function() {
             expect(spyEvent).toHaveBeenTriggered();
           });
 
-          it('travel reason: should handle change event', function() {
+          it('travel reason: should handle change event', function () {
             var selector = '.fx-travel-reason select:last';
             spyOn(instance, 'setVal');
             spyOn(instance, 'setLocationElement');
@@ -856,7 +856,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.$el.find('.fx-travel-reason-other').is(':visible')).toBe(false);
           });
 
-          it('travel reason: should call `this.setVal` passing params', function() {
+          it('travel reason: should call `this.setVal` passing params', function () {
             var selector = '.fx-travel-reason select:last';
             spyOn(instance, 'setVal');
             spyOn(instance, 'setState');
@@ -872,7 +872,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.setVal).toHaveBeenCalledWith('.fx-location-type', 'test-location');
           });
 
-          it('travel reason: should call `this.setState` passing params', function() {
+          it('travel reason: should call `this.setState` passing params', function () {
             var selector = '.fx-travel-reason select:last';
             spyOn(instance, 'setVal');
             spyOn(instance, 'setState');
@@ -887,7 +887,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.setState).toHaveBeenCalledWith('.fx-travel-reason-other', false);
           });
 
-          it('travel reason: should call `this.setLocationElement` passing params', function() {
+          it('travel reason: should call `this.setLocationElement` passing params', function () {
             var selector = '.fx-travel-reason select:last';
             spyOn(instance, 'setVal');
             spyOn(instance, 'setState');
@@ -907,7 +907,7 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          it('establishment location: should bind change listner', function() {
+          it('establishment location: should bind change listner', function () {
             var selector = '.fx-establishment-select select:last';
             var spyEvent = spyOnEvent(selector, 'change');
 
@@ -917,7 +917,7 @@ describe('Helpers.Blocks.js', function() {
             expect(spyEvent).toHaveBeenTriggered();
           });
 
-          it('establishment location: should set the `.fx-location-model`', function() {
+          it('establishment location: should set the `.fx-location-model`', function () {
             var selector = '.fx-establishment-select select:last';
 
             instance.bindListners();
@@ -926,7 +926,7 @@ describe('Helpers.Blocks.js', function() {
             expect($('.fx-location-model').val()).toEqual('establishment selected');
           });
 
-          it('establishment location: should call `this.getDistance` if feature is enabled', function() {
+          it('establishment location: should call `this.getDistance` if feature is enabled', function () {
             var deferred = $.Deferred();
             spyOn(instance, 'getDistance').and.returnValue(deferred.promise());
 
@@ -942,7 +942,7 @@ describe('Helpers.Blocks.js', function() {
             });
           });
 
-          it('net amount: should bind keyup listner', function() {
+          it('net amount: should bind keyup listner', function () {
             var selector = '.fx-travel-net-amount input';
             var spyEvent = spyOnEvent(selector, 'keyup');
 
@@ -952,7 +952,7 @@ describe('Helpers.Blocks.js', function() {
             expect(spyEvent).toHaveBeenTriggered();
           });
 
-          it('net amount: should update vat amount on key up', function() {
+          it('net amount: should update vat amount on key up', function () {
             var selector = '.fx-travel-net-amount input';
             spyOn(instance, 'setNumber');
 
@@ -970,18 +970,18 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...setLocationElement', function() {
-          it('should exist as a function', function() {
+        describe('...setLocationElement', function () {
+          it('should exist as a function', function () {
             expect(instance.setLocationElement).toEqual(jasmine.any(Function));
           });
 
-          it('should return an error if no params supplied', function() {
-            expect(function() {
+          it('should return an error if no params supplied', function () {
+            expect(function () {
               instance.setLocationElement();
             }).toThrowError('Missing param: obj, cannot build element');
           });
 
-          it('should call `this.attachSelectWithOptions` if param.locationType is supplied', function() {
+          it('should call `this.attachSelectWithOptions` if param.locationType is supplied', function () {
             spyOn(instance, 'attachSelectWithOptions');
             instance.setLocationElement({
               locationType: 'not empty'
@@ -989,7 +989,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.attachSelectWithOptions).toHaveBeenCalledWith('not empty', 'sample');
           });
 
-          it('should call `this.attachSelectWithOptions` with param', function() {
+          it('should call `this.attachSelectWithOptions` with param', function () {
             spyOn(instance, 'attachSelectWithOptions');
             instance.$el.find('.fx-location-model').val('');
             instance.setLocationElement({
@@ -998,7 +998,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.attachSelectWithOptions).toHaveBeenCalledWith('not empty', '');
           });
 
-          it('should call `this.displayLocationInput` ', function() {
+          it('should call `this.displayLocationInput` ', function () {
             spyOn(instance, 'displayLocationInput');
             instance.$el.find('.fx-location-model').val('');
             instance.setLocationElement({
@@ -1008,8 +1008,8 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...updateMileageElements', function() {
-          it('...should calculate for 25p', function() {
+        describe('...updateMileageElements', function () {
+          it('...should calculate for 25p', function () {
             instance.init();
 
             // API success callback
@@ -1030,7 +1030,7 @@ describe('Helpers.Blocks.js', function() {
 
           });
 
-          it('...should calculate for 45p', function() {
+          it('...should calculate for 45p', function () {
             instance.init();
 
             // API success callback
@@ -1050,7 +1050,7 @@ describe('Helpers.Blocks.js', function() {
             expect(instance.$el.find('.fx-travel-vat-amount input').val()).toEqual('');
           });
 
-          it('...should calculate for 20p', function() {
+          it('...should calculate for 20p', function () {
             instance.init();
 
             // API success callback
@@ -1072,15 +1072,15 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...getDistance', function() {
-          it('should return the id and augmented distance object...', function() {
+        describe('...getDistance', function () {
+          it('should return the id and augmented distance object...', function () {
             var deferred = $.Deferred();
             spyOn(moj.Helpers.API.Distance, 'query').and.returnValue(deferred.promise());
             instance.$el.find('#mileage_rate_id_1').prop('checked', true);
             instance.getDistance({
               claimid: 2,
               destination: "POSTCODE"
-            }).then(function(number, result) {
+            }).then(function (number, result) {
               expect(moj.Helpers.API.Distance.query).toHaveBeenCalledWith({
                 claimid: 2,
                 destination: 'POSTCODE'
@@ -1098,7 +1098,7 @@ describe('Helpers.Blocks.js', function() {
               distance: 204993
             });
           });
-          it('should populate and return an error ...', function() {
+          it('should populate and return an error ...', function () {
             var deferred = $.Deferred();
             spyOn(moj.Helpers.API.Distance, 'query').and.returnValue(deferred.promise());
             instance.$el.find('#mileage_rate_id_1').prop('checked', true);
@@ -1106,7 +1106,7 @@ describe('Helpers.Blocks.js', function() {
             instance.getDistance({
               claimid: 2,
               destination: "POSTCODE"
-            }).then(undefined, function(result) {
+            }).then(undefined, function (result) {
               expect(moj.Helpers.API.Distance.query).toHaveBeenCalledWith({
                 claimid: 2,
                 destination: 'POSTCODE'
@@ -1122,8 +1122,8 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...displayLocationInput', function() {
-          it('should update the view correctly', function() {
+        describe('...displayLocationInput', function () {
+          it('should update the view correctly', function () {
             instance.init();
             instance.displayLocationInput();
             expect(instance.$el.find('.fx-travel-location label:first').text()).toEqual('Destination');
@@ -1132,16 +1132,16 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...getRateId', function() {
-          it('...should return the correct rateId', function() {
+        describe('...getRateId', function () {
+          it('...should return the correct rateId', function () {
             instance.init();
             instance.$el.find('.fx-travel-mileage input[type=radio]:last').prop('checked', true);
             expect(instance.getRateId()).toEqual('2');
           });
         });
 
-        describe('...viewErrorHandler', function() {
-          it('...should set the correct view state', function() {
+        describe('...viewErrorHandler', function () {
+          it('...should set the correct view state', function () {
             instance.init();
             instance.viewErrorHandler('This is the message');
             expect(instance.$el.find('.fx-general-errors span').text()).toEqual('This is the message');
@@ -1149,21 +1149,21 @@ describe('Helpers.Blocks.js', function() {
           });
         });
 
-        describe('...attachSelectWithOptions', function() {
+        describe('...attachSelectWithOptions', function () {
           var optionsFixture = ['<option value="">Please select</option>',
             '<option value="135" data-postcode="SY23 1AS">Aberystwyth Justice Centre</option>',
             '<option value="136" selected="" data-postcode="GU11 1NY">Aldershot Magistrates\' Court</option>',
             '<option value="137" data-postcode="HP6 5AJ">Amersham Law Courts</option>',
             '<option value="139" data-postcode="HP21 7QZ">Aylesbury Magistrates\' Court and Family Court</option>")'
           ];
-          it('should return an error if no locationType', function() {
+          it('should return an error if no locationType', function () {
             instance.init();
-            expect(function() {
+            expect(function () {
               instance.attachSelectWithOptions();
             }).toThrowError('Missing param: locationType');
           });
 
-          it('should call the Establishments API with the correct params ', function() {
+          it('should call the Establishments API with the correct params ', function () {
             var deferred = $.Deferred();
             spyOn(moj.Helpers.API.Establishments, 'getAsSelectWithOptions').and.returnValue(deferred.promise());
 
@@ -1174,7 +1174,7 @@ describe('Helpers.Blocks.js', function() {
             });
 
           });
-          it('should update the view correctly', function() {
+          it('should update the view correctly', function () {
             var deferred = $.Deferred();
             spyOn(moj.Helpers.API.Establishments, 'getAsSelectWithOptions').and.returnValue(deferred.promise());
             expect(instance.$el.find('.fx-establishment-select').is(':visible')).toEqual(false);

--- a/spec/javascripts/modules-amountAssessed_spec.js
+++ b/spec/javascripts/modules-amountAssessed_spec.js
@@ -1,4 +1,4 @@
-describe("Modules.AmountAssessedBlock.js", function() {
+describe("Modules.AmountAssessedBlock.js", function () {
   var domFixture = $('<div class="main" />');
   var view = [
     '<div class="fx-assesment-hook">',
@@ -26,7 +26,7 @@ describe("Modules.AmountAssessedBlock.js", function() {
   ].join('');
 
 
-  beforeEach(function() {
+  beforeEach(function () {
     domFixture.append($(view));
     $('body').append(domFixture);
 
@@ -35,12 +35,12 @@ describe("Modules.AmountAssessedBlock.js", function() {
     moj.Modules.AmountAssessed.init();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     domFixture.empty();
   });
 
-  describe('Defaults', function() {
-    it('should have `this.config` defined', function() {
+  describe('Defaults', function () {
+    it('should have `this.config` defined', function () {
       var block = moj.Modules.AmountAssessed.blocks[0];
       expect(block.config).toEqual({
         hook: '.fx-assesment-hook',
@@ -56,7 +56,7 @@ describe("Modules.AmountAssessedBlock.js", function() {
       });
     });
 
-    it('should have `this.states` defined', function() {
+    it('should have `this.states` defined', function () {
       var block = moj.Modules.AmountAssessed.blocks[0];
       expect(block.states).toEqual({
         rejected: {
@@ -83,12 +83,12 @@ describe("Modules.AmountAssessedBlock.js", function() {
     });
   });
 
-  describe('Methods..', function() {
-    describe('...slider', function() {
-      it('should call correct $.fn', function(){
+  describe('Methods..', function () {
+    describe('...slider', function () {
+      it('should call correct $.fn', function () {
         var block = moj.Modules.AmountAssessed.blocks[0];
         var x = false;
-        $.fn.slideUp = function(){
+        $.fn.addClass = function () {
           x = true;
         }
         expect(x).toEqual(false)
@@ -100,20 +100,20 @@ describe("Modules.AmountAssessedBlock.js", function() {
   });
 });
 
-describe("Modules.AmountAssessed.js", function() {
-  beforeEach(function() {
+describe("Modules.AmountAssessed.js", function () {
+  beforeEach(function () {
     // reset to default state
     moj.Modules.AmountAssessed.init();
   });
 
-  afterEach(function() {});
+  afterEach(function () {});
 
-  describe('Defaults', function() {
-    it('should have a `blocks` array defined', function() {
+  describe('Defaults', function () {
+    it('should have a `blocks` array defined', function () {
       expect(moj.Modules.AmountAssessed.blocks).toEqual(jasmine.any(Array));
     });
 
-    it('should call `moj.Modules.AmountAssessedBlock` on init', function() {
+    it('should call `moj.Modules.AmountAssessedBlock` on init', function () {
       spyOn(moj.Modules, 'AmountAssessedBlock');
       moj.Modules.AmountAssessed.init();
       expect(moj.Modules.AmountAssessedBlock).toHaveBeenCalled();


### PR DESCRIPTION
#### What
Refactor CCCD stylesheets by removing inline css styles.

#### Ticket
[Stylesheet refactoring, inline styles](https://dsdmoj.atlassian.net/browse/CBO-992)

#### Why
The separation of concerns, programming fundamental, to separate css from the view.

The majority of inline css was based on jquery `show()` and `hide()` methods, the PR replaces those methods with `removeClass()` and `addClass()` 
