### PR TITLE
Fix claim case type field

### DIFF
--- a/app/views/external_users/claims/case_details/_case_type_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_case_type_fields.html.haml
@@ -17,4 +17,4 @@
         = t('.case_type_hint')
       = validation_error_message(@error_presenter, :case_type)
 
-    = f.select :case_type_id, @case_types.map{ |ct| [ct.name, ct.id, { data: { 'is-fixed-fee': ct.is_fixed_fee?, 'requires-cracked-dates': ct&.requires_cracked_dates?, 'requires-retrial-dates': ct&.requires_retrial_dates?, 'requires-trial-dates': ct&.requires_trial_dates? } }] }, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', id: 'case_type', 'aria-label': t('.case_type') }
+    = f.select :case_type_id, @case_types.map{ |ct| [ct.name, ct.id, { data: { 'is-fixed-fee': ct.is_fixed_fee?, 'requires-cracked-dates': ct&.requires_cracked_dates?, 'requires-retrial-dates': ct&.requires_retrial_dates?, 'requires-trial-dates': ct&.requires_trial_dates? } }] }, { include_blank: t('.select_option') }, { class: 'form-control', id: 'case_type', 'aria-label': t('.case_type') }

--- a/app/webpack/javascripts/modules/external_users/claims/CaseTypeCtrl.js
+++ b/app/webpack/javascripts/modules/external_users/claims/CaseTypeCtrl.js
@@ -39,7 +39,19 @@ moj.Modules.CaseTypeCtrl = {
   bindEvents: function () {
     var self = this;
 
-    $.subscribe('/onConfirm/case_type-select/', function (e, data) {
+    $('#case_type').change(function () {
+      var selectElement = document.querySelector('#case_type');
+      var selectedOption = $(this).find('option:selected');
+      var selectedText = selectedOption.text();
+      var selectedData = selectedOption.data();
+
+      $.publish('/onChange/case_type/', $.extend({
+        query: selectedText,
+        selectElement: selectElement
+      }, selectedData));
+    });
+
+    $.subscribe('/onChange/case_type/', function (e, data) {
       // Loop over the data object and fire the
       // methods as required, passing in the param
       self.eventCallback(e, data);
@@ -66,7 +78,7 @@ moj.Modules.CaseTypeCtrl = {
     $(this.els.fxAutocomplete).is(function (idx, el) {
       moj.Helpers.Autocomplete.new('#' + el.id, {
         showAllValues: true,
-        autoselect: false
+        autoselect: true
       });
     });
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1021,6 +1021,7 @@ en:
         case_type_fields:
           case_type: Case type
           case_type_hint: For example Trial
+          select_option: Choose a case type
           stage_type: What stage has the case reached?
           agfs_stage_type_hint: For example Trial started but not concluded
         cracked_trial_fields:

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -29,6 +29,7 @@ class ClaimFormPage < BasePage
   section :auto_offence, CommonAutocomplete, "#cc-offence"
 
   element :case_number, "#case_number"
+  element :case_type_dropdown, "#case_type"
 
   section :trial_details, "#trial-dates" do
     section :first_day_of_trial, CommonDateSection, '#first_day_of_trial'

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -16,8 +16,7 @@ When(/^I select the court '(.*?)'$/) do |court_name|
 end
 
 When(/^I select a case type of '(.*?)'$/) do |case_type|
-  @claim_form_page.auto_case_type.choose_autocomplete_option(case_type)
-  wait_for_ajax
+  @claim_form_page.case_type_dropdown.select case_type
 end
 
 When(/^I select a case stage of '(.*?)'$/) do |case_stage|

--- a/spec/javascripts/CaseTypeCtrl_spec.js
+++ b/spec/javascripts/CaseTypeCtrl_spec.js
@@ -70,7 +70,7 @@ describe('Modules.CaseTypeCtrl', function() {
     });
 
     describe('...bindEvents', function() {
-      it('...should `$.subscribe` to `/onConfirm/case_type-select/`', function() {
+      it('...should `$.subscribe` to `/onChange/case_type/`', function() {
         spyOn($, 'subscribe');
 
         CaseTypeCtrl.init();
@@ -95,7 +95,7 @@ describe('Modules.CaseTypeCtrl', function() {
         spyOn(CaseTypeCtrl.actions, 'requiresRetrialDates');
         spyOn(CaseTypeCtrl.actions, 'requiresCrackedDates');
 
-        $.publish('/onConfirm/case_type-select/', {
+        $.publish('/onChange/case_type/', {
           requiresCrackedDates: true,
           requiresRetrialDates: false,
           requiresTrialDates: true


### PR DESCRIPTION
#### What
Values simply typed into Case Type and Court combo boxes are lost on "save and continue"

I've found if you simply type the desired value in the Case Type and Court combo boxed in CCCD then their values are cleared when "Save and Continue" is pressed. This happens for both AGFS and LGFS claims.

#### Ticket

[Court details not saving](https://dsdmoj.atlassian.net/browse/CBO-934)
