### PR TITLE
Upgrade deprecated k8s APIs

### DIFF
--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: claim-for-crown-court-defence

--- a/kubernetes_deploy/api-sandbox/ingress.yaml
+++ b/kubernetes_deploy/api-sandbox/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cccd-app-ingress

--- a/kubernetes_deploy/dev-lgfs/deployment.yaml
+++ b/kubernetes_deploy/dev-lgfs/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: claim-for-crown-court-defence

--- a/kubernetes_deploy/dev-lgfs/ingress.yaml
+++ b/kubernetes_deploy/dev-lgfs/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cccd-app-ingress

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: claim-for-crown-court-defence

--- a/kubernetes_deploy/dev/ingress.yaml
+++ b/kubernetes_deploy/dev/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cccd-app-ingress

--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: claim-for-crown-court-defence

--- a/kubernetes_deploy/production/ingress.yaml
+++ b/kubernetes_deploy/production/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cccd-app-ingress

--- a/kubernetes_deploy/scripts/cronjob.sh
+++ b/kubernetes_deploy/scripts/cronjob.sh
@@ -45,7 +45,7 @@ function _cronjob() {
   esac
 
   case "$2" in
-    dev | staging | api-sandbox | production)
+    dev | dev-lgfs | staging | api-sandbox | production)
       environment=$2
       ;;
     *)

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: claim-for-crown-court-defence

--- a/kubernetes_deploy/staging/ingress.yaml
+++ b/kubernetes_deploy/staging/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cccd-app-ingress


### PR DESCRIPTION
#### What
upgrade effect k8s API configuration from 1.15 to 1.16

#### Ticket

[CBO-1346](https://dsdmoj.atlassian.net/browse/CBO-1346)

#### Why
From clud platform
>>As part of the work to upgrade the Kubernetes cluster from 1.15 to 1.16, a number of deprecated APIs have to be removed from the manifests used to create kubernetes resources. This means that users' YAML definitions will need to be updated. We have created a user guide page - Removing Deprecated APIs for Kubernetes version 1.16 explaining the changes users have to make. We have also consolidated the list of objects currently in the cluster which use deprecated APIs in the google spreadsheet . Please check and update your manifests if you have any of the deprecated APIs mentioned in the user guide.We are planning to do the upgrade on the sprint week commencing July 12. If you don’t update your manifests to use the latest API versions before July 12 you will get failures when deploying your applications after we upgrade the cluster to kubernetes 1.16.If you have any questions, please contact us in #ask-cloud-platform.

#### How
applied following [cloud-platform guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#removing-deprecated-apis-for-kubernetes-version-1-16)