### PR TITLE
Attempt to fix caseworker allocation filter

### DIFF
--- a/lib/caching/api_request.rb
+++ b/lib/caching/api_request.rb
@@ -71,7 +71,7 @@ module Caching
     end
 
     def save!(response)
-      ttl = (response.ttl || default_ttl).to_i
+      ttl = (response.headers[:cache_control]=='no-cache' ? 0 : default_ttl)
       body = response.body
       payload = [now, ttl, body].join(';')
 

--- a/lib/caching/api_request.rb
+++ b/lib/caching/api_request.rb
@@ -71,7 +71,7 @@ module Caching
     end
 
     def save!(response)
-      ttl = (response.headers[:cache_control]=='no-cache' ? 0 : default_ttl)
+      ttl = (response.ttl || default_ttl).to_i
       body = response.body
       payload = [now, ttl, body].join(';')
 

--- a/lib/caching/response.rb
+++ b/lib/caching/response.rb
@@ -16,10 +16,14 @@ module Caching
     end
 
     def ttl
-      cache_control[/max-age=([0-9]+)/, 1] || 0 if cache_control == 'no-cache'
+      max_age.to_i
     end
 
     private
+
+    def max_age
+      cache_control[/max-age=([0-9]+)/, 1] || 0
+    end
 
     def cache_control
       headers[:cache_control] || ''

--- a/lib/caching/response.rb
+++ b/lib/caching/response.rb
@@ -16,7 +16,7 @@ module Caching
     end
 
     def ttl
-      cache_control[/max-age=([0-9]+)/, 1]
+      cache_control[/max-age=([0-9]+)/, 1] || 0 if cache_control == 'no-cache'
     end
 
     private

--- a/lib/caching/response.rb
+++ b/lib/caching/response.rb
@@ -16,14 +16,11 @@ module Caching
     end
 
     def ttl
-      max_age.to_i
+      return 0 if cache_control.match?('no-cache')
+      cache_control[/max-age=([0-9]+)/, 1]
     end
 
     private
-
-    def max_age
-      cache_control[/max-age=([0-9]+)/, 1] || 0
-    end
 
     def cache_control
       headers[:cache_control] || ''

--- a/spec/api/v2/case_workers/allocate_spec.rb
+++ b/spec/api/v2/case_workers/allocate_spec.rb
@@ -83,5 +83,11 @@ RSpec.describe API::V2::CaseWorkers::Allocate do
         expect(body[:errors][1]).to match /Claim .* has already been allocated/
       end
     end
+
+    context 'caching' do
+      it 'should not cache response' do
+        expect(last_response.headers['Cache-Control'][/max-age=([0-9]+)/, 1]).to eq '0'
+      end
+    end
   end
 end

--- a/spec/lib/caching/api_request_spec.rb
+++ b/spec/lib/caching/api_request_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 require 'caching/api_request'
 
-describe Caching::ApiRequest do
+RSpec.describe Caching::ApiRequest do
   let(:url) { 'http://test.com/ping.json' }
 
+  let(:headers) { {} }
   let(:value1) { 'test value 1' }
-  let(:response1) { double('Response1', headers: {}, body: value1) }
+  let(:response1) { double('Response1', headers: headers, body: value1) }
   let(:value2) { 'test value 2' }
-  let(:response2) { double('Response2', headers: {}, body: value2) }
+  let(:response2) { double('Response2', headers: headers, body: value2) }
 
   before(:each) do
     Caching.backend = Caching::MemoryStore
@@ -62,28 +63,131 @@ describe Caching::ApiRequest do
     end
   end
 
-  describe 'writing and reading from the cache' do
+  describe '.cache' do
+    before do
+      allow(current_store).to receive(:set).and_call_original
+      allow(current_store).to receive(:get).and_call_original
+    end
+
     let(:current_store) { Caching.backend.current }
+    let(:max_age) { 3600 }
 
-    context 'caching new content' do
-      it 'should write to the cache and return the content' do
-        expect(current_store).to receive(:set).with(/api:/, /test value 1/).once.and_call_original
-        returned = described_class.cache(url) { response1 }
-        expect(returned).to eq(value1)
-      end
+    context 'when ttl option supplied' do
+      let(:headers) { {} }
+      let(:options) { { ttl: 1800 } }
 
-      it 'should cache again a stale content' do
-        Timecop.freeze(1.day.ago) do
+      context 'when cache is empty' do
+        before { Caching.clear }
+
+        it 'writes to the cache' do
+          described_class.cache(url) { response1 }
+          expect(current_store).to have_received(:set).with(/api:/, /test value 1/).once
+        end
+
+        it 'returns content' do
           returned = described_class.cache(url) { response1 }
           expect(returned).to eq(value1)
         end
+      end
 
