### PR TITLE
Remove  non applicable litigator fields from summary screen

### DIFF
--- a/app/views/external_users/claims/_summary_fee.html.haml
+++ b/app/views/external_users/claims/_summary_fee.html.haml
@@ -9,33 +9,34 @@
         %span
           = fee.case_numbers
 
-  %td
-    - if fee.date?
-      = fee.date
+  - unless @claim.lgfs? && fee.is_misc?
+    %td
+      - if fee.date?
+        = fee.date
 
-      - if fee.is_graduated? && fee.claim.actual_trial_length
-        = t('external_users.claims.graduated_fees.summary.actual_trial_length', count: fee.claim.actual_trial_length)
+        - if fee.is_graduated? && fee.claim.actual_trial_length
+          = t('external_users.claims.graduated_fees.summary.actual_trial_length', count: fee.claim.actual_trial_length)
 
-      - if fee.is_transfer? && fee.claim.actual_trial_length
-        = t('external_users.claims.transfer_fee.summary.actual_trial_length_value', count: fee.claim.actual_trial_length)
+        - if fee.is_transfer? && fee.claim.actual_trial_length
+          = t('external_users.claims.transfer_fee.summary.actual_trial_length_value', count: fee.claim.actual_trial_length)
 
-      - if fee.fee_type.unique_code.eql?('BABAF')
-        - if fee.first_day_of_trial
-          = fee.first_day_of_trial
+        - if fee.fee_type.unique_code.eql?('BABAF')
+          - if fee.first_day_of_trial
+            = fee.first_day_of_trial
 
-        - if fee.retrial_started_at
-          = fee.retrial_started_at
+          - if fee.retrial_started_at
+            = fee.retrial_started_at
 
-      - if fee.dates_attended.any?
-        = fee.dates_attended_delimited_string
+        - if fee.dates_attended.any?
+          = fee.dates_attended_delimited_string
 
-  %td.numeric
-    - if fee.calculated? || fee.is_graduated? || fee.is_transfer?
-      = fee.quantity
+    %td.numeric
+      - if fee.calculated? || fee.is_graduated? || fee.is_transfer?
+        = fee.quantity
 
-  %td.numeric
-    - if fee.calculated?
-      = fee.rate
+    %td.numeric
+      - if fee.calculated?
+        = fee.rate
 
   %td.numeric
     - if fee.display_amount?

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -48,12 +48,13 @@
         %tr
           %th{ scope: 'col' }
             = t('shared.summary.fee_type')
-          %th{ scope: 'col' }
-            = t('shared.summary.dates')
-          %th.numeric{ scope: 'col' }
-            = t('shared.summary.quantity')
-          %th.numeric{ scope: 'col' }
-            = t('shared.summary.rate')
+          - unless claim.lgfs?
+            %th{ scope: 'col' }
+              = t('shared.summary.dates')
+            %th.numeric{ scope: 'col' }
+              = t('shared.summary.quantity')
+            %th.numeric{ scope: 'col' }
+              = t('shared.summary.rate')
           %th.numeric{ scope: 'col' }
             = t('shared.summary.amount')
           %th.numeric{ scope: 'col' }
@@ -69,12 +70,13 @@
         %tr
           %th{ scope: 'row' }
             = t('shared.summary.total')
-          %td.numeric
-            = ''
-          %td.numeric
-            = ''
-          %td.numeric
-            = ''
+          - unless claim.lgfs?
+            %td.numeric
+              = ''
+            %td.numeric
+              = ''
+            %td.numeric
+              = ''
           %td.numeric
             = claim.send("#{section}_total")
           %td.numeric

--- a/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
@@ -65,6 +65,32 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     And I click Submit to LAA
     Then I should be on the check your claim page
 
+    And the following check your claim fee details should exist:
+      | section | row | prompt | value |
+      | basic-fees-section | 1 | Type of fee | Basic fee |
+      | basic-fees-section | 1 | Quantity | 1 |
+      | basic-fees-section | 1 | Rate | £694.00 |
+      | basic-fees-section | 1 | Net amount | £694.00 |
+      | basic-fees-section | 1 | VAT amount | £138.80 |
+      | basic-fees-section | 1 | Total amount | £832.80 |
+      | basic-fees-section | 2 | Type of fee | Daily attendance fee (3 to 40) |
+      | basic-fees-section | 2 | Quantity | 4 |
+      | basic-fees-section | 2 | Rate | £326.00|
+      | basic-fees-section | 2 | Net amount | £1,304.00 |
+      | basic-fees-section | 2 | VAT amount | £260.80 |
+      | basic-fees-section | 2 | Total amount | £1,564.80 |
+
+    And the following check your claim fee details should exist:
+      | section | row | prompt | value |
+      | miscellaneous-fees-section | 1 | Type of fee | Special preparation fee |
+      | miscellaneous-fees-section | 1 | Quantity | 1 |
+      | miscellaneous-fees-section | 1 | Rate | 39.00 |
+      | miscellaneous-fees-section | 1 | Net amount | 39.00 |
+      | miscellaneous-fees-section | 2 | Type of fee | Noting brief fee |
+      | miscellaneous-fees-section | 2 | Quantity | 1 |
+      | miscellaneous-fees-section | 2 | Rate | 108.00 |
+      | miscellaneous-fees-section | 2 | Net amount | 108.00 |
+
     When I click "Continue"
     Then I should be on the certification page
 

