### PR TITLE
Remove references to old prod and TD deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,24 +203,14 @@ You should now commit the cassette to the repo to ensure it is not unneccessaril
 
 ## Maintenance mode
 
-A conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To activate the conditional route you must provide the app server with either MAINTENANCE_MODE=true (kubernetes) or DOCKER_STATE=maintenance (template-deploy). Note that dotenv files cannot be used to set these envvars locally as the config gem (`settings.yml` file) is loaded before dotenv files.
+A conditional catchall routes exists in `routes.rb`. This directs all routes requested to the `pages#servicedown` controller and view. To activate the conditional route you must provide the app server with MAINTENANCE_MODE=true. Note that dotenv files cannot be used to set these envvars locally as the config gem (`settings.yml` file) is loaded before dotenv files.
 
 ```bash
 # activate maintenance mode locally
 MAINTENANCE_MODE=true rails s
 ```
 
-You can deploy the app in maintenance mode for both template-deploy orchestrated environments and kubernetes orchestrated environments:
-
-### Template-deploy maintenance mode
-- build the app using Jenkins as normal.
-- deploy the app (same/any build) to an environment selecting `maintenance` for the task option (jenkins string parameter)
-- to take site out of maintenance redeploy (same/any build) with `none` for the task
-
-Note that this is a quick fix method that leverages templates-deploy pre-existing environment variable `DOCKER_STATE` for purposes it was not intended for.
-
-### kubernetes maintenance mode
-You can switch on maintenance mode by deploying either from your local machine or via circleCI. Either method requires you to amend the `deployment.yaml` file for the relevant environment to add the env var `MAINTENANCE_MODE` with a value `'true'`.
+You can deploy the app in maintenance mode for kubernetes orchestrated environments by deploying either from your local machine or via circleCI. Either method requires you to amend the `deployment.yaml` file for the relevant environment to add the env var `MAINTENANCE_MODE` with a value `'true'`.
 
 example `deployment.yaml` config:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
 
 AWS S3, the **default** document storage mechanism, is stubbed out
 using webmock for all tests, and set to local storage in development mode.
-It is not possible to connect to the s3 buckets from you local machine
-as template-deploy uses AWS access credentials only applied on the server instances.
 
 See `config/aws.yaml` and note that because we use the [config](https://github.com/railsconfig/config) gem, secret settings like `Settings.aws.s3.access` require an envvar `SETTINGS__AWS__S3__ACCESS`.
 
@@ -61,7 +59,7 @@ rails server
 rails server -p 3001 -P /tmp/rails3001.pid
 ```
 
-To import JSON claims, or import via the API, you need to run a multi-threaded server like unicorn on port 3000.  This can be done with the following line, but the BetterErrors page will not work correctly if you get an exceptions.
+You can run a multi-process server like unicorn on port 3000. This can be done with the following line, but the BetterErrors page will not work correctly if you get an exceptions.
 
 ```
 rails server -e devunicorn
@@ -97,12 +95,10 @@ brew bundle
 
 ## Architecture
 
-This app was originally written as a single monolithic application, with the ability to import claims
-via a public API, or JSON uploads (AGFS claims only).  A decision was later taken to split the Caseworker
-off into a separate application, using the API to communicate to the main app.  This has only partially been
-done.  The CaseWorker allocation pages use the API to talk to the main application, rather than access the
-database directly.  In the dev environment, it accesses another server running on port 3001, which is why you
-need to start up the second server.
+This app was originally written as a single monolithic application, with the ability to import claims via a public API.  A decision was later taken to split the Caseworker off into a separate application, using the API to communicate to the main app.  This has only partially been
+done.  
+
+The CaseWorker allocation pages use the API to talk to the main application, rather than access the database directly.  In the local development environment, it accesses another server running on port 3001, which is why you need to start up the second server.
 
 ## Testing
 
@@ -112,7 +108,7 @@ To execute unit tests
 bundle exec rspec
 ```
 
-To execute cucumber test scenarios
+To execute cucumber feature tests
 
 ```
 bundle exec cucumber
@@ -293,6 +289,8 @@ To display the current state of the Sidekiq queues, as a logged in superadmin br
 With your local rails server running you can browse to ```http://localhost:3000/rails/mailers``` to view a list of current email templates
 
 ## Anonymised Database Dumps/restores
+
+*WARNING:* not tested since hosting migration
 
 In order to copy the live database, anonymising all entries, execute the following command:
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(_resource, params = {})
-    if Rails.env.development? || Rails.env.devunicorn? || RailsHost.demo? || RailsHost.dev?
+    if Rails.env.development? || Rails.env.devunicorn? || RailsHost.dev?
       new_user_session_url
     else
       new_feedback_url(params.merge(type: 'feedback'))

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -87,14 +87,6 @@ module TimedTransitions
           error: e.message)
     end
 
