### PR TITLE
Improve WCAG focus visibility

### DIFF
--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -9,29 +9,29 @@
     %thead
       %tr
         %th{ scope: 'col' }
-          = sortable 'type', t('.type'), 'aria-label': t('.type_sort_label'), tabindex: 0, id: 'type'
+          = sortable 'type', t('.type'), 'aria-label': t('.type_sort_label'), id: 'type'
 
         %th{ scope: 'col' }
-          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), tabindex: 0, id: 'case_number'
+          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number'
 
         %th{ scope: 'col' }
-          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), tabindex: 0, id: 'advocate'
+          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate'
 
         %th{ scope: 'col' }
           = t('.defendants')
 
         %th.numeric{ scope: 'col' }
-          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), tabindex: 0, id: 'total_inc_vat'
+          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat'
 
         - if params[:action] == 'archived'
           %th{ scope: 'col' }
-            = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), tabindex: 0, id: 'state'
+            = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state'
 
         %th{ scope: 'col' }
-          = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), tabindex: 0, id: 'case_type'
+          = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), id: 'case_type'
 
         %th.numeric{ scope: 'col' }
-          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), tabindex: 0, id: 'last_submitted_at'
+          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at'
 
         %th.message-placeholder{ scope: 'col' }
           = t('.messages')
@@ -39,13 +39,13 @@
       %tr.mobile-sort
         %th{ scope: 'col' }
           Sort by:
-          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), tabindex: 0, id: 'case_number_ms'
-          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), tabindex: 0, id: 'advocate_ms'
-          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), tabindex: 0, id: 'total_inc_vat_ms'
+          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number_ms'
+          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate_ms'
+          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat_ms'
           - if params[:action] == 'archived'
-            = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), tabindex: 0, id: 'state_ms'
-          = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), tabindex: 0, id: 'case_type_ms'
-          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), tabindex: 0, id: 'last_submitted_at_ms'
+            = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state_ms'
+          = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), id: 'case_type_ms'
+          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at_ms'
       - present_collection(claims).each do |claim|
         %tr{ class: claim.injection_error ? 'error injection-error' : nil }
           %td

--- a/app/views/external_users/claims/_main_claims_list.html.haml
+++ b/app/views/external_users/claims/_main_claims_list.html.haml
@@ -16,26 +16,26 @@
           = t('.type')
 
       %th{ scope: 'col' }
-        = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), tabindex: 0, id: 'case_number'
+        = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number'
 
       - if current_user.persona.admin?
         %th{ scope: 'col' }
-          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), tabindex: 0, id: 'advocate'
+          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate'
 
       %th{ scope: 'col' }
         = t('.defendants')
 
       %th.numeric{ scope: 'col' }
-        = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), tabindex: 0, id: 'total_inc_vat'
+        = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat'
 
       %th.numeric{ scope: 'col' }
-        = sortable 'amount_assessed', t('.assessed'), 'aria-label': t('.amount_assessed_sort_label'), tabindex: 0, id: 'amount_assessed'
+        = sortable 'amount_assessed', t('.assessed'), 'aria-label': t('.amount_assessed_sort_label'), id: 'amount_assessed'
 
       %th{ scope: 'col' }
-        = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), tabindex: 0, id: 'state'
+        = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state'
 
       %th.numeric{ scope: 'col' }
-        = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), tabindex: 0, id: 'last_submitted_at'
+        = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at'
 
       %th{ scope: 'col' }
         = t('.messages')
@@ -43,13 +43,13 @@
       %tr.mobile-sort
         %th{ scope: 'col' }
           Sort by:
-          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), tabindex: 0, id: 'case_number_ms'
+          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number_ms'
           - if current_user.persona.admin?
