### PR TITLE
Customize cracked trial detail fields for hardship

### DIFF
--- a/app/models/claim/advocate_hardship_claim.rb
+++ b/app/models/claim/advocate_hardship_claim.rb
@@ -28,6 +28,7 @@ module Claim
     before_validation do
       set_supplier_number
       assign_total_attrs
+      assign_cracked_details
     end
 
     SUBMISSION_STAGES = [
@@ -158,6 +159,10 @@ module Claim
         next if fee_type_ids.include?(basic_fee_type.id)
         basic_fees.build(fee_type: basic_fee_type, quantity: 0, amount: 0)
       end
+    end
+
+    def assign_cracked_details
+      self.trial_cracked_at = Date.today if requires_cracked_dates?
     end
 
     def cleaner

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -6,12 +6,14 @@
 
   = f.gov_uk_date_field(:trial_fixed_at, legend_text: t('.trial_fixed_at'), legend_class: 'govuk-legend', form_hint_text: t('.date_hint'), id: "trial_fixed_at",error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_fixed_at))
 
-  = f.gov_uk_date_field(:trial_cracked_at, legend_text: t('.trial_cracked_at'), legend_class: 'govuk-legend', form_hint_text: t('.date_hint'), id: "trial_cracked_at", error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_cracked_at))
+  - # = TODO: this needs testing
+  - unless @claim.hardship?
+    = f.gov_uk_date_field(:trial_cracked_at, legend_text: t('.trial_cracked_at'), legend_class: 'govuk-legend', form_hint_text: t('.date_hint'), id: "trial_cracked_at", error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_cracked_at))
 
   .form-group
     %fieldset{"aria-describedby": "radio-control-legend-cracked-trial"}
       %legend#radio-control-legend-cracked-trial.form-label-bold
-        = t('.trial_cracked_at_third')
+        = @claim.hardship? ? t('.trial_cracked_at_third.hardship') : t('.trial_cracked_at_third.default')
 
       = f.collection_radio_buttons(:trial_cracked_at_third, Settings.trial_cracked_at_third, :to_s, :humanize) do |b|
         .multiple-choice

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -6,7 +6,6 @@
 
   = f.gov_uk_date_field(:trial_fixed_at, legend_text: t('.trial_fixed_at'), legend_class: 'govuk-legend', form_hint_text: t('.date_hint'), id: "trial_fixed_at",error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_fixed_at))
 
-  - # = TODO: this needs testing
   - unless @claim.hardship?
     = f.gov_uk_date_field(:trial_cracked_at, legend_text: t('.trial_cracked_at'), legend_class: 'govuk-legend', form_hint_text: t('.date_hint'), id: "trial_cracked_at", error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_cracked_at))
 

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -105,7 +105,10 @@
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
-            = t('trial_cracked_at_third', scope: cracked_trial_fields)
+            - if claim.hardship?
+              = t('trial_cracked_at_third.hardship', scope: cracked_trial_fields)
+            - else
+              = t('trial_cracked_at_third.default', scope: cracked_trial_fields)
           %dd.govuk-summary-list__value
             = claim&.trial_cracked_at_third&.humanize
 

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -96,12 +96,13 @@
             %time{ 'aria-label': claim&.trial_fixed_at&.strftime(Settings.date_format_label), datetime: claim&.trial_fixed_at&.strftime(Settings.datetime_attribute) }
               = claim&.trial_fixed_at&.strftime(Settings.date_format)
 
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
-            = t('trial_cracked_at', scope: cracked_trial_fields)
-          %dd.govuk-summary-list__value
-            %time{ 'aria-label': claim&.trial_cracked_at&.strftime(Settings.date_format_label), datetime: claim&.trial_cracked_at&.strftime(Settings.datetime_attribute) }
-              = claim&.trial_cracked_at&.strftime(Settings.date_format)
+        - unless claim.hardship?
+          .govuk-summary-list__row
+            %dt.govuk-summary-list__key
+              = t('trial_cracked_at', scope: cracked_trial_fields)
+            %dd.govuk-summary-list__value
+              %time{ 'aria-label': claim&.trial_cracked_at&.strftime(Settings.date_format_label), datetime: claim&.trial_cracked_at&.strftime(Settings.datetime_attribute) }
+                = claim&.trial_cracked_at&.strftime(Settings.date_format)
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key

--- a/app/views/shared/_claim_cracked_trial_details.html.haml
+++ b/app/views/shared/_claim_cracked_trial_details.html.haml
@@ -19,6 +19,9 @@
 
 %tr
   %th{ scope: 'row' }
-    = t("#{cracked_trial_detail_translations}.trial_cracked_at_third")
+    - if claim.hardship?
+      = t("#{cracked_trial_detail_translations}.trial_cracked_at_third.hardship")
+    - else
+      = t("#{cracked_trial_detail_translations}.trial_cracked_at_third.default")
   %td
     = claim.trial_cracked_at_third.humanize rescue ''

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1013,7 +1013,9 @@ en:
         cracked_trial_fields:
           cracked_trial_details: Cracked trial details
           trial_cracked_at: Case cracked on
