### PR TITLE
AGFS - only display the Unused materials CLAR fee types for applicable case types

### DIFF
--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -26,6 +26,10 @@ module Claims
     end
 
     def eligible_agfs_misc_fee_types
+      trial_fee_filter(agfs_fee_types_by_claim_type)
+    end
+
+    def agfs_fee_types_by_claim_type
       return agfs_scheme_scope.supplementary if claim.supplementary?
       agfs_scheme_scope.without_supplementary_only
     end

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
       it { is_expected.to eq(nil) }
     end
 
-    fcontext 'with LGFS claim' do
+    context 'with LGFS claim' do
       subject(:unique_codes) { call.map(&:unique_code) }
 
       context 'with final claim' do


### PR DESCRIPTION
#### What
AGFS - only display the Unused materials CLAR fee types for applicable case types

#### Ticket

[CBO-1463](https://dsdmoj.atlassian.net/browse/CBO-1463)

#### Why
AGFS, only display Unused materials CLAR fee types for applicable AGFS claims.

Final, hardship and supplementary claims with a case type or case stage
of trial, cracked trial, retrial and cracked before retrial