### PR TITLE
Increase worker healtcheck period for livenessProbe

### DIFF
--- a/kubernetes_deploy/api-sandbox/deployment-worker.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment-worker.yaml
@@ -34,7 +34,7 @@ spec:
             exec:
               command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 300
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/kubernetes_deploy/dev-lgfs/deployment-worker.yaml
+++ b/kubernetes_deploy/dev-lgfs/deployment-worker.yaml
@@ -34,7 +34,7 @@ spec:
             exec:
               command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 300
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/kubernetes_deploy/dev/deployment-worker.yaml
+++ b/kubernetes_deploy/dev/deployment-worker.yaml
@@ -34,7 +34,7 @@ spec:
             exec:
               command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 300
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/kubernetes_deploy/production/deployment-worker.yaml
+++ b/kubernetes_deploy/production/deployment-worker.yaml
@@ -34,7 +34,7 @@ spec:
             exec:
               command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 300
           resources:
             limits:
               cpu: 2000m

--- a/kubernetes_deploy/staging/deployment-worker.yaml
+++ b/kubernetes_deploy/staging/deployment-worker.yaml
@@ -34,7 +34,7 @@ spec:
             exec:
               command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 300
           resources:
             limits:
               cpu: 2000m


### PR DESCRIPTION
#### What
Increase worker healtcheck period for livenessProbe

#### Ticket

[board ticket description](link)

#### Why

The rake task has to load the whole rails app
which is eating up cpu. This eventually caused
problems for the node.

Until we can implement a healthcheck that does not
require the rails app to be loaded I am increasing
the period between livenesProbe checks so that
cpu gets a chance to "cool" down.