### PR TITLE
Revert disbling of LGFS hardships

### DIFF
--- a/app/services/claims/context_mapper.rb
+++ b/app/services/claims/context_mapper.rb
@@ -16,7 +16,6 @@ module Claims
       @available_claim_types ||= @external_user.available_claim_types & @external_user.provider.available_claim_types
       @available_claim_types.tap do |arr|
         arr.delete_if { |el| hardship_types.include?(el) } unless Settings.hardship_claims_enabled?
-        arr.delete_if { |el| el.eql?(Claim::LitigatorHardshipClaim) } unless Settings.lgfs_hardship_claims_enabled?
       end
     end
 

--- a/app/services/claims/context_mapper.rb
+++ b/app/services/claims/context_mapper.rb
@@ -16,6 +16,7 @@ module Claims
       @available_claim_types ||= @external_user.available_claim_types & @external_user.provider.available_claim_types
       @available_claim_types.tap do |arr|
         arr.delete_if { |el| hardship_types.include?(el) } unless Settings.hardship_claims_enabled?
+        arr.delete_if { |el| el.eql?(Claim::LitigatorHardshipClaim) } unless Settings.lgfs_hardship_claims_enabled?
       end
     end
 

--- a/app/views/external_users/claim_types/selection.html.haml
+++ b/app/views/external_users/claim_types/selection.html.haml
@@ -12,8 +12,7 @@
           %h2.heading-large
             = t('.choose_claim_type_prompt_text')
 
-        - hacky_claim_types = @available_claim_types.reject {|ct| eql?(Claim::LitigatorHardshipClaim) && !Settings.lgfs_hardship_claims_enabled? }
-        - hacky_claim_types.each_with_index do |claim_type, index|
+        - @available_claim_types.each_with_index do |claim_type, index|
           .multiple-choice
             = radio_button_tag :claim_type, claim_type, index.zero?
             = label_tag "claim_type_#{claim_type}", nil do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,7 +96,6 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 # If enabled, providers with proper roles will see hardship claims in the list of advocate claim types
 hardship_claims_enabled?: <%= ENV['HARDSHIP_ENABLED'] || Rails.env.eql?('test') %>
 
-lgfs_hardship_claims_enabled?: <%= ENV['LGFS_HARDSHIP_ENABLED'] || Rails.env.eql?('test') %>
 # Feature flag to enable ability to set user email notification user preferences.  If true, external
 # users will be able to set preference to say whether they want email notifications of outstanding messages
 # on their claim

--- a/kubernetes_deploy/dev-agfs/deployment.yaml
+++ b/kubernetes_deploy/dev-agfs/deployment.yaml
@@ -51,8 +51,6 @@ spec:
               value: 'dev'
             - name: HARDSHIP_ENABLED
               value: 'true'
-            - name: LGFS_HARDSHIP_ENABLED
-              value: 'true'
             - name: RAILS_ENV
               value: 'production'
             - name: RAILS_SERVE_STATIC_FILES

--- a/kubernetes_deploy/dev-lgfs/deployment.yaml
+++ b/kubernetes_deploy/dev-lgfs/deployment.yaml
@@ -51,8 +51,6 @@ spec:
               value: 'dev'
             - name: HARDSHIP_ENABLED
               value: 'true'
-            - name: LGFS_HARDSHIP_ENABLED
-              value: 'true'
             - name: RAILS_ENV
               value: 'production'
             - name: RAILS_SERVE_STATIC_FILES

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -51,8 +51,6 @@ spec:
               value: 'dev'
             - name: HARDSHIP_ENABLED
               value: 'true'
-            - name: LGFS_HARDSHIP_ENABLED
-              value: 'true'
             - name: RAILS_ENV
               value: 'production'
             - name: RAILS_SERVE_STATIC_FILES


### PR DESCRIPTION
Business would like to keep enabled
and handle via assessment feedback for now.

Could merge this for now and if business change their mind we can `git cherry-pick ae8762433` to add back in