### PR TITLE
Modify handling of DI slack messages

### DIFF
--- a/app/services/claims/injection_channel.rb
+++ b/app/services/claims/injection_channel.rb
@@ -2,7 +2,6 @@ module Claims
   class InjectionChannel
     def self.for(claim)
       return 'cccd_development' if claim.nil?
-      return 'cccd-k8s-injection' if Settings.aws&.response_queue&.match?('laa-get-paid')
       claim.agfs? ? 'cccd_ccr_injection' : 'cccd_cclf_injection'
     end
   end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -11,12 +11,7 @@ class InjectionResponseService
     return failure(action: 'run!', uuid: @response['uuid']) unless @claim
 
     injection_attempt
-    # TEMP: always send slack message for live-1 SQS response queue
-    if Settings.aws&.response_queue&.match?('laa-get-paid')
-      slack.send_message!
-    else
-      slack.send_message! unless injection_attempt.notification_can_be_skipped?
-    end
+    slack.send_message! unless injection_attempt.notification_can_be_skipped?
     true
   end
 

--- a/spec/services/claims/injection_channel_spec.rb
+++ b/spec/services/claims/injection_channel_spec.rb
@@ -9,13 +9,6 @@ RSpec.describe Claims::InjectionChannel, type: :service do
     it { is_expected.to eql('cccd_development') }
   end
 
-  context 'when a response_queue name matches live-1 SQS name' do
-    before { allow(Settings.aws).to receive(:response_queue).and_return('laa-get-paid-test-responses-for-cccd') }
-    let(:claim) { create(:litigator_claim) }
-
-    it { is_expected.to eql('cccd-k8s-injection') }
-  end
-
   context 'when claim is for LGFS' do
     let(:claim) { create(:litigator_claim) }
 

--- a/spec/services/injection_response_service_spec.rb
+++ b/spec/services/injection_response_service_spec.rb
@@ -39,89 +39,47 @@ RSpec.describe InjectionResponseService, slack_bot: true do
   describe '#run!' do
     subject(:run!) { irs.run! }
 
-    context 'when not testing kubernetes' do
-      context 'when injection succeeded' do
-        let(:json) { valid_json_on_success }
-        include_examples 'creates injection attempts'
+    context 'when injection succeeded' do
+      let(:json) { valid_json_on_success }
+      include_examples 'creates injection attempts'
 
-        it 'marks injection as succeeded' do
-          run!
-          expect(injection_attempt.succeeded).to be_truthy
-        end
-
-        it 'does not send a slack message' do
-          run!
-          expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).not_to have_been_made
-        end
+      it 'marks injection as succeeded' do
+        run!
+        expect(injection_attempt.succeeded).to be_truthy
       end
 
-      context 'when injection failed' do
-        let(:json) { valid_json_on_failure }
-        include_examples 'creates injection attempts'
-
-        it 'marks injection as failed' do
-          run!
-          expect(injection_attempt.succeeded).to be_falsey
-        end
-
-        it 'sends a slack message' do
-          run!
-          expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made.times(1)
-        end
-
-        it 'adds error messages from the response' do
-          run!
-          expect(injection_attempt.error_messages).to be_present
-          expect(injection_attempt.error_messages).to be_an Array
-          expect(injection_attempt.error_messages).to include("No defendant found for Rep Order Number: '123456432'.","Another injection error.")
-        end
+      it 'does not send a slack message' do
+        run!
+        expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).not_to have_been_made
       end
     end
 
-    context 'when testing kubernetes' do
-      before { allow(Settings.aws).to receive(:response_queue).and_return('laa-get-paid-test-responses-for-cccd') }
+    context 'when injection failed' do
+      let(:json) { valid_json_on_failure }
+      include_examples 'creates injection attempts'
 
-      context 'when injection succeeded' do
-        let(:json) { valid_json_on_success }
-        include_examples 'creates injection attempts'
-
-        it 'marks injection as succeeded' do
-          run!
-          expect(injection_attempt.succeeded).to be_truthy
-        end
-
-        it 'sends a slack message' do
-          run!
-          expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made.times(1)
-        end
+      it 'marks injection as failed' do
+        run!
+        expect(injection_attempt.succeeded).to be_falsey
       end
 
-      context 'when injection failed' do
-        let(:json) { valid_json_on_failure }
-        include_examples 'creates injection attempts'
+      it 'sends a slack message' do
+        run!
+        expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made.times(1)
+      end
 
-        it 'marks injection as failed' do
-          run!
-          expect(injection_attempt.succeeded).to be_falsey
-        end
-
-        it 'sends a slack message' do
-          run!
-          expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).to have_been_made.times(1)
-        end
-
-        it 'adds error messages from the response' do
-          run!
-          expect(injection_attempt.error_messages).to be_present
-          expect(injection_attempt.error_messages).to be_an Array
-          expect(injection_attempt.error_messages).to include("No defendant found for Rep Order Number: '123456432'.","Another injection error.")
-        end
+      it 'adds error messages from the response' do
+        run!
+        expect(injection_attempt.error_messages).to be_present
+        expect(injection_attempt.error_messages).to be_an Array
+        expect(injection_attempt.error_messages).to include("No defendant found for Rep Order Number: '123456432'.","Another injection error.")
       end
 
       context 'with a known, ignorable, error' do
-        let(:error_message) { 'A case already exists for these case details.' }
+        let(:error_message) { '<blahblah>already exist<blahblah>' }
 
         it 'does not send a slack message' do
+          run!
           expect(a_request(:post, "https://hooks.slack.com/services/fake/endpoint")).not_to have_been_made
         end
       end


### PR DESCRIPTION
#### What
Redirect DI slack messages to the
normal channels and filter out success
and ignorable errors

#### Why
To put it back to how it was working
in TD as injection appears to be working
fine via live-1