### PR TITLE
Replace cleaner delegate lists with delegate_missing_to

### DIFF
--- a/app/models/claim/advocate_claim_cleaner.rb
+++ b/app/models/claim/advocate_claim_cleaner.rb
@@ -2,19 +2,7 @@ module Claim
   class AdvocateClaimCleaner
     attr_accessor :claim
 
-    delegate  :from_api?,
-              :case_type,
-              :requires_cracked_dates?,
-              :interim?,
-              :agfs?,
-              :offence,
-              :fixed_fees,
-              :basic_fees,
-              :trial_fixed_notice_at,
-              :trial_fixed_at,
-              :trial_cracked_at,
-              :trial_cracked_at_third,
-              to: :claim
+    delegate_missing_to :claim
 
     def initialize(claim)
       @claim = claim

--- a/app/models/claim/advocate_hardship_claim_cleaner.rb
+++ b/app/models/claim/advocate_hardship_claim_cleaner.rb
@@ -2,13 +2,7 @@ module Claim
   class AdvocateHardshipClaimCleaner
     attr_accessor :claim
 
-    delegate  :case_type,
-              :requires_cracked_dates?,
-              :trial_fixed_notice_at,
-              :trial_fixed_at,
-              :trial_cracked_at,
-              :trial_cracked_at_third,
-              to: :claim
+    delegate_missing_to :claim
 
     def initialize(claim)
       @claim = claim

--- a/app/models/claim/advocate_supplementary_claim_cleaner.rb
+++ b/app/models/claim/advocate_supplementary_claim_cleaner.rb
@@ -2,13 +2,7 @@ module Claim
   class AdvocateSupplementaryClaimCleaner
     attr_accessor :claim
 
-    delegate  :misc_fees,
-              :interim?,
-              :agfs?,
-              :supplementary?,
-              :hardship?,
-              :agfs_reform?,
-              to: :claim
+    delegate_missing_to :claim
 
     def initialize(claim)
       @claim = claim

--- a/app/models/claim/interim_claim_cleaner.rb
+++ b/app/models/claim/interim_claim_cleaner.rb
@@ -2,9 +2,7 @@ module Claim
   class InterimClaimCleaner
     attr_accessor :claim
 
-    delegate  :interim_fee,
-              :disbursements,
-              to: :claim
+    delegate_missing_to :claim
 
     def initialize(claim)
       @claim = claim

--- a/app/models/claim/litigator_claim_cleaner.rb
+++ b/app/models/claim/litigator_claim_cleaner.rb
@@ -2,10 +2,7 @@ module Claim
   class LitigatorClaimCleaner
     attr_accessor :claim
 
-    delegate  :case_type,
-              :graduated_fee,
-              :fixed_fee,
-              to: :claim
+    delegate_missing_to :claim
 
     def initialize(claim)
       @claim = claim

--- a/app/models/claim/litigator_hardship_claim_cleaner.rb
+++ b/app/models/claim/litigator_hardship_claim_cleaner.rb
@@ -2,8 +2,7 @@ module Claim
   class LitigatorHardshipClaimCleaner
     attr_accessor :claim
 
-    delegate :case_type,
-             to: :claim
+    delegate_missing_to :claim
 
     def initialize(claim)
       @claim = claim


### PR DESCRIPTION
#### What
Replace cleaner delegate lists with delegate_missing_to

#### Why
Remove repetetive and fragile manual delegation
with new(ish) rails method.

see this blog for more
https://blog.bigbinary.com/2017/05/30/rails-5-1-adds-delegate-missing-to.html