### PR TITLE
"Pre PTPH" case stage logic changes

### DIFF
--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -9,7 +9,10 @@ module ExternalUsers::ClaimsHelper
   end
 
   def build_dates_attended?(fee)
-    ['discontinuance', 'guilty plea'].include? fee.claim.case_type.name.downcase
+    [
+      ['discontinuance', 'guilty plea'].include?(fee.claim.case_type.name.downcase),
+      !fee.claim.hardship?
+    ].all?
   end
 
   def validation_error_message(error_presenter_or_resource, attribute)

--- a/app/models/case_stage.rb
+++ b/app/models/case_stage.rb
@@ -12,4 +12,5 @@ class CaseStage < ApplicationRecord
   validates :description, presence: { message: 'Case stage description must exist' }
 
   scope :chronological, -> { order(position: :asc) }
+  scope :active, -> { where.not("unique_code LIKE 'OBSOLETE%'") }
 end

--- a/app/models/claim/advocate_hardship_claim.rb
+++ b/app/models/claim/advocate_hardship_claim.rb
@@ -105,7 +105,7 @@ module Claim
     end
 
     def eligible_case_stages
-      CaseStage.agfs
+      CaseStage.agfs.active
     end
 
     # TODO: Hardship claim - can be shared with advocate final claim

--- a/app/views/external_users/advocates/hardship_claims/_basic_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/hardship_claims/_basic_fees_form_step.html.haml
@@ -7,4 +7,8 @@
 
 = render partial: 'external_users/advocates/advocate_category', locals: { f: f }
 
+- if claim.discontinuance?
+  = render partial: 'external_users/advocates/prosecution_evidence', locals: { f: f }
+
+
 = render partial: 'external_users/claims/basic_fees/fields', locals: { f: f }

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -95,6 +95,13 @@
         %td
           = claim.case_type&.name
 
+    - if claim.discontinuance?
+      %tr
+        %th{ scope: 'row' }
+          = t('common.prosecution_evidence')
+        %td
+          = t(claim.prosecution_evidence?.class)
+
     - if claim.agfs? && claim.case_type.present? && claim.requires_cracked_dates?
       = render partial: 'shared/claim_cracked_trial_details', locals: { claim: claim }
 

--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -1,9 +1,14 @@
 module SeedHelper
   class << self
     def update_or_create_case_stage!(options)
-      stage = CaseStage.find_by(unique_code: options[:unique_code])
-      stage.update!(options) if stage
-      stage = CaseStage.create!(options) unless stage
+      stage = CaseStage.find_by(id: options[:id])
+      if stage
+        puts "Updating case_stage #{stage.description}: #{options}"
+        stage.update!(options)
+      else
+        puts "Creating case_stage: #{options}"
+        stage = CaseStage.create!(options)
+      end
       stage
     end
 

