### PR TITLE
Use time zone helper for cronjobs

### DIFF
--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: cronjobber.hidde.co/v1alpha1
 kind: TZCronJob
 metadata:
   name: cccd-archive-stale

--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -1,9 +1,10 @@
 apiVersion: batch/v1beta1
-kind: CronJob
+kind: TZCronJob
 metadata:
   name: cccd-archive-stale
 spec:
   schedule: "5 0 * * *"
+  timezone: "Europe/London"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 7
   failedJobsHistoryLimit: 3

--- a/kubernetes_deploy/cron_jobs/clean_ecr.yaml
+++ b/kubernetes_deploy/cron_jobs/clean_ecr.yaml
@@ -1,11 +1,12 @@
 apiVersion: batch/v1beta1
-kind: CronJob
+kind: TZCronJob
 metadata:
   name: ecr-delete-untagged-images-cronjob
   # currently the secret is only available in the cccd-dev namespace
   namespace: cccd-dev
 spec:
   schedule: "0 */6 * * *"
+  timezone: "Europe/London"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   suspend: false

--- a/kubernetes_deploy/cron_jobs/clean_ecr.yaml
+++ b/kubernetes_deploy/cron_jobs/clean_ecr.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: cronjobber.hidde.co/v1alpha1
 kind: TZCronJob
 metadata:
   name: ecr-delete-untagged-images-cronjob


### PR DESCRIPTION
#### What
Ensure BST is accounted for in cronjobs

#### Why
Cronjobs are in UTC which is an hour
out during British Summer Time (BST).

CP have created a simple way to handle
Time zone sensitive cronjobs.

see [time-zone-cronjobs guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/TZ-Cronjobs.html#time-zone-cronjobs)