### PR TITLE
Cbo 1190 agfs hardship injection

### DIFF
--- a/app/interfaces/api/entities/ccr/adapted_hardship_fee.rb
+++ b/app/interfaces/api/entities/ccr/adapted_hardship_fee.rb
@@ -1,0 +1,18 @@
+module API
+  module Entities
+    module CCR
+      class AdaptedHardshipFee < AdaptedBaseFee
+        unexpose :case_numbers
+        expose :hardship_fee, as: :amount, format_with: :string
+
+        private
+
+        def hardship_fee
+          object.filtered_fees.inject(0) do |sum, basic_fee|
+            sum + basic_fee.amount
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/entities/ccr/hardship_claim.rb
+++ b/app/interfaces/api/entities/ccr/hardship_claim.rb
@@ -1,0 +1,36 @@
+module API
+  module Entities
+    module CCR
+      class HardshipClaim < BaseClaim
+        expose :case_type, using: API::Entities::CCR::CaseType
+        expose :offence, using: API::Entities::CCR::Offence
+        expose :first_day_of_trial,
+               :trial_fixed_notice_at,
+               :trial_fixed_at,
+               :trial_cracked_at,
+               :retrial_started_at,
+               format_with: :utc
+        expose :trial_cracked_at_third
+        expose :retrial_reduction
+
+        private
+
+        def adapted_hardship_fee
+          @adapted_hardship_fee ||= ::CCR::Fee::HardshipFeeAdapter.new(object)
+        end
+
+        def hardship_fees
+          adapted_hardship_fee.claimed? ? [adapted_hardship_fee] : []
+        end
+
+        def bills
+          data = []
+          data.push AdaptedHardshipFee.represent(hardship_fees)
+          data.push AdaptedMiscFee.represent(miscellaneous_fees)
+          data.push AdaptedExpense.represent(object.expenses)
+          data.flatten.as_json
+        end
+      end
+    end
+  end
+end

--- a/app/interfaces/api/v2/ccr_claim.rb
+++ b/app/interfaces/api/v2/ccr_claim.rb
@@ -9,9 +9,15 @@ module API
         end
 
         def entity_class
-          return API::Entities::CCR::InterimClaim if claim.interim?
-          return API::Entities::CCR::SupplementaryClaim if claim.supplementary?
-          API::Entities::CCR::FinalClaim
+          if claim.interim?
+            API::Entities::CCR::InterimClaim
+          elsif claim.supplementary?
+            API::Entities::CCR::SupplementaryClaim
+          elsif claim.hardship?
+            API::Entities::CCR::HardshipClaim
+          else
+            API::Entities::CCR::FinalClaim
+          end
         end
       end
 

--- a/app/services/ccr/fee/basic_fee_adaptable.rb
+++ b/app/services/ccr/fee/basic_fee_adaptable.rb
@@ -1,0 +1,37 @@
+module CCR
+  module Fee
+    module BasicFeeAdaptable
+      extend ActiveSupport::Concern
+
+      included do
+        def initialize(object = nil)
+          super(object) if object
+        end
+
+        def mappings
+          @mappings ||= fee_types.each_with_object({}) do |fee_type_unique_code, mappings|
+            mappings[fee_type_unique_code.to_sym] = { bill_type: bill_type, bill_subtype: bill_subtype }
+          end
+        end
+
+        def claimed?
+          filtered_fees.any? do |f|
+            f.amount&.positive? || f.quantity&.positive? || f.rate&.positive?
+          end
+        rescue NameError
+          raise ArgumentError, 'Instantiate with claim object to use this method'
+        end
+
+        def fee_types
+          %w[BABAF BADAF BADAH BADAJ BADAT BANOC BANDR BANPW BAPPE]
+        end
+
+        def filtered_fees
+          fees.select do |f|
+            fee_types.include?(f.fee_type.unique_code)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/ccr/fee/basic_fee_adapter.rb
+++ b/app/services/ccr/fee/basic_fee_adapter.rb
@@ -22,40 +22,15 @@
 #  * The BASAF, BAPCM and BACAV fees are handled
 #    as miscellaneous fees in CCR (i.e. AGFS_MISC_FEES).
 #
+
+require_relative 'basic_fee_adaptable'
+
 module CCR
   module Fee
     class BasicFeeAdapter < SimpleBillAdapter
       acts_as_simple_bill bill_type: 'AGFS_FEE', bill_subtype: 'AGFS_FEE'
 
