### PR TITLE
add bootsnap for faster loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'auto_strip_attributes',  '~> 2.6.0'
 gem 'autoprefixer-rails',     '~> 9.7'
 gem 'aws-sdk',                '~> 3'
 gem 'awesome_print'
+gem 'bootsnap', require: false
 gem 'cancancan',              '~> 3.1'
 gem 'cocoon',                 '~> 1.2.13'
 gem 'devise',                 '~> 4.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -869,6 +869,8 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.4.6)
+      msgpack (~> 1.0)
     brakeman (4.8.2)
     builder (3.2.4)
     byebug (11.1.3)
@@ -1187,6 +1189,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    msgpack (1.3.3)
     multi_json (1.14.1)
     multi_test (0.1.2)
     multipart-post (2.1.1)
@@ -1496,6 +1499,7 @@ DEPENDENCIES
   axe-matchers (~> 2.6)
   better_errors
   binding_of_caller
+  bootsnap
   brakeman
   byebug
   cancancan (~> 3.1)


### PR DESCRIPTION
#### What
adds bootsnap gem and use on boot

#### Why
This can have a [large performance benefit](https://github.com/Shopify/bootsnap#performance)
particularly for large apps such as CCCD.

[Rails also adds this as a default since 5.2](https://blog.bigbinary.com/2018/01/01/rails-5-2-adds-bootsnap-to-the-app-to-speed-up-boot-time.html)