### PR TITLE
CBO-1510 Non-descriptive labelling

### DIFF
--- a/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_additional_fee_fields.html.haml
@@ -23,7 +23,7 @@
     .form-group
       - fee_type_scope = fee.fee_type_code.downcase
       = f.adp_text_field :quantity,
-        label: t(".#{fee_type_scope}.quantity"),
+        label: t('.quantity'),
         hint_text: t(".#{fee_type_scope}.quantity_hint"),
         input_classes: 'quantity js-fee-quantity js-fee-calculator-quantity form-control-1-4',
         input_type: 'number',
@@ -33,7 +33,7 @@
     .form-group.js-unit-price-effectee
       .calculated-unit-fee
       = f.adp_text_field :rate,
-        label: t('.rate'),
+        label: t('.rate_html', context: f.object.description),
         input_classes: 'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
         input_type: 'currency',
         value: number_with_precision(f.object.rate, precision: 2),

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
@@ -15,7 +15,7 @@
     .js-graduated-price-effectee
       .calculated-grad-fee
       = f.adp_text_field :rate,
-        label: t('.net_amount'),
+        label: t('.net_amount_html', context: f.object.description),
         input_classes:'total fee-amount form-control-1-4 form-input-denote__input',
         input_type: 'currency',
         value: number_with_precision(f.object.rate, precision: 2),

--- a/app/views/external_users/claims/basic_fees/_extra_fee_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_extra_fee_fields.html.haml
@@ -27,7 +27,7 @@
       .js-graduated-price-effectee
         .calculated-grad-fee
         = f.adp_text_field :amount,
-          label: t('.net_amount'),
+          label: t('.net_amount_html', context: f.object.description),
           input_disabled: f.object.calculated? ? true : false,
           input_classes:'total fee-amount form-input-denote__input form-control-1-4',
           value: number_with_precision(f.object.amount, precision: 2),

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -13,20 +13,20 @@
 
     .form-group.first-name
       - @representation_order_count = 0
-      = f.adp_text_field :first_name, label: t('.first_name'), errors: @error_presenter
+      = f.adp_text_field :first_name, label: t('.first_name_html'), errors: @error_presenter
 
     .form-group.last-name
-      = f.adp_text_field :last_name, label: t('.last_name'), errors: @error_presenter
+      = f.adp_text_field :last_name, label: t('.last_name_html'), errors: @error_presenter
 
     .form-group.dob
-      %a{ id: "defendant_#{@defendant_count+1}_date_of_birth" }
-      = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
+      %a{ id: "defendant_#{@defendant_count+1}_date_of_birth_html" }
+      = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth_html'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
 
     - unless @claim.lgfs? && @claim.interim?
       .form-group
         .multiple-choice
           = f.check_box :order_for_judicial_apportionment
