### PR TITLE
CBO-1024: Refine Zendesk handling of tickets

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -62,6 +62,6 @@ class Feedback
   end
 
   def is_feedback_with_empty_comment?
-    feedback? && comment&.empty?
+    feedback? && comment.to_s.empty?
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -43,9 +43,7 @@ class Feedback
 
   def save
     return false unless valid?
-    # rubocop:disable Style/SafeNavigation
-    ZendeskSender.send!(self) unless comment && comment.empty?
-    # rubocop:enable Style/SafeNavigation
+    ZendeskSender.send!(self) unless is_feedback_with_empty_comment?
     true
   end
 
@@ -61,5 +59,9 @@ class Feedback
 
   def feedback_type_attributes
     FEEDBACK_TYPES[type.to_sym]
+  end
+
+  def is_feedback_with_empty_comment?
+    feedback? && comment.empty?
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -62,6 +62,6 @@ class Feedback
   end
 
   def is_feedback_with_empty_comment?
-    feedback? && comment.empty?
+    feedback? && comment&.empty?
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -43,7 +43,9 @@ class Feedback
 
   def save
     return false unless valid?
-    ZendeskSender.send!(self) unless self.comment&.empty?
+    # rubocop:disable Style/SafeNavigation
+    ZendeskSender.send!(self) unless comment && comment.empty?
+    # rubocop:enable Style/SafeNavigation
     true
   end
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -43,7 +43,7 @@ class Feedback
 
   def save
     return false unless valid?
-    ZendeskSender.send!(self)
+    ZendeskSender.send!(self) unless self.comment&.empty?
     true
   end
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -49,7 +49,19 @@ RSpec.describe Feedback, type: :model do
 
       context 'when valid' do
         it 'creates zendesk ticket and returns true' do
+          expect(ZendeskSender).to receive(:send!)
           expect(subject.save).to eq(true)
+        end
+
+        context 'and the comment is nil' do
+          let(:feedback_params) do
+            params.merge(type: 'feedback', comment: '', rating: '4')
+          end
+
+          it 'does not create a zendesk ticket but still returns true' do
+            expect(ZendeskSender).not_to receive(:send!)
+            expect(subject.save).to eq(true)
+          end
         end
       end
 
@@ -145,6 +157,7 @@ RSpec.describe Feedback, type: :model do
 
       context 'when valid' do
         it 'creates zendesk ticket and returns true' do
+          expect(ZendeskSender).to receive(:send!)
           expect(subject.save).to eq(true)
         end
       end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe Feedback, type: :model do
 
         context 'and the comment is nil' do
           let(:feedback_params) do
+            params.merge(type: 'feedback', comment: nil, rating: '4')
+          end
+
+          it 'does not create a zendesk ticket but still returns true' do
+            expect(ZendeskSender).not_to receive(:send!)
+            expect(subject.save).to eq(true)
+          end
+        end
+
+        context 'and the comment is empty' do
+          let(:feedback_params) do
             params.merge(type: 'feedback', comment: '', rating: '4')
           end
 


### PR DESCRIPTION
#### What
Do not submit to zendesk unless comments included
#### Ticket
[Refine Zendesk handling of tickets](https://dsdmoj.atlassian.net/browse/CBO-1024)
#### Why
The feedback score is now handled by Google Analytics and the empty values simply clutter up the zendesk views
#### How
When creating a feedback, as opposed to bug_report, do not send to zendesk unless comments are included.  
