### PR TITLE
Add lgfs clar scheme 9

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -55,7 +55,10 @@ module API
           desc 'Return all advocate categories'
           params { use :scheme_role_filter }
           get do
-            if scheme_role.in?(%i[agfs_scheme_10s agfs_scheme_11s agfs_scheme_12s])
+            case scheme_role
+            when :lgfs
+              []
+            when :agfs_scheme_10s, :agfs_scheme_11s, :agfs_scheme_12s
               Settings.agfs_reform_advocate_categories
             else
               Settings.advocate_categories

--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -12,8 +12,10 @@ module Claims
 
     private
 
-    LGFS_MISC_FEE_ELIGIBILITY = %w[MICJA MICJP MIEVI MISPF].freeze
-    LGFS_HARDSHIP_MISC_FEE_ELIGIBILITY = %w[MIEVI MISPF].freeze
+    LGFS_GENERAL_ELIGIBILITY = %w[MICJA MICJP MIEVI MISPF].freeze
+    LGFS_FIXED_FEE_ELIGIBILITY = (LGFS_GENERAL_ELIGIBILITY + %w[MIUPL]).freeze
+    LGFS_GRADUATED_FEE_ELIGIBILITY = (LGFS_GENERAL_ELIGIBILITY + %w[MIUMU MIUMO]).freeze
+    LGFS_HARDSHIP_FEE_ELIGIBILITY = %w[MIEVI MISPF].freeze
 
     attr_reader :claim
     delegate :case_type, :agfs?, :lgfs?, :agfs_reform?, :agfs_scheme_12?, :hardship?, to: :claim, allow_nil: true
@@ -36,12 +38,20 @@ module Claims
     end
 
     def elgible_lgfs_hardship_misc_fee_types
-      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_HARDSHIP_MISC_FEE_ELIGIBILITY)
+      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_HARDSHIP_FEE_ELIGIBILITY)
     end
 
     def eligible_lgfs_misc_fee_types
-      return Fee::MiscFeeType.lgfs if case_type&.is_fixed_fee?
-      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_MISC_FEE_ELIGIBILITY)
+      return lgfs_fixed_fee_misc_fee_types if case_type&.is_fixed_fee?
+      lgfs_graduated_fee_misc_fee_types
+    end
+
+    def lgfs_fixed_fee_misc_fee_types
+      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_FIXED_FEE_ELIGIBILITY)
+    end
+
+    def lgfs_graduated_fee_misc_fee_types
+      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_GRADUATED_FEE_ELIGIBILITY)
     end
   end
 end

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -17,6 +17,7 @@ class BaseValidator < ActiveModel::Validator
 
   def validate_fields(fields_class_method)
     return unless self.class.respond_to?(fields_class_method)
+
     fields = self.class.__send__(fields_class_method)
     fields.each do |field|
       __send__("validate_#{field}")

--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -39,7 +39,7 @@ module Fee
     end
 
     def run_base_fee_validators?
-      !@record.claim.lgfs?
+      !@record&.claim&.lgfs?
     end
 
     def validate_evidence_provision_fee

--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -12,6 +12,14 @@ module Fee
 
     private
 
+    def validate_fee_type
+      if run_base_fee_validators?
+        super
+      else
+        validate_presence(:fee_type, 'blank')
+      end
+    end
+
     def validate_quantity
       super if run_base_fee_validators?
     end

--- a/app/views/external_users/advocates/_advocate_category.html.haml
+++ b/app/views/external_users/advocates/_advocate_category.html.haml
@@ -10,6 +10,3 @@
         .multiple-choice.js-fee-calculator-advocate-type
           = b.radio_button('aria-labelledby': "radio-control-legend-category #{b.text.to_css_class}")
           = b.label(id: b.text.to_css_class) { b.value.to_s }
-
-
-

--- a/app/views/external_users/advocates/claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/claims/_miscellaneous_fees_form_step.html.haml
@@ -5,7 +5,10 @@
 
 = render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope)}
 %p
-  = t('page_intro_html', scope: locale_scope)
+  - if Settings.clar_enabled?
+    = t('clar_page_intro_html', scope: locale_scope)
+  - else
+    = t('page_intro_html', scope: locale_scope)
 
 = render partial: 'external_users/claims/misc_fees/advocates/fields', locals: { f: f }
 

