### PR TITLE
Fix fee summary sections to account for basic_fees

### DIFF
--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -62,9 +62,7 @@
             = t('shared.summary.total_amount')
 
       %tbody
-        -# The collection of fees
         - present_collection(collection.sort_by(&:position)).each.with_index(1) do |fee, index|
-          -# Each instance of a fee
           = render partial: 'external_users/claims/summary_fee', locals: { fee: fee }
 
       %tfoot
@@ -78,8 +76,8 @@
           %td.numeric
             = ''
           %td.numeric
-            = section.to_s.eql?('fixed_fees') ? claim.fixed_fees_total : claim.misc_fees_total
+            = claim.send("#{section}_total")
           %td.numeric
-            = section.to_s.eql?('fixed_fees') ? claim.fixed_fees_vat : claim.misc_fees_vat
+            = claim.send("#{section}_vat")
           %td.numeric
-            = section.to_s.eql?('fixed_fees') ? claim.fixed_fees_vat : claim.misc_fees_vat
+            = claim.send("#{section}_gross")


### PR DESCRIPTION
Fix fee summary sections to account for basic_fees

#### Ticket

[https://dsdmoj.atlassian.net/browse/CBO-1175](https://dsdmoj.atlassian.net/browse/CBO-1175)

#### Why
was only handling fixed fees or misc fees, neglecting
basic_fees.

<img width="847" alt="Screen Shot 2020-04-08 at 11 15 54" src="https://user-images.githubusercontent.com/7016425/78778745-ac887980-7993-11ea-9692-967a3fd6f64b.png">

#### How
use meta programming to rely on the
base presenter methods _total, _vat
and _gross for fee collections.