### PR TITLE
Cbo 1188 agfs hardship api

### DIFF
--- a/app/interfaces/api/entities/case_stage.rb
+++ b/app/interfaces/api/entities/case_stage.rb
@@ -1,0 +1,10 @@
+module API
+  module Entities
+    class CaseStage < BaseEntity
+      expose :case_type_id
+      expose :unique_code
+      expose :description
+      expose :roles
+    end
+  end
+end

--- a/app/interfaces/api/error_response.rb
+++ b/app/interfaces/api/error_response.rb
@@ -26,7 +26,7 @@ module API
       Fee::GraduatedFee, Fee::InterimFee, Fee::TransferFee, Fee::BasicFee, Fee::MiscFee, Fee::FixedFee,
       Expense, Disbursement, Defendant, DateAttended, RepresentationOrder,
       Claim::AdvocateClaim, Claim::AdvocateInterimClaim, Claim::AdvocateSupplementaryClaim,
-      Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim
+      Claim::LitigatorClaim, Claim::InterimClaim, Claim::TransferClaim, Claim::AdvocateHardshipClaim
     ].freeze
 
     def initialize(object)

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -148,6 +148,12 @@ module API
           desc 'Return all Transfer Case Conclusions'
           get { present ::Claim::TransferBrain::CASE_CONCLUSIONS.to_a, with: API::Entities::SimpleKeyValueList }
         end
+
+        resource :case_stages do
+          desc 'Return all Case Stages'
+          params { use :role_filter }
+          get { present CaseStage.__send__(role), with: API::Entities::CaseStage }
+        end
       end
     end
   end

--- a/app/interfaces/api/v1/external_users/claim.rb
+++ b/app/interfaces/api/v1/external_users/claim.rb
@@ -11,6 +11,7 @@ module API
           mount API::V1::ExternalUsers::Claims::Advocates::FinalClaim
           mount API::V1::ExternalUsers::Claims::Advocates::InterimClaim
           mount API::V1::ExternalUsers::Claims::Advocates::SupplementaryClaim
+          mount API::V1::ExternalUsers::Claims::Advocates::HardshipClaim
           mount API::V1::ExternalUsers::Claims::FinalClaim
           mount API::V1::ExternalUsers::Claims::InterimClaim
           mount API::V1::ExternalUsers::Claims::TransferClaim