-      def initialize(object = nil)
-        super(object) if object
-      end
-
-      def mappings
-        @mappings ||= fee_types.each_with_object({}) do |fee_type_unique_code, mappings|
-          mappings[fee_type_unique_code.to_sym] = { bill_type: bill_type, bill_subtype: bill_subtype }
-        end
-      end
-
-      def claimed?
-        filtered_fees.any? do |f|
-          f.amount&.positive? || f.quantity&.positive? || f.rate&.positive?
-        end
-      rescue NameError
-        raise ArgumentError, 'Instantiate with claim object to use this method'
-      end
-
-      private
-
-      def fee_types
-        %w[BABAF BADAF BADAH BADAJ BADAT BANOC BANDR BANPW BAPPE]
-      end
-
-      def filtered_fees
-        fees.select do |f|
-          fee_types.include?(f.fee_type.unique_code)
-        end
-      end
+      include BasicFeeAdaptable
     end
   end
 end

--- a/app/services/ccr/fee/hardship_fee_adapter.rb
+++ b/app/services/ccr/fee/hardship_fee_adapter.rb
@@ -1,0 +1,11 @@
+require_relative 'basic_fee_adaptable'
+
+module CCR
+  module Fee
+    class HardshipFeeAdapter < SimpleBillAdapter
+      acts_as_simple_bill bill_type: 'AGFS_ADVANCE', bill_subtype: 'AGFS_HARDSHIP'
+
+      include BasicFeeAdaptable
+    end
+  end
+end

--- a/spec/api/entities/ccr/adapted_hardship_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_hardship_fee_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe API::Entities::CCR::AdaptedHardshipFee, type: :adapter do
+  subject(:response) { JSON.parse(described_class.represent(adapted_hardship_fees).to_json).deep_symbolize_keys }
+
+  let(:claim) { create(:advocate_hardship_claim, :agfs_scheme_9, case_stage: build(:case_stage, :trial_not_concluded)) }
+  let(:adapted_hardship_fees) { ::CCR::Fee::HardshipFeeAdapter.new(claim) }
+
+  it 'exposes expected json key-value pairs' do
+    expect(response).to include(
+      bill_type: 'AGFS_ADVANCE',
+      bill_subtype: 'AGFS_HARDSHIP',
+    )
+  end
+
+  context '#amount' do
+    subject(:amount) { response[:amount] }
+
+    it 'exposes amount' do
+      expect(response.keys).to include(:amount)
+    end
+
+    context 'scheme 9' do
+      before do
+        claim.basic_fees.find_by(fee_type: Fee::BaseFeeType.find_by(unique_code: 'BABAF')).update(quantity: 1, rate: 10)
+        claim.fees << build(:basic_fee, :daf_fee, quantity: 1, rate: 1, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :daj_fee, quantity: 1, rate: 1, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :dah_fee, quantity: 1, rate: 1, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :noc_fee, quantity: 1, rate: 2, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :ndr_fee, quantity: 1, rate: 3, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :npw_fee, quantity: 20, amount: 50, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :ppe_fee, quantity: 1000, amount: 1000, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :cav_fee, quantity: 1, rate: 100, claim: claim) # not added to hardship - a CCR misc fee that is NOT injected
+        claim.fees << build(:basic_fee, :saf_fee, quantity: 1, rate: 100, claim: claim) # not added to hardship - a CCR misc fee that IS injected
+        claim.fees << build(:basic_fee, :pcm_fee, quantity: 1, rate: 100, claim: claim) # not added to hardship - a CCR misc fee that IS injected
+      end
+
+      it 'sums amounts of BABAF, BADAF, BADAJ, BADAH, BANOC, BANDR, BANPW, BAPPE fees' do
+        is_expected.to eql "1068.0"
+      end
+    end
+
+    context 'scheme 10+' do
+      let(:claim) { create(:advocate_hardship_claim, :agfs_scheme_10, case_stage: build(:case_stage, :trial_not_concluded)) }
+
+      before do
+        claim.basic_fees.find_by(fee_type: Fee::BaseFeeType.find_by(unique_code: 'BABAF')).update(quantity: 1, rate: 10)
+        claim.fees << build(:basic_fee, :dat_fee, quantity: 1, rate: 1, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :noc_fee, quantity: 1, rate: 2, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :ndr_fee, quantity: 1, rate: 3, claim: claim) # add to hardship
+        claim.fees << build(:basic_fee, :cav_fee, quantity: 1, rate: 100, claim: claim) # not added to hardship - a CCR misc fee that is NOT injected
+        claim.fees << build(:basic_fee, :saf_fee, quantity: 1, rate: 100, claim: claim) # not added to hardship - a CCR misc fee that IS injected
+        claim.fees << build(:basic_fee, :pcm_fee, quantity: 1, rate: 100, claim: claim) # not added to hardship - a CCR misc fee that IS injected
+      end
+
+      it 'sums amounts of BABAF, BADAT, BANOC, BANDR fees' do
+        is_expected.to eql "16.0"
+      end
+    end
+  end
+end

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -3,7 +3,7 @@
 # differentiate from other claim types.
 #
 FactoryBot.define do
