### PR TITLE
Fix smoke test

### DIFF
--- a/features/support/date_helper.rb
+++ b/features/support/date_helper.rb
@@ -1,4 +1,8 @@
+require Rails.root.join('spec', 'support', 'scheme_date_helpers')
+
 module DateHelper
+  include SchemeDateHelpers
+
   def set_date(date_string)
     date = Time.parse(date_string)
     self.day.set date.day.to_s
@@ -8,21 +12,6 @@ module DateHelper
 
   def set_invalid_date
     self.day.set '1'
-  end
-
-  def scheme_date_for(text)
-    case text&.downcase&.strip
-      when 'scheme 11' then
-        Settings.agfs_scheme_11_release_date.strftime
-      when 'scheme 10' || 'post agfs reform' then
-        Settings.agfs_fee_reform_release_date.strftime
-      when 'scheme 9' || 'pre agfs reform' then
-        "2016-01-01"
-      when 'lgfs' then
-        "2016-04-01"
-      else
-        "2016-01-01"
-    end
   end
 end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'cancan/matchers'
+require 'support/shared_examples_for_claim_types'
 
 RSpec.shared_examples 'user cannot' do |user, actions|
   actions.each do |action|

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/shared_examples_for_claim_types'
 
 class MockBaseClaim < Claim::BaseClaim
   SUBMISSION_STAGES = [

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -14,6 +14,7 @@
 #
 
 require 'rails_helper'
+require 'support/shared_examples_for_claim_types'
 
 RSpec.describe ExternalUser, type: :model do
   it_behaves_like 'roles', ExternalUser, ExternalUser::ROLES

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -15,6 +15,7 @@
 #
 
 require 'rails_helper'
+require 'support/shared_examples_for_claim_types'
 
 RSpec.describe Provider, type: :model do
   let(:firm) { create(:provider, :firm) }

--- a/spec/services/claims/context_mapper_spec.rb
+++ b/spec/services/claims/context_mapper_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/shared_examples_for_claim_types'
 
 RSpec.describe Claims::ContextMapper do
   # NOTE: the external user claim controller spec also test this to a degree

--- a/spec/support/api/claims/base_claim_test.rb
+++ b/spec/support/api/claims/base_claim_test.rb
@@ -1,9 +1,9 @@
 require_relative 'debuggable'
-require_relative '../../test_helpers'
+require_relative '../../scheme_date_helpers'
 
 class BaseClaimTest
   include Debuggable
-  include TestHelpers
+  include SchemeDateHelpers
 
   attr_accessor :client, :claim_uuid
 

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -1,5 +1,9 @@
+require_relative 'scheme_date_helpers'
+
 module FactoryHelpers
-    def add_defendant_and_reporder(claim, representation_order_date = nil)
+  include SchemeDateHelpers
+
+  def add_defendant_and_reporder(claim, representation_order_date = nil)
     defendant = if representation_order_date
                   create(:defendant, :without_reporder, claim: claim)
                 else

--- a/spec/support/scheme_date_helpers.rb
+++ b/spec/support/scheme_date_helpers.rb
@@ -1,0 +1,16 @@
+module SchemeDateHelpers
+  def scheme_date_for(text)
+    case text&.downcase&.strip
+      when 'scheme 11' then
+        Settings.agfs_scheme_11_release_date.strftime
+      when 'scheme 10' || 'post agfs reform' then
+        Settings.agfs_fee_reform_release_date.strftime
+      when 'scheme 9' || 'pre agfs reform' then
+        "2016-01-01"
+      when 'lgfs' then
+        "2016-04-01"
+      else
+        "2016-01-01"
+    end
+  end
+end

--- a/spec/support/shared_examples_for_claim_types.rb
+++ b/spec/support/shared_examples_for_claim_types.rb
@@ -1,0 +1,26 @@
+RSpec.shared_context 'claim-types helpers' do
+  let(:agfs_claim_types) { %w[agfs agfs_interim agfs_supplementary agfs_hardship] }
+  let(:lgfs_claim_types) { %w[lgfs_final lgfs_interim lgfs_transfer] }
+  let(:all_claim_types) { agfs_claim_types | lgfs_claim_types }
+end
+
+RSpec.shared_context 'claim-types object helpers' do
+  let(:agfs_claim_object_types) { %w[Claim::AdvocateClaim Claim::AdvocateInterimClaim Claim::AdvocateSupplementaryClaim Claim::AdvocateHardshipClaim] }
+  let(:lgfs_claim_object_types) { %w[Claim::LitigatorClaim Claim::InterimClaim Claim::TransferClaim] }
+  let(:all_claim_object_types) { agfs_claim_object_types | lgfs_claim_object_types }
+
+  # Usable outside examples
+  class << self
+    def agfs_claim_type_objects
+      [Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::AdvocateSupplementaryClaim, Claim::AdvocateHardshipClaim]
+    end
+
+    def lgfs_claim_type_objects
+      [Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim]
+    end
+
+    def all_claim_type_objects
+      agfs_claim_type_objects | lgfs_claim_type_objects
+    end
+  end
+end

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -12,33 +12,6 @@ module TestHelpers
 
   include DatabaseHousekeeping
 
-  shared_context 'claim-types helpers' do
-    let(:agfs_claim_types) { %w[agfs agfs_interim agfs_supplementary agfs_hardship] }
-    let(:lgfs_claim_types) { %w[lgfs_final lgfs_interim lgfs_transfer] }
-    let(:all_claim_types) { agfs_claim_types | lgfs_claim_types }
-  end
-
-  shared_context 'claim-types object helpers' do
-    let(:agfs_claim_object_types) { %w[Claim::AdvocateClaim Claim::AdvocateInterimClaim Claim::AdvocateSupplementaryClaim Claim::AdvocateHardshipClaim] }
-    let(:lgfs_claim_object_types) { %w[Claim::LitigatorClaim Claim::InterimClaim Claim::TransferClaim] }
-    let(:all_claim_object_types) { agfs_claim_object_types | lgfs_claim_object_types }
-
-    # Usable outside examples
-    class << self
-      def agfs_claim_type_objects
-        [Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::AdvocateSupplementaryClaim, Claim::AdvocateHardshipClaim]
-      end
-
-      def lgfs_claim_type_objects
-        [Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim]
-      end
-
-      def all_claim_type_objects
-        agfs_claim_type_objects | lgfs_claim_type_objects
-      end
-    end
-  end
-
   def expect_invalid_attribute_with_message(record, attribute, value, message)
     error_attribute = attribute if error_attribute.nil?
     set_value(record, attribute, value)

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -1,4 +1,5 @@
 require File.dirname(__FILE__) + '/database_housekeeping'
+require_relative 'scheme_date_helpers'
 
 module TestHelpers
   # Methods here are exposed globally to all rspec tests, but do not abuse this.
@@ -11,6 +12,7 @@ module TestHelpers
   # file or files that actually need it.
 
   include DatabaseHousekeeping
+  include SchemeDateHelpers
 
   def expect_invalid_attribute_with_message(record, attribute, value, message)
     error_attribute = attribute if error_attribute.nil?


### PR DESCRIPTION
#### What
smoke test was failing with error below. Also
share `scheme_date_for`.

```
+ bundle exec rake api:smoke_test
Seeding 'external_users'...
Seeding 'case_workers'...
rake aborted!
NoMethodError: undefined method `shared_context' for TestHelpers:Module
/usr/src/app/spec/support/test_helpers.rb:15:in `<module:TestHelpers>'
/usr/src/app/spec/support/test_helpers.rb:3:in `<top (required)>'
/usr/src/app/spec/support/api/claims/base_claim_test.rb:2:in `require_relative'
/usr/src/app/spec/support/api/claims/base_claim_test.rb:2:in `<top (required)>'
```

#### Why
Resulted from me adding some RSpec
`shared_contexts` into the test_helpers
file.

Have also shared the `scheme_date_for` helper
as a separate commit because it is used in multiple
places but uses the same logic.

#### How
Have moved those shared_contexts to their own
shared examples file `require`d where needed.
