### PR TITLE
CBO-1085: Reduce cucumber test time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
 
   cucumber-tests:
     executor: test-executor
-    parallelism: 2
+    parallelism: 4
     steps:
       - checkout
       - build-base

--- a/features/claims/advocate/advocate.feature
+++ b/features/claims/advocate/advocate.feature
@@ -1,34 +1,35 @@
 @javascript
-Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
+Feature: Advocate submits a claim
 
-  @fee_calc_vcr
-  Scenario: I create an Appeal against conviction claim, then submit it
+  @accessibility
+  Scenario: I create a claim, then submit it
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
+    Then the page should be accessible within "#content"
     And I click 'Start a claim'
+
+    Then the page should be accessible within "#content"
     And I select the fee scheme 'Advocate final fee'
+
     Then I should be on the new claim page
-
-    And I select the court 'Caernarfon'
-    And I select a case type of 'Appeal against conviction'
-    And I enter a case number of 'A20181234'
-
     And I should see a page title "Enter case details for advocate final fees claim"
+    And I select a case type of 'Appeal against conviction'
+    And I select the court 'Caernarfon'
+    And I enter a case number of 'A20181234'
+    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
-    And I enter defendant, scheme 10 representation order and MAAT reference
-    And I add another defendant, scheme 10 representation order and MAAT reference
-
     And I should see a page title "Enter defendant details for advocate final fees claim"
+    And I enter defendant, scheme 10 representation order and MAAT reference
+    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_ten/fixed_fee_calculations'
-
+    And I should see a page title "Enter fixed fees for advocate final fees claim"
     And I should see the advocate categories 'Junior,Leading junior,QC'
     And I select an advocate category of 'Junior'
     Then the fixed fee checkboxes should consist of 'Appeals to the crown court against conviction,Number of cases uplift,Number of defendants uplift,Standard appearance fee,"Adjourned appeals, committals and breaches"'
-
     And I select the 'Appeals to the crown court against conviction' fixed fee
     Then the fixed fee 'Appeals to the crown court against conviction' should have a rate of '250.00' and a hint of 'Number of days'
     And I select the 'Number of cases uplift' fixed fee with case numbers
@@ -40,65 +41,61 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     Then the summary total should equal '£528.00'
     Then I uncheck the fixed fee "Number of defendants uplift"
     Then the summary total should equal '£468.00'
-
-    And I should see a page title "Enter fixed fees for advocate final fees claim"
+    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
-    And I should be in the 'Miscellaneous fees' form page
 
+    And I should be in the 'Miscellaneous fees' form page
+    And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
     Then the last 'miscellaneous' fee rate should be populated with '108.00'
-
+    Then the page should be accessible within "#content"
     And I eject the VCR cassette
-
-    And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
     And I should be in the 'Travel expenses' form page
+    And I should see a page title "Enter travel expenses for advocate final fees claim"
     And I select an expense type "Parking"
     And I select a travel reason "View of crime scene"
     And I add an expense net amount for "34.56"
     And I add an expense date for scheme 10
-
-    And I should see a page title "Enter travel expenses for advocate final fees claim"
+    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I should be in the 'Supporting evidence' form page
+    And I should see a page title "Upload supporting evidence for advocate final fees claim"
     And I upload the document 'indictment.pdf'
     And I should see 10 evidence check boxes
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
-
-    And I should see a page title "Upload supporting evidence for advocate final fees claim"
+    Then the page should be accessible within "#content"
     Then I click Submit to LAA
 
     And I should be on the check your claim page
+    And I should see a page title "View claim summary for advocate final fees claim"
     And I should see 'Caernarfon'
     And I should see 'A20181234'
     And I should see 'Appeal against conviction'
-
     And I should not see 'Standard Offences'
     And I should see 'Junior'
-
     And I should see 'Appeals to the crown court against conviction'
     And I should see 'Number of cases uplift'
     And I should see 'Noting brief fee'
     And I should see 'Parking'
-
     And I should see 'indictment.pdf'
     And I should see 'A copy of the indictment'
     And I should see 'Bish bosh bash'
-
-    And I should see a page title "View claim summary for advocate final fees claim"
+    Then the page should be accessible within "#content"
     When I click "Continue"
+
     Then I should be on the certification page
-
-    When I check “I attended the main hearing”
-
     And I should see a page title "Certify and submit the advocate final fees claim"
+    When I check “I attended the main hearing”
+    Then the page should be accessible within "#content"
     And I click Certify and submit claim
 
-    And I should see a page title "Thank you for submitting your claim"
     Then I should be on the claim confirmation page
+    And I should see a page title "Thank you for submitting your claim"
+    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page

