### PR TITLE
Update the context mapper and routes

### DIFF
--- a/app/services/claims/context_mapper.rb
+++ b/app/services/claims/context_mapper.rb
@@ -12,9 +12,10 @@ module Claims
     end
 
     def available_claim_types
+      hardship_types = [Claim::AdvocateHardshipClaim, Claim::LitigatorHardshipClaim]
       @available_claim_types ||= @external_user.available_claim_types & @external_user.provider.available_claim_types
       @available_claim_types.tap do |arr|
-        arr.delete_if { |el| el.eql?(Claim::AdvocateHardshipClaim) } unless Settings.hardship_claims_enabled?
+        arr.delete_if { |el| hardship_types.include?(el) } unless Settings.hardship_claims_enabled?
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,7 @@ Rails.application.routes.draw do
       resources :claims, only: amend_actions
       resources :interim_claims, only: amend_actions
       resources :transfer_claims, only: amend_actions
-      resources :hardship_claims, only: amend_actions
+      resources :hardship_claims, only: amend_actions, constraints: lambda{ |request| Settings.hardship_claims_enabled? }
     end
   end
 

--- a/spec/services/claims/context_mapper_spec.rb
+++ b/spec/services/claims/context_mapper_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Claims::ContextMapper do
     context 'LGFS only provider' do
       let(:external_user) { create(:external_user, :litigator, provider: build(:provider, :lgfs)) }
       it { is_expected.to match_array(lgfs_claim_object_types) }
+
+      context 'when hardship claims enabled' do
+        before { allow(Settings).to receive(:hardship_claims_enabled?).and_return true }
+
+        it { is_expected.to include("Claim::LitigatorHardshipClaim") }
+      end
+
+      context 'when hardship claims disabled' do
+        before { allow(Settings).to receive(:hardship_claims_enabled?).and_return false }
+
+        it { is_expected.not_to include("Claim::LitigatorHardshipClaim") }
+      end
     end
 
     context 'AGFS and LGFS providers' do


### PR DESCRIPTION
Make sure we respect the Settings.hardship_claims_enabled? to hide the Claim::LitigatorHardshipClaim from the litigator new claim page
Update the routes to prevent accidental routing when the flag is not enabled