-          = f.label :order_for_judicial_apportionment, t('.order_for_judicial_apportionment'), class: 'judicial-apportionment-notice'
+          = f.label :order_for_judicial_apportionment, t('.order_for_judicial_apportionment_html'), class: 'judicial-apportionment-notice'
           = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
 
       .form-group

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -14,13 +14,13 @@
 
   .form-group.ro-date
     = f.gov_uk_date_field(:representation_order_date,
-                          legend_text: 'Representation order date',
+                          legend_text: t('.date_html'),
                           legend_class: 'govuk-legend',
                           id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date",
                           error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date"))
 
   .form-group.maat
     = f.adp_text_field :maat_reference,
-                        label: t('.maat_reference_number'),
+                        label: t('.maat_reference_number_html'),
                         hint_text: t('.maat_reference_number_eg'),
                         errors: @error_presenter

--- a/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
+++ b/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
@@ -6,7 +6,7 @@
 
   .form-group.disbursement-type.js-typeahead{ class: error_class?(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type") ? 'form-group-error dropdown_field_with_errors' : ''  }
     %a{ id: "disbursement_#{@disbursement_count}_disbursement_type" }
-    = f.label :disbursement_type_id, t('.disbursement_type'), class: 'form-label-bold'
+    = f.label :disbursement_type_id, t('.disbursement_type_html', context: t('.disbursement')), class: 'form-label-bold'
     = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")
     = f.select :disbursement_type_id,
       DisbursementType.active.map{ |disbursement| [disbursement.name, disbursement.id] },
@@ -15,14 +15,14 @@
 
   .form-group
     = f.adp_text_field :net_amount,
-      label: t('.net_amount'),
+      label: t('.net_amount_html', context: t('.disbursement')),
       input_classes:'amount fee-amount form-input-denote__input form-control-1-4',
       input_type: 'currency',
       value: number_with_precision(f.object.net_amount, precision: 2),
       errors: @error_presenter
 
     = f.adp_text_field :vat_amount,
-      label: t('.vat_amount'),
+      label: t('.vat_amount_html', context: t('.disbursement')),
       input_classes:'vat fee-vat form-input-denote__input form-control-1-4',
       input_type: 'currency',
       value: number_with_precision(f.object.vat_amount, precision: 2),

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -23,7 +23,7 @@
         -# SELECT: Expense types
         .form-group.fx-travel-expense-type
           = f.label :expense_type_id,
-            t('.type_of_expense'),
+            t('.type_of_expense_html'),
             { class: 'form-label-bold' }
 
           - expense_types_collection = present_collection(ExpenseType.for_claim_type(@claim))
@@ -37,7 +37,7 @@
         %a{ id: "expense_#{@expense_count}_reason_id" }
         .form-group.fx-travel-reason{ style: 'display: none;', class: error_classes }
           = f.label :reason_id, class: 'form-label-bold' do
-            = t('.travel_reason')
+            = t('.travel_reason_html')
             = validation_error_message(@error_presenter, "expense_#{@expense_count}_reason_id")
 
           - reasons_collection = present_collection(reasonset_for_expense_type(f.object.expense_type).values, TravelReasonPresenter)
@@ -46,7 +46,7 @@
         -# INPUT: Other travel reason input
         .form-group.fx-travel-reason-other{ style: f.object.reason_id.eql?(5) ? 'display: block;' : 'display: none;' }
           - present(f.object) do |expense|
-            = f.adp_text_field :reason_text, label: t('.reason_text'), input_classes: '', errors: @error_presenter
+            = f.adp_text_field :reason_text, label: t('.reason_text_html'), input_classes: '', errors: @error_presenter
 
     .grid-row
       .column-full
@@ -61,17 +61,17 @@
               = validation_error_message(@error_presenter, "expense_#{@expense_count}_location")
               = f.select :location, {}, {}, { class: 'form-control form-control-3-4', autocomplete: 'off' }
 
-          = f.adp_text_field :location, label: t('.location'), input_classes: 'form-control form-control-3-4 fx-location-model', errors: @error_presenter
+          = f.adp_text_field :location, label: t('.location_html'), input_classes: 'form-control form-control-3-4 fx-location-model', errors: @error_presenter
 
       .column-full
         -# INPUT: Travel hours
         .form-group.fx-travel-hours{ style: 'display: none;' }
-          = f.adp_text_field :hours, label: t('.hours'), input_classes: 'form-control-1-8', input_type: 'number', errors: @error_presenter
+          = f.adp_text_field :hours, label: t('.hours_html'), input_classes: 'form-control-1-8', input_type: 'number', errors: @error_presenter
 
 
         -# INPUT: Travel Distance
         .form-group-compound.fx-travel-distance{ style: 'display: none;' }
-          = f.adp_text_field :distance, label: t('.distance'), hint_text: t('.distance_hint'), input_type: 'number', input_classes: 'form-control-1-4', value: number_with_precision(f.object.distance, precision: 0), errors: @error_presenter
+          = f.adp_text_field :distance, label: t('.distance_html'), hint_text: t('.distance_hint'), input_type: 'number', input_classes: 'form-control-1-4', value: number_with_precision(f.object.distance, precision: 0), errors: @error_presenter
           - if @claim.lgfs?
             = govuk_detail t('.summary_heading') do
               = t('.summary_content')
@@ -82,7 +82,7 @@
         .form-group.fx-travel-mileage{ style: 'display: none;' }
           %fieldset
             %legend.form-label-bold
-              = t('.cost')
+              = t('.cost_html')
 
             -# Bike before Car.. due to hidden inputs
             .fx-travel-mileage-bike
@@ -104,7 +104,7 @@
         -# DATES: Expense date
         .form-group.fx-travel-date{ style: 'display: none;' }
           = f.gov_uk_date_field :date,
-            legend_text: t('.date'),
+            legend_text: t('.date_html'),
             form_hint_text: t('.date_hint'),
             legend_class: 'govuk-legend',
             id: "expense_#{@expense_count}_date",
@@ -115,7 +115,7 @@
         -# INPUT: Net amount
         .form-group.fx-travel-net-amount{ style: 'display: none;' }
           = f.adp_text_field :amount,
-                            label: t('.net_amount'),
+                            label: t('.net_amount_html'),
                             input_classes: 'form-input-denote__input rate',
                             input_type: 'currency',
                             errors: @error_presenter,
@@ -126,7 +126,7 @@
         - if @claim.lgfs?
           .form-group.fx-travel-vat-amount{ style: 'display: none;' }
             = f.adp_text_field :vat_amount,
-                            label: t('.vat_amount'),
+                            label: t('.vat_amount_html'),
                             input_classes: 'form-input-denote__input vat',
                             input_type: 'currency',
                             errors: @error_presenter,

--- a/app/views/external_users/claims/fixed_fees/advocates/_fixed_fee_fields.html.haml
+++ b/app/views/external_users/claims/fixed_fees/advocates/_fixed_fee_fields.html.haml
@@ -18,14 +18,14 @@
     - if f.object.fee_type.case_uplift?
       .form-group
         = f.adp_text_field :case_numbers,
-          label: t('.case_numbers'),
+          label: t('.case_numbers_html', context: f.object.description),
           input_classes:'js-fixed-fee-case-numbers',
           hint_text:'Separate by commas',
           errors: @error_presenter
 
     .form-group
       = f.adp_text_field :quantity,
-        label: t('.quantity'),
+        label: t('.quantity_html', context: f.object.description),
         hint_text: t('.quantity_hint'),
         hide_hint: true,
         input_classes:"quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity",
@@ -36,7 +36,7 @@
     .form-group.js-unit-price-effectee
       .calculated-unit-fee
       = f.adp_text_field :rate,
-          label: t('.rate'),
+          label: t('.rate_html', context: f.object.description),
           input_classes:'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
           input_type: 'currency',
           errors: @error_presenter,

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -10,7 +10,7 @@
   .form-group
     .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") ? 'form-group-error dropdown_field_with_errors' : '' }
       = f.label :fee_type_id_input,
-        t('.fee_type'),
+        t('.fee_type_html', context: t('.misc_fee')),
         { class: 'form-label-bold' }
 
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
@@ -26,7 +26,7 @@
     = render 'warnings/unused_material_over_3_hours'
 
   = f.adp_text_field :quantity,
-                          label: t('.quantity'),
+                          label: t('.quantity_html', context: t('.misc_fee')),
                           hint_text: t('.quantity_hint'),
                           hide_hint: true,
                           input_classes: 'quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity',
@@ -37,7 +37,7 @@
   .js-unit-price-effectee
     .calculated-unit-fee
     = f.adp_text_field :rate,
-        label: t('.rate'),
+        label: t('.rate_html', context: t('.misc_fee')),
         input_classes: 'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
         input_type: 'currency',
         errors: @error_presenter,

--- a/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
@@ -17,7 +17,7 @@
 
     .form-group
       = f.adp_text_field :quantity,
-        label: t('.quantity'),
+        label: t('.quantity_html', context: f.object.description),
         hint_text: t('.quantity_hint'),
         hide_hint: true,
         input_classes:"quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity",
@@ -28,7 +28,7 @@
     .form-group.js-unit-price-effectee
       .calculated-unit-fee
       = f.adp_text_field :rate,
-          label: t('.rate'),
+          label: t('.rate_html', context: f.object.description),
           input_classes:'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
           input_type: 'currency',
           errors: @error_presenter,

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -21,7 +21,7 @@
           .multiple-choice
             = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}",
               data: { unique_code: b.object.fee_type.unique_code})
-            = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { b.text }
+            = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { t('.type_of_fee_html', context: b.text) }
 
       = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
@@ -29,7 +29,7 @@
     = render 'warnings/unused_material_over_3_hours'
 
   = f.adp_text_field :amount,
-                    label: t('.net_amount'),
+                    label: t('.net_amount_html', context: t('.misc_fee')),
                     input_classes: 'total fee-rate form-input-denote__input form-control-1-4',
                     input_type: 'currency',
                     errors: @error_presenter,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -918,6 +918,7 @@ en:
         basic_fee_fields_primary:
           add_dates: Add another date
           net_amount: *net_amount
+          net_amount_html: Net amount <span class="govuk-visually-hidden">in pounds for %{context}</span>
           date_label:
             trial: Second day of trial
             cracked_trial: Date case cracked on
@@ -945,6 +946,7 @@ en:
               <p>We calculate the rate based upon the fee scheme, advocate category, offence and case type</p>
         extra_fee_fields:
           net_amount: *net_amount
+          net_amount_html: Net amount <span class="govuk-visually-hidden">in pounds for %{context}</span>
           help_how_we_calculate_rate_title: *how_is_this_calculated_help
           help_how_we_calculate_rate_body: We calculate the amount based upon the fee scheme, case type, offence, advocate category and fee type.
           npw:
@@ -952,7 +954,7 @@ en:
             quantity: Total number of prosecution witnesses
             quantity_hint: *empty_input
           ppe:
-            quantity: Total number of pages
+            quantity: Total number of pages of prosecution evidence
             quantity_hint: Please remove all cover sheets from the total count
             heading_html: |
               Pages of prosecution evidence (<abbr title="pages of prosecution evidence">PPE</abbr>)
@@ -969,6 +971,7 @@ en:
           amount: *net_amount
           remove: *remove
           rate: *rate
+          rate_html: Rate <span class="govuk-visually-hidden">in pounds for %{context}</span>
           help_how_we_calculate_rate_title: *how_is_this_calculated_help
           help_how_we_calculate_rate_body: We calculate the rate based upon the fee scheme, case type, offence, advocate category and fee type.
           daf:
@@ -1144,11 +1147,15 @@ en:
       defendants:
         defendant_fields:
           first_name: *first_name
+          first_name_html: First name <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           last_name: *last_name
+          last_name_html: Last name <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           full_name: Full name
-          date_of_birth: 'Date of birth'
+          date_of_birth: Date of birth
+          date_of_birth_html: Date of birth <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           judical_apportionment: Judicial apportionment
           order_for_judicial_apportionment:  Order for judicial apportionment
+          order_for_judicial_apportionment_html: Order for judicial apportionment <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           order_for_judicial_apportionment_help: Judicial apportionment is when the defendant has applied for and received an order confirming they are not required to pay the full amount of their defence costs. If applicable, please ensure you upload a copy of the order to your claim.
           add_another_rep_order: 'Add another representation order'
           remove_defendant: 'Remove defendant'
@@ -1160,8 +1167,10 @@ en:
           page_heading: Defendant details
         representation_order_fields:
           date: Representation order date
+          date_html: Representation order date <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           representation_order: Representation order details
           maat_reference_number: MAAT reference
+          maat_reference_number_html: MAAT reference <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           maat_reference_number_eg: 'this should be 7 digits long, starting with at least a 4'
           remove: Remove
         summary:
@@ -1240,9 +1249,12 @@ en:
         disbursement_fields:
           page_header: Disbursements
           net_amount: *net_amount
+          net_amount_html: Net amount <span class="govuk-visually-hidden">in pounds for %{context} <span class="fx-numberedList-number"></span></span>
           vat_amount: *vat_amount
+          vat_amount_html: VAT amount <span class="govuk-visually-hidden">in pounds for %{context} <span class="fx-numberedList-number"></span></span>
           total: Total
           disbursement_type: Type of disbursement
+          disbursement_type_html: Type of disbursement <span class="govuk-visually-hidden">for %{context} <span class="fx-numberedList-number"></span></span>
           disbursement: Disbursement
           remove: Remove
       expenses:
@@ -1261,25 +1273,35 @@ en:
             We use the postcode associated with your supplier number to automatically calculate the distance between your address and the destination, eg court or prison
           select_option: Please select
           travel_reason: Travel reason
+          travel_reason_html: Travel reason <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           type_of_expense: Type of expense
+          type_of_expense_html: Type of expense <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           expense: Expense
           cost: Cost per mile
+          cost_html: Cost per mile <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           location: Location
+          location_html: Location <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           reason_text: Other reason
+          reason_text_html: Other reason <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           add_date_attended: Add dates
           date: Date of expense
+          date_html: Date of expense <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           date_hint: For example 31 3 2017
           destination: Destination
           distance: Distance
+          distance_html: Distance <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           distance_hint: Total mileage for the return journey
           distance_summary_heading: How we calculate the distance
           distance_summary_text: |
             We use the postcode associated with your supplier number to automatically calculate the distance between your address and the destination, eg court or prison.
           hours: Hours
+          hours_html: Hours <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           net_amount: *net_amount
+          net_amount_html: Net amount <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
           remove: Remove
           total: Total amount
           vat_amount: *vat_amount
+          vat_amount_html: VAT amount <span class="govuk-visually-hidden">for travel expense <span class="fx-numberedList-number"></span></span>
         fields:
           add_another_expense: 'Add another expense'
           duplicate: Duplicate last expense
@@ -1382,9 +1404,12 @@ en:
           fixed_fee_fields:
             fixed_fee: "Fixed fee"
             quantity: *quantity
+            quantity_html: Quantity <span class="govuk-visually-hidden">for %{context}</span>
             quantity_hint: 'Enter a quantity'
             rate: *rate
+            rate_html: Rate <span class="govuk-visually-hidden">in pounds for %{context}</span>
             case_numbers: *case_numbers
+            case_numbers_html: Case number <span class="govuk-visually-hidden">for %{context}</span>
             no_dates: 'No dates currently selected.'
             fee_type: 'Type of fee'
             add_date_attended: 'Add another date'
@@ -1421,10 +1446,13 @@ en:
           misc_fee_fields:
             misc_fee: *miscellaneous_fee
             rate: Rate
+            rate_html: Rate <span class="govuk-visually-hidden">in pounds for %{context} <span class="fx-numberedList-number"></span></span>
             net_amount: *net_amount
             quantity: *quantity
             quantity_hint: Enter a quantity
+            quantity_html: Quantity <span class="govuk-visually-hidden">for %{context} <span class="fx-numberedList-number"></span></span>
             fee_type: *fee_type
+            fee_type_html: Fee of type <span class="govuk-visually-hidden">for %{context} <span class="fx-numberedList-number"></span></span>
             add_date_attended: Add dates
             remove: Remove
             no_dates: No dates currently selected.
@@ -1436,9 +1464,12 @@ en:
               misc_fee: *miscellaneous_fee
             misc_fee_fields:
               rate: Rate
+              rate_html: Rate <span class="govuk-visually-hidden">in pounds for %{context}</span>
               net_amount: *net_amount
+              net_amount_html: Net amount <span class="govuk-visually-hidden">in pounds for %{context} <span class="fx-numberedList-number"></span></span>
               quantity: *quantity
               quantity_hint: Enter a quantity
+              quantity_html: Quantity <span class="govuk-visually-hidden">for %{context}</span>
               add_date_attended: Add dates
               help_how_we_calculate_rate_title: *how_is_this_calculated_help
               help_how_we_calculate_rate_body: We calculate the rate based upon the fee scheme, advocate category and fee type.
@@ -1456,7 +1487,9 @@ en:
             misc_fee: *miscellaneous_fee
             fee_type: *fee_type
             case_numbers: *case_numbers
+            type_of_fee_html: '%{context} <span class="govuk-visually-hidden">for miscellaneous fee <span class="fx-numberedList-number"></span></span>'
             net_amount: *net_amount
+            net_amount_html: Net amount <span class="govuk-visually-hidden">in pounds for %{context} <span class="fx-numberedList-number"></span></span>
             remove: "Remove"
         summary:
           header: *miscellaneous_fees

--- a/features/page_objects/sections/lgfs_misc_fee_section.rb
+++ b/features/page_objects/sections/lgfs_misc_fee_section.rb
@@ -4,7 +4,7 @@ class FeeTypeSection < SitePrism::Section
   sections :radios, RadioSection, '.multiple-choice'
 
   def radio_labels
-    radios.map { |radio| radio.label.text }
+    radios.map { |radio| radio.label.text.gsub(/\n(.*)/, '') }
   end
 
   def choose(label)


### PR DESCRIPTION
#### What
We have added visually hidden text to duplicate label text to provide context to differentiate between the form labels.

#### Ticket
[Non-descriptive labelling](https://dsdmoj.atlassian.net/browse/CBO-1510)

#### Why
There are multiple form labels on a page with the same text, these are ambiguous for screen reader users that browse out of context.
