### PR TITLE
Add looks like a case number with feature flag

### DIFF
--- a/app/interfaces/api/v1/claim_params_helper.rb
+++ b/app/interfaces/api/v1/claim_params_helper.rb
@@ -10,7 +10,7 @@ module API
         optional :court_id, type: Integer, desc: 'REQUIRED: The unique identifier for this court'
         optional :case_type_id, type: Integer, desc: 'REQUIRED: The unique identifier of the case type'
         optional :offence_id, type: Integer, desc: 'REQUIRED: The unique identifier for this offence.'
-        optional :case_number, type: String, desc: 'REQUIRED: The case number'
+        optional :case_number, type: String, desc: 'REQUIRED: The case number or URN'
         optional :providers_ref, type: String, desc: 'OPTIONAL: Providers reference number'
         optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
         optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
@@ -40,7 +40,7 @@ module API
         use :user_email
         optional :supplier_number, type: String, desc: 'REQUIRED. The supplier number.'
         optional :transfer_court_id, type: Integer, desc: 'OPTIONAL: The unique identifier for the transfer court.'
-        optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number for the transfer court.'
+        optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number or URN for the transfer court.'
       end
 
       params :legacy_agfs_params do

--- a/app/interfaces/api/v1/claim_params_helper.rb
+++ b/app/interfaces/api/v1/claim_params_helper.rb
@@ -10,7 +10,11 @@ module API
         optional :court_id, type: Integer, desc: 'REQUIRED: The unique identifier for this court'
         optional :case_type_id, type: Integer, desc: 'REQUIRED: The unique identifier of the case type'
         optional :offence_id, type: Integer, desc: 'REQUIRED: The unique identifier for this offence.'
-        optional :case_number, type: String, desc: 'REQUIRED: The case number or URN'
+        if Settings.urn_enabled?
+          optional :case_number, type: String, desc: 'REQUIRED: The case number or URN'
+        else
+          optional :case_number, type: String, desc: 'REQUIRED: The case number'
+        end
         optional :providers_ref, type: String, desc: 'OPTIONAL: Providers reference number'
         optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
         optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
@@ -40,7 +44,11 @@ module API
         use :user_email
         optional :supplier_number, type: String, desc: 'REQUIRED. The supplier number.'
         optional :transfer_court_id, type: Integer, desc: 'OPTIONAL: The unique identifier for the transfer court.'
-        optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number or URN for the transfer court.'
+        if Settings.urn_enabled?
+          optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number or URN for the transfer court.'
+        else
+          optional :transfer_case_number, type: String, desc: 'OPTIONAL: The case number for the transfer court.'
+        end
       end
 
       params :legacy_agfs_params do

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -1,5 +1,7 @@
 class BaseValidator < ActiveModel::Validator
   CASE_NUMBER_PATTERN ||= /^[BASTU](199|20\d)\d{5}$/i.freeze
+  CASE_URN_PATTERN ||= /^[A-Za-z0-9]{1,20}$/i.freeze
+  CASE_NUMBER_OR_URN_PATTERN ||= /^[A-Za-z](199|20\d)\d{4,6}$/i.freeze
 
   # Override this method in the derived class
   def validate_step_fields; end
@@ -202,5 +204,10 @@ class BaseValidator < ActiveModel::Validator
   def vat_exceeds_max?(vat:, net:)
     max_vat = VatRate.vat_amount(net, @record.claim.vat_date, calculate: true)
     vat.round(2) > max_vat.round(2)
+  end
+
+  def looks_like_a_case_number?(attribute)
+    return if attr_blank?(attribute)
+    @record.__send__(attribute).match?(CASE_NUMBER_OR_URN_PATTERN)
   end
 end

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -74,8 +74,10 @@ class Claim::BaseClaimValidator < BaseValidator
   def validate_case_number
     @record.case_number&.upcase!
     validate_presence(:case_number, 'blank')
-    validate_pattern(:case_number, CASE_URN_PATTERN, 'invalid')
-    return unless looks_like_a_case_number?(:case_number)
+    if Settings.urn_enabled?
+      validate_pattern(:case_number, CASE_URN_PATTERN, 'invalid_case_number_or_urn')
+      return unless looks_like_a_case_number?(:case_number)
+    end
     validate_pattern(:case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 
@@ -93,8 +95,10 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def validate_transfer_case_number
     return if @record.errors[:transfer_case_number].present?
-    validate_pattern(:transfer_case_number, CASE_URN_PATTERN, 'invalid')
-    return unless looks_like_a_case_number?(:transfer_case_number)
+    if Settings.urn_enabled?
+      validate_pattern(:transfer_case_number, CASE_URN_PATTERN, 'invalid_case_number_or_urn')
+      return unless looks_like_a_case_number?(:transfer_case_number)
+    end
     validate_pattern(:transfer_case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -74,6 +74,8 @@ class Claim::BaseClaimValidator < BaseValidator
   def validate_case_number
     @record.case_number&.upcase!
     validate_presence(:case_number, 'blank')
+    validate_pattern(:case_number, CASE_URN_PATTERN, 'invalid')
+    return unless looks_like_a_case_number?(:case_number)
     validate_pattern(:case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 
@@ -91,6 +93,8 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def validate_transfer_case_number
     return if @record.errors[:transfer_case_number].present?
+    validate_pattern(:transfer_case_number, CASE_URN_PATTERN, 'invalid')
+    return unless looks_like_a_case_number?(:transfer_case_number)
     validate_pattern(:transfer_case_number, CASE_NUMBER_PATTERN, 'invalid')
   end
 

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -50,8 +50,12 @@ module Fee
       end
 
       def validate_case_number(case_number)
-        add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_URN_PATTERN)
-        validate_case_number_pattern(case_number) if case_number.match?(BaseValidator::CASE_NUMBER_OR_URN_PATTERN)
+        if Settings.urn_enabled?
+          add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_URN_PATTERN)
+          validate_case_number_pattern(case_number) if case_number.match?(BaseValidator::CASE_NUMBER_OR_URN_PATTERN)
+        else
+          validate_case_number_pattern(case_number)
+        end
         add_error(:case_numbers, 'eqls_claim_case_number') if case_number.casecmp?(claim.case_number)
       end
 

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -8,8 +8,6 @@
 module Fee
   module Concerns
     module CaseNumbersValidator
-      CASE_NUMBER_PATTERN = BaseValidator::CASE_NUMBER_PATTERN
-
       private
 
       # TODO: At time of writing the AGFS case uplift fee types are
@@ -52,8 +50,13 @@ module Fee
       end
 
       def validate_case_number(case_number)
-        add_error(:case_numbers, 'invalid') unless case_number.match?(CASE_NUMBER_PATTERN)
+        add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_URN_PATTERN)
+        validate_case_number_pattern(case_number) if case_number.match?(BaseValidator::CASE_NUMBER_OR_URN_PATTERN)
         add_error(:case_numbers, 'eqls_claim_case_number') if case_number.casecmp?(claim.case_number)