-  factory :claim, aliases: [:advocate_claim], class: Claim::AdvocateClaim do
+  factory :claim, aliases: [:advocate_claim, :advocate_final_claim], class: Claim::AdvocateClaim do
 
     # NOTE: this was introduced because it was the only way to get FactoryBot to set
     # model attributes on initialize (which seems not to be the default behaviour) and

--- a/spec/services/ccr/fee/basic_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/basic_fee_adapter_spec.rb
@@ -1,113 +1,11 @@
 require 'rails_helper'
-RSpec.shared_examples_for 'a basic fee adapter' do
-  describe '#mappings' do
-    subject { instance.mappings }
-
-    %i[BABAF BADAF BADAH BADAJ BANOC BANDR BANPW BAPPE].each do |basic_fee_unique_code|
-      it "includes mappings for basic fee #{basic_fee_unique_code} to a CCR Advocate Fee bill type - AGFS_FEE" do
-        is_expected.to include(basic_fee_unique_code => { bill_type: 'AGFS_FEE', bill_subtype: 'AGFS_FEE'})
-      end
-    end
-  end
-
-  describe '#bill_type' do
-    subject { instance.bill_type }
-
-    it 'returns CCR Advocate Fee bill type' do
-      is_expected.to eql 'AGFS_FEE'
-    end
-  end
-
-  describe '#bill_subtype' do
-    subject { instance.bill_subtype }
-
-    it 'returns CCR Advocate Fee bill subtype' do
-      is_expected.to eql 'AGFS_FEE'
-    end
-  end
-end
 
 RSpec.describe CCR::Fee::BasicFeeAdapter, type: :adapter do
-  context 'when instantiated without a claim object' do
-    subject(:instance) { described_class.new }
-
-    it_behaves_like 'a simple bill adapter', bill_type: 'AGFS_FEE', bill_subtype: 'AGFS_FEE' do
-      let(:fee) { instance_double(Fee::BasicFee) }
-    end
-
-    it_behaves_like 'a basic fee adapter' do
-      let(:instance) { described_class.new }
-    end
-
-    describe '#claimed?' do
-      subject { instance.claimed? }
-
-      it 'raises error' do
-        expect { subject }.to raise_error ArgumentError, 'Instantiate with claim object to use this method'
-      end
-    end
+  it_behaves_like 'a simple bill adapter', bill_type: 'AGFS_FEE', bill_subtype: 'AGFS_FEE' do
+    let(:fee) { instance_double(Fee::BasicFee) }
   end
 
