### PR TITLE
Use basic executor from circleci where possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,14 +100,21 @@ references:
 
   _script-build-app-container: &script-build-app-container
     run:
-        name: Build and push cccd docker image
-        command: |
-          .circleci/build.sh
+      name: Build and push cccd docker image
+      command: |
+        .circleci/build.sh
 
 # ------------------
 # EXECUTORS
 # ------------------
 executors:
+  basic-executor:
+    docker:
+      - image: cimg/base:2020.01
+        environment:
+          GITHUB_TEAM_NAME_SLUG: laa-get-paid
+          REPO_NAME: cccd
+
   cloud-platform-executor:
     docker:
     - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
@@ -265,7 +272,7 @@ jobs:
       - smoke-test
 
   smoke-test-notification:
-    executor: slack/alpine
+    executor: basic-executor
     steps:
       - smoke-test-notification
 
@@ -330,13 +337,13 @@ jobs:
       - *script-build-app-container
 
   hold-build-notification:
-    executor: cloud-platform-executor
+    executor: basic-executor
     steps:
       - hold-notification:
           message: "Do you want to build <$CIRCLE_BUILD_URL|$CIRCLE_BRANCH>?"
 
   hold-deploy-notification:
-    executor: cloud-platform-executor
+    executor: basic-executor
     steps:
       - hold-notification:
           message: "Deployment of <$CIRCLE_BUILD_URL|$CIRCLE_BRANCH> pending approval"

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 function _circleci_deploy() {
   usage="deploy -- deploy image from current commit to an environment
   Usage: $0 environment


### PR DESCRIPTION
#### What
Use basic executor from circleci where possible

#### Why
To reduce run times. Thanks @colinbruce

certain jobs do not require anything other than a basic
docker container to run. circleci provides convenience 
images which are very fast to spin up
see [CircleCI Next-generation Convenience Images
](https://circleci.com/docs/2.0/circleci-images/#next-generation-convenience-images)
- slack (hold) notifications

#### Further improvements possible
- build and push docker images should be doable to BUT have to install python and awscli and this seems to negate the time savings gained from use the convenience image as executor. This can be tested further to ensure we are not losing potential time savings. one alternative is to extend the convenience image with python and awscli if this is not too slow.