-          trial_cracked_at_third: Case cracked in
+          trial_cracked_at_third:
+            default: Case cracked in
+            hardship: If the case cracked today, which third would it be?
           date_hint: 'For example, 31 3 2017'
           trial_fixed_notice_at: 'Notice of 1st fixed/warned issued'
           trial_fixed_at: '1st fixed/warned trial'

--- a/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
@@ -16,7 +16,13 @@ Feature: Advocate tries to submit a hardship claim for a trial with miscellaneou
     And I select the court 'Caernarfon'
     And I enter a case number of 'A20201234'
 
-    And I select a case stage of 'Trial started but not concluded'
+    When I select a case stage of 'After PTPH before trial'
+    Then I should see hardship cracked trial fields
+
+    When I select a case stage of 'Retrial listed but not started'
+    Then I should see hardship cracked trial fields
+
+    When I select a case stage of 'Trial started but not concluded'
     Then I should see trial fields
 
     And I enter scheme 11 trial start date

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -2,6 +2,7 @@ require_relative 'sections/common_date_section'
 require_relative 'sections/common_autocomplete_section'
 require_relative 'sections/supplier_numbers_section'
 require_relative 'sections/retrial_section'
+require_relative 'sections/cracked_trial_section'
 require_relative 'sections/fee_dates_section_condensed'
 require_relative 'sections/fee_dates_section'
 require_relative 'sections/fee_section'
@@ -15,7 +16,6 @@ require_relative 'sections/offence_result_section'
 require_relative 'sections/advocate_category_section'
 require_relative 'sections/evidence_checklist_section'
 require_relative 'sections/yes_no_section'
-
 
 class ClaimFormPage < BasePage
   include SelectHelper
@@ -37,6 +37,7 @@ class ClaimFormPage < BasePage
   end
 
   section :retrial_details, RetrialSection, "#retrial-dates"
+  section :cracked_trial_details, CrackedTrialSection, "#cracked-trial-dates"
 
   sections :defendants, ".defendant-details" do
     element :first_name, "div.first-name input"

--- a/features/page_objects/sections/cracked_trial_section.rb
+++ b/features/page_objects/sections/cracked_trial_section.rb
@@ -1,0 +1,11 @@
+require_relative 'common_date_section'
+
+class CrackedTrialSection < SitePrism::Section
+  section :trial_fixed_notice_at, CommonDateSection, '#trial_fixed_notice_at'
+  section :trial_fixed_at, CommonDateSection, '#trial_fixed_at'
+  section :trial_cracked_at, CommonDateSection, '#trial_cracked_at'
+
+  element :first_third, "label[for='claim_trial_cracked_at_third_first_third']"
+  element :second_third, "label[for='claim_trial_cracked_at_third_second_third']"
+  element :final_third, "label[for='claim_trial_cracked_at_third_final_third']"
+end

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -206,6 +206,12 @@ Then(/^I should see retrial fields$/) do
   expect(@claim_form_page.retrial_details).to be_all_there
 end
 
+Then("I should see cracked trial fields") do
+  expect(@claim_form_page).to have_cracked_trial_details
+  expect(@claim_form_page.cracked_trial_details).to be_visible
+  expect(@claim_form_page.cracked_trial_details).to be_all_there
+end
+
 Then(/^the last fixed fee case numbers section should (not )?be visible$/) do |negate|
   if negate
     expect(@claim_form_page.fixed_fees.last).to_not have_case_numbers_section

--- a/features/step_definitions/advocate_hardship_claim_steps.rb
+++ b/features/step_definitions/advocate_hardship_claim_steps.rb
@@ -50,3 +50,12 @@ Then("I should see the offence details {string}") do |details|
       end
     end
 end
+
+Then("I should see hardship cracked trial fields") do
+  section = @advocate_hardship_claim_form_page.cracked_trial_details
+  expect(section.trial_fixed_notice_at).to be_visible
+  expect(section.trial_fixed_at).to be_visible
+  expect(section).not_to have_trial_cracked_at
+  expect(section).to have_content('If the case cracked today, which third would it be?')
+end
+

--- a/spec/factories/claim/advocate_hardship_claims.rb
+++ b/spec/factories/claim/advocate_hardship_claims.rb
@@ -4,10 +4,8 @@ FactoryBot.define do
     case_type { nil }
     case_stage
 
-    after(:build) { |claim| post_build_actions_for_draft_final_claim(claim) }
-
-    trait :submitted do
-      after(:create) { |c| c.submit! }
+    after(:build) do |claim|
+      set_creator(claim)
     end
 
     trait :authorised do

--- a/spec/factories/claim/advocate_hardship_claims.rb
+++ b/spec/factories/claim/advocate_hardship_claims.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     case_stage
 
     after(:build) do |claim|
