### PR TITLE
Attempt to fix leaky mock and stub

### DIFF
--- a/spec/support/shared_examples/models/s3_headers.rb
+++ b/spec/support/shared_examples/models/s3_headers.rb
@@ -28,10 +28,17 @@ RSpec.shared_examples 'an s3 bucket' do
 
     context ':s3_region' do
       subject(:s3_region) { described_class.s3_headers[:s3_region] }
+
+      before { allow(Settings.aws).to receive(:region).and_return(fake_aws_region) }
+
       let(:fake_aws_region) { 'eu-west-49' }
 
-      it 'includes region value from settings' do
-        expect(Settings.aws).to receive(:region).and_return(fake_aws_region)
+      it 'retrieves region from settings' do
+        s3_region
+        expect(Settings.aws).to have_received(:region)
+      end
+
+      it 'includes region value' do
         is_expected.to eql fake_aws_region
       end
     end


### PR DESCRIPTION
The mock in this test was leaking into others and raising
the following failure.
```
Failure/Error: expect(Settings.aws).to receive(:region).and_return(fake_aws_region)
  #<Double Config::Options> was originally created in one example but has leaked into another example and can no longer be used. rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
Shared Example Group: "an s3 bucket" called from ./spec/models/document_spec.rb:44
./spec/support/shared_examples/models/s3_headers.rb:34:in `block (4 levels) in <top (required)>'
./spec/vcr_helper.rb:83:in `block (3 levels) in <top (required)>'
./spec/vcr_helper.rb:82:in `block (2 levels) in <top (required)>'
```