### PR TITLE
Correct stub for fee calc

### DIFF
--- a/features/support/stub_calculator_requests.rb
+++ b/features/support/stub_calculator_requests.rb
@@ -1,6 +1,6 @@
 require 'webmock/cucumber'
 
 Before('@stub_calculator_request_and_fail') do
-  stub_request(:get, %r{\Ahttps://laa-fee-calculator(.*).k8s.integration.dsd.io/api/v1/.*\z}).
+  stub_request(:get, %r{\Ahttps://laa-fee-calculator.service(.*)/api/v1/.*\z}).
     to_return(status: 400, body: {'error': 'delete console.log from JS if this is in features'}.to_json, headers: {})
 end


### PR DESCRIPTION
#### What
Amend the stub that matches fee calculator for failure

#### Why
This was missed and should have been changed
when fee calculator was migrated to live-1.