### PR TITLE
Set explicit response js and all

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,7 +13,9 @@ class PagesController < ApplicationController
   def servicedown
     respond_to do |format|
       format.html { render :servicedown, layout: 'basic', status: region_specific_service_unavailable }
-      format.json { render json: [{ error: 'Temporarily unavailable' }], status: 503 }
+      format.json { render json: [{ error: 'Service temporarily unavailable' }], status: 503 }
+      format.js { render json: [{ error: 'Service temporarily unavailable' }], status: 503, content_type: 'text/json' }
+      format.all { render plain: 'error: Service temporarily unavailable', status: 503, content_type: 'text/plain' }
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,7 +14,7 @@ class PagesController < ApplicationController
     respond_to do |format|
       format.html { render :servicedown, layout: 'basic', status: region_specific_service_unavailable }
       format.json { render json: [{ error: 'Service temporarily unavailable' }], status: 503 }
-      format.js { render json: [{ error: 'Service temporarily unavailable' }], status: 503, content_type: 'text/json' }
+      format.js { render json: [{ error: 'Service temporarily unavailable' }], status: 503, content_type: 'application/json' }
       format.all { render plain: 'error: Service temporarily unavailable', status: 503, content_type: 'text/plain' }
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,10 +12,23 @@ class PagesController < ApplicationController
 
   def servicedown
     respond_to do |format|
-      format.html { render :servicedown, layout: 'basic', status: region_specific_service_unavailable }
-      format.json { render json: [{ error: 'Service temporarily unavailable' }], status: 503 }
-      format.js { render json: [{ error: 'Service temporarily unavailable' }], status: 503, content_type: 'application/json' }
-      format.all { render plain: 'error: Service temporarily unavailable', status: 503, content_type: 'text/plain' }
+      format.html do
+        render :servicedown, layout: 'basic', status: region_specific_service_unavailable
+      end
+      format.json do
+        render  json:
+                [{ error: 'Service temporarily unavailable' }],
+                status: 503
+      end
+      format.js do
+        render  json:
+                [{ error: 'Service temporarily unavailable' }],
+                status: 503,
+                content_type: 'application/json'
+      end
+      format.all do
+        render plain: 'error: Service temporarily unavailable', status: 503, content_type: 'text/plain'
+      end
     end
   end
 

--- a/spec/requests/pages/servicedown_spec.rb
+++ b/spec/requests/pages/servicedown_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Servicedown mode', type: :request do
 
   shared_examples 'maintenance json' do
     it { expect(response).to have_http_status :service_unavailable }
+    it { expect(response.content_type).to eql('application/json') }
     it { expect(response.body).to be_json }
     it { expect(response.body).to include_json({error: "Service temporarily unavailable"}.to_json) }
   end

--- a/spec/requests/pages/servicedown_spec.rb
+++ b/spec/requests/pages/servicedown_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe 'Servicedown mode', type: :request do
     it { expect(response.body).to include('planned maintenance') }
   end
 
+  shared_examples 'maintenance json' do
+    it { expect(response).to have_http_status :service_unavailable }
+    it { expect(response.body).to be_json }
+    it { expect(response.body).to include_json({error: "Service temporarily unavailable"}.to_json) }
+  end
+
   context '/ping' do
     before { get '/ping' }
     it { expect(response).to be_ok }
@@ -125,10 +131,32 @@ RSpec.describe 'Servicedown mode', type: :request do
 
     context '/api/case_types' do
       before { get '/api/case_types', params: { api_key: user.persona.provider.api_key, format: :json } }
+      it_behaves_like 'maintenance json'
+    end
+  end
 
+  context 'formatted responses' do
+    before { get '/', params: { format: mime } }
+
+    context 'html' do
+      let(:mime) { :html }
+      it_behaves_like 'maintenance page', status: 200
+    end
+
+    context 'json' do
+      let(:mime) { :json }
+      it_behaves_like 'maintenance json'
+    end
+
+    context 'js' do
+      let(:mime) { :js }
+      it_behaves_like 'maintenance json'
+    end
+
+    context 'all other' do
+      let(:mime) { :axd }
       it { expect(response).to have_http_status :service_unavailable }
-      it { expect(response.body).to be_json }
-      it { expect(response.body).to include_json({error: "Temporarily unavailable"}.to_json) }
+      it { expect(response.body).to include('Service temporarily unavailable') }
     end
   end
 end


### PR DESCRIPTION
#### What
Respond to js with json and unhandled mime types with plain text

#### Why
A neatening up of response for maintenance mode.
Previous maintenance page trial run revealed errors on
sentry resulting from other mime type formats requests.