--- a/app/views/external_users/advocates/hardship_claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/hardship_claims/_miscellaneous_fees_form_step.html.haml
@@ -5,6 +5,10 @@
 
 = render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope), fees_calculator_html: ''}
 %p
-  = t('page_intro_html', scope: locale_scope)
+  - if Settings.clar_enabled?
+    = t('clar_page_intro_html', scope: locale_scope)
+  - else
+    = t('page_intro_html', scope: locale_scope)
+
 
 = render partial: 'external_users/claims/misc_fees/advocates/fields', locals: { f: f }

--- a/app/views/external_users/advocates/supplementary_claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/supplementary_claims/_miscellaneous_fees_form_step.html.haml
@@ -5,6 +5,9 @@
 
 = render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope)}
 
+/ TODO: this may need a link to the unused material form if
+/ supplementary claims are expected to include them aswell.
+/ have left question with BA
 %p
   = t('page_intro_html', scope: locale_scope)
 

--- a/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
@@ -1,5 +1,8 @@
 %p
-  = t('.page_intro_html')
+  - if Settings.clar_enabled?
+    = t('.clar_page_intro_html')
+  - else
+    = t('.page_intro_html')
 
 #misc-fees.mod-fees
   #misc-fees-numberList.misc-fee-group-wrapper.fx-numberedList-hook

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -18,17 +18,9 @@
         - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
 
         = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
-          .multiple-choice{ data: { target: b.text.to_css_class } }
+          .multiple-choice
             = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}")
             = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { b.text }
-
-            - if b.object.unique_code.eql?('MISPF')
-              .panel.panel-border-narrow.js-hidden{ id: "special-preparation-fee"}
-                = t('.special_preparation_form_html')
-
-            - if b.object.unique_code.eql?('MIUMO')
-              .panel.panel-border-narrow.js-hidden{ id: "unused-materials-over-3-hours"}
-                = t('.unused_materials_form_html')
 
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -6,9 +6,9 @@
     = link_to_remove_association t('.remove'), f, wrapper_class: 'misc-fee-group', class: 'header-action fx-numberedList-action hidden'
 
   .form-group
-    .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count+1}_fee_type") }
-      %fieldset{ 'aria-describedby': "radio-control-legend-#{@misc_fee_count+1}" }
-        %legend{ id: "radio-control-legend-#{@misc_fee_count+1}" }
+    .fee-type{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") }
+      %fieldset{ 'aria-describedby': "radio-control-legend-#{@misc_fee_count}" }
+        %legend{ id: "radio-control-legend-#{@misc_fee_count}" }
           %span.form-label-bold
             = t('.fee_type')
 
@@ -16,15 +16,17 @@
 
         - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
         - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
-        = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
-          .multiple-choice
-            = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count+1} radio-control-legend-#{@misc_fee_count+1} #{b.text.to_css_class}")
-            - if misc_fee_types_collection.length == 1
-              = b.label(id: b.text.to_css_class, class: 'selected') { b.text }
-            - else
-              = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { b.text }
 
-      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count+1}_fee_type")
+        = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
+          .multiple-choice{ data: { target: b.text.to_css_class } }
+            = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}")
+            = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { b.text }
+
+            - if b.object.unique_code.eql?('MIUMO')
+              .panel.panel-border-narrow.js-hidden{ id: "unused-materials-over-3-hours"}
+                = t('.unused_materials_form_html')
+
+      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
   = f.adp_text_field :amount,
                     label: t('.net_amount'),

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -22,6 +22,10 @@
             = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}")
             = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { b.text }
 
+            - if b.object.unique_code.eql?('MISPF')
+              .panel.panel-border-narrow.js-hidden{ id: "special-preparation-fee"}
+                = t('.special_preparation_form_html')
+
             - if b.object.unique_code.eql?('MIUMO')
               .panel.panel-border-narrow.js-hidden{ id: "unused-materials-over-3-hours"}
                 = t('.unused_materials_form_html')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,9 +393,6 @@ en:
     providers: 'Search providers'
     claims: 'Search claims'
     caseworkers: 'Search case workers'
