### PR TITLE
Fix worst offending flickering spec

### DIFF
--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -397,9 +397,9 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller, fo
           edit_request.call
         end
 
-        it 'calls the build_fixed_fees method' do
-          expect(assigns(:claim).fixed_fees).to be_a ActiveRecord::Associations::CollectionProxy
-          expect(assigns(:claim).fixed_fees.length).to eql 5
+        it 'builds eligible fixed fees' do
+          claim = assigns(:claim)
+          expect(claim.fixed_fees.map(&:fee_type_id)).to match_array(claim.eligible_fixed_fee_types.map(&:id))
         end
       end
     end


### PR DESCRIPTION
Modify the worst offending flickering spec in attempt to fix

This test was not described appropriately and
is the worst offending flickering spec.

Not sure this will fix but at least it
tests the supposed of effect of the
`build_fixed_fees` method of the controller.