+      end
+
+      def validate_case_number_pattern(case_number)
+        add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_NUMBER_PATTERN)
       end
     end
   end

--- a/app/validators/fee/concerns/case_numbers_validator.rb
+++ b/app/validators/fee/concerns/case_numbers_validator.rb
@@ -51,12 +51,16 @@ module Fee
 
       def validate_case_number(case_number)
         if Settings.urn_enabled?
-          add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_URN_PATTERN)
-          validate_case_number_pattern(case_number) if case_number.match?(BaseValidator::CASE_NUMBER_OR_URN_PATTERN)
+          validate_case_number_or_urn_pattern(case_number)
         else
           validate_case_number_pattern(case_number)
         end
         add_error(:case_numbers, 'eqls_claim_case_number') if case_number.casecmp?(claim.case_number)
+      end
+
+      def validate_case_number_or_urn_pattern(case_number)
+        add_error(:case_numbers, 'invalid') unless case_number.match?(BaseValidator::CASE_URN_PATTERN)
+        validate_case_number_pattern(case_number) if case_number.match?(BaseValidator::CASE_NUMBER_OR_URN_PATTERN)
       end
 
       def validate_case_number_pattern(case_number)

--- a/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
@@ -13,20 +13,12 @@
     = f.hidden_field :fee_type_id, class: 'js-fee-type'
 
     - if f.object.fee_type.case_uplift?
-      - if Settings.urn_enabled?
-        .form-group
-          = f.adp_text_field :case_numbers,
-            label: t('.case_numbers_or_urns'),
-            input_classes: 'js-basic-fee-case-numbers fx-fee-case-numbers',
-            hint_text: 'Separate by commas',
-            errors: @error_presenter
-      - else
-        .form-group
-          = f.adp_text_field :case_numbers,
-            label: t('.case_numbers'),
-            input_classes: 'js-basic-fee-case-numbers fx-fee-case-numbers',
-            hint_text: 'Separate by commas',
-            errors: @error_presenter
+      .form-group
+        = f.adp_text_field :case_numbers,
+          label: Settings.urn_enabled? ? t('.case_numbers_or_urns') : t('.case_numbers'),
+          input_classes: 'js-basic-fee-case-numbers fx-fee-case-numbers',
+          hint_text: 'Separate by commas',
+          errors: @error_presenter
 
     .form-group
       - fee_type_scope = fee.fee_type_code.downcase

--- a/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
@@ -13,12 +13,20 @@
     = f.hidden_field :fee_type_id, class: 'js-fee-type'
 
     - if f.object.fee_type.case_uplift?
-      .form-group
-        = f.adp_text_field :case_numbers,
-          label: t('.case_numbers'),
-          input_classes: 'js-basic-fee-case-numbers fx-fee-case-numbers',
-          hint_text: 'Separate by commas',
-          errors: @error_presenter
+      - if Settings.urn_enabled?
+        .form-group
+          = f.adp_text_field :case_numbers,
+            label: t('.case_numbers_or_urns'),
+            input_classes: 'js-basic-fee-case-numbers fx-fee-case-numbers',
+            hint_text: 'Separate by commas',
+            errors: @error_presenter
+      - else
+        .form-group
+          = f.adp_text_field :case_numbers,
+            label: t('.case_numbers'),
+            input_classes: 'js-basic-fee-case-numbers fx-fee-case-numbers',
+            hint_text: 'Separate by commas',
+            errors: @error_presenter
 
     .form-group
       - fee_type_scope = fee.fee_type_code.downcase

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -16,11 +16,16 @@
 
     = f.collection_select :court_id, Court.alphabetical, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', id: 'court', 'aria-label': t('.court') }
 
-
-  = f.adp_text_field :case_number,
-    label: t('.case_number'),
-    hint_text: t('.case_number_hint'),
-    errors: @error_presenter
+  - if Settings.urn_enabled?
+    = f.adp_text_field :case_number,
+      label: t('.case_number_or_urn'),
+      hint_text: t('.case_number_or_urn_hint'),
+      errors: @error_presenter
+  - else
+    = f.adp_text_field :case_number,
+      label: t('.case_number'),
+      hint_text: t('.case_number_hint'),
+      errors: @error_presenter
 
   = render partial: 'external_users/claims/case_details/transfer_court_question_fields', locals: { f: f }
 

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -16,16 +16,10 @@
 
     = f.collection_select :court_id, Court.alphabetical, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', id: 'court', 'aria-label': t('.court') }
 
-  - if Settings.urn_enabled?
-    = f.adp_text_field :case_number,
-      label: t('.case_number_or_urn'),
-      hint_text: t('.case_number_or_urn_hint'),
-      errors: @error_presenter
-  - else
-    = f.adp_text_field :case_number,
-      label: t('.case_number'),
-      hint_text: t('.case_number_hint'),
-      errors: @error_presenter
+  = f.adp_text_field :case_number,
+    label: Settings.urn_enabled? ? t('.case_number_or_urn') : t('.case_number'),
+    hint_text: Settings.urn_enabled? ? t('.case_number_or_urn_hint') : t('.case_number_hint'),
+    errors: @error_presenter
 
   = render partial: 'external_users/claims/case_details/transfer_court_question_fields', locals: { f: f }
 

--- a/app/views/external_users/claims/case_details/_transfer_court_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_transfer_court_fields.html.haml
@@ -8,7 +8,7 @@
   = f.collection_select :transfer_court_id, Court.alphabetical, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', 'aria-label': t('.transfer_court') }
 
 .form-group.js-typeahead{ class: error_class?(@error_presenter, :transfer_case_number) }
-  - if Settings.urn_enabled?
-    = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number_or_urn'), hint_text: t('.transfer_case_number_or_urn_hint'), input_classes: '',  errors: @error_presenter
-  - else
-    = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number'), hint_text: t('.transfer_case_number_hint'), input_classes: '',  errors: @error_presenter
+  = f.adp_text_field :transfer_case_number,
+    label: Settings.urn_enabled? ? t('.transfer_case_number_or_urn') : t('.transfer_case_number'),
+    hint_text: Settings.urn_enabled? ? t('.transfer_case_number_or_urn_hint') : t('.transfer_case_number_hint'),
+    input_classes: '', errors: @error_presenter