-  context 'when instantiated with claim object' do
-    subject(:instance) { described_class.new(claim) }
-    let(:claim) { instance_double('claim') }
-
-    it_behaves_like 'a simple bill adapter', bill_type: 'AGFS_FEE', bill_subtype: 'AGFS_FEE' do
-      let(:fee) { instance_double(Fee::BasicFee) }
-    end
-
-    it_behaves_like 'a basic fee adapter' do
-      let(:instance) { described_class.new(claim) }
-    end
-
-    describe '#claimed?' do
-      subject { instance.claimed? }
-
-      let(:basic_fee_type) { instance_double(::Fee::BasicFeeType, unique_code: 'BABAF') }
-      let(:basic_fees) { [basic_fee] }
-      let(:basic_fee) do
-        instance_double(
-          ::Fee::BasicFee,
-          fee_type: basic_fee_type,
-          quantity: 0,
-          rate: 0,
-          amount: 0,
-          )
-      end
-
-      before do
-        expect(claim).to receive(:fees).at_least(:once).and_return basic_fees
-      end
-
-      it 'returns true when the basic fee has a positive qauntity' do
-        allow(basic_fee).to receive_messages(quantity: 1)
-        is_expected.to be true
-      end
-
-      it 'returns true when the basic fee has a positive amount' do
-        allow(basic_fee).to receive_messages(amount: 1.0)
-        is_expected.to be true
-      end
-
-      it 'returns true when the basic fee has a positive rate' do
-        allow(basic_fee).to receive_messages(rate: 1.0)
-        is_expected.to be true
-      end
-
-      it 'returns false when the basic fee has 0 values for quantity, rate and amount'do
-        allow(basic_fee).to receive_messages(quantity: 0, rate: 0, amount: 0)
-        is_expected.to be false
-      end
-
-      it 'returns false when the basic fee has nil values for quantity, rate and amount'do
-        allow(basic_fee).to receive_messages(quantity: nil, rate: nil, amount: nil)
-        is_expected.to be false
-      end
-
-      it 'returns false when the basic fee is not part of the CCR advocate fee' do
-        allow(basic_fee_type).to receive(:unique_code).and_return 'BAPCM'
-        is_expected.to be false
-      end
-    end
+  it_behaves_like 'a basic fee adapter', bill_type: 'AGFS_FEE', bill_subtype: 'AGFS_FEE' do
+    let(:claim) { create(:advocate_final_claim) }
   end
 end

