### PR TITLE
Amend parrellism of rspec 8 --> 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
 
   rspec-tests:
     executor: test-executor
-    parallelism: 8
+    parallelism: 6
     steps:
       - checkout
       - build-base
@@ -320,7 +320,7 @@ jobs:
       - run:
           name: Upload coverage results to Code Climate
           command: |
-            tmp/cc-test-reporter sum-coverage --output - --parts 8 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
+            tmp/cc-test-reporter sum-coverage --output - --parts 6 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
 
   build-app-container:
     executor: cloud-platform-executor


### PR DESCRIPTION
#### What
Amend parrellism of circleci rspec 8 --> 6

#### Why
A parrallelism of 8 reduces the test suite
run time to sub 7 minutes but as cucumber
takes upto 9 this is pointless.

In addition waiting for 8 containers is
also slow at busy periods and prevents
concurrent runs of jobs within the same
workflow and on other branchs and on other
projects - there is a limit 9 containers
across the entire ministry of justice :(

