### PR TITLE
Parse branch names to render safe for docker tagging

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -42,7 +42,8 @@ function _circleci_build() {
   if [ "${CIRCLE_BRANCH}" == "master" ]; then
     docker_registry_latest_tag="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-latest"
   else
-    docker_registry_latest_tag="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_BRANCH}-latest"
+    branch_name=$(echo $CIRCLE_BRANCH | tr '/\' '-')
+    docker_registry_latest_tag="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${branch_name}-latest"
   fi
 
   docker tag $docker_registry_tag $docker_registry_latest_tag

--- a/kubernetes_deploy/scripts/build.sh
+++ b/kubernetes_deploy/scripts/build.sh
@@ -49,7 +49,8 @@ function _build() {
       latest_tag=${docker_registry}:${component}-latest
       ;;
     *)
-      latest_tag=${docker_registry}:${component}-${current_branch}-latest
+      branch_name=$(echo $current_branch | tr '/\' '-')
+      latest_tag=${docker_registry}:${component}-${branch_name}-latest
       ;;
   esac
 


### PR DESCRIPTION
dependabot generated branchs, in particuler,
and branches generally can use characters that
are not allowed in docker tags. Replace them
with characters that are.