-        returned = described_class.cache(url) { response2 }
-        expect(returned).to eq(value2)
+      context 'when cache content is stale' do
+        before do
+          over_ttl = (options[:ttl]+1).seconds.ago
+          travel_to(over_ttl) do
+            described_class.cache(url) { response1 }
+          end
+        end
+
+        it 'writes to the cache' do
+          described_class.cache(url) { response2 }
+          expect(current_store).to have_received(:set).with(/api:/, /test value 2/).once
+        end
+
+        it 'returns new content' do
+          returned = described_class.cache(url) { response2 }
+          expect(returned).to eq(value2)
+        end
+      end
+
+      context 'when cache content is NOT stale' do
+        before do
+          under_ttl = (options[:ttl]-10).seconds.ago
+          travel_to(under_ttl) do
+            described_class.cache(url) { response1 }
+          end
+        end
+
+        it 'reads from the cache' do
+          described_class.cache(url) { response1 }
+          expect(current_store).to have_received(:get).with(/api:/).twice
+        end
+
+        it 'returns content from cache' do
+          returned = described_class.cache(url) { response1 }
+          expect(returned).to eq(value1)
+        end
       end
     end
 
-    context 'reading from cache existing content' do
+    context 'when max-age header set' do
+      let(:headers) { { cache_control: "max-age=#{max_age}" } }
+
+      context 'when cache is empty' do
+        before { Caching.clear }
+
+        it 'writes to the cache' do
+          described_class.cache(url) { response1 }
+          expect(current_store).to have_received(:set).with(/api:/, /test value 1/).once
+        end
+
+        it 'returns content' do
+          returned = described_class.cache(url) { response1 }
+          expect(returned).to eq(value1)
+        end
+      end
+
+      context 'when cache content is available and not stale' do
+        before do
+          under_max_age = (max_age-10).seconds.ago
+          travel_to(under_max_age) do
+            described_class.cache(url) { response1 }
+          end
+        end
+
+        it 'reads from the cache' do
+          described_class.cache(url) { response1 }
+          expect(current_store).to have_received(:get).with(/api:/).twice
+        end
+
+        it 'returns content from cache' do
+          returned = described_class.cache(url) { response1 }
+          expect(returned).to eq(value1)
+        end
+      end
+
+      context 'when cache content is stale' do
+        before do
+          over_max_age = (max_age+1).seconds.ago
+          travel_to(over_max_age) do
+            described_class.cache(url) { response1 }
+          end
+        end
+
+        it 'writes to the cache' do
+          described_class.cache(url) { response2 }
+          expect(current_store).to have_received(:set).with(/api:/, /test value 2/).once
+        end
+
+        it 'returns new content' do
+          returned = described_class.cache(url) { response2 }
+          expect(returned).to eq(value2)
+        end
+      end
+    end
+
+    context 'reading from cache' do
+      let(:headers) { { cache_control: "max-age=30" } }
+
       it 'should read from the cache and return the content' do
         expect(current_store).to receive(:set).with(/api:/, /test value 1/).once.and_call_original
         expect(current_store).not_to receive(:set).with(/api:/, /test value 2/)

--- a/spec/lib/caching/response_spec.rb
+++ b/spec/lib/caching/response_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Caching::Response do
   subject(:instance) { described_class.new(response) }
-  let(:response) { instance_double('mock_response', body: 'body content', headers: 'header content') }
+  let(:response) { instance_double('mock_response', body: 'body content', headers: {}) }
 
   describe '#validate!' do
     context 'with a valid response object' do
@@ -25,7 +25,7 @@ RSpec.describe Caching::Response do
   describe '#headers' do
     subject(:headers) { instance.headers }
 
-    it { is_expected.to eql 'header content' }
+    it { is_expected.to eql Hash.new }
   end
 
   describe '#ttl' do
@@ -33,16 +33,28 @@ RSpec.describe Caching::Response do
 
     let(:response) { instance_double('mock_response', body: 'body content', headers: headers ) }
 
-    context 'with max-age Cache-Control header' do
+    context 'with max-age Cache-Control headers' do
       let(:headers) { { cache_control: 'max-age=900, private, re-validate'} }
 
-      it { is_expected.to eql 900 }
+      it { is_expected.to eql '900' }
     end
 
-    context 'without max-age Cache-Control header' do
+    context 'with no-cache Cache-Control headers' do
       let(:headers) { { cache_control: 'no-cache' } }
 
       it { is_expected.to eql 0 }
+    end
+
+    context 'with unrelated Cache-Control headers' do
+      let(:headers) { { cache_control: 'private, re-validate' } }
+
+      it { is_expected.to eql nil }
+    end
+
+    context 'without Cache-Control headers' do
+      let(:headers) { {} }
+
+      it { is_expected.to eql nil }
     end
   end
 end

--- a/spec/lib/caching/response_spec.rb
+++ b/spec/lib/caching/response_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Caching::Response do
+  subject(:instance) { described_class.new(response) }
+  let(:response) { instance_double('mock_response', body: 'body content', headers: 'header content') }
+
+  describe '#validate!' do
+    context 'with a valid response object' do
+      it { is_expected.to be_a described_class }
+    end
+
+    context 'with invalid response object' do
+      let(:response) { instance_double('mock_response') }
+
+      it { expect{ instance }.to raise_error ArgumentError, /must implement/}
+    end
+  end
+
+  describe '#body' do
+    subject(:body) { instance.body }
+
+    it { is_expected.to eql 'body content' }
+  end
+
+  describe '#headers' do
+    subject(:headers) { instance.headers }
+
+    it { is_expected.to eql 'header content' }
+  end
+
+  describe '#ttl' do
+    subject(:ttl) { instance.ttl }
+
+    let(:response) { instance_double('mock_response', body: 'body content', headers: headers ) }
+
+    context 'with max-age Cache-Control header' do
+      let(:headers) { { cache_control: 'max-age=900, private, re-validate'} }
+
+      it { is_expected.to eql 900 }
+    end
+
+    context 'without max-age Cache-Control header' do
+      let(:headers) { { cache_control: 'no-cache' } }
+
+      it { is_expected.to eql 0 }
+    end
+  end
+end

