### PR TITLE
Fix evidence table long text wrapping

### DIFF
--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -670,11 +670,13 @@ Styling for Claims Messaging
     font-weight: 700;
   }
 
-  tbody td:first-child,
-  .success {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  td, th {
+    word-break: break-all;
+  }
+
+  td:first-child,
+  th:first-child {
+    width: 50%;
   }
 
   progress {
@@ -759,6 +761,19 @@ Styling for Claims Messaging
   }
 }
 
+table#download-files-report,
+table.previously-uploaded {
+  td, th {
+    word-break: break-all;
+  }
+}
+
+table#download-files-report {
+  td:first-child,
+  th:first-child {
+    width: 50%;
+  }
+}
 
 
 /*--- Ported from v1 stylesheets ---*/

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -407,3 +407,8 @@ table.nested-summary {
     }
   }
 }
+
+
+table.previously-uploaded th:first-child {
+  width: 75%;
+}


### PR DESCRIPTION
#### What
Long strings in Evidence table are breaking the page layout.

#### Ticket
[CBO-1216](https://dsdmoj.atlassian.net/browse/CBO-1216)

#### Why
Uploaded files with long names and no white space breaks the page layout

#### How
Wrap long string within table cell to stop the table breaking the page layout
