### PR TITLE
Fix pcm not applicable error for supplementary claims with ptph fee

### DIFF
--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -74,7 +74,7 @@ module Fee
     end
 
     def validate_pcm_quantity
-      if @record.claim.case_type.try(:allow_pcmh_fee_type?)
+      if @record.claim.supplementary? || @record.claim.case_type.try(:allow_pcmh_fee_type?)
         add_error(:quantity, 'pcm_numericality') if @record.quantity > 3
       else
         add_error(:quantity, 'pcm_not_applicable') unless @record.quantity.zero? || @record.quantity.blank?

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1027,6 +1027,14 @@ misc_fee:
       long: You must specify a whole number for this type of fee
       short: Whole number
       api: You must specify a whole number for this type of fee
+    pcm_invalid:
+      long: Enter a valid quantity for plea and trial preparation hearing
+      short: *enter_valid_quantity
+      api: Enter a valid quantity for plea and trial preparation hearing
+    pcm_numericality:
+      long: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+      short: Enter a valid quantity (1 to 3)
+      api: Enter a valid quantity (1 to 3) for plea and case management hearing fees
 
   case_numbers:
     _seq: 40

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
   let(:ppe_fee) { build :basic_fee, :ppe_fee, claim: claim }
   let(:npw_fee) { build :basic_fee, :npw_fee, claim: claim }
   let(:spf_fee) { build :misc_fee, :spf_fee, claim: claim }
+  let(:supplementary_claim) { build(:advocate_supplementary_claim) }
+  let(:supplementary_pcm_fee) { build :basic_fee, :pcm_fee, claim: supplementary_claim }
 
   before do
     claim.force_validation = true
@@ -394,6 +396,16 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
           it { should_error_if_equal_to_value(pcm_fee, :quantity, 1, 'pcm_not_applicable') }
           it { should_error_if_equal_to_value(pcm_fee, :quantity, -1, 'pcm_not_applicable') }
         end
+      end
+
+      context 'plea and case management hearing (PCM) for supplementary claims' do
+        before(:each) do
+          supplementary_claim.force_validation = true
+        end
+        it { should_error_if_equal_to_value(supplementary_pcm_fee, :quantity, 0, 'pcm_invalid') }
+        it { should_error_if_equal_to_value(supplementary_pcm_fee, :quantity, 4, 'pcm_numericality') }
+        it { should_be_valid_if_equal_to_value(supplementary_pcm_fee, :quantity, 3) }
+        it { should_be_valid_if_equal_to_value(supplementary_pcm_fee, :quantity, 1) }
       end
 
       context 'number of cases uplift (BANOC)' do


### PR DESCRIPTION
#### What
Provider's are currently unable to claim for PTPH on a supplementary claim because they are getting an error 'PCM not applicable'. This fixes that error to allow a provider to claim a quantity of between 1 and 3 PTPH on a supplementary claim (as with final claims). It also fixes the missing validation error messages so that a meaningful error is displayed.

#### Ticket
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=222&projectKey=CBO&modal=detail&selectedIssue=CBO-1163

#### Why
Software vendors have complained about this bug.

#### How
Amended existing validation for PTPH (which is based on case type) to include supplementary claims.
