### PR TITLE
Remove Unused material (over 3 hours) quantity validation

### DIFF
--- a/app/validators/fee/agfs/fee_type_rules.rb
+++ b/app/validators/fee/agfs/fee_type_rules.rb
@@ -12,7 +12,6 @@ module Fee
         end
 
         with_set_for_fee_type('MIUMO') do |set|
-          set << add_rule(:quantity, :min, 3.01, message: 'miumo_numericality')
           set << add_rule(*graduated_fee_type_only_rule)
         end
 

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -99,7 +99,9 @@
               Decimal
               %code
                 quantity
-              of over 3 (3.01+) only (not required for LGFS)
+              of over 0 (not required for LGFS)
+              %sup{ style: "font-size: 10px"}
+                3
               %br
               %br
               Only claimable on claims with a Graduated case type
@@ -122,6 +124,10 @@
                 2
               graduated case types include Trial, Retrial, Cracked Trial and Cracked before retrial. See
               %a{ href: '/api/documentation#!/api/getApiCaseTypes', target: '_blank' } api/case_types
+              %br
+              %sup{ style: "font-size: 10px"}
+                3
+              The number of hours in excess of the first 3 hours
     %li
       New AGFS offence codes
       %br/

--- a/config/locales/error_messages.en.yml
+++ b/config/locales/error_messages.en.yml
@@ -1058,10 +1058,6 @@ misc_fee:
       long: 'Enter a valid quantity for the #{misc_fee}'
       short: Must be exactly 1
       api: Enter a valid quantity (1) for unused material (upto 3 hours)
-    miumo_numericality:
-      long: 'Enter a valid quantity for the #{misc_fee}'
-      short: Must be over 3
-      api: Enter a valid quantity (+3) for unused material (over 3 hours)
 
   case_numbers:
     _seq: 40

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
     it { should_error_if_not_present(fee, :claim, 'blank') }
   end
 
-  describe '#validate_fee_type' do
+  fdescribe '#validate_fee_type' do
     shared_examples 'fixed-fee-case-type validator' do |options|
       let(:claim) { build :advocate_claim, case_type: case_type }
 
@@ -100,24 +100,24 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       before { create(:misc_fee_type, :miumo) }
 
       context 'with valid quantity' do
-        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.01) }
+        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 0.01) }
 
         it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(0) }
       end
 
       context 'with invalid quantity' do
-        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.00) }
+        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 0) }
 
         it { expect(fee).to be_invalid }
         it { expect { fee.valid? }.to change { fee.errors[:quantity].count }.by(1) }
         it {
           fee.valid?
-          expect(fee.errors[:quantity]).to include('miumo_numericality')
+          expect(fee.errors[:quantity]).to include('invalid')
         }
       end
 
       it_behaves_like 'fixed-fee-case-type validator', message: 'case_type_inclusion' do
-        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 3.01) }
+        let(:fee) { build(:misc_fee, :miumo_fee, claim: claim, quantity: 0.01) }
       end
     end
 

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
     it { should_error_if_not_present(fee, :claim, 'blank') }
   end
 
-  fdescribe '#validate_fee_type' do
+  describe '#validate_fee_type' do
     shared_examples 'fixed-fee-case-type validator' do |options|
       let(:claim) { build :advocate_claim, case_type: case_type }
 


### PR DESCRIPTION
#### What
Remove Unused material (over 3 hours) quantity validation

#### Ticket

TODO

#### Why
We have become aware of a logic issue with the current
implementation of the CLAR “Unused material (over 3 hours)”
fee type for AGFS. The regulations stipulate that the first 3
hours are claimable at the fixed rate in addition to any hours
over 3 at an hourly rate. This means we will be allowing any
quantity to be claimed for this fee type where each unit/hour
should be in excess of the first 3 hours.

example:
  3 and half hours of work for “Unused material” would be claimable
  as two fees: `quantity: 1` of type “Unused material (upto 3 hours)”
  and `quantity: 0.5` of type “Unused material (over 3 hours)”.