### PR TITLE
Only display "Unused materials" for applicable claim case types

### DIFF
--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -21,6 +21,8 @@ class CaseType < ApplicationRecord
   ROLES = %w[lgfs agfs interim].freeze
   include Roles
 
+  TRIAL_FEE_TYPES = %w[GRCBR GRRAK GRRTR GRTRL].freeze
+
   has_many :case_stages, dependent: :destroy
 
   auto_strip_attributes :name, squish: true, nullify: true
@@ -56,5 +58,9 @@ class CaseType < ApplicationRecord
 
   def is_graduated_fee?
     graduated_fee_type.nil? ? false : true
+  end
+
+  def is_trial_fee?
+    TRIAL_FEE_TYPES.include?(fee_type_code)
   end
 end

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -2,11 +2,13 @@ class Fee::MiscFeeType < Fee::BaseFeeType
   AGFS_SUPPLEMENTARY_ONLY_TYPES = %w[MISAF MIPCM].freeze
   AGFS_SUPPLEMENTARY_SHARED_TYPES = %w[MISAU MISPF MIWPF MIDTH MIDTW MIDHU MIDWU MIDSE MIDSU MIPHC MIUMU MIUMO].freeze
   AGFS_SUPPLEMENTARY_TYPES = (AGFS_SUPPLEMENTARY_ONLY_TYPES + AGFS_SUPPLEMENTARY_SHARED_TYPES).freeze
+  TRIAL_ONLY_TYPES = %w[MIUMU MIUMO].freeze
 
   default_scope { order(description: :asc) }
 
   scope :without_supplementary_only, -> { where.not(unique_code: AGFS_SUPPLEMENTARY_ONLY_TYPES) }
   scope :supplementary, -> { where(unique_code: AGFS_SUPPLEMENTARY_TYPES) }
+  scope :without_trial_fee_only, -> { where.not(unique_code: TRIAL_ONLY_TYPES) }
 
   def fee_category_name
     'Miscellaneous Fees'

--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -13,17 +13,21 @@ module Claims
     private
 
     LGFS_GENERAL_ELIGIBILITY = %w[MICJA MICJP MIEVI MISPF].freeze
-    LGFS_FIXED_FEE_ELIGIBILITY = (LGFS_GENERAL_ELIGIBILITY + %w[MIUPL]).freeze
-    LGFS_GRADUATED_FEE_ELIGIBILITY = (LGFS_GENERAL_ELIGIBILITY + %w[MIUMU MIUMO]).freeze
-    LGFS_HARDSHIP_FEE_ELIGIBILITY = %w[MIEVI MISPF MIUMU MIUMO].freeze
+    LGFS_FIXED_CLAIM_ELIGIBILITY = (LGFS_GENERAL_ELIGIBILITY + %w[MIUPL]).freeze
+    LGFS_TRIAL_CLAIM_ELIGIBILITY = (LGFS_GENERAL_ELIGIBILITY + Fee::MiscFeeType::TRIAL_ONLY_TYPES).freeze
+    LGFS_HARDSHIP_CLAIM_ELIGIBILITY = (%w[MIEVI MISPF] + Fee::MiscFeeType::TRIAL_ONLY_TYPES).freeze
 
     attr_reader :claim
     delegate :case_type, :agfs?, :lgfs?, :agfs_reform?, :agfs_scheme_12?, :hardship?, to: :claim, allow_nil: true
 
     def eligible_fee_types
       return eligible_agfs_misc_fee_types if agfs?
-      return eligible_lgfs_hardship_misc_fee_types if lgfs? && hardship?
       return eligible_lgfs_misc_fee_types if lgfs?
+    end
+
+    def eligible_agfs_misc_fee_types
+      return agfs_scheme_scope.supplementary if claim.supplementary?
+      agfs_scheme_scope.without_supplementary_only
     end
 
     def agfs_scheme_scope
@@ -32,26 +36,29 @@ module Claims
       Fee::MiscFeeType.agfs_scheme_9s
     end
 
