### PR TITLE
CBO-1207: hardship evidence checklist updates

### DIFF
--- a/app/models/doc_type.rb
+++ b/app/models/doc_type.rb
@@ -21,6 +21,8 @@ class DocType
   ].sort_by(&:sequence)
 
   FEE_REFORM_DOC_TYPE_IDS = [1, 3, 4, 6].freeze
+  AGFS_HARDSHIP_DOC_TYPE_IDS = [1, 4, 6, 7, 8, 9, 10, 11].freeze
+  LGFS_HARDSHIP_DOC_TYPE_IDS = [1, 4, 7, 9, 10].freeze
 
   def self.all
     DOCTYPES
@@ -28,6 +30,14 @@ class DocType
 
   def self.for_fee_reform
     DOCTYPES.select { |doc| FEE_REFORM_DOC_TYPE_IDS.include?(doc.id) }
+  end
+
+  def self.for_agfs_hardship
+    DOCTYPES.select { |doc| AGFS_HARDSHIP_DOC_TYPE_IDS.include?(doc.id) }
+  end
+
+  def self.for_lgfs_hardship
+    DOCTYPES.select { |doc| LGFS_HARDSHIP_DOC_TYPE_IDS.include?(doc.id) }
   end
 
   # returns a single DocType given its id

--- a/app/services/claims/fetch_eligible_document_types.rb
+++ b/app/services/claims/fetch_eligible_document_types.rb
@@ -9,9 +9,16 @@ module Claims
     end
 
     def call
-      return default_doc_types unless claim&.agfs?
-      return fee_reform_doc_types if claim.interim?
-      default_doc_types
+      case claim.type
+      when 'Claim::AdvocateInterimClaim'
+        fee_reform_doc_types
+      when 'Claim::LitigatorHardshipClaim'
+        DocType.for_lgfs_hardship
+      when 'Claim::AdvocateHardshipClaim'
+        DocType.for_agfs_hardship
+      else
+        default_doc_types
+      end
     end
 
     private

--- a/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
@@ -79,7 +79,7 @@ Feature: Advocate tries to submit a hardship claim for a trial with miscellaneou
     Then I should see a page title "Upload supporting evidence for advocate hardship fees claim"
 
     And I upload the document 'hardship.pdf'
-    And I should see 10 evidence check boxes
+    And I should see 8 evidence check boxes
     And I check the evidence boxes for 'Hardship supporting evidence'
     And I add some additional information
 

--- a/features/claims/litigator/hardship_claim_draft_submit.feature
+++ b/features/claims/litigator/hardship_claim_draft_submit.feature
@@ -44,6 +44,7 @@ Feature: Litigator completes hardship claims
 
     And I should see a page title "Upload supporting evidence for litigator hardship fees claim"
     And I upload the document 'hardship.pdf'
+    And I should see 5 evidence check boxes
     And I check the evidence boxes for 'Hardship supporting evidence'
     And I add some additional information
 

--- a/spec/models/doc_type_spec.rb
+++ b/spec/models/doc_type_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe DocType do
+  describe '#for_agfs_hardship' do
+    subject(:doc_types) { described_class.for_agfs_hardship }
+
+    specify { expect(doc_types.map(&:id)).to match_array([1, 4, 6, 7, 8, 9, 10, 11]) }
+  end
+
+  describe '#for_lgfs_hardship' do
+    subject(:doc_types) { described_class.for_lgfs_hardship }
+
+    specify { expect(doc_types.map(&:id)).to match_array([1, 4, 7, 9, 10]) }
+  end
+
   describe '.for_fee_reform' do
     subject(:doc_types) { described_class.for_fee_reform }
 

--- a/spec/services/claims/fetch_eligible_document_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_document_types_spec.rb
@@ -26,4 +26,20 @@ RSpec.describe Claims::FetchEligibleDocumentTypes do
       expect(document_types).to eq(DocType.for_fee_reform)
     end
   end
+
+  context 'when claim is for AGFS hardship' do
+    let(:claim) { build(:advocate_hardship_claim) }
+
+    it 'returns the correct subset of document types' do
+      expect(document_types).to eq(DocType.for_agfs_hardship)
+    end
+  end
+
+  context 'when claim is for LGFS hardship' do
+    let(:claim) { build(:litigator_hardship_claim) }
+
+    it 'returns the correct subset of document types' do
+      expect(document_types).to eq(DocType.for_lgfs_hardship)
+    end
+  end
 end


### PR DESCRIPTION
#### What
Reduce the number of evidence items shown for Hardship claims

#### Ticket
[evidence checklist for hardship claims](https://dsdmoj.atlassian.net/browse/CBO-1207)

#### Why
Currently the full checklist displays on both LGFS and AGFS claims - we know that some of the options wouldn't be applicable.

#### How
Update the DocType and FetchEligibleDocumentTypes models to allow the new list types to be built and returned

Update the hardship features to ensure that the new, shorter, lists are displayed