### PR TITLE
CBO-770: Add focus state for 'Add another' component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -97,6 +97,8 @@ if (!String.prototype.supplant) {
     moj.Modules.Autocomplete.typeaheadKickoff(insertedSelect);
     moj.Modules.Autocomplete.typeaheadBindEvents(typeaheadWrapper);
     moj.Modules.FeeFieldsDisplay.addFeeChangeEvent(insertedItem);
+
+    $insertedItem.find('.remove_fields:first').focus();
   });
 
   // Basic fees page

--- a/app/assets/javascripts/modules/external_users/claims/DuplicateExpenseCtrl.js
+++ b/app/assets/javascripts/modules/external_users/claims/DuplicateExpenseCtrl.js
@@ -1,6 +1,6 @@
 moj.Modules.DuplicateExpenseCtrl = {
   el: '.mod-expenses',
-  init: function() {
+  init: function () {
     this.$el = $(this.el);
 
     if (this.$el.length) {
@@ -8,16 +8,16 @@ moj.Modules.DuplicateExpenseCtrl = {
     }
   },
 
-  bindEvents: function() {
+  bindEvents: function () {
     var self = this;
 
-    this.$el.on('click', '.fx-duplicate-expense', function() {
+    this.$el.on('click', '.fx-duplicate-expense', function () {
       self.step1();
       // return false to stop the href;
       return false;
     });
 
-    $.subscribe('/step1/complete/', function(e, data) {
+    $.subscribe('/step1/complete/', function (e, data) {
       self.step2(data);
     });
   },
@@ -27,8 +27,8 @@ moj.Modules.DuplicateExpenseCtrl = {
    * publish the data for use
    * @return {[type]} [description]
    */
-  step1: function() {
-    this.mapFormData().then(function(data) {
+  step1: function () {
+    this.mapFormData().then(function (data) {
       $.publish('/step1/complete/', data);
     });
     return this;
@@ -40,7 +40,7 @@ moj.Modules.DuplicateExpenseCtrl = {
    * @param  {Object} data Models for the new section
    * @return {[type]}      [description]
    */
-  step2: function(data) {
+  step2: function (data) {
     this.$el.find('.add_fields').click();
     this.populateNewItem(data);
     return this;
@@ -51,7 +51,7 @@ moj.Modules.DuplicateExpenseCtrl = {
    * values and the change events are fired
    * @param  {Object} data The model for the new section
    */
-  populateNewItem: function(data) {
+  populateNewItem: function (data) {
     var $el = $('.expense-group:last');
     // expense type & travel reasons + other & milage rates
     this.setSelectValue($el, '.fx-travel-expense-type select', data.expense_type_id);
@@ -70,8 +70,8 @@ moj.Modules.DuplicateExpenseCtrl = {
     this.setInputValue($el, '.fx-travel-location input', data.location);
 
     // select the option by the data.location value
-    $el.find('.fx-establishment-select select option').filter(function(idx, el){
-      if($(el).text() == data.location){
+    $el.find('.fx-establishment-select select option').filter(function (idx, el) {
+      if ($(el).text() == data.location) {
         $(el).prop('selected', true);
         return;
       }
@@ -79,17 +79,20 @@ moj.Modules.DuplicateExpenseCtrl = {
 
     this.setRadioValue($el, '.fx-travel-mileage input', data.mileage_rate_id);
 
+    // set focus state on '.remove_fields' within the new section
+    $el.find('.remove_fields:last').focus();
+
     // trigger the side bar to recalculate all totals
     $('#claim-form').trigger('recalculate');
   },
 
-  setRadioValue: function($el, selector, val) {
+  setRadioValue: function ($el, selector, val) {
     if (val) {
       $el.find(selector + '[id$=mileage_rate_id_' + val + ']').prop('checked', true).click();
     }
   },
 
-  setSelectValue: function($el, selector, val, location_type) {
+  setSelectValue: function ($el, selector, val, location_type) {
     if (location_type) {
       $el.find(selector + ' option[data-location-type=' + location_type + ']').prop('selected', true);
       $el.find(selector).trigger('change');
@@ -101,7 +104,7 @@ moj.Modules.DuplicateExpenseCtrl = {
     }
   },
 
-  setInputValue: function($el, selector, val) {
+  setInputValue: function ($el, selector, val) {
     if (val) {
       $el.find(selector).val(val);
     }
@@ -112,7 +115,7 @@ moj.Modules.DuplicateExpenseCtrl = {
    * serialise them into an array
    * @return {Array} Serialised form elements
    */
-  getFormData: function() {
+  getFormData: function () {
     return $('.expense-group:last').find('input,select').serializeArray();
   },
 
@@ -123,7 +126,7 @@ moj.Modules.DuplicateExpenseCtrl = {
    * `<input name="this[is-the][0][modelname]" ../>`
    * @return {String}     the model name
    */
-  getKeyName: function(obj) {
+  getKeyName: function (obj) {
     var str;
     if (obj.name.indexOf('][') === -1) {
       return obj.name;
@@ -137,11 +140,11 @@ moj.Modules.DuplicateExpenseCtrl = {
    * @return {Object}   Key/Value pairs to
    * populate the duplicated expenses
    */
-  mapFormData: function() {
+  mapFormData: function () {
     var deferred = $.Deferred();
     var self = this;
     var data = {};
-    $.map(this.getFormData(), function(obj, idx) {
+    $.map(this.getFormData(), function (obj, idx) {
       var str = self.getKeyName(obj);
       if (obj.value) {
         data[str] = obj.value;
@@ -152,12 +155,12 @@ moj.Modules.DuplicateExpenseCtrl = {
   }
 };
 
-(function($) {
-  $.fn.serializeFormJSON = function() {
+(function ($) {
+  $.fn.serializeFormJSON = function () {
 
     var o = {};
     var a = this.serializeArray();
-    $.each(a, function() {
+    $.each(a, function () {
       if (o[this.name]) {
         if (!o[this.name].push) {
           o[this.name] = [o[this.name]];

--- a/app/assets/javascripts/plugins/jquery.numbered.elements.js
+++ b/app/assets/javascripts/plugins/jquery.numbered.elements.js
@@ -42,8 +42,9 @@
         throw Error('This is an error message');
       }
 
-      $(el).on('cocoon:after-insert', function (e) {
+      $(el).on('cocoon:after-insert', function (e, insertedItem) {
         self.updateNumbers();
+        insertedItem.find('.remove_fields:first').focus();
       });
 
       $(el).on('cocoon:after-remove', function (e) {
@@ -57,7 +58,6 @@
       var items = $(this.settings.wrapper).find(this.settings.item + ':visible');
 
       items.each(function (idx, el) {
-        // $(el).find(action).css('display', 'block');
         $(el).find(action).removeClass('hidden');
         $(el).find(number).text('');
         if (items.length > 1) {


### PR DESCRIPTION
#### What
'Add another' component focus state.

#### Ticket
[DAC accessibility resolution](https://dsdmoj.atlassian.net/browse/CBO-770)

#### Why
The tabbing order and focus state was incorrect when the 'Add another' component is used, this PR sets the focus state on the first available input when a new component is added and thereby resolves the tabbing order.
