### PR TITLE
Move ttlSecondsAfterFinished config to correct level

### DIFF
--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -7,11 +7,11 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
-  ttlSecondsAfterFinished: 250000
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
       backoffLimit: 0
+      ttlSecondsAfterFinished: 250000
       template:
         metadata:
           labels:

--- a/kubernetes_deploy/cron_jobs/clean_ecr.yaml
+++ b/kubernetes_deploy/cron_jobs/clean_ecr.yaml
@@ -9,13 +9,13 @@ spec:
   startingDeadlineSeconds: 3600
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
-  ttlSecondsAfterFinished: 250000
   suspend: false
   concurrencyPolicy: Allow
   jobTemplate:
     metadata:
       creationTimestamp: null
     spec:
+      ttlSecondsAfterFinished: 250000
       template:
         metadata:
           creationTimestamp: null


### PR DESCRIPTION
#### What
reposition ttlSecondsAfterFinished config to correct level

#### Why
This is currently wrong and having
no impact - jobs are being cleaned
up by pipeline too quickly.

see [user-guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/Cronjobs.html#kubernetes-cronjobs) for more