### PR TITLE
CBO-1191: LGFS hardship DI

### DIFF
--- a/app/interfaces/api/entities/cclf/adapted_hardship_fee.rb
+++ b/app/interfaces/api/entities/cclf/adapted_hardship_fee.rb
@@ -1,0 +1,18 @@
+module API
+  module Entities
+    module CCLF
+      class AdaptedHardshipFee < AdaptedBaseBill
+        expose :quantity, format_with: :integer_string
+        expose :amount, format_with: :string
+
+        private
+
+        delegate :bill_type, :bill_subtype, to: :adapter
+
+        def adapter
+          @adapter ||= ::CCLF::Fee::HardshipFeeAdapter.new(object)
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/cclf/hardship_claim.rb
+++ b/app/interfaces/api/entities/cclf/hardship_claim.rb
@@ -1,0 +1,14 @@
+module API
+  module Entities
+    module CCLF
+      class HardshipClaim < BaseClaim
+        def bills
+          data = []
+          data.push AdaptedHardshipFee.represent(object.hardship_fee)
+          data.push AdaptedMiscFee.represent(object.misc_fees)
+          data.as_json.flat_select { |bill| bill[:bill_type].present? }
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v2/cclf_claim.rb
+++ b/app/interfaces/api/v2/cclf_claim.rb
@@ -13,6 +13,8 @@ module API
             API::Entities::CCLF::InterimClaim
           elsif claim.transfer?
             API::Entities::CCLF::TransferClaim
+          elsif claim.hardship?
+            API::Entities::CCLF::HardshipClaim
           else
             API::Entities::CCLF::FinalClaim
           end

--- a/app/services/cclf/case_type_adapter.rb
+++ b/app/services/cclf/case_type_adapter.rb
@@ -35,6 +35,7 @@ module CCLF
     def bill_scenario
       return interim_bill_scenario if interim_scenario_applicable?
       return transfer_bill_scenario if transfer_scenario_applicable?
+      return hardship_bill_scenario if hardship_scenario_applicable?
       final_bill_scenario
     end
 
@@ -54,6 +55,14 @@ module CCLF
 
     def transfer_bill_scenario
       claim.transfer_detail&.bill_scenario
+    end
+
+    def hardship_scenario_applicable?
+      claim.hardship? && claim.lgfs? && hardship_bill_scenario
+    end
+
+    def hardship_bill_scenario
+      BILL_SCENARIOS[:HARDSHIP]
     end
 
     def final_bill_scenario

--- a/app/services/cclf/fee/hardship_fee_adapter.rb
+++ b/app/services/cclf/fee/hardship_fee_adapter.rb
@@ -1,0 +1,7 @@
+module CCLF
+  module Fee
+    class HardshipFeeAdapter < SimpleBillAdapter
+      acts_as_simple_bill bill_type: 'FEE_ADVANCE', bill_subtype: 'HARDSHIP'
+    end
+  end
+end

--- a/spec/api/entities/cclf/adapted_hardship_fee_spec.rb
+++ b/spec/api/entities/cclf/adapted_hardship_fee_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe API::Entities::CCLF::AdaptedHardshipFee, type: :adapter do
+  subject(:response) { JSON.parse(described_class.represent(hardship_fee).to_json, symbolize_names: true) }
+
+  let(:fee_type) { instance_double(Fee::HardshipFeeType, unique_code: 'HARDSHIP') }
+  let(:claim) { instance_double(Claim::LitigatorHardshipClaim) }
+  let(:hardship_fee) { instance_double(Fee::HardshipFee, claim: claim, fee_type: fee_type, amount: 111.01, quantity: 300) }
+
+  it_behaves_like 'a bill types delegator', ::CCLF::Fee::HardshipFeeAdapter do
+    let(:bill) { hardship_fee }
+  end
+
+  it { is_expected.to expose :bill_type }
+  it { is_expected.to expose :bill_subtype }
+  it { is_expected.to expose :amount }
+  it { is_expected.to expose :quantity }
+
+  it 'exposes expected json key-value pairs' do
+    is_expected.to include(
+      bill_type: 'FEE_ADVANCE',
+      bill_subtype: 'HARDSHIP',
+      amount: '111.01',
+      quantity: '300'
+    )
+  end
+end

--- a/spec/api/entities/cclf/case_type_spec.rb
+++ b/spec/api/entities/cclf/case_type_spec.rb
@@ -5,7 +5,7 @@ describe API::Entities::CCLF::CaseType do
   let(:case_type) { build(:case_type, :trial) }
 
   context 'delegation' do
-    let(:claim) { instance_double(::Claim::LitigatorClaim, case_type: case_type, interim?: false, transfer?: false) }
+    let(:claim) { instance_double(::Claim::LitigatorClaim, case_type: case_type, interim?: false, transfer?: false, hardship?: false) }
     let(:adapter_klass) { ::CCLF::CaseTypeAdapter }
     let(:adapter) { instance_double(adapter_klass) }
 