-  prep_forms:
-    advocates_html: Complete <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/503308/af1-special-prep-form.pdf" target="_blank" rel="external" title="Special Prep Form">special prep form</a> and attach
-    litigators_html: Complete <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special Prep Form">special prep form</a> and attach
   disk_evidence:
     header: 'Evidence supplied on disk'
     question: 'Will you be sending electronic evidence for this claim?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1455,14 +1455,6 @@ en:
             case_numbers: *case_numbers
             net_amount: *net_amount
             remove: "Remove"
-            special_preparation_form_html: |
-              You will need to complete a
-              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special prep form">Special prep form</a>
-              and attach to the claim.
-            unused_materials_form_html: |
-              You will need to complete an
-              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Unused materials form">Unused materials form</a>
-              and attach to the claim.
         summary:
           header: *miscellaneous_fees
       financial_summary:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1378,10 +1378,6 @@ en:
             fixed_fees: 'Fixed fees'
             page_header: 'Fixed fees'
             page_hint: *fees_vat_prompt
-            page_intro_html: |
-              If needed, please complete
-              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special Prep Form">special prep form</a>
-              and attach to the claim.
           fixed_fee_fields:
             fixed_fee: "Fixed fee"
             quantity: *quantity
@@ -1459,9 +1455,13 @@ en:
             case_numbers: *case_numbers
             net_amount: *net_amount
             remove: "Remove"
+            special_preparation_form_html: |
+              You will need to complete a
+              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special prep form">Special prep form</a>
+              and attach to the claim.
             unused_materials_form_html: |
               You will need to complete an
-              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special Prep Form">Unused materials form</a>
+              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Unused materials form">Unused materials form</a>
               and attach to the claim.
         summary:
           header: *miscellaneous_fees

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1442,6 +1442,11 @@ en:
             misc_fees: *miscellaneous_fees
             add_misc_fee: Add another fee
             page_hint: *fees_vat_prompt
+            clar_page_intro_html: |
+              If needed, please complete
+              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special Prep Form">special prep form</a>
+              and/or <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Unused materials (over 3 hours) form">Unused materials (over 3 hours) form</a>
+              and attach to the claim.
             page_intro_html: |
               If needed, please complete
               <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special Prep Form">special prep form</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1406,6 +1406,11 @@ en:
       misc_fees:
         page_header: *miscellaneous_fees
         page_hint: *fees_vat_prompt
+        clar_page_intro_html: |
+          If needed, please complete an
+          <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" target="_blank" rel="external" title="Special Prep Forms">appropriate special prep form</a>
+          and/or <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" target="_blank" rel="external" title="Unused materials (over 3 hours) form">Unused materials (over 3 hours) form</a>
+          and attach to the claim.
         page_intro_html: |
           If needed, please complete an
           <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" target="_blank" rel="external" title="Special Prep Forms">appropriate special prep form</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1447,7 +1447,7 @@ en:
         litigators:
           fields:
             misc_fees: *miscellaneous_fees
-            add_misc_fee: "Add another fee"
+            add_misc_fee: Add another fee
             page_hint: *fees_vat_prompt
             page_intro_html: |
               If needed, please complete
@@ -1459,7 +1459,10 @@ en:
             case_numbers: *case_numbers
             net_amount: *net_amount
             remove: "Remove"
-
+            unused_materials_form_html: |
+              You will need to complete an
+              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external" title="Special Prep Form">Unused materials form</a>
+              and attach to the claim.
         summary:
           header: *miscellaneous_fees
       financial_summary:
@@ -1961,7 +1964,6 @@ en:
       invalid_claim: 'Claim is not in a state to be submitted'
     claim:
       advocate_category: Advocate category
-      litigator_category: 'Litigator category'
       assignee: "Assigned to:"
       case: Case
       case_cracked: Case cracked in

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -115,7 +115,7 @@ reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).ch
 agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
 agfs_scheme_11_release_date: <%= Date.new(2018, 12, 31) %>
 agfs_scheme_12_release_date: <%= Date.new(2020, 10, 1) %>