-            = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), tabindex: 0, id: 'advocate_ms'
-          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), tabindex: 0, id: 'total_inc_vat_ms'
-          = sortable 'amount_assessed', t('.assessed'), 'aria-label': t('.amount_assessed_sort_label'), tabindex: 0, id: 'amount_assessed_ms'
-          = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), tabindex: 0, id: 'state_ms'
-          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), tabindex: 0, id: 'last_submitted_at_ms'
+            = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate_ms'
+          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat_ms'
+          = sortable 'amount_assessed', t('.assessed'), 'aria-label': t('.amount_assessed_sort_label'), id: 'amount_assessed_ms'
+          = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state_ms'
+          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at_ms'
       - present_collection(claims).each do |claim|
         %tr{ id: dom_id(claim), class: claim.state }
 

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
@@ -7,9 +7,11 @@
     .form-group
       = render partial: 'external_users/claims/basic_fees/offence_display', locals: { claim: @claim }
 
-    = f.hidden_field :fee_type_id, value: f.object.fee_type_id, class: 'js-fee-type'
-    = f.label :quantity, 'Fee calculator days', class: 'visually-hidden'
-    = f.text_field :quantity, value: 1, class: 'js-fee-calculator-days visually-hidden'
+    .form-group.visually-hidden{ 'aria-hidden': 'true' }
+      = f.hidden_field :fee_type_id, value: f.object.fee_type_id, class: 'js-fee-type'
+      = f.label :quantity, 'Fee calculator days', class: 'form-label-bold'
+      = f.text_field :quantity, value: 1, class: 'form-control js-fee-calculator-days', readonly: true, tabindex: -1
+
     .js-graduated-price-effectee
       .calculated-grad-fee
       = f.adp_text_field :rate,

--- a/app/views/external_users/claims/interim_fee/_calculator_help.html.haml
+++ b/app/views/external_users/claims/interim_fee/_calculator_help.html.haml
@@ -1,15 +1,15 @@
-.js-interim-effectivePcmh.help-wrapper.visually-hidden
+.js-interim-effectivePcmh.help-wrapper.js-hidden
   = govuk_detail t('.help_how_we_calculate_amount_title') do
     = t('.help_how_we_calculate_amount_body.effective_pcmh')
 
-.js-interim-trialDates.help-wrapper.visually-hidden
+.js-interim-trialDates.help-wrapper.js-hidden
   = govuk_detail t('.help_how_we_calculate_amount_title') do
     = t('.help_how_we_calculate_amount_body.trial_start')
 
-.js-interim-retrialDates.help-wrapper.visually-hidden
+.js-interim-retrialDates.help-wrapper.js-hidden
   = govuk_detail t('.help_how_we_calculate_amount_title') do
     = t('.help_how_we_calculate_amount_body.retrial_start')
 
-.js-interim-legalAidTransfer.help-wrapper.visually-hidden
+.js-interim-legalAidTransfer.help-wrapper.js-hidden
   = govuk_detail t('.help_how_we_calculate_amount_title') do
     = t('.help_how_we_calculate_amount_body.retrial_new_solicitor')

--- a/app/views/external_users/claims/interim_fee/_fields.html.haml
+++ b/app/views/external_users/claims/interim_fee/_fields.html.haml
@@ -17,7 +17,7 @@
       / TODO: rename js-interim-classes after interim fee descriptions for clarity
       /
       .form-group
-        .js-interim-ppe.js-fee-calculator-effector.visually-hidden
+        .js-interim-ppe.js-fee-calculator-effector.js-hidden
           = inf.adp_text_field :quantity,
             label: t('.ppe_total'),
             hint_text: t('.ppe_total_hint'),
@@ -26,11 +26,11 @@
             value: fee.quantity, errors: @error_presenter,
             error_key:'interim_fee.quantity'
 
-        .js-interim-effectivePcmh.visually-hidden
+        .js-interim-effectivePcmh.js-hidden
           = f.anchored_without_label 'effective_pcmh_date'
           = f.gov_uk_date_field(:effective_pcmh_date, legend_text: t('.effective_pcmh_date'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :effective_pcmh_date))
 
