### PR TITLE
Add smoke test and notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,9 @@ references:
         command: |
           .circleci/build.sh
 
+# ------------------
+# EXECUTORS
+# ------------------
 executors:
   cloud-platform-executor:
     docker:
@@ -109,6 +112,33 @@ executors:
       environment:
         GITHUB_TEAM_NAME_SLUG: laa-get-paid
         REPO_NAME: cccd
+
+  smoke-test-executor:
+    working_directory: ~/repo
+    docker:
+      - image: ${ECR_ENDPOINT}/laa-get-paid/cccd:app-latest
+        environment:
+          RAILS_ENV: test
+          CBO_BASE_DATABASE_DATABASE: cccd_smoke_test
+          CBO_BASE_DATABASE_USERNAME: circleci
+          CBO_BASE_DATABASE_PASSWORD: "circleci"
+          CBO_BASE_DATABASE_HOST: localhost
+          ADVOCATE_PASSWORD: just-be-present
+          CASE_WORKER_PASSWORD: just-be-present
+          ADMIN_PASSWORD: just-be-present
+          SECRET_KEY_BASE: just-be-present
+          SUPERADMIN_USERNAME: just-be-present
+          SUPERADMIN_PASSWORD: just-be-present
+          PGHOST: 127.0.0.1
+          PGUSER: postgres
+          TZ: Europe/London
+          GITHUB_TEAM_NAME_SLUG: laa-get-paid
+          REPO_NAME: cccd
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: cccd_smoke_test
+          POSTGRES_PASSWORD: "circleci"
 
   test-executor:
     working_directory: ~/repo
@@ -128,6 +158,9 @@ executors:
           POSTGRES_DB: cccd_test
           POSTGRES_PASSWORD: ""
 
+# ------------------
+# COMMANDS
+# ------------------
 commands:
   build-base:
     steps:
@@ -154,6 +187,9 @@ commands:
           color: '#3AA3E3'
           message: "Deployment pending approval"
 
+# ------------------
+# JOBS
+# ------------------
 jobs:
   build-test-container:
     executor: test-executor
@@ -165,6 +201,20 @@ jobs:
       - *install-codeclimate
       - *persist-codeclimate
       - build-base
+
+  smoke-test:
+    executor: smoke-test-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Run smoke test
+          command: |
+            pwd
+            ls -lha
+            echo "CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY"
+            ./runtests.sh
 
   rspec-tests:
     executor: test-executor
@@ -219,7 +269,8 @@ jobs:
     executor: cloud-platform-executor
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - *script-build-app-container
 
   hold-notification:
@@ -257,6 +308,9 @@ jobs:
       - deploy-to:
           environment: dev
 
+# ------------------
+# WORKFLOWS
+# ------------------
 workflows:
   version: 2
   build-test-deploy:
@@ -329,3 +383,18 @@ workflows:
       - deploy-production:
           requires:
             - hold-production
+
+  # master-smoke-test:
+  #   jobs:
+  #     - pull-app-container
+  #     - smoke-test:
+  #         requires:
+  #           - pull-app-container
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+
+  scheduled-smoke-test:
+    jobs:
+      - smoke-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,8 +195,7 @@ jobs:
     executor: test-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - *create-tmp-dir
       - *install-codeclimate
       - *persist-codeclimate
@@ -206,8 +205,7 @@ jobs:
     executor: smoke-test-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run:
           name: Run smoke test
           command: |
@@ -269,8 +267,7 @@ jobs:
     executor: cloud-platform-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - *script-build-app-container
 
   hold-notification:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,29 +114,29 @@ executors:
         REPO_NAME: cccd
 
   smoke-test-executor:
-    working_directory: ~/repo
+    working_directory: /usr/src/app
     docker:
       - image: ${ECR_ENDPOINT}/laa-get-paid/cccd:app-latest
+        entrypoint: |
+          docker/docker-entrypoint.sh
         environment:
           RAILS_ENV: test
-          CBO_BASE_DATABASE_DATABASE: cccd_smoke_test
-          CBO_BASE_DATABASE_USERNAME: circleci
-          CBO_BASE_DATABASE_PASSWORD: "circleci"
-          CBO_BASE_DATABASE_HOST: localhost
           ADVOCATE_PASSWORD: just-be-present
           CASE_WORKER_PASSWORD: just-be-present
           ADMIN_PASSWORD: just-be-present
           SECRET_KEY_BASE: just-be-present
-          SUPERADMIN_USERNAME: just-be-present
+          SUPERADMIN_USERNAME: superadmin@circleci.com
           SUPERADMIN_PASSWORD: just-be-present
           PGHOST: 127.0.0.1
           PGUSER: postgres
+          DATABASE_URL: postgres://postgres:circleci@127.0.0.1:5432/cccd_smoke_test
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
+          LIVE1_DB_TASK: none
       - image: circleci/postgres:9.6-alpine
         environment:
