### PR TITLE
CBO-1208: Timestamp authorise on MI

### DIFF
--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -114,7 +114,7 @@ class ClaimCsvPresenter < BasePresenter
 
   def completed_at
     completion_steps = @journey.select { |step| COMPLETED_STATES.include?(step.to) }
-    completion_steps.present? ? completion_steps.first.created_at.strftime('%d/%m/%Y') : 'n/a'
+    completion_steps.present? ? completion_steps.first.created_at.strftime('%d/%m/%Y %H:%M') : 'n/a'
   end
 
   def current_or_end_state

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe ClaimCsvPresenter do
 
         it 'date of last assessment' do
           presenter.present! do |claim_journeys|
-            expect(claim_journeys.first).to include((Time.zone.now - 1.day).strftime('%d/%m/%Y'))
+            expect(claim_journeys.first).to include((Time.zone.now - 1.day).strftime('%d/%m/%Y %H:%M'))
             expect(claim_journeys.second).to include('n/a', 'n/a')
           end
         end


### PR DESCRIPTION
#### What
Add the timestamp of last authorise

#### Ticket
[CBO-1208](https://dsdmoj.atlassian.net/browse/CBO-1208)

#### Why
This was shown in the message view per claim, adding it
here makes it simpler for the MI users to manage
performance

#### How
Update the strftime format from `%d/%m/%Y` to `%d/%m/%Y %H:%M`