### PR TITLE
Prevent stdout output when running case stage seeds

### DIFF
--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -3,10 +3,10 @@ module SeedHelper
     def update_or_create_case_stage!(options)
       stage = CaseStage.find_by(id: options[:id])
       if stage
-        puts "Updating case_stage #{stage.description}: #{options}"
+        Rails.logger.info "Updating case_stage #{stage.description}: #{options}"
         stage.update!(options)
       else
-        puts "Creating case_stage: #{options}"
+        Rails.logger.info "Creating case_stage: #{options}"
         stage = CaseStage.create!(options)
       end
       stage

--- a/lib/tasks/case_stages.rake
+++ b/lib/tasks/case_stages.rake
@@ -1,6 +1,6 @@
 namespace :db do
   namespace :seed do
-    desc 'Seed case_stages inot the database (case_types must exist for foreign keys)'
+    desc 'Seed case_stages into the database (case_types must exist for foreign keys)'
     task :case_stages => :environment do
       load("#{Rails.root}/db/seeds/case_stages.rb")
     end

--- a/lib/tasks/logging.rake
+++ b/lib/tasks/logging.rake
@@ -1,0 +1,33 @@
+# Rake tasks to help with output to logs and console
+#
+# examples
+# $ rake stdout db:seed:case_stages
+# $ rake debug db:seed:case_stages
+# $ rake info db:seed:case_stages
+# $ rake warn db:seed:case_stages
+# $ rake error db:seed:case_stages
+#
+desc 'Redirect logging to stdout. prefix other tasks with this task to use'
+task :stdout => [:environment] do
+  Rails.logger = Logger.new(STDOUT)
+end
+
+desc 'Set logging to debug level. prefix other tasks with this task to use'
+task :debug => [:environment, :stdout] do
+  Rails.logger.level = Logger::DEBUG
+end
+
+desc 'Set logging to info level. prefix other tasks with this task to use'
+task :info => [:environment, :stdout] do
+  Rails.logger = Logger.new(STDOUT)
+end
+
+desc 'Set logging to debug level. prefix other tasks with this task to use'
+task :warn => [:environment, :stdout] do
+  Rails.logger.level = Logger::WARN
+end
+
+desc 'Set logging to error level. prefix other tasks with this task to use'
+task :error => [:environment, :stdout] do
+  Rails.logger.level = Logger::WARN
+end


### PR DESCRIPTION
#### What
- Prevent stdout output when running case stage seeds
- Add rake tasks to help with output to logs and console

   examples:
   $ rake stdout db:seed:case_stages
   $ rake debug db:seed:case_stages
   $ rake info db:seed:case_stages
   $ rake warn db:seed:case_stages
   $ rake error db:seed:case_stages

#### Why
the output is printed/clutters test suite runs. but its
nice to have the output to the console when running
tasks in development or on servers.