### PR TITLE
Govuk frontend

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,7 @@
   %meta{ name: 'format-detection', content: 'telephone=no' }
 
   = stylesheet_pack_tag 'application', media: 'all'
+  = stylesheet_pack_tag 'govuk-frontend', media: 'all'
 
   - if GoogleAnalytics::DataTracking.enabled?
     = render partial: 'layouts/analytics', :formats => [:js], locals: { adapter: GoogleAnalytics::DataTracking.adapter_name }
@@ -72,5 +73,6 @@
         $('.ga-client-id').val(clientId);
       });
 
+  = javascript_pack_tag 'govuk-frontend'
 
 = render template: 'layouts/govuk_template'

--- a/app/webpack/packs/govuk-frontend.js
+++ b/app/webpack/packs/govuk-frontend.js
@@ -1,0 +1,6 @@
+import '../stylesheets/govuk-frontend.scss'
+
+// fonts & images
+require.context('govuk-frontend/govuk/assets', true)
+
+require('govuk-frontend').initAll()

--- a/app/webpack/stylesheets/govuk-frontend.scss
+++ b/app/webpack/stylesheets/govuk-frontend.scss
@@ -1,0 +1,19 @@
+// GOV.UK Frontend (Design System)
+@function frontend-font-url($filename) {
+  @return url('~assets/fonts/'+ $filename);
+}
+
+@function frontend-image-url($filename) {
+  @return url('~assets/images/'+ $filename);
+}
+
+$govuk-font-url-function: frontend-font-url;
+$govuk-image-url-function: frontend-image-url;
+
+// Compatibility mode can be turned off when migration is complete
+// https://frontend.design-system.service.gov.uk/compatibility-mode/#turn-off-39-compatibility-mode-39
+$govuk-compatibility-govukelements: true;
+$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govukfrontendtoolkit: true;
+
+@import '~govuk-frontend/govuk/all';

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['node_modules/govuk_frontend_toolkit']
+  resolved_paths: ['node_modules/govuk-frontend/govuk', 'node_modules/govuk_frontend_toolkit']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "cocoon": "nathanvda/cocoon",
     "dropzone": "^5.5.1",
     "govuk-elements-sass": "^3.1.3",
+    "govuk-frontend": "^3.6.0",
     "govuk_frontend_toolkit": "8.2.0",
     "jquery": "1.12.4",
     "jquery-accessible-accordion-aria": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,6 +3321,11 @@ govuk-elements-sass@^3.1.3:
   dependencies:
     govuk_frontend_toolkit "^7.1.0"
 
+govuk-frontend@^3.6.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.7.0.tgz#2eb2130c3c9f7c701c7ecdb300cc91106275a414"
+  integrity sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg==
+
 govuk_frontend_toolkit@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.2.0.tgz#6f23bd9bbce02b22c82f4ebba6cd4b07a2141fd7"


### PR DESCRIPTION
#### What
Add the govuk-frontend (Govuk Design System) package to the application

#### Ticket
[Implement govuk-frontend](https://dsdmoj.atlassian.net/browse/CBO-1243)

#### Why
The deprecated dependencies are starting to create issues as we upgrade Rails, the asset pipeline  and other dependencies.
This will aid in the migration efforts from govukelements, govuktemplate and govukfrontendtoolkit to the the Design System.

#### How
- Install govuk-frontend via npm
- Run govuk-frontend in compatibility mode until migration is complete
