### PR TITLE
CBO-1236: allow archiving of hardship cases

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -125,7 +125,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def unarchive
     claim_url = external_users_claim_url(@claim)
-    return redirect_to claim_url, alert: t('.not_archived') unless @claim.archived_pending_delete?
+    return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
     @claim = PreviousVersionOfClaim.new(@claim).call
     @claim.zeroise_nil_totals!
     @claim.save!(validate: false)
@@ -552,5 +552,9 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def flash_message_for(event, status)
     status ? { notice: "Claim #{event}d" } : { alert: "Claim could not be #{event}d" }
+  end
+
+  def unarchive_allowed?
+    @claim.archived_pending_delete? || @claim.archived_pending_review?
   end
 end

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -38,7 +38,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   end
 
   def archived
-    @claims = @claims_context.archived_pending_delete
+    @claims = @claims_context.where(state: %w[archived_pending_delete archived_pending_review])
     search(:archived_pending_delete) if params[:search].present?
     sort_and_paginate(column: 'last_submitted_at', direction: 'desc')
   end

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -114,7 +114,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def destroy
     message = if @claim.draft?
                 flash_message_for :delete, claim_updater.delete
-              elsif @claim.can_archive_pending_delete?
+              elsif @claim.can_archive_pending_delete? || @claim.can_archive_pending_review?
                 flash_message_for :archive, claim_updater.archive
               else
                 { alert: 'This claim cannot be deleted' }

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -12,7 +12,7 @@ module Claims
     CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES    = %w[allocated].freeze
     CASEWORKER_DASHBOARD_UNALLOCATED_STATES         = %w[submitted redetermination awaiting_written_reasons].freeze
     CASEWORKER_DASHBOARD_ARCHIVED_STATES            = %w[ authorised part_authorised rejected
-                                                          refused archived_pending_delete].freeze
+                                                          refused archived_pending_delete archived_pending_review].freeze
     VALID_STATES_FOR_REDETERMINATION                = %w[authorised part_authorised refused rejected].freeze
     VALID_STATES_FOR_ARCHIVAL                       = %w[authorised part_authorised refused rejected].freeze
     VALID_STATES_FOR_ALLOCATION                     = %w[submitted redetermination awaiting_written_reasons].freeze

--- a/app/models/claims/state_machine.rb
+++ b/app/models/claims/state_machine.rb
@@ -12,7 +12,8 @@ module Claims
     CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES    = %w[allocated].freeze
     CASEWORKER_DASHBOARD_UNALLOCATED_STATES         = %w[submitted redetermination awaiting_written_reasons].freeze
     CASEWORKER_DASHBOARD_ARCHIVED_STATES            = %w[ authorised part_authorised rejected
-                                                          refused archived_pending_delete archived_pending_review].freeze
+                                                          refused archived_pending_delete
+                                                          archived_pending_review].freeze
     VALID_STATES_FOR_REDETERMINATION                = %w[authorised part_authorised refused rejected].freeze
     VALID_STATES_FOR_ARCHIVAL                       = %w[authorised part_authorised refused rejected].freeze
     VALID_STATES_FOR_ALLOCATION                     = %w[submitted redetermination awaiting_written_reasons].freeze

--- a/app/presenters/claim_csv_presenter.rb
+++ b/app/presenters/claim_csv_presenter.rb
@@ -14,7 +14,7 @@ class ClaimCsvPresenter < BasePresenter
 
   def sorted_and_filtered_state_transitions
     claim_state_transitions.sort.reject do |transition|
-      %w[draft archived_pending_delete].include?(transition.to) ||
+      %w[draft archived_pending_delete archived_pending_review].include?(transition.to) ||
         transition.created_at < Time.now - 6.months
     end
   end

--- a/app/presenters/claim_state_transition_presenter.rb
+++ b/app/presenters/claim_state_transition_presenter.rb
@@ -62,6 +62,9 @@ class ClaimStateTransitionPresenter < BasePresenter
       },
       'archived_pending_delete' => {
         'CaseWorker' => 'Claim archived', 'ExternalUser' => 'Your claim has been archived'
+      },
+      'archived_pending_review' => {
+        'CaseWorker' => 'Claim archived', 'ExternalUser' => 'Your claim has been archived'
       }
     }
   end

--- a/app/services/claims/external_user_claim_updater.rb
+++ b/app/services/claims/external_user_claim_updater.rb
@@ -12,7 +12,11 @@ module Claims
     end
 
     def archive
-      claim.archive_pending_delete!(audit_attributes)
+      if claim.hardship?
+        claim.archive_pending_review!(audit_attributes)
+      else
+        claim.archive_pending_delete!(audit_attributes)
+      end
     end
 
     def clone_rejected

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -52,7 +52,7 @@
             - if claim.rejected?
               = button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: 'patch', class: 'button resubmit-claim', form_class: 'inline-form'
             = link_to t('.archive'), external_users_claim_path(claim), method: :delete, data: { confirm: t('.confirm_text') }, class: 'button', role: 'button'
