### PR TITLE
expose actual_trial_length for api creation of transfer claims

### DIFF
--- a/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
@@ -20,6 +20,9 @@ module API::V1::ExternalUsers
         optional :case_conclusion_id,
                  type: Integer,
                  desc: I18n.t('api.v1.external_users.claims.transfer_claim.params.case_conclusion_id')
+        optional :actual_trial_length,
+                 type: Integer,
+                 desc: I18n.t('api.v1.external_users.claims.transfer_claim.params.actual_trial_length')
       end
 
       namespace :transfer do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2694,6 +2694,7 @@ en:
           transfer_claim:
             params:
               case_conclusion_id: 'REQUIRED/UNREQUIRED: Only required for new litigators that transferred onto unelected cases at specific stages.'
+              actual_trial_length: 'REQUIRED/UNREQUIRED: The total days claimed for the transfer fee.'
       defendant:
         params:
           api_key: 'REQUIRED: The API authentication key of the provider'

--- a/spec/api/v1/external_users/claims/integration/litigator_claim_creation_spec.rb
+++ b/spec/api/v1/external_users/claims/integration/litigator_claim_creation_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe 'API claim creation for LGFS' do
       let(:representation_order_date) { Date.new(2018, 03, 31).as_json }
 
       specify 'Case management system creates a valid scheme 9 transfer fee claim' do
-        post ClaimApiEndpoints.for(:transfer).create, claim_params.merge(offence_id: offence.id, **transfer_detail_params), format: :json
+        post ClaimApiEndpoints.for(:transfer).create, claim_params.merge(offence_id: offence.id, **transfer_detail_params, actual_trial_length: 11), format: :json
         expect(last_response.status).to eql 201
 
         claim = Claim::BaseClaim.find_by(uuid: last_response_uuid)
@@ -389,6 +389,7 @@ RSpec.describe 'API claim creation for LGFS' do
         post endpoint(:expenses), expense_params.merge(claim_id: claim.uuid, expense_type_id: expense_hotel.id), format: :json
         expect(last_response.status).to eql 201
         expect(claim.expenses.size).to eql 2
+        expect(claim.actual_trial_length).to eql 11
         expect(claim).to be_valid_api_lgfs_claim(fee_scheme: ['LGFS', 9], offence: offence, total: 1345.25, vat_amount: 269.05)
       end
     end


### PR DESCRIPTION
#### What
enable transfer claims to be submitted via api with
and actual trial length

#### Ticket

[CBO-1340](https://dsdmoj.atlassian.net/browse/CBO-1340)

#### Why
currently the api does not expose this in swagger docs and a vendor queried this

--------

#### TODO (wip)

 - [X] expose in swagger docs
 - [x] add tests for actual trial length