-    def eligible_agfs_misc_fee_types
-      return agfs_scheme_scope.supplementary if claim.supplementary?
-      agfs_scheme_scope.without_supplementary_only
-    end
-
-    def eligible_lgfs_hardship_misc_fee_types
-      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_HARDSHIP_FEE_ELIGIBILITY)
-    end
-
     def eligible_lgfs_misc_fee_types
-      return lgfs_fixed_fee_misc_fee_types if case_type&.is_fixed_fee?
-      lgfs_graduated_fee_misc_fee_types
+      fee_types = if hardship?
+                    lgfs_hardship_misc_fee_types
+                  elsif case_type&.is_fixed_fee?
+                    lgfs_fixed_fee_misc_fee_types
+                  else
+                    lgfs_trial_fee_misc_fee_types
+                  end
+
+      return fee_types if case_type&.is_trial_fee? || case_type.nil?
+      fee_types.without_trial_fee_only
+    end
+
+    def lgfs_hardship_misc_fee_types
+      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_HARDSHIP_CLAIM_ELIGIBILITY)
     end
 
     def lgfs_fixed_fee_misc_fee_types
-      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_FIXED_FEE_ELIGIBILITY)
+      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_FIXED_CLAIM_ELIGIBILITY)
     end
 
-    def lgfs_graduated_fee_misc_fee_types
-      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_GRADUATED_FEE_ELIGIBILITY)
+    def lgfs_trial_fee_misc_fee_types
+      Fee::MiscFeeType.lgfs.where(unique_code: LGFS_TRIAL_CLAIM_ELIGIBILITY)
     end
   end
 end

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -77,7 +77,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
 
     And I should be in the 'Miscellaneous fees' form page
     And I should see a page title "Enter miscellaneous fees for litigator final fees claim"
-    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee,Unused materials (upto 3 hours), Unused materials (over 3 hours)'
+    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee'
     And I add a litigator miscellaneous fee 'Costs judge application'
 
     When I click "Continue" in the claim form

--- a/features/claims/litigator/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/transfer_claim_draft_submit.feature
@@ -66,7 +66,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And I eject the VCR cassette
 
     And I should be in the 'Miscellaneous fees' form page
-    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee,Unused materials (upto 3 hours), Unused materials (over 3 hours)'
+    And the first miscellaneous fee should have fee types 'Costs judge application,Costs judge preparation,Evidence provision fee,Special preparation fee'
     And I add a litigator miscellaneous fee 'Costs judge application'
 
     And I should see a page title "Enter miscellaneous fees for litigator transfer fees claim"

--- a/spec/factories/claim/transfer_claims.rb
+++ b/spec/factories/claim/transfer_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :transfer_claim, class: Claim::TransferClaim do
+  factory :transfer_claim, aliases: [:litigator_transfer_claim], class: Claim::TransferClaim do
     litigator_base_setup
     claim_state_common_traits
     case_type { nil }

--- a/spec/models/case_type_spec.rb
+++ b/spec/models/case_type_spec.rb
@@ -67,6 +67,28 @@ RSpec.describe CaseType, type: :model do
     end
   end
 
