### PR TITLE
Prevent seeding of sample users on application load

### DIFF
--- a/lib/demo_data/demo_seeds.rb
+++ b/lib/demo_data/demo_seeds.rb
@@ -1,8 +1,0 @@
-%w(
-  external_users
-  case_workers
-).
-each do |seed|
-  puts "Seeding '#{seed}'..."
-  load File.join(Rails.root, 'lib', 'demo_data', 'demo_seeds', "#{seed}.rb")
-end

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -47,7 +47,10 @@ namespace :claims do
 
   desc 'Creates sample users'
   task :sample_users => :environment do
-    load File.join(Rails.root, 'lib', 'demo_data', 'demo_seeds.rb')
+    %w(external_users case_workers).each do |seed|
+      puts "Seeding '#{seed}'..."
+      load File.join(Rails.root, 'lib', 'demo_data', 'demo_seeds', "#{seed}.rb")
+    end
   end
 
   desc 'ADP Task: Loads dummy claims'
@@ -61,11 +64,11 @@ namespace :claims do
     Rake::Task['claims:demo_data:transfers'].invoke(params[:num_claims_per_state], params[:num_external_users])
   end
 
-  namespace  :demo_data do
+  namespace :demo_data do
     desc 'ADP Task: Load seed data and demo external users, providers and case workers [num_claims_per_state=1, num_claims_per_user=1]'
     task :seed do
       Rake::Task['db:seed'].invoke
-      load File.join(Rails.root, 'lib', 'demo_data', 'demo_seeds.rb')
+      Rake::Task['claims:sample_users'].invoke
     end
 
     desc 'ADP Task: Load demo data Advocate Claims [num_claims_per_state=1, num_claims_per_user=1]'


### PR DESCRIPTION
#### What
Bug fix to prevent seeding of sample users on application load

#### Why
unnecessary and slows console load

This has been happening for a long time and should
not have been.

It was caused by autoload of `lib` dir in combination
with the existence `lib/demo_data/demo_seeds.rb` file
which loads the seeds as soon as it is loaded (i.e.
on application boot, due to autoload of lib dir).

To explicitly load sample users use:
```
rake claims:sample_users
```