### PR TITLE
Fix bug in delete ECR image script

### DIFF
--- a/.github/actions/delete-ecr-images/entrypoint
+++ b/.github/actions/delete-ecr-images/entrypoint
@@ -93,9 +93,9 @@ module GithubAction
   end
 end
 
-puts "Looking for #{GithubAction.tag_name}"
+puts "Looking for #{GithubAction.tag_name}!"
 images = ECR::Images.where(tag_name: GithubAction.tag_name)
-puts "Found #{images.count} matching images" unless images.empty?
+puts "Found #{images.count} matching images!"
 images.delete_all
 
 GithubAction.output("Deleted ECR images: #{images.count}")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Advocate Defence Payments
-### a.k.a Claim for crown court defence
+# Claim for crown court defence
+### a.k.a Advocate Defence Payments, Crime Billing Online
 
 [![CircleCI](https://circleci.com/gh/ministryofjustice/Claim-for-Crown-Court-Defence/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/Claim-for-Crown-Court-Defence/tree/master)
 [![Code Climate](https://codeclimate.com/github/ministryofjustice/Claim-for-Crown-Court-Defence/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/Claim-for-Crown-Court-Defence)


### PR DESCRIPTION
#### What
Remove `empty?` call

#### Why
Not really needed and `empty?` is not
part of `Enumerable`mixin, so would have
to be written/forward to `@collection` if
needed - but keep it simple.