+  describe 'is_trial_fee?' do
+    subject { case_type.is_trial_fee? }
+
+    context 'with fee_type_code matching "trial" fee case type' do
+      let(:case_type) { create(:case_type, fee_type_code: 'GRTRL') }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with fee_type_code not matching "trial" fee case type' do
+      let(:case_type) { create(:case_type, fee_type_code: 'GRGLT') }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with nil fee_type_code' do
+      let(:case_type) { create(:case_type, fee_type_code: nil) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   context 'scopes' do
     before(:all) { seed_case_types }
     after(:all) { destroy_case_types }

--- a/spec/models/fee/misc_fee_type_spec.rb
+++ b/spec/models/fee/misc_fee_type_spec.rb
@@ -59,8 +59,22 @@ RSpec.describe Fee::MiscFeeType do
         create(:misc_fee_type, unique_code: 'MISAU')
       end
 
-      it 'returns fee types with unique codes defined in class constants' do
+      it 'returns fee types excluding those for only supplementary claims' do
         is_expected.to match_array(%w[MISAU])
+      end
+    end
+
+    describe '.without_trial_fee_only' do
+      subject { described_class.without_trial_fee_only.map(&:unique_code) }
+
+      before do
+        create(:misc_fee_type, unique_code: 'MISPF' )
+        create(:misc_fee_type, unique_code: 'MIUMU')
+        create(:misc_fee_type, unique_code: 'MIUMO')
+      end
+
+      it 'returns fee types excluding those only for "trial" case type claims' do
+        is_expected.to match_array(%w[MISPF])
       end
     end
   end

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -32,6 +32,26 @@ RSpec.shared_examples 'fetches AGFS fee scheme misc fee types excluding suppleme
   end
 end
 
+RSpec.shared_context 'pre CLAR rep order date' do
+  let(:pre_clar_date) { Settings.clar_release_date.end_of_day - 1.day }
+
+  before do
+    allow(claim)
+      .to receive(:earliest_representation_order_date)
+      .and_return(pre_clar_date)
+  end
+end
+
+RSpec.shared_context 'post CLAR rep order date' do
+  let(:post_clar_date) { Settings.clar_release_date.beginning_of_day }
+
+  before do
+    allow(claim)
+      .to receive(:earliest_representation_order_date)
+      .and_return(post_clar_date)
+  end
+end
+
 RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
   before(:all) do |example|
     allow(Settings).to receive(:clar_enabled?).and_return true
@@ -64,9 +84,6 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
       it { is_expected.to eq(nil) }
     end
 
-    # LGFS misc fees are those eligible for lgfs (via roles)
-    # but excluding defendant uplifts since these are catered
-    # for by fee calculation.
     fcontext 'with LGFS claim' do
       subject(:unique_codes) { call.map(&:unique_code) }
 
@@ -87,50 +104,41 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
           context 'when appeal against sentence' do
             let(:case_type) { CaseType.find_by(fee_type_code: 'FXASE') }
 
-            it 'includes defendant uplift' do
-              is_expected.to include('MIUPL')
-            end
-
-            it 'returns all expected fee types' do
-              is_expected.to match_array %w[MICJA MICJP MIUPL MIEVI MISPF]
-            end
+            it { is_expected.to include('MIUPL') }
+            it { is_expected.to match_array %w[MICJA MICJP MIUPL MIEVI MISPF] }
           end
         end
 
         context 'with graduated case type fee claim' do
+          context 'with any non-fixed-fee case type' do
+            let(:case_type) { create(:case_type, is_fixed_fee: false) }
+
+            it { is_expected.not_to include('MIUPL') }
+          end
+
           context 'with "trial" fee claim' do
-            context 'when trial' do
-              let(:case_type) { CaseType.find_by(fee_type_code: 'GRTRL') }
+            let(:case_type) { CaseType.find_by(fee_type_code: 'GRTRL') }
 
-              it 'includes unused materials' do
-                is_expected.to include(*%w[MIUMU MIUMO])
-              end
+            context 'with rep order pre CLAR' do
+              include_context 'pre CLAR rep order date'
 
-              it 'returns all LGFS misc fee types except defendant uplifts' do
-                is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
-              end
+              it { is_expected.to match_array %w[MICJA MICJP MIEVI MISPF] }
             end
 
-            context 'when cracked trial' do
-              let(:case_type) { CaseType.find_by(fee_type_code: 'GRRAK') }
+            context 'with rep order post CLAR' do
+              include_context 'post CLAR rep order date'
 
-              it 'returns all LGFS misc fee types except defendant uplifts' do
-                is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
-              end
+              it { is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO] }
             end
           end
 
           context 'with "non-trial" fee claim' do
