### PR TITLE
Enable deletion of images via github actiion

### DIFF
--- a/.github/actions/delete-ecr-images/entrypoint
+++ b/.github/actions/delete-ecr-images/entrypoint
@@ -16,10 +16,9 @@ module ECR
 
     def delete
       command = "aws ecr batch-delete-image --repository-name #{ECR.repository_name} --image-ids imageDigest=#{imageDigest}"
-      puts "issue command: #{command}"
-      # Open3.popen3(command) do |_stdin, stdout, _stderr, _wait_thr|
-      #   stdout.read
-      # end
+      Open3.popen3(command) do |_stdin, stdout, _stderr, _wait_thr|
+        stdout.read
+      end
     end
 
     def method_missing(method_name, *args, &block)
@@ -56,10 +55,9 @@ module ECR
     def batch_delete_all
       digests = map { |image| { imageDigest: image.imageDigest } }
       command = "aws ecr batch-delete-image --repository-name #{ECR.repository_name} --image-ids \"#{digests.to_json}\""
-      puts "issue command: #{command}"
-      # Open3.popen3(command) do |_stdin, stdout, _stderr, _wait_thr|
-      #   stdout.read
-      # end
+      Open3.popen3(command) do |_stdin, stdout, _stderr, _wait_thr|
+        stdout.read
+      end
     end
 
     def self.where(tag_name:)
@@ -95,26 +93,10 @@ module GithubAction
   end
 end
 
-puts "looking for #{GithubAction.tag_name}"
+puts "Looking for #{GithubAction.tag_name}"
 images = ECR::Images.where(tag_name: GithubAction.tag_name)
-puts '--------- images start ----------'
-images.each do |image|
-  puts "digest: #{image.imageDigest}"
-  puts "tags: #{image.imageTags.join(', ')}"
-end
-puts '---------- images end ---------'
-
-puts '---------- test map &delete ---------'
-images.map(&:delete)
-puts '---------- test map &delete end ---------'
-
-puts '---------- test delete all ---------'
+puts "Found #{images.count} matching images" unless images.empty?
 images.delete_all
-puts '---------- test delete all end ---------'
-
-puts '---------- test batch delete all ---------'
-images.batch_delete_all
-puts '---------- test batch delete all end ---------'
 
 GithubAction.output("Deleted ECR images: #{images.count}")
 

--- a/.github/workflows/delete_ecr_image.yml
+++ b/.github/workflows/delete_ecr_image.yml
@@ -8,12 +8,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Output
-      run: |
-          echo '--------JSON START------------'
-          echo $(jq . $GITHUB_EVENT_PATH)
-          echo '--------JSON END------------'
-
     - name: delete-ecr-image
       id: ecr-deletion
       uses: ./.github/actions/delete-ecr-images
@@ -22,7 +16,6 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         ECR_REPOSITORY_NAME: 'laa-get-paid/cccd'
-
-    - name: Final output
+    - name: Delete image count
       run: |
         echo "${{ steps.ecr-deletion.outputs.deleted-images }}"


### PR DESCRIPTION
#### What
Uncomment the code for actual deletion
of ECR images for deleted branches.

#### Ticket

[CBO-1083](https://dsdmoj.atlassian.net/browse/CBO-1083)

#### Why
Remove ECR images for branches as part
of strategy to only retain images we need.