--- a/features/claims/advocate/scheme_eleven/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_fixed_fee_claim_submit.feature
@@ -6,33 +6,27 @@ Feature: Advocate tries to submit a claim for a Fixed fee (Appeal against convic
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
 
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I select the court 'Caernarfon'
     And I select a case type of 'Appeal against conviction'
     And I enter a case number of 'A20181234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, scheme 11 representation order and MAAT reference
     And I add another defendant, scheme 11 representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
-    Then the page should be accessible within "#content"
     Then I click the link 'Back'
     And I should be in the 'Defendant details' form page
 
     Then I should see 'Defendant 1'
     And I should see 'Defendant 2'
     And I should see 2 representation orders
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -44,11 +38,9 @@ Feature: Advocate tries to submit a claim for a Fixed fee (Appeal against convic
     And I select the 'Appeals to the crown court against conviction' fixed fee
     Then the fixed fee 'Appeals to the crown court against conviction' should have a rate of '330.00' and a hint of 'Number of days'
     Then the summary total should equal '£330.00'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
-    Then the page should be accessible within "#content"
 
     Then I click the link 'Back'
     And I should be in the 'Fixed fees' form page
@@ -57,5 +49,4 @@ Feature: Advocate tries to submit a claim for a Fixed fee (Appeal against convic
     Then I click "Continue" in the claim form
     And I should be in the 'Fixed fees' form page
     And I should see the error 'Total value claimed must be greater than £0.00'
-    Then the page should be accessible within "#content"
     And I eject the VCR cassette

--- a/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
@@ -6,11 +6,9 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate supplementary fee'
 
-    Then the page should be accessible within "#content"
     Then I should be on the advocate supplementary new claim page
 
     When I enter a providers reference of 'AGFS supplementary fee test'
@@ -18,7 +16,6 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I enter a case number of 'A20191234'
 
     And I should see a page title "Enter case details for advocate supplementary fee claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I enter defendant, scheme 11 representation order and MAAT reference
@@ -27,7 +24,6 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     Given I insert the VCR cassette 'features/claims/advocate/scheme_eleven/supplementary_fee_calculations'
 
     And I should see a page title "Enter defendant details for advocate supplementary fee claim"
-    Then the page should be accessible within "#content"
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
     And I should see the advocate categories 'Junior,Leading junior,QC'
@@ -59,7 +55,6 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
       | miscellaneous | Standard appearance fee | 91.00 | Number of days | true |
       | miscellaneous | Standard appearance fee uplift | 36.40 | Number of additional defendants | true |
       | miscellaneous | Wasted preparation fee | 39.39 | Number of hours | true |
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -73,7 +68,6 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I add an expense net amount for "34.56"
 
     And I should see a page title "Enter travel expenses for advocate supplementary fee claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     When I upload the document 'judicial_appointment_order.pdf'
@@ -82,7 +76,6 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for advocate msupplementary fee claim"
-    Then the page should be accessible within "#content"
     When I click "Continue" in the claim form
     And I should be on the check your claim page
 
@@ -124,20 +117,16 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
       | supporting-evidence-section | Supporting evidence | judicial_appointment_order.pdf |
       | supporting-evidence-section | Supporting evidence checklist | Order in respect of judicial apportionment |
 
-    Then the page should be accessible within "#content"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
 
     And I should see a page title "Certify and submit the advocate supplementary fees claim"
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 
     And I should see a page title "Thank you for submitting your claim"
-    Then the page should be accessible within "#content"
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20191234' should be listed with a status of 'Submitted' and a claimed amount of '£728.10'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_eleven/advocate_trial_claim_offences.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_trial_claim_offences.feature
@@ -4,10 +4,8 @@ Feature: Advocate creates a claim for a final fee trial case under scheme 11
   Scenario: Successful renders scheme 11 offences
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I enter a case number of 'A20181234'
@@ -16,12 +14,10 @@ Feature: Advocate creates a claim for a final fee trial case under scheme 11
     And I select the court 'Blackfriars'
 
     And I enter scheme 11 trial start and end dates
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, scheme 11 representation order and MAAT reference
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
 
@@ -39,4 +35,3 @@ Feature: Advocate creates a claim for a final fee trial case under scheme 11
     Then the offence should have moved from 'Band: 17.1' to 'Band: 8.1'
     And I search for a post agfs reform offence 'unauthorised air traffic controllers'
     Then the offence should have moved from 'Band: 17.1' to 'Band: 16.3'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_eleven/misc_fee_removal.feature
+++ b/features/claims/advocate/scheme_eleven/misc_fee_removal.feature
@@ -6,22 +6,18 @@ Feature: Advocate can add and remove miscelleaneous fees
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I select the court 'Caernarfon'
     And I select a case type of 'Appeal against conviction'
     And I enter a case number of 'A20181234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant' form page
 
     And I enter defendant, scheme 11 representation order and MAAT reference
     And I add another defendant, scheme 11 representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     Then I click the link 'Back'
@@ -30,7 +26,6 @@ Feature: Advocate can add and remove miscelleaneous fees
     Then I should see 'Defendant 1'
     And I should see 'Defendant 2'
     And I should see 2 representation orders
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -42,16 +37,13 @@ Feature: Advocate can add and remove miscelleaneous fees
     And I select the 'Appeals to the crown court against conviction' fixed fee
     Then the fixed fee 'Appeals to the crown court against conviction' should have a rate of '330.00' and a hint of 'Number of days'
     Then the summary total should equal '£330.00'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
     And I add a calculated miscellaneous fee 'Abuse of process hearings (half day)' with quantity of '1'
     And I add a calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '1'
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
     Then I should be in the 'Travel expenses' form page
-    Then the page should be accessible within "#content"
 
     When I click the link 'Back'
     And I should be in the 'Miscellaneous fees' form page
@@ -59,17 +51,13 @@ Feature: Advocate can add and remove miscelleaneous fees
 
     When I click last remove link
     Then the last 'miscellaneous' fee rate should be populated with '131.00'
-    Then the page should be accessible within "#content"
 
     When I click "Continue" in the claim form
     Then I should be in the 'Travel expenses' form page
-    Then the page should be accessible within "#content"
 
     When I click the link 'Back'
     Then I should be in the 'Miscellaneous fees' form page
     And the last 'miscellaneous' fee rate should be populated with '131.00'
-    Then the page should be accessible within "#content"
 
     When I click last remove link
     Then I should not see 'Remove'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
@@ -6,10 +6,8 @@ Feature: Advocate admin submits a claim for a Trial case
     Given I am a signed in advocate admin
     And There are other advocates in my provider
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     When I choose 'Doe, John (AC135)' as the instructed advocate
@@ -19,7 +17,6 @@ Feature: Advocate admin submits a claim for a Trial case
     Then I should see retrial fields
     And I select a case type of 'Trial'
     And I enter scheme 9 trial start and end dates
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
@@ -28,7 +25,6 @@ Feature: Advocate admin submits a claim for a Trial case
 
     Given I am later on the Your claims page
     Then Claim 'A20161234' should be listed with a status of 'Draft'
-    Then the page should be accessible within "#content"
 
     When I click the claim 'A20161234'
     And I edit the claim's defendants
@@ -39,12 +35,10 @@ Feature: Advocate admin submits a claim for a Trial case
     And I should see a page title "Enter defendant details for advocate final fees claim"
     Then I click "Continue" in the claim form
     And I select the offence category 'Activities relating to opium'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit'
 
     And I should see a page title "Enter offence details for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I should see the advocate categories 'Junior alone,Led junior,Leading junior,QC'
@@ -56,7 +50,6 @@ Feature: Advocate admin submits a claim for a Trial case
     And I select the 'Number of cases uplift' basic fee with quantity of 1 with case numbers
 
     And I should see a page title "Enter graduated fees for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
@@ -66,7 +59,6 @@ Feature: Advocate admin submits a claim for a Trial case
     And I eject the VCR cassette
 
     And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I select an expense type "Hotel accommodation"
@@ -76,7 +68,6 @@ Feature: Advocate admin submits a claim for a Trial case
     And I add an expense date for scheme 9
 
     And I should see a page title "Enter travel expenses for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
     And I upload the document 'judicial_appointment_order.pdf'
     And I should see 10 evidence check boxes
@@ -84,10 +75,8 @@ Feature: Advocate admin submits a claim for a Trial case
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click Submit to LAA
     And I should be on the check your claim page
-    Then the page should be accessible within "#content"
 
     And I should see 'Blackfriars'
     And I should see 'A20161234'
@@ -108,19 +97,15 @@ Feature: Advocate admin submits a claim for a Trial case
     And I should see 'Bish bosh bash'
 
     And I should see a page title "View claim summary for advocate final fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
 
     And I should see a page title "Certify and submit the advocate final fees claim"
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£2,097.07'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
@@ -6,36 +6,30 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I select the court 'Blackfriars'
     And I select a case type of 'Trial'
     And I enter a case number of 'A20161234'
     And I enter scheme 9 trial start and end dates
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
     And I save as draft
 
     Given I am later on the Your claims page
     Then Claim 'A20161234' should be listed with a status of 'Draft'
-    Then the page should be accessible within "#content"
 
     When I click the claim 'A20161234'
     And I edit the claim's defendants
     And I enter defendant, scheme 9 representation order and MAAT reference
     And I add another defendant, scheme 9 representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit'
 
@@ -48,12 +42,10 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     And I select an advocate category of 'Junior alone'
     And the basic fee net amount should be populated with '694.00'
     And I select the 'Daily attendance fee (3 to 40)' basic fee with quantity of 4
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
     And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -63,14 +55,12 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     And I select a travel reason "View of crime scene"
     And I add an expense net amount for "34.56"
     And I add an expense date for scheme 9
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
     And I upload 3 documents
     And I check the boxes for the uploaded documents
     And I add some additional information
-    Then the page should be accessible within "#content"
 
     And I click Submit to LAA
     Then I should be on the check your claim page
@@ -79,12 +69,9 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£2,615.47'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
@@ -6,22 +6,18 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I select the court 'Blackfriars'
     And I select a case type of 'Appeal against sentence'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_nine/fixed_fee_calculations'
@@ -30,12 +26,10 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     Then the fixed fee checkboxes should consist of 'Appeals to the crown court against sentence,Number of cases uplift,Number of defendants uplift,Standard appearance fee,"Adjourned appeals, committals and breaches"'
     And I select the 'Appeals to the crown court against sentence' fixed fee
     Then the fixed fee 'Appeals to the crown court against sentence' should have a rate of '108.00' and a hint of 'Number of days'
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I goto claim form step 'case details'
     And I select a case type of 'Appeal against conviction'
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I goto claim form step 'fixed fees'
@@ -48,7 +42,6 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     Then the fixed fee 'Number of cases uplift' should have a rate of '26.00'
 
     And I should see a page title "Enter fixed fees for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
@@ -57,7 +50,6 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     And I eject the VCR cassette
 
     And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I select an expense type "Parking"
@@ -66,7 +58,6 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     And I add an expense date for scheme 9
 
     And I should see a page title "Enter travel expenses for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I upload 3 documents
@@ -78,17 +69,13 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     And I should be on the check your claim page
 
     And I should see a page title "View claim summary for advocate final fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£379.87'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_ten/advocate_expense_page.feature
+++ b/features/claims/advocate/scheme_ten/advocate_expense_page.feature
@@ -4,10 +4,8 @@ Feature: Advocate creates, saves, edits claims and expenses
   Scenario: Travel expenses page
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I enter a case number of 'A20181234'
@@ -16,7 +14,6 @@ Feature: Advocate creates, saves, edits claims and expenses
     And I enter scheme 10 trial start and end dates
 
     And I should see a page title "Enter case details for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft
@@ -62,4 +59,3 @@ Feature: Advocate creates, saves, edits claims and expenses
     Then I should see '20p'
     Then I should see '873'
     Then I should see '£174.60'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_ten/advocate_interim_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_interim_claim_edit_submit.feature
@@ -5,17 +5,14 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate warrant fee'
-    Then the page should be accessible within "#content"
     Then I should be on the advocate interim new claim page
 
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20181234'
 
     And I should see a page title "Enter case details for advocate warrant fees claim"
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
     And I save as draft
@@ -23,18 +20,15 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
 
     Given I am later on the Your claims page
     Then Claim 'A20181234' should be listed with a status of 'Draft'
-    Then the page should be accessible within "#content"
 
     When I click the claim 'A20181234'
     And I edit the claim's defendants
     And I enter defendant, scheme 10 representation order and MAAT reference
 
     And I should see a page title "Enter defendant details for advocate warrant fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I search for the scheme 10 offence 'Absconding from lawful custody'
-    Then the page should be accessible within "#content"
     Then I select the first search result
 
     And I select an advocate category of 'Junior'
@@ -42,7 +36,6 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     And I enter a Warrant net amount of '100'
 
     And I should see a page title "Enter fees for advocate warrant fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I select an expense type "Parking"
@@ -51,7 +44,6 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     And I add an expense date for scheme 10
 
     And I should see a page title "Enter travel expenses for advocate warrant fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I upload 3 documents
@@ -59,23 +51,19 @@ Feature: Advocate partially fills out a draft AGFS interim claim for a trial, th
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for advocate warrant fees claim"
-    Then the page should be accessible within "#content"
     And I click Submit to LAA
     Then I should be on the check your claim page
 
     And I should see a page title "View claim summary for advocate warrant fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue"
 
     Then I should be on the certification page
     When I check “I attended the main hearing”
 
     And I should see a page title "Certify and submit the advocate warrant fees claim"
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20181234' should be listed with a status of 'Submitted' and a claimed amount of '£161.47'
-    Then the page should be accessible within "#content"

--- a/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
@@ -5,10 +5,8 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
   Scenario: Successful submission
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I enter a case number of 'A20181234'
@@ -17,7 +15,6 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I enter scheme 10 trial start and end dates
 
     And I should see a page title "Enter case details for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft
@@ -37,7 +34,6 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
 
     And I search for the scheme 10 offence 'Absconding from lawful custody'
     Given I insert the VCR cassette 'features/claims/advocate/scheme_ten/trial_claim_edit'
-    Then the page should be accessible within "#content"
 
     When I select the first search result
     Then I should be in the 'Graduated fees' form page
@@ -52,7 +48,6 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I select the 'Number of cases uplift' basic fee with quantity of 1 with case numbers
 
     And I should see a page title "Enter graduated fees for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended '2018-04-01'
@@ -71,7 +66,6 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I add an expense date for scheme 10
 
     And I should see a page title "Enter travel expenses for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I upload the document 'judicial_appointment_order.pdf'
@@ -80,7 +74,6 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for advocate final fees claim"
-    Then the page should be accessible within "#content"
     Then I click Submit to LAA
 
     Then I should be on the check your claim page
@@ -104,21 +97,17 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I should see 'Bish bosh bash'
 
     And I should see a page title "View claim summary for advocate final fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue"
     Then I should be on the certification page
 
     When I check “I attended the main hearing”
 
     And I should see a page title "Certify and submit the advocate final fees claim"
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
 
     Then I should be on the claim confirmation page
     And I should see a page title "Thank you for submitting your claim"
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20181234' should be listed with a status of 'Submitted' and a claimed amount of '£1,009.87'
-    Then the page should be accessible within "#content"

--- a/features/claims/downtime_banner.feature
+++ b/features/claims/downtime_banner.feature
@@ -16,3 +16,4 @@ Feature: A downtime warning banner will appear on every page until downtime date
     When the current date is '2019-11-21'
     And I refresh the page
     Then the downtime banner is not displayed
+    Then the page should be accessible within "#content"

--- a/features/claims/litigator/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_claim_draft_submit.feature
@@ -7,10 +7,8 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator interim fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new interim claim page
 
     When I choose the supplier number '1A222Z'
@@ -20,7 +18,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I enter a case number of 'A20161234'
 
     And I should see a page title "Enter case details for litigator interim fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I should see a page title "Enter defendant details for litigator interim fees claim"
@@ -37,7 +34,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I add another defendant, LGFS representation order and MAAT reference
 
     And I should see a page title "Enter defendant details for litigator interim fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I select the offence category 'Handling stolen goods'
@@ -46,7 +42,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     Given I insert the VCR cassette 'features/claims/litigator/interim_fee_calculations'
 
     And I should see a page title "Enter offence details for litigator interim fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue" in the claim form
 
     And I should be in the 'Interim fee' form page
@@ -72,7 +67,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator interim fees claim"
-    Then the page should be accessible within "#content"
     And I click Submit to LAA
     Then I should be on the check your claim page
     And I should see 'Blackfriars'
@@ -102,17 +96,13 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I should see 'Bish bosh bash'
 
     And I should see a page title "View claim summary for litigator interim fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue"
     Then I should be on the certification page
 
     And I should see a page title "Certify and submit the litigator interim fees claim"
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£414.48'
-    Then the page should be accessible within "#content"

--- a/features/claims/litigator/interim_trial_warrant_claim_draft_submit.feature
+++ b/features/claims/litigator/interim_trial_warrant_claim_draft_submit.feature
@@ -6,17 +6,14 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator interim fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new interim claim page
 
     When I choose the supplier number '1A222Z'
     And I select the court 'Blackfriars'
     And I select a case type of 'Trial'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft
@@ -30,13 +27,11 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     And I enter defendant, LGFS representation order and MAAT reference
     And I add another defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/claims/litigator/interim_warrant_fee_calculations'
 
@@ -48,7 +43,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I enter '2016-01-01' as the warrant issued date
     And I enter '2016-04-01' as the warrant executed date
     And I enter '680.39' in the interim fee total field
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -58,7 +52,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I select a travel reason "View of crime scene"
     And I add an expense net amount for "34.56"
     And I add an expense date for LGFS
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -66,7 +59,6 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I check the boxes for the uploaded documents
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
-    Then the page should be accessible within "#content"
 
     And I click Submit to LAA
     Then I should be on the check your claim page
@@ -75,11 +67,8 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     Then I should be on the certification page
 
     And I click Certify and submit claim
-    Then the page should be accessible within "#content"
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£721.86'
-    Then the page should be accessible within "#content"

--- a/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_draft_submit.feature
@@ -7,10 +7,8 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new claim page
 
     And I should see 3 supplier number radios
@@ -20,7 +18,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2016-04-01'
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft
@@ -34,12 +31,10 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I edit the claim's case details
 
     Then I should see a supplier number select list
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I enter defendant, LGFS representation order and MAAT reference
     And I add another defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/claims/litigator/fixed_fee_calculations'
     Then I click "Continue" in the claim form
@@ -49,7 +44,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I fill '2018-11-01' as the fixed fee date
     And I fill '2' as the fixed fee quantity
     Then I should see fixed fee total '£232.98'
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -76,13 +70,11 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I add an expense date for LGFS
 
     And I should see a page title "Enter travel expenses for litigator final fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I upload 1 document
     And I check the boxes for the uploaded documents
     And I add some additional information
-    Then the page should be accessible within "#content"
 
     And I click Submit to LAA
     Then I should be on the check your claim page
@@ -95,17 +87,13 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should not see 'Trial concluded on'
 
     And I should see a page title "View claim summary for litigator final fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue"
     Then I should be on the certification page
 
     And I should see a page title "Certify and submit the litigator final fees claim"
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£754.71'
-    Then the page should be accessible within "#content"

--- a/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
+++ b/features/claims/litigator/litigator_contempt_claim_with_errors_submit.feature
@@ -7,10 +7,8 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new claim page
 
     When I choose the supplier number '1A222Z'
@@ -18,7 +16,6 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     And I select a case type of 'Contempt'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2018-04-01'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
@@ -33,18 +30,15 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     And I fill '2018-11-01' as the fixed fee date
     And I fill '2' as the fixed fee quantity
     Then I should see fixed fee total '£232.98'
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
     Then I click "Continue" in the claim form
 
     And I should be in the 'Miscellaneous fees' form page
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I should be in the 'Disbursements' form page
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I should be in the 'Travel expenses' form page
@@ -57,7 +51,6 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
 
     Then I should see in the sidebar total '£347.73'
     Then I should see in the sidebar vat total '£15.50'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -66,11 +59,9 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     Then I should see in the sidebar vat total '£15.50'
 
     And I enter the date for the first expense '2016-04-02'
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I should be in the 'Supporting evidence' form page
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -79,4 +70,3 @@ Feature: Litigator fills out a final fee claim, there is an error, fixes it and 
     Then I should be on the certification page
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"

--- a/features/claims/litigator/litigator_expense_page.feature
+++ b/features/claims/litigator/litigator_expense_page.feature
@@ -6,10 +6,8 @@ Feature: Litigator expense specific page features
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new claim page
 
     When I choose the supplier number '1A222Z'
@@ -17,13 +15,11 @@ Feature: Litigator expense specific page features
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2018-04-01'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I save as draft
     Then I should see 'Draft claim saved'
-    Then the page should be accessible within "#content"
 
     Given I am later on the Your claims page
     When I click the claim 'A20161234'
@@ -54,6 +50,5 @@ Feature: Litigator expense specific page features
     Then I should see 'Cost per mile'
     Then I should see '20p per mile'
     Then I should see 'Other reason'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -7,10 +7,8 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new claim page
     And I should see a page title "Enter case details for litigator final fees claim"
     And I should see 3 supplier number radios
@@ -19,11 +17,9 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2016-04-01'
-    Then the page should be accessible within "#content"
     Then I click "Continue" I should be on the 'Case details' page and see a "Choose a supplier number" error
 
     When I choose the supplier number '1A222Z'
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
     Then I should be in the 'Defendant details' form page
     And I should see a page title "Enter defendant details for litigator final fees claim"
@@ -39,7 +35,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I edit the claim's case details
     And I should see a page title "Enter case details for litigator final fees claim"
     And I should see a supplier number select list
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Defendant details' form page
@@ -64,7 +59,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I select the offence category 'Handling stolen goods'
     And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/claims/litigator/graduated_fee_calculations'
 
@@ -76,7 +70,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     Then the graduated fee amount should be populated with '429.12'
     When I enter '51' in the PPE total graduated fee field
     Then the graduated fee amount should be populated with '437.89'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -86,7 +79,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should see a page title "Enter miscellaneous fees for litigator final fees claim"
     And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee'
     And I add a litigator miscellaneous fee 'Costs judge application'
-    Then the page should be accessible within "#content"
 
     When I click "Continue" in the claim form
     Then I should be in the 'Disbursements' form page
@@ -102,7 +94,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I select a travel reason "View of crime scene"
     And I add an expense net amount for "34.56"
     And I add an expense date for scheme 10
-    Then the page should be accessible within "#content"
 
     When I click "Continue" in the claim form
     Then I should be in the 'Supporting evidence' form page
@@ -111,7 +102,6 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I upload the document 'indictment.pdf'
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
-    Then the page should be accessible within "#content"
 
     When I click Submit to LAA
     Then I should be on the check your claim page
@@ -127,18 +117,14 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should not see 'First day of trial'
     And I should not see 'Estimated trial length'
     And I should not see 'Trial concluded on'
-    Then the page should be accessible within "#content"
 
     When I click "Continue"
     Then I should be on the certification page
     And I should see a page title "Certify and submit the litigator final fees claim"
-    Then the page should be accessible within "#content"
 
     When I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£823.84'
-    Then the page should be accessible within "#content"

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -7,10 +7,8 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator transfer fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new transfer claim page
     And I should see a page title "Enter fees for litigator transfer fees claim"
 
@@ -19,7 +17,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I select the transfer stage 'Before trial transfer'
     And I enter the transfer date '2015-05-21'
     And I select a case conclusion of 'Cracked'
-    Then the page should be accessible within "#content"
 
     And I click "Continue" in the claim form
 
@@ -29,7 +26,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I enter the case concluded date
 
     And I should see a page title "Enter case details for litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I should see a page title "Enter defendant details for litigator transfer fees claim"
@@ -46,7 +42,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I add another defendant, LGFS representation order and MAAT reference
 
     And I should see a page title "Enter defendant details for litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
 
     And I select the offence category 'Handling stolen goods'
@@ -55,7 +50,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     Given I insert the VCR cassette 'features/claims/litigator/transfer_fee_calculations'
 
     And I should see a page title "Enter offence details for litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
 
     Then the transfer fee amount should be populated with '269.08'
@@ -67,7 +61,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     Then the transfer fee amount should be populated with '274.37'
 
     And I should see a page title "Enter fees for litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I eject the VCR cassette
@@ -77,7 +70,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I add a litigator miscellaneous fee 'Costs judge application'
 
     And I should see a page title "Enter miscellaneous fees for litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
 
     And I add a disbursement 'Computer experts' with net amount '125.40' and vat amount '25.08'
@@ -91,7 +83,6 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I select a travel reason "View of crime scene"
     And I add an expense net amount for "34.56"
     And I add an expense date for LGFS
-    Then the page should be accessible within "#content"
 
     When I click "Continue" in the claim form
     Then I should be in the 'Supporting evidence' form page
@@ -103,23 +94,18 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     Then I click Submit to LAA
     And I should be on the check your claim page
     And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
 
     And I should see a page title "View claim summary for litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     When I click "Continue"
     Then I should be on the certification page
 
     And I should see a page title "Certify and submit the litigator transfer fees claim"
-    Then the page should be accessible within "#content"
     And I click Certify and submit claim
     Then I should be on the claim confirmation page
-    Then the page should be accessible within "#content"
 
     When I click View your claims
     Then I should be on the your claims page
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£660.32'
-    Then the page should be accessible within "#content"

--- a/features/claims/timed_retention_banner.feature
+++ b/features/claims/timed_retention_banner.feature
@@ -13,3 +13,4 @@ Feature: A timed retention banner will appear on the claims list, until the user
     Then The timed retention banner is not visible
     When I click 'Your claims' link
     Then The timed retention banner is not visible
+    Then the page should be accessible within "#content"

--- a/features/fee_calculator/advocate/fixed_fee_calculator.feature
+++ b/features/fee_calculator/advocate/fixed_fee_calculator.feature
@@ -6,24 +6,18 @@ Feature: Advocate completes fixed fee page using calculator
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
-    Then the page should be accessible within "#content"
 
     And I select the court 'Blackfriars'
     And I select a case type of 'Appeal against conviction'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
-    Then the page should be accessible within "#content"
 
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -57,37 +51,29 @@ Feature: Advocate completes fixed fee page using calculator
       | fixed | Number of cases uplift | 104.00 |
       | fixed | Number of defendants uplift | 104.00 |
       | fixed | Standard appearance fee | 173.00 |
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
     Then I click "Continue" in the claim form
     And I am on the miscellaneous fees page
-    Then the page should be accessible within "#content"
 
   @fee_calc_vcr
   Scenario: I create a fixed fee which has a fixed amount calculated value
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
-    Then the page should be accessible within "#content"
 
     And I select the court 'Blackfriars'
     And I select a case type of 'Elected cases not proceeded'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
-    Then the page should be accessible within "#content"
 
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -110,12 +96,10 @@ Feature: Advocate completes fixed fee page using calculator
       | fixed | Elected case not proceeded | 194.00 | Number of days | true |
       | fixed | Number of cases uplift | 38.80 | Number of additional cases | true |
       | fixed | Number of defendants uplift | 38.80 | Number of additional defendants | true |
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
     Then I click "Continue" in the claim form
     And I am on the miscellaneous fees page
-    Then the page should be accessible within "#content"
 
     And all the fixed fees should have their price_calculated values set to true

--- a/features/fee_calculator/advocate/graduated_fee_calculator.feature
+++ b/features/fee_calculator/advocate/graduated_fee_calculator.feature
@@ -6,10 +6,8 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
 
     And I enter a providers reference of 'AGFS test graduated fee calculation'
@@ -17,22 +15,18 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter scheme 9 trial long start and end dates
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, scheme 9 representation order and MAAT reference
     And I add another defendant, scheme 9 representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/advocate/graduated_fee_trial_calculator'
 
     When I select the offence category 'Murder'
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
     And I should be in the 'Graduated fees' form page
     # Flickers alot (related to page load speed problems??)
@@ -41,10 +35,8 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     # advocate category impacts "basic" fee
     When I select an advocate category of 'Junior alone'
     And the basic fee net amount should be populated with '1632.00'
-    Then the page should be accessible within "#content"
     And I select an advocate category of 'QC'
     Then the basic fee net amount should be populated with '2856.00'
-    Then the page should be accessible within "#content"
 
     When I select the 'Daily attendance fee (3 to 40)' basic fee with quantity of 38
     And I select the 'Daily attendance fee (41 to 50)' basic fee with quantity of 10
@@ -75,18 +67,14 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     Then the pages of prosecution evidence net amount should be populated with '0.00'
     When I enter '51' pages of prosecution evidence
     Then the pages of prosecution evidence net amount should be populated with '1.63'
-    Then the page should be accessible within "#content"
 
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
-    Then the page should be accessible within "#content"
 
     # offence impact on "basic" fee
     When I goto claim form step 'offence details'
     And I select the offence category 'Activities relating to opium'
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
-    Then the page should be accessible within "#content"
     Then the basic fee net amount should be populated with '2529.00'
     Then the following fee details should exist:
       | section | fee_description | rate | hint | help |
@@ -100,13 +88,11 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
       | basic | Number of cases uplift | 505.80 | Number of additional cases | true |
     And the prosecution witnesses net amount should be populated with '6.53'
     And the pages of prosecution evidence net amount should be populated with '1.63'
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
-    Then the page should be accessible within "#content"
     And the following fees should have their price_calculated set to true: 'BABAF,BADAF,BADAH,BADAJ,BASAF,BAPCM,BACAV,BANDR,BANOC,BANPW,BAPPE'
 
   @fee_calc_vcr
@@ -114,12 +100,9 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
-    Then the page should be accessible within "#content"
 
     And I enter a providers reference of 'AGFS test graduated fee calculation'
     And I select a case type of 'Retrial'
@@ -127,25 +110,20 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     And I enter a case number of 'A20161234'
     And I enter scheme 9 retrial long start and end dates
     And I choose to apply retrial reduction
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
-    Then the page should be accessible within "#content"
 
     And I enter defendant, scheme 9 representation order and MAAT reference
     And I add another defendant, scheme 9 representation order and MAAT reference
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/advocate/graduated_fee_retrial_calculator'
 
     When I select the offence category 'Murder'
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
     And I should be in the 'Graduated fees' form page
-    Then the page should be accessible within "#content"
     Then the basic fee net amount should be populated with '0.00'
 
     # advocate category impacts "basic" fee (retrial interval within a month, 30% reduction)
@@ -153,18 +131,14 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     Then the basic fee net amount should be populated with '1142.40'
     When I select an advocate category of 'QC'
     Then the basic fee net amount should be populated with '1999.20'
-    Then the page should be accessible within "#content"
 
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
-    Then the page should be accessible within "#content"
 
     # offence impact on "basic" fee
     When I goto claim form step 'offence details'
     And I select the offence category 'Activities relating to opium'
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
-    Then the page should be accessible within "#content"
     Then the basic fee net amount should be populated with '1770.30'
 
     When I select the 'Daily attendance fee (3 to 40)' basic fee with quantity of 38
@@ -197,16 +171,13 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     Then the pages of prosecution evidence net amount should be populated with '0.00'
     When I enter '51' pages of prosecution evidence
     Then the pages of prosecution evidence net amount should be populated with '1.14'
-    Then the page should be accessible within "#content"
 
     # retrial interval impact on "basic" fee (retrial interval greater than a month, 20% reduction)
     When I click "Continue" in the claim form
     And I goto claim form step 'case details'
-    Then the page should be accessible within "#content"
     And I enter retrial long start and end dates with 32 day interval
     And I click "Continue" in the claim form
     And I goto claim form step 'basic fees'
-    Then the page should be accessible within "#content"
     Then the basic fee net amount should be populated with '2023.20'
     And the following fee details should exist:
       | section | fee_description | rate | hint | help |
@@ -228,15 +199,12 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     Then the pages of prosecution evidence net amount should be populated with '0.00'
     When I enter '51' pages of prosecution evidence
     Then the pages of prosecution evidence net amount should be populated with '1.30'
-    Then the page should be accessible within "#content"
 
     # retrial reduction impact on "basic" fee
     When I goto claim form step 'case details'
     And I choose not to apply retrial reduction
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
     And I goto claim form step 'basic fees'
-    Then the page should be accessible within "#content"
     Then the basic fee net amount should be populated with '2529.00'
     And the following fee details should exist:
       | section | fee_description | rate | hint | help |
@@ -250,50 +218,40 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
       | basic | Number of cases uplift | 505.80 | Number of additional cases | true |
     And the prosecution witnesses net amount should be populated with '6.53'
     And the pages of prosecution evidence net amount should be populated with '1.63'
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
     And the following fees should have their price_calculated set to true: 'BABAF,BADAF,BADAH,BADAJ,BASAF,BAPCM,BACAV,BANDR,BANOC,BANPW,BAPPE'
-    Then the page should be accessible within "#content"
 
   @fee_calc_vcr
   Scenario: I create a scheme 9 AGFS graduated discontinuance fee claim using calculated value
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
-    Then the page should be accessible within "#content"
 
     And I enter a providers reference of 'AGFS test graduated fee calculation'
     And I select a case type of 'Discontinuance'
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
-    Then the page should be accessible within "#content"
 
     And I enter defendant, scheme 9 representation order and MAAT reference
     And I add another defendant, scheme 9 representation order and MAAT reference
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/advocate/graduated_fee_trial_calculator'
 
     When I select the offence category 'Murder'
-    Then the page should be accessible within "#content"
     And I click "Continue" in the claim form
     And I should be in the 'Graduated fees' form page
-    Then the page should be accessible within "#content"
 
     Then I should not see 'Pages of prosecution evidence (PPE)'
     And I should not see 'Prosecution witnesses'
@@ -305,17 +263,14 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
 
     When I answer 'Yes' to was prosecution evidence served on this case?
     And the basic fee net amount should be populated with '979.00'
-    Then the page should be accessible within "#content"
 
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
-    Then the page should be accessible within "#content"
     And the following fees should have their price_calculated set to true: 'BABAF'
 
     When I click "Continue" in the claim form
     When I click "Continue" in the claim form
     When I click "Continue" in the claim form
     Then I should see "Was prosecution evidence served on this case? Yes"
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette

--- a/features/fee_calculator/advocate/misc_fee_calculator.feature
+++ b/features/fee_calculator/advocate/misc_fee_calculator.feature
@@ -6,36 +6,28 @@ Feature: Advocate completes misc fee page using calculator
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
-    Then the page should be accessible within "#content"
 
     And I select the court 'Blackfriars'
     And I select a case type of 'Appeal against conviction'
     And I enter a case number of 'A20174321'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
-    Then the page should be accessible within "#content"
 
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
 
     Then I click "Continue" in the claim form
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/advocate/misc_fee_calculator'
 
     And I select an advocate category of 'QC'
     And I select the 'Appeals to the crown court against conviction' fixed fee
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
-    Then the page should be accessible within "#content"
 
     When I add a calculated miscellaneous fee 'Wasted preparation fee'
     And I add a calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '2'
@@ -53,16 +45,13 @@ Feature: Advocate completes misc fee page using calculator
       | miscellaneous | Wasted preparation fee | 74.00 | Number of hours | true |
       | miscellaneous | Hearings relating to disclosure (whole day) | 497.00 | Number of days | true |
       | miscellaneous | Hearings relating to disclosure (whole day uplift) | 298.20 | Number of additional defendants | true |
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
     Then I click "Continue" in the claim form
     And I should be in the 'Travel expenses' form page
     And all the misc fees should have their price_calculated values set to true
-    Then the page should be accessible within "#content"
 
     And I save as draft
     Then I should see 'Draft claim saved'
     And Claim 'A20174321' should be listed with a status of 'Draft' and a claimed amount of '£2,905.68'
-    Then the page should be accessible within "#content"

--- a/features/fee_calculator/calculator_offline.feature
+++ b/features/fee_calculator/calculator_offline.feature
@@ -6,24 +6,18 @@ Feature: Advocate completes fixed fees, but calculator offline
 
     Given I am a signed in advocate
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the new claim page
-    Then the page should be accessible within "#content"
 
     And I select the court 'Blackfriars'
     And I select a case type of 'Appeal against sentence'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
-    Then the page should be accessible within "#content"
 
     And I enter defendant, representation order and MAAT reference
     And I add another defendant, representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
@@ -31,7 +25,5 @@ Feature: Advocate completes fixed fees, but calculator offline
     And I select the 'Appeals to the crown court against sentence' fixed fee
     Then the 'Appeals to the crown court against sentence' fixed fee rate should be in the calculator error state
     When I set the 'Appeals to the crown court against sentence' fixed fee value to '108.00'
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form
     And I am on the miscellaneous fees page
-    Then the page should be accessible within "#content"

--- a/features/fee_calculator/litigator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/litigator/fixed_fee_calculator.feature
@@ -7,12 +7,9 @@ Feature: litigator completes fixed fee page using calculator
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new claim page
-    Then the page should be accessible within "#content"
 
     When I choose the supplier number '1A222Z'
     And I enter a providers reference of 'LGFS test fixed fee calculation'
@@ -20,13 +17,11 @@ Feature: litigator completes fixed fee page using calculator
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2018-04-01'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, LGFS representation order and MAAT reference
     And I add another defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/litigator/fixed_fee_calculator'
 
@@ -39,30 +34,25 @@ Feature: litigator completes fixed fee page using calculator
     Then I should see fixed fee total '£349.47'
     And I fill '2' as the fixed fee quantity
     Then I should see fixed fee total '£698.94'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
 
     And I goto claim form step 'case details'
     And I select a case type of 'Hearing subsequent to sentence'
-    Then the page should be accessible within "#content"
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I goto claim form step 'fixed fees'
     Then the fixed fee rate should be populated with '155.32'
     Then I should see fixed fee total '£310.64'
-    Then the page should be accessible within "#content"
 
     And I goto claim form step 'case details'
     And I select a case type of 'Elected cases not proceeded'
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
-    Then the page should be accessible within "#content"
 
     And I goto claim form step 'fixed fees'
     Then the fixed fee rate should be populated with '330.33'
     Then I should see fixed fee total '£660.66'
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -70,4 +60,3 @@ Feature: litigator completes fixed fee page using calculator
     And I should be in the 'Miscellaneous fees' form page
 
     And the fixed fee should have its price_calculated value set to true
-    Then the page should be accessible within "#content"

--- a/features/fee_calculator/litigator/graduated_fee_calculator.feature
+++ b/features/fee_calculator/litigator/graduated_fee_calculator.feature
@@ -7,10 +7,8 @@ Feature: litigator completes graduated fee page using calculator
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new claim page
 
     When I choose the supplier number '1A222Z'
@@ -19,19 +17,16 @@ Feature: litigator completes graduated fee page using calculator
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date '2018-04-01'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
 
     And I select the offence category 'Abandonment of children under two'
     Then the offence class list is set to 'C: Lesser offences involving violence or damage and less serious drug offences'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/litigator/graduated_fee_calculator'
 
@@ -49,7 +44,6 @@ Feature: litigator completes graduated fee page using calculator
     And I goto claim form step 'offence details'
     And I select the offence category 'Murder'
     Then the offence class list is set to 'A: Homicide and related grave offences'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Graduated fee' form page
@@ -58,7 +52,6 @@ Feature: litigator completes graduated fee page using calculator
     # case type impact
     And I goto claim form step 'case details'
     And I select a case type of 'Trial'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
     And I goto claim form step 'graduated fees'
@@ -74,21 +67,18 @@ Feature: litigator completes graduated fee page using calculator
     # ppe impact for trials (boundary 96 plus for 3 day trial)
     When I enter '96' in the PPE total graduated fee field
     Then the graduated fee amount should be populated with '1732.86'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
 
     # defendant uplift impact
     And I goto claim form step 'defendants'
     And I add another defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
 
     And I goto claim form step 'graduated fees'
     And the graduated fee amount should be populated with '2079.43'
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -96,4 +86,3 @@ Feature: litigator completes graduated fee page using calculator
     And I should be in the 'Miscellaneous fees' form page
 
     And the graduated fee should have its price_calculated value set to true
-    Then the page should be accessible within "#content"

--- a/features/fee_calculator/litigator/interim_fee_calculator.feature
+++ b/features/fee_calculator/litigator/interim_fee_calculator.feature
@@ -7,12 +7,9 @@ Feature: litigator completes interim fee page using calculator
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator interim fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new interim claim page
-    Then the page should be accessible within "#content"
 
     And I click "Continue" in the claim form
     And I should be in the 'Case details' form page
@@ -22,19 +19,16 @@ Feature: litigator completes interim fee page using calculator
     And I select the court 'Blackfriars'
     And I select a case type of 'Trial'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
 
     And I select the offence category 'Murder'
     Then the offence class list is set to 'A: Homicide and related grave offences'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/litigator/interim_trial_fee_calculator'
 
@@ -48,7 +42,6 @@ Feature: litigator completes interim fee page using calculator
     When I enter '81' in the PPE total interim fee field
     Then the interim fee amount should be populated with '686.46'
     And I enter the effective PCMH date '2018-04-01'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Supporting evidence' form page
@@ -57,12 +50,10 @@ Feature: litigator completes interim fee page using calculator
     And I goto claim form step 'offence details'
     And I select the offence category 'Violent disorder'
     Then the offence class list is set to 'B: Offences involving serious violence or damage and serious drug offences'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Interim fee' form page
     And the interim fee amount should be populated with '596.46'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Supporting evidence' form page
@@ -70,7 +61,6 @@ Feature: litigator completes interim fee page using calculator
     # defendant uplift impact
     And I goto claim form step 'defendants'
     And I add another defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
@@ -92,13 +82,11 @@ Feature: litigator completes interim fee page using calculator
     Then the interim fee amount should be populated with '1317.19'
     When I enter '71' in the PPE total interim fee field
     Then the interim fee amount should be populated with '1332.56'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Supporting evidence' form page
 
     And the interim fee should have its price_calculated value set to true
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -108,12 +96,9 @@ Feature: litigator completes interim fee page using calculator
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator interim fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new interim claim page
-    Then the page should be accessible within "#content"
 
     And I click "Continue" in the claim form
     And I should be in the 'Case details' form page
@@ -123,19 +108,16 @@ Feature: litigator completes interim fee page using calculator
     And I select the court 'Blackfriars'
     And I select a case type of 'Retrial'
     And I enter a case number of 'A20161234'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page
 
     And I enter defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
 
     And I select the offence category 'Murder'
     Then the offence class list is set to 'A: Homicide and related grave offences'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/litigator/interim_retrial_fee_calculator'
 
@@ -150,7 +132,6 @@ Feature: litigator completes interim fee page using calculator
     And the interim fee amount should be populated with '457.64'
     And I enter the legal aid transfer date '2018-04-01'
     And I enter the first trial concluded date '2018-04-01'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Supporting evidence' form page
@@ -159,7 +140,6 @@ Feature: litigator completes interim fee page using calculator
     And I goto claim form step 'offence details'
     And I select the offence category 'Violent disorder'
     Then the offence class list is set to 'B: Offences involving serious violence or damage and serious drug offences'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Interim fee' form page
@@ -168,7 +148,6 @@ Feature: litigator completes interim fee page using calculator
     # defendant uplift impact
     And I goto claim form step 'defendants'
     And I add another defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
@@ -191,12 +170,10 @@ Feature: litigator completes interim fee page using calculator
     And the interim fee amount should be populated with '1317.19'
     And I enter '71' in the PPE total interim fee field
     And the interim fee amount should be populated with '1332.56'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Supporting evidence' form page
 
     And the interim fee should have its price_calculated value set to true
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette

--- a/features/fee_calculator/litigator/transfer_fee_calculator.feature
+++ b/features/fee_calculator/litigator/transfer_fee_calculator.feature
@@ -7,10 +7,8 @@ Feature: litigator completes transfer fee page using calculator
     Given I am a signed in litigator
     And My provider has supplier numbers
     And I am on the 'Your claims' page
-    Then the page should be accessible within "#content"
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator transfer fee'
-    Then the page should be accessible within "#content"
     Then I should be on the litigator new transfer claim page
 
     When I choose the litigator type option 'New'
@@ -18,7 +16,6 @@ Feature: litigator completes transfer fee page using calculator
     And I select the transfer stage 'During trial transfer'
     And I enter the transfer date '2016-04-01'
     And I select a case conclusion of 'Trial'
-    Then the page should be accessible within "#content"
 
     And I click "Continue" in the claim form
 
@@ -26,7 +23,6 @@ Feature: litigator completes transfer fee page using calculator
     And I select the court 'Blackfriars'
     And I enter a case number of 'A20161234'
     And I enter the case concluded date
-    Then the page should be accessible within "#content"
 
     And I click "Continue" in the claim form
 
@@ -34,14 +30,12 @@ Feature: litigator completes transfer fee page using calculator
     And I should be in the 'Defendant details' form page
 
     And I enter defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
 
     And I select the offence category 'Murder'
     Then the offence class list is set to 'A: Homicide and related grave offences'
-    Then the page should be accessible within "#content"
 
     Given I insert the VCR cassette 'features/fee_calculator/litigator/transfer_fee_calculator'
 
@@ -65,7 +59,6 @@ Feature: litigator completes transfer fee page using calculator
     And I goto claim form step 'offence details'
     And I select the offence category 'Abandonment of children under two'
     Then the offence class list is set to 'C: Lesser offences involving violence or damage and less serious drug offences'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Transfer details' form page
@@ -79,7 +72,6 @@ Feature: litigator completes transfer fee page using calculator
     And I choose the elected case option 'No'
     And I select the transfer stage 'Up to and including PCMH transfer'
     And I select a case conclusion of 'Guilty plea'
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I goto claim form step 'transfer fees'
@@ -92,19 +84,16 @@ Feature: litigator completes transfer fee page using calculator
     # ppe impact for guilty plea
     When I enter '41' in the PPE total graduated fee field
     Then the transfer fee amount should be populated with '445.57'
-    Then the page should be accessible within "#content"
 
     # defendant uplift impact
     And I goto claim form step 'defendants'
     And I add another defendant, LGFS representation order and MAAT reference
-    Then the page should be accessible within "#content"
 
     Then I click "Continue" in the claim form
     And I should be in the 'Offence details' form page
 
     And I goto claim form step 'transfer fees'
     Then the transfer fee amount should be populated with '531.49'
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -112,4 +101,3 @@ Feature: litigator completes transfer fee page using calculator
     And I should be in the 'Miscellaneous fees' form page
 
     And the transfer fee should have its price_calculated value set to true
-    Then the page should be accessible within "#content"

--- a/features/refuse_claim.feature
+++ b/features/refuse_claim.feature
@@ -10,7 +10,6 @@ Feature: Case worker rejects a claim, providing a reason
     And I insert the VCR cassette 'features/case_workers/claims/refuse'
 
     When I am signed in as the case worker
-    Then the page should be accessible within "#content"
     And the reject refuse messaging feature is released
     And I select the claim
     And I click the refused radio button
@@ -23,11 +22,9 @@ Feature: Case worker rejects a claim, providing a reason
     Then the last message contains 'Your claim has been refused'
     Then the last message contains 'Duplicate claim'
     Then the last message contains 'Whatever will be will be'
-    Then the page should be accessible within "#content"
 
     When I click your claims
     Then the claim I've just updated is no longer in the list
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette
 
@@ -40,7 +37,6 @@ Feature: Case worker rejects a claim, providing a reason
     And I insert the VCR cassette 'features/case_workers/claims/refuse'
 
     When I am signed in as the case worker
-    Then the page should be accessible within "#content"
     And I select the claim
     And I click the refused radio button
     And I select the refusal reason 'Wrong Instructed Advocate'
@@ -53,10 +49,8 @@ Feature: Case worker rejects a claim, providing a reason
     Then the last message contains 'Your claim has been refused'
     Then the last message contains 'Wrong Instructed Advocate'
     Then the last message contains 'Whatever I like'
-    Then the page should be accessible within "#content"
 
     When I click your claims
     Then the claim I've just updated is no longer in the list
-    Then the page should be accessible within "#content"
 
     And I eject the VCR cassette

--- a/features/reject_claim.feature
+++ b/features/reject_claim.feature
@@ -16,12 +16,14 @@ Feature: Case worker rejects a claim, providing a reason
     And I select the rejection reason 'No indictment attached'
     And I select the rejection reason 'Other'
     And I enter rejection reason text 'Whatever will be will be'
+    Then the page should be accessible within "#content"
     And I click update
     Then the status at top of page should be Rejected
     Then message 3 contains 'Claim rejected'
     Then the last message contains 'Your claim has been rejected'
     Then the last message contains 'No indictment attached'
     Then the last message contains 'Whatever will be will be'
+    Then the page should be accessible within "#content"
 
     When I click your claims
     Then the claim I've just updated is no longer in the list


### PR DESCRIPTION
#### What
Reduce cucumber test times

#### Ticket
[Investigate cucumber performance issue](https://dsdmoj.atlassian.net/browse/CBO-1085)

#### Why
Cucumber runtime in CircleCI has rocketed to ~35mins, this is too long and should be reduced to an acceptable time frame <= 12mins.

#### How
Introducing AXE to Cucumber tests seems have dramatically increased the test time.
I had originally added axe steps at each page within each test scenario, most of the steps (i.e: `And I am on the 'Your claims' page`) were repeated across each feature.
This meant we were testing the same page multiple times, thereby increasing the time it took to run our tests, I have since remove such examples and reduce the amount of time axe is run on the same page.

--------

#### TODO (wip)

 - [ ] Research a more robust method of testing all variation within all views, while keeping test times <= 12mins 
