### PR TITLE
Remove case number validation

### DIFF
--- a/app/interfaces/api/v1/claim_params_helper.rb
+++ b/app/interfaces/api/v1/claim_params_helper.rb
@@ -10,7 +10,7 @@ module API
         optional :court_id, type: Integer, desc: 'REQUIRED: The unique identifier for this court'
         optional :case_type_id, type: Integer, desc: 'REQUIRED: The unique identifier of the case type'
         optional :offence_id, type: Integer, desc: 'REQUIRED: The unique identifier for this offence.'
-        optional :case_number, type: String, desc: 'REQUIRED: The case number'
+        optional :case_number, type: String, desc: 'REQUIRED: The case number or URN'
         optional :providers_ref, type: String, desc: 'OPTIONAL: Providers reference number'
         optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
         optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
@@ -40,7 +40,7 @@ module API
         use :user_email
         optional :supplier_number, type: String, desc: 'REQUIRED. The supplier number.'
         optional :transfer_court_id, type: Integer, desc: 'OPTIONAL: The unique identifier for the transfer court.'
-        optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number for the transfer court.'
+        optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number or URN for the transfer court.'
       end
 
       params :legacy_agfs_params do

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -1,5 +1,5 @@
 class BaseValidator < ActiveModel::Validator
-  CASE_NUMBER_PATTERN ||= /^[BASTU](199|20\d)\d{5}$/i.freeze
+  CASE_NUMBER_PATTERN ||= /^[A-Za-z0-9]{1,20}$/i.freeze
 
   # Override this method in the derived class
   def validate_step_fields; end

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -9,6 +9,18 @@
 
 %section.api-documentation
   %hr
+  %h2 1st April 2020
+  %ul.list-bullet
+    %li
+      Case Number modified to also accept URNs
+      %br/
+      %br/
+      These are <= 20 characters and alphanumeric
+      %br/
+      %br/
+
+%section.api-documentation
+  %hr
   %h2 15th July 2019
   %ul.list-bullet
     %li

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -941,7 +941,7 @@ en:
               Please enter the number of pages of prosecution evidence to help the caseworker assess the correct offence class.
 
         additional_fee_fields:
-          case_numbers: Additional case numbers
+          case_numbers: Additional case numbers or URNs
           quantity: *quantity
           quantity_hint: *empty_input
           add_date_attended: Add another date
@@ -1008,8 +1008,8 @@ en:
           advocate_category: 'Advocate category'
           case_details: 'Case details'
           case_offence: 'Case & offence'
-          case_number: 'Case number'
-          case_number_hint: For example T20170101
+          case_number: 'Case number or URN'
+          case_number_hint: For example T20170101 or 05PP1000915
           case_type: 'Case type'
           case_type_hint: For example Trial
           court: 'Court'
@@ -1024,8 +1024,8 @@ en:
           offence_class: 'Offence class'
           select_offence_class: 'Please select'
         transfer_court_fields:
-          transfer_case_number: Case number
-          transfer_case_number_hint: For example T20170101
+          transfer_case_number: Case number or URN
+          transfer_case_number_hint: For example T20170101 or 05PP1000915
           transfer_court: Court
           transfer_court_hint: For example Cardiff
         trial_detail_fields:

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -144,13 +144,13 @@ court:
 case_number:
   _seq: 50
   blank:
-    long: Enter a case number for example A20161234
+    long: The case number should be less than 21 characters and alphanumeric
     short: Enter a case number
-    api: Enter a case number for example A20161234
+    api: The case number should be less than 21 characters and alphanumeric
   invalid:
-    long: The case number must be in the format A20161234
+    long: The case number should be less than 21 characters and alphanumeric
     short: Invalid case number
-    api: The case number must be in the format A20161234
+    api: The case number should be less than 21 characters and alphanumeric
 
 transfer_court:
   _seq: 55
@@ -170,9 +170,9 @@ transfer_case_number:
     short: Enter a transfer case number
     api: Enter a transfer case number for example A20161234
   invalid:
-    long: The transfer case number must be in the format A20161234
+    long: The transfer case number should be less than 21 characters and alphanumeric
     short: Invalid transfer case number