--- a/vcr/cassettes/features/case_workers/claims/authorise.yml
+++ b/vcr/cassettes/features/case_workers/claims/authorise.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=b31e7f04-cf4c-4c74-af0b-a5a85c6b148b&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=e6afeeae-6ec2-4e46-ba93-63ff1ed308c7&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -20,32 +20,31 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"e6abc19332f779160116382470e8b2a0"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"aec9474a1fe41fd670929046d811d499"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 799b8097-a8b8-413f-a082-1a977df436f6
+      - 7113aede-d65b-42e1-ae81-1184cb5225ea
       X-Runtime:
-      - '0.046265'
+      - '0.058767'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"9b2c3857-ef83-4175-9fdc-0475f528453e","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:32:59Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"90402eb7-a4da-4db9-9ae8-857ccdc539c0","first_name":"Izetta","last_name":"Nikolaus","email":"ernie.abbott@morar.io"},"defendants":[{"id":1,"uuid":"25f21c08-d97c-4c62-8a43-aa40d4948d06","first_name":"Tenisha","last_name":"Lesch","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"886a8aee-e7c7-4a0a-8e74-3aad4b1c77f6","maat_reference":"4563508","date":"2016-01-01"},{"id":2,"uuid":"f74d352e-8672-445f-a3e4-bb0c5fccaff4","maat_reference":"7703832","date":"2018-08-22"}]}],"case_type":{"id":160,"name":"Case
-        Type 7","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"bc5932d9-e0bd-4cd0-ac2b-c9cc6c4f6fcb","first_name":"Willy","last_name":"Gaylord","email":"willy.gaylord@laa.gov.uk"},{"id":1,"uuid":"b102e957-7dd5-45b9-b82f-3c30487379d8","first_name":"Shawn","last_name":"Lueilwitz","email":"shawn.lueilwitz@laa.gov.uk"}],"court":{"id":763,"code":"TRW-7","name":"Heaney
-        LLC-7","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:00 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"7c3501a8-2289-4704-a98e-0199d26145cc","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T12:08:34Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"e0b2c7a9-a816-4a1b-820a-8d24cd46f5a2","first_name":"Edmond","last_name":"Becker","email":"abe_wyman@adams.io"},"defendants":[{"id":1,"uuid":"c32776ce-84de-4110-81ae-a0dcd46c32ad","first_name":"Robert","last_name":"Hyatt","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"8719724f-d04f-4c61-a9e9-9d6ed3eb7a08","maat_reference":"4290781","date":"2016-01-01"},{"id":2,"uuid":"e055d894-9a65-4966-aacf-faaf6835ac86","maat_reference":"6209476","date":"2019-09-24"}]}],"case_type":{"id":288,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"5ea272db-dd54-49eb-9d4c-8ab2e1438224","first_name":"Jarrett","last_name":"Donnelly","email":"jarrett.donnelly@laa.gov.uk"},{"id":1,"uuid":"a301ae74-4228-4d4e-ad19-d0b2e59bf1aa","first_name":"Shantae","last_name":"Witting","email":"shantae.witting@laa.gov.uk"}],"court":{"id":1025,"code":"ZHS-1","name":"Brown,
+        Windler and Douglas-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 12:08:38 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=b31e7f04-cf4c-4c74-af0b-a5a85c6b148b&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=e6afeeae-6ec2-4e46-ba93-63ff1ed308c7&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +52,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -63,25 +62,24 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"0f0ab097fd690cb84090dde90b170a1a"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"4625177ddc82bc13840526d19c949926"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 10d47017-d955-429b-a628-2045177eb557
+      - ef178a5f-2faa-41f5-95cc-bde18a7284da
       X-Runtime:
-      - '0.015156'
+      - '0.020195'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: '{"pagination":{"current_page":1,"total_pages":0,"total_count":0,"limit_value":10},"items":[]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:02 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Thu, 08 Oct 2020 12:08:51 GMT
+recorded_with: VCR 6.0.0

--- a/vcr/cassettes/features/case_workers/claims/injection_error.yml
+++ b/vcr/cassettes/features/case_workers/claims/injection_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=a59e80d1-4818-47e6-a9c3-9613bde6fe3c&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=4859bd0c-babb-43bf-8de7-22793b46d0db&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -20,33 +20,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"a039d226c3c7a44ba1dd889ecf63d0fa"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"b2a59eb02319aec6a5279b5d23be5c00"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - fb958af8-eb21-406e-9673-f2a07e252241
+      - 547d5afa-e83b-4bc3-af59-c76213ba3fdd
       X-Runtime:
-      - '0.053846'
+      - '0.577614'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"d41b8144-e618-41bc-bb23-0bd026c2ca70","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:33:04Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"49853682-de7b-445c-9fde-8a22bcae5837","first_name":"Kami","last_name":"Deckow","email":"gertrud@rippinpadberg.io"},"defendants":[{"id":1,"uuid":"bfa7fe36-bdd2-4958-aa0d-2bf6d241e753","first_name":"George","last_name":"Raynor","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"09300a16-36b9-4968-ab6e-523cfe6d90b3","maat_reference":"7402719","date":"2016-01-01"},{"id":2,"uuid":"a436d03d-8a8a-46fc-85d7-2f9b85379971","maat_reference":"8573907","date":"2018-08-22"}]}],"case_type":{"id":161,"name":"Case
-        Type 8","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[{"succeeded":false,"error_messages":["injection
-        error 1","injection error 2"],"deleted_at":null}],"case_workers":[{"id":2,"uuid":"8be50d3a-c5d9-4d52-8abd-933041e45706","first_name":"Conrad","last_name":"Kuphal","email":"conrad.kuphal@laa.gov.uk"},{"id":1,"uuid":"fa1a8fda-7d43-4ee5-a3af-ec0fa9e30c79","first_name":"Faustino","last_name":"Schneider","email":"faustino.schneider@laa.gov.uk"}],"court":{"id":764,"code":"BFS-8","name":"Nader
-        Inc-8","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:05 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"c76e02f1-ee0c-49fa-aa08-06f580b73f91","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T09:25:12Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"577b0bbf-9896-410a-abc4-06a0116e7017","first_name":"Len","last_name":"Hayes","email":"leigh.smitham@quitzon.co"},"defendants":[{"id":1,"uuid":"4e7ebf65-2cdf-4cc9-8421-9da146612ba1","first_name":"Hershel","last_name":"Breitenberg","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"e3d7c0ba-f517-45d4-bc83-ff25a76564ca","maat_reference":"9717529","date":"2016-01-01"},{"id":2,"uuid":"4ca15c1e-81d6-487a-b6b1-bdc07246db32","maat_reference":"6241201","date":"2019-09-24"}]}],"case_type":{"id":232,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[{"succeeded":false,"error_messages":["injection
+        error 1","injection error 2"],"deleted_at":null}],"case_workers":[{"id":2,"uuid":"2df8d084-f2ba-401b-8be8-e97edb0e4005","first_name":"Cesar","last_name":"Medhurst","email":"cesar.medhurst@laa.gov.uk"},{"id":1,"uuid":"3f25c943-6bb8-4f20-b6be-f5c91be68c6f","first_name":"Jerold","last_name":"Blanda","email":"jerold.blanda@laa.gov.uk"}],"court":{"id":701,"code":"BSK-1","name":"Dach,
+        Olson and Reichert-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 09:25:16 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=a59e80d1-4818-47e6-a9c3-9613bde6fe3c&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=4859bd0c-babb-43bf-8de7-22793b46d0db&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -54,7 +53,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -64,33 +63,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"a039d226c3c7a44ba1dd889ecf63d0fa"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"b2a59eb02319aec6a5279b5d23be5c00"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - cc7a7ca8-8ac7-4331-bf30-99edf1c83b5a
+      - 6220cb17-20b2-48be-b6bb-638727a67e26
       X-Runtime:
-      - '0.083865'
+      - '0.049009'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"d41b8144-e618-41bc-bb23-0bd026c2ca70","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:33:04Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"49853682-de7b-445c-9fde-8a22bcae5837","first_name":"Kami","last_name":"Deckow","email":"gertrud@rippinpadberg.io"},"defendants":[{"id":1,"uuid":"bfa7fe36-bdd2-4958-aa0d-2bf6d241e753","first_name":"George","last_name":"Raynor","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"09300a16-36b9-4968-ab6e-523cfe6d90b3","maat_reference":"7402719","date":"2016-01-01"},{"id":2,"uuid":"a436d03d-8a8a-46fc-85d7-2f9b85379971","maat_reference":"8573907","date":"2018-08-22"}]}],"case_type":{"id":161,"name":"Case
-        Type 8","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[{"succeeded":false,"error_messages":["injection
-        error 1","injection error 2"],"deleted_at":null}],"case_workers":[{"id":2,"uuid":"8be50d3a-c5d9-4d52-8abd-933041e45706","first_name":"Conrad","last_name":"Kuphal","email":"conrad.kuphal@laa.gov.uk"},{"id":1,"uuid":"fa1a8fda-7d43-4ee5-a3af-ec0fa9e30c79","first_name":"Faustino","last_name":"Schneider","email":"faustino.schneider@laa.gov.uk"}],"court":{"id":764,"code":"BFS-8","name":"Nader
-        Inc-8","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:05 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"c76e02f1-ee0c-49fa-aa08-06f580b73f91","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T09:25:12Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"577b0bbf-9896-410a-abc4-06a0116e7017","first_name":"Len","last_name":"Hayes","email":"leigh.smitham@quitzon.co"},"defendants":[{"id":1,"uuid":"4e7ebf65-2cdf-4cc9-8421-9da146612ba1","first_name":"Hershel","last_name":"Breitenberg","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"e3d7c0ba-f517-45d4-bc83-ff25a76564ca","maat_reference":"9717529","date":"2016-01-01"},{"id":2,"uuid":"4ca15c1e-81d6-487a-b6b1-bdc07246db32","maat_reference":"6241201","date":"2019-09-24"}]}],"case_type":{"id":232,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[{"succeeded":false,"error_messages":["injection
+        error 1","injection error 2"],"deleted_at":null}],"case_workers":[{"id":2,"uuid":"2df8d084-f2ba-401b-8be8-e97edb0e4005","first_name":"Cesar","last_name":"Medhurst","email":"cesar.medhurst@laa.gov.uk"},{"id":1,"uuid":"3f25c943-6bb8-4f20-b6be-f5c91be68c6f","first_name":"Jerold","last_name":"Blanda","email":"jerold.blanda@laa.gov.uk"}],"court":{"id":701,"code":"BSK-1","name":"Dach,
+        Olson and Reichert-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 09:25:16 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=a59e80d1-4818-47e6-a9c3-9613bde6fe3c&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=4859bd0c-babb-43bf-8de7-22793b46d0db&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -98,7 +96,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -108,28 +106,27 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"a95e863480620f45fbd9113af27d9264"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"157f91dc7f685618e4d270f6ecccf5b2"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - a02b6cfd-5e2f-4ad5-9901-c7c8528f65ae
+      - c6e8a95c-57de-4ad1-8a57-02e00cc7fbf9
       X-Runtime:
-      - '0.042861'
+      - '0.071217'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"d41b8144-e618-41bc-bb23-0bd026c2ca70","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:33:04Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"49853682-de7b-445c-9fde-8a22bcae5837","first_name":"Kami","last_name":"Deckow","email":"gertrud@rippinpadberg.io"},"defendants":[{"id":1,"uuid":"bfa7fe36-bdd2-4958-aa0d-2bf6d241e753","first_name":"George","last_name":"Raynor","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"09300a16-36b9-4968-ab6e-523cfe6d90b3","maat_reference":"7402719","date":"2016-01-01"},{"id":2,"uuid":"a436d03d-8a8a-46fc-85d7-2f9b85379971","maat_reference":"8573907","date":"2018-08-22"}]}],"case_type":{"id":161,"name":"Case
-        Type 8","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[{"succeeded":false,"error_messages":["injection
-        error 1","injection error 2"],"deleted_at":"2019-09-06T11:33:06+01:00"}],"case_workers":[{"id":2,"uuid":"8be50d3a-c5d9-4d52-8abd-933041e45706","first_name":"Conrad","last_name":"Kuphal","email":"conrad.kuphal@laa.gov.uk"},{"id":1,"uuid":"fa1a8fda-7d43-4ee5-a3af-ec0fa9e30c79","first_name":"Faustino","last_name":"Schneider","email":"faustino.schneider@laa.gov.uk"}],"court":{"id":764,"code":"BFS-8","name":"Nader
-        Inc-8","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:07 GMT
-recorded_with: VCR 5.0.0
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"c76e02f1-ee0c-49fa-aa08-06f580b73f91","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T09:25:12Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"577b0bbf-9896-410a-abc4-06a0116e7017","first_name":"Len","last_name":"Hayes","email":"leigh.smitham@quitzon.co"},"defendants":[{"id":1,"uuid":"4e7ebf65-2cdf-4cc9-8421-9da146612ba1","first_name":"Hershel","last_name":"Breitenberg","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"e3d7c0ba-f517-45d4-bc83-ff25a76564ca","maat_reference":"9717529","date":"2016-01-01"},{"id":2,"uuid":"4ca15c1e-81d6-487a-b6b1-bdc07246db32","maat_reference":"6241201","date":"2019-09-24"}]}],"case_type":{"id":232,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[{"succeeded":false,"error_messages":["injection
+        error 1","injection error 2"],"deleted_at":"2020-10-08T10:25:28+01:00"}],"case_workers":[{"id":2,"uuid":"2df8d084-f2ba-401b-8be8-e97edb0e4005","first_name":"Cesar","last_name":"Medhurst","email":"cesar.medhurst@laa.gov.uk"},{"id":1,"uuid":"3f25c943-6bb8-4f20-b6be-f5c91be68c6f","first_name":"Jerold","last_name":"Blanda","email":"jerold.blanda@laa.gov.uk"}],"court":{"id":701,"code":"BSK-1","name":"Dach,
+        Olson and Reichert-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 09:25:29 GMT
+recorded_with: VCR 6.0.0

--- a/vcr/cassettes/features/case_workers/claims/messaging.yml
+++ b/vcr/cassettes/features/case_workers/claims/messaging.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=787b6244-58fb-40a4-92f9-a693d2c74ac7&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=66535104-96c3-422b-a556-04d8adbbcde9&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -20,32 +20,30 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"16e3b1f570728430b4348be7d1ba4801"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"e4e30ce5cb0a16dbff3c38f11d14c1c8"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 6538c606-ce59-496f-bafc-2dbee70969ad
+      - 57eec5da-6c22-428f-9d8e-81de9d8fd308
       X-Runtime:
-      - '0.066917'
+      - '0.240926'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"24d1e02d-3c5c-4a4d-be77-e70d3159d376","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:32:23Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"7229c4e8-146e-4471-9e53-997d84cfe629","first_name":"Denny","last_name":"Klocko","email":"willy@funkhodkiewicz.biz"},"defendants":[{"id":1,"uuid":"bb8b812f-d8fa-405f-918b-b6c6a296b58e","first_name":"Sonny","last_name":"Nikolaus","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"0083a5bb-e3b6-4312-b608-e42c9433b965","maat_reference":"4498196","date":"2016-01-01"},{"id":2,"uuid":"d62dec62-0b63-4b8b-94f5-2f93bec799e4","maat_reference":"6173751","date":"2018-08-22"}]}],"case_type":{"id":154,"name":"Case
-        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"584b1fd1-1437-4930-860b-17254750a390","first_name":"Tyrell","last_name":"Mosciski","email":"tyrell.mosciski@laa.gov.uk"},{"id":1,"uuid":"affd9fff-5a3d-4a0d-b040-47adb25e6cf1","first_name":"Cristy","last_name":"Upton","email":"cristy.upton@laa.gov.uk"}],"court":{"id":757,"code":"IEZ-1","name":"Schmeler,
-        Feeney and Okuneva-1","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:32:24 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"753797f9-be6e-420d-a4fe-974da801242a","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T10:32:11Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"2d50cea0-ed90-449b-89f1-e6776a5cada0","first_name":"Magda","last_name":"Parisian","email":"veronika.von@lehner-renner.info"},"defendants":[{"id":1,"uuid":"d46d5f91-76e0-42ec-b9f0-f1e4f5d7fcbf","first_name":"Thanh","last_name":"Rolfson","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"dcba5a04-c94d-4be1-9779-ef0cbfc5b0cf","maat_reference":"9281807","date":"2016-01-01"},{"id":2,"uuid":"f89bf09e-333f-4b1d-be91-74c7e4c64a64","maat_reference":"5293587","date":"2019-09-24"}]}],"case_type":{"id":260,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"e3ae9a39-db41-4e50-b44f-703603d2f530","first_name":"Mariano","last_name":"Upton","email":"mariano.upton@laa.gov.uk"},{"id":1,"uuid":"60cf3f79-9b22-4db4-b4d6-e5cc920c73b7","first_name":"Lindsey","last_name":"Boyle","email":"lindsey.boyle@laa.gov.uk"}],"court":{"id":863,"code":"NWY-1","name":"Ebert-Goldner-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 10:32:15 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=787b6244-58fb-40a4-92f9-a693d2c74ac7&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=66535104-96c3-422b-a556-04d8adbbcde9&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +51,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -63,27 +61,25 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"db1fe938fa555c8adb1191dfbcad7dd2"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"eb363bdf1da52ad04b274042d0dc55a1"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 0d04cc43-aac0-455d-bf63-3e28b52dbb98
+      - 07ae27ed-1b6e-40c4-8ff8-ea00a2617178
       X-Runtime:
-      - '0.050765'
+      - '0.119731'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"24d1e02d-3c5c-4a4d-be77-e70d3159d376","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:32:23Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":2,"unread_messages_count":1,"external_user":{"id":1,"uuid":"7229c4e8-146e-4471-9e53-997d84cfe629","first_name":"Denny","last_name":"Klocko","email":"willy@funkhodkiewicz.biz"},"defendants":[{"id":1,"uuid":"bb8b812f-d8fa-405f-918b-b6c6a296b58e","first_name":"Sonny","last_name":"Nikolaus","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"0083a5bb-e3b6-4312-b608-e42c9433b965","maat_reference":"4498196","date":"2016-01-01"},{"id":2,"uuid":"d62dec62-0b63-4b8b-94f5-2f93bec799e4","maat_reference":"6173751","date":"2018-08-22"}]}],"case_type":{"id":154,"name":"Case
-        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"584b1fd1-1437-4930-860b-17254750a390","first_name":"Tyrell","last_name":"Mosciski","email":"tyrell.mosciski@laa.gov.uk"},{"id":1,"uuid":"affd9fff-5a3d-4a0d-b040-47adb25e6cf1","first_name":"Cristy","last_name":"Upton","email":"cristy.upton@laa.gov.uk"}],"court":{"id":757,"code":"IEZ-1","name":"Schmeler,
-        Feeney and Okuneva-1","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:32:29 GMT
-recorded_with: VCR 5.0.0
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"753797f9-be6e-420d-a4fe-974da801242a","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T10:32:11Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":2,"unread_messages_count":1,"external_user":{"id":1,"uuid":"2d50cea0-ed90-449b-89f1-e6776a5cada0","first_name":"Magda","last_name":"Parisian","email":"veronika.von@lehner-renner.info"},"defendants":[{"id":1,"uuid":"d46d5f91-76e0-42ec-b9f0-f1e4f5d7fcbf","first_name":"Thanh","last_name":"Rolfson","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"dcba5a04-c94d-4be1-9779-ef0cbfc5b0cf","maat_reference":"9281807","date":"2016-01-01"},{"id":2,"uuid":"f89bf09e-333f-4b1d-be91-74c7e4c64a64","maat_reference":"5293587","date":"2019-09-24"}]}],"case_type":{"id":260,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"e3ae9a39-db41-4e50-b44f-703603d2f530","first_name":"Mariano","last_name":"Upton","email":"mariano.upton@laa.gov.uk"},{"id":1,"uuid":"60cf3f79-9b22-4db4-b4d6-e5cc920c73b7","first_name":"Lindsey","last_name":"Boyle","email":"lindsey.boyle@laa.gov.uk"}],"court":{"id":863,"code":"NWY-1","name":"Ebert-Goldner-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 10:32:42 GMT
+recorded_with: VCR 6.0.0

--- a/vcr/cassettes/features/case_workers/claims/refuse.yml
+++ b/vcr/cassettes/features/case_workers/claims/refuse.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=7df7aba1-3036-4fd4-9b13-8b9557b9511f&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=a893f8d9-efd9-4d78-9bc6-893c549d4622&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -20,31 +20,31 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"8fe9fcc512cae63487c6e27578f4f822"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"d4e5b56b1c364639a9018e3adf1172ad"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 7cb01f58-9620-4056-a893-e08b668b2b10
+      - f9c4c4c0-98e8-4413-a225-1fe3d5d79a24
       X-Runtime:
-      - '0.043193'
+      - '0.060305'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"33e604dc-d166-4213-a433-34baf94420c2","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:33:13Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"7da0234d-351b-4cd7-b8e6-6f58cfd22be7","first_name":"Barbara","last_name":"Stanton","email":"rudy@ryan.name"},"defendants":[{"id":1,"uuid":"2962ae65-0bd3-4fd8-9ea3-985aa069e7b1","first_name":"Kenneth","last_name":"Doyle","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"d7bb80e7-157a-4b1b-bbc2-43804b04bd3b","maat_reference":"6913820","date":"2016-01-01"},{"id":2,"uuid":"29ab448e-6604-4238-b07f-749ba92050ac","maat_reference":"6361582","date":"2018-08-22"}]}],"case_type":{"id":162,"name":"Case
-        Type 9","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"66a4e2d2-5f09-47dc-b66a-c05cf155e6c9","first_name":"Haywood","last_name":"Labadie","email":"haywood.labadie@laa.gov.uk"},{"id":1,"uuid":"61b2ffe1-9b60-43c9-a5e3-1ba5e4389208","first_name":"Del","last_name":"Schumm","email":"del.schumm@laa.gov.uk"}],"court":{"id":765,"code":"ZDA-9","name":"Haag-Sipes-9","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:15 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"134d84f0-a708-456e-b0b6-b2e9622e8b16","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T12:13:25Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"d8c284ef-c9a6-4e67-ba4a-bc3a601e7131","first_name":"Burton","last_name":"West","email":"brady_fay@romaguera.biz"},"defendants":[{"id":1,"uuid":"8bea3d86-d769-47d3-8612-1b970ababdfa","first_name":"Charita","last_name":"Runolfsson","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"beefb4a4-cb30-42aa-86a9-58e741b48030","maat_reference":"6299856","date":"2016-01-01"},{"id":2,"uuid":"1817a4c2-93c2-4dc6-a68e-33fe142cea62","maat_reference":"4209000","date":"2019-09-24"}]}],"case_type":{"id":302,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"a2d37b6b-c272-41ce-9993-9776657e8057","first_name":"Preston","last_name":"Koss","email":"preston.koss@laa.gov.uk"},{"id":1,"uuid":"b56bde22-9a86-471c-87d0-e1fc046cda7f","first_name":"Terrie","last_name":"Pagac","email":"terrie.pagac@laa.gov.uk"}],"court":{"id":1106,"code":"ALY-1","name":"Goyette
+        Group-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 12:13:28 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=7df7aba1-3036-4fd4-9b13-8b9557b9511f&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=a893f8d9-efd9-4d78-9bc6-893c549d4622&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -52,7 +52,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -62,25 +62,24 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"af05eefd3cf4c0875b60382409d46200"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"216a18275239c1f3183f4dfee577974d"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 94c4f884-20dd-4b99-980f-dffb8f355f29
+      - 687d786c-5555-4813-a63c-475abc6da0d0
       X-Runtime:
-      - '0.013995'
+      - '0.015508'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: '{"pagination":{"current_page":1,"total_pages":0,"total_count":0,"limit_value":10},"items":[]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:17 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Thu, 08 Oct 2020 12:13:31 GMT
+recorded_with: VCR 6.0.0

--- a/vcr/cassettes/features/case_workers/claims/reject.yml
+++ b/vcr/cassettes/features/case_workers/claims/reject.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=da530c5d-0c13-4631-9010-dc9effa6baee&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=96622b60-1767-4ee2-b697-31d462c246a5&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -20,32 +20,31 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"59a6ba1ef50c98d76656779294b4d022"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"a1803fdd3b44d583fc82f2b5820fe01d"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - bf34d711-bca8-4924-8288-8aaa7927c288
+      - 8981981e-5f9a-41a6-922f-496e89796556
       X-Runtime:
-      - '0.043879'
+      - '0.581478'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"0e4d6f99-22f3-484f-9a12-303c869ddf24","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:33:22Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"015e604d-c843-4f43-8475-432220e28a0d","first_name":"Akiko","last_name":"Grady","email":"roselee@johnstonjohnson.com"},"defendants":[{"id":1,"uuid":"ce690c97-5079-4fe0-919c-e263a5709567","first_name":"Yevette","last_name":"Ruecker","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"b602edf8-b9ba-4b59-a1f0-3b37857c41c8","maat_reference":"5316921","date":"2016-01-01"},{"id":2,"uuid":"22a743d8-746c-4bae-a61d-7e0f2545f509","maat_reference":"8747138","date":"2018-08-22"}]}],"case_type":{"id":164,"name":"Case
-        Type 11","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"610ed15e-c6b7-4e50-a60b-edebdb070eff","first_name":"Ambrose","last_name":"Prohaska","email":"ambrose.prohaska@laa.gov.uk"},{"id":1,"uuid":"88da5207-7089-461e-877f-81c969f0299d","first_name":"Federico","last_name":"Herzog","email":"federico.herzog@laa.gov.uk"}],"court":{"id":767,"code":"TNO-11","name":"Goodwin,
-        Walsh and Kirlin-11","court_type":"crown"}}]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:24 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"d3399304-05e7-40ca-bc2e-58c658bb53ea","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T12:04:20Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"23dbaf94-9a89-4a13-8e39-6ab9a996b0f8","first_name":"Rayna","last_name":"Boyle","email":"gene.bashirian@heaney-schulist.info"},"defendants":[{"id":1,"uuid":"b2d30860-bd08-41a7-b3a8-a8059c8118df","first_name":"Jacquelynn","last_name":"Homenick","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"7231b436-8e6c-4fe3-b02b-1c1f77e6ba41","maat_reference":"8548627","date":"2016-01-01"},{"id":2,"uuid":"d5ec42e0-8040-440a-a05f-cd7617e4b9ce","maat_reference":"7870315","date":"2019-09-24"}]}],"case_type":{"id":274,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"52485175-1d67-470c-a556-d7cd94253f47","first_name":"Antonio","last_name":"Batz","email":"antonio.batz@laa.gov.uk"},{"id":1,"uuid":"0a170281-6750-4fa4-bb26-e965a86294f5","first_name":"Branden","last_name":"Ebert","email":"branden.ebert@laa.gov.uk"}],"court":{"id":944,"code":"TZY-1","name":"Jakubowski
+        and Sons-1","court_type":"crown"}}]}'
+  recorded_at: Thu, 08 Oct 2020 12:04:24 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=da530c5d-0c13-4631-9010-dc9effa6baee&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=96622b60-1767-4ee2-b697-31d462c246a5&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +52,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.5p114
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -63,25 +62,24 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"b55ab78caf9db9078f755e5225dc06e4"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
+      - W/"6ab4a683c8548640a72bdc16d46c53f3"
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - da3d04dd-bf06-417f-93a4-68c76a74edd3
+      - 9e3ea7fb-178a-47a8-be7b-022fd28f375f
       X-Runtime:
-      - '0.014323'
+      - '0.031138'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: '{"pagination":{"current_page":1,"total_pages":0,"total_count":0,"limit_value":10},"items":[]}'
-    http_version: 
-  recorded_at: Fri, 06 Sep 2019 10:33:26 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Thu, 08 Oct 2020 12:04:49 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### What
Try to fix delays in claims appearing in caseworkers allocated claims list reported on Zendesk.

"We’ve had multiple reports over the last couple of weeks that instead of this being instantaneous its taking anything upto 15 minutes for the claims to disappear from the allocation page.  Similar delays have been reported in the transitions once a claim has been assessed by a caseworker. "

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1449

#### Why
The delays appeared to start following a Grape/Grape-Swagger/Rackdependency update (https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/3466/files). Investigation appeared to confirm that the delays didn't happen on a branch without this update.

The difference seems to be a result of a change to response.headers; (testing locally) before dependency update:-
```
:content_type=>"application/json",
 :vary=>"Accept-Encoding",
 :etag=>"W/\"2ca6dcecf50860fb0ca8e75b40a7a46c\"",
 :cache_control=>"max-age=0, private, must-revalidate",
 :x_meta_request_version=>"0.7.2",
 :x_request_id=>"3bb45ab8-6c96-480b-aac1-3c663486f00f",
 :x_runtime=>"0.098327",
 :transfer_encoding=>"chunked"
```
after update:-
```
:cache_control=>"no-cache",
 :content_type=>"application/json",
 :vary=>"Accept-Encoding",
 :etag=>"W/\"a1bb929082d714a3ce835f3d3d8555be\"",
 :x_meta_request_version=>"0.7.2",
 :x_request_id=>"e92abfbe-00e5-4df9-9786-be3f7ebeefb3",
 :x_runtime=>"1.338278",
 :transfer_encoding=>"chunked"
```
This resulted in response.ttl being evaluated to nil and api-request.rb instead using default_ttl (900 seconds).

#### How
Set ttl = 0 if cache_control == 'no-cache'

--------

#### TODO (wip)

 - [X] Tested creating a claim/allocating claims/reallocating claims on CCCD-dev
 - [ ] additional testing required?
