### PR TITLE
Change CLAR release date

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -114,7 +114,7 @@ reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).ch
 
 agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
 agfs_scheme_11_release_date: <%= Date.new(2018, 12, 31) %>
-agfs_scheme_12_release_date: <%= Date.new(2020, 10, 1) %>
+agfs_scheme_12_release_date: <%= Date.new(2020, 9, 17) %>
 clar_enabled?: <%= ENV.fetch('CLAR_ENABLED', 'false')&.downcase&.eql?('true') %>
 
 # number of weeks in one state before automatic transition to archived pending delete

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -119,13 +119,13 @@ RSpec.describe FeeScheme, type: :model do
     end
 
     context 'when date is just before scheme 12 cut over date' do
-      let(:the_date) { Date.new(2020, 9, 30) }
+      let(:the_date) { Date.new(2020, 9, 16) }
 
       it { is_expected.to eq agfs_scheme_eleven }
     end
 
     context 'when date is on/after scheme 12 cut over date' do
-      let(:the_date) { Date.new(2020, 10, 1) }
+      let(:the_date) { Date.new(2020, 9, 17) }
 
       it { is_expected.to eq agfs_scheme_twelve }
     end


### PR DESCRIPTION
#### What
Amend CLAR release date. same as AGFS scheme 12 release date

#### Why
The statutory instrument introducing
the Criminal Legal Aid Review changes
has been "laid". The resulting release
date for the legislation is therefore
the 17th September 2020.

[regulations](https://www.legislation.gov.uk/uksi/2020/903/contents/made)