### PR TITLE
fix rspec test results not storing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ references:
       command: |
         tmp/cc-test-reporter before-build
         TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
-        bundle exec rspec ${TESTS} --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec
+        bundle exec rspec ${TESTS} --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
         tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
 
   _cucumber: &cucumber


### PR DESCRIPTION
#### What
change the output for rspec results

#### Why
unlike cucumber the output for rspec
seems to need to go to one file and that
file must be specified in the rspec command.

currently rspec test results are not getting
stored and test summary not available.