### PR TITLE
amend default dependabot reviewer

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,4 +9,4 @@ update_configs:
     # Apply default reviewer and label to created
     # pull requests
     default_reviewers:
-      - "crime-billing-online"
+      - "ministryofjustice/crime-billing-online"


### PR DESCRIPTION
#### What
amend default dependabot reviewer

#### Why
reference to `crime-billing-online`
was not working. I believe it has to be namespaced
to the organization.