### PR TITLE
Revert ingress annotations

### DIFF
--- a/kubernetes_deploy/api-sandbox/ingress.yaml
+++ b/kubernetes_deploy/api-sandbox/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: cccd-app-ingress
   namespace: cccd-api-sandbox
-  annotations:
-    kubernetes.io/ingress.class: cccd-api-sandbox
 spec:
   rules:
     - host: api-sandbox.claim-crown-court-defence.service.justice.gov.uk

--- a/kubernetes_deploy/dev-lgfs/ingress.yaml
+++ b/kubernetes_deploy/dev-lgfs/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: cccd-app-ingress
   namespace: cccd-dev-lgfs
-  annotations:
-    kubernetes.io/ingress.class: cccd-dev-lgfs
 spec:
   rules:
     - host: dev-lgfs.claim-crown-court-defence.service.justice.gov.uk

--- a/kubernetes_deploy/dev/ingress.yaml
+++ b/kubernetes_deploy/dev/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: cccd-app-ingress
   namespace: cccd-dev
-  annotations:
-    kubernetes.io/ingress.class: cccd-dev
 spec:
   rules:
     - host: dev.claim-crown-court-defence.service.justice.gov.uk

--- a/kubernetes_deploy/staging/ingress.yaml
+++ b/kubernetes_deploy/staging/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: cccd-app-ingress
   namespace: cccd-staging
-  annotations:
-    kubernetes.io/ingress.class: cccd-staging
 spec:
   rules:
     - host: staging.claim-crown-court-defence.service.justice.gov.uk


### PR DESCRIPTION
#### What
Revert ingress annotations

#### Why
> In response to this morning's incident, we are moving
services' ingresses back to the default ingress controller
(we'll publish full details of why this is necessary in our
post-incident report).

> If you have a dedicated ingress controller (i.e. you have a
custom kubernetes.io/ingress.class annotation), please remove this
annotation from your ingress definitions before redeploying your service.

> If you redeploy your service and change back to your dedicated ingress
controller, after we have moved your ingress to the default ingress
controller, your service will be unavailable.