### PR TITLE
change dropzone error msg

### DIFF
--- a/app/assets/javascripts/modules/external_users/claims/Dropzone.js
+++ b/app/assets/javascripts/modules/external_users/claims/Dropzone.js
@@ -169,8 +169,8 @@ moj.Modules.Dropzone = {
           tableRow.replaceWith(this.notificationHTML(fileName, 'error', 'The server failed to process your file.'));
           this.status.html('The server failed to process your file.');
         } else {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'error', error));
-          this.status.html(fileName + ' ' + error);
+          tableRow.replaceWith(this.notificationHTML(fileName, 'error', xhr.responseJSON.error));
+          this.status.html(fileName + ' ' + xhr.responseJSON.error);
         }
       }, this),
 


### PR DESCRIPTION
#### What
When uploading specific file type (for example '.docx'), no status message is displayed once file upload is complete.

#### Ticket
[Supporting evidence upload, no status message](https://dsdmoj.atlassian.net/browse/CBO-1224)

#### How
I have changed the response used to display the status message.