### PR TITLE
CBO-1226: LGFS hardship fee page update

### DIFF
--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -13,12 +13,14 @@ module Claims
     private
 
     LGFS_MISC_FEE_ELIGIBILITY = %w[MICJA MICJP MIEVI MISPF].freeze
+    LGFS_HARDSHIP_MISC_FEE_ELIGIBILITY = %w[MIEVI MISPF].freeze
 
     attr_reader :claim
-    delegate :case_type, :agfs?, :lgfs?, :agfs_reform?, to: :claim, allow_nil: true
+    delegate :case_type, :agfs?, :lgfs?, :agfs_reform?, :hardship?, to: :claim, allow_nil: true
 
     def eligible_fee_types
       return eligible_agfs_misc_fee_types if agfs?
+      return elgible_lgfs_hardship_misc_fee_types if lgfs? && hardship?
       return eligible_lgfs_misc_fee_types if lgfs?
     end
 
@@ -30,6 +32,10 @@ module Claims
     def eligible_agfs_misc_fee_types
       return agfs_scheme_scope.supplementary if claim.supplementary?
       agfs_scheme_scope.without_supplementary_only
+    end
+
+    def elgible_lgfs_hardship_misc_fee_types
+      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_HARDSHIP_MISC_FEE_ELIGIBILITY)
     end
 
     def eligible_lgfs_misc_fee_types

--- a/features/claims/litigator/hardship_claim_draft_submit.feature
+++ b/features/claims/litigator/hardship_claim_draft_submit.feature
@@ -39,7 +39,11 @@ Feature: Litigator completes hardship claims
     Then the hardship fee amount should be populated with '412.81'
     And I eject the VCR cassette
 
-    Then I click "Continue" in the claim form and move to the 'Miscellaneous fees' form page
+    When I click "Continue" in the claim form and move to the 'Miscellaneous fees' form page
+    Then I should see 'Evidence provision fee'
+    And I should see 'Special preparation fee'
+    And I should not see 'Costs judge application'
+    And I should not see 'Costs judge preparation' 
     Then I click "Continue" in the claim form and move to the 'Supporting evidence' form page
 
     And I should see a page title "Upload supporting evidence for litigator hardship fees claim"

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
           end
         end
       end
+
+      context 'hardship fee claim' do
+        subject { call.map(&:unique_code) }
+
+        let(:claim) do
+          create(:litigator_hardship_claim)
+        end
+
+        it 'returns only non-cost judge LGFS misc fee types' do
+          is_expected.to match_array %w[MIEVI MISPF]
+        end
+      end
     end
 
     context 'AGFS' do


### PR DESCRIPTION
#### What/Ticket
[remove unnecessary misc fee options from hardship page](https://dsdmoj.atlassian.net/browse/CBO-1226)

#### Why
The misc fee options in LGFS hardship are identical to the final fee options BUT some are incompatible with hardship claims. 
Both cost judge application and preparation cannot ever apply to a hardship claim and given these also can't data inject into CCLF onto a non-final fee claim its advisable to remove them entirely. 

#### How
Update Claims::FetchEligibleMiscFeeTypes  to add explicit handling for LGFS Hardship misc fee types, also updating the feature tests to ensure that only the correct fee types are displayed