--- a/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
@@ -86,10 +86,32 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I should see 'Absconding from lawful custody'
     And I should see 'Junior'
 
-    And I should see 'Basic fee'
-    And I should see 'Number of cases uplift'
-    And I should see 'Special preparation fee'
-    And I should see 'Noting brief fee'
+    And the following check your claim fee details should exist:
+      | section | row | prompt | value |
+      | basic-fees-section | 1 | Type of fee | Basic fee |
+      | basic-fees-section | 1 | Quantity | 1 |
+      | basic-fees-section | 1 | Rate | £550.00 |
+      | basic-fees-section | 1 | Net amount | £550.00 |
+      | basic-fees-section | 1 | VAT amount | £110.00 |
+      | basic-fees-section | 1 | Total amount | £660.00 |
+      | basic-fees-section | 2 | Type of fee | Number of cases uplift T20170001 |
+      | basic-fees-section | 2 | Quantity | 1 |
+      | basic-fees-section | 2 | Rate | £110.00|
+      | basic-fees-section | 2 | Net amount | £110.00 |
+      | basic-fees-section | 2 | VAT amount | £22.00 |
+      | basic-fees-section | 2 | Total amount | £132.00 |
+
+    And the following check your claim fee details should exist:
+      | section | row | prompt | value |
+      | miscellaneous-fees-section | 1 | Type of fee | Special preparation fee |
+      | miscellaneous-fees-section | 1 | Quantity | 1 |
+      | miscellaneous-fees-section | 1 | Rate | 39.00 |
+      | miscellaneous-fees-section | 1 | Net amount | 39.00 |
+      | miscellaneous-fees-section | 2 | Type of fee | Noting brief fee |
+      | miscellaneous-fees-section | 2 | Quantity | 1 |
+      | miscellaneous-fees-section | 2 | Rate | 108.00 |
+      | miscellaneous-fees-section | 2 | Net amount | 108.00 |
+
     And I should see 'Hotel accommodation'
 
     And I should see 'judicial_appointment_order.pdf'

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -118,6 +118,19 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should not see 'Estimated trial length'
     And I should not see 'Trial concluded on'
 
+    And the following check your claim fee details should exist:
+      | section | row | prompt | value |
+      | miscellaneous-fees-section | 1 | Type of fee | Costs judge application |
+      | miscellaneous-fees-section | 1 | Net amount | 135.78 |
+      | miscellaneous-fees-section | 1 | VAT amount | 135.78 |
+      | miscellaneous-fees-section | 1 | Total amount | 135.78 |
+
+    And the following check your claim fee details should not exist:
+      | section | row | prompt |
+      | miscellaneous-fees-section | 1 | Quantity |
+      | miscellaneous-fees-section | 1 | Rate |
+      | miscellaneous-fees-section | 1 | Dates |
+
     When I click "Continue"
     Then I should be on the certification page
     And I should see a page title "Certify and submit the litigator final fees claim"

--- a/features/step_definitions/claim_summary_steps.rb
+++ b/features/step_definitions/claim_summary_steps.rb
@@ -8,12 +8,16 @@ Then(/^the following check your claim details should exist:$/) do |table|
   end
 end
 
-Then(/^the following check your claim fee details should exist:$/) do |table|
+Then(/^the following check your claim fee details should (not )?exist:$/) do |negate, table|
   expect(@claim_summary_page).to be_displayed
   table.hashes.each do |row|
     within @claim_summary_page.find("##{row['section']}") do
-      expect(page).to have_content(row['prompt'])
-      expect(page).to have_content(row['value'])
+      if negate
+        expect(page).to_not have_content(row['prompt'])
+      else
+        expect(page).to have_content(row['prompt'])
+        expect(page).to have_content(row['value'])
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
Remove dates, quantity and rates from summary/check your claim page for litigator claim misc fees.

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1475.

#### Why
These fields are not used.

#### How
Disabled the display of these fields in the relevant view(s).
