### PR TITLE
Enable CLAR on api-sandbox

### DIFF
--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://laa-fee-calculator.service.justice.gov.uk/api/v1
+            - name: CLAR_ENABLED
+              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
#### What
Enable seeding and flag for CLAR on api-sandbox

#### Why
So we can seed CLAR changes so that software vendors
can try out CLAR changes before they are implemented

There is a separate branch to deploy this change but
the enabling should go into master in any event