### PR TITLE
Replace content_tag with tag

### DIFF
--- a/app/form_builders/adp_form_builder.rb
+++ b/app/form_builders/adp_form_builder.rb
@@ -28,7 +28,7 @@ class AdpFormBuilder < ActionView::Helpers::FormBuilder
   private
 
   def anchor_and_label_markup(anchor_name, label, options = {})
-    anchor_html = content_tag(:a, nil, { id: anchor_name }.merge(options[:anchor_attributes] || {}))
+    anchor_html = tag.a(nil, { id: anchor_name }.merge(options[:anchor_attributes] || {}))
     label_html = nil
 
     if label

--- a/app/form_builders/adp_text_field.rb
+++ b/app/form_builders/adp_text_field.rb
@@ -28,7 +28,7 @@ class AdpTextField
     extract_options
   end
 
-  # the methods output_buffer= and output_buffer are required by the content_tag
+  # the methods output_buffer= and output_buffer are required by the tag
   # methods, called from the validation_error_message in ExternalUsers::ClaimsHelper
   #
   def output_buffer=(value)

--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -29,7 +29,7 @@ module ExternalUsers::ClaimsHelper
 
   def validation_message_from_presenter(presenter, attribute)
     if presenter.errors_for?(attribute.to_sym)
-      content_tag :span, class: 'error error-message' do
+      tag.span(class: 'error error-message') do
         presenter.field_level_error_for(attribute.to_sym)
       end
     else
@@ -39,7 +39,7 @@ module ExternalUsers::ClaimsHelper
 
   def validation_message_from_errors_hash(resource, attribute)
     if resource[attribute]
-      content_tag :span, class: 'error error-message' do
+      tag.span(class: 'error error-message') do
         resource[attribute].join(', ')
       end
     else

--- a/app/presenters/fee/base_fee_presenter.rb
+++ b/app/presenters/fee/base_fee_presenter.rb
@@ -95,7 +95,7 @@ class Fee::BaseFeePresenter < BasePresenter
   end
 
   def hint_tag(text)
-    h.content_tag :div, text, class: 'form-hint'
+    h.tag.div(text, class: 'form-hint')
   end
 
   def not_applicable
@@ -103,7 +103,7 @@ class Fee::BaseFeePresenter < BasePresenter
   end
 
   def not_applicable_tag(text)
-    h.content_tag :span, text, aria: { label: 'not applicable' }
+    h.tag.span(text, aria: { label: 'not applicable' })
   end
 
   def not_applicable_html

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -6,7 +6,7 @@ class MessagePresenter < BasePresenter
   end
 
   def body
-    h.content_tag :div do
+    h.tag.div do
       h.concat(simple_format(message.body))
       attachment_field if message.attachment.present?
     end
@@ -19,8 +19,8 @@ class MessagePresenter < BasePresenter
 
   def download_file_link
     h.concat(
-      h.content_tag(
-        :a, "#{attachment_file_name} (#{attachment_file_size})",
+      h.tag.a(
+        "#{attachment_file_name} (#{attachment_file_size})",
         href: "/messages/#{message.id}/download_attachment",
         title: 'Download ' + attachment_file_name
       )

--- a/app/views/layouts/_user.html.haml
+++ b/app/views/layouts/_user.html.haml
@@ -1,5 +1,5 @@
 %ul#proposition-links
   %li
-    = govuk_link_to content_tag(:span, 'Your account ', class: 'visuallyhidden') + current_user.name, signed_in_user_profile_path, class: cp(signed_in_user_profile_path)
+    = govuk_link_to tag.span('Your account', class: 'visuallyhidden') + current_user.name, signed_in_user_profile_path, class: cp(signed_in_user_profile_path)
   %li
     = govuk_link_to 'Sign out', destroy_user_session_path, method: :delete


### PR DESCRIPTION
#### What
Replace content_tag with tag

#### Why
content_tag is legacy syntax

see https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag
for details.