### PR TITLE
remove back-ticks as they are interpreted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,8 +180,8 @@ commands:
           command: |
             .circleci/deploy.sh << parameters.environment >>
       - slack/status:
-          success_message: ":tada: deploy of `${CIRCLE_BRANCH}` to << parameters.environment >> successful!"
-          failure_message: ":red_circle: deploy of `${CIRCLE_BRANCH}` to << parameters.environment >> failed!"
+          success_message: ":tada: deploy of ${CIRCLE_BRANCH} to << parameters.environment >> successful!"
+          failure_message: ":red_circle: deploy of ${CIRCLE_BRANCH} to << parameters.environment >> failed!"
 
   smoke-test:
      steps:


### PR DESCRIPTION
#### What
remove back-ticks as they are interpreted

#### Why
use of back-ticks to format text in
a slack attachment does not work and
results in the text being ignored.

remove until there is time to find a way
of escaping these (have tried the obvious
`\` escape char to no effect).