### PR TITLE
Add BillType to MI Report

### DIFF
--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -3,6 +3,17 @@ class ClaimCsvPresenter < BasePresenter
 
   COMPLETED_STATES = %w[rejected refused authorised part_authorised].freeze
   SUBMITTED_STATES = %w[submitted redetermination awaiting_written_reasons].freeze
+  AGFS_CLAIM_TYPES = %w[
+    Claim::AdvocateClaim
+    Claim::AdvocateInterimClaim
+    Claim::AdvocateSupplementaryClaim
+  ].freeze
+  LGFS_CLAIM_TYPES = %w[
+    Claim::LitigatorClaim
+    Claim::InterimClaim
+    Claim::TransferClaim
+    Claim::LitigatorHardshipClaim
+  ].freeze
 
   def present!
     yield parsed_journeys if block_given?
@@ -61,13 +72,25 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def scheme
-    if %w[Claim::AdvocateClaim Claim::AdvocateInterimClaim Claim::AdvocateSupplementaryClaim].include? type
+    if AGFS_CLAIM_TYPES.include? type
       'AGFS'
-    elsif %w[Claim::LitigatorClaim Claim::InterimClaim Claim::TransferClaim].include? type
+    elsif LGFS_CLAIM_TYPES.include? type
       'LGFS'
     else
       'Unknown'
     end
+  end
+
+  def bill_type
+    [
+      scheme,
+      type.demodulize
+          .sub('Claim', '')
+          .gsub(/([A-Z])/, ' \1')
+          .gsub(/(Advocate |Litigator )/, '')
+          .gsub(/(Advocate|Litigator)$/, 'Final')
+          .strip
+    ].join(' ')
   end
 
   def disk_evidence_case

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -3,17 +3,6 @@ class ClaimCsvPresenter < BasePresenter
 
   COMPLETED_STATES = %w[rejected refused authorised part_authorised].freeze
   SUBMITTED_STATES = %w[submitted redetermination awaiting_written_reasons].freeze
-  AGFS_CLAIM_TYPES = %w[
-    Claim::AdvocateClaim
-    Claim::AdvocateInterimClaim
-    Claim::AdvocateSupplementaryClaim
-  ].freeze
-  LGFS_CLAIM_TYPES = %w[
-    Claim::LitigatorClaim
-    Claim::InterimClaim
-    Claim::TransferClaim
-    Claim::LitigatorHardshipClaim
-  ].freeze
 
   def present!
     yield parsed_journeys if block_given?
@@ -72,9 +61,9 @@ class ClaimCsvPresenter < BasePresenter
   end
 
   def scheme
-    if AGFS_CLAIM_TYPES.include? type
+    if claim.agfs?
       'AGFS'
-    elsif LGFS_CLAIM_TYPES.include? type
+    elsif claim.lgfs?
       'LGFS'
     else
       'Unknown'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,6 +54,7 @@ claim_csv_headers:
   - :supplier_number
   - :organisation
   - :case_type_name
+  - :bill_type
   - :claim_total
   - :submission_type
   - :submitted_at

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -44,15 +44,6 @@ RSpec.describe ClaimCsvPresenter do
 
         context 'AGFS' do
           it 'scheme' do
-            presenter.present! do |claim_journeys|
-              expect(claim_journeys.first).to include('AGFS')
-              expect(claim_journeys.second).to include('AGFS')
-            end
-          end
-        end
-
-        context 'AGFS' do
-          it 'scheme' do
             presenter.update_column(:type, 'Claim::AdvocateInterimClaim')
 
             presenter.present! do |claim_journeys|
@@ -72,6 +63,8 @@ RSpec.describe ClaimCsvPresenter do
         end
 
         context 'LGFS' do
+          let(:claim) { create(:litigator_claim, :redetermination) }
+
           it 'scheme' do
             presenter.update_column(:type, 'Claim::LitigatorClaim')
 
@@ -82,11 +75,11 @@ RSpec.describe ClaimCsvPresenter do
           end
 
           it 'bill_type' do
-            presenter.update_column(:type, 'Claim::LitigatorClaim')
+            presenter.update_column(:type, 'Claim::LitigatorHardshipClaim')
 
             presenter.present! do |claim_journeys|
-              expect(claim_journeys.first).to include('LGFS Final')
-              expect(claim_journeys.second).to include('LGFS Final')
+              expect(claim_journeys.first).to include('LGFS Hardship')
+              expect(claim_journeys.second).to include('LGFS Hardship')
             end
           end
         end

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ClaimCsvPresenter do
 
-  let(:claim)               { create(:redetermination_claim) }
-  let(:presenter)             { ClaimCsvPresenter.new(claim, view) }
+  let(:claim) { create(:redetermination_claim) }
+  let(:presenter) { ClaimCsvPresenter.new(claim, view) }
   let(:previous_user) { create(:user, first_name: 'Thea', last_name: 'Conway') }
   let(:another_user) { create(:user, first_name: 'Hilda', last_name: 'Rogers') }
 
