### PR TITLE
Reduce time of rspec sweet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ references:
       command: |
         mkdir -p tmp/
         mkdir -p tmp/coverage/
+        mkdir -p /tmp/test-results/rspec
+        mkdir -p /tmp/test-results/cucumber
 
   _install-codeclimate: &install-codeclimate
     run:
@@ -79,16 +81,16 @@ references:
       name: Run rspec tests
       command: |
         tmp/cc-test-reporter before-build
-        TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=classname)
-        bundle exec rspec ${TESTS} --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
+        TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
+        bundle exec rspec ${TESTS} --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
         tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
 
   _cucumber: &cucumber
     run:
         name: Run cucumber tests
         command: |
-          FEATURES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
-          bundle exec cucumber ${FEATURES} --format junit --out ~/cucumber/junit.xml
+          FEATURES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings --timings-type=filename)
+          bundle exec cucumber ${FEATURES} --format junit --out /tmp/test-results/cucumber/junit.xml
 
   _install-wkhtmltopdf: &install-wkhtmltopdf
     run:
@@ -285,7 +287,7 @@ jobs:
       - store_artifacts:
           path: tmp/coverage
       - store_test_results:
-          path: ~/rspec
+          path: /tmp/test-results/rspec
 
   cucumber-tests:
     executor: test-executor
@@ -300,7 +302,7 @@ jobs:
       - store_artifacts:
           path: tmp/capybara
       - store_test_results:
-          path: ~/cucumber
+          path: /tmp/test-results/cucumber
 
   other-tests:
     executor: test-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ references:
       command: |
         tmp/cc-test-reporter before-build
         TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
+        echo $TESTS
         bundle exec rspec ${TESTS}
         tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
 
@@ -269,7 +270,7 @@ jobs:
 
   rspec-tests:
     executor: test-executor
-    parallelism: 4
+    parallelism: 8
     steps:
       - checkout
       - build-base
@@ -314,7 +315,8 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            tmp/cc-test-reporter sum-coverage --output - --parts 4 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
+            echo "move to command and append to rspec job to use CIRCLE_NODE_TOTAL for parts"
+            tmp/cc-test-reporter sum-coverage --output - --parts 8 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
 
   build-app-container:
     executor: cloud-platform-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,17 +79,16 @@ references:
       name: Run rspec tests
       command: |
         tmp/cc-test-reporter before-build
-        TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
-        echo $TESTS
-        bundle exec rspec ${TESTS}
+        TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=classname)
+        bundle exec rspec ${TESTS} --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
         tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
 
   _cucumber: &cucumber
     run:
         name: Run cucumber tests
         command: |
-          FEATURES=$(circleci tests glob "features/**/*.feature" | circleci tests split)
-          bundle exec cucumber ${FEATURES} --format progress --color
+          FEATURES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
+          bundle exec cucumber ${FEATURES} --format junit --out ~/cucumber/junit.xml
 
   _install-wkhtmltopdf: &install-wkhtmltopdf
     run:
@@ -285,6 +284,8 @@ jobs:
             - coverage/codeclimate.*.json
       - store_artifacts:
           path: tmp/coverage
+      - store_test_results:
+          path: ~/rspec
 
   cucumber-tests:
     executor: test-executor
@@ -298,6 +299,8 @@ jobs:
       - *cucumber
       - store_artifacts:
           path: tmp/capybara
+      - store_test_results:
+          path: ~/cucumber
 
   other-tests:
     executor: test-executor
@@ -315,7 +318,6 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            echo "move to command and append to rspec job to use CIRCLE_NODE_TOTAL for parts"
             tmp/cc-test-reporter sum-coverage --output - --parts 8 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
 
   build-app-container:

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :development, :devunicorn, :test do
   gem 'rack-livereload', '~> 0.3.16'
   gem 'rspec-rails', '~> 4.0.0'
   gem 'rspec-collection_matchers'
+  gem 'rspec_junit_formatter'
   gem 'net-ssh'
   gem 'net-scp'
   gem 'rubocop', '~> 0.82'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1319,6 +1319,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -1552,6 +1554,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-mocks
   rspec-rails (~> 4.0.0)
+  rspec_junit_formatter
   rubocop (~> 0.82)
   rubocop-performance
   rubocop-rails


### PR DESCRIPTION
#### What
RSpec suite has slowed, try to speed up

#### Ticket

[CBO-1212](https://dsdmoj.atlassian.net/browse/CBO-1212)

#### Why
Following introduction of hardship claims the code
base and test suite has grown significantly. The test
suite for rspec takes over 15 minutes to run.

#### How
Run rspec in 8 parrallel containers/executors, up
from 4. In addition split the specs across the containers
based on timings. This is the most efficient use
of containers but will require metadata storage on
circleci - which is analysed by circle to optimise
the runs across the "nodes", placing slowest tests with fewer
other tests...we shall see.

Already down from 15 minutes to sub 12 minutes with the
parrallel instances, although competition for containers
can delay the start potentially?!