### PR TITLE
Enable clar on non prod envs ready for seeding

### DIFF
--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
+            - name: CLAR_ENABLED
+              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
+            - name: CLAR_ENABLED
+              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
#### What
Enable clar on non prod envs ready for seeding

#### Why
before seeding the new fee scheme we must set
this env var/flag. Note the flag is
also used directly to show link to the
published (hopefully) unused materials form