### PR TITLE
Remove prebuilt dates attended for hardship claims

### DIFF
--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -9,7 +9,10 @@ module ExternalUsers::ClaimsHelper
   end
 
   def build_dates_attended?(fee)
-    ['discontinuance', 'guilty plea'].include? fee.claim.case_type.name.downcase
+    [
+      ['discontinuance', 'guilty plea'].include?(fee.claim.case_type.name.downcase),
+      !fee.claim.hardship?
+    ].all?
   end
 
   def validation_error_message(error_presenter_or_resource, attribute)

--- a/spec/helpers/external_users/claims_helper_spec.rb
+++ b/spec/helpers/external_users/claims_helper_spec.rb
@@ -286,64 +286,66 @@ describe ExternalUsers::ClaimsHelper do
     end
   end
 
-  describe 'build_dates_attended??' do
+  describe '#build_dates_attended?' do
     subject { helper.build_dates_attended?(fee) }
 
-    context 'when claim fee_scheme is nine' do
-      let(:claim) { build(:advocate_claim, case_type: case_type) }
-      let(:fee) { build :basic_fee, :baf_fee, claim: claim }
+    let(:claim) { create(:claim, case_type: case_type) }
+    let(:fee) { build :basic_fee, :baf_fee, claim: claim }
+
+    context 'when claim is not hardship' do
+      before { allow(claim).to receive(:hardship?).and_return false }
 
       context 'and has a case type of Trial' do
         let(:case_type) { build(:case_type, :trial) }
-
         it { is_expected.to be false }
       end
 
       context 'and has a case type of Retrial' do
         let(:case_type) { build(:case_type, :retrial) }
-
         it { is_expected.to be false }
-      end
-
-      context 'and has a case type of Guilty pLea' do
-        let(:case_type) { build(:case_type, :guilty_plea) }
-
-        it { is_expected.to be true }
       end
 
       context 'and has a case type of Contempt' do
         let(:case_type) { build(:case_type, :contempt) }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when claim fee_scheme is ten' do
-      let!(:scheme_10) { create(:fee_scheme, :agfs_ten)}
-      let(:claim) { create(:advocate_claim, :agfs_scheme_10, case_type: case_type) }
-      let(:fee) { build :basic_fee, :baf_fee, claim: claim }
-
-      context 'and has a case type of Trial' do
-        let(:case_type) { build(:case_type, :trial) }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and has a case type of Retrial' do
-        let(:case_type) { build(:case_type, :retrial) }
-
         it { is_expected.to be false }
       end
 
       context 'and has a case type of Guilty plea' do
         let(:case_type) { build(:case_type, :guilty_plea) }
-
         it { is_expected.to be true }
+      end
+
+      context 'and has a case type of Discontinuance' do
+        let(:case_type) { build(:case_type, :discontinuance) }
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when claim is hardship' do
+      before { allow(claim).to receive(:hardship?).and_return true }
+
+      context 'and has a case type of Trial' do
+        let(:case_type) { build(:case_type, :trial) }
+        it { is_expected.to be false }
+      end
+
+      context 'and has a case type of Retrial' do
+        let(:case_type) { build(:case_type, :retrial) }
+        it { is_expected.to be false }
       end
 
       context 'and has a case type of Contempt' do
         let(:case_type) { build(:case_type, :contempt) }
+        it { is_expected.to be false }
+      end
 
+      context 'and has a case type of Guilty plea' do
+        let(:case_type) { build(:case_type, :guilty_plea) }
+        it { is_expected.to be false }
+      end
+
+      context 'and has a case type of Discontinuance' do
+        let(:case_type) { build(:case_type, :discontinuance) }
         it { is_expected.to be false }
       end
     end


### PR DESCRIPTION
#### What
Remove prebuilt dates attended for hardship claims

#### Ticket

[CBO-1219](https://dsdmoj.atlassian.net/browse/CBO-1219)

#### Why
Pre PTHP (evidence served) and Pre PTHP (no evidence served)
case stages for hardships are mapped to discontinuance
and guilty plea cases behind the scenes. These case types
prompt the user to enter a date attended on the fee page
normally, but this is not appropriate for hardship claims.