### PR TITLE
Non descriptive heading

### DIFF
--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -1,7 +1,8 @@
-%h2.heading-large
+%h2.govuk-heading-l
   = local_assigns.has_key?(:header) ? header : t('common.fees')
-  - if local_assigns[:editable]
-    = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+- if local_assigns[:editable]
+  = govuk_link_to t('common.change_html', context: t('common.fees')), edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change'
 
 -# TODO: Avoid use of these checks and just display info
 -# based on configuration

--- a/app/views/external_users/claims/additional_information/_summary.html.haml
+++ b/app/views/external_users/claims/additional_information/_summary.html.haml
@@ -1,8 +1,9 @@
-.form-section
-  %h3.heading-medium
+.app-summary-section
+  %h3.govuk-heading-m
     = t('external_users.claims.additional_information.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :supporting_evidence, anchor: 'additional_info', referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.additional_information.summary.header')), edit_polymorphic_path(claim, step: :supporting_evidence, anchor: 'additional_info', referrer: :summary), class: 'link-change'
 
   - if claim.additional_information.present?
     = simple_format(claim.additional_information)

--- a/app/views/external_users/claims/basic_fees/_summary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_summary.html.haml
@@ -1,4 +1,4 @@
 - unless claim.fixed_fee_case?
   - locale_claim_type_context = claim.hardship? ? 'hardship_claims' : 'claims'
-  #basic-fees-section.form-section
+  #basic-fees-section.app-summary-section
     = render partial: 'external_users/claims/summary_fees', locals: { claim: claim, header: t("external_users.#{locale_claim_type_context}.basic_fees.summary.header"), collection: claim.basic_fees.reject(&:blank?), editable: editable, section: section, step: :basic_fees }

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -3,11 +3,12 @@
 - trial_detail_fields = %i[external_users claims case_details trial_detail_fields]
 - retrial_detail_fields = %i[external_users claims case_details retrial_detail_fields]
 
-#case-details-section.form-section
-  %h2.heading-large
+#case-details-section.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.case_details.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :case_details, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.case_details.summary.header')), edit_polymorphic_path(claim, step: :case_details, referrer: :summary), class: 'link-change'
 
   - if claim.mandatory_case_details?
     = govuk_summary_list do

--- a/app/views/external_users/claims/defendants/_summary.html.haml
+++ b/app/views/external_users/claims/defendants/_summary.html.haml
@@ -1,8 +1,9 @@
-#defendants-section.form-section
-  %h2.heading-large
+#defendants-section.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.defendants.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :defendants, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.defendants.summary.header')), edit_polymorphic_path(claim, step: :defendants, referrer: :summary), class: 'link-change'
 
   - defendant_fields_scope = 'external_users.claims.defendants.defendant_fields'
   - rep_order_fields_scope = 'external_users.claims.defendants.representation_order_fields'

--- a/app/views/external_users/claims/disbursements/_summary.html.haml
+++ b/app/views/external_users/claims/disbursements/_summary.html.haml
@@ -1,9 +1,10 @@
 - step = local_assigns[:step] ? local_assigns[:step] : :disbursements
-.form-section
-  %h2.heading-large
+.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.disbursements.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.disbursements.summary.header')), edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change'
 
   - if claim.disbursements.empty?
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]

--- a/app/views/external_users/claims/expenses/_summary.html.haml
+++ b/app/views/external_users/claims/expenses/_summary.html.haml
@@ -1,8 +1,9 @@
-#expenses-section.form-section
-  %h2.heading-large
+#expenses-section.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.expenses.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :travel_expenses, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.expenses.summary.header')), edit_polymorphic_path(claim, step: :travel_expenses, referrer: :summary), class: 'link-change'
 
   - if claim.expenses.empty?
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]

--- a/app/views/external_users/claims/fixed_fees/_summary.html.haml
+++ b/app/views/external_users/claims/fixed_fees/_summary.html.haml
@@ -1,3 +1,3 @@
 - if claim.fixed_fee_case?
-  .form-section
+  .app-summary-section
     = render partial: 'external_users/claims/summary_fees', locals: { claim: claim, header: t('external_users.claims.fixed_fees.summary.header'), collection: claim.fixed_fees, editable: editable, section: section, step: :fixed_fees }

--- a/app/views/external_users/claims/graduated_fees/_summary.html.haml
+++ b/app/views/external_users/claims/graduated_fees/_summary.html.haml
@@ -1,3 +1,3 @@
 - unless claim.fixed_fee_case?