-    api: The transfer case number must be in the format A20161234
+    api: The transfer case number should be less than 21 characters and alphanumeric
 
 first_day_of_trial:
   _seq: 70

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -144,9 +144,9 @@ court:
 case_number:
   _seq: 50
   blank:
-    long: The case number should be less than 21 characters and alphanumeric
-    short: Enter a case number
-    api: The case number should be less than 21 characters and alphanumeric
+    long: Enter a case number or URN
+    short: Enter a case number or URN
+    api: Enter a case number of URN
   invalid:
     long: The case number should be less than 21 characters and alphanumeric
     short: Invalid case number

--- a/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
@@ -85,4 +85,12 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
     body = last_response.body
     expect(body).to include("The case number should be less than 21 characters and alphanumeric")
   end
+
+  it 'returns 200 and valid when case_number is a valid common platform URN' do
+    valid_params[:case_number] = 'ABCDEFGHIJ1234567890'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(200)
+    body = last_response.body
+    expect(body).to include("valid")
+  end
 end

--- a/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
     post_to_validate_endpoint
     expect(last_response.status).to eq(400)
     body = last_response.body
-    expect(body).to include("The case number must be in the format A20161234")
+    expect(body).to include("The case number should be less than 21 characters and alphanumeric")
   end
 
   it 'returns 400 and JSON error when case_number contains a special character' do
@@ -83,6 +83,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
     post_to_validate_endpoint
     expect(last_response.status).to eq(400)
     body = last_response.body
-    expect(body).to include("The case number must be in the format A20161234")
+    expect(body).to include("The case number should be less than 21 characters and alphanumeric")
   end
 end

--- a/spec/api/v1/external_users/claims/integration/advocate_claim_creation.rb
+++ b/spec/api/v1/external_users/claims/integration/advocate_claim_creation.rb
@@ -246,16 +246,6 @@ RSpec.shared_examples 'scheme 10 advocate final claim' do |options|
       expect(claim.expenses.size).to eql 2
     end
   end
-
-  context "common platform graduated fee claim on #{ClaimApiEndpoints.for(options[:relative_endpoint]).create}" do
-    let(:case_type) { CaseType.find_by(fee_type_code: 'GRTRL') } # Trial
-    let(:case_number) { 'ABCDEFGHIJ1234567890' }
-
-    specify 'Case management system creates a claim with a Common Platform URN' do
-      post ClaimApiEndpoints.for(:advocate).create, claim_params.merge(offence_id: offence.id, case_number: case_number, transfer_case_number: transfer_case_number), format: :json
-      expect(last_response.status).to eql 201
-    end
-  end
 end
 
 RSpec.describe 'API claim creation for AGFS' do

--- a/spec/api/v1/external_users/claims/integration/advocate_claim_creation.rb
+++ b/spec/api/v1/external_users/claims/integration/advocate_claim_creation.rb
@@ -246,6 +246,16 @@ RSpec.shared_examples 'scheme 10 advocate final claim' do |options|
       expect(claim.expenses.size).to eql 2
     end
   end
+
+  context "common platform graduated fee claim on #{ClaimApiEndpoints.for(options[:relative_endpoint]).create}" do
+    let(:case_type) { CaseType.find_by(fee_type_code: 'GRTRL') } # Trial
+    let(:case_number) { 'ABCDEFGHIJ1234567890' }
+
+    specify 'Case management system creates a claim with a Common Platform URN' do
+      post ClaimApiEndpoints.for(:advocate).create, claim_params.merge(offence_id: offence.id, case_number: case_number, transfer_case_number: transfer_case_number), format: :json
+      expect(last_response.status).to eql 201
+    end
+  end
 end
 
 RSpec.describe 'API claim creation for AGFS' do

--- a/spec/api/v1/external_users/claims/integration/litigator_claim_creation.rb
+++ b/spec/api/v1/external_users/claims/integration/litigator_claim_creation.rb
@@ -423,5 +423,16 @@ RSpec.describe 'API claim creation for LGFS' do
         expect(claim).to be_valid_api_lgfs_claim(fee_scheme: ['LGFS', 9], offence: nil, total: 349.47, vat_amount: 69.89)
       end
     end
