### PR TITLE
Revert "CBO-1207: hardship evidence checklist updates"

### DIFF
--- a/app/models/doc_type.rb
+++ b/app/models/doc_type.rb
@@ -21,8 +21,6 @@ class DocType
   ].sort_by(&:sequence)
 
   FEE_REFORM_DOC_TYPE_IDS = [1, 3, 4, 6].freeze
-  AGFS_HARDSHIP_DOC_TYPE_IDS = [1, 4, 6, 7, 8, 9, 10, 11].freeze
-  LGFS_HARDSHIP_DOC_TYPE_IDS = [1, 4, 7, 9, 10].freeze
 
   def self.all
     DOCTYPES
@@ -30,14 +28,6 @@ class DocType
 
   def self.for_fee_reform
     DOCTYPES.select { |doc| FEE_REFORM_DOC_TYPE_IDS.include?(doc.id) }
-  end
-
-  def self.for_agfs_hardship
-    DOCTYPES.select { |doc| AGFS_HARDSHIP_DOC_TYPE_IDS.include?(doc.id) }
-  end
-
-  def self.for_lgfs_hardship
-    DOCTYPES.select { |doc| LGFS_HARDSHIP_DOC_TYPE_IDS.include?(doc.id) }
   end
 
   # returns a single DocType given its id

--- a/app/services/claims/fetch_eligible_document_types.rb
+++ b/app/services/claims/fetch_eligible_document_types.rb
@@ -9,16 +9,9 @@ module Claims
     end
 
     def call
-      case claim.type
-      when 'Claim::AdvocateInterimClaim'
-        fee_reform_doc_types
-      when 'Claim::LitigatorHardshipClaim'
-        DocType.for_lgfs_hardship
-      when 'Claim::AdvocateHardshipClaim'
-        DocType.for_agfs_hardship
-      else
-        default_doc_types
-      end
+      return default_doc_types unless claim&.agfs?
+      return fee_reform_doc_types if claim.interim?
+      default_doc_types
     end
 
     private

--- a/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
@@ -79,7 +79,7 @@ Feature: Advocate tries to submit a hardship claim for a trial with miscellaneou
     Then I should see a page title "Upload supporting evidence for advocate hardship fees claim"
 
     And I upload the document 'hardship.pdf'
-    And I should see 8 evidence check boxes
+    And I should see 10 evidence check boxes
     And I check the evidence boxes for 'Hardship supporting evidence'
     And I add some additional information
 

--- a/features/claims/litigator/hardship_claim_draft_submit.feature
+++ b/features/claims/litigator/hardship_claim_draft_submit.feature
@@ -48,7 +48,6 @@ Feature: Litigator completes hardship claims
 
     And I should see a page title "Upload supporting evidence for litigator hardship fees claim"
     And I upload the document 'hardship.pdf'
-    And I should see 5 evidence check boxes
     And I check the evidence boxes for 'Hardship supporting evidence'
     And I add some additional information
 

--- a/spec/models/doc_type_spec.rb
+++ b/spec/models/doc_type_spec.rb
@@ -1,18 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe DocType do
-  describe '#for_agfs_hardship' do
-    subject(:doc_types) { described_class.for_agfs_hardship }
-
-    specify { expect(doc_types.map(&:id)).to match_array([1, 4, 6, 7, 8, 9, 10, 11]) }
-  end
-
-  describe '#for_lgfs_hardship' do
-    subject(:doc_types) { described_class.for_lgfs_hardship }
-
-    specify { expect(doc_types.map(&:id)).to match_array([1, 4, 7, 9, 10]) }
-  end
-
   describe '.for_fee_reform' do
     subject(:doc_types) { described_class.for_fee_reform }
 

--- a/spec/services/claims/fetch_eligible_document_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_document_types_spec.rb
@@ -26,20 +26,4 @@ RSpec.describe Claims::FetchEligibleDocumentTypes do
       expect(document_types).to eq(DocType.for_fee_reform)
     end
   end
-
-  context 'when claim is for AGFS hardship' do
-    let(:claim) { build(:advocate_hardship_claim) }
-
-    it 'returns the correct subset of document types' do
-      expect(document_types).to eq(DocType.for_agfs_hardship)
-    end
-  end
-
-  context 'when claim is for LGFS hardship' do
-    let(:claim) { build(:litigator_hardship_claim) }
-
-    it 'returns the correct subset of document types' do
-      expect(document_types).to eq(DocType.for_lgfs_hardship)
-    end
-  end
 end


### PR DESCRIPTION
Reverts ministryofjustice/Claim-for-Crown-Court-Defence#3352

The implementation of this broke allocation because of strange interactions inside the state machine... an attempt at a quick fix in state machine caused a cascade of errors, so reverting the change now and allowing a leisurely review/fix is probably best.
[error ticket](https://dsdmoj.atlassian.net/browse/CBO-1229)
[original ticket](https://dsdmoj.atlassian.net/browse/CBO-1207)