### PR TITLE
Add correct id/object to edit user link

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -11,7 +11,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
       user_name: user.name,
       claim_case_number: claim.case_number,
       claim_url: external_users_claim_url(claim, messages: true),
-      edit_user_url: edit_external_users_admin_external_user_url(user)
+      edit_user_url: edit_external_users_admin_external_user_url(user.persona)
     )
     mail(to: user.email)
   end


### PR DESCRIPTION
#### What
Add correct id/object to edit user link

#### Ticket

[CBO-1259](https://dsdmoj.atlassian.net/browse/CBO-1259)

#### Why
Currently the link links based on an id
that is not the user in question. This could
result in a not found if no external_user with that id
exists or unauthorised if they exist but no in the same
chamber/firm or a working link to an entirely different
person, if `current_user` happens to have a access to that
persons account.

The route and controller expect the id of the
`external_user`, not the `user` itself.

#### TODO

needs some manual testing and possibly some automated testing
here.