### PR TITLE
Set travel expense input focus

### DIFF
--- a/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -562,7 +562,9 @@ moj.Helpers.Blocks = {
 
       $detached = this.radioStateManager($detached, state);
 
-      return $parent.append($detached);
+      $parent.append($detached);
+
+      return $parent.find('.fx-travel-expense-type select').focus();
     };
 
     /**


### PR DESCRIPTION
#### What
The select element, onchange, uses jQuery's `.detach()` method to remove elements, in doing so the tab order position is lost, we reapply its position by setting the focus state on the select element. 

#### Ticket
[Element initiated change of context with no warning](https://dsdmoj.atlassian.net/browse/CBO-1504)

#### Why
When users attempt to interact with the 'Type of expense' select element using the arrow keys, additional select and input fields appear on the page, however, focus does not remain in the select element.
