### PR TITLE
Amend circleci resource_classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ references:
 # ------------------
 executors:
   basic-executor:
+    resource_class: small
     docker:
       - image: cimg/base:2020.01
         environment:
@@ -81,6 +82,7 @@ executors:
           REPO_NAME: cccd
 
   cloud-platform-executor:
+    resource_class: small
     docker:
     - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
       environment:
@@ -88,6 +90,7 @@ executors:
         REPO_NAME: cccd
 
   smoke-test-executor:
+    resource_class: medium
     working_directory: /usr/src/app
     docker:
       - image: ${ECR_ENDPOINT}/laa-get-paid/cccd:app-latest
@@ -329,8 +332,8 @@ jobs:
 
   rspec-tests:
     executor: test-executor
+    resource_class: large
     parallelism: 6
-    resource_class: medium+
     steps:
       - checkout
       - build-base
@@ -341,6 +344,7 @@ jobs:
 
   cucumber-tests:
     executor: test-executor
+    resource_class: medium
     parallelism: 4
     steps:
       - checkout
@@ -352,6 +356,7 @@ jobs:
 
   other-tests:
     executor: test-executor
+    resource_class: small
     steps:
       - checkout
       - build-base
@@ -361,6 +366,7 @@ jobs:
 
   upload-coverage:
     executor: test-executor
+    resource_class: small
     steps:
       - *attach-tmp-workspace
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,7 @@ jobs:
   rspec-tests:
     executor: test-executor
     parallelism: 6
+    resource_class: medium+
     steps:
       - checkout
       - build-base


### PR DESCRIPTION
#### What
use circleci resource_class to provide extra RAM and
CPU for rspec job

#### Why
Improve speed. ucrrenlty can take 10 to 15 minutes.

see https://circleci.com/docs/2.0/configuration-reference/#resource_class

#### Detail
- [x] add large resource_class to rspec. 
      10000+ tests taking 15 minutes. is a bottleneck!

- [x] add small resource for basic-executor and cloud-platform-executor
   These typically only need a small amount of resource but some jobs
   may require more (like build and push build). Specific jobs using
   one of these executors can have their resource overridden at the
   job level. 

I note that, possibly just a coincidence, that changing the
app container build job to `large` from `medium(default)` 
saw no improvement on build time, but that making it a
`small` did cause an improvement.