### PR TITLE
Unstub leaky `Settings` stub explicitly

### DIFF
--- a/spec/support/shared_examples/models/s3_headers.rb
+++ b/spec/support/shared_examples/models/s3_headers.rb
@@ -30,6 +30,7 @@ RSpec.shared_examples 'an s3 bucket' do
       subject(:s3_region) { described_class.s3_headers[:s3_region] }
 
       before { allow(Settings.aws).to receive(:region).and_return(fake_aws_region) }
+      after { allow(Settings.aws).to receive(:region).and_call_original }
 
       let(:fake_aws_region) { 'eu-west-49' }
 


### PR DESCRIPTION
#### What
Unstub settings stub explicitly

#### Why
This, like other, stubs on the Settings
file values seems to leak intermittently,
causing this error:

```
Failure/Error: Settings.aws.region
  #<Double Config::Options> was originally created in one example but has leaked into another example and can no longer be used. rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
Shared Example Group: "an s3 bucket" called from ./spec/models/message_spec.rb:30
./app/models/concerns/s3_headers.rb:19:in `region'
./app/models/concerns/s3_headers.rb:12:in `s3_headers'
./spec/support/shared_examples/models/s3_headers.rb:22:in `block (4 levels) in <top (required)>'
./spec/support/shared_examples/models/s3_headers.rb:25:in `block (4 levels) in <top (required)>'
./spec/vcr_helper.rb:83:in `block (3 levels) in <top (required)>'
./spec/vcr_helper.rb:82:in `block (2 levels) in <top (required)>'
```

#### How
To avoid this we explcitly unstub the stubbed
value after each test, calling the original
method.