+            include_context 'post CLAR rep order date'
+
             context 'when case type is Guilty plea' do
               let(:case_type) { CaseType.find_by(fee_type_code: 'GRGLT') }
 
-              it 'excludes unused materials' do
-                is_expected.not_to include(*%w[MIUMU MIUMO])
-              end
-
-              it 'returns all expected fee types' do
-                is_expected.to match_array %w[MICJA MICJP MIEVI MISPF]
-              end
+              it { is_expected.to match_array %w[MICJA MICJP MIEVI MISPF] }
             end
           end
         end
@@ -139,19 +147,43 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
       context 'with hardship fee claim' do
         let(:claim) { create(:litigator_hardship_claim, case_stage: case_stage) }
 
-        context 'with "trial" case stage' do
-          let(:case_stage) { create(:case_stage, :trial_not_sentenced) }
+        context 'when rep order is post CLAR' do
+          include_context 'post CLAR rep order date'
 
-          it 'returns only non-cost judge LGFS misc fee types' do
-            is_expected.to match_array %w[MIEVI MISPF MIUMU MIUMO]
+          context 'with "trial" case stage' do
+            let(:case_stage) { create(:case_stage, :trial_not_sentenced) }
+
+            it 'returns only non-cost-judge LGFS misc fee types' do
+              is_expected.to match_array %w[MIEVI MISPF MIUMU MIUMO]
+            end
+          end
+
+          context 'with "non-trial" case stage' do
+            let(:case_stage) { create(:case_stage, :guilty_plea_not_sentenced) }
+
+            it 'returns only non-cost-judge, non-trial LGFS misc fee types' do
+              is_expected.to match_array %w[MIEVI MISPF]
+            end
           end
         end
 
-        context 'with "non-trial" case stage' do
-          let(:case_stage) { create(:case_stage, :guilty_plea_not_sentenced) }
+        context 'when rep order is pre CLAR' do
+          include_context 'pre CLAR rep order date'
 
-          it 'returns only non-cost, non-trial LGFS misc fee types' do
-            is_expected.to match_array %w[MIEVI MISPF]
+          context 'with "trial" case stage' do
+            let(:case_stage) { create(:case_stage, :trial_not_sentenced) }
+
+            it 'returns only non-cost-judge, non-CLAR LGFS misc fee types' do
+              is_expected.to match_array %w[MIEVI MISPF]
+            end
+          end
+
+          context 'with "non-trial" case stage' do
+            let(:case_stage) { create(:case_stage, :guilty_plea_not_sentenced) }
+
+            it 'returns only non-cost-judge, non-trial LGFS misc fee types' do
+              is_expected.to match_array %w[MIEVI MISPF]
+            end
           end
         end
       end
@@ -159,8 +191,20 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
       context 'with transfer fee claim' do
         let(:claim) { create(:litigator_transfer_claim, case_type: nil) }
 
-        it 'returns all LGFS misc fee types except defendant uplifts' do
-          is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
+        context 'with rep order pre CLAR' do
+          include_context 'pre CLAR rep order date'
+
+          it 'returns all LGFS misc fee types except defendant uplifts' do
+            is_expected.to match_array %w[MICJA MICJP MIEVI MISPF]
+          end
+        end
+
+        context 'with rep order post CLAR' do
+          include_context 'post CLAR rep order date'
+
+          it 'returns all LGFS misc fee types except defendant uplifts' do
+            is_expected.to match_array %w[MICJA MICJP MIEVI MISPF MIUMU MIUMO]
+          end
         end
       end
     end


### PR DESCRIPTION
#### What
only display the Unused materials CLAR fee types for applicable case types

#### Ticket

[CBO-1463](https://dsdmoj.atlassian.net/browse/CBO-1463)

#### Why
LGFS - only display Unused materials CLAR fee types for applicable claims as below:


#### TODO (wip)

 - [X] only for trial, cracked trial, retrial and cracked before retrial
 - [X] only for final, hardship and transfer claims
 - [x] only for post release date if available