### PR TITLE
CBO-1221: Refactor the LGFS CaseStage view handling

### DIFF
--- a/app/views/external_users/claims/case_details/_case_type_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_case_type_fields.html.haml
@@ -1,11 +1,14 @@
 - if @claim.hardship?
-  #cc-case-stage.form-group{ class: error_class?(@error_presenter, :case_stage) ? 'form-group-error dropdown_field_with_errors' : '' }
-    %label.form-label-bold{ for: 'case_stage' }
-      = t('.stage_type')
+  - if @claim.agfs?
+    #cc-case-stage.form-group{ class: error_class?(@error_presenter, :case_stage) ? 'form-group-error dropdown_field_with_errors' : '' }
+      %label.form-label-bold{ for: 'case_stage' }
+        = t('.stage_type')
       .form-hint.xsmall.zero-vert-margin
-        = t(".#{@claim.agfs? ? 'agfs' : 'lgfs'}_stage_type_hint")
+        = t('.agfs_stage_type_hint')
       = validation_error_message(@error_presenter, :case_stage)
-    = f.select :case_stage_id, @case_stages.map{ |cs| [cs.description, cs.id, { data: { 'is-fixed-fee': cs.is_fixed_fee?, 'requires-cracked-dates': cs&.requires_cracked_dates?, 'requires-retrial-dates': cs&.requires_retrial_dates?, 'requires-trial-dates': cs&.requires_trial_dates? } }] }, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', id: 'case_stage', 'aria-label': t('.stage_type') }
+      = f.select :case_stage_id, @case_stages.map{ |cs| [cs.description, cs.id, { data: { 'is-fixed-fee': cs.is_fixed_fee?, 'requires-cracked-dates': cs&.requires_cracked_dates?, 'requires-retrial-dates': cs&.requires_retrial_dates?, 'requires-trial-dates': cs&.requires_trial_dates? } }] }, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', id: 'case_stage', 'aria-label': t('.stage_type') }
+  -elsif @claim.lgfs?
+    = f.hidden_field(:case_stage_id, value: @case_stages.first.id)
 - else
   #cc-case-type.form-group{ class: error_class?(@error_presenter, :case_type) ? 'form-group-error dropdown_field_with_errors' : '' }
     %label.form-label-bold{ for: 'case_type' }

--- a/app/views/external_users/litigators/hardship_claims/_case_details_form_step.html.haml
+++ b/app/views/external_users/litigators/hardship_claims/_case_details_form_step.html.haml
@@ -1,6 +1,10 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
+.form-group
+  %p.panel.panel-border-wide
+    =t('.case_stage_warning_html')
+
 %h2.heading-large
   = t('.page_heading')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1021,7 +1021,6 @@ en:
           case_type_hint: For example Trial
           stage_type: What stage has the case reached?
           agfs_stage_type_hint: For example Trial started but not concluded
-          lgfs_stage_type_hint: For example Pre PTPH or PTPH adjourned
         cracked_trial_fields:
           cracked_trial_details: Cracked trial details
           trial_cracked_at: Case cracked on
@@ -1880,6 +1879,11 @@ en:
         case_details_form_step:
           page_title: *lgfs_hardship_claims_title
           page_heading: Case details
+          case_stage_warning_html: |
+            An LGFS hardship claim can only be made before the PTPH or the PTPH has been adjourned for a further hearing</br>
+            If you think your claim is valid, but it is post PTPH please see
+            <a href="https://www.gov.uk/guidance/financial-relief-for-legal-aid-practitioners" target="_blank" rel="external" title="COVID 19 Remuneration Regulations">COVID 19 Remuneration Regulations</a>
+            for guidance
 
         defendants_form_step:
           page_title: Enter defendant details for litigator hardship fees claim

--- a/features/claims/litigator/hardship_claim_draft_submit.feature
+++ b/features/claims/litigator/hardship_claim_draft_submit.feature
@@ -14,7 +14,6 @@ Feature: Litigator completes hardship claims
     When I choose the supplier number '1A222Z'
     And I enter a providers reference of 'LGFS test hardship fee for covid-19'
     And I select the court 'Blackfriars'
-    And I select a case stage of 'Pre PTPH or PTPH adjourned'
     And I enter a case number of 'A20201234'
 
     Then I click "Continue" in the claim form and move to the 'Defendant details' form page


### PR DESCRIPTION
#### What
As a provider I do not want to have to make multiple clicks to show, and choose, a single item in a drop down list

#### Ticket
[CBO-1221](https://dsdmoj.atlassian.net/browse/CBO-1221)

#### How
* Add a panel to the top of the page explaining the LGFS
  case_stage limitations
* Replace the case_stage section drop down with a hidden
  field with the single LGFS case_stage id in it
* Update the LGFS hardship feature to remove the option
  to select the case stage, but still check the output
  of it on the summary page