-agfs_scheme_12_enabled?: <%= ENV.fetch('AGFS_TWELVE_ENABLED', 'false')&.downcase&.eql?('true') %>
+clar_enabled?: <%= ENV.fetch('AGFS_TWELVE_ENABLED', 'false')&.downcase&.eql?('true') %>
 
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -115,7 +115,7 @@ reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).ch
 agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
 agfs_scheme_11_release_date: <%= Date.new(2018, 12, 31) %>
 agfs_scheme_12_release_date: <%= Date.new(2020, 10, 1) %>
-clar_enabled?: <%= ENV.fetch('AGFS_TWELVE_ENABLED', 'false')&.downcase&.eql?('true') %>
+clar_enabled?: <%= ENV.fetch('CLAR_ENABLED', 'false')&.downcase&.eql?('true') %>
 
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16

--- a/db/seeds/schemas/add_agfs_fee_scheme_12.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_12.rb
@@ -24,12 +24,12 @@ module Seeds
           \sAGFS scheme 12 fee_type count: #{scheme_12_fee_type_count}
           \s------------------------------------------------------------
           Status: #{agfs_fee_scheme_12.present? && scheme_12_offence_count > 0 ? 'up' : 'down'}
-          Enabled: #{Settings.agfs_scheme_12_enabled?}
+          Enabled: #{Settings.clar_enabled?}
         STATUS
       end
 
       def up
-        puts 'AGFS scheme 12 is not enabled. You must enable in settings first!'.yellow unless Settings.agfs_scheme_12_enabled?
+        puts 'AGFS scheme 12 is not enabled. You must enable in settings first!'.yellow unless Settings.clar_enabled?
         create_or_update_agfs_scheme_eleven
         create_agfs_scheme_twelve
         create_agfs_scheme_twelve_offences
@@ -88,7 +88,7 @@ module Seeds
       end
 
       def create_or_update_agfs_scheme_eleven
-        return unless Settings.agfs_scheme_12_enabled?
+        return unless Settings.clar_enabled?
 
         print "Finding AGFS scheme 11".yellow
         agfs_fee_scheme_eleven = FeeScheme.find_by(name: 'AGFS', version: 11, start_date: Settings.agfs_scheme_11_release_date.beginning_of_day)
@@ -101,7 +101,7 @@ module Seeds
       end
 
       def create_agfs_scheme_twelve
-        return unless Settings.agfs_scheme_12_enabled?
+        return unless Settings.clar_enabled?
         print "Finding or creating scheme 12 with start date #{Settings.agfs_scheme_12_release_date.beginning_of_day}...".yellow
         print "\n" && return if pretending?
         FeeScheme.find_or_create_by(name: 'AGFS', version: 12, start_date: Settings.agfs_scheme_12_release_date.beginning_of_day)
@@ -109,7 +109,7 @@ module Seeds
       end
 
       def create_agfs_scheme_twelve_offences
-        return unless Settings.agfs_scheme_12_enabled?
+        return unless Settings.clar_enabled?
 
         puts "Scheme 12 offence count before: #{scheme_12_offence_count}".yellow
         copy_scheme_11_offences
@@ -117,7 +117,7 @@ module Seeds
       end
 
       def create_scheme_twelve_fee_types
-        return unless Settings.agfs_scheme_12_enabled?
+        return unless Settings.clar_enabled?
 
         puts "Scheme 12 fee type count before: #{scheme_12_fee_type_count}".yellow
         Rake::Task['data:migrate:fee_types:reseed'].invoke(pretending?)

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -77,7 +77,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I should be in the 'Miscellaneous fees' form page
     And I should see a page title "Enter miscellaneous fees for litigator final fees claim"
-    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee'
+    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee,Unused materials (upto 3 hours), Unused materials (over 3 hours)'
     And I add a litigator miscellaneous fee 'Costs judge application'
 
     When I click "Continue" in the claim form

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -66,7 +66,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I eject the VCR cassette
 
     And I should be in the 'Miscellaneous fees' form page
-    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee'
+    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee,Unused materials (upto 3 hours), Unused materials (over 3 hours)'
     And I add a litigator miscellaneous fee 'Costs judge application'
 
     And I should see a page title "Enter miscellaneous fees for litigator transfer fees claim"

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -82,7 +82,7 @@ And(/^I add a litigator miscellaneous fee '(.*)'$/) do |name|
 end
 
 Then(/^the first miscellaneous fee should have fee types\s*'([^']*)'$/) do |descriptions|
