### PR TITLE
Remove email notification enabled flag

### DIFF
--- a/app/views/external_users/admin/external_users/_form.html.haml
+++ b/app/views/external_users/admin/external_users/_form.html.haml
@@ -20,17 +20,16 @@
         = user_fields.label :email_confirmation, t('.email_confirmation'), class: 'form-label-bold'
         = user_fields.email_field :email_confirmation, class: 'form-control'
 
-    - if Settings.email_notification_enabled?
-      .form-group
-        %fieldset.inline{ 'aria-describedby': 'radio-control-legend-email' }
-          %legend#radio-control-legend-email
-            %span.heading-medium
-              = t('.email_notification')
+    .form-group
+      %fieldset.inline{ 'aria-describedby': 'radio-control-legend-email' }
+        %legend#radio-control-legend-email
+          %span.heading-medium
+            = t('.email_notification')
 
-          = user_fields.collection_radio_buttons(:email_notification_of_message, [true, false], :to_s, :to_s) do |b|
-            .multiple-choice
-              = b.radio_button('aria-labelledby': "radio-control-legend-email #{b.text.to_css_class}")
-              = b.label { (b.value.to_s == 'true' ? t('.answer_yes') : t('.answer_no')) }
+        = user_fields.collection_radio_buttons(:email_notification_of_message, [true, false], :to_s, :to_s) do |b|
+          .multiple-choice
+            = b.radio_button('aria-labelledby': "radio-control-legend-email #{b.text.to_css_class}")
+            = b.label { (b.value.to_s == 'true' ? t('.answer_yes') : t('.answer_no')) }
 
     - if current_user.persona.admin?
       .form-group

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -19,9 +19,8 @@
       = t('.supplier_number')
     %th{ scope: 'col' }
       = t('.email')
-    - if Settings.email_notification_enabled?
-      %th{ scope: 'col' }
-        = t('.email_confirmation')
+    %th{ scope: 'col' }
+      = t('.email_confirmation')
     %th{ scope: 'col' }
       = t('.actions')
   %tbody
@@ -35,9 +34,8 @@
           = advocate.supplier_number ? advocate.supplier_number : '-'
         %td{ 'data-label': t('.email') }
           = govuk_mail_to advocate.email, advocate.email, { title: t('.email_title', external_user: advocate.name) }
-        - if Settings.email_notification_enabled?
-          %td{ 'data-label': t('.email_confirmation') }
-            = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
+        %td{ 'data-label': t('.email_confirmation') }
+          = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
         %td.user-controls{ 'data-label': t('.actions') }
           - if advocate.active?
             = govuk_link_to t('.edit'),  edit_external_users_admin_external_user_path(advocate)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,11 +94,6 @@ downtime_warning_date: <%= Date.new(2019, 11, 20) %>
 # If enabled, users with proper roles will see scheme radio buttons to filter the list
 scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 
-# Feature flag to enable ability to set user email notification user preferences.  If true, external
-# users will be able to set preference to say whether they want email notifications of outstanding messages
-# on their claim
-email_notification_enabled?: true
-
 # Feature flag to enable maintenance mode
 # If enabled all routes mapped to pages#servicedown on startup
 #


### PR DESCRIPTION
#### What
Remove email_notification_enabled? feature flag

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1490

#### Why
This was set to true 4 years ago and has not been changed since, so presuming no longer required.
