### PR TITLE
Separate workflows for master and branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,9 +353,13 @@ jobs:
 # ------------------
 workflows:
   version: 2
-  build-test-deploy:
+  test-build-deploy-master:
     jobs:
-      - build-test-container
+      - build-test-container:
+          filters:
+            branches:
+              only:
+                - master
       - other-tests:
           requires:
             - build-test-container
@@ -376,60 +380,88 @@ workflows:
       - smoke-test:
           requires:
             - build-app-container
-          filters:
-            branches:
-              only:
-                - master
       - auto-deploy-dev:
           requires:
-            - build-app-container
-          filters:
-            branches:
-              only:
-                - master
+            - smoke-test
       - hold-notification:
           requires:
-            - build-app-container
-      - hold-dev:
-          type: approval
-          requires:
-            - hold-notification
-          filters:
-            branches:
-              ignore:
-                - master
-      - deploy-dev:
-          requires:
-            - hold-dev
-          filters:
-            branches:
-              ignore:
-                - master
+            - smoke-test
       - hold-api-sandbox:
           type: approval
           requires:
-            - hold-notification
+            - smoke-test
       - deploy-api-sandbox:
           requires:
             - hold-api-sandbox
       - hold-staging:
           type: approval
           requires:
-            - hold-notification
+            - smoke-test
       - deploy-staging:
           requires:
             - hold-staging
       - hold-production:
           type: approval
           requires:
-            - hold-notification
-          filters:
-            branches:
-              only:
-                - master
+            - smoke-test
       - deploy-production:
           requires:
             - hold-production
+
+  test-branch:
+    jobs:
+      - build-test-container:
+          filters:
+            branches:
+              ignore:
+                - master
+      - other-tests:
+          requires:
+            - build-test-container
+      - rspec-tests:
+          requires:
+            - build-test-container
+      - cucumber-tests:
+          requires:
+            - build-test-container
+      - upload-coverage:
+          requires:
+            - rspec-tests
+            - cucumber-tests
+            - other-tests
+
+  build-deploy-branch:
+    jobs:
+      - hold-branch-build:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - master
+      - build-app-container:
+          requires:
+            - hold-branch-build
+      - hold-dev:
+          type: approval
+          requires:
+            - build-app-container
+      - hold-staging:
+          type: approval
+          requires:
+            - build-app-container
+      - hold-api-sandbox:
+          type: approval
+          requires:
+            - build-app-container
+      - deploy-dev:
+          requires:
+            - hold-dev
+      - deploy-staging:
+          requires:
+            - hold-staging
+      - deploy-api-sandbox:
+          requires:
+            - hold-api-sandbox
 
   scheduled-smoke-test:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,26 @@ commands:
           success_message: ":tada: deploy of <$CIRCLE_BUILD_URL|$CIRCLE_BRANCH> to << parameters.environment >> successful!"
           failure_message: ":red_circle: deploy of <$CIRCLE_BUILD_URL|$CIRCLE_BRANCH> to << parameters.environment >> failed!"
 
+  hold-notification:
+    description: >
+      Display a slack notification
+    parameters:
+      message:
+        description: slack message
+        type: string
+    steps:
+      - run:
+          name: Set slack notification options
+          command: |
+            if [[ $CIRCLE_BRANCH == "master" ]]; then
+              echo 'export CUSTOM_SLACK_COLOR="#FF8C00"' >> $BASH_ENV
+            else
+              echo 'export CUSTOM_SLACK_COLOR="#3AA3E3"' >> $BASH_ENV
+            fi
+      - slack/approval:
+          color: $CUSTOM_SLACK_COLOR
+          message: << parameters.message >>
+
   smoke-test:
      steps:
       - run:
@@ -303,19 +323,16 @@ jobs:
       - setup_remote_docker
       - *script-build-app-container
 
-  hold-notification:
+  hold-build-notification:
     executor: cloud-platform-executor
     steps:
-      - run:
-          name: Set slack options for branch
-          command: |
-            if [[ $CIRCLE_BRANCH == "master" ]]; then
-              echo 'export CUSTOM_SLACK_COLOR="#FF8C00"' >> $BASH_ENV
-            else
-              echo 'export CUSTOM_SLACK_COLOR="#3AA3E3"' >> $BASH_ENV
-            fi
-      - slack/approval:
-          color: $CUSTOM_SLACK_COLOR
+      - hold-notification:
+          message: "Do you want to build <$CIRCLE_BUILD_URL|$CIRCLE_BRANCH>?"
+
+  hold-deploy-notification:
+    executor: cloud-platform-executor
+    steps:
+      - hold-notification:
           message: "Deployment of <$CIRCLE_BUILD_URL|$CIRCLE_BRANCH> pending approval"
 
   deploy-dev:
@@ -383,7 +400,7 @@ workflows:
       - auto-deploy-dev:
           requires:
             - smoke-test
-      - hold-notification:
+      - hold-deploy-notification:
           requires:
             - smoke-test
       - hold-api-sandbox:
@@ -432,6 +449,7 @@ workflows:
 
   build-deploy-branch:
     jobs:
+      - hold-build-notification
       - hold-branch-build:
           type: approval
           filters:

--- a/README.md
+++ b/README.md
@@ -331,11 +331,25 @@ The claim's provider has an attribute 'vat_registered' which governs whether or 
 
 For both VAT registered and unregistered LGFS providers, a VAT amount field is provided for manual input of VAT
 
+
+## Build and Deploy
+
+### CircleCI
+
+CircleCI is configured such that:
+
+1. merges to `master` will automatically build a docker container image for the app, tag it as `app-latest` and push to our AWS elastic container registry (ECR). The image will be smoke tested before then requiring approval for deployment.
+
+2. branches have 2 separate workflows. The first runs the test suite against the branch without any user interaction. The second workflow requires approval to build a container and then enables deployment to individual non-production environments (approval required).
+
+The build and deploy scripts can be found in the root `.circleci` directory.
+
 ### Kubernetes
 
-Config for kubernetes object can be found under `kubernetes_deploy/`. In addition scripts in `kubernetes_deploy/scripts` are available for the most common tasks, namely build, deploy, job, cronjob.
+CCCD's stack orchestration tool is kubernetes. Config for kubernetes can be found under the `kubernetes_deploy/` directory. Note, however, that the infrastructure is defined in the [Cloud platform environments repository](https://github.com/ministryofjustice/cloud-platform-environments)
 
-Thes can be used as any script once you have correct access to AWS:
+Build and deploy from your local machine can be achieved using scripts in `kubernetes_deploy/scripts` *and can be used once you have access to AWS*. These facilitate the most common tasks, namely build, deploy, apply a job, apply a cronjob.
+
 
 ```
 # build and deploy master to dev
@@ -348,7 +362,7 @@ kubernetes_deploy/scripts/deploy.sh dev latest
 There are two cronjobs, `clean_ecr` and `archive_stale`. Any change to the `archive_stale` jobs config (`kubernetes_deploy/cron_jobs/archive_stale.yml`) are applied as part of the deployment process (because it relies on the app image), but any changes to the standalone `clean_ecr` job need to be applied from the commandline, as below
 
 ```
-# apply changes to `kubernetes_deploy/cron_jobs/clean_ecr.yml`
+# apply changes to made to `kubernetes_deploy/cron_jobs/clean_ecr.yml`
 kubernetes_deploy/scripts/cronjob.sh clean_ecr
 ```
 
@@ -356,7 +370,7 @@ kubernetes_deploy/scripts/cronjob.sh clean_ecr
 
 Bug reports and pull requests are welcome.
 
-1. Fork the project (https://github.com/ministryofjustice/advocate-defence-payments/fork)
+1. Fork the project (https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/fork)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit until you are happy with your contribution (`git commit -am 'Add some feature'`)
 4. Push the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
#### What

creates 3 separate workflows:
1. one for master
2. one for running test suite on branch
3. one for build and deploy of branch

#### Ticket

[CBO-1090](https://dsdmoj.atlassian.net/browse/CBO-1090)

#### Why

workflow differences between master and branches
have become complex. Separate workflows are
clearer and easier to manage.

Aims are to ensure
  - branch CI should require user intervention for build
    to avoid building and pushing containers unnecessarily
    since there is a cost and time impact.

  - branch CI goes green as and when tests pass, alone.