-  descriptions = descriptions.split(',')
+  descriptions = descriptions.split(',').map(&:strip)
   expect(@litigator_claim_form_page.miscellaneous_fees.first.fee_type).to be_visible
   expect(@litigator_claim_form_page.miscellaneous_fees.first.fee_type.radio_labels).to match_array(descriptions)
 end

--- a/kubernetes_deploy/dev-lgfs/deployment.yaml
+++ b/kubernetes_deploy/dev-lgfs/deployment.yaml
@@ -75,7 +75,7 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
-            - name: AGFS_TWELVE_ENABLED
+            - name: CLAR_ENABLED
               value: 'true'
             - name: DATABASE_URL
               valueFrom:

--- a/lib/assets/data/fee_types.csv
+++ b/lib/assets/data/fee_types.csv
@@ -104,5 +104,5 @@ ID,DESCRIPTION,CODE,UNIQUE_CODE,MAX_AMOUNT,CALCULATED,CLASS,ROLES,PARENT_ID,QUAN
 105,Plea and trial preparation hearing,PCM,MIPCM,999,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_9;agfs_scheme_10,,FALSE
 106,Hardship,HARDSHIP,HARDSHIP,,FALSE,Fee::HardshipFeeType,lgfs,,FALSE
 107,Paper heavy case,PHC,MIPHC,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_12,,TRUE
-108,Unused materials (upto 3 hours),UMU,MIUMU,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_12,,FALSE
-109,Unused materials (over 3 hours),UMO,MIUMO,,TRUE,Fee::MiscFeeType,agfs;agfs_scheme_12,,TRUE
+108,Unused materials (upto 3 hours),UMU,MIUMU,,TRUE,Fee::MiscFeeType,lgfs;agfs;agfs_scheme_12,,FALSE
+109,Unused materials (over 3 hours),UMO,MIUMO,,TRUE,Fee::MiscFeeType,lgfs;agfs;agfs_scheme_12,,TRUE

--- a/lib/extensions/string_extension.rb
+++ b/lib/extensions/string_extension.rb
@@ -40,7 +40,7 @@ module StringExtension
   end
 
   def to_css_class
-    downcase.strip.tr(' _', '--')
+    downcase.strip.tr(' _', '-').tr('()', '')
   end
 
   private

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -375,7 +375,9 @@ RSpec.describe API::V1::DropdownData do
     context 'when role is lgfs' do
       let(:role) { 'lgfs' }
 
-      include_examples 'returns agfs scheme 9 advocate categories'
+      it 'returns no advocate categories' do
+        expect(parsed_response).to be_empty
+      end
     end
   end
 

--- a/spec/api/v1/external_users/claims/integration/advocate_claim_creation_spec.rb
+++ b/spec/api/v1/external_users/claims/integration/advocate_claim_creation_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe 'API claim creation for AGFS' do
   include ApiSpecHelper
 
   before do
-    allow(Settings).to receive(:agfs_scheme_12_enabled?).and_return true
+    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
     seed_case_types
     seed_fee_types

--- a/spec/factories/fee_schemes.rb
+++ b/spec/factories/fee_schemes.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
     trait :agfs_eleven do
       start_date { Date.new(2018, 12, 31).beginning_of_day }
-      end_date { (Settings.agfs_scheme_12_release_date.end_of_day - 1.day) if Settings.agfs_scheme_12_enabled? }
+      end_date { (Settings.agfs_scheme_12_release_date.end_of_day - 1.day) if Settings.clar_enabled? }
       version { 11 }
     end
 

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
       roles { %w[agfs agfs_scheme_12] }
     end
 
+    trait :lgfs_agfs_scheme_12 do
+      roles { %w[lgfs agfs agfs_scheme_12] }
+    end
+
     trait :agfs_all_schemes do
       roles { %w[agfs agfs_scheme_9 agfs_scheme_10] }
     end
@@ -300,7 +304,7 @@ FactoryBot.define do
         unique_code { 'MIUMU' }
         calculated { true }
         quantity_is_decimal { true }
-        agfs_scheme_12
+        lgfs_agfs_scheme_12
       end
 
       trait :miumo do
