### PR TITLE
Rename and add MI date fields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,12 +58,6 @@ Metrics/BlockLength:
     - state_machine
     - resource
 
-Metrics/ModuleLength:
-  Exclude:
-    - 'app/models/claims/calculations.rb'
-    - 'app/models/claims/state_machine.rb'
-    - 'app/helpers/application_helper.rb'
-
 Style/DateTime:
   AllowCoercion: true
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,6 +36,13 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 37
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'app/presenters/concerns/management_information_reportable.rb'
+    - 'app/models/claims/calculations.rb'
+    - 'app/models/claims/state_machine.rb'
+    - 'app/helpers/application_helper.rb'
+
 # Offense count: 2
 # Configuration parameters: IgnoredMethods, Max.
 Metrics/PerceivedComplexity:

--- a/app/presenters/concerns/management_information_reportable.rb
+++ b/app/presenters/concerns/management_information_reportable.rb
@@ -45,9 +45,17 @@ module ManagementInformationReportable
       @journey.first.to == 'submitted' ? 'new' : @journey.first.to
     end
 
-    def submitted_at
+    def transitioned_at
       submission_steps = @journey.select { |step| SUBMITTED_STATES.include?(step.to) }
       submission_steps.present? ? submission_steps.first.created_at.strftime('%d/%m/%Y') : 'n/a'
+    end
+
+    def last_submitted_at
+      claim.last_submitted_at.strftime('%d/%m/%Y')
+    end
+
+    def originally_submitted_at
+      original_submission_date.strftime('%d/%m/%Y')
     end
 
     def allocated_at

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,6 +49,7 @@ max_item_amount: 200_000.00     # An item is each of the individual expenses, di
 max_claim_amount: 1_000_000.00  # The total sum of all the individual items in a claim
 
 claim_csv_headers:
+  - :id
   - :scheme
   - :case_number
   - :supplier_number
@@ -57,7 +58,9 @@ claim_csv_headers:
   - :bill_type
   - :claim_total
   - :submission_type
-  - :submitted_at
+  - :transitioned_at
+  - :last_submitted_at
+  - :originally_submitted_at
   - :allocated_at
   - :completed_at
   - :current_or_end_state

--- a/spec/presenters/management_information_presenter_spec.rb
+++ b/spec/presenters/management_information_presenter_spec.rb
@@ -1,19 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe ManagementInformationPresenter do
-
   let(:claim) { create(:redetermination_claim) }
   let(:presenter) { ManagementInformationPresenter.new(claim, view) }
   let(:previous_user) { create(:user, first_name: 'Thea', last_name: 'Conway') }
   let(:another_user) { create(:user, first_name: 'Hilda', last_name: 'Rogers') }
 
-
   context '#present!' do
-
     context 'generates a line of CSV for each time a claim passes through the system' do
-
       context 'with identical values for' do
-
         it 'case_number' do
           presenter.present! do |claim_journeys|
             expect(claim_journeys.first).to include(claim.case_number)
@@ -170,7 +165,6 @@ RSpec.describe ManagementInformationPresenter do
             expect(presenter.case_worker).to eq case_worker_name
           end
         end
-
       end
 
       # Case worker name isn't unique - might not be the user who was working on this case just before redetermination
@@ -257,7 +251,7 @@ RSpec.describe ManagementInformationPresenter do
 
       context 'and unique values for' do
         before { Timecop.freeze(Time.now) }
-        after  { Timecop.return }
+        after { Timecop.return }
 
         it 'submission type' do
           presenter.present! do |claim_journeys|
@@ -313,7 +307,7 @@ RSpec.describe ManagementInformationPresenter do
 
       context 'archived_pending_delete' do
         let(:claim) { create(:archived_pending_delete_claim) }
-       
+
         it 'adds a single row to the MI' do
           ManagementInformationPresenter.new(claim, view).present! do |csv|
             expect(csv.size).to eql 1
@@ -341,7 +335,7 @@ RSpec.describe ManagementInformationPresenter do
             expect(csv.size).to eql 1
           end
         end
-        
+
         it 'should not be reflected in the MI' do
           ManagementInformationPresenter.new(claim, view).present! do |csv|
             expect(csv[0]).not_to include('archived_pending_review')
@@ -354,7 +348,6 @@ RSpec.describe ManagementInformationPresenter do
           end
         end
       end
-
 
       context 'state transitions reasons' do
         let(:claim) { create(:allocated_claim) }

--- a/spec/presenters/management_information_presenter_spec.rb
+++ b/spec/presenters/management_information_presenter_spec.rb
@@ -222,6 +222,39 @@ RSpec.describe ManagementInformationPresenter do
         it { is_expected.to eq claim.misc_fees.map{ |f| f.fee_type.description.tr(',', '')}.join(' ') }
       end
 