-  .form-section
+  .app-summary-section
     = render partial: 'external_users/claims/summary_fees', locals: { claim: claim, header: t('external_users.claims.graduated_fees.summary.header'), fee: claim.graduated_fee, editable: editable, section: section, step: :graduated_fees }

--- a/app/views/external_users/claims/hardship_fee/_summary.html.haml
+++ b/app/views/external_users/claims/hardship_fee/_summary.html.haml
@@ -1,8 +1,9 @@
-.form-section
-  %h2.heading-large
+.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.hardship_fee.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :hardship_fees, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.hardship_fee.summary.header')), edit_polymorphic_path(claim, step: :hardship_fees, referrer: :summary), class: 'link-change'
 
   - if claim.hardship_fee.nil?
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]

--- a/app/views/external_users/claims/interim_fee/_summary.html.haml
+++ b/app/views/external_users/claims/interim_fee/_summary.html.haml
@@ -1,8 +1,9 @@
-.form-section
-  %h2.heading-large
+.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.interim_fee.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :interim_fees, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.interim_fee.summary.header')), edit_polymorphic_path(claim, step: :interim_fees, referrer: :summary), class: 'link-change'
 
   - if claim.interim_fee.nil? || claim.interim_fee.is_disbursement?
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]

--- a/app/views/external_users/claims/misc_fees/_summary.html.haml
+++ b/app/views/external_users/claims/misc_fees/_summary.html.haml
@@ -1,4 +1,4 @@
-#miscellaneous-fees-section.form-section
+#miscellaneous-fees-section.app-summary-section
   = render partial: 'summary_fees', locals: { claim: claim, header: t('external_users.claims.misc_fees.summary.header'), collection: claim.misc_fees, editable: editable, section: section, step: :miscellaneous_fees }
 
   - if claim.requires_interim_claim_info?

--- a/app/views/external_users/claims/offence_details/_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_summary.html.haml
@@ -1,9 +1,10 @@
 - unless claim.fixed_fee_case?
-  #offence-details-section.form-section
-    %h2.heading-large
+  #offence-details-section.app-summary-section
+    %h2.govuk-heading-l
       = t('external_users.claims.offence_details.summary.header')
-      - if local_assigns[:editable]
-        = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :offence_details, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+    - if local_assigns[:editable]
+      = govuk_link_to t('common.change_html', context: t('external_users.claims.offence_details.summary.header')), edit_polymorphic_path(claim, step: :offence_details, referrer: :summary), class: 'link-change'
 
     - if claim.offence
       = govuk_summary_list do

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -22,17 +22,18 @@
             %li
               = t("external_users.claims.#{section}.summary.header")
 
-  %h2.heading-large
-    = t('.page_heading')
-
   .grid-row
     .column-full
-      = render partial: 'external_users/claims/final_claim_cost_summary', locals: { claim: claim }
+      .app-cost-summary-section
+        %h2.govuk-heading-l
+          = t('.page_heading')
 
-      .form-buttons
-        = link_to t('buttons.continue'), new_external_users_claim_certification_path(claim), { class: 'button btn-spacer-20', role: 'button', 'aria-label': t('.button_label') }
-        = link_to t('buttons.save_a_draft'), external_users_root_path, class: 'button-gray-3 btn-spacer-20', role: 'button'
-        = link_to t('buttons.delete_draft'), external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button-warning', role: 'button'
+        = render partial: 'external_users/claims/final_claim_cost_summary', locals: { claim: claim }
+
+        .form-buttons
+          = link_to t('buttons.continue'), new_external_users_claim_certification_path(claim), { class: 'button btn-spacer-20', role: 'button', 'aria-label': t('.button_label') }
+          = link_to t('buttons.save_a_draft'), external_users_root_path, class: 'button-gray-3 btn-spacer-20', role: 'button'
+          = link_to t('buttons.delete_draft'), external_users_claim_path(claim), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button-warning', role: 'button'
 
   .grid-row
     .column-full

--- a/app/views/external_users/claims/supporting_evidence/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_evidence/_summary.html.haml
@@ -1,8 +1,9 @@
-#supporting-evidence-section.form-section
-  %h2.heading-large
+#supporting-evidence-section.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.supporting_evidence_checklist.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :supporting_evidence, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.supporting_evidence_checklist.summary.header')), edit_polymorphic_path(claim, step: :supporting_evidence, referrer: :summary), class: 'link-change'
 
   - if claim.mandatory_supporting_evidence?
     = govuk_summary_list do