-          POSTGRES_USER: circleci
+          POSTGRES_USER: postgres
           POSTGRES_DB: cccd_smoke_test
           POSTGRES_PASSWORD: "circleci"
 
@@ -204,14 +204,9 @@ jobs:
   smoke-test:
     executor: smoke-test-executor
     steps:
-      - checkout
-      - setup_remote_docker
       - run:
           name: Run smoke test
           command: |
-            pwd
-            ls -lha
-            echo "CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY"
             ./runtests.sh
 
   rspec-tests:
@@ -330,6 +325,13 @@ workflows:
       - build-app-container:
           requires:
             - upload-coverage
+      - smoke-test:
+          requires:
+            - build-app-container
+          filters:
+            branches:
+              only:
+                - master
       - auto-deploy-dev:
           requires:
             - build-app-container
@@ -381,17 +383,13 @@ workflows:
           requires:
             - hold-production
 
-  # master-smoke-test:
-  #   jobs:
-  #     - pull-app-container
-  #     - smoke-test:
-  #         requires:
-  #           - pull-app-container
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-
   scheduled-smoke-test:
+    triggers:
+      - schedule:
+          cron: 0,10,20,30 * * * *
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - smoke-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,14 +431,13 @@ workflows:
             - hold-production
 
   scheduled-smoke-test:
-    # triggers:
-    #   - schedule:
-    #       cron: "0,15,30,45 * * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - master
-    #             - scheduled-smoke-test
+    triggers:
+      - schedule:
+          cron: "5 8 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - smoke-test
       - smoke-test-notification:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ executors:
         entrypoint: |
           docker/docker-entrypoint.sh
         environment:
+          BASH: true
           RAILS_ENV: test
           ADVOCATE_PASSWORD: just-be-present
           CASE_WORKER_PASSWORD: just-be-present
@@ -127,8 +128,6 @@ executors:
           SECRET_KEY_BASE: just-be-present
           SUPERADMIN_USERNAME: superadmin@circleci.com
           SUPERADMIN_PASSWORD: just-be-present
-          PGHOST: 127.0.0.1
-          PGUSER: postgres
           DATABASE_URL: postgres://postgres:circleci@127.0.0.1:5432/cccd_smoke_test
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
@@ -137,26 +136,24 @@ executors:
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: postgres
-          POSTGRES_DB: cccd_smoke_test
           POSTGRES_PASSWORD: "circleci"
+          POSTGRES_DB: cccd_smoke_test
 
   test-executor:
     working_directory: ~/repo
     docker:
       - image: circleci/ruby:2.6.5-node-browsers
         environment:
-          CBO_BASE_DATABASE_DATABASE: cccd_test
-          PGHOST: 127.0.0.1
-          PGUSER: postgres
           RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:circleci@127.0.0.1:5432/cccd_test
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: "circleci"
           POSTGRES_DB: cccd_test
-          POSTGRES_PASSWORD: ""
 
 # ------------------
 # COMMANDS
@@ -169,6 +166,8 @@ commands:
       - *save-cache
 
   deploy-to:
+    description: >
+      Deploy CCCD to the specified environment
     parameters:
       environment:
         description: destination environment
@@ -177,15 +176,59 @@ commands:
       - checkout
       - setup_remote_docker
       - run:
-          name: deploy to << parameters.environment >>
+          name: deploying ${CIRCLE_BRANCH} to << parameters.environment >>
           command: |
             .circleci/deploy.sh << parameters.environment >>
+      - slack/status:
+          success_message: ":tada: deploy of `${CIRCLE_BRANCH}` to << parameters.environment >> successful!"
+          failure_message: ":red_circle: deploy of `${CIRCLE_BRANCH}` to << parameters.environment >> failed!"
 
-  notify-approval:
+  smoke-test:
+     steps:
+      - run:
+          name: Persistence - prepare result storage
+          command: mkdir -p /tmp/smoke_test
+      - run:
+          name: Run smoke test
+          command: |
+            if ./runtests.sh; then
+              echo 'true' > /tmp/smoke_test/success
+            else
+              echo 'false' > /tmp/smoke_test/success
+            fi
+      - run:
+          name: test success storage
+          command: echo `cat /tmp/smoke_test/success`
+      - persist_to_workspace:
+          root: /tmp/smoke_test
+          paths:
+            - success
+
+  smoke-test-notification:
     steps:
-      - slack/approval:
-          color: '#3AA3E3'
-          message: "Deployment pending approval"
+      - attach_workspace:
+          at: /tmp/smoke_test
+      - run:
+          name: Setting - determine success of smoke test
+          command: |
+            if [[ `cat /tmp/smoke_test/success` == "true" ]]; then
+              echo "Smoke test succeeded!";
+              echo 'export CUSTOM_SLACK_MESSAGE=":tada: smoke test of $CIRCLE_BRANCH successful!"' >> $BASH_ENV
+              echo 'export CUSTOM_SLACK_COLOR="#008000"' >> $BASH_ENV
+              exit 0
+            else
+              echo 'export CUSTOM_SLACK_MESSAGE=":no_smoking: smoke test $CIRCLE_BRANCH failed!"' >> $BASH_ENV
+              echo 'export CUSTOM_SLACK_COLOR="#FF0000"' >> $BASH_ENV
+              echo "Smoke test failed!";
+            fi
+      - run:
+          name: test result storage
+          command: |
+             echo `cat /tmp/smoke_test/success`
+      - slack/notify:
+          title: ":smoke_it: Smoke test"
+          message: $CUSTOM_SLACK_MESSAGE
+          color: $CUSTOM_SLACK_COLOR
 
 # ------------------
 # JOBS
@@ -204,10 +247,12 @@ jobs:
   smoke-test:
     executor: smoke-test-executor
     steps:
-      - run:
-          name: Run smoke test
-          command: |
-            ./runtests.sh
+      - smoke-test
+
+  smoke-test-notification:
+    executor: slack/alpine
+    steps:
+      - smoke-test-notification
 
   rspec-tests:
     executor: test-executor
@@ -268,7 +313,9 @@ jobs:
   hold-notification:
     executor: cloud-platform-executor
     steps:
-      - notify-approval
+      - slack/approval:
+          color: '#3AA3E3'
+          message: "Deployment pending approval"
 
   deploy-dev:
     executor: cloud-platform-executor
@@ -384,12 +431,16 @@ workflows:
             - hold-production
 
   scheduled-smoke-test:
-    triggers:
-      - schedule:
-          cron: 0,10,20,30 * * * *
-          filters:
-            branches:
-              only:
-                - master
+    # triggers:
+    #   - schedule:
+    #       cron: "0,15,30,45 * * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - master
+    #             - scheduled-smoke-test
     jobs:
       - smoke-test
+      - smoke-test-notification:
+          requires:
+            - smoke-test

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,11 +18,7 @@ devunicorn:
 
 test: &test
   <<: *default
-  database: <%= ENV['CBO_BASE_DATABASE_DATABASE'] || 'cbo_test' %>
-
-develop:
-  <<: *default
-  database: cbo_develop
+  database: <%= ENV['CBO_BASE_DATABASE_DATABASE'] || 'cccd_test' %>
 
 production:
   <<: *default

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -13,7 +13,7 @@ namespace :api do
   end
 
   desc "Smoke test for the REST API"
-  task :smoke_test, [:io] => :environment do |task,args|
+  task :smoke_test, [:io] => :environment do |task, args|
     Rake::Task['claims:sample_users'].invoke
 
     require "#{Rails.root.join('spec', 'support', 'api', 'api_test_client')}"

--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -36,10 +36,7 @@ namespace :api do
       io.puts api_client.full_error_messages.join("\n")
       raise "API Error: ADP RESTful API smoke test failure!"
     end
-
   end
-
-
 
   desc 'Run specific api test to reproduce reported bugs'
   task :debug => :environment do
@@ -78,5 +75,4 @@ namespace :api do
       puts "Only available in development mode"
     end
   end
-
 end

--- a/runtests.sh
+++ b/runtests.sh
@@ -2,6 +2,6 @@
 set -ex
 
 printf '\e[33mExecuting smoke test\e[0m\n'
-bundle exec rake db:migrate
-bundle exec rake db:seed
-bundle exec rake api:smoke_test
+# bundle exec rake db:migrate
+# bundle exec rake db:seed
+# bundle exec rake api:smoke_test

--- a/runtests.sh
+++ b/runtests.sh
@@ -2,6 +2,6 @@
 set -ex
 
 printf '\e[33mExecuting smoke test\e[0m\n'
-# bundle exec rake db:migrate
-# bundle exec rake db:seed
-# bundle exec rake api:smoke_test
+bundle exec rake db:migrate
+bundle exec rake db:seed
+bundle exec rake api:smoke_test


### PR DESCRIPTION
#### What
Add smoke test of application with team notification

#### Ticket

[CBO-815](https://dsdmoj.atlassian.net/browse/CBO-815)

#### Why
To sanity/smoke test the `actual` built app
to ensure it passes fundamental functional checks,
over and above the test suite.

#### How
use circleCI to run the smoke test
against a container based on the latest
master branch's image from ECR.

Use slack orb plus some customization to
notify the team

--------

#### TODO (wip)

 - [X] smoke test running against latest image
 - [X] smoke test notifies success and failure
 - [ ] cronjob to run smoke test at 9am each morning
 - [ ] additional master branch merge step to run smoke test