### PR TITLE
Extend i18n load path

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Note that appending directly to I18n.load_paths instead of to
+# the application's configured i18n will not override translations
+# from external gems.
+# see https://guides.rubyonrails.org/i18n.html#configure-the-i18n-module
+
+I18n.load_path = I18n.load_path +
+                 Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]


### PR DESCRIPTION
#### What
load separate translation files, allowing
the break up of the enormous `en.yml` file.

#### Why
Refactor to enable of the enormouse `en.yml`
file.

#### How
By including other paths in the i18n gems load path
we can separate out sections of the en.yml file
into logical groupings which are transparently combined
at load time.