### PR TITLE
Remove non-existent role reference

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -58,7 +58,7 @@ module API
             case scheme_role
             when :lgfs
               []
-            when :agfs_scheme_10s, :agfs_scheme_11s, :agfs_scheme_12s
+            when :agfs_scheme_10s, :agfs_scheme_12s
               Settings.agfs_reform_advocate_categories
             else
               Settings.advocate_categories


### PR DESCRIPTION
#### What
Remove agfs scheme 11 role reference from api docs

#### Why
Should have been removed with[ previous PR](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/3508) that
removed it from the role filter list

This role does not exist. Note, that it
should exist and a seperate piece of work
will be needed to apply it consistently (i.e. feature debt)
