### PR TITLE
todos - remove update_amount_assessed

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -46,23 +46,6 @@ class Assessment < Determination
     save!
   end
 
-  # TODO: this appears to only be used by update_amount_assessed
-  # which is only used in tests, or tests directly??!
-  def update_values(*args)
-    raise 'Cannot update an assessment that has values' if present?
-    update_values!(*args)
-  end
-
-  # TODO: this appears to only be used by update_amount_assessed
-  # which is only used in tests, or tests directly??!
-  def update_values!(fees, expenses, disbursements, time = Time.now)
-    self.fees = fees unless fees.nil?
-    self.expenses = expenses unless expenses.nil?
-    self.disbursements = disbursements unless disbursements.nil?
-    self.created_at = time
-    save!
-  end
-
   private
 
   def set_paper_trail_event!

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -287,11 +287,6 @@ module Claim
       end
     end
 
-    # TODO: this appears to only be used by tests
-    def update_amount_assessed(options)
-      assessment.update_values(options[:fees], options[:expenses], options[:disbursements])
-    end
-
     def pretty_type
       type.demodulize.sub('Claim', '').downcase
     end

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -840,7 +840,7 @@ def build_sortable_claims_sample(advocate)
       claim.state = 'draft'
       create(:misc_fee, claim: claim, quantity: n*1, rate: n*1)
       claim.state = old_state
-      claim.assessment.update_values!(claim.fees_total, 0, 0) if claim.authorised?
+      claim.assessment.update!(fees: claim.fees_total, expenses: 0, disbursements: 0) if claim.authorised?
     end
   end
 end

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -188,7 +188,7 @@ def random_case_number
 end
 
 def set_amount_assessed(claim)
-  claim.update_amount_assessed(fees: random_amount, expenses: random_amount)
+  claim.assessment.update!(fees: random_amount, expenses: random_amount)
 end
 
 def random_amount

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe Assessment do
 
     it 'determines rate using VatRate model' do
       expect(VatRate).to receive(:vat_amount).at_least(:once).and_call_original
-      assessment.update_values(150.0, 250.0, 0)
+      assessment.update!(fees: 150.0, expenses: 250.0, disbursements: 0) 
     end
 
     it 'updates determination\'s vat_amount' do
-      expect { assessment.update_values(150.0, 250.0, 0) }.to change(assessment, :vat_amount).from(0).to(80)
+      expect { assessment.update!(fees: 150.0, expenses: 250.0, disbursements: 0)  }.to change(assessment, :vat_amount).from(0).to(80)
     end
   end
 
@@ -105,7 +105,7 @@ RSpec.describe Assessment do
       context 'litigator claims' do
         let(:assessment) { create(:litigator_claim, apply_vat: true).assessment }
         it 'should not update/calculate the VAT amount' do
-          expect { assessment.update_values(100.0, 250.0, 150.0) }.not_to change(assessment, :vat_amount)
+          expect { assessment.update!(fees: 100.0, expenses: 250.0, disbursements: 150.0)  }.not_to change(assessment, :vat_amount)
         end
       end
     end
@@ -125,27 +125,6 @@ RSpec.describe Assessment do
       expect(reloaded_assessment.expenses).to eq 0
       expect(reloaded_assessment.disbursements).to eq 0
       expect(reloaded_assessment.total).to eq 0
-    end
-  end
-
-  describe '#update_values' do
-    let(:assessment) { create(:assessment) }
-
-    it 'raises error if assessment already made' do
-      assessment.update_values(:assessment, 1, 2, 3)
-
-      expect {
-        assessment.update_values(100, 200, 300)
-      }.to raise_error RuntimeError, "Cannot update an assessment that has values"
-    end
-
-    it 'updates the fields' do
-      assessment.update_values(888.88, 333.33, 150.00, DateTime.new(2016, 1, 2, 3, 4, 5))
-      assessment.reload
-      expect(assessment.fees).to eq 888.88
-      expect(assessment.expenses).to eq 333.33
-      expect(assessment.disbursements).to eq 150.00
-      expect(assessment.created_at).to eq DateTime.new(2016, 1, 2, 3, 4, 5)
     end
   end
 end

--- a/spec/models/claim/advocate_hardship_claim_spec.rb
+++ b/spec/models/claim/advocate_hardship_claim_spec.rb
@@ -1,7 +1,8 @@
 RSpec.shared_examples 'trial_cracked_at assigner' do
   subject { claim.trial_cracked_at }
 