-    # NOTE: at time of writing this class is called
-    # by batch_transitioner which is called by rake
-    # task claims::archive_stale which is called
-    # by a cron job defined in the template deploy
-    # repo (see cron.sls) and which logs to /var/log/archive_stale.log
-    # in the nginx container on ONE INSTANCE ONLY of
-    # gamma and staging boxes only ...OMG!
-    #
     def log(level = :info, action:, message:, succeeded:, error: nil)
       LogStuff.send(
         level.to_sym,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,7 +95,7 @@ email_notification_enabled?: true
 # Feature flag to enable maintenance mode
 # If enabled all routes mapped to pages#servicedown on startup
 #
-maintenance_mode_enabled?: <%= ENV.fetch('DOCKER_STATE', nil)&.downcase&.eql?('maintenance') || ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql?('true') %>
+maintenance_mode_enabled?: <%= ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql?('true') %>
 
 feature_flags_enabled?: true
 active_features: []

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -175,7 +175,7 @@ govuk_notify:
     new_external_litigator_admin: 'new_external_litigator_admin_template_uuid'
     unlock_instructions: 'unlock_instructions_template_uuid'
 
-notify_report_errors: <%= ENV["ENV"].in?(%w[api-sandbox demo disaster gamma production]) %>
+notify_report_errors: <%= ENV["ENV"].in?(%w[api-sandbox production]) %>
 
 postcode_regexp: !ruby/regexp '/\A([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})\z/'
 

--- a/db/seeds/disbursement_types.rb
+++ b/db/seeds/disbursement_types.rb
@@ -42,5 +42,5 @@ disbursement_types.each do |row|
   SeedHelper.find_or_create_disbursement_type!(record_id, unique_code, name, deleted_at)
 end
 
-# This is to ensure API Sandbox and Gamma are in sync regarding the IDs
+# This is to ensure api-sandbox and production are in sync regarding the IDs
 DisbursementType.connection.execute("ALTER SEQUENCE disbursement_types_id_seq restart with #{max_id + 1}")

--- a/db/seeds/expense_types.rb
+++ b/db/seeds/expense_types.rb
@@ -20,5 +20,5 @@ expense_types.each do |fields|
   SeedHelper.find_or_create_expense_type!(record_id, name, roles, reason_set, code)
 end
 
-# This is to ensure API Sandbox and Gamma are in sync regarding the IDs
+# This is to ensure api-andbox and production are in sync regarding the IDs
 ExpenseType.connection.execute("ALTER SEQUENCE expense_types_id_seq restart with #{max_id + 1}")

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,28 +2,6 @@
 # last modified 17-05-2019
 set +ex
 
-# output gets written to /var/log/upstart/... with template-deploy
-#
-case ${DOCKER_STATE} in
-migrate)
-    printf '\e[33mINFO: executing rake db:migrate\e[0m\n'
-    bundle exec rake db:migrate
-    ;;
-seed)
-    printf '\e[33mINFO: executing rake db:seed\e[0m\n'
-    bundle exec rake db:seed
-    ;;
-reload)
-    printf '\e[33mINFO: executing rake db:create + db:reload\e[0m\n'
-    bundle exec rake db:create
-    bundle exec rake db:reload
-    ;;
-reseed)
-    printf '\e[33mINFO: executing rake db:reseed\e[0m\n'
-    bundle exec rake db:reseed
-    ;;
-esac
-
 case ${LIVE1_DB_TASK} in
 migrate)
     printf '\e[33mINFO: executing rake db:migrate\e[0m\n'