--- a/app/interfaces/api/v1/external_users/claims/advocates/hardship_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/hardship_claim.rb
@@ -1,0 +1,46 @@
+module API::V1::ExternalUsers
+  module Claims
+    module Advocates
+      class HardshipClaim < Grape::API
+        helpers API::V1::ClaimParamsHelper, API::V1::HardshipClaimParamsHelper
+
+        params do
+          def i18n_scope
+            %i[api v1 external_users claims advocate_claim params]
+          end
+
+          def local_t(attribute)
+            I18n.t(attribute.to_s, scope: i18n_scope)
+          end
+          use :agfs_hardship_params
+          use :legacy_agfs_params
+          optional :advocate_category,
+                   type: String,
+                   desc: local_t(:advocate_category),
+                   values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories).uniq
+
+          use :agfs_hardship_trial_params
+          use :common_agfs_params
+        end
+
+        namespace :advocates do
+          namespace :hardship do
+            desc 'Create an Advocate hardship claim.'
+            post do
+              create_resource(::Claim::AdvocateHardshipClaim)
+              status api_response.status
+              api_response.body
+            end
+
+            desc 'Validate an Advocate hardship claim.'
+            post '/validate' do
+              validate_resource(::Claim::AdvocateHardshipClaim)
+              status api_response.status
+              api_response.body
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v1/hardship_claim_params_helper.rb
+++ b/app/interfaces/api/v1/hardship_claim_params_helper.rb
@@ -1,0 +1,40 @@
+module API
+  module V1
+    module HardshipClaimParamsHelper
+      extend Grape::API::Helpers
+      # REQUIRED params (note: use optional but describe as required in order to let model validations bubble-up)
+      #
+      params :agfs_hardship_params do
+        optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the provider'
+        optional :creator_email, type: String, desc: I18n.t('api.v1.common_params.creator_email')
+        optional :court_id, type: Integer, desc: 'REQUIRED: The unique identifier for this court'
+        optional :offence_id, type: Integer, desc: 'REQUIRED: The unique identifier for this offence.'
+        optional :case_number, type: String, desc: 'REQUIRED: The case number'
+        optional :providers_ref, type: String, desc: 'OPTIONAL: Providers reference number'
+        optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
+        optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
+        optional :travel_expense_additional_information,
+                 type: String,
+                 desc: I18n.t('api.v1.common_params.travel_expense_additional_information')
+        optional :apply_vat, type: Boolean, desc: 'OPTIONAL: Include VAT (JSON Boolean data type: true or false)'
+        optional :prosecution_evidence, type: Boolean, desc: 'OPTIONAL: Pages of prosecution evidence > 0?'
+      end
+
+      params :agfs_hardship_trial_params do
+        optional :case_stage_unique_code, type: String, desc: 'REQUIRED: The unique code for the case stage.'
+        optional :first_day_of_trial, type: String, desc: 'OPTIONAL: YYYY-MM-DD', standard_json_format: true
+        optional :estimated_trial_length, type: Integer, desc: 'OPTIONAL: The estimated trial length in days'
+        optional :trial_concluded_at,
+                 type: String,
+                 desc: 'OPTIONAL: The date the trial concluded (YYYY-MM-DD)',
+                 standard_json_format: true
+        optional :retrial_started_at,
+                 type: String,
+                 desc: 'OPTIONAL: YYYY-MM-DD', standard_json_format: true
+        optional :retrial_estimated_length,
+                 type: Integer,
+                 desc: 'OPTIONAL: The estimated retrial length in days'
+      end
+    end
+  end
+end

--- a/app/models/claim/advocate_hardship_claim.rb
+++ b/app/models/claim/advocate_hardship_claim.rb
@@ -123,6 +123,10 @@ module Claim
       :advocate
     end
 
+    def case_stage_unique_code=(code)
+      self.case_stage = CaseStage.find_by!(unique_code: code)
+    end
+
     def agfs?
       self.class.agfs?
     end

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -9,6 +9,32 @@
 
 %section.api-documentation
   %hr
+  %h2 1st May 2020
+  %ul.list-bullet
+    %li
+      Addition of Advocate hardship type endpoint
+      %br/
+      %br/
+      In line with the web application interface, a new endpoint to facilitate the creation of "Advocate hardship claims" has been added.
+      %br/
+      %br/
+      The new endpoint is interactively documented at the links below:
+      %ul.list-bullet
+        %li
+          %a{ href: '/api/documentation?#!/api/postApiExternalUsersClaimsAdvocatesHardship', target: '_blank' } advocate hardship claim creation
+        %li
+          %a{ href: '/api/documentation?#!/api/documentation#!/api/postApiExternalUsersClaimsAdvocatesHardshipValidate', target: '_blank' } advocate hardship claim validate
+      %br/
+      %br/
+      A list of valid Case Stages (to be used when creating a hardship claim) can be retrieved via:
+      %table
+        %tr
+          %td GET /api/case_stages
+      %br/
+      %br/
+
+%section.api-documentation
+  %hr
   %h2 15th July 2019
   %ul.list-bullet
     %li

--- a/spec/api/entities/case_stage_spec.rb
+++ b/spec/api/entities/case_stage_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe API::Entities::CaseStage do
+
+  let(:case_stage) { instance_double(::CaseStage, id: 1, case_type_id: 8, unique_code: 'PREPTPH', description: 'Pre PTPH', roles: ['agfs']) }
+
+  it 'represents the case stage entity' do
+    result = described_class.represent(case_stage).to_json
+    expect(result).to eq '{"case_type_id":8,"unique_code":"PREPTPH","description":"Pre PTPH","roles":["agfs"]}'
+  end
+end

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe API::V1::DropdownData do
   DISBURSEMENT_TYPE_ENDPOINT  = "/api/disbursement_types"
   TRANSFER_STAGES_ENDPOINT    = "/api/transfer_stages"
   TRANSFER_CASE_CONCLUSIONS_ENDPOINT = "/api/transfer_case_conclusions"
