### PR TITLE
Adjust message control timing

### DIFF
--- a/app/views/shared/_claim_history.html.haml
+++ b/app/views/shared/_claim_history.html.haml
@@ -8,12 +8,13 @@
 .messages-container.no-print
   .messages-list{ 'aria-label': t('shared.claim_accordion.h2_messages'), role: 'region', tabindex: 0 }
     = render partial: 'shared/history_items_list', locals: { claim: claim }
+
   .messages-print-link
     = govuk_link_to t('.print_messages'), open_messages_url
-  .message-status
-    = t('.status')
-    %span.message-success
-    %span.message-error
+
+  .govuk-grid-row.message-status{ class: 'govuk-!-margin-0', role: 'status' }
+    .govuk-grid-column-full.message-success
+    .govuk-grid-column-full.message-error
 
   - if show_message_controls?(claim)
     .js-controls.message-controls{ 'data-auth-url': message_controls_url }

--- a/app/webpack/javascripts/modules/Modules.Messaging.js
+++ b/app/webpack/javascripts/modules/Modules.Messaging.js
@@ -28,7 +28,6 @@ moj.Modules.Messaging = {
     if(status === true){
       $('.message-success').text(rorData.statusMessage);
       adpMsg.clearErrorMsg();
-      adpMsg.toggleStatusBar();
 
       adpMsg.clearUserMessageBody();
       $('.no-messages').hide();
@@ -39,24 +38,9 @@ moj.Modules.Messaging = {
     }else{
       $('.message-error').text(rorData.statusMessage);
       adpMsg.clearSuccessMsg();
-      adpMsg.toggleStatusBar();
     }
   },
-  /**********************************
-   Toggles the show/hide of Message status
-   **********************************/
-  //toggleStatusBar
-  toggleStatusBar : function(){
-    //Slide in the status
-    $('.message-status')
-        .animate({left:'0px'},{
-          complete : function(){
-            setTimeout(function(){
-              $('.message-status').animate({left: '-9999px'});
-            },5000);
-          }
-        });
-  },
+
   /**********************************
    Clear the User message so they can
    input another message

--- a/app/webpack/stylesheets/_messages.scss
+++ b/app/webpack/stylesheets/_messages.scss
@@ -279,9 +279,6 @@
   }
 
   .message-status {
-    position: relative;
-    left: -9999px;
-
     .message-success {
       color: $green;
       font-weight: 700;


### PR DESCRIPTION
#### What
We have removed the timeout on `.message-status` on the claim history page as this failed to meet WCAG 2.2.1.
We have also added a `role` attribute to the element to describe the role of the element to screen readers.
On a side note, we have also applied the GOV.UK grid systems to help with the layout of the message status.

#### Ticket
[Timing adjustable](https://dsdmoj.atlassian.net/browse/CBO-1501)

#### Why
Status message had a set timeout, this would problematic for cognitive impaired users who may not be able to decipher the text quickly enough before it disappears.
