### PR TITLE
Improve link text description

### DIFF
--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -38,8 +38,8 @@
           = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
         %td.user-controls{ 'data-label': t('.actions') }
           - if advocate.active?
-            = govuk_link_to t('.edit'),  edit_external_users_admin_external_user_path(advocate)
+            = govuk_link_to t('.edit_html', context: advocate.name), edit_external_users_admin_external_user_path(advocate)
             = ' | '
-            = govuk_link_to t('.delete'), external_users_admin_external_user_path(advocate), method: :delete, data: { confirm: t('.confirmation') }
+            = govuk_link_to t('.delete_html', context: advocate.name), external_users_admin_external_user_path(advocate), method: :delete, data: { confirm: t('.confirmation') }
           - else
             Inactive

--- a/app/views/external_users/claims/_api_promo_banner.html.haml
+++ b/app/views/external_users/claims/_api_promo_banner.html.haml
@@ -1,12 +1,11 @@
 - if claim.new_record? && show_api_promo_to_user?
 
   .js-callout-banner{'data-setting': 'api_promo_seen'}
-    = govuk_warning_text 'Do you use a case management system?', 'Note'
+    = govuk_warning_text t('callout_banner.api_promo_warning_text')
 
     %p
-      = "You may be able to create claims without re-typing. "
-      = link_to 'Read more information.', api_landing_page_path
+      = t('callout_banner.api_promo_information_html', href: api_landing_page_path)
 
     %ul.list
       %li.hide-link
-        = link_to 'Do not show this message again', settings_user_path(current_user.id, api_promo_seen: 1), method: :put, remote: true
+        = link_to t('callout_banner.api_promo_hide_banner'), settings_user_path(current_user.id, api_promo_seen: 1), method: :put, remote: true

--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -15,7 +15,7 @@
 
         .form-group
           %input.button.left.btn-spacer-20{ name: 'commit_continue', type: 'submit', value: 'Save and continue' }
-          %a.fx-clear-selection{ href: '#' }
+          %a.fx-clear-selection{ href: '#', 'aria-label': t('clear_offence_details', scope: "#{locale_scope}.actions") }
             = t('clear_selection', scope: "#{locale_scope}.actions")
 
 .form-group.mod-search-input

--- a/app/views/external_users/shared/_hardship_claims_banner.html.haml
+++ b/app/views/external_users/shared/_hardship_claims_banner.html.haml
@@ -1,10 +1,10 @@
 - if show_hardship_claims_banner_to_user?
   .js-callout-banner{'data-setting': 'hardship_claims_banner_seen'}
-    = govuk_warning_text 'The amended arrangements for hardship claims are being introduced from 1st May 2020.', 'Information'
+    = govuk_warning_text t('callout_banner.hardship_warning_text')
 
     %ul.list
       %li
-        = govuk_link_to 'More information', hardship_claims_page_path
+        = govuk_link_to t('callout_banner.hardship_information'), hardship_claims_page_path
 
       %li.hide-link
-        = govuk_link_to 'Do not show this message again', settings_user_path(current_user.id, hardship_claims_banner_seen: 1), method: :put, remote: true
+        = govuk_link_to t('callout_banner.hardship_hide_banner'), settings_user_path(current_user.id, hardship_claims_banner_seen: 1), method: :put, remote: true

--- a/app/views/external_users/shared/_timed_retention_banner.html.haml
+++ b/app/views/external_users/shared/_timed_retention_banner.html.haml
@@ -1,11 +1,11 @@
 - if show_timed_retention_banner_to_user?
 
   .js-callout-banner{'data-setting': 'timed_retention_banner_seen'}
-    = govuk_warning_text 'Time-limited retention of claims is being introduced from 19th September 2016.'
+    = govuk_warning_text t('callout_banner.time_retention_warning_text')
 
     %ul.list
       %li
-        = govuk_link_to 'More information', timed_retention_page_path
+        = govuk_link_to t('callout_banner.time_retention_information'), timed_retention_page_path
 
       %li.hide-link