+  CASE_STAGE_ENDPOINT         = "/api/case_stages"
 
   FORBIDDEN_DROPDOWN_VERBS = [:post, :put, :patch, :delete]
   ALL_DROPDOWN_ENDPOINTS = [
@@ -30,7 +31,8 @@ RSpec.describe API::V1::DropdownData do
       EXPENSE_REASONS_ENDPOINT,
       DISBURSEMENT_TYPE_ENDPOINT,
       TRANSFER_STAGES_ENDPOINT,
-      TRANSFER_CASE_CONCLUSIONS_ENDPOINT
+      TRANSFER_CASE_CONCLUSIONS_ENDPOINT,
+      CASE_STAGE_ENDPOINT
   ]
 
   let(:provider) { create(:provider) }
@@ -63,13 +65,15 @@ RSpec.describe API::V1::DropdownData do
         EXPENSE_REASONS_ENDPOINT => API::Entities::ExpenseReasonSet.represent(ExpenseType.reason_sets).to_json,
         DISBURSEMENT_TYPE_ENDPOINT => API::Entities::DisbursementType.represent(DisbursementType.active).to_json,
         TRANSFER_STAGES_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::TRANSFER_STAGES.to_a).to_json,
-        TRANSFER_CASE_CONCLUSIONS_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::CASE_CONCLUSIONS.to_a).to_json
+        TRANSFER_CASE_CONCLUSIONS_ENDPOINT => API::Entities::SimpleKeyValueList.represent(Claim::TransferBrain::CASE_CONCLUSIONS.to_a).to_json,
+        CASE_STAGE_ENDPOINT => API::Entities::CaseStage.represent(CaseStage.all).to_json
       }
     end
 
     before do
       seed_fee_schemes
       seed_case_types
+      seed_case_stages
       create_list(:court, 2)
       create_list(:offence_class, 2, :with_lgfs_offence)
       create_list(:offence, 2, :with_fee_scheme_nine)

--- a/spec/api/v1/external_users/claim_spec.rb
+++ b/spec/api/v1/external_users/claim_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe API::V1::ExternalUsers::Claim do
     /api/external_users/claims/advocates/supplementary
     /api/external_users/claims/advocates/supplementary/validate
 
+    /api/external_users/claims/advocates/hardship
+    /api/external_users/claims/advocates/hardship/validate
+
     /api/external_users/claims/final
     /api/external_users/claims/final/validate
 

--- a/spec/api/v1/external_users/claims/advocates/hardship_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/hardship_claim_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::ExternalUsers::Claims::Advocates::HardshipClaim do
+  include Rack::Test::Methods
+  include ApiSpecHelper
+
+  HARDSHIP_CLAIM_ENDPOINT = 'advocates/hardship'.freeze
+
+  let(:claim_class) { Claim::AdvocateHardshipClaim }
+  let!(:provider)       { create(:provider) }
+  let!(:other_provider) { create(:provider) }
+  let!(:vendor)         { create(:external_user, :admin, provider: provider) }
+  let!(:advocate)       { create(:external_user, :advocate, provider: provider) }
+  let!(:other_vendor)   { create(:external_user, :admin, provider: other_provider) }
+  let!(:offence)        { create(:offence)}
+  let!(:court)          { create(:court)}
+  let!(:valid_params)   { {
+      api_key: provider.api_key,
+      creator_email: vendor.user.email,
+      user_email: advocate.user.email,
+      case_stage_unique_code: FactoryBot.create(:case_stage, :trial_not_concluded).unique_code,
+      case_number: 'A20201234',
+      first_day_of_trial: "2020-01-01",
+      trial_concluded_at: "2020-01-09",
+      estimated_trial_length: 10,
+      actual_trial_length: 9,
+      advocate_category: 'Led junior',
+      offence_id: offence.id,
+      court_id: court.id } }
+
+  after(:all) { clean_database }
+
+  include_examples 'advocate claim test setup'
+  it_behaves_like 'a claim endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim validate endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim create endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
+
+  describe "POST #{ClaimApiEndpoints.for(HARDSHIP_CLAIM_ENDPOINT).validate}" do
+    subject(:post_to_validate_endpoint) do
+      post ClaimApiEndpoints.for(HARDSHIP_CLAIM_ENDPOINT).validate, valid_params, format: :json
+    end
+  
+    it 'returns 200 when parameters that are optional for hardship claims are empty' do
+      valid_params.delete(:last_day_of_trial)
+      valid_params.delete(:estimated_trial_length)
+      valid_params.delete(:actual_trial_length)
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(200)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,7 @@ SimpleCov.configure do
   add_filter 'app/validators/expense_v1_validator.rb'         # no longer used - can be removed when all claims with v1 expenses deleted (see PT https://www.pivotaltracker.com/story/show/119351871 )
   add_filter 'lib/caching/redis_store.rb'                     # unable to mock a local instance of Redis
   add_filter 'lib/messaging'                                  # all the files used in the proof of concept to export calims to LAA systems
