### PR TITLE
Remove clar_enabled? flag

### DIFF
--- a/app/views/external_users/advocates/claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/claims/_miscellaneous_fees_form_step.html.haml
@@ -5,10 +5,7 @@
 
 = render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope)}
 %p
-  - if Settings.clar_enabled?
-    = t('clar_page_intro_html', scope: locale_scope)
-  - else
-    = t('page_intro_html', scope: locale_scope)
+  = t('page_intro_html', scope: locale_scope)
 
 = render partial: 'external_users/claims/misc_fees/advocates/fields', locals: { f: f }
 

--- a/app/views/external_users/advocates/hardship_claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/hardship_claims/_miscellaneous_fees_form_step.html.haml
@@ -5,10 +5,7 @@
 
 = render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope), fees_calculator_html: ''}
 %p
-  - if Settings.clar_enabled?
-    = t('clar_page_intro_html', scope: locale_scope)
-  - else
-    = t('page_intro_html', scope: locale_scope)
+  = t('page_intro_html', scope: locale_scope)
 
 
 = render partial: 'external_users/claims/misc_fees/advocates/fields', locals: { f: f }

--- a/app/views/external_users/advocates/supplementary_claims/_miscellaneous_fees_form_step.html.haml
+++ b/app/views/external_users/advocates/supplementary_claims/_miscellaneous_fees_form_step.html.haml
@@ -6,10 +6,7 @@
 = render partial: 'external_users/claims/fees_shared_header', locals: {page_header: t('page_header', scope: locale_scope), page_hint: t('page_hint', scope: locale_scope)}
 
 %p
-  - if Settings.clar_enabled?
-    = t('clar_page_intro_html', scope: locale_scope)
-  - else
-    = t('page_intro_html', scope: locale_scope)
+  = t('page_intro_html', scope: locale_scope)
 
 = render partial: 'external_users/advocates/advocate_category', locals: { f: f }
 

--- a/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
@@ -1,8 +1,5 @@
 %p
-  - if Settings.clar_enabled?
-    = t('.clar_page_intro_html')
-  - else
-    = t('.page_intro_html')
+  = t('.page_intro_html')
 
 #misc-fees.mod-fees
   #misc-fees-numberList.misc-fee-group-wrapper.fx-numberedList-hook

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1406,14 +1406,10 @@ en:
       misc_fees:
         page_header: *miscellaneous_fees
         page_hint: *fees_vat_prompt
-        clar_page_intro_html: |
-          If needed, please complete an
-          <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" target="_blank" rel="external">appropriate special prep form <span class="visuallyhidden">opens in new window</span></a>
-          or <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" target="_blank" rel="external">unused materials (over 3 hours) form <span class="visuallyhidden">opens in new window</span></a>
-          and attach to the claim.
         page_intro_html: |
           If needed, please complete an
           <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" target="_blank" rel="external">appropriate special prep form <span class="visuallyhidden">opens in new window</span></a>
+          or <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" target="_blank" rel="external">unused materials (over 3 hours) form <span class="visuallyhidden">opens in new window</span></a>
           and attach to the claim.
         advocates:
           fields:
@@ -1447,14 +1443,10 @@ en:
             misc_fees: *miscellaneous_fees
             add_misc_fee: Add another fee
             page_hint: *fees_vat_prompt
-            clar_page_intro_html: |
-              If needed, please complete
-              <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external">special prep form <span class="visuallyhidden">opens in new window</span></a>
-              or <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external">unused materials (over 3 hours) form <span class="visuallyhidden">opens in new window</span></a>
-              and attach to the claim.
             page_intro_html: |
               If needed, please complete
               <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external">special prep form <span class="visuallyhidden">opens in new window</span></a>
+              or <a href="https://www.gov.uk/government/publications/lf1-claim-litigator-fees" target="_blank" rel="external">unused materials (over 3 hours) form <span class="visuallyhidden">opens in new window</span></a>
               and attach to the claim.
           misc_fee_fields:
             misc_fee: *miscellaneous_fee

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,7 +104,6 @@ reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).ch
 agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
 agfs_scheme_11_release_date: <%= Date.new(2018, 12, 31) %>
 clar_release_date: <%= Date.new(2020, 9, 17) %>
-clar_enabled?: <%= ENV.fetch('CLAR_ENABLED', 'false')&.downcase&.eql?('true') %>
 
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16

--- a/db/seeds/schemas/add_agfs_fee_scheme_12.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_12.rb
@@ -156,7 +156,7 @@ module Seeds
         Offence.transaction do
           agfs_scheme_eleven_offences.each do |offence|
             if pretending?
-              puts "#{offence.unique_code} => #{offence.unique_code.sub('~11','~12')}".yellow
+              puts "[WOULD-COPY] " + "#{offence.unique_code} => #{offence.unique_code.sub('~11','~12')}".yellow
             else
               new_offence = offence.dup
               new_offence.unique_code = new_offence.unique_code.sub('~11','~12')
