### PR TITLE
Add looks like a case number

### DIFF
--- a/app/interfaces/api/v1/claim_params_helper.rb
+++ b/app/interfaces/api/v1/claim_params_helper.rb
@@ -10,7 +10,7 @@ module API
         optional :court_id, type: Integer, desc: 'REQUIRED: The unique identifier for this court'
         optional :case_type_id, type: Integer, desc: 'REQUIRED: The unique identifier of the case type'
         optional :offence_id, type: Integer, desc: 'REQUIRED: The unique identifier for this offence.'
-        optional :case_number, type: String, desc: 'REQUIRED: The case number'
+        optional :case_number, type: String, desc: 'REQUIRED: The case number or URN'
         optional :providers_ref, type: String, desc: 'OPTIONAL: Providers reference number'
         optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
         optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
@@ -40,7 +40,7 @@ module API
         use :user_email
         optional :supplier_number, type: String, desc: 'REQUIRED. The supplier number.'
         optional :transfer_court_id, type: Integer, desc: 'OPTIONAL: The unique identifier for the transfer court.'
-        optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number for the transfer court.'
+        optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number or URN for the transfer court.'
       end
 
       params :legacy_agfs_params do

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -1,5 +1,7 @@
 class BaseValidator < ActiveModel::Validator
   CASE_NUMBER_PATTERN ||= /^[BASTU](199|20\d)\d{5}$/i.freeze
+  CASE_URN_PATTERN ||= /^[A-Za-z0-9]{1,20}$/i.freeze
+  CASE_NUMBER_OR_URN_PATTERN ||= /^[A-Za-z](199|20\d)\d{4,6}$/i.freeze
 
   # Override this method in the derived class
   def validate_step_fields; end
@@ -202,5 +204,10 @@ class BaseValidator < ActiveModel::Validator
   def vat_exceeds_max?(vat:, net:)
     max_vat = VatRate.vat_amount(net, @record.claim.vat_date, calculate: true)
     vat.round(2) > max_vat.round(2)
+  end
+
+  def looks_like_a_case_number?(attribute)
+    return if attr_blank?(attribute)
+    @record.__send__(attribute).match?(CASE_NUMBER_OR_URN_PATTERN)
   end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -74,6 +74,8 @@ class Claim::BaseClaimValidator < BaseValidator
   def validate_case_number
     @record.case_number&.upcase!
     validate_presence(:case_number, 'blank')
+    validate_pattern(:case_number, CASE_URN_PATTERN, 'invalid')
+    return unless looks_like_a_case_number?(:case_number)
     validate_pattern(:case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 
@@ -91,6 +93,8 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def validate_transfer_case_number
     return if @record.errors[:transfer_case_number].present?
+    validate_pattern(:transfer_case_number, CASE_URN_PATTERN, 'invalid')
+    return unless looks_like_a_case_number?(:transfer_case_number)
     validate_pattern(:transfer_case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -8,8 +8,6 @@
 module Fee
   module Concerns
     module CaseNumbersValidator
-      CASE_NUMBER_PATTERN = BaseValidator::CASE_NUMBER_PATTERN
-
       private
 
       # TODO: At time of writing the AGFS case uplift fee types are
@@ -52,8 +50,13 @@ module Fee
       end
 
       def validate_case_number(case_number)
-        add_error(:case_numbers, 'invalid') unless case_number.match?(CASE_NUMBER_PATTERN)
+        add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_URN_PATTERN)
+        validate_case_number_pattern(case_number) if case_number.match?(BaseValidator::CASE_NUMBER_OR_URN_PATTERN)
         add_error(:case_numbers, 'eqls_claim_case_number') if case_number.casecmp?(claim.case_number)
+      end
+
+      def validate_case_number_pattern(case_number)
+        add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_NUMBER_PATTERN)
       end
     end
   end

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -9,6 +9,18 @@
 
 %section.api-documentation
   %hr
+  %h2 1st September 2020
+  %ul.list-bullet
+    %li
+      Case Number modified to also accept URNs
+      %br/
+      %br/
+      These are <= 20 characters and alphanumeric
+      %br/
+      %br/
+
+%section.api-documentation
+  %hr
   %h2 12th May 2020
   %ul.list-bullet
     %li
@@ -34,8 +46,6 @@
       %table
         %tr
           %td GET /api/case_stages
-      %br/
-      %br/
 
 %section.api-documentation
   %hr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -960,7 +960,7 @@ en:
               Please enter the number of pages of prosecution evidence to help the caseworker assess the correct offence class.
 
         additional_fee_fields:
