### PR TITLE
Enable use of k8s current context in "local" scripts

### DIFF
--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -20,102 +20,23 @@ spec:
           restartPolicy: Never
           containers:
           - name: cronjob-worker
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-not-a-real-tag
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
             imagePullPolicy: Always
             command:
               - bundle
               - exec
               - rake
               - claims:archive_stale
+
+            envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
             env:
-            - name: ENV
-              value: 'cronjob-worker'
-            - name: RAILS_ENV
-              value: 'production'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: cccd-rds
-                  key: url
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SECRET_KEY_BASE
-            - name: CASE_WORKER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: CASE_WORKER_PASSWORD
-            - name: ADVOCATE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: ADVOCATE_PASSWORD
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: AWS_REGION
-            - name: SETTINGS__AWS__S3__REGION
-              value: 'eu-west-2'
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
-            - name: SETTINGS__AWS__S3__BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: bucket_name
-            - name: SETTINGS__SLACK__BOT_URL
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__SLACK__BOT_URL
-            - name: SETTINGS__GOVUK_NOTIFY__API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__GOVUK_NOTIFY__API_KEY
-            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__MESSAGE_ADDED_EMAIL
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__MESSAGE_ADDED_EMAIL
-            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_USER
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_USER
-            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_ADVOCATE_ADMIN
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_ADVOCATE_ADMIN
-            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_LITIGATOR_ADMIN
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__NEW_EXTERNAL_LITIGATOR_ADMIN
-            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__PASSWORD_RESET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__PASSWORD_RESET
-            - name: SETTINGS__GOVUK_NOTIFY__TEMPLATES__UNLOCK_INSTRUCTIONS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: SETTINGS__GOVUK_NOTIFY__TEMPLATES__UNLOCK_INSTRUCTIONS
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-elasticache-redis
                   key: url

--- a/kubernetes_deploy/jobs/dump.yaml
+++ b/kubernetes_deploy/jobs/dump.yaml
@@ -26,8 +26,6 @@ spec:
                 name: cccd-secrets
 
           env:
-            - name: RAILS_ENV
-              value: 'production'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/jobs/migrate.yaml
+++ b/kubernetes_deploy/jobs/migrate.yaml
@@ -16,18 +16,16 @@ spec:
             - exec
             - rake
             - db:migrate
+
+          envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
           env:
-            - name: RAILS_ENV
-              value: 'production'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-secrets
-                  key: AWS_REGION
-            - name: SECRET_KEY_BASE
-              value: just-be-present

--- a/kubernetes_deploy/jobs/seed.yaml
+++ b/kubernetes_deploy/jobs/seed.yaml
@@ -24,8 +24,6 @@ spec:
                 name: cccd-secrets
 
           env:
-            - name: RAILS_ENV
-              value: 'production'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes_deploy/scripts/cronjob.sh
+++ b/kubernetes_deploy/scripts/cronjob.sh
@@ -4,7 +4,7 @@ function _cronjob() {
   Usage: cronjob job environment [branch]
   Where:
     job [archive_stale|clean_ecr]
-    environment [dev|staging|api-sandbox|production]
+    environment [dev|dev-lgfs|staging|api-sandbox|production]
     branch [<branchname>-latest|commit-sha]
 
   Example:
@@ -27,15 +27,14 @@ function _cronjob() {
     return 0
   fi
 
-  context='live-1'
-
   case "$1" in
     archive_stale)
       job=$1
       ;;
     clean_ecr)
-      echo "Setting environment to dev as only this has the ECR secret..."
-      kubectl apply --context ${context} -n cccd-dev -f kubernetes_deploy/cron_jobs/$1.yaml
+      echo "Setting namespace to dev as only this has the ECR secret..."
+      kubectl config set-context --current --namespace=cccd-dev
+      kubectl apply -f kubernetes_deploy/cron_jobs/$1.yaml
       return $?
       ;;
     *)
@@ -62,18 +61,20 @@ function _cronjob() {
     current_version=$3
   fi
 
+  context=$(kubectl config current-context)
   component=app
   docker_registry=754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd
   docker_image_tag=${docker_registry}:${component}-${current_version}
 
   printf "\e[33m--------------------------------------------------\e[0m\n"
-  printf "\e[33mJob: kubernetes_deploy/cron_jobs/${job}.yaml\e[0m\n"
+  printf "\e[33mCronJob file: ${job}.yaml\e[0m\n"
   printf "\e[33mContext: $context\e[0m\n"
   printf "\e[33mEnvironment: $environment\e[0m\n"
   printf "\e[33mDocker image: $docker_image_tag\e[0m\n"
   printf "\e[33m--------------------------------------------------\e[0m\n"
 
-  kubectl set image -f kubernetes_deploy/cron_jobs/${job}.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply --context ${context} -n cccd-${environment} -f -
+  kubectl config set-context --current --namespace=cccd-${environment}
+  kubectl set image -f kubernetes_deploy/cron_jobs/${job}.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
 
 }
 

--- a/kubernetes_deploy/scripts/deploy.sh
+++ b/kubernetes_deploy/scripts/deploy.sh
@@ -49,13 +49,10 @@ function _deploy() {
     current_version=$2
   fi
 
-  context='live-1'
+  context=$(kubectl config current-context)
   component=app
   docker_registry=754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd
   docker_image_tag=${docker_registry}:${component}-${current_version}
-
-  kubectl config set-context ${context} --namespace=cccd-${environment}
-  kubectl config use-context ${context}
 
   printf "\e[33m--------------------------------------------------\e[0m\n"
   printf "\e[33mContext: $context\e[0m\n"
@@ -63,7 +60,7 @@ function _deploy() {
   printf "\e[33mDocker image: $docker_image_tag\e[0m\n"
   printf "\e[33m--------------------------------------------------\e[0m\n"
 
-  # TODO: check if image exists and if not offer to build or abort
+  kubectl config set-context --current --namespace=cccd-${environment}
 
   # apply common config
   kubectl apply -f kubernetes_deploy/${environment}/secrets.yaml


### PR DESCRIPTION
#### What
Fix a reuseability issue in the k8s scripts

#### Why
k8s scripts had context hardcoded to 'live-1'
which is not the default context name. Some devs
used 'live-1' as the name. Devs can set any name
they like in the `~/kube/config` to the
https://api.live-1.cloud-platform.service.justice.gov.uk
server so it should not be hardcoded.

#### Also

 - tidy up unneeded/simpler secrets config