+  
+    context "common platform graduated fee claim" do
+      let(:case_type) { CaseType.find_by(fee_type_code: 'GRTRL') } # Trial
+      let(:representation_order_date) { Date.new(2018, 03, 31).as_json }
+      let(:case_number) { 'ABCDEFGHIJ1234567890' }
+
+      specify 'Case management system creates a claim with a Common Platform URN' do
+        post ClaimApiEndpoints.for(:final).create, claim_params.merge(offence_id: offence.id, actual_trial_length: 10), format: :json
+        expect(last_response.status).to eql 201
+      end
+    end
   end
 end

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
     "source" => 'web',
     "case_type_id" => case_type.id.to_s,
     "court_id" => court.id.to_s,
-    "case_number" => "CASE98989",
+    "case_number" => "CASE98989-",
     "advocate_category" => "QC",
     "offence_class_id" => "2",
     "offence_id" => offence.id.to_s,

--- a/spec/services/claims/update_claim_spec.rb
+++ b/spec/services/claims/update_claim_spec.rb
@@ -66,7 +66,7 @@ describe Claims::UpdateClaim do
     end
 
     context 'unsuccessful updates' do
-      let(:claim_params) { { case_number: '123' } }
+      let(:claim_params) { { case_number: '123456789012345678901' } }
 
       it 'is unsuccessful' do
         expect(subject.claim).not_to receive(:update_claim_document_owners)

--- a/spec/services/claims/update_draft_spec.rb
+++ b/spec/services/claims/update_draft_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Claims::UpdateDraft do
     end
 
     context 'unsuccessful draft updates' do
-      let(:claim_params) { { case_number: '123' } }
+      let(:claim_params) { { case_number: '123/' } }
 
       it 'is unsuccessful' do
         subject.call

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -264,7 +264,7 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
           valid_params[:case_number] = -1
           post_to_create_endpoint
           expect_error_response("Choose a court", 0)
-          expect_error_response("The case number must be in the format A20161234", 1)
+          expect_error_response("The case number should be less than 21 characters and alphanumeric", 1)
         end
 
         it "response 400 and JSON error array of model validation INVALID errors" do

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -85,11 +85,11 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
     end
 
     it 'when a single invalid format of case number entered' do
-      should_error_if_equal_to_value(noc_fee, :case_numbers, '123', 'invalid')
+      should_error_if_equal_to_value(noc_fee, :case_numbers, '12 3', 'invalid')
     end
 
     it 'when any case number is of invalid format' do
-      noc_fee.case_numbers = 'A20161234,Z123,A20158888'
+      noc_fee.case_numbers = 'A20161234,Z123*,A20158888'
       should_error_with(noc_fee, :case_numbers, 'invalid')
     end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
     end
 
     it 'should error if invalid' do
-      claim.case_number = 'T87654321'
+      claim.case_number = 'T87654321?'
       should_error_with(claim, :case_number, 'invalid')
     end
 

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -85,7 +85,7 @@ RSpec.shared_examples "common advocate litigator validations" do |external_user_
     end
 
     it 'should error if wrong format' do
-      claim.transfer_case_number = 'ABC'
+      claim.transfer_case_number = 'ABC_'
       should_error_with(claim, :transfer_case_number, 'invalid')
     end
 
@@ -113,7 +113,7 @@ RSpec.shared_examples "common advocate litigator validations" do |external_user_
 
         context 'and transfer case number has an invalid format' do
           before do
-            claim.transfer_case_number = 'ABC'
+            claim.transfer_case_number = 'ABC_'
           end
 
           it 'contains an invalid error on transfer case number' do


### PR DESCRIPTION
#### What

Remove validation for case number pattern, to allow users to record common platform URNs in the case number field. Validate that these are alphanumeric and <= 20 characters.

#### Ticket

https://dsdmoj.atlassian.net/browse/CACP-180

#### Why

To allow users to record URNs when common platform goes live (CP cases will not have a case_number).

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