@@ -309,7 +313,7 @@ FactoryBot.define do
         unique_code { 'MIUMO' }
         calculated { true }
         quantity_is_decimal { true }
-        agfs_scheme_12
+        lgfs_agfs_scheme_12
       end
 
       trait :miupl do

--- a/spec/lib/extensions/string_extension_spec.rb
+++ b/spec/lib/extensions/string_extension_spec.rb
@@ -110,10 +110,25 @@ describe String do
     end
   end
 
-  describe '#to_css_class' do
-    it "should look right" do
-      expect('Part authorised'.to_css_class).to eq('part-authorised')
-      expect(' Pa_rt authori_s ed'.to_css_class).to eq('pa-rt-authori-s-ed')
+  fdescribe '#to_css_class' do
+    it "downcases all chars" do
+      expect('part AUTHORISED'.to_css_class).to eq('part-authorised')
+    end
+
+    it "replaces whitespace with hyphens" do
+      expect('part authorised'.to_css_class).to eq('part-authorised')
+    end
+
+    it "replaces underscore with hyphens" do
+      expect('part_authorised'.to_css_class).to eq('part-authorised')
+    end
+
+    it "replaces braces with blank" do
+      expect('authorised (in part)'.to_css_class).to eq('authorised-in-part')
+    end
+
+    it "strips whitespace from ends" do
+      expect(' part authorised '.to_css_class).to eq('part-authorised')
     end
   end
 end

--- a/spec/lib/extensions/string_extension_spec.rb
+++ b/spec/lib/extensions/string_extension_spec.rb
@@ -110,7 +110,7 @@ describe String do
     end
   end
 
-  fdescribe '#to_css_class' do
+  describe '#to_css_class' do
     it "downcases all chars" do
       expect('part AUTHORISED'.to_css_class).to eq('part-authorised')
     end

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe FeeScheme, type: :model do
     before do
-      allow(Settings).to receive(:agfs_scheme_12_enabled?).and_return true
+      allow(Settings).to receive(:clar_enabled?).and_return true
       seed_fee_schemes
     end
 

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -3,7 +3,7 @@ require "rspec/mocks/standalone" # required for mocking/unmocking in before/afte
 
 RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
   before(:all) do |example|
-    allow(Settings).to receive(:agfs_scheme_12_enabled?).and_return true
+    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
     seed_case_types
     seed_fee_types
@@ -11,7 +11,7 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
 
   after(:all) do
     clean_database
-    allow(Settings).to receive(:agfs_scheme_12_enabled?).and_call_original
+    allow(Settings).to receive(:clar_enabled?).and_call_original
   end
 
   context 'with delegations' do

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -75,18 +75,6 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
             is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
           end
         end
-
-        # TODO: waiting BA answer on whether unused materials claimable on non-fixed fee types
-        # Cracked before retrial, Discontinuance, Guilty plea, Retrial
-        context 'Guilty plea', skip: '# TODO: waiting BA answer on whether unused materials claimable on non-fixed fee types' do
-          let(:claim) do
-            create(:litigator_claim, :without_fees, case_type: CaseType.find_by(name: 'Trial') )
-          end
-
-          it 'returns all LGFS misc fee types except defendant uplifts' do
-            is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
-          end
-        end
       end
 
       context 'hardship fee claim' do

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
         expect(call.map(&:lgfs?)).to be_all true
       end
 
-      fcontext 'fixed fee claim' do
+      context 'fixed fee claim' do
         let(:claim) do
           create(:litigator_claim, :without_fees, case_type: CaseType.find_by(name: 'Appeal against sentence') )
         end

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -37,41 +37,59 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
     # but excluding defendant uplifts since these are catered
     # for by fee calculation.
     context 'LGFS' do
+      subject(:unique_codes) { call.map(&:unique_code) }
+
       let(:claim) { create(:litigator_claim, :without_fees) }
 
-      it { is_expected.to all(be_a(Fee::MiscFeeType)) }
+      it { expect(call).to all(be_a(Fee::MiscFeeType)) }
 
       it 'returns LGFS only misc fee types' do
         expect(call.map(&:lgfs?)).to be_all true
       end
 