--- a/db/seeds/case_stages.rb
+++ b/db/seeds/case_stages.rb
@@ -14,7 +14,7 @@ require Rails.root.join('db','seed_helper')
 SeedHelper.update_or_create_case_stage!(
   id: 11,
   description: 'Pre PTPH (evidence served)',
-  unique_code: 'PREPTPHES',
+  unique_code: 'OBSOLETE3',
   position: 5,
   case_type_id: CaseType.find_by(fee_type_code: 'GRGLT').id,
   roles: %w(agfs)
@@ -22,7 +22,7 @@ SeedHelper.update_or_create_case_stage!(
 
 SeedHelper.update_or_create_case_stage!(
   id: 1,
-  description: 'Pre PTPH (no evidence served)',
+  description: 'Pre PTPH',
   unique_code: 'PREPTPH',
   position: 10,
   case_type_id: CaseType.find_by(fee_type_code: 'GRDIS').id,

--- a/spec/helpers/external_users/claims_helper_spec.rb
+++ b/spec/helpers/external_users/claims_helper_spec.rb
@@ -286,64 +286,66 @@ describe ExternalUsers::ClaimsHelper do
     end
   end
 
-  describe 'build_dates_attended??' do
+  describe '#build_dates_attended?' do
     subject { helper.build_dates_attended?(fee) }
 
-    context 'when claim fee_scheme is nine' do
-      let(:claim) { build(:advocate_claim, case_type: case_type) }
-      let(:fee) { build :basic_fee, :baf_fee, claim: claim }
+    let(:claim) { create(:claim, case_type: case_type) }
+    let(:fee) { build :basic_fee, :baf_fee, claim: claim }
+
+    context 'when claim is not hardship' do
+      before { allow(claim).to receive(:hardship?).and_return false }
 
       context 'and has a case type of Trial' do
         let(:case_type) { build(:case_type, :trial) }
-
         it { is_expected.to be false }
       end
 
       context 'and has a case type of Retrial' do
         let(:case_type) { build(:case_type, :retrial) }
-
         it { is_expected.to be false }
-      end
-
-      context 'and has a case type of Guilty pLea' do
-        let(:case_type) { build(:case_type, :guilty_plea) }
-
-        it { is_expected.to be true }
       end
 
       context 'and has a case type of Contempt' do
         let(:case_type) { build(:case_type, :contempt) }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when claim fee_scheme is ten' do
-      let!(:scheme_10) { create(:fee_scheme, :agfs_ten)}
-      let(:claim) { create(:advocate_claim, :agfs_scheme_10, case_type: case_type) }
-      let(:fee) { build :basic_fee, :baf_fee, claim: claim }
-
-      context 'and has a case type of Trial' do
-        let(:case_type) { build(:case_type, :trial) }
-
-        it { is_expected.to be false }
-      end
-
-      context 'and has a case type of Retrial' do
-        let(:case_type) { build(:case_type, :retrial) }
-
         it { is_expected.to be false }
       end
 
       context 'and has a case type of Guilty plea' do
         let(:case_type) { build(:case_type, :guilty_plea) }
-
         it { is_expected.to be true }
+      end
+
+      context 'and has a case type of Discontinuance' do
+        let(:case_type) { build(:case_type, :discontinuance) }
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when claim is hardship' do
+      before { allow(claim).to receive(:hardship?).and_return true }
+
+      context 'and has a case type of Trial' do
+        let(:case_type) { build(:case_type, :trial) }
+        it { is_expected.to be false }
+      end
+
+      context 'and has a case type of Retrial' do
+        let(:case_type) { build(:case_type, :retrial) }
+        it { is_expected.to be false }
       end
 
       context 'and has a case type of Contempt' do
         let(:case_type) { build(:case_type, :contempt) }
+        it { is_expected.to be false }
+      end
 
+      context 'and has a case type of Guilty plea' do
+        let(:case_type) { build(:case_type, :guilty_plea) }
+        it { is_expected.to be false }
+      end
+
+      context 'and has a case type of Discontinuance' do
+        let(:case_type) { build(:case_type, :discontinuance) }
         it { is_expected.to be false }
       end
     end


### PR DESCRIPTION
#### What
replace "Pre PTPH (evidence served)" and "Pre PTPH (no evidence served)"
with "Pre PTPH" case stage and map to discontinuance. In addition remove
the date field for "Date of discontinuance" on the "hardship fees" page

#### Ticket

[CBO-1215](https://dsdmoj.atlassian.net/browse/CBO-1215)
[CBO-1219](https://dsdmoj.atlassian.net/browse/CBO-1219)
[CBO-1220](https://dsdmoj.atlassian.net/browse/CBO-1220)

#### Why
Pre PTPH with evidence and pre PTPH without evidence
are handled as discontinuances with a question regarding
evidence for final claims and hardship claims should 
follow this pattern too.

Fee calc considerations: The fee calc api handles
discontinuance scenario as a guilty plea or half a guilty
plea fee anyway.

DI considerations: not injecting hardships yet anyway
and it may well be that all hardships need injecting
as FEE_ADVANCES in any event.


#### How
Remove extraneous case stage "Pre PTPH (evidence served)"
and rename "Pre PTPH (no evidence served)" to "Pre PTPH"
then rely on "evidence served question" to calculate the
correct fee - as with final claims for discontinuance.