### PR TITLE
Disable messaging for lgfs interim claims post assessment

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -39,7 +39,11 @@ module ClaimsHelper
   end
 
   def messaging_permitted?(message)
-    (current_user_is_external_user? && !message.claim.redeterminable?) || message.claim_action.present?
+    return true if message.claim_action.present?
+    if current_user_is_external_user?
+      return !Claims::StateMachine::VALID_STATES_FOR_REDETERMINATION.include?(message.claim.state)
+    end
+    false
   end
 
   def display_downtime_warning?

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe ClaimsHelper do
     end
   end
 
-  describe '#messaging_permitted' do
+  describe '#messaging_permitted?' do
     subject { messaging_permitted?(message) }
 
     let(:claim) { build :claim, state: state }

--- a/vcr/cassettes/features/case_workers/claims/messaging.yml
+++ b/vcr/cassettes/features/case_workers/claims/messaging.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=66535104-96c3-422b-a556-04d8adbbcde9&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=7b46a7fd-7f42-487b-bb27-a0cba1bd54c1&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -20,30 +20,31 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"e4e30ce5cb0a16dbff3c38f11d14c1c8"
+      - W/"02ba8cf13bc944cf3a799be2f58689e5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 57eec5da-6c22-428f-9d8e-81de9d8fd308
+      - b36f4d9f-4a1a-4f45-bda3-5e71908211d4
       X-Runtime:
-      - '0.240926'
+      - '0.603046'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"753797f9-be6e-420d-a4fe-974da801242a","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T10:32:11Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"2d50cea0-ed90-449b-89f1-e6776a5cada0","first_name":"Magda","last_name":"Parisian","email":"veronika.von@lehner-renner.info"},"defendants":[{"id":1,"uuid":"d46d5f91-76e0-42ec-b9f0-f1e4f5d7fcbf","first_name":"Thanh","last_name":"Rolfson","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"dcba5a04-c94d-4be1-9779-ef0cbfc5b0cf","maat_reference":"9281807","date":"2016-01-01"},{"id":2,"uuid":"f89bf09e-333f-4b1d-be91-74c7e4c64a64","maat_reference":"5293587","date":"2019-09-24"}]}],"case_type":{"id":260,"name":"Case
-        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"e3ae9a39-db41-4e50-b44f-703603d2f530","first_name":"Mariano","last_name":"Upton","email":"mariano.upton@laa.gov.uk"},{"id":1,"uuid":"60cf3f79-9b22-4db4-b4d6-e5cc920c73b7","first_name":"Lindsey","last_name":"Boyle","email":"lindsey.boyle@laa.gov.uk"}],"court":{"id":863,"code":"NWY-1","name":"Ebert-Goldner-1","court_type":"crown"}}]}'
-  recorded_at: Thu, 08 Oct 2020 10:32:15 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"9d0a258f-632b-4f00-b90d-4c26c87d1d73","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-26T12:43:04Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"8ef773a4-ee1d-4ef9-ac26-5f3ef970c5a7","first_name":"Chieko","last_name":"Erdman","email":"jae@thiel-jacobi.name"},"defendants":[{"id":1,"uuid":"19ddfe9e-eb07-418a-9041-44730ffc0640","first_name":"Marion","last_name":"Spinka","date_of_birth":"1990-10-26","representation_orders":[{"id":1,"uuid":"4ec32dda-a047-4457-9cb5-30cda4c288d6","maat_reference":"8917610","date":"2016-01-01"},{"id":2,"uuid":"bc976be2-821a-4fd7-b1d7-1edb6fa67c4d","maat_reference":"7630280","date":"2019-10-12"}]}],"case_type":{"id":101,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"ff218a72-be1e-4a69-8321-087a3e01c92a","first_name":"Mohammad","last_name":"Schiller","email":"mohammad.schiller@laa.gov.uk"},{"id":1,"uuid":"f1522896-3df4-4fe6-a28e-c7ff83afb9af","first_name":"Corliss","last_name":"Effertz","email":"corliss.effertz@laa.gov.uk"}],"court":{"id":503,"code":"SQK-1","name":"Shanahan,
+        Feeney and Parker-1","court_type":"crown"}}]}'
+  recorded_at: Mon, 26 Oct 2020 12:43:08 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=66535104-96c3-422b-a556-04d8adbbcde9&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=7b46a7fd-7f42-487b-bb27-a0cba1bd54c1&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -61,25 +62,26 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"eb363bdf1da52ad04b274042d0dc55a1"
+      - W/"ea7387374bfcdc874a841b6a751ffb47"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 07ae27ed-1b6e-40c4-8ff8-ea00a2617178
+      - cf902ed7-79f9-4ef0-bb82-b6166d1fa71d
       X-Runtime:
-      - '0.119731'
+      - '0.095082'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"753797f9-be6e-420d-a4fe-974da801242a","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-08T10:32:11Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":2,"unread_messages_count":1,"external_user":{"id":1,"uuid":"2d50cea0-ed90-449b-89f1-e6776a5cada0","first_name":"Magda","last_name":"Parisian","email":"veronika.von@lehner-renner.info"},"defendants":[{"id":1,"uuid":"d46d5f91-76e0-42ec-b9f0-f1e4f5d7fcbf","first_name":"Thanh","last_name":"Rolfson","date_of_birth":"1990-10-08","representation_orders":[{"id":1,"uuid":"dcba5a04-c94d-4be1-9779-ef0cbfc5b0cf","maat_reference":"9281807","date":"2016-01-01"},{"id":2,"uuid":"f89bf09e-333f-4b1d-be91-74c7e4c64a64","maat_reference":"5293587","date":"2019-09-24"}]}],"case_type":{"id":260,"name":"Case
-        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"e3ae9a39-db41-4e50-b44f-703603d2f530","first_name":"Mariano","last_name":"Upton","email":"mariano.upton@laa.gov.uk"},{"id":1,"uuid":"60cf3f79-9b22-4db4-b4d6-e5cc920c73b7","first_name":"Lindsey","last_name":"Boyle","email":"lindsey.boyle@laa.gov.uk"}],"court":{"id":863,"code":"NWY-1","name":"Ebert-Goldner-1","court_type":"crown"}}]}'
-  recorded_at: Thu, 08 Oct 2020 10:32:42 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":1,"limit_value":10},"items":[{"id":1,"uuid":"9d0a258f-632b-4f00-b90d-4c26c87d1d73","case_number":"A20161234","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2020-10-26T12:43:04Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":2,"unread_messages_count":1,"external_user":{"id":1,"uuid":"8ef773a4-ee1d-4ef9-ac26-5f3ef970c5a7","first_name":"Chieko","last_name":"Erdman","email":"jae@thiel-jacobi.name"},"defendants":[{"id":1,"uuid":"19ddfe9e-eb07-418a-9041-44730ffc0640","first_name":"Marion","last_name":"Spinka","date_of_birth":"1990-10-26","representation_orders":[{"id":1,"uuid":"4ec32dda-a047-4457-9cb5-30cda4c288d6","maat_reference":"8917610","date":"2016-01-01"},{"id":2,"uuid":"bc976be2-821a-4fd7-b1d7-1edb6fa67c4d","maat_reference":"7630280","date":"2019-10-12"}]}],"case_type":{"id":101,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":2,"uuid":"ff218a72-be1e-4a69-8321-087a3e01c92a","first_name":"Mohammad","last_name":"Schiller","email":"mohammad.schiller@laa.gov.uk"},{"id":1,"uuid":"f1522896-3df4-4fe6-a28e-c7ff83afb9af","first_name":"Corliss","last_name":"Effertz","email":"corliss.effertz@laa.gov.uk"}],"court":{"id":503,"code":"SQK-1","name":"Shanahan,
+        Feeney and Parker-1","court_type":"crown"}}]}'
+  recorded_at: Mon, 26 Oct 2020 12:43:35 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### What
Disable external user messaging for lgfs interim claims post assessment

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1314

#### Why
Providers were adding messages to lgfs interim claims after they had been assessed. Because lgfs interim claims cannot be redetermined these messages were not being seen by caseworkers.

#### How
Fixed/amended messaging_permitted? in claims_helper.rb so that messaging is disabled for lgfs interim post assessment claims (previously this was relying on redeterminable? in base_claim.rb which did not work for lgfs interim claims, as these are not redeterminable). Added tests in claims_helper_spec.