--- a/app/views/external_users/claims/case_details/_transfer_court_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_transfer_court_fields.html.haml
@@ -8,4 +8,7 @@
   = f.collection_select :transfer_court_id, Court.alphabetical, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control fx-autocomplete', 'aria-label': t('.transfer_court') }
 
 .form-group.js-typeahead{ class: error_class?(@error_presenter, :transfer_case_number) }
-  = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number'), hint_text: t('.transfer_case_number_hint'), input_classes: '',  errors: @error_presenter
+  - if Settings.urn_enabled?
+    = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number_or_urn'), hint_text: t('.transfer_case_number_or_urn_hint'), input_classes: '',  errors: @error_presenter
+  - else
+    = f.adp_text_field :transfer_case_number, label: t('.transfer_case_number'), hint_text: t('.transfer_case_number_hint'), input_classes: '',  errors: @error_presenter

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -9,6 +9,18 @@
 
 %section.api-documentation
   %hr
+  %h2 1st September 2020
+  %ul.list-bullet
+    %li
+      Case Number modified to also accept URNs
+      %br/
+      %br/
+      These are <= 20 characters and alphanumeric
+      %br/
+      %br/
+
+%section.api-documentation
+  %hr
   %h2 12th May 2020
   %ul.list-bullet
     %li
@@ -34,8 +46,6 @@
       %table
         %tr
           %td GET /api/case_stages
-      %br/
-      %br/
 
 %section.api-documentation
   %hr

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -9,7 +9,7 @@
 
 %section.api-documentation
   %hr
-  %h2 1st September 2020
+  %h2 Date TBC
   %ul.list-bullet
     %li
       Case Number modified to also accept URNs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -960,7 +960,7 @@ en:
               Please enter the number of pages of prosecution evidence to help the caseworker assess the correct offence class.
 
         additional_fee_fields:
-          case_numbers: Additional case numbers
+          case_numbers: Additional case numbers or URNs
           quantity: *quantity
           quantity_hint: *empty_input
           add_date_attended: Add another date
@@ -1041,6 +1041,8 @@ en:
           case_number_hint: For example T20170101
           case_type: *case_type
           case_stage: *case_stage
+          case_number: 'Case number or URN'
+          case_number_hint: For example T20170101 or 05PP1000915
           court: 'Court'
           court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
@@ -1052,8 +1054,8 @@ en:
           offence_class: 'Offence class'
           select_offence_class: 'Please select'
         transfer_court_fields:
-          transfer_case_number: Case number
-          transfer_case_number_hint: For example T20170101
+          transfer_case_number: Case number or URN
+          transfer_case_number_hint: For example T20170101 or 05PP1000915
           transfer_court: Court
           transfer_court_hint: For example Cardiff
         transfer_court_question_fields:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -960,7 +960,8 @@ en:
               Please enter the number of pages of prosecution evidence to help the caseworker assess the correct offence class.
 
         additional_fee_fields:
-          case_numbers: Additional case numbers or URNs
+          case_numbers: Additional case numbers
+          case_numbers_or_urns: Additional case numbers or URNs
           quantity: *quantity
           quantity_hint: *empty_input
           add_date_attended: Add another date
@@ -1041,8 +1042,8 @@ en:
           case_number_hint: For example T20170101
           case_type: *case_type
           case_stage: *case_stage
-          case_number: 'Case number or URN'
-          case_number_hint: For example T20170101 or 05PP1000915
+          case_number_or_urn: 'Case number or URN'
+          case_number_or_urn_hint: For example T20170101 or 05PP1000915
           court: 'Court'
           court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
@@ -1054,8 +1055,10 @@ en:
           offence_class: 'Offence class'
           select_offence_class: 'Please select'
         transfer_court_fields:
-          transfer_case_number: Case number or URN
-          transfer_case_number_hint: For example T20170101 or 05PP1000915
+          transfer_case_number: Case number
+          transfer_case_number_hint: For example T20170101
+          transfer_case_number_or_urn: Case number or URN
+          transfer_case_number_or_urn_hint: For example T20170101 or 05PP1000915
           transfer_court: Court
           transfer_court_hint: For example Cardiff
         transfer_court_question_fields:

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -170,13 +170,13 @@ court:
 case_number:
   _seq: 50
   blank:
-    long: Enter a case number for example A20161234
-    short: Enter a case number
-    api: Enter a case number for example A20161234
+    long: Enter a case number or URN
+    short: Enter a case number or URN
+    api: Enter a case number of URN
   invalid:
-    long: The case number must be in the format A20161234
+    long: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
     short: Invalid case number
-    api: The case number must be in the format A20161234
+    api: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
 transfer_court:
   _seq: 55
@@ -195,10 +195,10 @@ transfer_case_number:
     long: Enter a transfer case number for example A20161234
     short: Enter a transfer case number
     api: Enter a transfer case number for example A20161234
-  invalid:
-    long: The transfer case number must be in the format A20161234
+  invalid:  
+    long: The transfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
     short: Invalid transfer case number
-    api: The transfer case number must be in the format A20161234
+    api: The trasfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
 first_day_of_trial:
   _seq: 70

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -170,10 +170,14 @@ court:
 case_number:
   _seq: 50
   blank:
-    long: Enter a case number or URN
-    short: Enter a case number or URN
-    api: Enter a case number of URN
+    long: Enter a case number
+    short: Enter a case number
+    api: Enter a case number
   invalid:
+    long: The case number must be in the format A20161234
+    short: Invalid case number
+    api: The case number must be in the format A20161234
+  invalid_case_number_or_urn:
     long: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
     short: Invalid case number
     api: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -199,10 +199,14 @@ transfer_case_number:
     long: Enter a transfer case number for example A20161234
     short: Enter a transfer case number
     api: Enter a transfer case number for example A20161234
-  invalid:  
+  invalid:
+    long: The transfer case number must be in the format A20161234
+    short: Invalid transfer case number
+    api: The transfer case number must be in the format A20161234
+  invalid_case_number_or_urn:  
     long: The transfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
     short: Invalid transfer case number
-    api: The trasfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
+    api: The transfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
 first_day_of_trial:
   _seq: 70

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -105,7 +105,7 @@ maintenance_mode_enabled?: <%= ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql
 # Feature flag to enable urn
 # If enabled users can enter a urn or case number
 #
-urn_enabled?: true
+urn_enabled?: <%= ENV.fetch('URN_ENABLED', nil)&.downcase&.eql?('true') %>
 
 feature_flags_enabled?: true
 active_features: []

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,12 +95,17 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 # Feature flag to enable ability to set user email notification user preferences.  If true, external
 # users will be able to set preference to say whether they want email notifications of outstanding messages
 # on their claim
-email_notification_enabled?: true
+email_notification_enabled?: false
 
 # Feature flag to enable maintenance mode
 # If enabled all routes mapped to pages#servicedown on startup
 #
 maintenance_mode_enabled?: <%= ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql?('true') %>
