### PR TITLE
Bump codeclimates rubocop from 0-83 to 0-92

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ plugins:
             - "(call _ expose ___)" # exlude expose methods
   rubocop:
     enabled: true
-    channel: rubocop-0-83
+    channel: rubocop-0-92
     config:
       file: .rubocop.yml
   brakeman:

--- a/app/models/claims/allocation_filters.rb
+++ b/app/models/claims/allocation_filters.rb
@@ -69,7 +69,7 @@ module Claims::AllocationFilters
       where(type: 'Claim::InterimClaim')
         .joins(:fees)
         .where('"fees"."fee_type_id" = ?',
-               Fee::InterimFeeType.where(description: fee_type_description).pluck(:id).first)
+               Fee::InterimFeeType.where(description: fee_type_description).pick(:id))
     end
   end
 end


### PR DESCRIPTION
This should have been part of the rubocop gem bump to
version 0.93.1.

#### What
Bump codeclimates rubocop from 0-83 to 0-92

The latest available version for codeclimate at time of
writing is 0-92

see https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop
for latest.

#### Why
Inline with test suites version or as close to
it as possible