### PR TITLE
Patch error being raised by sentry

### DIFF
--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -13,7 +13,7 @@ module Claims::Calculations
     if category.blank?
       calculate_total_for(fees)
     else
-      fees_records = public_send(category)
+      fees_records = public_send(category) if respond_to?(category)
       fees_records.is_a?(Enumerable) ? calculate_total_for(fees_records) : calculate_fee_total(fees_records)
     end
   end


### PR DESCRIPTION
#### What
Patch [this sentry error](https://sentry.service.dsd.io/mojds/private-beta/issues/40562/)

#### Why
```
ActionView::Template::ErrorExternalUsers::ClaimsController#summary
undefined method `fixed_fees' for #<Claim::InterimClaim:0x00005590865b2dd8> Did you mean? fixed_fee_case?
```

This error results from API submissions
creating LGFS interim claims which
they are marking as a fixed_fee_case despite
the fact it is an interim claim. Interim claims
cannot have fixed fees. Marking them as such
makes the summary attempt to load there fixed_fees,
which they do not have.

This fix deals with this error, but others
may be exposed as a result.