+
+# Feature flag to enable urn
+# If enabled users can enter a urn or case number
+#
+urn_enabled?: false
 
 feature_flags_enabled?: true
 active_features: []

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,7 +95,7 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 # Feature flag to enable ability to set user email notification user preferences.  If true, external
 # users will be able to set preference to say whether they want email notifications of outstanding messages
 # on their claim
-email_notification_enabled?: false
+email_notification_enabled?: true
 
 # Feature flag to enable maintenance mode
 # If enabled all routes mapped to pages#servicedown on startup
@@ -105,7 +105,7 @@ maintenance_mode_enabled?: <%= ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql
 # Feature flag to enable urn
 # If enabled users can enter a urn or case number
 #
-urn_enabled?: false
+urn_enabled?: true
 
 feature_flags_enabled?: true
 active_features: []

--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: 'UA-37377084-48'
             - name: MAINTENANCE_MODE
               value: 'false'
+            - name: URN_ENABLED
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/kubernetes_deploy/dev-lgfs/deployment.yaml
+++ b/kubernetes_deploy/dev-lgfs/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: 'UA-37377084-48'
             - name: MAINTENANCE_MODE
               value: 'false'
+            - name: URN_ENABLED
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: 'UA-37377084-48'
             - name: MAINTENANCE_MODE
               value: 'false'
+            - name: URN_ENABLED
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: 'UA-37377084-37'
             - name: MAINTENANCE_MODE
               value: 'false'
+            - name: URN_ENABLED
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: 'UA-37377084-48'
             - name: MAINTENANCE_MODE
               value: 'false'
+            - name: URN_ENABLED
+              value: 'false'
             - name: SETTINGS__SLACK__BOT_NAME
               value: 'Injectotron'
             - name: SETTINGS__SLACK__FAIL_ICON

--- a/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
@@ -70,67 +70,73 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
     end
   end
 
-  it 'returns 400 and JSON error when URN is too long' do
-    valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHIJA'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(400)
-    body = last_response.body
-    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
-  end
+  context 'urn feature flag enabled' do
+    before do
+      allow(Settings).to receive(:urn_enabled?).and_return(true)
+    end
+    
+    it 'returns 400 and JSON error when URN is too long' do
+      valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHIJA'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+    end
 
-  it 'returns 400 and JSON error when URN contains a special character' do
-    valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHI_'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(400)
-    body = last_response.body
-    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
-  end
+    it 'returns 400 and JSON error when URN contains a special character' do
+      valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHI_'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+    end
 
-  it 'returns 400 and JSON error when the case number does not start with a BAST or U' do
-    valid_params[:case_number] = 'G20209876'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(400)
-    body = last_response.body
-    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
-  end
+    it 'returns 400 and JSON error when the case number does not start with a BAST or U' do
+      valid_params[:case_number] = 'G20209876'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be in the format A20161234")
+    end
 
-  it 'returns 400 and JSON error when the case number is too long' do
-    valid_params[:case_number] = 'T202098761'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(400)
-    body = last_response.body
-    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
-  end
+    it 'returns 400 and JSON error when the case number is too long' do
+      valid_params[:case_number] = 'T202098761'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be in the format A20161234")
+    end
 
-  it 'returns 400 and JSON error when the case number is too short' do
-    valid_params[:case_number] = 'T2020987'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(400)
-    body = last_response.body
-    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
-  end
+    it 'returns 400 and JSON error when the case number is too short' do
+      valid_params[:case_number] = 'T2020987'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be in the format A20161234")
+    end
 
-  it 'returns 200 and valid when case_number is a valid common platform URN' do
-    valid_params[:case_number] = 'ABCDEFGHIJ1234567890'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(200)
-    body = last_response.body
-    expect(body).to include("valid")
-  end
+    it 'returns 200 and valid when case_number is a valid common platform URN' do
+      valid_params[:case_number] = 'ABCDEFGHIJ1234567890'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(200)
+      body = last_response.body
+      expect(body).to include("valid")
+    end
 
-  it 'returns 200 and valid when the URN is a valid URN containing a year' do
-    valid_params[:case_number] = '120207575'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(200)
-    body = last_response.body
-    expect(body).to include("valid")
-  end
+    it 'returns 200 and valid when the URN is a valid URN containing a year' do
+      valid_params[:case_number] = '120207575'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(200)
+      body = last_response.body
+      expect(body).to include("valid")
+    end
 
-  it 'returns 200 and valid when case_number is a valid case number' do
-    valid_params[:case_number] = 'T20202601'
-    post_to_validate_endpoint
-    expect(last_response.status).to eq(200)
-    body = last_response.body
-    expect(body).to include("valid")
+    it 'returns 200 and valid when case_number is a valid case number' do
+      valid_params[:case_number] = 'T20202601'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(200)
+      body = last_response.body
+      expect(body).to include("valid")
+    end
   end
 end

--- a/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
@@ -70,6 +70,52 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
     end
   end
 
+  context 'urn feature flag disabled' do
+    before do
+      allow(Settings).to receive(:urn_enabled?).and_return(false)
+    end
+    
+    it 'returns 400 and JSON error when the case number does not start with a BAST or U' do
+      valid_params[:case_number] = 'G20209876'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be in the format A20161234")
+    end
+
+    it 'returns 400 and JSON error when the case number is too long' do
+      valid_params[:case_number] = 'T202098761'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be in the format A20161234")
+    end
+
+    it 'returns 400 and JSON error when the case number is too short' do
+      valid_params[:case_number] = 'T2020987'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be in the format A20161234")
+    end
+
+    it 'returns 400 and JSON error when the case number is a valid common platform URN' do
+      valid_params[:case_number] = 'ABCDEFGHIJ1234567890'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(400)
+      body = last_response.body
+      expect(body).to include("The case number must be in the format A20161234")
+    end
+
+    it 'returns 200 and valid when case_number is a valid case number' do
+      valid_params[:case_number] = 'T20202601'
+      post_to_validate_endpoint
+      expect(last_response.status).to eq(200)
+      body = last_response.body
+      expect(body).to include("valid")
+    end
+  end
+
   context 'urn feature flag enabled' do
     before do
       allow(Settings).to receive(:urn_enabled?).and_return(true)

--- a/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
       :offence_id => offence.id,
       :court_id => court.id } }
 
+  subject(:post_to_validate_endpoint) { post ClaimApiEndpoints.for(FINAL_CLAIM_ENDPOINT).validate, valid_params, format: :json }
+
   after(:all) { clean_database }
 
   include_examples 'advocate claim test setup'
@@ -42,9 +44,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
  
   # TODO: write a generic date error handling spec and share
   describe "POST #{ClaimApiEndpoints.for(FINAL_CLAIM_ENDPOINT).validate}" do