@@ -60,6 +60,15 @@ RSpec.describe ClaimCsvPresenter do
               expect(claim_journeys.second).to include('AGFS')
             end
           end
+
+          it 'bill_type' do
+            presenter.update_column(:type, 'Claim::AdvocateInterimClaim')
+
+            presenter.present! do |claim_journeys|
+              expect(claim_journeys.first).to include('AGFS Interim')
+              expect(claim_journeys.second).to include('AGFS Interim')
+            end
+          end
         end
 
         context 'LGFS' do
@@ -69,6 +78,15 @@ RSpec.describe ClaimCsvPresenter do
             presenter.present! do |claim_journeys|
               expect(claim_journeys.first).to include('LGFS')
               expect(claim_journeys.second).to include('LGFS')
+            end
+          end
+
+          it 'bill_type' do
+            presenter.update_column(:type, 'Claim::LitigatorClaim')
+
+            presenter.present! do |claim_journeys|
+              expect(claim_journeys.first).to include('LGFS Final')
+              expect(claim_journeys.second).to include('LGFS Final')
             end
           end
         end
@@ -273,7 +291,7 @@ RSpec.describe ClaimCsvPresenter do
           it 'the rejection reason code should be reflected in the MI' do
             allow_any_instance_of(ClaimStateTransition).to receive(:reason_code).and_return('no_rep_order')
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('no_rep_order')
+              expect(csv[0][12]).to eq('no_rep_order')
             end
           end
         end
@@ -285,7 +303,7 @@ RSpec.describe ClaimCsvPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('no_rep_order')
+              expect(csv[0][12]).to eq('no_rep_order')
             end
           end
         end
@@ -297,7 +315,7 @@ RSpec.describe ClaimCsvPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('no_rep_order, wrong_case_no')
+              expect(csv[0][12]).to eq('no_rep_order, wrong_case_no')
             end
           end
         end
@@ -309,8 +327,8 @@ RSpec.describe ClaimCsvPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('other')
-              expect(csv[0][12]).to eq('Rejection reason')
+              expect(csv[0][12]).to eq('other')
+              expect(csv[0][13]).to eq('Rejection reason')
             end
           end
         end
@@ -323,7 +341,7 @@ RSpec.describe ClaimCsvPresenter do
           it 'the refusal reason code should be reflected in the MI' do
             allow_any_instance_of(ClaimStateTransition).to receive(:reason_code).and_return('no_rep_order')
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('no_rep_order')
+              expect(csv[0][12]).to eq('no_rep_order')
             end
           end
         end
@@ -335,7 +353,7 @@ RSpec.describe ClaimCsvPresenter do
 
           it 'the refusal reason code should be reflected in the MI' do
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('no_rep_order')
+              expect(csv[0][12]).to eq('no_rep_order')
             end
           end
         end
@@ -347,7 +365,7 @@ RSpec.describe ClaimCsvPresenter do
 
           it 'the refusal reason code should be reflected in the MI' do
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('no_rep_order, wrong_case_no')
+              expect(csv[0][12]).to eq('no_rep_order, wrong_case_no')
             end
           end
         end
@@ -359,8 +377,8 @@ RSpec.describe ClaimCsvPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ClaimCsvPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][11]).to eq('other')
-              expect(csv[0][12]).to eq('Rejection reason')
+              expect(csv[0][12]).to eq('other')
+              expect(csv[0][13]).to eq('Rejection reason')
             end
           end
         end

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Stats::ManagementInformationGenerator do
       expect(contents.size).to eq(valid_claims.size + 1)
     end
     
-    it 'has 18 columns' do
-      expect(contents.first.split(',').count).to eql 18
+    it 'has 19 columns' do
+      expect(contents.first.split(',').count).to eql 19
     end
   end
   


### PR DESCRIPTION
#### What
Add a new, Bill Type, column to the MI Report

#### Ticket

[Amend MI reporting to include the bill type](https://dsdmoj.atlassian.net/browse/CBO-1186)

#### Why
This is required for - case management to monitor bill volume intakes and use this information for resourcing. It is likely to also be used for policy and finance to determine how much providers are utilising this option (and given that we may not be able to identify the claims as hardship in CCR and CCLF it is important to have this in place.  It may also be useful for monitoring the number of claims we will end up having in the new state of "archived pending review" and allow caseworkers to match up the claims the final bills. 

#### How
Extend the MI report headers and add and a new generator for extracting the required values from the Claim::BaseClaim.type

--------

#### TODO (wip)

 - [ ] Extend this to include the AGFS case type once the two branches can be merged