-      context 'defendant uplift' do
-        subject { call.map(&:unique_code) }
-
-        context 'fixed fee claim' do
-          let(:claim) do
-            create(:litigator_claim, :without_fees, case_type: CaseType.find_by(name: 'Appeal against sentence') )
-          end
-
-          it 'returns all LGFS misc fee types' do
-            is_expected.to match_array %w[MICJA MICJP MIUPL MIEVI MISPF]
-          end
+      fcontext 'fixed fee claim' do
+        let(:claim) do
+          create(:litigator_claim, :without_fees, case_type: CaseType.find_by(name: 'Appeal against sentence') )
         end
 
-        context 'graduated fee claim' do
+        it 'includes defendant uplift' do
+          is_expected.to include('MIUPL')
+        end
+
+        it 'excludes unused materials' do
+          is_expected.not_to include('MIUMU', 'MIUMO')
+        end
+
+        it 'returns all expected fee types' do
+          is_expected.to match_array %w[MICJA MICJP MIUPL MIEVI MISPF]
+        end
+      end
+
+      context 'graduated fee claim' do
+        context 'Trial' do
           let(:claim) do
             create(:litigator_claim, :without_fees, case_type: CaseType.find_by(name: 'Trial') )
           end
 
           it 'returns all LGFS misc fee types except defendant uplifts' do
-            is_expected.to match_array %w[MICJA MICJP MIEVI MISPF]
+            is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
+          end
+        end
+
+        # TODO: waiting BA answer on whether unused materials claimable on non-fixed fee types
+        # Cracked before retrial, Discontinuance, Guilty plea, Retrial
+        context 'Guilty plea', skip: '# TODO: waiting BA answer on whether unused materials claimable on non-fixed fee types' do
+          let(:claim) do
+            create(:litigator_claim, :without_fees, case_type: CaseType.find_by(name: 'Trial') )
+          end
+
+          it 'returns all LGFS misc fee types except defendant uplifts' do
+            is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
           end
         end
       end
 
       context 'hardship fee claim' do
-        subject { call.map(&:unique_code) }
-
         let(:claim) do
           create(:litigator_hardship_claim)
         end

--- a/spec/services/claims/fetch_eligible_offences_spec.rb
+++ b/spec/services/claims/fetch_eligible_offences_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Claims::FetchEligibleOffences, type: :service do
   subject(:offences) { described_class.for(claim) }
 
   before do
-    allow(Settings).to receive(:agfs_scheme_12_enabled?).and_return true
+    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
   end
 

--- a/spec/services/fee_reform/search_offences_spec.rb
+++ b/spec/services/fee_reform/search_offences_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe FeeReform::SearchOffences, type: :service do
   before do
-    allow(Settings).to receive(:agfs_scheme_12_enabled?).and_return true
+    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
   end
 

--- a/spec/support/seed_helpers.rb
+++ b/spec/support/seed_helpers.rb
@@ -8,7 +8,7 @@ module SeedHelpers
     FeeScheme.find_or_create_by(name: 'AGFS', version: 10, start_date: Settings.agfs_fee_reform_release_date.beginning_of_day, end_date: Settings.agfs_scheme_11_release_date - 1.day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 11, start_date: Settings.agfs_scheme_11_release_date.beginning_of_day)
 
-    if Settings.agfs_scheme_12_enabled?
+    if Settings.clar_enabled?
       FeeScheme.find_by(name: 'AGFS', version: 11).update(end_date: Settings.agfs_scheme_12_release_date.end_of_day - 1.day)
       FeeScheme.find_or_create_by(name: 'AGFS', version: 12, start_date: Settings.agfs_scheme_12_release_date.beginning_of_day)
     end

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -3,14 +3,14 @@ require_relative 'shared_examples_for_advocate_litigator'
 require_relative 'shared_examples_for_step_validators'
 
 RSpec.describe Claim::InterimClaimValidator, type: :validator do
-  include_context "force-validation"
+  include_context 'force-validation'
 
   let(:litigator) { build(:external_user, :litigator) }
   let(:interim_fee) { build(:interim_fee) }
   let(:claim) { create(:interim_claim, interim_fee: interim_fee) }
 
   include_examples 'common advocate litigator validations', :litigator