+  add_filter 'db/seed_helper.rb'
 
   # exclude patterns from test coverage results
   add_filter %r{^/lib\/rack/} # only used to prevent feature test flickering

--- a/spec/support/api/api_test_client.rb
+++ b/spec/support/api/api_test_client.rb
@@ -40,6 +40,7 @@ class ApiTestClient
     AdvocateClaimTest.new(client: self).test_creation!
     AdvocateInterimClaimTest.new(client: self).test_creation!
     AdvocateSupplementaryClaimTest.new(client: self).test_creation!
+    AdvocateHardshipClaimTest.new(client: self).test_creation!
     LitigatorFinalClaimTest.new(client: self).test_creation!
     LitigatorInterimClaimTest.new(client: self).test_creation!
     LitigatorTransferClaimTest.new(client: self).test_creation!

--- a/spec/support/api/claims/advocate_hardship_claim_test.rb
+++ b/spec/support/api/claims/advocate_hardship_claim_test.rb
@@ -1,0 +1,89 @@
+require_relative 'base_claim_test'
+
+class AdvocateHardshipClaimTest < BaseClaimTest
+  def agfs_schema?
+    true
+  end
+
+  def test_creation!
+    puts 'starting'
+
+    # create a claim
+    response = client.post_to_endpoint('claims/advocates/hardship', claim_data)
+    return if client.failure
+
+    self.claim_uuid = id_from_json(response)
+
+    # add a defendant
+    response = client.post_to_endpoint('defendants', defendant_data)
+
+    # add representation order
+    defendant_id = id_from_json(response)
+    client.post_to_endpoint('representation_orders', representation_order_data(defendant_id))
+
+    # UPDATE basic fee
+    client.post_to_endpoint('fees', basic_fee_data)
+
+    # CREATE miscellaneous fee
+    response = client.post_to_endpoint('fees', misc_fee_data)
+
+    # add date attended to miscellaneous fee
+    attended_item_id = id_from_json(response)
+    client.post_to_endpoint('dates_attended', date_attended_data(attended_item_id, 'fee'))
+
+    # add expense
+    client.post_to_endpoint('expenses', expense_data(role: 'agfs'))
+  ensure
+    clean_up
+  end
+
+  def claim_data
+    case_stage_unique_code = json_value_at_index(client.get_dropdown_endpoint(CASE_STAGE_ENDPOINT, api_key, role: 'agfs'), 'unique_code')
+    advocate_category = json_value_at_index(client.get_dropdown_endpoint(ADVOCATE_CATEGORY_ENDPOINT, api_key))
+    offence_id = json_value_at_index(client.get_dropdown_endpoint(OFFENCE_ENDPOINT, api_key), 'id')
+    court_id = json_value_at_index(client.get_dropdown_endpoint(COURT_ENDPOINT, api_key), 'id')
+   
+    {
+      "api_key": api_key,
+      "creator_email": 'advocateadmin@example.com',
+      "advocate_email": 'advocate@example.com',
+      "case_number": 'B20161234',
+      "providers_ref": SecureRandom.uuid[3..15].upcase,
+      "case_stage_unique_code": case_stage_unique_code,
+      "first_day_of_trial": '2020-04-01',
+      "estimated_trial_length": 1,
+      "actual_trial_length": 1,
+      "trial_concluded_at": '2020-04-02',
+      "advocate_category": advocate_category,
+      "offence_id": offence_id,
+      "court_id": court_id,
+      "cms_number": '12345678',
+      "additional_information": 'string',
+      "apply_vat": true,
+    }
+  end
+
+  def basic_fee_data
+    fee_type_id = json_value_at_index(client.get_dropdown_endpoint(FEE_TYPE_ENDPOINT, api_key, category: 'basic', role: 'agfs'), 'id')
+
+    {
+      "api_key": api_key,
+      "claim_id": claim_uuid,
+      "fee_type_id": fee_type_id,
+      "quantity": 1,
+      "rate": 255.50
+    }
+  end
+
+  def misc_fee_data
+    fee_type_id = json_value_at_index(client.get_dropdown_endpoint(FEE_TYPE_ENDPOINT, api_key, category: 'misc', role: 'agfs'), 'id')
+
+    {
+      "api_key": api_key,
+      "claim_id": claim_uuid,
+      "fee_type_id": fee_type_id,
+      "quantity": 2,
+      "rate": 1.55
+    }
+  end
+end

