### PR TITLE
Add more logging and document scheduler daemon testing

### DIFF
--- a/app/jobs/stats_report_generation_job.rb
+++ b/app/jobs/stats_report_generation_job.rb
@@ -5,6 +5,11 @@ class StatsReportGenerationJob < ApplicationJob
     LogStuff.send(:info, class: self.class.name, action: 'perform') do
       "Stats report job starting for report type: #{report_type}"
     end
+
     Stats::StatsReportGenerator.call(report_type)
+
+    LogStuff.send(:info, class: self.class.name, action: 'perform') do
+      "Stats report job finished for report type: #{report_type}"
+    end
   end
 end

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -53,7 +53,7 @@ module Stats
     end
 
     def write_report(report_result)
-      log(:info, :write_report, "start writing report #{report_name}...")
+      log(:info, :write_report, "Writing report #{report_name} to DB...")
       update(
         document: StringIO.new(report_result.content),
         document_file_name: "#{report_name}_#{started_at.to_s(:number)}.#{report_result.format}",
@@ -76,7 +76,6 @@ module Stats
     end
 
     def download_filename
-      # TODO: set the appropriate format as required
       "#{report_name}_#{started_at.to_s(:number)}.csv"
     end
 

--- a/app/services/stats/management_information_generator.rb
+++ b/app/services/stats/management_information_generator.rb
@@ -21,19 +21,6 @@ module Stats
 
     attr_reader :format
 
-    def log_error(error)
-      LogStuff.send(:error,
-                    self.class.name,
-                    error_message: "#{error.class} - #{error.message}",
-                    error_backtrace: error.backtrace.inspect.to_s) do
-                      'MI Report generation error'
-                    end
-    end
-
-    def log_info(message)
-      LogStuff.send(:info, message)
-    end
-
     def headers
       Settings.claim_csv_headers.map { |header| header.to_s.humanize }
     end
@@ -46,20 +33,33 @@ module Stats
     # keeping existent behaviour for now
     def generate_new_report
       log_info('Report generation started...')
-      CSV.generate do |csv|
+      content = CSV.generate do |csv|
         csv << headers
         active_non_draft_claims.find_each do |claim|
-          log_info("Adding claim to report with id: #{claim.id} ...")
           ManagementInformationPresenter.new(claim, 'view').present! do |claim_journeys|
             if claim_journeys.any?
-              log_info("Adding journey for claim: #{claim.id}")
               claim_journeys.each { |journey| csv << journey }
             end
           end
         end
       end
+      log_info('Report generation finished')
+      content
     rescue StandardError => e
       log_error(e)
+    end
+
+    def log_error(error)
+      LogStuff.error(class: self.class.name,
+                     action: caller_locations(1,1)[0].label,
+                     error_message: "#{error.class} - #{error.message}",
+                     error_backtrace: error.backtrace.inspect.to_s) do
+                      'MI Report generation error'
+                    end
+    end
+
+    def log_info(message)
+      LogStuff.info(class: self.class.name, action: caller_locations(1,1)[0].label) { message }
     end
   end
 end

--- a/app/services/stats/management_information_generator.rb
+++ b/app/services/stats/management_information_generator.rb
@@ -37,9 +37,7 @@ module Stats
         csv << headers
         active_non_draft_claims.find_each do |claim|
           ManagementInformationPresenter.new(claim, 'view').present! do |claim_journeys|
-            if claim_journeys.any?
-              claim_journeys.each { |journey| csv << journey }
-            end
+            claim_journeys.each { |journey| csv << journey } if claim_journeys.any?
           end
         end
       end
@@ -51,15 +49,15 @@ module Stats
 
     def log_error(error)
       LogStuff.error(class: self.class.name,
-                     action: caller_locations(1,1)[0].label,
+                     action: caller_locations(1, 1)[0].label,
                      error_message: "#{error.class} - #{error.message}",
                      error_backtrace: error.backtrace.inspect.to_s) do
-                      'MI Report generation error'
-                    end
+                       'MI Report generation error'
+                     end
     end
 
     def log_info(message)
-      LogStuff.info(class: self.class.name, action: caller_locations(1,1)[0].label) { message }
+      LogStuff.info(class: self.class.name, action: caller_locations(1, 1)[0].label) { message }
     end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # log to stdout
   # config.logstasher.logger_path = config.logstasher.logger = Logger.new(STDOUT)
 
-  jsonlogger = LogStuff.new_logger("#{Rails.root}/log/logstash_development.log", Logger::INFO)
+  jsonlogger = LogStuff.new_logger("#{Rails.root}/log/logstash_test.log", Logger::INFO)
   config.logstasher.source = 'ccd_test'
   # Reuse logstasher logger with logstuff
   LogStuff.setup(:logger => jsonlogger)

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,7 @@
 
 - [Setting up development environment](#setting-up-development-environment)
 - [Sidekiq Console](#sidekiq-console)
+- [Scheduler daemon](#scheduler-daemon)
 - [Mailer previewing](#mailer-previewing)
 - [Anonymised Database Dumps and restores](#anonymised-database-dumps-and-restores)
 - [A note on architecture](#a-note-on-architecture)
@@ -99,6 +100,17 @@ bundle exec sidekiq
 ```
 
 To display the current state of the Sidekiq queues, as a logged in superadmin browse to `/sidekiq`
+
+## Scheduler daemon
+
+To process scheduler daemon jobs in development run the scheduler in a terminal and set the relevant scheduler "task" to run regularly (see [scheduled_tasks](../scheduled_tasks) directory)
+
+see [schedular_daemon](https://github.com/ssoroka/scheduler_daemon) for details.
+
+```
+# run scheduler daemon in console mode
+bundle exec scheduler_daemon run
+```
 
 ## Mailer previewing
 

--- a/scheduled_tasks/management_information_generation_task.rb
+++ b/scheduled_tasks/management_information_generation_task.rb
@@ -5,9 +5,10 @@ class ManagementInformationGenerationTask < Scheduler::SchedulerTask
   every '1d', first_at: Chronic.parse('next 3 am')
 
   def run
-    log('Management Information Generation started')
+    LogStuff.info { 'Management Information Generation started' }
     Stats::StatsReportGenerator.call('management_information')
+    LogStuff.info { 'Management Information Generation finished' }
   rescue StandardError => e
-    log('Management Information Generation error: ' + e.message)
+    LogStuff.error { 'Management Information Generation error: ' + e.message }
   end
 end

--- a/scheduled_tasks/poll_injection_responses_task.rb
+++ b/scheduled_tasks/poll_injection_responses_task.rb
@@ -2,7 +2,7 @@ require 'chronic'
 
 # https://github.com/ssoroka/scheduler_daemon
 class PollInjectionResponsesTask < Scheduler::SchedulerTask
-  environments :production, :demo
+  environments :production
   every '1m'
 
   def run

--- a/spec/jobs/stats_report_generation_job_spec.rb
+++ b/spec/jobs/stats_report_generation_job_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe StatsReportGenerationJob, type: :job do
-  describe '#perform' do
-    let(:report_type) { 'provisional_assessment' }
-    let(:result) { double(:generator_result) }
+  subject(:job) { described_class.new }
 
-    subject(:job) { described_class.new }
+  describe '#perform' do
+    subject (:perform) { job.perform(report_type) }
+
+    let(:report_type) { 'provisional_assessment' }
 
     it 'calls the stats report generator with the provided report type' do
-      expect(Stats::StatsReportGenerator).to receive(:call).with(report_type).and_return(result)
-      expect(job.perform(report_type)).to eq(result)
+      expect(Stats::StatsReportGenerator).to receive(:call).with(report_type)
+      perform
     end
   end
 end

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -38,30 +38,30 @@ RSpec.describe Stats::ManagementInformationGenerator do
     }
     let!(:draft_claim) { create(:draft_claim) }
     let!(:non_active_claim) { Timecop.freeze(frozen_time) { create(:allocated_claim) } }
-    
+
     it 'returns CSV content with a header and a row for all active non-draft claims' do
       expect(contents.size).to eq(valid_claims.size + 1)
     end
-    
+
     it 'has expected columns' do
       expect(contents.first.split(',')).to match_array(report_columns)
     end
   end
-  
+
   context 'logging' do
     let!(:error) { StandardError.new('test error') }
 
     it 'can log info using LogStuff' do
       expect(LogStuff).to receive(:send)
       .with(:info, 'Report generation started...')
-      described_class.call 
+      described_class.call
     end
-    
+
     it 'can log errors with LogStuff' do
       expect(LogStuff).to receive(:send)
       .with(
-        :error, 
-        'Stats::ManagementInformationGenerator', 
+        :error,
+        'Stats::ManagementInformationGenerator',
         error_message: "#{error.class} - #{error.message}",
         error_backtrace: error.backtrace.inspect.to_s) do
           'MI Report generation error'
@@ -69,5 +69,4 @@ RSpec.describe Stats::ManagementInformationGenerator do
       described_class.new.send(:log_error, error)
     end
   end
-  
 end

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
                           'AF1/LF1 processed by',
                           'Misc fees'] }
 
-  context 'data generation' do
+  context 'when generating data' do
     subject(:contents) { result.content.split("\n")}
 
     let!(:valid_claims) {
@@ -48,25 +48,25 @@ RSpec.describe Stats::ManagementInformationGenerator do
     end
   end
 
-  context 'logging' do
-    let!(:error) { StandardError.new('test error') }
+  context 'For logging' do
+    let(:error) { StandardError.new('test error') }
 
-    it 'can log info using LogStuff' do
-      expect(LogStuff).to receive(:send)
-      .with(:info, 'Report generation started...')
-      described_class.call
+    context 'when successful' do
+      it 'uses LogStuff to log start and end' do
+        expect(LogStuff).to receive(:info).twice
+        described_class.call
+      end
     end
 
-    it 'can log errors with LogStuff' do
-      expect(LogStuff).to receive(:send)
-      .with(
-        :error,
-        'Stats::ManagementInformationGenerator',
-        error_message: "#{error.class} - #{error.message}",
-        error_backtrace: error.backtrace.inspect.to_s) do
-          'MI Report generation error'
-        end
-      described_class.new.send(:log_error, error)
+    context 'when error raised' do
+      before do
+        allow(CSV).to receive(:generate).and_raise error
+      end
+
+      it 'uses LogStuff to log error' do
+        expect(LogStuff).to receive(:error).once
+        described_class.call
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
Add logging for scheduler and remove extraneous logging
for MI. Add scheduler daemon testing in development
to README docs.

#### Why
So we know what stage MI report reached at what time
before/if failure.