-        - if claim.archived_pending_delete?
+        - if claim.archived_pending_delete? || claim.archived_pending_review?
           = t('.actions')
           .action-wrapper
             = button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: 'patch', class: 'button', form_class: 'inline-form'

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -663,7 +663,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
   end
 
   describe "PATCH #unarchive" do
-    context 'when archived claim' do
+    context 'when archived_pending_delete claim' do
       let(:claim) do
         claim = create(:authorised_claim, external_user: advocate)
         claim.archive_pending_delete!
@@ -679,6 +679,26 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
 
         it 'redirects to external users root url' do
           expect(response).to redirect_to(external_users_claims_url)
+        end
+      end
+
+      context 'when archived_pending_review claim' do
+        let(:claim) do
+          claim = create(:advocate_hardship_claim, :rejected, external_user: advocate)
+          claim.archive_pending_review!
+          claim
+        end
+  
+        context 'when the current version of paper trail is used' do
+          before { patch :unarchive, params: { id: claim } }
+  
+          it 'unarchives the claim and restores to state prior to archiving' do
+            expect(claim.reload).to be_rejected
+          end
+  
+          it 'redirects to external users root url' do
+            expect(response).to redirect_to(external_users_claims_url)
+          end
         end
       end
     end

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -626,6 +626,16 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
         end
       end
 
+      context 'when non-draft hardship claim in a valid state for archival' do
+        let(:claim) { create(:advocate_hardship_claim, :rejected, external_user: advocate) }
+
+        it "sets the claim's state to 'archived_pending_review'" do
+          expect(Claim::BaseClaim.active.count).to eq(1) 
+          expect(claim.reload.state).to eq 'archived_pending_review'
+          expect(flash[:notice]).to eq 'Claim archived'
+        end
+      end
+
       context 'when non-draft claim in an invalid state for archival' do
         let(:claim) { create(:archived_pending_delete_claim, external_user: advocate) }
 

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -279,6 +279,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
         before do
           create(:draft_claim, external_user: advocate)
           create(:archived_pending_delete_claim, external_user: advocate)
+          create(:hardship_archived_pending_review_claim, external_user: advocate)
           create(:draft_claim, external_user: other_advocate)
         end
 
@@ -290,7 +291,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
           end
           it 'should assign claims to archived only' do
             get :archived
-            expect(assigns(:claims)).to eq(advocate.claims.archived_pending_delete)
+            expect(assigns(:claims)).to match_array(advocate.claims.where(state: %w[archived_pending_delete archived_pending_review]))
           end
         end
 
@@ -302,7 +303,7 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller, focus: true d
           end
           it 'should assign claims to archived only' do
             get :archived
-            expect(assigns(:claims)).to eq(advocate_admin.provider.claims.archived_pending_delete)
+            expect(assigns(:claims)).to match_array(advocate.claims.where(state: %w[archived_pending_delete archived_pending_review]))
           end
         end
       end

--- a/spec/factories/claim/advocate_hardship_claims.rb
+++ b/spec/factories/claim/advocate_hardship_claims.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     trait :rejected do
       after(:create) { |c| c.submit!; c.allocate!; c.reject! }
     end
+
+    factory :hardship_archived_pending_review_claim do
+      after(:create) { |c| advance_to_pending_review(c) }
+    end
   end
 end

--- a/spec/factories/claim/advocate_hardship_claims.rb
+++ b/spec/factories/claim/advocate_hardship_claims.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :authorised do
       after(:create) { |c| authorise_claim(c) }
     end
+
+    trait :rejected do
+      after(:create) { |c| c.submit!; c.allocate!; c.reject! }
+    end
   end
 end

--- a/spec/models/claims/search_spec.rb
+++ b/spec/models/claims/search_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Claims::Search do
       end
     }
     let(:archived_pending_delete_claim) { create(:litigator_claim, :archived_pending_delete) }
+    let(:archived_pending_review_claim) { create(:hardship_archived_pending_review_claim) }
 
     # NOTE: Claim::BaseClaim is including this module, hence testing
     # it on the claim class itself
@@ -32,6 +33,7 @@ RSpec.describe Claims::Search do
       rejected_claim
       refused_claim
       archived_pending_delete_claim
+      archived_pending_review_claim
     end
 
     context 'for archived claims' do
@@ -54,8 +56,8 @@ RSpec.describe Claims::Search do
         end
 
         it 'returns all archived claims' do
-          expected_claim_ids = [authorised_claim, part_authorised_claim, rejected_claim, refused_claim, archived_pending_delete_claim].map(&:id)
-          expect(query.count).to eq(5)
+          expected_claim_ids = [authorised_claim, part_authorised_claim, rejected_claim, refused_claim, archived_pending_delete_claim, archived_pending_review_claim].map(&:id)
+          expect(query.count).to eq(6)
           expect(query.map(&:id)).to match_array(expected_claim_ids)
         end
       end