-        .js-interim-retrialDates.visually-hidden
+        .js-interim-retrialDates.js-hidden
           = f.anchored_without_label 'retrial_started_at'
           = f.gov_uk_date_field(:retrial_started_at, legend_text: t('.retrial_started_at'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :retrial_started_at))
 
@@ -41,7 +41,7 @@
             hint_text: t('.number_days_hint'),
             errors: @error_presenter
 
-        .js-interim-trialDates.visually-hidden
+        .js-interim-trialDates.js-hidden
           = f.anchored_without_label 'first_day_of_trial'
           = f.gov_uk_date_field(:first_day_of_trial, legend_text: t('.first_day_of_trial'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :first_day_of_trial))
 
@@ -52,14 +52,14 @@
             hint_text: t('.number_days_hint'),
             errors: @error_presenter
 
-        .js-interim-legalAidTransfer.visually-hidden
+        .js-interim-legalAidTransfer.js-hidden
           = f.anchored_without_label 'legal_aid_transfer_date'
           = f.gov_uk_date_field(:legal_aid_transfer_date, legend_text: t('.legal_aid_transfer_date'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :legal_aid_transfer_date))
 
           = f.anchored_without_label 'trial_concluded_at'
           = f.gov_uk_date_field(:trial_concluded_at, legend_text: t('.trial_concluded_at'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, :trial_concluded_at))
 
-        .js-interim-warrant.visually-hidden
+        .js-interim-warrant.js-hidden
           .warrant-fee-issued-date-group
             = inf.anchored_attribute 'warrant_issued_date'
             = inf.gov_uk_date_field :warrant_issued_date, legend_text: t('.warrant_issued'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_fee.warrant_issued_date')
@@ -68,7 +68,7 @@
             = inf.anchored_attribute 'warrant_executed_date'
             = inf.gov_uk_date_field :warrant_executed_date, legend_text: t('.warrant_executed'), legend_class: 'govuk-legend', error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_fee.warrant_executed_date')
 
-      .js-interim-feeTotal.js-graduated-price-effectee.visually-hidden
+      .js-interim-feeTotal.js-graduated-price-effectee.js-hidden
         .calculated-grad-fee
         = inf.adp_text_field :amount,
           label: t('.amount'),
@@ -86,5 +86,5 @@
     %hr
 
     #disbursements.form-group
-      .js-interim-disbursements.visually-hidden
+      .js-interim-disbursements.js-hidden
         = render partial: 'external_users/claims/disbursements/fields', locals: { f: f }

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -7,7 +7,7 @@
           = claim.case_number
           %span.unique-id-small= claim.unique_id
     .column-one-third
-      .claim-status{ tabindex: 0 }
+      .claim-status
         = t('.status')
         = govuk_tag claim.state.humanize, class: "app-tag--#{claim.state}"
 

--- a/app/webpack/javascripts/modules/external_users/claims/InterimFeeFieldsDisplay.js
+++ b/app/webpack/javascripts/modules/external_users/claims/InterimFeeFieldsDisplay.js
@@ -42,9 +42,9 @@ moj.Modules.InterimFeeFieldsDisplay = {
       $.each(elements, function(name, val) {
 
         if (val) {
-          $('.js-interim-' + name).show().removeClass('visually-hidden');
+          $('.js-interim-' + name).show().removeClass('js-hidden');
         } else {
-          $('.js-interim-' + name).hide().find('input, select, textarea').each(function(i, e) {
+          $('.js-interim-' + name).hide().addClass('js-hidden').find('input, select, textarea').each(function(i, e) {
             $(this).val('').prop('checked', false);
           });
         }


### PR DESCRIPTION
#### What
Help users know which element has the keyboard focus.

#### Ticket
[Hidden inputs focus order](https://dsdmoj.atlassian.net/browse/CBO-1499)

#### Why
To meet the WCAG 2.4.7: Focus Visible criterion.