-    subject(:post_to_validate_endpoint) do
-      post ClaimApiEndpoints.for(FINAL_CLAIM_ENDPOINT).validate, valid_params, format: :json
-    end
 
     it 'returns 400 and JSON error when dates are not in acceptable format' do
       valid_params[:first_day_of_trial] = '01-01-2015'
@@ -69,5 +68,69 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
         expect(body).to include(error)
       end
     end
+  end
+
+  it 'returns 400 and JSON error when URN is too long' do
+    valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHIJA'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when URN contains a special character' do
+    valid_params[:case_number] = 'ABCDEFGHIJABCDEFGHI_'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when the case number does not start with a BAST or U' do
+    valid_params[:case_number] = 'G20209876'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when the case number is too long' do
+    valid_params[:case_number] = 'T202098761'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 400 and JSON error when the case number is too short' do
+    valid_params[:case_number] = 'T2020987'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(400)
+    body = last_response.body
+    expect(body).to include("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)")
+  end
+
+  it 'returns 200 and valid when case_number is a valid common platform URN' do
+    valid_params[:case_number] = 'ABCDEFGHIJ1234567890'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(200)
+    body = last_response.body
+    expect(body).to include("valid")
+  end
+
+  it 'returns 200 and valid when the URN is a valid URN containing a year' do
+    valid_params[:case_number] = '120207575'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(200)
+    body = last_response.body
+    expect(body).to include("valid")
+  end
+
+  it 'returns 200 and valid when case_number is a valid case number' do
+    valid_params[:case_number] = 'T20202601'
+    post_to_validate_endpoint
+    expect(last_response.status).to eq(200)
+    body = last_response.body
+    expect(body).to include("valid")
   end
 end

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
     "source" => 'web',
     "case_type_id" => case_type.id.to_s,
     "court_id" => court.id.to_s,
-    "case_number" => "CASE98989",
+    "case_number" => "CASE98989-",
     "advocate_category" => "QC",
     "offence_class_id" => "2",
     "offence_id" => offence.id.to_s,

--- a/spec/services/claims/update_claim_spec.rb
+++ b/spec/services/claims/update_claim_spec.rb
@@ -66,7 +66,7 @@ describe Claims::UpdateClaim do
     end
 
     context 'unsuccessful updates' do
-      let(:claim_params) { { case_number: '123' } }
+      let(:claim_params) { { case_number: '123456789012345678901' } }
 
       it 'is unsuccessful' do
         expect(subject.claim).not_to receive(:update_claim_document_owners)

--- a/spec/services/claims/update_draft_spec.rb
+++ b/spec/services/claims/update_draft_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Claims::UpdateDraft do
     end
 
     context 'unsuccessful draft updates' do
-      let(:claim_params) { { case_number: '123' } }
+      let(:claim_params) { { case_number: '123/' } }
 
       it 'is unsuccessful' do
         subject.call

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -262,10 +262,8 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
       context "existing but invalid value" do
         it "response 400 and JSON error array of model validation BLANK errors" do
           valid_params[:court_id] = -1
-          # valid_params[:case_number] = -1
           post_to_create_endpoint
           expect_error_response("Choose a court", 0)
-          # expect_error_response("The case number must be in the format A20161234", 1)
         end
 
         it "response 400 and JSON error array of model validation INVALID errors" do

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -265,7 +265,7 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
           valid_params[:case_number] = -1
           post_to_create_endpoint
           expect_error_response("Choose a court", 0)
-          expect_error_response("The case number must be in the format A20161234", 1)
+          expect_error_response("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)", 1)
         end
 
         it "response 400 and JSON error array of model validation INVALID errors" do

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -258,14 +258,14 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
           expect{ post_to_create_endpoint }.not_to change { claim_class.active.count }
         end
       end
-
+     
       context "existing but invalid value" do
         it "response 400 and JSON error array of model validation BLANK errors" do
           valid_params[:court_id] = -1
-          valid_params[:case_number] = -1
+          # valid_params[:case_number] = -1
           post_to_create_endpoint
           expect_error_response("Choose a court", 0)
-          expect_error_response("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)", 1)
+          # expect_error_response("The case number must be in the format A20161234", 1)
         end
 
         it "response 400 and JSON error array of model validation INVALID errors" do
@@ -274,6 +274,30 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
           post_to_create_endpoint
           expect_error_response("Choose a court", 0)
           expect_error_response("Enter a case number", 1)
+        end
+      end
+
+      context 'urn feature flag disabled' do
+        before do
+          allow(Settings).to receive(:urn_enabled?).and_return(false)
+        end
+       
+        it "response 400 and JSON error array of model validation BLANK errors" do
+          valid_params[:case_number] = -1
+          post_to_create_endpoint
+          expect_error_response("The case number must be in the format A20161234", 0)
+        end
+      end
+
+      context 'urn feature flag enabled' do
+        before do
+          allow(Settings).to receive(:urn_enabled?).and_return(true)
+        end
+        
+        it "response 400 and JSON error array of model validation BLANK errors" do
+          valid_params[:case_number] = -1
+          post_to_create_endpoint
+          expect_error_response("The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)", 0)
         end
       end
 

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -58,33 +58,55 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
       before do
         noc_fee.claim.source = 'api'
       end
+      
+      context 'urn feature flag disabled' do
+        before do
+          allow(Settings).to receive(:urn_enabled?).and_return(false)
+        end
+      
+        it 'when case_numbers is blank and quantity is not zero' do
+          noc_fee.quantity = 1
+          should_not_error(noc_fee, :case_numbers)
+        end
 
-      it 'when case_numbers is blank and quantity is not zero' do
-        noc_fee.quantity = 1
-        should_not_error(noc_fee, :case_numbers)
-      end
-    end
-  
-    it 'when single valid format of case number entered' do
-        noc_fee.case_numbers = 'A20161234'
-        should_not_error(noc_fee, :case_numbers)
-    end
-   
-    context 'urn feature flag enabled' do
-      before do
-        allow(Settings).to receive(:urn_enabled?).and_return(true)
+        it 'when single valid format of case number entered' do
+          noc_fee.case_numbers = 'A20161234'
+          should_not_error(noc_fee, :case_numbers)
+        end
+
+        it 'when quantity and number of additional cases match' do
+          noc_fee.quantity = 2
+          noc_fee.case_numbers = 'A20161234,T20171234'
+          should_not_error(noc_fee, :case_numbers)
+        end
       end
 
-      it 'when single valid format of URN entered' do
-        noc_fee.case_numbers = '1234567890AAAAAAAAAA'
-        should_not_error(noc_fee, :case_numbers)
-      end
-    end
+      context 'urn feature flag enabled' do
+        before do
+          allow(Settings).to receive(:urn_enabled?).and_return(true)
+        end
 
