### PR TITLE
Increase worker memory limits

### DIFF
--- a/kubernetes_deploy/production/deployment-worker.yaml
+++ b/kubernetes_deploy/production/deployment-worker.yaml
@@ -35,6 +35,13 @@ spec:
               command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 30
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 3Gi
+            requests:
+              cpu: 10m
+              memory: 1000Mi
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/kubernetes_deploy/staging/deployment-worker.yaml
+++ b/kubernetes_deploy/staging/deployment-worker.yaml
@@ -35,6 +35,13 @@ spec:
               command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 30
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 3Gi
+            requests:
+              cpu: 10m
+              memory: 1000Mi
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets


### PR DESCRIPTION
#### What
Increase the memory limits for the worker pod

#### Ticket

[CBO-1560](https://dsdmoj.atlassian.net/browse/CBO-1560)

#### Why
Fix MI report regeneration. This was broken for quite
a while

#### How
Increase resource `limit` so process memory usage does not
exceed it for the MI report run. This was causing
the pod/container to cycle loosing the report
before it was finished.

Important - Include the `request` limit as well as not doing so
will cause k8s  to apply the `limit` to the `request`, which will
reserve that amount of memory immediately, possibly causing the
pod to be unable to start. The request values should be
set to the default values set in the cloud-platform-environment
`limitrange.yaml` file