-  let(:claim) { build(:advocate_hardship_claim, case_stage: case_stage, **cracked_details) }
+  let(:claim) { build(:advocate_hardship_claim, case_stage: case_stage, **cracked_details, assessment: assessment) }
+  let(:assessment) { build(:assessment) }
 
   let(:cracked_details) do
     {
@@ -65,7 +66,7 @@ RSpec.shared_examples 'trial_cracked_at assigner' do
 
       it 'authorising an amount does NOT assign trial_cracked_at' do
         expect {
-          claim.update_amount_assessed(fees: random_amount, expenses: random_amount)
+          claim.assessment.update!(fees: random_amount, expenses: random_amount)
           claim.authorise!
         }.not_to change { claim.trial_cracked_at }
       end

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -252,17 +252,6 @@ RSpec.describe Claim::BaseClaim do
         is_expected.to have_attributes(fees: 0.0, expenses: 0.0, disbursements: 0.0)
       end
     end
-
-    describe '#update_amount_assessed' do
-      subject { claim.assessment }
-      let(:claim) { create(:advocate_claim) }
-
-      before { claim.update_amount_assessed(fees: 100.0, expenses: 200.0) }
-
-      it 'updates the specified assessment attributes' do
-        is_expected.to have_attributes(fees: 100.0, expenses: 200.0, disbursements: 0.0)
-      end
-    end
   end
 
   describe '#fixed_fee_case?' do

--- a/spec/models/claims/financial_summary_spec.rb
+++ b/spec/models/claims/financial_summary_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Claims::FinancialSummary, type: :model do
 
     let!(:authorised_claim) do
       claim = create(:authorised_claim)
-      claim.assessment.update_values!(claim.fees_total, claim.expenses_total, claim.disbursements_total)
+      claim.assessment.update!(fees: claim.fees_total, expenses: claim.expenses_total, disbursements: claim.disbursements_total)
       claim
     end
 

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Claims::StateMachine, type: :model do
 
   describe '#around_transition' do
     let(:claim) { create(:submitted_claim) }
+    let(:assessment) { create(:assessment) }
     let(:case_type) { create(:case_type, :cbr) }
 
     context 'sets flag to disable all validations' do
@@ -68,7 +69,7 @@ RSpec.describe Claims::StateMachine, type: :model do
     context 'sets flag to enable only assessment validations' do
       before do
         claim.allocate!
-        claim.update_amount_assessed(fees: 100.00)
+        claim.assessment.update!(fees: 100.00)
       end
 
       %i[authorise! authorise_part!].each do |transition|

--- a/spec/presenters/assessment_presenter_spec.rb
+++ b/spec/presenters/assessment_presenter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AssessmentPresenter do
   context 'currency fields' do
     let(:currency_pattern) { /£\d,\d{3}\.\d{2}/ }
 
-    before { claim.assessment.update_values(1452.33, 2455.77, 1505.24) }
+    before { claim.assessment.update!(fees: 1452.33, expenses: 2455.77, disbursements: 1505.24) }
 
     it 'totals formatted as currency' do
       expect(presenter.fees_total).to match currency_pattern

--- a/spec/presenters/claim/base_claim_presenter_spec.rb
+++ b/spec/presenters/claim/base_claim_presenter_spec.rb
@@ -175,21 +175,21 @@ RSpec.describe Claim::BaseClaimPresenter do
 
   describe 'assessment_fees' do
     it 'should return formatted assessment fees' do
-      claim.assessment.update_values(1234.56, 0.0, 300.0)
+      claim.assessment.update!(fees: 1234.56, expenses: 0.0, disbursements: 300.0)
       expect(subject.assessment_fees).to eq '£1,234.56'
     end
   end
 
   describe 'assessment_expenses' do
     it 'should return formatted assessment expenses' do
-      claim.assessment.update_values(0.0, 1234.56, 300.0)
+      claim.assessment.update!(fees: 0.0, expenses: 1234.56, disbursements: 300.0)
       expect(subject.assessment_expenses).to eq '£1,234.56'
     end
   end
 
   describe 'assessment_disbursements' do
     it 'should return formatted assessment disbursements' do
-      claim.assessment.update_values(0.0, 0.0, 300.0)
+      claim.assessment.update!(fees: 0.0, expenses: 0.0, disbursements: 300.0)
       expect(subject.assessment_disbursements).to eq '£300.00'
     end
   end
@@ -337,7 +337,7 @@ RSpec.describe Claim::BaseClaimPresenter do
       before do
         claim.submit!
         claim.allocate!
-        claim.assessment.update_values(100, 20.43, 50.45)
+        claim.assessment.update!(fees: 100, expenses: 20.43, disbursements: 50.45)
         claim.authorise!
       end
 

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
 
         context 'when assessment included' do
           it 'raises no errors' do
-            claim.update_amount_assessed(fees: 100.00)
+            claim.assessment.update!(fees: 100.00)
             expect { claim.authorise! }.to_not raise_only_amount_assessed_error
           end
         end
@@ -140,7 +140,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
 
         context 'when assessment included' do
           it 'raises no errors' do
-            claim.update_amount_assessed(fees: 100.00)
+            claim.assessment.update!(fees: 100.00)
             expect { claim.authorise_part! }.to_not raise_only_amount_assessed_error
           end
         end
@@ -470,7 +470,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
     before { claim.submit!; claim.allocate! }
 
     let(:assessed_claim)  do
-      claim.update_amount_assessed(fees: 101.22, expenses: 28.55, disbursements: 92.66)
+      claim.assessment.update!(fees: 101.22, expenses: 28.55, disbursements: 92.66)
       claim
     end
 


### PR DESCRIPTION
#### What
Remove update_amound_assessed, update_values and update_values! methods

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1495

#### Why
Remove code that is only used by specs (and fix code climate issue).
