### PR TITLE
MIGRATION DAY: Switch off downtime warning banner

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,7 +80,7 @@ timed_retention_banner_enabled?: true
 
 # Feature flag to enable or disable the downtime warning
 # If enabled, all users will see it up until "downtime_warning_date"
-downtime_warning_enabled?: true
+downtime_warning_enabled?: false
 downtime_warning_date: <%= Date.new(2019, 11, 20) %>
 
 # Feature flag to enable or disable the scheme filters in the claims list page


### PR DESCRIPTION
#### What
Switch off downtime warning banner

#### Why
Once cutover we can deactivate the warning
banner.

The banner deactivates the day after
the downtime_warning_date anyway, but this
can/should be deployed once we are done with
with cutover to live-1.