-    it 'when quantity and number of additional cases match' do
-      noc_fee.quantity = 2
-      noc_fee.case_numbers = 'A20161234,T20171234'
-      should_not_error(noc_fee, :case_numbers)
+        it 'when case_numbers is blank and quantity is not zero' do
+          noc_fee.quantity = 1
+          should_not_error(noc_fee, :case_numbers)
+        end
+
+        it 'when single valid format of case number entered' do
+          noc_fee.case_numbers = 'A20161234'
+          should_not_error(noc_fee, :case_numbers)
+        end
+
+        it 'when single valid format of URN entered' do
+          noc_fee.case_numbers = '1234567890AAAAAAAAAA'
+          should_not_error(noc_fee, :case_numbers)
+        end
+
+        it 'when quantity and number of additional cases match' do
+          noc_fee.quantity = 2
+          noc_fee.case_numbers = 'A20161234,1234567890AAAAAAAAAA'
+          should_not_error(noc_fee, :case_numbers)
+        end
+      end
     end
   end
 
@@ -93,24 +115,6 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
       noc_fee.quantity = 1
       noc_fee.case_numbers = ''
       should_error_with(noc_fee, :case_numbers, 'blank')
-    end
-
-    it 'when a single invalid format of case number entered' do
-      should_error_if_equal_to_value(noc_fee, :case_numbers, 'G20208765', 'invalid')
-    end
-    
-    it 'when a single invalid format of URN entered' do
-      should_error_if_equal_to_value(noc_fee, :case_numbers, '12 3', 'invalid')
-    end
-
-    it 'when any case number is of invalid format' do
-      noc_fee.case_numbers = 'A20161234,Z123*,A20158888'
-      should_error_with(noc_fee, :case_numbers, 'invalid')
-    end
-
-    it 'when any URN is of invalid format' do
-      noc_fee.case_numbers = 'ABCDEFGHIJ,Z123*,1234567890'
-      should_error_with(noc_fee, :case_numbers, 'invalid')
     end
 
     it 'when case_numbers is not blank and quantity is 0' do
@@ -128,6 +132,54 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
       noc_fee.case_numbers = claim.case_number
       should_error_with(noc_fee, :case_numbers, 'eqls_claim_case_number')
     end
+
+    context 'urn feature flag disabled' do
+      before do
+        allow(Settings).to receive(:urn_enabled?).and_return(false)
+      end
+
+      it 'when a single invalid format of case number entered' do
+        should_error_if_equal_to_value(noc_fee, :case_numbers, 'G20208765', 'invalid')
+      end
+
+      it 'when a single invalid format of URN entered' do
+        should_error_if_equal_to_value(noc_fee, :case_numbers, '12 3', 'invalid')
+      end
+
+      it 'when any case number is of invalid format' do
+        noc_fee.case_numbers = 'A20161234,Z123*,A20158888'
+        should_error_with(noc_fee, :case_numbers, 'invalid')
+      end
+
+      it 'when any URN is of invalid format' do
+        noc_fee.case_numbers = 'ABCDEFGHIJ,Z123*,1234567890'
+        should_error_with(noc_fee, :case_numbers, 'invalid')
+      end
+    end
+
+    context 'urn feature flag enabled' do
+      before do
+        allow(Settings).to receive(:urn_enabled?).and_return(true)
+      end
+
+      it 'when a single invalid format of case number entered' do
+        should_error_if_equal_to_value(noc_fee, :case_numbers, 'G20208765', 'invalid')
+      end
+
+      it 'when a single invalid format of URN entered' do
+        should_error_if_equal_to_value(noc_fee, :case_numbers, '12 3', 'invalid')
+      end
+
+      it 'when any case number is of invalid format' do
+        noc_fee.case_numbers = 'A20161234,Z123*,A20158888'
+        should_error_with(noc_fee, :case_numbers, 'invalid')
+      end
+
+      it 'when any URN is of invalid format' do
+        noc_fee.case_numbers = 'ABCDEFGHIJ,Z123*,1234567890'
+        should_error_with(noc_fee, :case_numbers, 'invalid')
+      end
+    end 
   end
 
   context 'when there is more than one case uplift' do

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -64,15 +64,21 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
         should_not_error(noc_fee, :case_numbers)
       end
     end
-
+  
     it 'when single valid format of case number entered' do
-      noc_fee.case_numbers = 'A20161234'
-      should_not_error(noc_fee, :case_numbers)
+        noc_fee.case_numbers = 'A20161234'
+        should_not_error(noc_fee, :case_numbers)
     end
+   
+    context 'urn feature flag enabled' do
+      before do
+        allow(Settings).to receive(:urn_enabled?).and_return(true)
+      end
 
-    it 'when single valid format of URN entered' do
-      noc_fee.case_numbers = '1234567890AAAAAAAAAA'
-      should_not_error(noc_fee, :case_numbers)
+      it 'when single valid format of URN entered' do
+        noc_fee.case_numbers = '1234567890AAAAAAAAAA'
+        should_not_error(noc_fee, :case_numbers)
+      end
     end
 
     it 'when quantity and number of additional cases match' do

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -70,6 +70,11 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
       should_not_error(noc_fee, :case_numbers)
     end
 
+    it 'when single valid format of URN entered' do
+      noc_fee.case_numbers = '1234567890AAAAAAAAAA'
+      should_not_error(noc_fee, :case_numbers)
+    end
+
     it 'when quantity and number of additional cases match' do
       noc_fee.quantity = 2
       noc_fee.case_numbers = 'A20161234,T20171234'
@@ -85,11 +90,20 @@ RSpec.shared_examples 'common AGFS number of cases uplift validations' do
     end
 
     it 'when a single invalid format of case number entered' do
-      should_error_if_equal_to_value(noc_fee, :case_numbers, '123', 'invalid')
+      should_error_if_equal_to_value(noc_fee, :case_numbers, 'G20208765', 'invalid')
+    end
+    
+    it 'when a single invalid format of URN entered' do
+      should_error_if_equal_to_value(noc_fee, :case_numbers, '12 3', 'invalid')
     end
 
     it 'when any case number is of invalid format' do
-      noc_fee.case_numbers = 'A20161234,Z123,A20158888'
+      noc_fee.case_numbers = 'A20161234,Z123*,A20158888'
+      should_error_with(noc_fee, :case_numbers, 'invalid')
+    end
+
+    it 'when any URN is of invalid format' do
+      noc_fee.case_numbers = 'ABCDEFGHIJ,Z123*,1234567890'
       should_error_with(noc_fee, :case_numbers, 'invalid')
     end
 

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -95,10 +95,27 @@ RSpec.describe 'Advocate interim claim WEB validations' do
     context 'but case number is invalid' do
       let(:attributes) { valid_attributes.merge(case_number: 'invalid-cn') }
 
