### PR TITLE
Amend caseworker allocation filter to show hardship as case_type for lgfs claims

### DIFF
--- a/app/interfaces/api/v2/query_helper.rb
+++ b/app/interfaces/api/v2/query_helper.rb
@@ -25,6 +25,7 @@ module API::V2
                 WHEN 'Claim::AdvocateSupplementaryClaim' THEN 'Supplementary'
                 WHEN 'Claim::AdvocateInterimClaim' THEN 'Warrant'
                 WHEN 'Claim::TransferClaim' THEN 'Transfer'
+                WHEN 'Claim::LitigatorHardshipClaim' THEN 'Hardship'
               END
             ELSE ct.name
           END as case_type,


### PR DESCRIPTION
####  What
Amend caseworker allocation filter to show hardship as case_type for lgfs claims

#### Ticket
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=222&modal=detail&selectedIssue=CBO-1203

#### Why
This was previously being displayed as null

#### How
This change has also been for agfs claims - see
https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/3306
