### PR TITLE
Attempt to fix <Double (anonymous)> was originally created in one exa…

### DIFF
--- a/spec/lib/geckoboard_publisher/travel_automation_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/travel_automation_report_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe GeckoboardPublisher::TravelAutomationReport, geckoboard: true do
     subject { described_class.new.push! }
 
     before do
-      allow(Settings).to receive_message_chain(:geckoboard, :widgets, :travel_automation).and_return(widget_key)
+      allow(Settings.geckoboard.widgets).to receive(:travel_automation).and_return(widget_key)
       subject
     end
     let(:endpoint) { "https://push.geckoboard.com/v1/send/#{Settings.geckoboard.widgets.travel_automation}" }

--- a/spec/lib/geckoboard_publisher/travel_automation_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/travel_automation_report_spec.rb
@@ -143,6 +143,11 @@ RSpec.describe GeckoboardPublisher::TravelAutomationReport, geckoboard: true do
       allow(Settings.geckoboard.widgets).to receive(:travel_automation).and_return(widget_key)
       subject
     end
+
+    after do
+      allow(Settings.geckoboard.widgets).to receive(:travel_automation).and_call_original
+    end
+
     let(:endpoint) { "https://push.geckoboard.com/v1/send/#{Settings.geckoboard.widgets.travel_automation}" }
 
     context 'when the widget key has not been set' do


### PR DESCRIPTION
#### What
Attempt to fix the following test flicker

  1) GeckoboardPublisher::TravelAutomationReport#push! when the widget key has been set posts to geckoboard
     Failure/Error: allow(Settings).to receive_message_chain(:geckoboard, :widgets, :travel_automation).and_return(widget_key)
       <Double (anonymous)> was originally created in one example but has leaked into another example and can no longer be used. rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
     ./spec/lib/geckoboard_publisher/travel_automation_report_spec.rb:143:in `block (3 levels) in <top (required)>'
     ./spec/vcr_helper.rb:83:in `block (3 levels) in <top (required)>'
     ./spec/vcr_helper.rb:82:in `block (2 levels) in <top (required)>'


#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1466

#### Why
Rspec failures/flickers slow development

#### How
Recreated flicker on master using bundle exec rspec --seed 52208, this now passes.