-      specify {
-        is_expected.to be_invalid
-        expect(claim.errors[:case_number]).to match_array(['invalid'])
-      }
+      context 'urn feature flag disabled' do
+        before do
+          allow(Settings).to receive(:urn_enabled?).and_return(false)
+        end
+
+        specify {
+          is_expected.to be_invalid
+          expect(claim.errors[:case_number]).to match_array(['invalid'])
+        }
+      end
+
+      context 'urn feature flag enabled' do
+        before do
+          allow(Settings).to receive(:urn_enabled?).and_return(true)
+        end
+
+        specify {
+          is_expected.to be_invalid
+          expect(claim.errors[:case_number]).to match_array(['invalid_case_number_or_urn'])
+        }
+      end
     end
 
     context 'when case was transferred from another court' do
@@ -147,11 +164,28 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       context 'but the transfer case number is invalid' do
         let(:attributes) { valid_attributes.merge(transfer_case_number: 'invalid-tcn') }
+        
+        context 'urn feature flag disabled' do
+          before do
+            allow(Settings).to receive(:urn_enabled?).and_return(false)
+          end
+    
+          specify {
+            is_expected.to be_invalid
+            expect(claim.errors[:transfer_case_number]).to match_array(['invalid'])
+          }
+        end
 
-        specify {
-          is_expected.to be_invalid
-          expect(claim.errors[:transfer_case_number]).to match_array(['invalid'])
-        }
+        context 'urn feature flag enabled' do
+          before do
+            allow(Settings).to receive(:urn_enabled?).and_return(true)
+          end
+    
+          specify {
+            is_expected.to be_invalid
+            expect(claim.errors[:transfer_case_number]).to match_array(['invalid_case_number_or_urn'])
+          }
+        end
       end
     end
   end

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -255,23 +255,29 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       end
     end
   end
-
-  context 'with unique reference numbers' do
-    it 'should not error if valid' do
-      claim.case_number = 'ABCDEFGHIJ1234567890'
-      expect(claim).to be_valid
+  
+  context 'urn feature flag enabled' do
+    before do
+      allow(Settings).to receive(:urn_enabled?).and_return(true)
     end
-
-    it 'is invalid if contains non alphanumeric characters' do
-      %w(_ - * ? ,).each do |character|
-        claim.case_number = 'KLMNOPQRST134456789' + character
-        should_error_with(claim, :case_number, 'invalid')
+  
+    context 'with unique reference numbers' do
+      it 'should not error if valid' do
+        claim.case_number = 'ABCDEFGHIJ1234567890'
+        expect(claim).to be_valid
       end
-    end
 
-    it 'is invalid if the URN is too long' do
-      claim.case_number = '1234567890UVWXYZABCDE'
-      should_error_with(claim, :case_number, 'invalid')
+      it 'is invalid if contains non alphanumeric characters' do
+        %w(_ - * ? ,).each do |character|
+          claim.case_number = 'KLMNOPQRST134456789' + character
+          should_error_with(claim, :case_number, 'invalid_case_number_or_urn')
+        end
+      end
+
+      it 'is invalid if the URN is too long' do
+        claim.case_number = '1234567890UVWXYZABCDE'
+        should_error_with(claim, :case_number, 'invalid_case_number_or_urn')
+      end
     end  
   end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -213,43 +213,50 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
   end
 
   context 'case_number' do
-    it 'should error if not present' do
-      claim.case_number = nil
-      should_error_with(claim, :case_number, "blank")
-    end
+    context 'urn feature flag disabled' do
 
-    it 'should not error if valid' do
-      claim.case_number = 'T20161234'
-      expect(claim).to be_valid
-    end
+      before do
+        allow(Settings).to receive(:urn_enabled?).and_return(false)
+      end
 
-    it 'should error if too short' do
-      claim.case_number = 'T2020432'
-      should_error_with(claim, :case_number, 'invalid')
-    end
+      it 'should error if not present' do
+        claim.case_number = nil
+        should_error_with(claim, :case_number, "blank")
+      end
 
-    it 'should error if too long' do
-      claim.case_number = 'T202043298'
-      should_error_with(claim, :case_number, 'invalid')
-    end
+      it 'should not error if valid' do
+        claim.case_number = 'T20161234'
+        expect(claim).to be_valid
+      end
 
-    it 'should error if it doesnt start with BAST or U' do
-      claim.case_number = 'G20204321'
-      should_error_with(claim, :case_number, 'invalid')
-    end
+      it 'should error if too short' do
+        claim.case_number = 'T2020432'
+        should_error_with(claim, :case_number, 'invalid')
+      end
 
-    it 'upcases the first letter and does not error' do
-      claim.case_number = 't20161234'
-      expect(claim).to be_valid
-      expect(claim.case_number).to eq 'T20161234'
-    end
+      it 'should error if too long' do
+        claim.case_number = 'T202043298'
+        should_error_with(claim, :case_number, 'invalid')
+      end
 
-    it 'validates against the regex' do
-      %w(A S T U).each do |letter|
-        (1990..2020).each do |year|
-          %w(0001 1111 9999).each do |number|
-            case_number = [letter, year, number].join
-            expect(case_number.match(BaseValidator::CASE_NUMBER_PATTERN)).to be_truthy
+      it 'should error if it doesnt start with BAST or U' do
+        claim.case_number = 'G20204321'
+        should_error_with(claim, :case_number, 'invalid')
+      end
+
+      it 'upcases the first letter and does not error' do
+        claim.case_number = 't20161234'
+        expect(claim).to be_valid
+        expect(claim.case_number).to eq 'T20161234'
+      end
+
+      it 'validates against the regex' do
+        %w(A S T U).each do |letter|
+          (1990..2020).each do |year|
+            %w(0001 1111 9999).each do |number|
+              case_number = [letter, year, number].join
+              expect(case_number.match(BaseValidator::CASE_NUMBER_PATTERN)).to be_truthy
+            end
           end
         end
       end
@@ -259,6 +266,11 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
   context 'urn feature flag enabled' do
     before do
       allow(Settings).to receive(:urn_enabled?).and_return(true)
+    end
+
+    it 'should error if not present' do
+      claim.case_number = nil
+      should_error_with(claim, :case_number, "blank")
     end
   
     context 'with unique reference numbers' do
@@ -278,7 +290,46 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         claim.case_number = '1234567890UVWXYZABCDE'
         should_error_with(claim, :case_number, 'invalid_case_number_or_urn')
       end
