### PR TITLE
Use plain ruby script for worker healthcheck

### DIFF
--- a/bin/worker_healthcheck
+++ b/bin/worker_healthcheck
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+module Worker
+  def self.healthcheck
+    abort 'sidekiq not found' unless system('pgrep -f sidekiq')
+  end
+end
+
+Worker.healthcheck

--- a/kubernetes_deploy/api-sandbox/deployment-worker.yaml
+++ b/kubernetes_deploy/api-sandbox/deployment-worker.yaml
@@ -27,12 +27,12 @@ spec:
           command: ['bundle', 'exec', 'sidekiq']
           readinessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
-            initialDelaySeconds: 15
-            periodSeconds: 10
+              command: ['bin/worker_healthcheck']
+            initialDelaySeconds: 20
+            periodSeconds: 30
           livenessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+              command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
 

--- a/kubernetes_deploy/dev-lgfs/deployment-worker.yaml
+++ b/kubernetes_deploy/dev-lgfs/deployment-worker.yaml
@@ -27,12 +27,12 @@ spec:
           command: ['bundle', 'exec', 'sidekiq']
           readinessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
-            initialDelaySeconds: 15
-            periodSeconds: 10
+              command: ['bin/worker_healthcheck']
+            initialDelaySeconds: 20
+            periodSeconds: 30
           livenessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+              command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
 

--- a/kubernetes_deploy/dev/deployment-worker.yaml
+++ b/kubernetes_deploy/dev/deployment-worker.yaml
@@ -27,12 +27,12 @@ spec:
           command: ['bundle', 'exec', 'sidekiq']
           readinessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
-            initialDelaySeconds: 15
-            periodSeconds: 10
+              command: ['bin/worker_healthcheck']
+            initialDelaySeconds: 20
+            periodSeconds: 30
           livenessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+              command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
 

--- a/kubernetes_deploy/production/deployment-worker.yaml
+++ b/kubernetes_deploy/production/deployment-worker.yaml
@@ -27,12 +27,12 @@ spec:
           command: ['bundle', 'exec', 'sidekiq']
           readinessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
-            initialDelaySeconds: 15
-            periodSeconds: 10
+              command: ['bin/worker_healthcheck']
+            initialDelaySeconds: 20
+            periodSeconds: 30
           livenessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+              command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
           resources:

--- a/kubernetes_deploy/staging/deployment-worker.yaml
+++ b/kubernetes_deploy/staging/deployment-worker.yaml
@@ -27,12 +27,12 @@ spec:
           command: ['bundle', 'exec', 'sidekiq']
           readinessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
-            initialDelaySeconds: 15
-            periodSeconds: 10
+              command: ['bin/worker_healthcheck']
+            initialDelaySeconds: 20
+            periodSeconds: 30
           livenessProbe:
             exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+              command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
           resources:

--- a/lib/tasks/worker.rake
+++ b/lib/tasks/worker.rake
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-namespace :worker do
-  desc 'Test if sidekiq process is running. raises error if not.'
-  task healthcheck: :environment do
-    raise StandardError if `pgrep -f sidekiq`.blank?
-  end
-end


### PR DESCRIPTION
#### What
Use plain ruby script for worker healthcheck

Also, tweak `readinesProbe` period to reduce
interval.

#### Ticket

[CBO-1580](https://dsdmoj.atlassian.net/browse/CBO-1580)

#### Why
Previous healthcheck was a rake task that
was loading the rails app every 30 seconds.
This was using a lot of cpu and causing
the node to need cycling more often.