### PR TITLE
Add grape swagger rails gems assests to manifest

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -12,3 +12,7 @@
 //= link govuk-template-print.css
 //= link fonts.css
 //= link application.js
+
+// swagger docs
+//= link grape_swagger_rails/application.css
+//= link grape_swagger_rails/application.js


### PR DESCRIPTION
#### What
Add grape swagger rails gems assests to manifest

#### Ticket

[CBO-1254](https://dsdmoj.atlassian.net/browse/CBO-1254)

#### Why
The swagger docs don't work/appear without these.

#### How
Following move to rails 6.0.3.1 and introduction
of a manifest files to handle sprocket issues these
assests were missed