--- a/app/views/external_users/claims/transfer_detail/_summary.html.haml
+++ b/app/views/external_users/claims/transfer_detail/_summary.html.haml
@@ -1,10 +1,11 @@
 - transfer_detail_translations = 'external_users.claims.transfer_fee.summary'
 
-.form-section
-  %h2.heading-medium
+.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.transfer_detail.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :transfer_fee_details, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.transfer_detail.summary.header')), edit_polymorphic_path(claim, step: :transfer_fee_details, referrer: :summary), class: 'link-change'
 
   - if local_assigns.has_key?(:editable) && !local_assigns[:editable]
     = render partial: 'external_users/claims/summary/section_status', locals: { claim: claim, section: section, step: :transfer_fee_details }

--- a/app/views/external_users/claims/transfer_fee/_summary.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_summary.html.haml
@@ -1,8 +1,9 @@
-#transfer-fees-section.form-section
-  %h2.heading-large
+#transfer-fees-section.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.transfer_fee.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('external_users.claims.additional_information.summary.change'), edit_polymorphic_path(claim, step: :transfer_fees, referrer: :summary), class: 'link-change', 'aria-label': t('external_users.claims.transfer_detail.summary.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.transfer_fee.summary.header')), edit_polymorphic_path(claim, step: :transfer_fees, referrer: :summary), class: 'link-change'
 
   - if claim.transfer_fee.nil?
     %p

--- a/app/views/external_users/claims/warrant_fee/_summary.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_summary.html.haml
@@ -1,8 +1,9 @@
-.form-section
-  %h2.heading-large
+.app-summary-section
+  %h2.govuk-heading-l
     = t('external_users.claims.warrant_fee.summary.header')
-    - if local_assigns[:editable]
-      = govuk_link_to t('.change'), edit_polymorphic_path(claim, step: :interim_fees, referrer: :summary), class: 'link-change', 'aria-label': t('.change_link_label')
+
+  - if local_assigns[:editable]
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.warrant_fee.summary.header')), edit_polymorphic_path(claim, step: :interim_fees, referrer: :summary), class: 'link-change'
 
   - if claim.warrant_fee.nil?
     %p

--- a/app/webpack/stylesheets/_layout.scss
+++ b/app/webpack/stylesheets/_layout.scss
@@ -108,6 +108,7 @@ td {
 }
 
 // Replacement for the deprecated `.form-section`
+.app-cost-summary-section,
 .app-summary-section {
   @include govuk-responsive-margin(9, "bottom");
   position: relative;

--- a/app/webpack/stylesheets/_layout.scss
+++ b/app/webpack/stylesheets/_layout.scss
@@ -106,3 +106,9 @@ td {
     }
   }
 }
+
+// Replacement for the deprecated `.form-section`
+.app-summary-section {
+  @include govuk-responsive-margin(9, "bottom");
+  position: relative;
+}

--- a/app/webpack/stylesheets/_links.scss
+++ b/app/webpack/stylesheets/_links.scss
@@ -13,7 +13,18 @@ a.fix {
   }
 }
 
-a.link-change,
+.link-change {
+  @include govuk-responsive-margin(4, "bottom");
+  @include govuk-media-query ($from: desktop) {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  display: block;
+  font-weight: 700;
+}
+
 a.link-remove {
   @include core-19;
   float: right;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -349,6 +349,7 @@ en:
       claim_creator: Claim creator
       providers_ref: Reference number
       providers_ref_hint: Your internal reference number for this claim
+    change_html: Change <span class="govuk-visually-hidden">%{context}</span>
     court: Court
     crown_court: Crown court
     transfer_court: Transfer court

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -175,7 +175,7 @@ Then(/^I should see "([^"]*)"$/) do |arg1|
 end
 
 And(/^I should see the field '(.*?)' with value '(.*?)' in '(.*?)'$/) do |field, value, section|
-  within(page.find(:css, 'div.form-section', text: section)) do
+  within(page.find(:css, 'div.app-summary-section', text: section)) do
     expect(page).to have_content(value)
   end
 end


### PR DESCRIPTION
#### What
Make headings descriptive by moving nested hyperlinks outside of the heading tags.

Secondary
- updated the heading classes
- replaced redundant class name `.form-section` with `.app-summary-section` in summary view and related partials

#### Ticket
[Non-descriptive headings](https://dsdmoj.atlassian.net/browse/CBO-1511)

#### Why
The “Change” links have been included as part of the heading structure. This is confusing for screen reader users as the heading is ambiguous with the hypertext included.
