### PR TITLE
Prevent deletion of succesful jobs for approx. 3 days

### DIFF
--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -5,8 +5,9 @@ metadata:
 spec:
   schedule: "5 0 * * *"
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 7
+  successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  ttlSecondsAfterFinished: 250000
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:

--- a/kubernetes_deploy/cron_jobs/clean_ecr.yaml
+++ b/kubernetes_deploy/cron_jobs/clean_ecr.yaml
@@ -9,6 +9,7 @@ spec:
   startingDeadlineSeconds: 3600
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
+  ttlSecondsAfterFinished: 250000
   suspend: false
   concurrencyPolicy: Allow
   jobTemplate:


### PR DESCRIPTION
#### What
Prevent deletion of succesful jobs for just under 3 days

#### Why
Cloud platforms has introduced a pipeline
that destroys successful jobs regardless
of `successfulJobsHistoryLimit` value.

#### How
This can be circumnavigated by using
`ttlSecondsAfterFinished`

see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/Cronjobs.html#deploying-a-cronjob-to-your-namespace
for more information.