### PR TITLE
Correct unused material (over 3 hours) boundaries

### DIFF
--- a/app/validators/fee/fee_type_rules.rb
+++ b/app/validators/fee/fee_type_rules.rb
@@ -7,7 +7,7 @@ module Fee
       end
 
       with_set_for_fee_type('MIUMO') do |set|
-        set << add_rule(:quantity, :min, 3, message: 'miumo_numericality')
+        set << add_rule(:quantity, :min, 3.01, message: 'miumo_numericality')
         set << add_rule(*graduated_fee_type_only_rule)
       end
 

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -99,7 +99,7 @@
               Decimal
               %code
                 quantity
-              of 3+ only (not required for LGFS)
+              of over 3 (3.01+) only (not required for LGFS)
               %br
               %br
               Only claimable on claims with a Graduated case type

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1055,8 +1055,8 @@ misc_fee:
       api: Enter a valid quantity (1) for unused material (upto 3 hours)
     miumo_numericality:
       long: 'Enter a valid quantity for the #{misc_fee}'
-      short: Must be at least 3
-      api: Enter a valid quantity (3+) for unused material (over 3 hours)
+      short: Must be over 3
+      api: Enter a valid quantity (+3) for unused material (over 3 hours)
 
   case_numbers:
     _seq: 40

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -100,13 +100,13 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       before { create(:misc_fee_type, :miumo) }
 
       context 'with valid quantity' do
-        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.00) }
+        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.01) }
 
         it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(0) }
       end
 
       context 'with invalid quantity' do
-        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 2.99) }
+        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.00) }
 
         it { expect(fee).to be_invalid }
         it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(1) }
@@ -117,7 +117,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       end
 
       it_behaves_like 'fixed-fee-case-type validator', message: 'case_type_inclusion' do
-        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.00) }
+        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.01) }
       end
     end
 


### PR DESCRIPTION
Unused materials over 3 hours should be at least 3.01 hours to be valid

3 hours is not valid. currently it is accepting 3.00
hours incorrectly.