### PR TITLE
Move agfs schme 12 release date to end of september

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -109,7 +109,7 @@ reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).ch
 
 agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
 agfs_scheme_11_release_date: <%= Date.new(2018, 12, 31) %>
-agfs_scheme_12_release_date: <%= Date.new(2020, 8, 31) %>
+agfs_scheme_12_release_date: <%= Date.new(2020, 10, 1) %>
 agfs_scheme_12_enabled?: <%= ENV.fetch('AGFS_TWELVE_ENABLED', 'false')&.downcase&.eql?('true') %>
 
 # number of weeks in one state before automatic transition to archived pending delete

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -119,13 +119,13 @@ RSpec.describe FeeScheme, type: :model do
     end
 
     context 'when date is just before scheme 12 cut over date' do
-      let(:the_date) { Date.new(2020, 06, 30) }
+      let(:the_date) { Date.new(2020, 9, 30) }
 
       it { is_expected.to eq agfs_scheme_eleven }
     end
 
     context 'when date is on/after scheme 12 cut over date' do
-      let(:the_date) { Date.new(2020, 8, 31) }
+      let(:the_date) { Date.new(2020, 10, 1) }
 
       it { is_expected.to eq agfs_scheme_twelve }
     end


### PR DESCRIPTION
#### What
Move agfs scheme 12 release date to 1/10/2020

#### Why
The Statutory instrument has not been laid yet. Once
laid it will enacted 21 days later. Moving to 1/10/2020 as placeholder for now.