### PR TITLE
Amend case_stages seeder

### DIFF
--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -1,7 +1,8 @@
 module SeedHelper
   class << self
-    def find_or_create_case_stage!(options)
+    def update_or_create_case_stage!(options)
       stage = CaseStage.find_by(unique_code: options[:unique_code])
+      stage.update!(options) if stage
       stage = CaseStage.create!(options) unless stage
       stage
     end

--- a/db/seeds/case_stages.rb
+++ b/db/seeds/case_stages.rb
@@ -11,9 +11,8 @@
 
 require Rails.root.join('db','seed_helper')
 
-ActiveRecord::Base.connection.reset_pk_sequence!(:case_stages)
-
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 1,
   description: 'Pre PTPH',
   unique_code: 'PREPTPH',
   position: 10,
@@ -21,7 +20,8 @@ SeedHelper.find_or_create_case_stage!(
   roles: %w(agfs)
 )
 
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 2,
   description: 'After PTPH before trial',
   unique_code: 'AFTPTPH',
   position: 20,
@@ -29,15 +29,17 @@ SeedHelper.find_or_create_case_stage!(
   roles: %w(agfs)
 )
 
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 3,
   description: 'Trial started but not concluded',
   unique_code: 'TRLSBNC',
   position: 30,
   case_type_id: CaseType.find_by(fee_type_code: 'GRTRL').id,
-  roles: %w(agfs lgfs)
+  roles: %w(agfs)
 )
 
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 4,
   description: 'Guilty plea not yet sentenced',
   unique_code: 'GLTNYS',
   position: 40,
@@ -45,7 +47,8 @@ SeedHelper.find_or_create_case_stage!(
   roles: %w(agfs)
 )
 
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 5,
   description: 'Trial ended not yet sentenced',
   unique_code: 'TRLENYS',
   position: 50,
@@ -53,7 +56,8 @@ SeedHelper.find_or_create_case_stage!(
   roles: %w(agfs)
 )
 
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 6,
   description: 'Retrial listed but not started',
   unique_code: 'RTRLBNS',
   position: 60,
@@ -61,7 +65,8 @@ SeedHelper.find_or_create_case_stage!(
   roles: %w(agfs)
 )
 
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 7,
   description: 'Retrial started but not concluded',
   unique_code: 'RTRSBNC',
   position: 70,
@@ -69,7 +74,8 @@ SeedHelper.find_or_create_case_stage!(
   roles: %w(agfs)
 )
 
-SeedHelper.find_or_create_case_stage!(
+SeedHelper.update_or_create_case_stage!(
+  id: 8,
   description: 'Retrial ended not yet sentenced',
   unique_code: 'RTRENYS',
   position: 80,


### PR DESCRIPTION
#### What
Amend case_stage seeding

Convert to update_or_create logic to
allow update of existing case stages

also, explicitly add id to seeds.

#### Why
Once claims are associated with a claim via
id these should not be changed as it would
 change their case stage and therefore case type.

This would be bad!