--- a/spec/support/api/claims/base_claim_test.rb
+++ b/spec/support/api/claims/base_claim_test.rb
@@ -19,6 +19,7 @@ class BaseClaimTest
   DISBURSEMENT_TYPE_ENDPOINT  = 'disbursement_types'.freeze
   TRANSFER_STAGES_ENDPOINT    = 'transfer_stages'.freeze
   TRANSFER_CASE_CONCLUSIONS_ENDPOINT = 'transfer_case_conclusions'.freeze
+  CASE_STAGE_ENDPOINT         = 'case_stages'.freeze
 
   ADVOCATE_TEST_EMAIL  = 'advocateadmin@example.com'.freeze
   LITIGATOR_TEST_EMAIL = 'litigatoradmin@example.com'.freeze

--- a/spec/support/seed_helpers.rb
+++ b/spec/support/seed_helpers.rb
@@ -14,7 +14,7 @@ module SeedHelpers
     load_seed 'case_types'
   end
 
-  def seed_case_stage
+  def seed_case_stages
     load_seed 'case_stages'
   end
 

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -212,11 +212,12 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
         before { post_to_create_endpoint }
 
         it "has attributes matching the params" do
-          valid_params.each do |attribute, value|
-            next if [:api_key, :creator_email, :user_email].include?(attribute) # because these are used for authentication and authorisation only
-            valid_params[attribute] = value.to_date if claim.send(attribute).class.eql?(Date) # because the saved claim record has Date objects but the param has date strings
-            expect(claim.send(attribute).to_s).to eq valid_params[attribute].to_s # some strings are converted to ints on save
-          end
+           valid_params.each do |attribute, value|
+             next if [:api_key, :creator_email, :user_email].include?(attribute) # because these are used for authentication and authorisation only
+             next if [:case_stage_unique_code].include?(attribute) # used internally for adding case stage to hardship claims only
+             valid_params[attribute] = value.to_date if claim.send(attribute).class.eql?(Date) # because the saved claim record has Date objects but the param has date strings
+             expect(claim.send(attribute).to_s).to eq valid_params[attribute].to_s # some strings are converted to ints on save
+           end
         end
 
         it "belongs to the user whose email was specified in params" do


### PR DESCRIPTION
#### What

Added api endpoints for advocate hardship claims.

#### Ticket

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=222&modal=detail&selectedIssue=CBO-1188

#### Why

To allow external users (eventually) to submit advocate hardship claims with their case management systems via the the api endpoints.

#### How

Added POST /api/external_users/claims/advocates/hardship/validate and POST /api/external_users/claims/advocates/hardship endpoints.