-  include_examples "common litigator validations", :interim_claim
+  include_examples 'common litigator validations', :interim_claim
 
   include_examples 'common partial validations', {
     case_details: %i[

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -3,13 +3,13 @@ require_relative 'shared_examples_for_advocate_litigator'
 require_relative 'shared_examples_for_step_validators'
 
 RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
-  include_context "force-validation"
+  include_context 'force-validation'
 
   let(:litigator) { build(:external_user, :litigator) }
   let(:claim) { create(:litigator_claim) }
 
   include_examples 'common advocate litigator validations', :litigator
-  include_examples "common litigator validations"
+  include_examples 'common litigator validations'
 
   include_examples 'common partial validations', {
     case_details: %i[

--- a/spec/validators/claim/litigator_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_hardship_claim_validator_spec.rb
@@ -3,14 +3,14 @@ require_relative 'shared_examples_for_advocate_litigator'
 require_relative 'shared_examples_for_step_validators'
 
 RSpec.describe Claim::LitigatorHardshipClaimValidator, type: :validator do
-  include_context "force-validation"
+  include_context 'force-validation'
 
   let(:claim) { create(:litigator_hardship_claim, case_type: create(:case_type, :all_roles, is_fixed_fee: false)) }
 
   before { seed_fee_schemes }
 
-  include_examples "common advocate litigator validations", :litigator, case_type: false
-  include_examples "common litigator validations", :hardship_claim
+  include_examples 'common advocate litigator validations', :litigator, case_type: false
+  include_examples 'common litigator validations', :hardship_claim
 
   context 'case_type_id' do
     before { claim.case_type_id = 1 }

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       before { create(:misc_fee_type, :miumu) }
 
       context 'with valid quantity' do
-        let(:fee) { build(:misc_fee, :miumu_fee, quantity: 1) }
+        let(:fee) { build(:misc_fee, :miumu_fee, claim: claim, quantity: 1) }
 
         it { expect(fee).to be_valid }
-        it { expect(fee.errors[:quantity]).to be_empty}
+        it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(0) }
       end
 
       context 'with invalid quantity' do
-        let(:fee) { build(:misc_fee, :miumu_fee, quantity: 1.01) }
+        let(:fee) { build(:misc_fee, :miumu_fee, claim: claim, quantity: 1.01) }
 
         it { expect(fee).to be_invalid }
         it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(1) }
@@ -71,10 +71,10 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         let(:fee) { build(:misc_fee, :miumo_fee, quantity: 3.00) }
 
         it { expect(fee).to be_valid }
-        it { expect(fee.errors[:quantity]).to be_empty}
+        it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(0) }
       end
 
-      context 'with valid quantity' do
+      context 'with invalid quantity' do
         let(:fee) { build(:misc_fee, :miumo_fee, quantity: 2.99) }
 
         it { expect(fee).to be_invalid }

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -22,6 +22,28 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
 
     describe '#validate_fee_type' do
       it { should_error_if_not_present(fee, :fee_type, 'blank') }
+
+      context 'when validating Unused material (upto 3 hours)' do
+        before { create(:misc_fee_type, :miumu) }
+
+        context 'with zero quantity' do
+          let(:fee) { build(:misc_fee, :miumu_fee, claim: claim, quantity: 0) }
+
+          it { expect(fee).to be_valid }
+          it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(0) }
+        end
+      end
+
+      context 'when validating Unused material (over 3 hours)' do
+        before { create(:misc_fee_type, :miumo) }
+
+        context 'with zero quantity' do
+          let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 0) }
+
+          it { expect(fee).to be_valid }
+          it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(0) }
+        end
+      end
     end
 
     include_examples 'common LGFS amount validations'


### PR DESCRIPTION
Implement LGFS CLAR changes 

#### What
Changes required to meet Criminal Legal Aid Review (CLAR)
requirements. From a busines perspective this is to be referred
to as LGFS scheme 9 (due to reversion of previous
LGFS fee schemes)

#### Ticket

[CBO-1408](https://dsdmoj.atlassian.net/browse/CBO-1408)

#### Why
CLAR requires changes the way LGFS claims are handled

#### How

--------

#### TODO (wip)

- [x] display of fee type option (conditional on date of seed)
- [x] display of fee type link to form
- [x] conditional display of fee based on a "release date"
- [X] DI exclusion test
