### PR TITLE
Update rubocop_todo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,9 @@ Lint/RedundantCopDisableDirective:
 
 # Offense count: 58
 Metrics/AbcSize:
-  Max: 87
+  Max: 90
+  Exclude:
+    - app/models/claims/state_machine.rb
 
 # Offense count: 23
 # Configuration parameters: CountComments.


### PR DESCRIPTION
#### What
extend ABC limit in rubocop todo

#### Why
The hardship handling adds more complexity to the state machine, this excludes the check completely as it was skewing the numbers considerably
