### PR TITLE
Remove timeout retention enabled flag

### DIFF
--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -63,8 +63,7 @@ module ExternalUsers::ClaimsHelper
   end
 
   def show_timed_retention_banner_to_user?
-    Settings.timed_retention_banner_enabled? &&
-      current_user_is_external_user? &&
+    current_user_is_external_user? &&
       current_user.setting?(:timed_retention_banner_seen).nil?
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -77,10 +77,6 @@ expense_schema_version: 2
 # If enabled, users will see it, and will have a 'dismiss' link to hide and do not show it again
 api_promo_enabled?: true
 
-# Feature flag to enable or disable the timed retention banner
-# If enabled, external users will see it, and will have a 'dismiss' link to hide and do not show it again
-timed_retention_banner_enabled?: true
-
 # Feature flag to enable or disable the hardship claim banner
 # If enabled, external users will see it, and will have a 'dismiss' link to hide and do not show it again
 hardship_claims_banner_enabled?: true

--- a/features/claims/timed_retention_banner.feature
+++ b/features/claims/timed_retention_banner.feature
@@ -4,7 +4,6 @@ Feature: A timed retention banner will appear on the claims list, until the user
   Scenario: I go to the claims page, should see the timed retention banner, dismiss it and do not see it again
 
     Given I am a signed in advocate
-    And The timed retention banner feature flag is enabled
     And I am on the 'Your claims' page
 
     Then The timed retention banner is visible

--- a/features/step_definitions/timed_retention_banner_steps.rb
+++ b/features/step_definitions/timed_retention_banner_steps.rb
@@ -1,7 +1,3 @@
-Given(/^The timed retention banner feature flag is enabled$/) do
-  allow(Settings).to receive(:timed_retention_banner_enabled?).and_return(true)
-end
-
 And(/^The timed retention banner (is|is not) visible$/) do |visibility|
   selector = 'div.js-callout-banner[data-setting=timed_retention_banner_seen]'
 

--- a/spec/helpers/external_users/claims_helper_spec.rb
+++ b/spec/helpers/external_users/claims_helper_spec.rb
@@ -55,42 +55,28 @@ describe ExternalUsers::ClaimsHelper do
     let(:user_settings) { {} }
 
     before do
-      allow(Settings).to receive(:timed_retention_banner_enabled?).and_return(timed_retention_banner_enabled)
       allow(current_user).to receive(:settings).and_return(user_settings)
       allow(helper).to receive(:current_user).and_return(current_user)
     end
 
-    context 'feature flag enabled' do
-      let(:timed_retention_banner_enabled) { true }
+    context 'user is not an external user' do
+      let(:current_user) { create(:case_worker).user }
 
-      context 'user is not an external user' do
-        let(:current_user) { create(:case_worker).user }
-
-        it 'should return false' do
-          expect(helper.show_timed_retention_banner_to_user?).to be_falsey
-        end
-      end
-
-      context 'user has not seen yet the promo' do
-        it 'should return true' do
-          expect(helper.show_timed_retention_banner_to_user?).to be_truthy
-        end
-      end
-
-      context 'user has seen the promo' do
-        let(:user_settings) { {timed_retention_banner_seen: '1'} }
-
-        it 'should return false' do
-          expect(helper.show_timed_retention_banner_to_user?).to be_falsey
-        end
+      it 'should return false' do
+        expect(helper.show_timed_retention_banner_to_user?).to be_falsey
       end
     end
 
-    context 'feature flag disabled' do
-      let(:timed_retention_banner_enabled) { false }
+    context 'user has not seen yet the promo' do
+      it 'should return true' do
+        expect(helper.show_timed_retention_banner_to_user?).to be_truthy
+      end
+    end
 
-      it 'should return false regardless of the user setting' do
-        expect(helper).not_to receive(:current_user)
+    context 'user has seen the promo' do
+      let(:user_settings) { {timed_retention_banner_seen: '1'} }
+
+      it 'should return false' do
         expect(helper.show_timed_retention_banner_to_user?).to be_falsey
       end
     end


### PR DESCRIPTION
What
Remove timeout_retention_enabled? feature flag

Ticket
https://dsdmoj.atlassian.net/browse/CBO-1492

Why
This was set to true 4 years ago and has not been changed since, so presuming no longer required.
