### PR TITLE
Replace comma separator regexp function

### DIFF
--- a/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -123,7 +123,7 @@ moj.Helpers.Blocks = {
     };
 
     this.render = function () {
-      this.$el.find('.total').html('&pound;' + moj.Helpers.Blocks.addCommas(this.totals.total.toFixed(2)));
+      this.$el.find('.total').html(moj.Helpers.Blocks.formatNumber(this.totals.total));
       this.$el.find('.total').data('total', this.totals.total);
     };
   },
@@ -729,15 +729,9 @@ moj.Helpers.Blocks = {
       }
     }
   },
-  addCommas: function (nStr) {
-    nStr += '';
-    var x = nStr.split('.');
-    var x1 = x[0];
-    var x2 = x.length > 1 ? '.' + x[1] : '';
-    var rgx = /(\d+)(\d{3})/;
-    while (rgx.test(x1)) {
-      x1 = x1.replace(rgx, '$1' + ',' + '$2');
-    }
-    return x1 + x2;
+  formatNumber: function (nStr) {
+    const option = { style: 'currency', currency: 'GBP', minimumFractionDigits: 2 }
+    const numberFormat = new Intl.NumberFormat('en', option)
+    return numberFormat.format(nStr)
   }
 };

--- a/app/webpack/javascripts/modules/external_users/claims/SideBar.js
+++ b/app/webpack/javascripts/modules/external_users/claims/SideBar.js
@@ -85,7 +85,7 @@ moj.Modules.SideBar = {
     this.sanitzeFeeToFloat();
     $.each(this.totals, function(key, val) {
       selector = '.total-' + key;
-      value = '&pound;' + moj.Helpers.Blocks.addCommas(val.toFixed(2));
+      value = moj.Helpers.Blocks.formatNumber(val);
       $(self.el).find(selector).html(value);
     });
   },

--- a/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -164,7 +164,7 @@
       var rate = $feeGroup.find('input.fee-rate').val();
       var quantity = $feeGroup.find('input.fee-quantity').val();
       var value = (rate * quantity);
-      var text = '&pound;' + moj.Helpers.Blocks.addCommas(value.toFixed(2));
+      var text = moj.Helpers.Blocks.formatNumber(value);
       $el.html(text);
     },
 

--- a/spec/javascripts/helpers-sidebar_spec.js
+++ b/spec/javascripts/helpers-sidebar_spec.js
@@ -7,21 +7,21 @@ describe('Helpers.Blocks.js', function () {
   });
 
   describe('Methods', function () {
-    describe('...addCommas', function () {
+    describe('...formatNumber', function () {
       it('should format the numbers correctly', function () {
         var expected = {
-          0: '0.01',
-          1: '0.11',
-          2: '1.11',
-          3: '11.11',
-          4: '111.11',
-          5: '1,111.11',
-          6: '11,111.11',
-          7: '111,111,111.11'
+          0: '£0.01',
+          1: '£0.11',
+          2: '£1.11',
+          3: '£11.11',
+          4: '£111.11',
+          5: '£1,111.11',
+          6: '£11,111.11',
+          7: '£111,111,111.11'
         };
 
         ['0.01', '0.11', '1.11', '11.11', '111.11', '1111.11', '11111.11', '111111111.11'].forEach(function (val, idx) {
-          expect(expected[idx]).toBe(moj.Helpers.Blocks.addCommas(val));
+          expect(expected[idx]).toBe(moj.Helpers.Blocks.formatNumber(val));
         });
       });
     });


### PR DESCRIPTION
#### What
Existing function replaced by built in constructor `Intl.NumberFormat`.
Use of currency symbol, comma separator and decimal places, now replaced by a single function.

#### Ticket
[CBO-1471: Resolve Sonarqube FrontEnd issues](https://dsdmoj.atlassian.net/browse/CBO-1471)

#### Why
Sonarqube identified security issue with regex within function.
