### PR TITLE
Enable acceptance of URN in case number field

### DIFF
--- a/kubernetes_deploy/api-sandbox/app-config.yaml
+++ b/kubernetes_deploy/api-sandbox/app-config.yaml
@@ -10,7 +10,7 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://api-sandbox.claim-crown-court-defence.service.justice.gov.uk'
   GA_TRACKER_ID: 'UA-37377084-48'
   MAINTENANCE_MODE: 'false'
-  URN_ENABLED: 'false'
+  URN_ENABLED: 'true'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'
   SETTINGS__SLACK__SUCCESS_ICON: ':taytay:'

--- a/kubernetes_deploy/dev-lgfs/app-config.yaml
+++ b/kubernetes_deploy/dev-lgfs/app-config.yaml
@@ -10,7 +10,7 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://dev-lgfs.claim-crown-court-defence.service.justice.gov.uk'
   GA_TRACKER_ID: 'UA-37377084-48'
   MAINTENANCE_MODE: 'false'
-  URN_ENABLED: 'false'
+  URN_ENABLED: 'true'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'
   SETTINGS__SLACK__SUCCESS_ICON: ':taytay:'

--- a/kubernetes_deploy/dev/app-config.yaml
+++ b/kubernetes_deploy/dev/app-config.yaml
@@ -10,7 +10,7 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://dev.claim-crown-court-defence.service.justice.gov.uk'
   GA_TRACKER_ID: 'UA-37377084-48'
   MAINTENANCE_MODE: 'false'
-  URN_ENABLED: 'false'
+  URN_ENABLED: 'true'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'
   SETTINGS__SLACK__SUCCESS_ICON: ':taytay:'

--- a/kubernetes_deploy/production/app-config.yaml
+++ b/kubernetes_deploy/production/app-config.yaml
@@ -10,7 +10,7 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://claim-crown-court-defence.service.gov.uk'
   GA_TRACKER_ID: 'UA-37377084-37'
   MAINTENANCE_MODE: 'false'
-  URN_ENABLED: 'false'
+  URN_ENABLED: 'true'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'
   SETTINGS__SLACK__SUCCESS_ICON: ':taytay:'

--- a/kubernetes_deploy/staging/app-config.yaml
+++ b/kubernetes_deploy/staging/app-config.yaml
@@ -10,7 +10,7 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
   GA_TRACKER_ID: 'UA-37377084-48'
   MAINTENANCE_MODE: 'false'
-  URN_ENABLED: 'false'
+  URN_ENABLED: 'true'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'
   SETTINGS__SLACK__SUCCESS_ICON: ':taytay:'


### PR DESCRIPTION
#### What
Enable acceptance of URN in case number field

#### Ticket

[CBO-1266](https://dsdmoj.atlassian.net/browse/CBO-1266)

#### Why

With the release of common platform cases will
start to be identifiable by URN or case number
so this field has been repurposed to accept them

The flag switches this on. CCR and CCLF have
been amended to handle URNs for DI now so
we can go ahead and accept them in CCCD and
they will be injected into CCR/CCLF as expected.