### PR TITLE
MIGRATION DAY: Turn of maintenance mode on live-1 production permanently

### DIFF
--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: GA_TRACKER_ID
               value: 'UA-37377084-37'
             - name: MAINTENANCE_MODE
-              value: 'true'
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON


### PR DESCRIPTION
#### What
Permanently set prod maintenance mode off in config

#### Why
Currently live-1 prod is in maintenance mode
to prevent access. This can be changed easily
locally by changing the env var `MAINTENANCE_MODE`
to false and applying directly.

This PR is to merge to master after live-1 prod
goes fully live on cutover day.