-    end  
+    end
+
+    context 'with case numbers' do
+      it 'should not error if valid' do
+        claim.case_number = 'T20161234'
+        expect(claim).to be_valid
+      end
+
+      it 'should error if too short' do
+        claim.case_number = 'T2020432'
+        should_error_with(claim, :case_number, 'invalid')
+      end
+
+      it 'should error if too long' do
+        claim.case_number = 'T202043298'
+        should_error_with(claim, :case_number, 'invalid')
+      end
+
+      it 'should error if it doesnt start with BAST or U' do
+        claim.case_number = 'G20204321'
+        should_error_with(claim, :case_number, 'invalid')
+      end
+
+      it 'upcases the first letter and does not error' do
+        claim.case_number = 't20161234'
+        expect(claim).to be_valid
+        expect(claim.case_number).to eq 'T20161234'
+      end
+
+      it 'validates against the regex' do
+        %w(A S T U).each do |letter|
+          (1990..2020).each do |year|
+            %w(0001 1111 9999).each do |number|
+              case_number = [letter, year, number].join
+              expect(case_number.match(BaseValidator::CASE_NUMBER_PATTERN)).to be_truthy
+            end
+          end
+        end
+      end
+    end 
   end
 
   context 'estimated_trial_length' do

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -223,8 +223,18 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
       expect(claim).to be_valid
     end
 
-    it 'should error if invalid' do
-      claim.case_number = 'T87654321'
+    it 'should error if too short' do
+      claim.case_number = 'T2020432'
+      should_error_with(claim, :case_number, 'invalid')
+    end
+
+    it 'should error if too long' do
+      claim.case_number = 'T202043298'
+      should_error_with(claim, :case_number, 'invalid')
+    end
+
+    it 'should error if it doesnt start with BAST or U' do
+      claim.case_number = 'G20204321'
       should_error_with(claim, :case_number, 'invalid')
     end
 
@@ -244,6 +254,25 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         end
       end
     end
+  end
+
+  context 'with unique reference numbers' do
+    it 'should not error if valid' do
+      claim.case_number = 'ABCDEFGHIJ1234567890'
+      expect(claim).to be_valid
+    end
+
+    it 'is invalid if contains non alphanumeric characters' do
+      %w(_ - * ? ,).each do |character|
+        claim.case_number = 'KLMNOPQRST134456789' + character
+        should_error_with(claim, :case_number, 'invalid')
+      end
+    end
+
+    it 'is invalid if the URN is too long' do
+      claim.case_number = '1234567890UVWXYZABCDE'
+      should_error_with(claim, :case_number, 'invalid')
+    end  
   end
 
   context 'estimated_trial_length' do

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -81,7 +81,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     end
 
     it 'should error if wrong format' do
-      claim.transfer_case_number = 'ABC'
+      claim.transfer_case_number = 'ABC_'
       should_error_with(claim, :transfer_case_number, 'invalid')
     end
 
@@ -109,7 +109,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
 
         context 'and transfer case number has an invalid format' do
           before do
-            claim.transfer_case_number = 'ABC'
+            claim.transfer_case_number = 'ABC_'
           end
 
           it 'contains an invalid error on transfer case number' do

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -80,9 +80,26 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
       should_not_error(claim, :transfer_case_number)
     end
 
-    it 'should error if wrong format' do
-      claim.transfer_case_number = 'ABC_'
-      should_error_with(claim, :transfer_case_number, 'invalid')
+    context 'urn feature flag disabled' do
+      before do
+        allow(Settings).to receive(:urn_enabled?).and_return(false)
+      end
+
+      it 'should error if wrong format' do
+        claim.transfer_case_number = 'ABC_'
+        should_error_with(claim, :transfer_case_number, 'invalid')
+      end
+    end
+
+    context 'urn feature flag enabled' do
+      before do
+        allow(Settings).to receive(:urn_enabled?).and_return(true)
+      end
+
+      it 'should error if wrong format' do
+        claim.transfer_case_number = 'ABC_'
+        should_error_with(claim, :transfer_case_number, 'invalid_case_number_or_urn')
+      end
     end
 
     context 'when case was transferred from another court' do
@@ -112,8 +129,24 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
             claim.transfer_case_number = 'ABC_'
           end
 
-          it 'contains an invalid error on transfer case number' do
-            should_error_with(claim, :transfer_case_number, 'invalid')
+          context 'urn feature flag disabled' do
+            before do
+              allow(Settings).to receive(:urn_enabled?).and_return(false)
+            end
+
+            it 'contains an invalid error on transfer case number' do
+              should_error_with(claim, :transfer_case_number, 'invalid')
+            end
+          end
+
+          context 'urn feature flag enabled' do
+            before do
+              allow(Settings).to receive(:urn_enabled?).and_return(true)
+            end
+
+            it 'contains an invalid error on transfer case number' do
+              should_error_with(claim, :transfer_case_number, 'invalid_case_number_or_urn')
+            end
           end
         end
       end

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -85,6 +85,11 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
         allow(Settings).to receive(:urn_enabled?).and_return(false)
       end
 
+      it 'should NOT error if valid case_number' do
+        claim.transfer_case_number = 'A20161234'
+        should_not_error(claim, :transfer_case_number)
+      end
+
       it 'should error if wrong format' do
         claim.transfer_case_number = 'ABC_'
         should_error_with(claim, :transfer_case_number, 'invalid')
@@ -94,6 +99,16 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     context 'urn feature flag enabled' do
       before do
         allow(Settings).to receive(:urn_enabled?).and_return(true)
+      end
+
+      it 'should NOT error if valid case_number' do
+        claim.transfer_case_number = 'A20161234'
+        should_not_error(claim, :transfer_case_number)
+      end
+
+      it 'should NOT error if valid URN' do
+        claim.transfer_case_number = 'ABCDEFGHIJ1234567890'
+        should_not_error(claim, :transfer_case_number)
       end
 
       it 'should error if wrong format' do


### PR DESCRIPTION
#### What
Allow users to record a Common Platform URN or Case Number, and add a feature flag to enable this functionality to be turned on/off.

See also https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/3231

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1441
https://dsdmoj.atlassian.net/browse/CBO-1266

#### Why
To allow users to enter Common Platform URNs in the current case number field, and to attempt to ensure that in the short to medium term users do not enter too many invalid case numbers.

To enable the URN functionality to be turned on and off so that it can be released into production turned off, and then turned on when Common Platform goes live.

#### How
Add looks_like_a_case_number? functionality to validate that when users enter a Case numbers or URN that looks similar to a current case number these are validated against the current pattern for case numbers. The format for the CN_PATTERN regex may need changing if it rejects too many valid URNs.

Add urn_enabled? feature flag to turn the URN enabled functionality on or off.