### PR TITLE
Increase server and cloning timeout

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -87,7 +87,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   def clone_rejected
     draft = nil
-    Timeout.timeout(15) do
+    Timeout.timeout(20) do
       draft = claim_updater.clone_rejected
     end
     LogStuff.send(:info,

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -90,24 +90,27 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
     Timeout.timeout(15) do
       draft = claim_updater.clone_rejected
     end
-    LogStuff.send(:info, 'ExternalUsers::ClaimsController',
+    LogStuff.send(:info,
+                  'ExternalUsers::ClaimsController',
                   action: 'clone',
                   claim_id: @claim.id,
                   documents: @claim.documents.count,
-                  total_size: @claim.documents.sum(:document_file_size)) do
+                  total_size: helpers.number_to_human_size(@claim.documents.sum(:document_file_size))) do
       'Redraft succeeded'
     end
 
     redirect_to edit_polymorphic_path(draft), notice: 'Draft created'
   rescue StandardError => e
-    LogStuff.send(:error, 'ExternalUsers::ClaimsController',
+    LogStuff.send(:error,
+                  'ExternalUsers::ClaimsController',
                   action: 'clone',
                   claim_id: @claim.id,
                   documents: @claim.documents.count,
-                  total_size: @claim.documents.sum(:document_file_size),
-                  error: e.message) do
+                  total_size: helpers.number_to_human_size(@claim.documents.sum(:document_file_size)),
+                  error: "#{e.class}: #{e.message}") do
       'Redraft failed'
     end
+
     redirect_to external_users_claims_url, alert: t('external_users.claims.redraft.error_html').html_safe
   end
 

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -3,11 +3,11 @@ if ENV['RAILS_ENV']=="development"
   timeout 5000
 else
   worker_processes Integer(ENV["WEB_CONCURRENCY"] || 2)
-  timeout 15
+  timeout 20
 end
 
 if ENV["RAILS_ENV"] == 'production'
-  timeout 15
+  timeout 20
   preload_app true
 
   before_fork do |server, worker|


### PR DESCRIPTION
#### What
increase the timeouts for all requests and cloning. Also
present total file sizes in log in human readable format.

#### Ticket

[relates to CBO-1233](https://dsdmoj.atlassian.net/browse/CBO-1233)

#### Why
At time of writing approximately 6.5% of
cloning attempts failed, mostly due
to timeouts. This is a quick fix to assess
impact and avoid the work needed for more rubost
appraoches such as backgrounding.

#### How
Increase unicorn web server request timeouts from
15 to 20 seconds generally, and cloning timeouts
inline with this.