### PR TITLE
Remove link from the legend

### DIFF
--- a/app/views/external_users/claims/_date_attended_fields.html.haml
+++ b/app/views/external_users/claims/_date_attended_fields.html.haml
@@ -8,7 +8,8 @@
     - error_prefix = "date_attended_0"
 
   - unless hide_remove
-    = link_to_remove_association t(".remove"), f, {class: "date-action"}
+    = link_to_remove_association f, class: 'govuk-link' do
+      = t('common.remove_html', context: t('.date_attended'))
 
   .fee-date-from
     - if defined?(locale_scope)
@@ -19,4 +20,4 @@
     - else
       - date_text = t('.date_attended')
 
-    = f.gov_uk_date_field :date, legend_text: date_text, legend_class: "form-label-bold", id: "#{error_prefix}_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, "#{error_prefix}_date")
+    = f.gov_uk_date_field :date, legend_text: date_text, id: "#{error_prefix}_date", error_messages: gov_uk_date_field_error_messages(@error_presenter, "#{error_prefix}_date")

--- a/app/views/external_users/claims/_date_attended_fields_condensed.html.haml
+++ b/app/views/external_users/claims/_date_attended_fields_condensed.html.haml
@@ -20,4 +20,5 @@
         = validation_error_message(@error_presenter, "#{error_prefix}_date_to")
 
     .column-one-third.fee-date-remove
-      = link_to_remove_association t('.remove'), f
+      = link_to_remove_association f, class: 'govuk-link' do
+        = t('common.remove_html', context: t('external_users.claims.date_attended_fields.date_attended'))

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -5,11 +5,9 @@
       %span.heading-medium
         = t('.defendant')
         %span.fx-numberedList-number
-        = link_to_remove_association f, class: 'header-action fx-numberedList-action hidden' do
-          = t('.remove')
-          %span.visuallyhidden
-            = t('.defendant')
-            %span.fx-numberedList-number
+
+    = link_to_remove_association f, class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+      = t('common.remove_html', context: t('.defendant'))
 
     .form-group.first-name
       - @representation_order_count = 0

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -6,21 +6,19 @@
       %span.heading-medium
         = t('.representation_order')
         %span.fx-numberedList-number
-        = link_to_remove_association f, class: 'header-action fx-numberedList-action hidden' do
-          = t('.remove')
-          %span.visuallyhidden
-            = t('.representation_order')
-            %span.fx-numberedList-number
 