-        = govuk_link_to 'Do not show this message again', settings_user_path(current_user.id, timed_retention_banner_seen: 1), method: :put, remote: true
+        = govuk_link_to t('callout_banner.time_retention_hide_banner'), settings_user_path(current_user.id, timed_retention_banner_seen: 1), method: :put, remote: true

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -34,7 +34,7 @@
     .file-to-be-uploaded
       %span.filename
       = ' | '
-      %a{ href: '#', title: t('.remove_file_tool_tip') }
+      %a{ href: '#', 'aria-label': t('.remove_file_tool_tip') }
         = t('.remove')
 
     .submit-column

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -701,8 +701,10 @@ en:
           advocates: 'Users'
           add_advocate: 'Add User'
           edit: *edit
+          edit_html: Edit <span class="govuk-visually-hidden">user %{context}</span>
           email: 'Email'
           delete: *delete
+          delete_html: Delete <span class="govuk-visually-hidden">user %{context}</span>
           confirm_delete: 'Are you sure?'
           first_name: 'Name'
           last_name: 'Surname'
@@ -1111,6 +1113,7 @@ en:
           answer_no: *global_no
       offence_details:
         actions:
+          clear_offence_details: Clear offence details
           clear_selection: Clear selection
         fields:
           offence_band: Band
@@ -2728,3 +2731,17 @@ en:
       comment_hint: "Don't include any personal or sensitive information."
       send: Send
       rating: 'Overall, how satisfied were you with this service?'
+
+  callout_banner:
+    api_promo_hide_banner: Do not show API information again
+    api_promo_information_html:
+      You may be able to create claims without re-typing. <a class="govuk-link" href="%{href}">Read more on API information</a>.
+    api_promo_warning_text: Do you use a case management system?
+
+    hardship_hide_banner: Do not show hardship claims information again
+    hardship_information: More information on hardship claims
+    hardship_warning_text: The amended arrangements for hardship claims are being introduced from 1st May 2020.
+
+    time_retention_hide_banner: Do not show time-limited retention information again
+    time_retention_information: More information on time-limited retention
+    time_retention_warning_text: Time-limited retention of claims is being introduced from 19th September 2016.

--- a/features/claims/api_promo.feature
+++ b/features/claims/api_promo.feature
@@ -11,7 +11,7 @@ Feature: An API promotion banner will appear on the create claim page, until the
 
     And The API promo banner is visible
     Then the page should be accessible within "#content"
-    When I click the link 'Do not show this message again'
+    When I click the link 'Do not show API information again'
     Then The API promo banner is not visible
 
     When I click the link 'Home'

--- a/features/claims/hardship_claims_banner.feature
+++ b/features/claims/hardship_claims_banner.feature
@@ -11,7 +11,7 @@ Feature: A hardship claims banner will appear on the claims list, until the user
     Then The hardship claims banner is visible
     And the page should be accessible within "#content"
 
-    When I click the link 'Do not show this message again'
+    When I click the link 'Do not show hardship claims information again'
     Then The hardship claims banner is not visible
 
     When I click the link 'Home'

--- a/features/claims/timed_retention_banner.feature
+++ b/features/claims/timed_retention_banner.feature
@@ -8,7 +8,7 @@ Feature: A timed retention banner will appear on the claims list, until the user
 
     Then The timed retention banner is visible
     Then the page should be accessible within "#content"
-    When I click the link 'Do not show this message again'
+    When I click the link 'Do not show time-limited retention information again'
     Then The timed retention banner is not visible
     When I click 'Your claims' link
     Then The timed retention banner is not visible


### PR DESCRIPTION
#### What
Improved the link text description for users that browse out of context.

#### Ticket
[Ambiguous links](https://dsdmoj.atlassian.net/browse/CBO-1513)

#### Why
Some page fail to meet WCAG 2.4.9 criterion. Users that browse out of context will not understand the purpose of these links.