--- a/lib/demo_data/demo_seeds/external_users.rb
+++ b/lib/demo_data/demo_seeds/external_users.rb
@@ -3,7 +3,7 @@ require Rails.root.join('db','seed_helper')
 # NOTE:
 #   the following provider names can be destroyed using the claims destroyer
 #   and should therefore be used so that we can "clean-up" data on staging
-#   and gamma (be very careful)
+#   and production (be very careful)
 #
 # SAMPLE_PROVIDERS = ['Test chamber','Test firm A', 'Test firm B']
 #

--- a/lib/rails_host.rb
+++ b/lib/rails_host.rb
@@ -1,5 +1,5 @@
 class RailsHost
-  VALID_ENVS = %w[dev demo staging api-sandbox gamma production].freeze
+  VALID_ENVS = %w[dev staging api-sandbox production].freeze
 
   def self.env
     ENV['ENV']

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -252,7 +252,7 @@ namespace :db do
   end
 
   def production_protected
-    raise 'This operation was aborted because the result might destroy production data' if ActiveRecord::Base.connection_config[:database] =~ /gamma/
+    raise 'This operation was aborted because the result might destroy production data' if Rails.host.production?
   end
 
   def with_config

--- a/lib/tasks/redcentric.rake
+++ b/lib/tasks/redcentric.rake
@@ -64,8 +64,8 @@ namespace :redcentric do
   end
 
   def environment_protected
-    raise 'The operation was aborted because the result might destroy production data!' if ActiveRecord::Base.connection_config[:database] =~ /gamma/
-    raise 'The operation was aborted because it is intended only for use in the demo environment!' if ActiveRecord::Base.connection_config[:database] !~ /demo/
+    raise 'The operation was aborted because the result might destroy production data!' if Rails.host.production?
+    raise 'The operation was aborted because it is intended only for use in the dev environment!' unless Rails.host.dev?
   end
 
   def ccr_claim_api uuid:, api_key:

--- a/script/db_dump.rb
+++ b/script/db_dump.rb
@@ -10,9 +10,7 @@ ENVIRONMENTS = {
   'dev' => %w(dev adp_dev_new),
   'staging' => %w(staging adp_staging),
   'api-sandbox' => %w(api-sandbox adp_api-sandbox),
-  'demo' => %w(demo adp_demo),
-  'disaster' => %w(disaster adp_disaster),
-  'gamma' => %w(gamma adp_gamma)
+  'production' => %w(production adp_production)
 }
 
 def ssh_user

--- a/script/downtime.rb
+++ b/script/downtime.rb
@@ -5,10 +5,9 @@ require 'uri'
 
 ENVIRONMENTS = {
     'dev' => 'dev-adp.dsd.io',
-    'demo' => 'demo-adp.dsd.io',
     'sandbox' => 'api-sandbox-adp.dsd.io',
     'staging' => 'staging-adp.dsd.io',
-    'gamma' => 'claim-crown-court-defence.service.gov.uk'
+    'production' => 'claim-crown-court-defence.service.gov.uk'
 }
 
 def hostname

--- a/spec/lib/rails_host_spec.rb
+++ b/spec/lib/rails_host_spec.rb
@@ -1,58 +1,105 @@
 require 'rails_helper'
 
 RSpec.describe RailsHost do
+  around do |example|
+    with_env(environment) { example.run }
+  end
+
   describe '.env' do
     subject { described_class.env }
 
-    around do |example|
-      with_env('staging') { example.run }
+    context 'staging' do
+      let(:environment) { 'staging' }
+
+      it 'returns value of environment variable ENV' do
+        is_expected.to eq('staging')
+      end
     end
 
-    it 'returns value of environment variable ENV' do
-      is_expected.to eq('staging')
+    context 'api-sandbox' do
+      let(:environment) { 'api-sandbox' }
+
+      it 'returns value of environment variable ENV' do
+        is_expected.to eq('api-sandbox')
+      end
+    end
+
+    context 'production' do
+      let(:environment) { 'production' }
+
+      it 'returns value of environment variable ENV' do
+        is_expected.to eq('production')
+      end
+    end
+
+    context 'gibberish' do
+      let(:environment) { 'gibberish' }
+
+      it 'returns value of environment variable ENV' do
+        is_expected.to eq('gibberish')
+      end
     end
   end
 