@@ -108,6 +110,13 @@ RSpec.describe Claims::Search do
             ])
           ])
         }
+        let(:archived_pending_review_claim) {
+          create(:hardship_archived_pending_review_claim, case_number: 'T20751665', defendants: [
+            create(:defendant, first_name: 'Mary', last_name: 'Doe', representation_orders: [
+              create(:representation_order, maat_reference: '1111158')
+            ])
+          ])
+        }
 
         it 'includes related filters in the SQL query' do
           filters = [
@@ -121,8 +130,8 @@ RSpec.describe Claims::Search do
         end
 
         it 'returns all matching archived claims' do
-          expected_claim_ids = [authorised_claim, part_authorised_claim, archived_pending_delete_claim].map(&:id)
-          expect(query.count).to eq(3)
+          expected_claim_ids = [authorised_claim, part_authorised_claim, archived_pending_delete_claim, archived_pending_review_claim].map(&:id)
+          expect(query.count).to eq(4)
           expect(query.map(&:id)).to match_array(expected_claim_ids)
         end
       end

--- a/spec/presenters/claim_csv_presenter_spec.rb
+++ b/spec/presenters/claim_csv_presenter_spec.rb
@@ -273,6 +273,51 @@ RSpec.describe ClaimCsvPresenter do
         end
       end
 
+      context 'archived_pending_delete' do
+        let(:claim) { create(:archived_pending_delete_claim) }
+       
+        it 'adds a single row to the MI' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv.size).to eql 1
+          end
+        end
+
+        it 'should not be reflected in the MI' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv[0]).not_to include('archived_pending_delete')
+          end
+        end
+
+        it 'and the claim should be reflected as being in the state prior to archive' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv[0]).to include('authorised')
+          end
+        end
+      end
+
+      context 'archived_pending_review' do
+        let(:claim) { create(:hardship_archived_pending_review_claim) }
+
+        it 'adds a single row to the MI' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv.size).to eql 1
+          end
+        end
+        
+        it 'should not be reflected in the MI' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv[0]).not_to include('archived_pending_review')
+          end
+        end
+
+        it 'and the claim should be reflected as being in the state prior to archive' do
+          ClaimCsvPresenter.new(claim, view).present! do |csv|
+            expect(csv[0]).to include('authorised')
+          end
+        end
+      end
+
+
       context 'state transitions reasons' do
         let(:claim) { create(:allocated_claim) }
 

--- a/spec/services/claims/external_user_claim_updater_spec.rb
+++ b/spec/services/claims/external_user_claim_updater_spec.rb
@@ -16,15 +16,25 @@ module Claims
     end
 
     describe '#archive' do
-      let(:claim) { create :rejected_claim }
-
+      before { subject.archive }
       after(:each) do
         expect(claim.last_state_transition.author_id).to eq(current_user.id)
       end
 
-      it 'archives the claim' do
-        subject.archive
-        expect(claim.archived_pending_delete?).to be_truthy
+      context 'when the claim is non-hardship' do
+        let(:claim) { create :rejected_claim }
+
+        it 'archives the claim' do
+          expect(claim.archived_pending_delete?).to be_truthy
+        end
+      end
+
+      context 'when the claim is a hardship' do
+        let(:claim) { create :advocate_hardship_claim, :rejected }
+
+        it 'archives the claim' do
+          expect(claim.archived_pending_review?).to be_truthy
+        end
       end
     end
 

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -46,6 +46,14 @@ module FactoryHelpers
     c.archive_pending_delete!
   end
 
+  def advance_to_pending_review(c)
+    allocate_claim(c)
+    c.reload
+    set_amount_assessed(c)
+    c.authorise!
+    c.archive_pending_review!
+  end
+
   def make_claim_creator_advocate_admin(claim)
     advocate_admin = claim.external_user.provider.external_users.admins.sample
     advocate_admin ||= create(:external_user, :admin, provider: claim.external_user.provider)


### PR DESCRIPTION
#### What
The caseworker user need was to retain hardship claims indefinitely, so we disabled a provider's ability to archive them. Providers weren't advised of this change in functionality and have been contacting via zendesk thinking there was a problem. I have responded advising of the rationale and asking for feedback about this approach as we didn't consider the impacts on the providers case view screens

#### Ticket
[Investigate hardship non-archiving strategy for provider view](https://dsdmoj.atlassian.net/browse/CBO-1236)

#### Why
Feedback contained in this ticket ( and will be added to as more comes in) indicates that the hardship claims may be cluttering up their claim views. So in order to improve the user experience we may need to come up with a method of moving the hardship claims away from the main claim view whilst still not archiving them - potentially creating another new state in the state machine

#### How
Add handlers for the new states required by hardship state changes