### PR TITLE
Amend healthcheck httpstatus

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -26,7 +26,7 @@ class HeartbeatController < ApplicationController
       num_claims: Claim::BaseClaim.count
     }
 
-    status = :bad_gateway unless checks.values.all?
+    status = :bad_gateway unless checks.except(:sidekiq_queue).values.all?
     render status: status, json: { checks: checks }
   end
 


### PR DESCRIPTION
Amend failed job healthcheck http status

#### What
Exclude existance of sidekiq deadsets and retrysets from failed healthcheck http status

#### Ticket

[CBO-1063](https://dsdmoj.atlassian.net/browse/CBO-1063)

#### Why
Returning a 502 for Sidekiq deadset and retry set presence
is causing live-1 cluster to intercept at the nginx level and redirect
to the default/generic bad-gateway page.

In addition, the healthcheck is used to tell if the
app is healthy. A single failed job does not
denote the app as unhealthy in any event.

#### How
Exclude unhealthy sidekiq jobs from unhealthy app for the purposes
of healthcheck response. Return 502 only if a possible infrastructure healthcheck fails.