-  context 'api_sandbox' do
-    around do |example|
-      with_env('api-sandbox') { example.run }
+  describe '.host' do
+    context 'valid environments' do
+      context 'api-sandbox' do
+        let(:environment) { 'api-sandbox' }
+
+        it 'returns the rails host envirobment name' do
+          expect(Rails.host.env).to eq 'api-sandbox'
+        end
+
+        it '#api_sandbox?' do
+          expect(Rails.host.api_sandbox?).to be true
+        end
+
+        it 'returns false for dev' do
+          expect(Rails.host.dev?).to be false
+        end
+      end
+
+      context 'staging' do
+        let(:environment) { 'staging' }
+
+        it 'returns the rails environement host name' do
+          expect(Rails.host.env).to eq 'staging'
+        end
+
+        it 'returns true for staging?' do
+          expect(Rails.host.staging?).to be true
+        end
+
+        it 'returns false for dev' do
+          expect(Rails.host.dev?).to be false
+        end
+      end
+
+      context 'production' do
+        let(:environment) { 'production' }
+
+        it 'returns the rails environement host name' do
+          expect(Rails.host.env).to eq 'production'
+        end
+
+        it 'returns true for production?' do
+          expect(Rails.host.production?).to be true
+        end
+
+        it 'returns false for dev' do
+          expect(Rails.host.dev?).to be false
+        end
+      end
     end
 
-    it 'should return the rails host envirobment name' do
-      expect(Rails.host.env).to eq 'api-sandbox'
-    end
+    context 'invalid environments' do
+      let(:environment) { 'gibberish' }
 
-    it 'should return true for api_sandbox?' do
-      expect(Rails.host.api_sandbox?).to be true
-    end
-
-    it 'should return false for demo' do
-      expect(Rails.host.demo?).to be false
-    end
-
-    it 'should raise method missing if invalid method name' do
-      expect {
-        Rails.host.gibberish?
-
-      }.to raise_error NoMethodError, /undefined method .gibberish\?/
-    end
-  end
-
-  context 'staging' do
-    around do |example|
-      with_env('staging') { example.run }
-    end
-
-    it 'should return the rails environement host name' do
-      expect(Rails.host.env).to eq 'staging'
-    end
-
-    it 'should return true for staging?' do
-      expect(Rails.host.staging?).to be true
-    end
-
-    it 'should return false for demo' do
-      expect(Rails.host.demo?).to be false
+      it 'raises method missing if invalid method name' do
+        expect {
+          Rails.host.gibberish?
+        }.to raise_error NoMethodError, /undefined method .gibberish\?/
+      end
     end
   end
 end

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -13,7 +13,7 @@ module GoogleAnalytics
           allow(described_class).to receive(:adapter).and_return('Adapter')
         end
 
-        %w(staging gamma production).each do |host|
+        %w(staging production).each do |host|
           it "returns true when host is #{host}" do
             allow(RailsHost).to receive(:env).and_return(host)
             expect(described_class.enabled?).to be_truthy
@@ -26,12 +26,12 @@ module GoogleAnalytics
           allow(described_class).to receive(:adapter).and_return(nil)
         end
 
-        it 'returns false when host is demo' do
-          allow(RailsHost).to receive(:env).and_return('gamma')
+        it 'returns false when host is dev' do
+          allow(RailsHost).to receive(:env).and_return('dev')
           expect(described_class.enabled?).to be_falsey
         end
 
-        it 'raises if not adapter' do
+        it 'raises error if no adapter' do
           allow(described_class).to receive(:enabled?).and_return(true)
           expect{
             described_class.track()

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       end
     end
 
-    # TODO: this will become default after gamma/private beta claims archived/deleted
+    # TODO: this will become default after production claims archived/deleted
     context 'for fees entered after rate was reintroduced' do
       it 'should require a rate of more than zero' do
         fee.amount = nil


### PR DESCRIPTION
#### What
Remove vestiges of template-deploy version
of app from the codebase


#### Why
To remove obsolete code and thereby avoid
future confusion.

#### How

remove reference to `gamma` - old TD
name for production environment - and
DOCKER_STATE env var - used by TD to
apply fab(ric) tasks during deployment.