### PR TITLE
Attempt to fix test flicker

### DIFF
--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Stats::StatsReportGenerator, type: :service do
   describe '.call' do
     context 'when the report type is not valid' do
+      before do
+        allow(Settings).to receive(:notify_report_errors).and_return(false)
+      end
+
       let(:report_type) { 'some-report-type' }
 
       it 'raises an invalid report type error' do


### PR DESCRIPTION
#### What
Attempt to fix flickering test stats_report_generator_spec.rb

#### Ticket
n/a  - see for example https://app.circleci.com/pipelines/github/ministryofjustice/Claim-for-Crown-Court-Defence/1867/workflows/9feea4fb-63b3-4717-b7dd-9720a3c2a085/jobs/25795/parallel-runs/2

#### Why
CircleCI failures are slowing down development

#### How
The error suggests that somehow Settings.notify_report_errors is being evaluated to true during the it 'raises an invalid report type error' test in stats_report_generator_spec.rb (this is the only way to reach line 52 in stats_report_generator.rb ).
 
```
ActiveSupport::Notifications.instrument 'call_failed.stats_report',
                                              id: report_record&.id, name: report_type, error: error
```

Add a
```

     before do
         allow(Settings).to receive(:notify_report_errors).and_return(false)
      end
```

to this test to try and stop the flicker.
