### PR TITLE
Attempt to fix urn display issue for long urns

### DIFF
--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -132,6 +132,10 @@ class Claim::BaseClaimPresenter < BasePresenter
     claim.case_number.blank? ? 'N/A' : claim.case_number
   end
 
+  def formatted_case_number
+    claim.case_number.blank? ? 'N/A' : claim.case_number.scan(/.{1,3}/).join(' ')
+  end
+
   def unique_id
     "##{claim.id}"
   end

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -4,7 +4,7 @@
       %h1
         = t('.case_number')
         %span.case-number-header
-          = claim.case_number
+          = claim.formatted_case_number
           %span.unique-id-small= claim.unique_id
     .column-one-third
       .claim-status

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -70,6 +70,10 @@ header.main-header {
     @include core-36;
     display: block;
     font-weight: 700;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    word-wrap: break-word;
+    hyphens: auto;
   }
 
   .claim-status {

--- a/spec/presenters/claim/base_claim_presenter_spec.rb
+++ b/spec/presenters/claim/base_claim_presenter_spec.rb
@@ -106,6 +106,11 @@ RSpec.describe Claim::BaseClaimPresenter do
     end
   end
 
+  it '#formatted_case_number' do
+    subject.case_number = 'S20094903'
+    expect(subject.formatted_case_number).to eql('S20 094 903')
+  end
+
   describe '#valid_transitions' do
     it 'should list valid transitions from allocated' do
       claim.state = 'allocated'


### PR DESCRIPTION
#### What
Fix issue identified by @alanmaydwell where long urns were being partially covered by the status field

#### Ticket
n/a

#### Why
Fix display issue

#### How
With thanks to suggested solution from @naseberry , allow casenumber/urn field to split into multiple lines.