--- a/spec/services/ccr/fee/hardship_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/hardship_fee_adapter_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe CCR::Fee::HardshipFeeAdapter, type: :adapter do
+  context 'when instantiated without a claim object' do
+    subject(:instance) { described_class.new }
+
+    it_behaves_like 'a simple bill adapter', bill_type: 'AGFS_ADVANCE', bill_subtype: 'AGFS_HARDSHIP' do
+      let(:fee) { instance_double(Fee::BasicFee) }
+    end
+
+    it_behaves_like 'a basic fee adapter', bill_type: 'AGFS_ADVANCE', bill_subtype: 'AGFS_HARDSHIP' do
+      let(:claim) { create(:advocate_hardship_claim) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,8 +52,10 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  # config.filter_run :focus
-  # config.run_all_when_everything_filtered = true
+  # NOTE: you can also use `fit`, `fdescribe`, `fcontext` to focus specs
+  #
+  config.filter_run_including focus: true unless ENV['CI']
+  config.run_all_when_everything_filtered = true
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:

--- a/spec/support/shared_examples_for_fee_adapters.rb
+++ b/spec/support/shared_examples_for_fee_adapters.rb
@@ -58,3 +58,118 @@ RSpec.shared_examples 'a bill types delegator' do |adapter_klass|
     subject
   end
 end
+
+RSpec.shared_examples_for 'a basic fee adapter' do |options|
+  describe '#mappings' do
+    subject { described_class.new.mappings }
+
+    %i[BABAF BADAF BADAH BADAJ BANOC BANDR BANPW BAPPE].each do |basic_fee_unique_code|
+      it "includes mappings for basic fee #{basic_fee_unique_code} to a CCR Advocate Fee bill - #{options[:bill_type]}/#{options[:bill_subtype]}" do
+        is_expected.to include(basic_fee_unique_code => { bill_type: options[:bill_type], bill_subtype: options[:bill_subtype]})
+      end
+    end
+  end
+
+  describe '#fee_types' do
+    subject(:fee_types) { described_class.new.fee_types }
+
+    it 'returns CCR adaptable basic fee type codes' do
+      is_expected.to match_array %w[BABAF BADAF BADAH BADAJ BADAT BANOC BANDR BANPW BAPPE]
+    end
+  end
+
+  describe 'filtered_fees' do
+    subject(:filtered_fees) { described_class.new(claim).filtered_fees }
+
+    before do
+      claim.fees << build(:basic_fee, :baf_fee, claim: claim) unless claim.fees.map {|f| f.fee_type.unique_code }.include? 'BABAF'
+      claim.fees << build(:basic_fee, :daf_fee, claim: claim)
+      claim.fees << build(:basic_fee, :daj_fee, claim: claim)
+      claim.fees << build(:basic_fee, :dah_fee, claim: claim)
+      claim.fees << build(:basic_fee, :dat_fee, claim: claim)
+      claim.fees << build(:basic_fee, :noc_fee, claim: claim)
+      claim.fees << build(:basic_fee, :ndr_fee, claim: claim)
+      claim.fees << build(:basic_fee, :npw_fee, claim: claim)
+      claim.fees << build(:basic_fee, :ppe_fee, claim: claim)
+      claim.fees << build(:basic_fee, :cav_fee, claim: claim) # not adaptable
+      claim.fees << build(:basic_fee, :saf_fee, claim: claim) # not adaptable
+      claim.fees << build(:basic_fee, :pcm_fee, claim: claim) # not adaptable
+    end
+
+    it 'returns array of basic fee objects' do
+      is_expected.to all(be_a(Fee::BasicFee))
+    end
+
+    it 'returns only CCR adaptable basic fees' do
+      expect(filtered_fees.map {|f| f.fee_type.unique_code }).to match_array %w[BABAF BADAF BADAJ BADAH BADAT BANOC BANDR BANPW BAPPE]
+    end
+  end
+
+  describe '#claimed?' do
+    subject(:claimed?) { instance.claimed? }
+
+    context 'when instantiated without a claim object' do
+      let(:instance) { described_class.new }
+
+      it 'raises error' do
+        expect { claimed? }.to raise_error ArgumentError, 'Instantiate with claim object to use this method'
+      end
+    end
+
+    context 'when instantiated with claim object' do
+      let(:instance) { described_class.new(claim) }
+      let(:claim) { instance_double('claim') }
+
+      let(:basic_fee_type) { instance_double(::Fee::BasicFeeType, unique_code: 'BABAF') }
+      let(:basic_fees) { [basic_fee] }
+      let(:basic_fee) do
+        instance_double(
+          ::Fee::BasicFee,
+          fee_type: basic_fee_type,
+          quantity: 0,
+          rate: 0,
+          amount: 0,
+          )
+      end
+
+      before do
+        expect(claim).to receive(:fees).at_least(:once).and_return basic_fees
+      end
+
+      it 'returns true when the basic fee has a positive qauntity' do
+        allow(basic_fee).to receive_messages(quantity: 1)
+        is_expected.to be true
+      end
+
+      it 'returns true when the basic fee has a positive amount' do
+        allow(basic_fee).to receive_messages(amount: 1.0)
+        is_expected.to be true
+      end
+
+      it 'returns true when the basic fee has a positive rate' do
+        allow(basic_fee).to receive_messages(rate: 1.0)
+        is_expected.to be true
+      end
+
+      it 'returns false when the basic fee has 0 values for quantity, rate and amount'do
+        allow(basic_fee).to receive_messages(quantity: 0, rate: 0, amount: 0)
+        is_expected.to be false
+      end
+
+      it 'returns false when the basic fee has nil values for quantity, rate and amount'do
+        allow(basic_fee).to receive_messages(quantity: nil, rate: nil, amount: nil)
+        is_expected.to be false
+      end
+
+      context 'with filtered out fees' do
+        %w[BASAF BAPCM BACAV].each do |fee_type_unique_code|
+          it "returns false when basic fee is of type #{fee_type_unique_code}" do
+            allow(basic_fee_type).to receive(:unique_code).and_return fee_type_unique_code
+            allow(basic_fee).to receive_messages(amount: 1)
+            is_expected.to be false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Enable data injection of AdvocateHardshipClaims between CCCD and CCR

#### Ticket
[CBO-1190](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=222&modal=detail&selectedIssue=CBO-1190)

#### Why
So that AdvocateHardshipClaims are injected into CCR without caseworker involvement

#### How
expose bill JSON response to CCR DI endpoint that, for hardship claims, sums certain basic fees into a single AGFS_ADVANCE/AGFS_HARDSHIP bill type. basic fees that map to CCR MISC fees will be sent as misc fees still. expenses also sent in the normal format.

--------
**TODO**
- [X] Agree a common json template for the injection of AdvocateHardshipClaims between CCCD and CCR.
- [X] amend CCCD to expose hardship claims to CCR endpoint using the agreed JSON template
- [X] activate CCCD staging --> CCR UAT data injection (SQS filter policy)
- [ ] manual testing by tester and case workers

**Other requirements**
- [ ] release any CCR changes required
- [ ] activate CCCD production --> CCR production data injection (SQS filter policy)

