### PR TITLE
Add panel component helpers using a lib and railtie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,7 @@ group :test do
   gem 'kaminari-rspec'
   gem 'launchy', '~> 2.5.0'
   gem 'rails-controller-testing'
+  gem 'rspec-html-matchers', '~> 0.9.2'
   gem 'rspec-mocks'
   gem 'shoulda-matchers', '>= 4.0.0.rc1'
   gem 'simplecov-csv', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1314,6 +1314,9 @@ GEM
     rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
+    rspec-html-matchers (0.9.2)
+      nokogiri (~> 1)
+      rspec (>= 3.0.0.a, < 4)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -1571,6 +1574,7 @@ DEPENDENCIES
   remotipart (~> 1.4)
   rest-client (~> 2.1)
   rspec-collection_matchers
+  rspec-html-matchers (~> 0.9.2)
   rspec-mocks
   rspec-rails (~> 4.0.1)
   rspec_junit_formatter

--- a/app/views/external_users/claims/confirmation.html.haml
+++ b/app/views/external_users/claims/confirmation.html.haml
@@ -2,12 +2,7 @@
   = t('.page_title')
 
 - present(@claim) do |claim|
-  .govuk-panel.govuk-panel--confirmation
-    %h1.govuk-panel__title
-      = t('.thanks')
-
-    .govuk-panel__body
-      = t('.will_be_processed')
+  = govuk_panel t('.thanks'), t('.will_be_processed')
 
   .claim-confirmation
     %h2.heading-medium

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -544,28 +544,6 @@ Styling for Claims Messaging
   height: 16px;
 }
 
-.govuk-panel--confirmation {
-  background-color: $turquoise;
-  color: $page-colour;
-  text-align: center;
-  padding-top: $gutter * 2;
-  padding-bottom: $gutter * 2;
-  margin-bottom: $gutter;
-
-  .govuk-panel__title {
-    @include core-36;
-    color: $page-colour;
-    font-weight: 700;
-    margin-bottom: $gutter;
-  }
-
-  .govuk-panel__body {
-    @include core-27;
-    color: $page-colour;
-  }
-}
-
-
 .confirmation-tick {
   width: 36px;
   height: 36px;

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,9 +3,13 @@ require_relative 'boot'
 require 'rails/all'
 
 require 'susy'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+# Custom railties that are not gems can be required here
+require_relative '../lib/govuk_component'
 
 module AdvocateDefencePayments
   class Application < Rails::Application

--- a/lib/govuk_component.rb
+++ b/lib/govuk_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module GovukComponent
+  require_relative 'govuk_component/railtie' if defined?(Rails)
+end

--- a/lib/govuk_component/panel_helpers.rb
+++ b/lib/govuk_component/panel_helpers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GovukComponent
+  module PanelHelpers
+    def govuk_panel(title = nil, body = nil, tag_options = {})
+      tag_options = prepend_classes('govuk-panel govuk-panel--confirmation', tag_options)
+
+      tag.div(tag_options) do
+        concat tag.h1(sanitize(title), class: 'govuk-panel__title')
+        concat tag.div(sanitize(body), class: 'govuk-panel__body')
+      end
+    end
+
+    private
+
+    def prepend_classes(classes_to_prepend, options = {})
+      classes = options[:class].present? ? options[:class].split(' ') : []
+      classes.prepend(classes_to_prepend.split(' '))
+      options[:class] = classes.join(' ')
+      options
+    end
+  end
+end

--- a/lib/govuk_component/railtie.rb
+++ b/lib/govuk_component/railtie.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails'
+
+module GovukComponent
+  class Railtie < Rails::Railtie
+    initializer 'govuk_component.panel_helpers' do
+      ActiveSupport.on_load(:action_view) { include GovukComponent::PanelHelpers }
+    end
+  end
+end

--- a/spec/lib/govuk_component/panel_helpers_spec.rb
+++ b/spec/lib/govuk_component/panel_helpers_spec.rb
@@ -1,15 +1,35 @@
 # frozen_string_literal: true
 
 RSpec.describe GovukComponent::PanelHelpers, type: :helper do
-  describe '#govuk_panel' do
-    it 'renders govuk-panel component' do
-      rendered = helper.govuk_panel('Application complete', 'Your reference number<br><strong>HDJ2123F</strong>')
-      expected_markup = '<div class="govuk-panel govuk-panel--confirmation">'\
-                        '<h1 class="govuk-panel__title">Application complete</h1>'\
-                        '<div class="govuk-panel__body">Your reference number<br><strong>HDJ2123F</strong></div>'\
-                        '</div>'
+  include RSpecHtmlMatchers
 
-      expect(rendered).to eql expected_markup
+  describe '#govuk_panel' do
+    subject(:markup) { helper.govuk_panel('My panel heading', 'My content') }
+
+    it 'adds panel with govuk class' do
+      is_expected.to have_tag(:div, with: { class: 'govuk-panel govuk-panel--confirmation' })
+    end
+
+    it 'adds nested h1 tag with govuk class' do
+      is_expected.to have_tag(:div) do
+        with_tag(:h1, with: { class: 'govuk-panel__title' }, text: 'My panel heading')
+      end
+    end
+
+    it 'adds nested div tag with govuk class' do
+      is_expected.to have_tag(:div) do
+        with_tag(:div, with: { class: 'govuk-panel__body' }, text: 'My content')
+      end
+    end
+
+    context 'with custom classes' do
+      subject(:markup) do
+        helper.govuk_panel('My panel heading', 'My content', class: 'my-custom-class1 my-custom-class2')
+      end
+
+      it 'adds panel with custom classes, prepended by govuk class' do
+        is_expected.to have_tag(:div, with: { class: 'govuk-panel govuk-panel--confirmation my-custom-class1 my-custom-class2' })
+      end
     end
   end
 end

--- a/spec/lib/govuk_component/panel_helpers_spec.rb
+++ b/spec/lib/govuk_component/panel_helpers_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukComponent::PanelHelpers, type: :helper do
+  describe '#govuk_panel' do
+    it 'renders govuk-panel component' do
+      rendered = helper.govuk_panel('Application complete', 'Your reference number<br><strong>HDJ2123F</strong>')
+      expected_markup = '<div class="govuk-panel govuk-panel--confirmation">'\
+                        '<h1 class="govuk-panel__title">Application complete</h1>'\
+                        '<div class="govuk-panel__body">Your reference number<br><strong>HDJ2123F</strong></div>'\
+                        '</div>'
+
+      expect(rendered).to eql expected_markup
+    end
+  end
+end


### PR DESCRIPTION
#### What
Add the Govuk Panel component and replace existing markup

#### Ticket
[Add component - Panel](https://dsdmoj.atlassian.net/browse/CBO-1322)

#### Why
Migrating to GDS design system to enable a consistent user experience

#### How
This pattern should make moving to a rails extension
gem easier, and make it easy to add components
in a modular fashion.

The GovukComponent::Railtie class mixes in the
helpers at boot time. see [this good blog on the subject](https://blog.capsens.eu/rails-6-boot-sequence-d289b44d2e94)

To get around the fact that railties need to be
intialized early in the boot sequence the railtie
is `require`'d in the `config/application.rb` (just after
normal Gem `require`ing). Once moved to a gem this can
be removed and would simply work as part of the normal
`Bundler.require(*Rails.groups)` call in that file.
