### PR TITLE
Remove superflous default live-1 cluster ingresses

### DIFF
--- a/kubernetes_deploy/api-sandbox/ingress.yaml
+++ b/kubernetes_deploy/api-sandbox/ingress.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: cccd-api-sandbox
 spec:
   rules:
-    - host: cccd-api-sandbox.apps.live-1.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: cccd-app-service
-              servicePort: 80
     - host: api-sandbox.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
@@ -20,8 +13,6 @@ spec:
               serviceName: cccd-app-service
               servicePort: 80
   tls:
-    - hosts:
-      - cccd-api-sandbox.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
       - api-sandbox.claim-crown-court-defence.service.justice.gov.uk
       secretName: cccd-api-sandbox-cert

--- a/kubernetes_deploy/dev/ingress.yaml
+++ b/kubernetes_deploy/dev/ingress.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: cccd-dev
 spec:
   rules:
-    - host: cccd-dev.apps.live-1.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: cccd-app-service
-              servicePort: 80
     - host: dev.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
@@ -20,8 +13,6 @@ spec:
               serviceName: cccd-app-service
               servicePort: 80
   tls:
-    - hosts:
-      - cccd-dev.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
       - dev.claim-crown-court-defence.service.justice.gov.uk
       secretName: cccd-dev-cert

--- a/kubernetes_deploy/production/ingress.yaml
+++ b/kubernetes_deploy/production/ingress.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: cccd-production
 spec:
   rules:
-    - host: cccd-production.apps.live-1.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: cccd-app-service
-              servicePort: 80
     - host: claim-crown-court-defence.service.gov.uk
       http:
         paths:
@@ -20,8 +13,6 @@ spec:
               serviceName: cccd-app-service
               servicePort: 80
   tls:
-    - hosts:
-      - cccd-production.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
       - claim-crown-court-defence.service.gov.uk
       secretName: cccd-production-cert

--- a/kubernetes_deploy/staging/ingress.yaml
+++ b/kubernetes_deploy/staging/ingress.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: cccd-staging
 spec:
   rules:
-    - host: cccd-staging.apps.live-1.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: cccd-app-service
-              servicePort: 80
     - host: staging.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
@@ -20,8 +13,6 @@ spec:
               serviceName: cccd-app-service
               servicePort: 80
   tls:
-    - hosts:
-      - cccd-staging.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
       - staging.claim-crown-court-defence.service.justice.gov.uk
       secretName: cccd-staging-cert


### PR DESCRIPTION
#### What
Removes the default live-1 cluster ingresses

Note: has already been applied on the fly using edit command

#### Ticket

[CBO-1075](https://dsdmoj.atlassian.net/browse/CBO-1075)

#### Why
To prevent connection using default live-1 cluster ingress and certificates. This is recommended by Cloud platform