### PR TITLE
Fix accessibility violation raised by axe-matchers

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -1,11 +1,11 @@
 = render partial: 'errors/error_summary', locals: { ep: @allocation, error_summary: t('.error_summary') }
 
-.notice-summary.hidden{ role: 'group', 'aria-labelledby': 'notice-summary-heading', tabindex: '-1' }
-  %span.heading-medium.notice-summary-heading{ id: 'notice-summary-heading' }
+.notice-summary.hidden{ role: 'group', 'aria-labelledby': 'notice-summary-heading-id', tabindex: '-1' }
+  %span#notice-summary-heading-id.heading-medium.notice-summary-heading
     %span.msg
 
-.error-summary.hidden{ role: 'group', 'aria-labelledby': 'error-summary-heading', tabindex: '-1' }
-  %span#error-summary-heading.heading-medium.error-summary-heading
+.error-summary.hidden{ role: 'group', 'aria-labelledby': 'error-summary-heading-id', tabindex: '-1' }
+  %span#error-summary-heading-id.heading-medium.error-summary-heading
     %span.msg
 
 #api-key.grid-row{ data: { api_key: current_user.api_key } }

--- a/features/page_objects/allocation_page.rb
+++ b/features/page_objects/allocation_page.rb
@@ -3,8 +3,6 @@ class AllocationPage < BasePage
 
   set_url "/case_workers/admin"
 
-  element :notice, "#notice-summary-heading"
-
   element :allocate, "input.button.allocation-submit"
 
   section :auto_caseworker, CommonAutocomplete, "#cc-caseworker"


### PR DESCRIPTION
#### What
Fix a duplicate aria tag for flash notices

#### Why
Couple of features started raising this but not clear
why this started happening now (axe-matcher update perhaps)
as page has not been changed.

```
Found 1 accessibility violation:

      1) duplicate-id-aria: IDs used in ARIA and labels must be unique (critical)
          https://dequeuniversity.com/rules/axe/3.5/duplicate-id-aria?application=axeAPI
          The following 1 node violate this rule:

              Selector: .notice-summary[aria-labelledby="notice-summary-heading"][role="group"] > h1
              HTML: <h1 class="heading-medium notice-summary-heading" id="notice-summary-heading">Signed in successfully.</h1>
              Fix any of the following:
              - Document has multiple elements referenced with ARIA with the same id attribute: notice-summary-heading

      Invocation: axe.run({"include":[["#content"]]}, callback); (RuntimeError)
      features/authentication.feature:9:in `Then the page should be accessible within "#content"'
```