+      claim.fees << build(:basic_fee, :baf_fee, claim: claim)
       set_creator(claim)
     end
 

--- a/spec/models/claim/advocate_hardship_claim_spec.rb
+++ b/spec/models/claim/advocate_hardship_claim_spec.rb
@@ -1,3 +1,46 @@
+RSpec.shared_examples 'hardship cracked trial' do
+  subject { claim.trial_cracked_at }
+
+  let(:claim) { build(:advocate_hardship_claim, case_stage: case_stage, **cracked_details) }
+
+  let(:cracked_details) do
+    {
+      trial_fixed_notice_at: Date.current - 3.days,
+      trial_fixed_at: Date.current - 1,
+      trial_cracked_at: nil,
+      trial_cracked_at_third: 'final_third'
+    }
+  end
+
+  context 'when the claim is not yet saved' do
+    it { is_expected.to eql nil }
+  end
+
+  context 'when the claim is saved' do
+    before do
+      travel_to(1.week.ago) do
+        claim.save
+      end
+    end
+
+    it 'sets trial_cracked_at to date saved' do
+      is_expected.to eql 1.week.ago.to_date
+    end
+  end
+
+  context 'when they submit the claim' do
+    before do
+      travel_to(1.week.ago) do
+        claim.save
+      end
+    end
+
+    it 'sets trial_cracked_at on submit!' do
+      expect{ claim.submit! }.to change { claim.trial_cracked_at }.from(1.week.ago.to_date).to(Date.today)
+    end
+  end
+end
+
 RSpec.describe Claim::AdvocateHardshipClaim, type: :model do
   let(:claim) { build(:advocate_hardship_claim) }
 
@@ -100,55 +143,18 @@ RSpec.describe Claim::AdvocateHardshipClaim, type: :model do
   end
 
   describe '#assign_trial_cracked_at' do
-    subject { claim.trial_cracked_at }
-
-    let(:claim) { build(:advocate_hardship_claim, case_stage: case_stage, **cracked_details) }
-
-    let(:cracked_details) {
-      {
-        trial_fixed_notice_at: Date.current - 3.days,
-        trial_fixed_at: Date.current - 1,
-        trial_cracked_at: nil,
-        trial_cracked_at_third: 'final_third'
-      }
-    }
-
     context 'with cracked trial (After PTPH before trial)' do
       let(:case_stage) { create(:case_stage, :cracked_trial) }
 
-      context 'when the claim is not yet saved' do
-        it { is_expected.to eql nil }
-      end
-
-      context 'when the claim is saved' do
-        before do
-          travel_to(1.week.ago) do
-            claim.save
-          end
-        end
-
-        it 'sets trial_cracked_at to date saved' do
-          is_expected.to eql 1.week.ago.to_date
-        end
-      end
-
-      context 'when they submit the claim' do
-        before do
-          travel_to(1.week.ago) do
-            claim.save
-          end
-        end
-
-        it 'sets trial_cracked_at on submit!' do
-          expect{ claim.submit! }.to change { claim.trial_cracked_at }.from(1.week.ago.to_date).to(Date.today)
-        end
+      it_behaves_like 'hardship cracked trial' do
+        let(:case_stage) { create(:case_stage, :cracked_trial) }
       end
     end
 
-    xcontext 'with cracked before trial (Retrial listed but not started)' do
-      let(:case_stage) { create(:case_stage, :retrial_not_started) }
-
-      # TODO: same as above
+    context 'with cracked before trial (Retrial listed but not started)' do
+      it_behaves_like 'hardship cracked trial' do
+        let(:case_stage) { create(:case_stage, :retrial_not_started) }
+      end
     end
   end
 end

--- a/spec/models/claim/advocate_hardship_claim_spec.rb
+++ b/spec/models/claim/advocate_hardship_claim_spec.rb
@@ -135,7 +135,6 @@ RSpec.describe Claim::AdvocateHardshipClaim, type: :model do
       context 'when they submit the claim' do
         before do
           travel_to(1.week.ago) do
-            claim.fees << build(:basic_fee, :baf_fee, claim: claim)
             claim.save
           end
         end

--- a/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
 
         it 'test setup' do
           expect(claim.defendants.size).to eql 1
-          expect(claim.basic_fees.map { |f| f.fee_type.unique_code }.sort).to eql(%w[BANDR])
+          expect(claim.basic_fees.map { |f| f.fee_type.unique_code }.sort).to include('BANDR')
         end
 
         it 'should not error' do


### PR DESCRIPTION
#### What
- default trial_cracked_at on save
- hide trial_cracked_at field
- custom question for third radios

##### Ticket
[CBO-1205](https://dsdmoj.atlassian.net/browse/CBO-1205)

#### Why
Hardship claims have not really cracked
but are to be treated as cracked for purposes
of fees

#### How
trial_cracked_at set to current date when claim saved, but
only if claim requires cracked details and is in a draft state
or its state is transitioning from draft to submitted