-          case_numbers: Additional case numbers
+          case_numbers: Additional case numbers or URNs
           quantity: *quantity
           quantity_hint: *empty_input
           add_date_attended: Add another date
@@ -1041,6 +1041,8 @@ en:
           case_number_hint: For example T20170101
           case_type: *case_type
           case_stage: *case_stage
+          case_number: 'Case number or URN'
+          case_number_hint: For example T20170101 or 05PP1000915
           court: 'Court'
           court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
@@ -1052,8 +1054,8 @@ en:
           offence_class: 'Offence class'
           select_offence_class: 'Please select'
         transfer_court_fields:
-          transfer_case_number: Case number
-          transfer_case_number_hint: For example T20170101
+          transfer_case_number: Case number or URN
+          transfer_case_number_hint: For example T20170101 or 05PP1000915
           transfer_court: Court
           transfer_court_hint: For example Cardiff
         transfer_court_question_fields:

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -170,13 +170,13 @@ court:
 case_number:
   _seq: 50
   blank:
-    long: Enter a case number for example A20161234
-    short: Enter a case number
-    api: Enter a case number for example A20161234
+    long: Enter a case number or URN
+    short: Enter a case number or URN
+    api: Enter a case number of URN
   invalid:
-    long: The case number must be in the format A20161234
+    long: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
     short: Invalid case number
-    api: The case number must be in the format A20161234
+    api: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
 transfer_court:
   _seq: 55
@@ -195,10 +195,10 @@ transfer_case_number:
     long: Enter a transfer case number for example A20161234
     short: Enter a transfer case number
     api: Enter a transfer case number for example A20161234
-  invalid:
-    long: The transfer case number must be in the format A20161234
+  invalid:  
+    long: The transfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
     short: Invalid transfer case number
-    api: The transfer case number must be in the format A20161234
+    api: The trasfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
 first_day_of_trial:
   _seq: 70

--- a/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
       :offence_id => offence.id,
       :court_id => court.id } }
 
+  subject(:post_to_validate_endpoint) { post ClaimApiEndpoints.for(FINAL_CLAIM_ENDPOINT).validate, valid_params, format: :json }
+
   after(:all) { clean_database }
 
   include_examples 'advocate claim test setup'
@@ -42,9 +44,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
  
   # TODO: write a generic date error handling spec and share
   describe "POST #{ClaimApiEndpoints.for(FINAL_CLAIM_ENDPOINT).validate}" do
-    subject(:post_to_validate_endpoint) do
-      post ClaimApiEndpoints.for(FINAL_CLAIM_ENDPOINT).validate, valid_params, format: :json
-    end
 
     it 'returns 400 and JSON error when dates are not in acceptable format' do
       valid_params[:first_day_of_trial] = '01-01-2015'
@@ -69,5 +68,69 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
         expect(body).to include(error)
       end
     end
+  end
+
+  it 'returns 400 and JSON error when URN is too long' do
+    valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHIJA'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when URN contains a special character' do
+    valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHI_'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when the case number does not start with a BAST or U' do
+    valid_params[:case_number] = 'G20209876'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when the case number is too long' do
+    valid_params[:case_number] = 'T202098761'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when the case number is too short' do
+    valid_params[:case_number] = 'T2020987'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 200 and valid when case_number is a valid common platform URN' do
+    valid_params[:case_number] = 'ABCDEFGHIJ1234567890'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(200)
+    body = last_response.body
+    expect(body).to include("valid")
+  end
+
+  it 'returns 200 and valid when the URN is a valid URN containing a year' do
+    valid_params[:case_number] = '120207575'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(200)
+    body = last_response.body
+    expect(body).to include("valid")
+  end
+
+  it 'returns 200 and valid when case_number is a valid case number' do
+    valid_params[:case_number] = 'T20202601'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(200)
+    body = last_response.body
+    expect(body).to include("valid")
   end
 end

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
     "source" => 'web',
     "case_type_id" => case_type.id.to_s,
     "court_id" => court.id.to_s,
-    "case_number" => "CASE98989",
+    "case_number" => "CASE98989-",
     "advocate_category" => "QC",
     "offence_class_id" => "2",
     "offence_id" => offence.id.to_s,

--- a/spec/services/claims/update_claim_spec.rb
+++ b/spec/services/claims/update_claim_spec.rb
@@ -66,7 +66,7 @@ describe Claims::UpdateClaim do
     end
 
     context 'unsuccessful updates' do
-      let(:claim_params) { { case_number: '123' } }
+      let(:claim_params) { { case_number: '123456789012345678901' } }
 
       it 'is unsuccessful' do
         expect(subject.claim).not_to receive(:update_claim_document_owners)

