### PR TITLE
Fixes error in master test suite

### DIFF
--- a/spec/models/fee/interim_fee_spec.rb
+++ b/spec/models/fee/interim_fee_spec.rb
@@ -20,6 +20,7 @@
 #
 
 require 'rails_helper'
+require_relative 'shared_examples_for_duplicable'
 
 RSpec.describe Fee::InterimFee do
   let(:fee)               { build :interim_fee }


### PR DESCRIPTION
fixes:
```
An error occurred while loading ./spec/models/fee/interim_fee_spec.rb.
Failure/Error: include_examples 'duplicable fee'

ArgumentError:
  Could not find shared examples "duplicable fee"
```