### PR TITLE
Add hardship caseworker allocation filter

### DIFF
--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -115,6 +115,13 @@ en:
       other_refuse:
         short: *other
         long: *blank
+    refused_advocate_hardship_claims:
+      duplicate_claim:
+        short: *duplicate_claim_short
+        long: *duplicate_claim_long
+      other_refuse:
+        short: *other
+        long: *blank
     global:
       timed_transition:
         short: automated transition by system


### PR DESCRIPTION
#### What
Allow caseworker admins to filter agfs hardship claims in the allocation queue.

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1170

#### Why
This will allow caseworker admins to filter and allocate agfs hardship claims.

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
