### PR TITLE
Cbo 1170 caseworker allocation filter agfs

### DIFF
--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -37,6 +37,7 @@ module API
         expose :injection_errored
         expose :cav_warning
         expose :supplementary
+        expose :hardship
       end
 
       private
@@ -130,6 +131,10 @@ module API
 
       def supplementary
         object.case_type.eql?('Supplementary').to_i
+      end
+
+      def hardship
+        object.scheme_type.eql?('AdvocateHardship').to_i
       end
     end
   end

--- a/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
@@ -25,6 +25,8 @@
       = t('.warrants')
     %option{ value: 'supplementary' }
       = t('.supplementary')
+    %option{ value: 'hardship' }
+      = t('.hardship')
 
 
 #filter-tasks-lgfs.form-group.dtFilter.dtFilterLGFS.hidden{ data: { scheme: 'lgfs' } }

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -115,6 +115,13 @@ en:
       other_refuse:
         short: *other
         long: *blank
+    refused_advocate_hardship_claims:
+      duplicate_claim:
+        short: *duplicate_claim_short
+        long: *duplicate_claim_long
+      other_refuse:
+        short: *other
+        long: *blank
     global:
       timed_transition:
         short: automated transition by system

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2397,6 +2397,7 @@ en:
           trial: Trial
           warrants: Warrants
           supplementary: Supplementary
+          hardship: Hardship
       management_information:
         validate_report_type:
           invalid_report_type: &invalid_report_type The requested report type is not supported

--- a/features/step_definitions/caseworker_claim_allocation_steps.rb
+++ b/features/step_definitions/caseworker_claim_allocation_steps.rb
@@ -174,7 +174,7 @@ end
 When(/^I should see the AGFS filters$/) do
   options = %w(All Fixed\ fee Cracked Trial Guilty\ Plea Redetermination
                Awaiting\ written\ reasons Disk\ evidence Injection\ errors
-               Warrants Supplementary)
+               Warrants Supplementary Hardship)
   expect(page.find('#filter-tasks-agfs')).to have_select(options: options)
 end
 

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -66,7 +66,8 @@ describe API::Entities::SearchResult do
           risk_based_bills: 0,
           injection_errored: 0,
           cav_warning: 0,
-          supplementary: 0
+          supplementary: 0,
+          hardship: 0
         }
       end
 


### PR DESCRIPTION
#### What
Allow caseworker admins to filter in the allocation queue for agfs hardship claims.

#### Ticket

https://dsdmoj.atlassian.net/browse/CBO-1170.

#### Why
To allow hardship claims to be filtered and then allocated.

#### How

--------

#### TODO (wip)

 - [ ] Add tests for new functionality

