### PR TITLE
Amend output for cucumber and rspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ references:
       command: |
         tmp/cc-test-reporter before-build
         TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
-        bundle exec rspec ${TESTS} --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
+        bundle exec rspec ${TESTS} --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec
         tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
 
   _cucumber: &cucumber
@@ -90,7 +90,7 @@ references:
         name: Run cucumber tests
         command: |
           FEATURES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings --timings-type=filename)
-          bundle exec cucumber ${FEATURES} --format junit --out /tmp/test-results/cucumber/junit.xml
+          bundle exec cucumber ${FEATURES} --format junit --out /tmp/test-results/cucumber
 
   _install-wkhtmltopdf: &install-wkhtmltopdf
     run:


### PR DESCRIPTION
change output redirect

#### What
change output redirect to a folder, from a file

#### Why
Currently the files seem be going into dir named after the file
specified rather than into file itself. circleci docs are pretty
misleading in this area.

```
Archiving the following test results
  * /tmp/test-results/cucumber/junit.xml/TEST-features-000.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-authorise_claim.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-claims-advocate-scheme_eleven-advocate_supplementary_claim_submit.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-claims-advocate-scheme_nine-advocate_claim_draft_edit_submit.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-claims-advocate-scheme_ten-advocate_interim_claim_edit_submit.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-claims-hardship_claims_banner.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-claims-litigator-litigator_contempt_claim_draft_submit.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-claims-litigator-transfer_claim_draft_submit.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-fee_calculator-advocate-misc_fee_calculator.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-fee_calculator-litigator-interim_fee_calculator.xml
  * /tmp/test-results/cucumber/junit.xml/TEST-features-provider_management.xml

Uploaded
```

Hopefully this will also fix the inability to find the timings data

```
No timing found for "features/000.feature"
No timing found for "features/001_messaging.feature"
No timing found for "features/allocation.feature"
No timing found for "features/authentication.feature"
```