@@ -17,7 +17,7 @@ describe API::Entities::CCLF::CaseType do
   end
 
   context 'for final claims' do
-    let(:claim) { instance_double(::Claim::LitigatorClaim, case_type: case_type, interim?: false, transfer?: false) }
+    let(:claim) { instance_double(::Claim::LitigatorClaim, case_type: case_type, interim?: false, transfer?: false, hardship?: false) }
 
     it 'exposes expected bill scenario' do
       is_expected.to include(bill_scenario: 'ST1TS0T4')
@@ -26,7 +26,7 @@ describe API::Entities::CCLF::CaseType do
 
   context 'for interim claims with an interim fee other than warrant or disbursement only' do
     let(:fee) { build(:interim_fee, :effective_pcmh) }
-    let(:claim) { instance_double(::Claim::InterimClaim, case_type: case_type, interim?: true, transfer?: false, interim_fee: fee) }
+    let(:claim) { instance_double(::Claim::InterimClaim, case_type: case_type, interim?: true, transfer?: false, hardship?: false, interim_fee: fee) }
 
     it 'exposes expected bill scenario' do
       is_expected.to include(bill_scenario: 'ST1TS0T0')
@@ -34,7 +34,7 @@ describe API::Entities::CCLF::CaseType do
   end
 
   context 'for transfer claims' do
-    let(:claim) { instance_double(::Claim::TransferClaim, case_type: case_type, interim?: false, transfer?: true, transfer_detail: transfer_detail) }
+    let(:claim) { instance_double(::Claim::TransferClaim, case_type: case_type, interim?: false, transfer?: true, hardship?: false, transfer_detail: transfer_detail) }
     let(:transfer_detail) { build(:transfer_detail, :with_specific_mapping) }
 
     it 'response has expected bill scenario' do

--- a/spec/factories/claim/litigator_hardship_claims.rb
+++ b/spec/factories/claim/litigator_hardship_claims.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :litigator_hardship_claim, class: Claim::LitigatorHardshipClaim do
     litigator_base_setup
     case_type { nil }
-    case_stage
+    case_stage { build :case_stage, :pre_ptph_or_ptph_adjourned }
 
     after(:build) { |claim| post_build_actions_for_draft_hardship_claim(claim) }
 

--- a/spec/services/cclf/case_type_adapter_spec.rb
+++ b/spec/services/cclf/case_type_adapter_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 RSpec.describe CCLF::CaseTypeAdapter, type: :adapter do
   subject { described_class.new(claim).bill_scenario }
   let(:case_type) { instance_double(::CaseType) }
+  let(:case_stage) { instance_double(::CaseStage) }
 
   include TransferBrainHelpers
 
   before do
     allow(claim).to receive(:interim?).and_return false
     allow(claim).to receive(:transfer?).and_return false
+    allow(claim).to receive(:hardship?).and_return false
   end
 
   describe '#bill_scenario' do
@@ -87,6 +89,17 @@ RSpec.describe CCLF::CaseTypeAdapter, type: :adapter do
           end
         end
       end
+    end
+
+    context 'hardship claim' do
+      let(:claim) { instance_double(::Claim::LitigatorHardshipClaim) }
+
+      before do
+        allow(claim).to receive(:hardship?).and_return true
+        allow(claim).to receive(:lgfs?).and_return true
+      end
+
+      it { is_expected.to eql 'ST2TS1T0' }
     end
   end
 end

--- a/spec/services/cclf/fee/hardship_fee_adaptor_spec.rb
+++ b/spec/services/cclf/fee/hardship_fee_adaptor_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CCLF::Fee::HardshipFeeAdapter, type: :adapter do
+  it_behaves_like 'a simple bill adapter', bill_type: 'FEE_ADVANCE', bill_subtype: 'HARDSHIP' do
+    let(:fee) { instance_double(Fee::HardshipFee) }
+  end
+end


### PR DESCRIPTION
#### What
Enable LGFS hardship claims to be injected into CCR

#### Ticket

[CCCD DI: LGFS hardship claim data injection into CCLF](https://dsdmoj.atlassian.net/browse/CBO-1191)

#### Why
Remove need for caseworkers to copy type all values from CCCD into CCLF

#### How
Add new entities to the API to allow a hardship claim to be presented in such a way that the CCLF injector can parse and successfully inject it.

--------

#### TODO (wip)
 - [X] Ensure LGFS Hardship claims created in CCCD can be manually injected into CCLF
 - [X] Ensure CCLF can receive the data and successfully inject it
 - [ ] Configure queues so that claims can be automatically injected - TODO AFTER RELEASE