### PR TITLE
Updates inline with rubocop 0.85 bump

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ plugins:
             - "(call _ expose ___)" # exlude expose methods
   rubocop:
     enabled: true
-    channel: rubocop-0-81
+    channel: rubocop-0-83
     config:
       file: .rubocop.yml
   brakeman:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 
@@ -82,6 +85,12 @@ Style/HashTransformKeys:
   Enabled: true
 
 Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
   Enabled: true
 
 Style/SlicingWithRange:

--- a/app/interfaces/api/v2/case_workers/allocate.rb
+++ b/app/interfaces/api/v2/case_workers/allocate.rb
@@ -9,7 +9,7 @@ module API
             optional :claim_ids,
                      type: Array[Integer],
                      desc: I18n.t('api.v2.allocate.params.claim_ids'),
-                     coerce_with: ->(val) { val.split(/[,]/).map(&:to_i) }
+                     coerce_with: ->(val) { val.split(',').map(&:to_i) }
           end
 
           resource :allocate, desc: 'Allocate claims' do


### PR DESCRIPTION
#### What
Opt-in to new rubocop 0.85 cops

#### Why
add new cops and fix existing violation

``` The following cops were added to RuboCop, but are not configured.
Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
- Lint/MixedRegexpCaptureTypes (0.85)
- Style/RedundantRegexpCharacterClass (0.85)
- Style/RedundantRegexpEscape (0.85) For more information:
https://docs.rubocop.org/rubocop/versioning.html
```