--- a/spec/services/claims/update_draft_spec.rb
+++ b/spec/services/claims/update_draft_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Claims::UpdateDraft do
     end
 
     context 'unsuccessful draft updates' do
-      let(:claim_params) { { case_number: '123' } }
+      let(:claim_params) { { case_number: '123/' } }
 
       it 'is unsuccessful' do
         subject.call

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -265,7 +265,7 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
           valid_params[:case_number] = -1
           post_to_create_endpoint
           expect_error_response("Choose a court", 0)
-          expect_error_response("The case number must be in the format A20161234", 1)
+          expect_error_response("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)", 1)
         end
 
         it "response 400 and JSON error array of model validation INVALID errors" do

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -70,6 +70,11 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
       should_not_error(noc_fee, :case_numbers)
     end
 
+    it 'when single valid format of URN entered' do
+      noc_fee.case_numbers = '1234567890AAAAAAAAAA'
+      should_not_error(noc_fee, :case_numbers)
+    end
+
     it 'when quantity and number of additional cases match' do
       noc_fee.quantity = 2
       noc_fee.case_numbers = 'A20161234,T20171234'
@@ -85,11 +90,20 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
     end
 
     it 'when a single invalid format of case number entered' do
-      should_error_if_equal_to_value(noc_fee, :case_numbers, '123', 'invalid')
+      should_error_if_equal_to_value(noc_fee, :case_numbers, 'G20208765', 'invalid')
+    end
+    
+    it 'when a single invalid format of URN entered' do
+      should_error_if_equal_to_value(noc_fee, :case_numbers, '12 3', 'invalid')
     end
 
     it 'when any case number is of invalid format' do
-      noc_fee.case_numbers = 'A20161234,Z123,A20158888'
+      noc_fee.case_numbers = 'A20161234,Z123*,A20158888'
+      should_error_with(noc_fee, :case_numbers, 'invalid')
+    end
+
+    it 'when any URN is of invalid format' do
+      noc_fee.case_numbers = 'ABCDEFGHIJ,Z123*,1234567890'
       should_error_with(noc_fee, :case_numbers, 'invalid')
     end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -223,8 +223,18 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       expect(claim).to be_valid
     end
 
-    it 'should error if invalid' do
-      claim.case_number = 'T87654321'
+    it 'should error if too short' do
+      claim.case_number = 'T2020432'
+      should_error_with(claim, :case_number, 'invalid')
+    end
+
+    it 'should error if too long' do
+      claim.case_number = 'T202043298'
+      should_error_with(claim, :case_number, 'invalid')
+    end
+
+    it 'should error if it doesnt start with BAST or U' do
+      claim.case_number = 'G20204321'
       should_error_with(claim, :case_number, 'invalid')
     end
 
@@ -244,6 +254,25 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         end
       end
     end
+  end
+
+  context 'with unique reference numbers' do
+    it 'should not error if valid' do
+      claim.case_number = 'ABCDEFGHIJ1234567890'
+      expect(claim).to be_valid
+    end
+
+    it 'is invalid if contains non alphanumeric characters' do
+      %w(_ - * ? ,).each do |character|
+        claim.case_number = 'KLMNOPQRST134456789' + character
+        should_error_with(claim, :case_number, 'invalid')
+      end
+    end
+
+    it 'is invalid if the URN is too long' do
+      claim.case_number = '1234567890UVWXYZABCDE'
+      should_error_with(claim, :case_number, 'invalid')
+    end  
   end
 
   context 'estimated_trial_length' do

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -81,7 +81,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     end
 
     it 'should error if wrong format' do
-      claim.transfer_case_number = 'ABC'
+      claim.transfer_case_number = 'ABC_'
       should_error_with(claim, :transfer_case_number, 'invalid')
     end
 
@@ -109,7 +109,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
 
         context 'and transfer case number has an invalid format' do
           before do
-            claim.transfer_case_number = 'ABC'
+            claim.transfer_case_number = 'ABC_'
           end
 
           it 'contains an invalid error on transfer case number' do


### PR DESCRIPTION
#### What
As suggested, add looks_like_a_case_number? functionality to validate that when users enter a Case numbers or URN that looks similar to a current case number these are validated against the current pattern for case numbers. The format for the CN_PATTERN regex may need changing if it rejects too many valid URNs.

#### Ticket
https://dsdmoj.atlassian.net/browse/CACP-263

#### Why
To allow users to enter Common Platform URNs in the current case number field, and to attempt to ensure that in the short to medium term users do not enter too many invalid case numbers.

#### How
