### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ gem 'laa-fee-calculator-client', '~> 1.1'
 gem 'wicked_pdf', '~> 1.4'
 
 group :production, :devunicorn do
-  gem 'rails_12factor', '0.0.3'
   gem 'unicorn-rails', '2.2.1'
   gem 'unicorn-worker-killer', '~> 0.4.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1271,11 +1271,6 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.1)
       actionpack (= 6.0.1)
       activesupport (= 6.0.1)
@@ -1550,7 +1545,6 @@ DEPENDENCIES
   rack-livereload (~> 0.3.16)
   rails (~> 6.0.1)
   rails-controller-testing
-  rails_12factor (= 0.0.3)
   redis (~> 4.1.3)
   remotipart (~> 1.4)
   rest-client (~> 2.1)

--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: 'api-sandbox'
             - name: RAILS_ENV
               value: 'production'
+            - name: RAILS_SERVE_STATIC_FILES
+              value: only-presence-required-to-enable
             - name: GRAPE_SWAGGER_ROOT_URL
               value: 'https://api-sandbox.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: 'dev'
             - name: RAILS_ENV
               value: 'production'
+            - name: RAILS_SERVE_STATIC_FILES
+              value: only-presence-required-to-enable
             - name: GRAPE_SWAGGER_ROOT_URL
               value: 'https://dev.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID

--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: 'production'
             - name: RAILS_ENV
               value: 'production'
+            - name: RAILS_SERVE_STATIC_FILES
+              value: only-presence-required-to-enable
             - name: GRAPE_SWAGGER_ROOT_URL
               value: 'https://claim-crown-court-defence.service.gov.uk'
             - name: GA_TRACKER_ID

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: 'staging'
             - name: RAILS_ENV
               value: 'production'
+            - name: RAILS_SERVE_STATIC_FILES
+              value: only-presence-required-to-enable
             - name: GRAPE_SWAGGER_ROOT_URL
               value: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
             - name: GA_TRACKER_ID


### PR DESCRIPTION
Not needed since rails 5

see https://github.com/heroku/rails_12factor#new-rails-5-apps

#### NOTE:
 will need testing on staging to ensure
 assets are still available

- [x] test on staging