### PR TITLE
Fix hardship hardship endpoint constant already initialized warning

### DIFF
--- a/spec/api/v1/external_users/claims/advocates/hardship_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/hardship_claim_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::HardshipClaim do
   include Rack::Test::Methods
   include ApiSpecHelper
 
-  HARDSHIP_CLAIM_ENDPOINT = 'advocates/hardship'.freeze
+  ADVOCATE_HARDSHIP_CLAIM_ENDPOINT = 'advocates/hardship'.freeze
 
   let(:claim_class) { Claim::AdvocateHardshipClaim }
   let!(:provider)       { create(:provider) }
@@ -31,13 +31,13 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::HardshipClaim do
   after(:all) { clean_database }
 
   include_examples 'advocate claim test setup'
-  it_behaves_like 'a claim endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
-  it_behaves_like 'a claim validate endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
-  it_behaves_like 'a claim create endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim endpoint', relative_endpoint: ADVOCATE_HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim validate endpoint', relative_endpoint: ADVOCATE_HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim create endpoint', relative_endpoint: ADVOCATE_HARDSHIP_CLAIM_ENDPOINT
 
-  describe "POST #{ClaimApiEndpoints.for(HARDSHIP_CLAIM_ENDPOINT).validate}" do
+  describe "POST #{ClaimApiEndpoints.for(ADVOCATE_HARDSHIP_CLAIM_ENDPOINT).validate}" do
     subject(:post_to_validate_endpoint) do
-      post ClaimApiEndpoints.for(HARDSHIP_CLAIM_ENDPOINT).validate, valid_params, format: :json
+      post ClaimApiEndpoints.for(ADVOCATE_HARDSHIP_CLAIM_ENDPOINT).validate, valid_params, format: :json
     end
   
     it 'returns 200 when parameters that are optional for hardship claims are empty' do

--- a/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe API::V1::ExternalUsers::Claims::Litigators::HardshipClaim do
   include Rack::Test::Methods
   include ApiSpecHelper
 
-  HARDSHIP_CLAIM_ENDPOINT = 'litigators/hardship'.freeze
+  LITIGATOR_HARDSHIP_CLAIM_ENDPOINT = 'litigators/hardship'.freeze
 
   let(:claim_class) { Claim::LitigatorHardshipClaim }
   let!(:provider) { create(:provider, :lgfs) }
@@ -27,7 +27,7 @@ RSpec.describe API::V1::ExternalUsers::Claims::Litigators::HardshipClaim do
   after(:all) { clean_database }
 
   include_examples 'litigator claim test setup'
-  it_behaves_like 'a claim endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
-  it_behaves_like 'a claim validate endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
-  it_behaves_like 'a claim create endpoint', relative_endpoint: HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim validate endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+  it_behaves_like 'a claim create endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
 end


### PR DESCRIPTION
#### What
When specs run this is generating a warning: already initialized constant HARDSHIP_CLAIM_ENDPOINT

#### Ticket
n/a

#### Why
Prevent warning being generated.

#### How
Renamed endpoints ADVOCATE_HARDSHIP_CLAIM_ENDPOINT and LITIGATOR_HARDSHIP_CLAIM_ENDPOINT.