@@ -171,9 +171,12 @@ module Seeds
       end
 
       def set_offence_pk_sequence(sequence_start)
-        raise StandardError, 'Sequence cannot be set to value less than greatest id in use' if Offence.ids.max > sequence_start
-        return if pretending?
-
+        if pretending?
+          print "Resetting offences sequence to max offence id unless Offence.ids.max > sequence_start (#{Offence.ids.max} > #{sequence_start})...".yellow
+          puts 'not resetting'.green
+          return
+        end
+        raise StandardError, "Sequence cannot be set to value less than greatest id in use - #{Offence.ids.max} > #{sequence_start}" if Offence.ids.max > sequence_start
         ActiveRecord::Base.connection.set_pk_sequence!('offences', sequence_start)
       end
 

--- a/db/seeds/schemas/add_agfs_fee_scheme_12.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_12.rb
@@ -25,12 +25,10 @@ module Seeds
           \sAGFS scheme 12 new fee_type count: #{scheme_12_only_fee_types.count}
           \s------------------------------------------------------------
           Status: #{agfs_fee_scheme_12.present? && scheme_12_offence_count > 0 ? 'up' : 'down'}
-          Enabled: #{Settings.clar_enabled?}
         STATUS
       end
 
       def up
-        puts 'AGFS scheme 12 is not enabled. You must enable in settings first!'.yellow unless Settings.clar_enabled?
         create_or_update_agfs_scheme_eleven
         create_agfs_scheme_twelve
         create_agfs_scheme_twelve_offences
@@ -106,8 +104,6 @@ module Seeds
       end
 
       def create_or_update_agfs_scheme_eleven
-        return unless Settings.clar_enabled?
-
         print "Finding AGFS scheme 11".yellow
         agfs_fee_scheme_eleven = FeeScheme.find_by(name: 'AGFS', version: 11, start_date: Settings.agfs_scheme_11_release_date.beginning_of_day)
         agfs_fee_scheme_eleven ? print("...found\n".green) : print("...not found\n".red)
@@ -121,8 +117,6 @@ module Seeds
       end
 
       def create_agfs_scheme_twelve
-        return unless Settings.clar_enabled?
-
         print "Finding or creating scheme 12 with start date #{Settings.clar_release_date.beginning_of_day}...".yellow
         print "...not created\n".green if pretending?
         return if pretending?
@@ -132,16 +126,12 @@ module Seeds
       end
 
       def create_agfs_scheme_twelve_offences
-        return unless Settings.clar_enabled?
-
         puts "Scheme 12 offence count before: #{scheme_12_offence_count}".yellow
         copy_scheme_11_offences
         puts "Scheme 12 offence count after: #{scheme_12_offence_count}".yellow
       end
 
       def create_scheme_twelve_fee_types
-        return unless Settings.clar_enabled?
-
         puts "Scheme 12 fee type count before: #{scheme_12_fee_type_count}".yellow
         Rake::Task['data:migrate:fee_types:reseed'].invoke(pretending?)
         puts "Scheme 12 fee type count after: #{scheme_12_fee_type_count}".yellow

--- a/kubernetes_deploy/api-sandbox/deployment.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment.yaml
@@ -75,8 +75,6 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://laa-fee-calculator.service.justice.gov.uk/api/v1
-            - name: CLAR_ENABLED
-              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/dev-lgfs/deployment.yaml
+++ b/kubernetes_deploy/dev-lgfs/deployment.yaml
@@ -75,8 +75,6 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
-            - name: CLAR_ENABLED
-              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/dev/deployment.yaml
+++ b/kubernetes_deploy/dev/deployment.yaml
@@ -75,8 +75,6 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
-            - name: CLAR_ENABLED
-              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/production/deployment.yaml
+++ b/kubernetes_deploy/production/deployment.yaml
@@ -75,8 +75,6 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://laa-fee-calculator.service.justice.gov.uk/api/v1
-            - name: CLAR_ENABLED
-              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yaml
+++ b/kubernetes_deploy/staging/deployment.yaml
@@ -75,8 +75,6 @@ spec:
               value: 'eu-west-2'
             - name: LAA_FEE_CALCULATOR_HOST
               value: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
-            - name: CLAR_ENABLED
-              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/spec/api/v1/external_users/claims/integration/advocate_claim_creation_spec.rb
+++ b/spec/api/v1/external_users/claims/integration/advocate_claim_creation_spec.rb
@@ -350,7 +350,6 @@ RSpec.describe 'API claim creation for AGFS' do
   include ApiSpecHelper
 
   before do
-    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
     seed_case_types
     seed_fee_types

--- a/spec/factories/fee_schemes.rb
+++ b/spec/factories/fee_schemes.rb
@@ -7,19 +7,19 @@ FactoryBot.define do
 
     trait :agfs_nine do
       start_date { Date.new(2016, 0o1, 0o1).beginning_of_day }
-      end_date { Date.new(2018, 0o3, 31).end_of_day }
+      end_date { Settings.agfs_fee_reform_release_date.end_of_day - 1.day }
       version { 9 }
     end
 
     trait :agfs_ten do
