### PR TITLE
Remove `agfs_scheme_11` fee_type dropdown data filter

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -14,7 +14,7 @@ module API
           optional :role,
                    type: String,
                    desc: I18n.t('api.v1.dropdown_data.params.role_filter'),
-                   values: %w[agfs agfs_scheme_9 agfs_scheme_10 agfs_scheme_11 agfs_scheme_12 lgfs]
+                   values: %w[agfs agfs_scheme_9 agfs_scheme_10 agfs_scheme_12 lgfs]
         end
 
         def role

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -360,12 +360,6 @@ RSpec.describe API::V1::DropdownData do
       include_examples 'returns agfs scheme 10+ advocate categories'
     end
 
-    context 'when role is agfs_scheme_11' do
-      let(:role) { 'agfs_scheme_11' }
-
-      include_examples 'returns agfs scheme 10+ advocate categories'
-    end
-
     context 'when role is agfs_scheme_12' do
       let(:role) { 'agfs_scheme_12' }
 


### PR DESCRIPTION
#### What
Remove `agfs_scheme_11` fee_type dropdown data filter
from API swagger doc endpoint

#### Why
There is no agfs_scheme_11 role and therefore we cannot
filter by this. Currently causing error when this filter
is selected

We may want to map role filter behavior differently so
that, but am asking vendors:

 - agfs_scheme_11 returns agfs_scheme_10 fee types
 - agfs_scheme_12 returns agfs_scheme_10 + agfs_scheme_12 fee types