### PR TITLE
Bump circleCI 2.0 to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,4 @@
-# Ruby CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
-#
-version: 2
+version: 2.1
 
 references:
   _cloud-platform-container: &cloud-platform-container


### PR DESCRIPTION
#### What
Upgrade to circleCI 2.1

#### Why
To enable use of latest syntax and features
(orbs, pipelines, auto-cancel, executors, commands
and parameters).

see [circleCI 2.1 overview](https://discuss.circleci.com/t/circleci-2-1-config-overview/26057) for more.

#### Ticket

[1067](https://dsdmoj.atlassian.net/browse/CBO-1067)