+      describe '#transitioned_at' do
+        it 'set per transition' do
+          presenter.present! do |claim_journeys|
+            expect(claim_journeys.first).to include((Time.zone.now - 3.day).strftime('%d/%m/%Y'))
+            expect(claim_journeys.second).to include((Time.zone.now).strftime('%d/%m/%Y'))
+          end
+        end
+      end
+
+      describe '#last_submitted_at' do
+        subject { presenter.last_submitted_at }
+
+        let(:last_submitted_at) { Date.new(2017, 9, 20) }
+
+        before do
+          claim.last_submitted_at = last_submitted_at
+        end
+
+        it { is_expected.to eql last_submitted_at.strftime('%d/%m/%Y') }
+      end
+
+      describe '#originally_submitted_at' do
+        subject { presenter.originally_submitted_at }
+
+        let(:original_submission_date) { Date.new(2015, 6, 18) }
+
+        before do
+          claim.original_submission_date = original_submission_date
+        end
+
+        it { is_expected.to eql original_submission_date.strftime('%d/%m/%Y') }
+      end
+
       context 'and unique values for' do
         before { Timecop.freeze(Time.now) }
         after  { Timecop.return }
@@ -230,13 +263,6 @@ RSpec.describe ManagementInformationPresenter do
           presenter.present! do |claim_journeys|
             expect(claim_journeys.first).to include('new')
             expect(claim_journeys.second).to include('redetermination')
-          end
-        end
-
-        it 'date submitted' do
-          presenter.present! do |claim_journeys|
-            expect(claim_journeys.first).to include((Time.zone.now - 3.day).strftime('%d/%m/%Y'))
-            expect(claim_journeys.second).to include((Time.zone.now).strftime('%d/%m/%Y'))
           end
         end
 
@@ -332,6 +358,7 @@ RSpec.describe ManagementInformationPresenter do
 
       context 'state transitions reasons' do
         let(:claim) { create(:allocated_claim) }
+        let(:colidx) { 15 }
 
         context 'rejected with a single reason as a string ' do
           before do
@@ -341,7 +368,7 @@ RSpec.describe ManagementInformationPresenter do
           it 'the rejection reason code should be reflected in the MI' do
             allow_any_instance_of(ClaimStateTransition).to receive(:reason_code).and_return('no_rep_order')
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('no_rep_order')
+              expect(csv[0][colidx]).to eq('no_rep_order')
             end
           end
         end
@@ -353,7 +380,7 @@ RSpec.describe ManagementInformationPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('no_rep_order')
+              expect(csv[0][colidx]).to eq('no_rep_order')
             end
           end
         end
@@ -365,7 +392,7 @@ RSpec.describe ManagementInformationPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('no_rep_order, wrong_case_no')
+              expect(csv[0][colidx]).to eq('no_rep_order, wrong_case_no')
             end
           end
         end
@@ -377,8 +404,8 @@ RSpec.describe ManagementInformationPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('other')
-              expect(csv[0][13]).to eq('Rejection reason')
+              expect(csv[0][colidx]).to eq('other')
+              expect(csv[0][colidx+1]).to eq('Rejection reason')
             end
           end
         end
@@ -391,7 +418,7 @@ RSpec.describe ManagementInformationPresenter do
           it 'the refusal reason code should be reflected in the MI' do
             allow_any_instance_of(ClaimStateTransition).to receive(:reason_code).and_return('no_rep_order')
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('no_rep_order')
+              expect(csv[0][colidx]).to eq('no_rep_order')
             end
           end
         end
@@ -403,7 +430,7 @@ RSpec.describe ManagementInformationPresenter do
 
           it 'the refusal reason code should be reflected in the MI' do
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('no_rep_order')
+              expect(csv[0][colidx]).to eq('no_rep_order')
             end
           end
         end
@@ -415,7 +442,7 @@ RSpec.describe ManagementInformationPresenter do
 
           it 'the refusal reason code should be reflected in the MI' do
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('no_rep_order, wrong_case_no')
+              expect(csv[0][colidx]).to eq('no_rep_order, wrong_case_no')
             end
           end
         end
@@ -427,8 +454,8 @@ RSpec.describe ManagementInformationPresenter do
 
           it 'the rejection reason code should be reflected in the MI' do
             ManagementInformationPresenter.new(claim, view).present! do |csv|
-              expect(csv[0][12]).to eq('other')
-              expect(csv[0][13]).to eq('Rejection reason')
+              expect(csv[0][colidx]).to eq('other')
+              expect(csv[0][colidx+1]).to eq('Rejection reason')
             end
           end
         end

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Stats::ManagementInformationGenerator do
   subject(:result) { described_class.call }
 
   let(:frozen_time) { Time.new(2015, 3, 10, 11, 44, 55) }
-  let(:report_columns) { ['Scheme',
+  let(:report_columns) { ['Id',
+                          'Scheme',
                           'Case number',
                           'Supplier number',
                           'Organisation',
@@ -12,7 +13,9 @@ RSpec.describe Stats::ManagementInformationGenerator do
                           'Bill type',
                           'Claim total',
                           'Submission type',
-                          'Submitted at',
+                          'Transitioned at',
+                          'Last submitted at',
+                          'Originally submitted at',
                           'Allocated at',
                           'Completed at',
                           'Current or end state',


### PR DESCRIPTION
#### What
Rename and add MI date fields

#### Ticket

[CBO-637](https://dsdmoj.atlassian.net/browse/CBO-637)

#### Why
Case workers are confused by the name "Submitted at".

They need to see either the last_submitted_at date or
the original_submission_date, but we are not sure what is
most applicable for their purposes.

So, we are adding the two new dates and they can then decide
what they want.

Note: "Submitted at" column in MI is the date the claim transitioned
to a state of submitted, awaiting_written_reasons or redetermination