### PR TITLE
Fix notify_mailer_spec flicker

### DIFF
--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -1,16 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe NotifyMailer, type: :mailer do
-
   describe 'message_added_email' do
     let(:template) { '4240bf0e-0000-444e-9c30-0d1bb64a2fb4' }
-
-    # NOTE: set id explicitly to differentiate external_user.id from user.id
-    # because if left to factories/db it will often set them to the same value
-    # due to sequence resetting.
     let(:provider) { create(:provider, :agfs)}
-    let(:external_user) { create(:external_user, provider: provider, id: 101) }
-    let(:creator_external_user) { create(:external_user, provider: provider, id: 201) }
+    let(:external_user) { create(:external_user, provider: provider) }
+    let(:creator_external_user) { create(:external_user, provider: provider) }
     let(:claim) { create(:advocate_final_claim) }
 
     before do


### PR DESCRIPTION
#### What
Fix spec flicker

#### WHy
Specifying the id occassionally causes:
```
Failure/Error: let(:creator_external_user) { create(:external_user, provider: provider, id: 201) }

ActiveRecord::RecordNotUnique:
  PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "external_users_pkey"
  DETAIL:  Key (id)=(201) already exists.
./spec/mailers/notify_mailer_spec.rb:13:in `block (3 levels) in <top (required)>'
./spec/mailers/notify_mailer_spec.rb:18:in `block (3 levels) in <top (required)>'
./spec/vcr_helper.rb:83:in `block (3 levels) in <top (required)>'
./spec/vcr_helper.rb:82:in `block (2 levels) in <top (required)>'
--- Caused by: ---
PG::UniqueViolation:
  ERROR:  duplicate key value violates unique constraint "external_users_pkey"
  DETAIL:  Key (id)=(201) already exists.
  ./spec/mailers/notify_mailer_spec.rb:13:in `block (3 levels) in <top (required)>'

```