-  .form-group.ro-date
-    = f.gov_uk_date_field(:representation_order_date,
-                          legend_text: t('.date_html'),
-                          legend_class: 'govuk-legend',
-                          id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date",
-                          error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date"))
+    = link_to_remove_association f, class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+      = t('common.remove_html', context: t('.representation_order'))
 
-  .form-group.maat
-    = f.adp_text_field :maat_reference,
-                        label: t('.maat_reference_number_html'),
-                        hint_text: t('.maat_reference_number_eg'),
-                        errors: @error_presenter
+    .form-group.ro-date
+      = f.gov_uk_date_field(:representation_order_date,
+                            legend_text: t('.date_html'),
+                            legend_class: 'govuk-legend',
+                            id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date",
+                            error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date"))
+
+    .form-group.maat
+      = f.adp_text_field :maat_reference,
+                          label: t('.maat_reference_number_html'),
+                          hint_text: t('.maat_reference_number_eg'),
+                          errors: @error_presenter

--- a/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
+++ b/app/views/external_users/claims/disbursements/_disbursement_fields.html.haml
@@ -1,34 +1,39 @@
 .form-section.disbursement-group.nested-fields.fx-fee-group.fx-numberedList-item.js-block.fx-do-init{ data: { type:'disbursements', autovat: 'false', 'block-type': 'FeeBlockManualAmounts' } }
-  %h2.bold-medium
-    = t('.disbursement')
-    %span.fx-numberedList-number
-    = link_to_remove_association t('.remove'), f, wrapper_class: 'disbursement-group', class: 'header-action fx-numberedList-action hidden'
 
-  .form-group.disbursement-type.js-typeahead{ class: error_class?(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type") ? 'form-group-error dropdown_field_with_errors' : ''  }
-    %a{ id: "disbursement_#{@disbursement_count}_disbursement_type" }
-    = f.label :disbursement_type_id, t('.disbursement_type_html', context: t('.disbursement')), class: 'form-label-bold'
-    = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")
-    = f.select :disbursement_type_id,
-      DisbursementType.active.map{ |disbursement| [disbursement.name, disbursement.id] },
-      { include_blank: ''.html_safe },
-      { class: 'form-control form-control-full fx-autocomplete', 'aria-label': t('.disbursement_type') }
+  %fieldset
+    %legend
+      %span.heading-medium
+        = t('.disbursement')
+        %span.fx-numberedList-number
 
-  .form-group
-    = f.adp_text_field :net_amount,
-      label: t('.net_amount_html', context: t('.disbursement')),
-      input_classes:'amount fee-amount form-input-denote__input form-control-1-4',
-      input_type: 'currency',
-      value: number_with_precision(f.object.net_amount, precision: 2),
-      errors: @error_presenter
+    = link_to_remove_association f, wrapper_class: 'disbursement-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+      = t('common.remove_html', context: t('.disbursement'))
 
-    = f.adp_text_field :vat_amount,
-      label: t('.vat_amount_html', context: t('.disbursement')),
-      input_classes:'vat fee-vat form-input-denote__input form-control-1-4',
-      input_type: 'currency',
-      value: number_with_precision(f.object.vat_amount, precision: 2),
-      errors: @error_presenter
+    .form-group.disbursement-type.js-typeahead{ class: error_class?(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type") ? 'form-group-error dropdown_field_with_errors' : ''  }
+      %a{ id: "disbursement_#{@disbursement_count}_disbursement_type" }
+      = f.label :disbursement_type_id, t('.disbursement_type_html', context: t('.disbursement')), class: 'form-label-bold'
+      = validation_error_message(@error_presenter, "disbursement_#{@disbursement_count}_disbursement_type")
+      = f.select :disbursement_type_id,
+        DisbursementType.active.map{ |disbursement| [disbursement.name, disbursement.id] },
+        { include_blank: ''.html_safe },
+        { class: 'form-control form-control-full fx-autocomplete', 'aria-label': t('.disbursement_type') }
 
-    %label.form-label-bold
-      = t('.total')
-    .total{ data: { total: number_to_currency(f.object.total) } }
-      = number_to_currency(f.object.total)
+    .form-group
+      = f.adp_text_field :net_amount,
+        label: t('.net_amount_html', context: t('.disbursement')),
+        input_classes:'amount fee-amount form-input-denote__input form-control-1-4',
+        input_type: 'currency',
+        value: number_with_precision(f.object.net_amount, precision: 2),
+        errors: @error_presenter
+
+      = f.adp_text_field :vat_amount,
+        label: t('.vat_amount_html', context: t('.disbursement')),
+        input_classes:'vat fee-vat form-input-denote__input form-control-1-4',
+        input_type: 'currency',
+        value: number_with_precision(f.object.vat_amount, precision: 2),
+        errors: @error_presenter
+
+      %label.form-label-bold
+        = t('.total')
+      .total{ data: { total: number_to_currency(f.object.total) } }
+        = number_to_currency(f.object.total)

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -5,131 +5,130 @@
     = f.hidden_field :location_type, { class: 'fx-location-type' }
     = f.hidden_field :calculated_distance, { class: 'fx-travel-calculated-distance' }
 
-    %h3.heading-medium
-      = t('.expense')
-      %span.fx-numberedList-number
-      %span.fx-remove-link
-      = link_to_remove_association f, wrapper_class: 'expense-group', class: 'header-action fx-numberedList-action hidden' do
-        = t('.remove')
-        %span.visuallyhidden
+    %fieldset
+      %legend
+        %span.heading-medium
           = t('.expense')
           %span.fx-numberedList-number
 
-    %p.fx-general-errors{ style: 'display: none;' }
-      %span
+      = link_to_remove_association f, wrapper_class: 'expense-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+        = t('common.remove_html', context: t('.expense'))
 
-    .grid-row
-      .column-full
-        -# SELECT: Expense types
-        .form-group.fx-travel-expense-type
-          = f.label :expense_type_id,
-            t('.type_of_expense_html'),
-            { class: 'form-label-bold' }
+      %p.fx-general-errors{ style: 'display: none;' }
+        %span
 
-          - expense_types_collection = present_collection(ExpenseType.for_claim_type(@claim))
-          = f.select :expense_type_id, expense_types_collection.map { |et| [et.name, et.id, { data: et.data_attributes }] }, { include_blank: t('.select_option') }, { class: 'form-control form-control-3-4' }
-          = validation_error_message(@error_presenter, "expense_#{@expense_count}_expense_type")
+      .grid-row
+        .column-full
+          -# SELECT: Expense types
+          .form-group.fx-travel-expense-type
+            = f.label :expense_type_id,
+              t('.type_of_expense_html'),
+              { class: 'form-label-bold' }
 
-      .column-full
-        -# SELECT: Travel reasons
-        - error_classes = error_class?(@error_presenter, "expense_#{@expense_count}_reason_id")
-        - error_classes += ' form-group-error' if error_classes.present?
-        %a{ id: "expense_#{@expense_count}_reason_id" }
-        .form-group.fx-travel-reason{ style: 'display: none;', class: error_classes }
-          = f.label :reason_id, class: 'form-label-bold' do
-            = t('.travel_reason_html')
-            = validation_error_message(@error_presenter, "expense_#{@expense_count}_reason_id")
+            - expense_types_collection = present_collection(ExpenseType.for_claim_type(@claim))
+            = f.select :expense_type_id, expense_types_collection.map { |et| [et.name, et.id, { data: et.data_attributes }] }, { include_blank: t('.select_option') }, { class: 'form-control form-control-3-4' }
+            = validation_error_message(@error_presenter, "expense_#{@expense_count}_expense_type")
 
-          - reasons_collection = present_collection(reasonset_for_expense_type(f.object.expense_type).values, TravelReasonPresenter)
-          = f.select :reason_id, reasons_collection.map { |et| [et.reason, et.id, { data: et.data_attributes }] }, { include_blank: t('.select_option') }, { class: 'form-control form-control-3-4' }
+        .column-full
+          -# SELECT: Travel reasons
+          - error_classes = error_class?(@error_presenter, "expense_#{@expense_count}_reason_id")
+          - error_classes += ' form-group-error' if error_classes.present?
+          %a{ id: "expense_#{@expense_count}_reason_id" }
+          .form-group.fx-travel-reason{ style: 'display: none;', class: error_classes }
+            = f.label :reason_id, class: 'form-label-bold' do
+              = t('.travel_reason_html')
+              = validation_error_message(@error_presenter, "expense_#{@expense_count}_reason_id")
 
-        -# INPUT: Other travel reason input
-        .form-group.fx-travel-reason-other{ style: f.object.reason_id.eql?(5) ? 'display: block;' : 'display: none;' }
-          - present(f.object) do |expense|
-            = f.adp_text_field :reason_text, label: t('.reason_text_html'), input_classes: '', errors: @error_presenter
+            - reasons_collection = present_collection(reasonset_for_expense_type(f.object.expense_type).values, TravelReasonPresenter)
+            = f.select :reason_id, reasons_collection.map { |et| [et.reason, et.id, { data: et.data_attributes }] }, { include_blank: t('.select_option') }, { class: 'form-control form-control-3-4' }
 
-    .grid-row
-      .column-full
-        -# INPUT: Location
-        .fx-travel-location{ style: 'display: none;' }
+          -# INPUT: Other travel reason input
+          .form-group.fx-travel-reason-other{ style: f.object.reason_id.eql?(5) ? 'display: block;' : 'display: none;' }
+            - present(f.object) do |expense|
+              = f.adp_text_field :reason_text, label: t('.reason_text_html'), input_classes: '', errors: @error_presenter
 
+      .grid-row
+        .column-full
+          -# INPUT: Location
+          .fx-travel-location{ style: 'display: none;' }
+
+            - if @claim.lgfs?
+              - error_classes = error_class?(@error_presenter, "expense_#{@expense_count}_location")
+              - error_classes += ' form-group-error' if error_classes.present?
+              .form-group.fx-establishment-select.has-select{ style: 'display: none;', class: error_classes }
+                = f.label :location, nil, class: 'form-label-bold'
+                = validation_error_message(@error_presenter, "expense_#{@expense_count}_location")
+                = f.select :location, {}, {}, { class: 'form-control form-control-3-4', autocomplete: 'off' }
+
+            = f.adp_text_field :location, label: t('.location_html'), input_classes: 'form-control form-control-3-4 fx-location-model', errors: @error_presenter
+
+        .column-full
+          -# INPUT: Travel hours
+          .form-group.fx-travel-hours{ style: 'display: none;' }
+            = f.adp_text_field :hours, label: t('.hours_html'), input_classes: 'form-control-1-8', input_type: 'number', errors: @error_presenter
+
+
+          -# INPUT: Travel Distance
+          .form-group-compound.fx-travel-distance{ style: 'display: none;' }
+            = f.adp_text_field :distance, label: t('.distance_html'), hint_text: t('.distance_hint'), input_type: 'number', input_classes: 'form-control-1-4', value: number_with_precision(f.object.distance, precision: 0), errors: @error_presenter
+            - if @claim.lgfs?
+              = govuk_detail t('.summary_heading') do
+                = t('.summary_content')
+
+      .grid-row
+        .column-full
+          -# RADIOS: Cost per mile
+          .form-group.fx-travel-mileage{ style: 'display: none;' }
+            %fieldset
+              %legend.form-label-bold
+                = t('.cost_html')
+
+              -# Bike before Car.. due to hidden inputs
+              .fx-travel-mileage-bike
+                = f.collection_radio_buttons(:mileage_rate_id, Expense::BIKE_MILEAGE_RATES.values, :id, :description) do |b|
+                  .multiple-choice
+                    = b.radio_button
+                    = b.label { b.object.description }
+                = validation_error_message(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")
+
+              .fx-travel-mileage-car
+                = f.collection_radio_buttons(:mileage_rate_id, Expense::CAR_MILEAGE_RATES.values, :id, :description) do |b|
+                  .multiple-choice
+                    = b.radio_button
+                    = b.label { b.object.description }
+                = validation_error_message(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")
+
+
+        .column-full
+          -# DATES: Expense date
+          .form-group.fx-travel-date{ style: 'display: none;' }
+            = f.gov_uk_date_field :date,
+              legend_text: t('.date_html'),
+              form_hint_text: t('.date_hint'),
+              legend_class: 'govuk-legend',
+              id: "expense_#{@expense_count}_date",
+              error_messages: gov_uk_date_field_error_messages(@error_presenter, "expense_#{@expense_count}_date")
+
+      .grid-row
+        .column-full
+          -# INPUT: Net amount
+          .form-group.fx-travel-net-amount{ style: 'display: none;' }
+            = f.adp_text_field :amount,
+                              label: t('.net_amount_html'),
+                              input_classes: 'form-input-denote__input rate',
+                              input_type: 'currency',
+                              errors: @error_presenter,
+                              value: number_with_precision(f.object.amount || 0, precision: 2)
+
+        .column-full
+          -# INPUT: VAT amount
           - if @claim.lgfs?
-            - error_classes = error_class?(@error_presenter, "expense_#{@expense_count}_location")
-            - error_classes += ' form-group-error' if error_classes.present?
-            .form-group.fx-establishment-select.has-select{ style: 'display: none;', class: error_classes }
-              = f.label :location, nil, class: 'form-label-bold'
-              = validation_error_message(@error_presenter, "expense_#{@expense_count}_location")
-              = f.select :location, {}, {}, { class: 'form-control form-control-3-4', autocomplete: 'off' }
-
-          = f.adp_text_field :location, label: t('.location_html'), input_classes: 'form-control form-control-3-4 fx-location-model', errors: @error_presenter
-
-      .column-full
-        -# INPUT: Travel hours
-        .form-group.fx-travel-hours{ style: 'display: none;' }
-          = f.adp_text_field :hours, label: t('.hours_html'), input_classes: 'form-control-1-8', input_type: 'number', errors: @error_presenter
-
-
-        -# INPUT: Travel Distance
-        .form-group-compound.fx-travel-distance{ style: 'display: none;' }
-          = f.adp_text_field :distance, label: t('.distance_html'), hint_text: t('.distance_hint'), input_type: 'number', input_classes: 'form-control-1-4', value: number_with_precision(f.object.distance, precision: 0), errors: @error_presenter
-          - if @claim.lgfs?
-            = govuk_detail t('.summary_heading') do
-              = t('.summary_content')
-
-    .grid-row
-      .column-full
-        -# RADIOS: Cost per mile
-        .form-group.fx-travel-mileage{ style: 'display: none;' }
-          %fieldset
-            %legend.form-label-bold
-              = t('.cost_html')
-
-            -# Bike before Car.. due to hidden inputs
-            .fx-travel-mileage-bike
-              = f.collection_radio_buttons(:mileage_rate_id, Expense::BIKE_MILEAGE_RATES.values, :id, :description) do |b|
-                .multiple-choice
-                  = b.radio_button
-                  = b.label { b.object.description }
-              = validation_error_message(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")
-
-            .fx-travel-mileage-car
-              = f.collection_radio_buttons(:mileage_rate_id, Expense::CAR_MILEAGE_RATES.values, :id, :description) do |b|
-                .multiple-choice
-                  = b.radio_button
-                  = b.label { b.object.description }
-              = validation_error_message(@error_presenter, "expense_#{@expense_count}_mileage_rate_id")
-
-
-      .column-full
-        -# DATES: Expense date
-        .form-group.fx-travel-date{ style: 'display: none;' }
-          = f.gov_uk_date_field :date,
-            legend_text: t('.date_html'),
-            form_hint_text: t('.date_hint'),
-            legend_class: 'govuk-legend',
-            id: "expense_#{@expense_count}_date",
-            error_messages: gov_uk_date_field_error_messages(@error_presenter, "expense_#{@expense_count}_date")
-
-    .grid-row
-      .column-full
-        -# INPUT: Net amount
-        .form-group.fx-travel-net-amount{ style: 'display: none;' }
-          = f.adp_text_field :amount,
-                            label: t('.net_amount_html'),
-                            input_classes: 'form-input-denote__input rate',
-                            input_type: 'currency',
-                            errors: @error_presenter,
-                            value: number_with_precision(f.object.amount || 0, precision: 2)
-
-      .column-full
-        -# INPUT: VAT amount
-        - if @claim.lgfs?
-          .form-group.fx-travel-vat-amount{ style: 'display: none;' }
-            = f.adp_text_field :vat_amount,
-                            label: t('.vat_amount_html'),
-                            input_classes: 'form-input-denote__input vat',
-                            input_type: 'currency',
-                            errors: @error_presenter,
-                            value: number_with_precision(f.object.vat_amount, precision: 2)
+            .form-group.fx-travel-vat-amount{ style: 'display: none;' }
+              = f.adp_text_field :vat_amount,
+                              label: t('.vat_amount_html'),
+                              input_classes: 'form-input-denote__input vat',
+                              input_type: 'currency',
+                              errors: @error_presenter,
+                              value: number_with_precision(f.object.vat_amount, precision: 2)
 
     %hr/

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -2,68 +2,73 @@
 - claim = present(f.object.claim)
 
 .form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{ data: { 'type': 'miscFees', autovat: @claim.apply_vat? ? 'true' : 'false', 'block-type': 'FeeBlockCalculator' } }
-  %span.bold-medium
-    = t('.misc_fee')
-    %span.fx-numberedList-number
-    = link_to_remove_association t('.remove'), f, wrapper_class: 'misc-fee-group', class: 'header-action fx-numberedList-action hidden'
 
-  .form-group
-    .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") ? 'form-group-error dropdown_field_with_errors' : '' }
-      = f.label :fee_type_id_input,
-        t('.fee_type_html', context: t('.misc_fee')),
-        { class: 'form-label-bold' }
+  %fieldset
+    %legend
+      %span.heading-medium
+        = t('.misc_fee')
+        %span.fx-numberedList-number
 
-      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
+    = link_to_remove_association f, wrapper_class: 'misc-fee-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+      = t('common.remove_html', context: t('.misc_fee'))
 
-      = f.select :fee_type_id,
-        options_for_select(claim.eligible_misc_fee_type_options_for_select, f.object&.fee_type&.id),
-        { include_blank: ''.html_safe },
-        { class: 'form-control form-control-full js-misc-fee-type js-fee-type js-fee-calculator-fee-type typeahead fx-misc-fee-calculation',
-        id: "misc_fee_#{@misc_fee_count}_fee_type",
-        'aria-label': t('.fee_type') }
+    .form-group
+      .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") ? 'form-group-error dropdown_field_with_errors' : '' }
+        = f.label :fee_type_id_input,
+          t('.fee_type_html', context: t('.misc_fee')),
+          { class: 'form-label-bold' }
 
-  .form-group.fx-unused-materials-warning.js-hidden
-    = render 'warnings/unused_material_over_3_hours'
+        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
 
-  = f.adp_text_field :quantity,
-                          label: t('.quantity_html', context: t('.misc_fee')),
-                          hint_text: t('.quantity_hint'),
-                          hide_hint: true,
-                          input_classes: 'quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity',
-                          input_type: 'number',
-                          value: fee.quantity,
-                          errors: @error_presenter
+        = f.select :fee_type_id,
+          options_for_select(claim.eligible_misc_fee_type_options_for_select, f.object&.fee_type&.id),
+          { include_blank: ''.html_safe },
+          { class: 'form-control form-control-full js-misc-fee-type js-fee-type js-fee-calculator-fee-type typeahead fx-misc-fee-calculation',
+          id: "misc_fee_#{@misc_fee_count}_fee_type",
+          'aria-label': t('.fee_type') }
 
-  .js-unit-price-effectee
-    .calculated-unit-fee
-    = f.adp_text_field :rate,
-        label: t('.rate_html', context: t('.misc_fee')),
-        input_classes: 'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
-        input_type: 'currency',
-        errors: @error_presenter,
-        input_readonly: f.object.price_calculated?,
-        value: number_with_precision(f.object.rate, precision: 2)
+    .form-group.fx-unused-materials-warning.js-hidden
+      = render 'warnings/unused_material_over_3_hours'
 
-  .js-fee-calculator-success
-    = f.hidden_field :price_calculated, value: f.object.price_calculated?
+    = f.adp_text_field :quantity,
+                            label: t('.quantity_html', context: t('.misc_fee')),
+                            hint_text: t('.quantity_hint'),
+                            hide_hint: true,
+                            input_classes: 'quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity',
+                            input_type: 'number',
+                            value: fee.quantity,
+                            errors: @error_presenter
 
-  .fee-calc-help-wrapper.form-group.hidden
-    = govuk_detail t('.help_how_we_calculate_rate_title') do
-      = t('.help_how_we_calculate_rate_body')
+    .js-unit-price-effectee
+      .calculated-unit-fee
+      = f.adp_text_field :rate,
+          label: t('.rate_html', context: t('.misc_fee')),
+          input_classes: 'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
+          input_type: 'currency',
+          errors: @error_presenter,
+          input_readonly: f.object.price_calculated?,
+          value: number_with_precision(f.object.rate, precision: 2)
 
-  .cccd-summary-list
-    %dl.govuk-summary-list
-      .govuk-summary-list__row
-        %dt.govuk-summary-list__key
-          = t('.net_amount')
-        %dd.govuk-summary-list__value.fee-net-amount.currency-indicator.total
-          = fee.amount || number_to_currency(0)
+    .js-fee-calculator-success
+      = f.hidden_field :price_calculated, value: f.object.price_calculated?
 
-  .dates-wrapper.form-group
-    %div
-      = f.fields_for :dates_attended do |date_attended|
-        = render 'date_attended_fields', f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "misc_fee_#{@misc_fee_count}"
+    .fee-calc-help-wrapper.form-group.hidden
+      = govuk_detail t('.help_how_we_calculate_rate_title') do
+        = t('.help_how_we_calculate_rate_body')
 
-    = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: '', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
+    .cccd-summary-list
+      %dl.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            = t('.net_amount')
+          %dd.govuk-summary-list__value.fee-net-amount.currency-indicator.total
+            = fee.amount || number_to_currency(0)
+
+    .dates-wrapper.form-group
+      %div
+        = f.fields_for :dates_attended do |date_attended|
+          = render 'date_attended_fields', f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "misc_fee_#{@misc_fee_count}"
+
+      = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: '', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
 
   %hr/

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -1,38 +1,42 @@
 .form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{ data: { 'type': 'miscFees', autovat: @claim.apply_vat? ? 'true' : 'false' } }
-  %h2.bold-medium
-    %span
-      = t('.misc_fee')
-      %span.fx-numberedList-number
-    = link_to_remove_association t('.remove'), f, wrapper_class: 'misc-fee-group', class: 'header-action fx-numberedList-action hidden'
 
-  .form-group
-    .fee-type{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") }
-      %fieldset{ 'aria-describedby': "radio-control-legend-#{@misc_fee_count}" }
-        %legend{ id: "radio-control-legend-#{@misc_fee_count}" }
-          %span.form-label-bold
-            = t('.fee_type')
+  %fieldset
+    %legend
+      %span.heading-medium
+        = t('.misc_fee')
+        %span.fx-numberedList-number
 
-        %a{ id: "misc_fee_#{@misc_fee_count}_fee_type" }
+    = link_to_remove_association f, wrapper_class: 'misc-fee-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+      = t('common.remove_html', context: t('.misc_fee'))
 
-        - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
-        - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
+    .form-group
+      .fee-type{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") }
+        %fieldset{ 'aria-describedby': "radio-control-legend-#{@misc_fee_count}" }
+          %legend{ id: "radio-control-legend-#{@misc_fee_count}" }
+            %span.form-label-bold
+              = t('.fee_type')
 
-        = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
-          .multiple-choice
-            = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}",
-              data: { unique_code: b.object.fee_type.unique_code})
-            = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { t('.type_of_fee_html', context: b.text) }
+          %a{ id: "misc_fee_#{@misc_fee_count}_fee_type" }
 
-      = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
+          - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
+          - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
 
-  .form-group.fx-unused-materials-warning.js-hidden
-    = render 'warnings/unused_material_over_3_hours'
+          = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
+            .multiple-choice
+              = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}",
+                data: { unique_code: b.object.fee_type.unique_code})
+              = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { t('.type_of_fee_html', context: b.text) }
 
-  = f.adp_text_field :amount,
-                    label: t('.net_amount_html', context: t('.misc_fee')),
-                    input_classes: 'total fee-rate form-input-denote__input form-control-1-4',
-                    input_type: 'currency',
-                    errors: @error_presenter,
-                    value: number_with_precision(f.object.amount, precision: 2)
+        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
+
+    .form-group.fx-unused-materials-warning.js-hidden
+      = render 'warnings/unused_material_over_3_hours'
+
+    = f.adp_text_field :amount,
+                      label: t('.net_amount_html', context: t('.misc_fee')),
+                      input_classes: 'total fee-rate form-input-denote__input form-control-1-4',
+                      input_type: 'currency',
+                      errors: @error_presenter,
+                      value: number_with_precision(f.object.amount, precision: 2)
 
   %hr/

--- a/app/views/shared/_supplier_number_fields.html.haml
+++ b/app/views/shared/_supplier_number_fields.html.haml
@@ -1,25 +1,31 @@
 .supplier-number-group.form-group.mod-supplier-details.fx-numberedList-item
-  %h2.heading-small
-    = t('.details_heading')
-    %span.fx-numberedList-number
+  %fieldset
+    %legend
+      %span.heading-medium
+        = t('.details_heading')
+        %span.fx-numberedList-number
+
     - editable = f.object.new_record? || f.object.supplier_number.blank? || !f.object.valid?
     - if editable
-      = link_to_remove_association t('.remove'), f, wrapper_class: 'supplier-number-group', class: 'header-action fx-numberedList-action hidden'
+      = link_to_remove_association f, wrapper_class: 'supplier-number-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+        = t('common.remove_html', context: t('.details_heading'))
     - else
       - if f.object.has_non_archived_claims?
-        %span.form-hint
-          Cannot remove supplier number while claims are still in progress
+        .form-group
+          %span.form-hint
+            Cannot remove supplier number while claims are still in progress
       - else
-        = link_to_remove_association t('.remove'), f, wrapper_class: 'supplier-number-group', class: 'header-action fx-numberedList-action hidden'
+        = link_to_remove_association f, wrapper_class: 'supplier-number-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
+          = t('common.remove_html', context: t('.details_heading'))
 
-  -# adp_text_field does not allow to use rails defaults locales for model attributes :S
-  - attributes_scope = 'activerecord.attributes.supplier_number'
-  - form_scope = 'shared.providers.form.supplier_details'
+    -# adp_text_field does not allow to use rails defaults locales for model attributes :S
+    - attributes_scope = 'activerecord.attributes.supplier_number'
+    - form_scope = 'shared.providers.form.supplier_details'
 
-  = f.adp_text_field :name, id: "lgfs_supplier_number_#{f.options[:child_index]}_name", label: t('label.supplier_name', scope: form_scope), hint_text: t('hint_text.supplier_name', scope: form_scope), disabled: !editable, errors: f.options[:parent_builder].object.errors
+    = f.adp_text_field :name, id: "lgfs_supplier_number_#{f.options[:child_index]}_name", label: t('label.supplier_name', scope: form_scope), hint_text: t('hint_text.supplier_name', scope: form_scope), disabled: !editable, errors: f.options[:parent_builder].object.errors
 
-  = f.adp_text_field :postcode, id: "lgfs_supplier_number_#{f.options[:child_index]}_postcode", label: t('label.postcode', scope: form_scope), hint_text: t('hint_text.postcode', scope: form_scope), input_classes: 'form-control-1-4', disabled: !editable, errors: f.options[:parent_builder].object.errors
+    = f.adp_text_field :postcode, id: "lgfs_supplier_number_#{f.options[:child_index]}_postcode", label: t('label.postcode', scope: form_scope), hint_text: t('hint_text.postcode', scope: form_scope), input_classes: 'form-control-1-4', disabled: !editable, errors: f.options[:parent_builder].object.errors
 
-  = f.adp_text_field :supplier_number, id: "lgfs_supplier_number_#{f.options[:child_index]}_supplier_number", label: t('label.supplier_number', scope: form_scope), hint_text: t('hint_text.supplier_number', scope: form_scope), input_classes: 'form-control-1-4', disabled: !editable, errors: f.options[:parent_builder].object.errors
+    = f.adp_text_field :supplier_number, id: "lgfs_supplier_number_#{f.options[:child_index]}_supplier_number", label: t('label.supplier_number', scope: form_scope), hint_text: t('hint_text.supplier_number', scope: form_scope), input_classes: 'form-control-1-4', disabled: !editable, errors: f.options[:parent_builder].object.errors
 
   %hr/

--- a/app/webpack/javascripts/plugins/jquery.numbered.elements.js
+++ b/app/webpack/javascripts/plugins/jquery.numbered.elements.js
@@ -58,7 +58,7 @@
       var items = $(this.settings.wrapper).find(this.settings.item + ':visible');
 
       items.each(function (idx, el) {
-        $(el).find(action).removeClass('hidden');
+        $(el).find(action).removeClass('govuk-!-display-none');
         $(el).find(number).text('');
         if (items.length > 1) {
           $(el).find(number).text(idx + 1);

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -203,3 +203,7 @@ p.file-upload-name {
   margin: $gutter-one-sixth 0 0;
   font-style: italic;
 }
+
+.heading-medium {
+  margin-top: 0;
+}

--- a/app/webpack/stylesheets/_cocoon.scss
+++ b/app/webpack/stylesheets/_cocoon.scss
@@ -1,0 +1,12 @@
+.remove_fields {
+  @include govuk-responsive-margin(4, "bottom");
+  @include govuk-media-query ($from: desktop) {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  display: block;
+  font-weight: 700;
+  z-index: 1;
+}

--- a/app/webpack/stylesheets/_forms.scss
+++ b/app/webpack/stylesheets/_forms.scss
@@ -1,6 +1,8 @@
 /*--- Form Settings ---*/
 
 fieldset {
+  position: relative;
+
   &.error {
     border-left-width: 3px;
 
@@ -11,6 +13,9 @@ fieldset {
   }
 
   legend {
+    @include govuk-media-query ($from: desktop) {
+      float: left;
+    }
     width: $full-width;
   }
 

--- a/app/webpack/stylesheets/_mod-fees.scss
+++ b/app/webpack/stylesheets/_mod-fees.scss
@@ -7,40 +7,13 @@
     position: relative;
   }
 
-  .header-action,
-  .date-action {
-    float: right;
-    @include core-19;
-    font-weight: 700;
-  }
-
-  .date-action {
-    position: absolute;
-    right: 40%;
-  }
-}
-
-.expense-group {
-  @extend .mod-fees;
-
-  /*--- Ported from v1 stylesheets ---*/
-  fieldset {
-    legend {
-      .fx-remove-link {
-        float: right;
-        font-weight: normal;
-      }
-    }
-  }
-}
-
-
-/*--- Ported from v1 stylesheets ---*/
-
-.defendants {
   .header-action {
     float: right;
     @include core-19;
     font-weight: 700;
   }
+}
+
+.expense-group {
+  @extend .mod-fees;
 }

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -200,6 +200,7 @@ form {
 
   .nested-fields {
     margin-bottom: $gutter-two-thirds;
+    position: relative;
   }
 
 
@@ -760,11 +761,6 @@ table#download-files-report {
     #js-vat {
       display: none;
     }
-  }
-
-  .remove_fields {
-    display: block;
-    margin-top: $gutter-one-third;
   }
 }
 

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -46,7 +46,7 @@ $path: '~images/';
 
 @import '~susy/sass/susy';
 @import '~govuk_frontend_toolkit/stylesheets/url-helpers'; // Function to output image-url, or prefixed path (Rails and Compass only)
-
+@import '~govuk-frontend/govuk/base';
 
 
 /*
@@ -85,6 +85,7 @@ $path: '~images/';
 @import 'warnings';
 @import 'print';
 
+@import 'cocoon';
 @import 'components/tag';
 
 

--- a/app/webpack/stylesheets/components/_tag.scss
+++ b/app/webpack/stylesheets/components/_tag.scss
@@ -1,5 +1,3 @@
-@import '~govuk-frontend/govuk/components/tag/tag';
-
 .app-tag--authorised,
 .app-tag--accepted {
   color: govuk-shade(govuk-colour("green"), 20) !important;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,6 +364,7 @@ en:
     upload: Import claims
     download: Download
     remove: Remove
+    remove_html: Remove <span class="govuk-visually-hidden">%{context} <span class="fx-numberedList-number"></span></span>
     edit: Edit
     delete: Delete
     view: View

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -54,7 +54,7 @@ When(/^I add another defendant, (.*?)representation order and MAAT reference$/) 
 end
 
 Then(/^I should see (\d+)\s*representation orders$/) do |count|
-  expect(@claim_form_page).to have_content("Representation order details", count: count)
+  expect(@claim_form_page).to have_selector("fieldset legend", text: "Representation order details", count: count)
 end
 
 When(/^I upload (\d+) documents?$/) do |count|


### PR DESCRIPTION
#### What
Remove the 'Remove' link from the `<legend>` so the hypertext does not interfere with the grouping of the inputs

#### Ticket
[Link within Legend](https://dsdmoj.atlassian.net/browse/CBO-1503)

#### Why
When navigating through the forms out of context, form elements that contain the word 'Remove' is confusing as users are entering information.