-      start_date { Date.new(2018, 0o4, 0o1).beginning_of_day }
-      end_date { Date.new(2018, 12, 30).end_of_day }
+      start_date { Settings.agfs_fee_reform_release_date.beginning_of_day }
+      end_date { Settings.agfs_scheme_11_release_date.end_of_day - 1.day }
       version { 10 }
     end
 
     trait :agfs_eleven do
-      start_date { Date.new(2018, 12, 31).beginning_of_day }
-      end_date { (Settings.clar_release_date.end_of_day - 1.day) if Settings.clar_enabled? }
+      start_date { Settings.agfs_scheme_11_release_date.beginning_of_day }
+      end_date { Settings.clar_release_date.end_of_day - 1.day }
       version { 11 }
     end
 
@@ -30,8 +30,16 @@ FactoryBot.define do
     end
 
     # scheme 8 (default)
-    # TODO: current seeds for LGFS fee schemes represent scheme 8 as 9
+    # NOTE: current seeds for LGFS fee schemes represent scheme 8 as 9
     # but there are no functional changes that are impacted.
+    #
+    # Following CLAR release on the 17/09/2020 the LGFS fee scheme is
+    # technically scheme 9, according to the business. However, no new
+    # lgfs fee scheme has been added - it probably should be - instead
+    # simply adding the new "Unused material" fee type(s) without fee
+    # calculation (inline with other LGFS misc fees) and validating
+    # its presence using the CLAR release date compared to rep order
+    # date.
     trait :lgfs do
       name { 'LGFS' }
       start_date { Date.new(2014, 03, 20).beginning_of_day }

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe FeeScheme, type: :model do
     before do
-      allow(Settings).to receive(:clar_enabled?).and_return true
       seed_fee_schemes
     end
 

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require "rspec/mocks/standalone" # required for mocking/unmocking in before/after(:all) block
 
 RSpec.shared_context 'pre CLAR rep order date' do
   let(:pre_clar_date) { Settings.clar_release_date.end_of_day - 1.day }

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -45,7 +45,6 @@ end
 
 RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
   before(:all) do |example|
-    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
     seed_case_types
     seed_fee_types
@@ -53,7 +52,6 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
 
   after(:all) do
     clean_database
-    allow(Settings).to receive(:clar_enabled?).and_call_original
   end
 
   let(:trial_only_types) { %w[MIUMU MIUMO] }

--- a/spec/services/claims/fetch_eligible_offences_spec.rb
+++ b/spec/services/claims/fetch_eligible_offences_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Claims::FetchEligibleOffences, type: :service do
   subject(:offences) { described_class.for(claim) }
 
   before do
-    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
   end
 

--- a/spec/services/fee_reform/search_offences_spec.rb
+++ b/spec/services/fee_reform/search_offences_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe FeeReform::SearchOffences, type: :service do
   before do
-    allow(Settings).to receive(:clar_enabled?).and_return true
     seed_fee_schemes
   end
 

--- a/spec/support/seed_helpers.rb
+++ b/spec/support/seed_helpers.rb
@@ -6,12 +6,8 @@ module SeedHelpers
     FeeScheme.find_or_create_by(name: 'LGFS', version: 9, start_date: Date.new(2014, 03, 20).beginning_of_day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 9, start_date: Date.new(2012, 04, 01).beginning_of_day, end_date: Date.new(2018, 03, 31).end_of_day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 10, start_date: Settings.agfs_fee_reform_release_date.beginning_of_day, end_date: Settings.agfs_scheme_11_release_date - 1.day)
-    FeeScheme.find_or_create_by(name: 'AGFS', version: 11, start_date: Settings.agfs_scheme_11_release_date.beginning_of_day)
-
-    if Settings.clar_enabled?
-      FeeScheme.find_by(name: 'AGFS', version: 11).update(end_date: Settings.clar_release_date.end_of_day - 1.day)
-      FeeScheme.find_or_create_by(name: 'AGFS', version: 12, start_date: Settings.clar_release_date.beginning_of_day)
-    end
+    FeeScheme.find_or_create_by(name: 'AGFS', version: 11, start_date: Settings.agfs_scheme_11_release_date.beginning_of_day, end_date: Settings.clar_release_date.end_of_day - 1.day)
+    FeeScheme.find_or_create_by(name: 'AGFS', version: 12, start_date: Settings.clar_release_date.beginning_of_day)
   end
 
   def seed_case_types


### PR DESCRIPTION
Now that we are beyond the clar release date this is no longer
required.


#### What
remove flag used to enable CLAR seeding and display

#### Why
now we are post CLAR release this needs cleaning up to avoid future developer confusion



#### Ticket

[https://dsdmoj.atlassian.net/browse/CBO-1528](https://dsdmoj.atlassian.net/browse/CBO-1528)

#### TODO (wip)

 - [X] flag setting removed
 - [X] flag env var removed
 - [x] dependencies on flag amended (check seed and rollback tasks still work)