### PR TITLE
Extend advocate claim endpoint's deprecation date

### DIFF
--- a/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
@@ -27,7 +27,7 @@ module API::V1::ExternalUsers
       namespace '/' do
         desc 'DEPRECATED: Create an Advocate final claim. see advocates/final endpoint'
         post do
-          deprecate(datetime: Time.new(2020, 3, 31), link: "#{request.base_url}/api/release_notes")
+          deprecate(datetime: Time.new(2020, 9, 30), link: "#{request.base_url}/api/release_notes")
           create_resource(::Claim::AdvocateClaim)
           status api_response.status
           api_response.body
@@ -35,7 +35,7 @@ module API::V1::ExternalUsers
 
         desc 'DEPRECATED: Validate an Advocate final claim. see advocates/final/validate endpoint'
         post '/validate' do
-          deprecate(datetime: Time.new(2020, 3, 31), link: "#{request.base_url}/api/release_notes")
+          deprecate(datetime: Time.new(2020, 9, 30), link: "#{request.base_url}/api/release_notes")
           validate_resource(::Claim::AdvocateClaim)
           status api_response.status
           api_response.body

--- a/spec/api/v1/external_users/claims/advocate_final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocate_final_claim_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::AdvocateClaim do
   it_behaves_like 'a claim endpoint', relative_endpoint: :advocate
   it_behaves_like 'a claim validate endpoint', relative_endpoint: :advocate
   it_behaves_like 'a claim create endpoint', relative_endpoint: :advocate
-  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :validate, deprecation_datetime: Time.new(2020, 3, 31)
-  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :create, deprecation_datetime: Time.new(2020, 3, 31)
+  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :validate, deprecation_datetime: Time.new(2020, 9, 30)
+  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :create, deprecation_datetime: Time.new(2020, 9, 30)
 
   # TODO: write a generic date error handling spec and share
   describe "POST #{ClaimApiEndpoints.for(:advocate).validate}" do


### PR DESCRIPTION
#### What
Extend advocate claim endpoint's deprecation date

#### Ticket
N/A

#### Why
There are still vendors using this API endpoint
and the team is currently focused on other work.

Supporting vendors to transition, or not,
needs discussing with product management.

In the meantime this prevents us from being
blocked while keeping the reminder to remove
the endpoint in place.
