### PR TITLE
Remove redundant foreign_key default on belongs_to relations

### DIFF
--- a/app/models/case_worker_claim.rb
+++ b/app/models/case_worker_claim.rb
@@ -11,7 +11,7 @@
 
 class CaseWorkerClaim < ApplicationRecord
   belongs_to :case_worker
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   after_create :generate_message_statuses
   after_create :set_claim_allocated!

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -14,7 +14,7 @@
 class Certification < ApplicationRecord
   auto_strip_attributes :certified_by, squish: true, nullify: true
 
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
   belongs_to :certification_type
 
   validates_with CertificationValidator

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -32,10 +32,10 @@ module Claim
     numeric_attributes :fees_total, :expenses_total, :disbursements_total, :total, :vat_amount
 
     belongs_to :court
-    belongs_to :transfer_court, foreign_key: 'transfer_court_id', class_name: 'Court'
+    belongs_to :transfer_court, class_name: 'Court'
     belongs_to :offence
     belongs_to :external_user
-    belongs_to :creator, foreign_key: 'creator_id', class_name: 'ExternalUser'
+    belongs_to :creator, class_name: 'ExternalUser'
     belongs_to :case_type
     belongs_to :case_stage
 

--- a/app/models/claim/transfer_detail.rb
+++ b/app/models/claim/transfer_detail.rb
@@ -15,7 +15,7 @@ module Claim
   class TransferDetail < ApplicationRecord
     include TransferBrainDelegatable
 
-    belongs_to :claim, class_name: 'Claim::TransferClaim', foreign_key: :claim_id, inverse_of: :transfer_detail
+    belongs_to :claim, class_name: 'Claim::TransferClaim', inverse_of: :transfer_detail
     acts_as_gov_uk_date :transfer_date, error_clash_behaviour: :override_with_gov_uk_date_field_error
     transfer_brain_delegate :allocation_type, :bill_scenario, :transfer_stage, :ppe_required, :days_claimable
 

--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -16,9 +16,9 @@
 #
 
 class ClaimStateTransition < ApplicationRecord
-  belongs_to :claim, class_name: '::Claim::BaseClaim', foreign_key: :claim_id
-  belongs_to :author, class_name: 'User', foreign_key: :author_id
-  belongs_to :subject, class_name: 'User', foreign_key: :subject_id
+  belongs_to :claim, class_name: '::Claim::BaseClaim'
+  belongs_to :author, class_name: 'User'
+  belongs_to :subject, class_name: 'User'
 
   serialize :reason_code, Array
   alias_attribute :reason_codes, :reason_code

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -17,7 +17,7 @@ class Defendant < ApplicationRecord
   include Duplicable
   auto_strip_attributes :first_name, :last_name, squish: true, nullify: true
 
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
   has_many :representation_orders, dependent: :destroy, inverse_of: :defendant
 
   validates_with DefendantValidator

--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -18,7 +18,7 @@ class Determination < ApplicationRecord
   include NumberCommaParser
   numeric_attributes :fees, :expenses, :disbursements
 
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: 'claim_id'
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   before_save :calculate_total, :calculate_vat
 

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -18,7 +18,7 @@ class Disbursement < ApplicationRecord
   include Duplicable
 
   belongs_to :disbursement_type
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   numeric_attributes :net_amount, :vat_amount, :total
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -28,8 +28,8 @@ class Document < ApplicationRecord
   include Duplicable
 
   belongs_to :external_user
-  belongs_to :creator, foreign_key: 'creator_id', class_name: 'ExternalUser'
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :creator, class_name: 'ExternalUser'
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   validates_attachment :document,
                        presence: { message: 'Document must have an attachment' },

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -43,7 +43,7 @@ class Expense < ApplicationRecord
   numeric_attributes :rate, :amount, :vat_amount, :quantity, :distance, :hours
 
   belongs_to :expense_type
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   has_many :dates_attended, as: :attended_item, dependent: :destroy, inverse_of: :attended_item
 

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -35,7 +35,7 @@ module Fee
 
     auto_strip_attributes :case_numbers, squish: true, nullify: true
 
-    belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+    belongs_to :claim, class_name: 'Claim::BaseClaim'
     belongs_to :fee_type, class_name: 'Fee::BaseFeeType'
     belongs_to :sub_type, class_name: 'Fee::BaseFeeType'
 

--- a/app/models/fee/fixed_fee_type.rb
+++ b/app/models/fee/fixed_fee_type.rb
@@ -18,7 +18,7 @@
 
 class Fee::FixedFeeType < Fee::BaseFeeType
   has_many :children, class_name: 'Fee::FixedFeeType', foreign_key: :parent_id
-  belongs_to :parent, class_name: 'Fee::FixedFeeType', foreign_key: :parent_id
+  belongs_to :parent, class_name: 'Fee::FixedFeeType'
 
   default_scope -> { order(parent_id: :desc, description: :asc) }
 

--- a/app/models/injection_attempt.rb
+++ b/app/models/injection_attempt.rb
@@ -16,7 +16,7 @@ class InjectionAttempt < ApplicationRecord
   include JsonAttrParser
   scope :exclude_error, ->(error_ilike) { where.not('coalesce(error_messages::text,\'\') ILIKE ?', error_ilike) }
 
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   validates :claim, presence: true
 

--- a/app/models/interim_claim_info.rb
+++ b/app/models/interim_claim_info.rb
@@ -3,7 +3,7 @@ class InterimClaimInfo < ApplicationRecord
 
   self.table_name = 'interim_claim_info'
 
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   validates_with InterimClaimInfoValidator
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,8 +17,8 @@
 class Message < ApplicationRecord
   include S3Headers
 
-  belongs_to :claim, class_name: 'Claim::BaseClaim', foreign_key: :claim_id
-  belongs_to :sender, foreign_key: :sender_id, class_name: 'User', inverse_of: :messages_sent
+  belongs_to :claim, class_name: 'Claim::BaseClaim'
+  belongs_to :sender, class_name: 'User', inverse_of: :messages_sent
   has_many :user_message_statuses, dependent: :destroy
 
   attr_accessor :claim_action, :written_reasons_submitted

--- a/spec/models/claim_state_transition_spec.rb
+++ b/spec/models/claim_state_transition_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ClaimStateTransition, type: :model do
+  it { should belong_to(:claim).class_name('::Claim::BaseClaim') }
+  it { should belong_to(:author).class_name('User') }
+  it { should belong_to(:subject).class_name('User') }
+
   describe '.decided_this_month' do
     let(:state) { :rejected }
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -31,7 +31,7 @@ TEMPFILE_NAME = File.join(Rails.root, 'tmp', 'document_spec', 'test.txt')
 RSpec.describe Document, type: :model do
 
   it { should belong_to(:external_user) }
-  it { should belong_to(:creator).class_name('ExternalUser').with_foreign_key('creator_id') }
+  it { should belong_to(:creator).class_name('ExternalUser') }
   it { should belong_to(:claim) }
   it { should delegate_method(:provider_id).to(:external_user) }
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -18,7 +18,7 @@ require 'rails_helper'
 
 RSpec.describe Message, type: :model do
   it { should belong_to(:claim) }
-  it { should belong_to(:sender).class_name('User').with_foreign_key('sender_id').inverse_of(:messages_sent) }
+  it { should belong_to(:sender).class_name('User').inverse_of(:messages_sent) }
   it { should have_many(:user_message_statuses) }
 
   it { should validate_presence_of(:sender).with_message('Message sender cannot be blank') }

--- a/spec/support/shared_examples/models/shared_examples_for_base_claim.rb
+++ b/spec/support/shared_examples/models/shared_examples_for_base_claim.rb
@@ -1,10 +1,10 @@
 RSpec.shared_examples 'a base claim' do
   context '.belongs_to' do
     it { is_expected.to belong_to(:external_user) }
-    it { is_expected.to belong_to(:creator).class_name('ExternalUser').with_foreign_key('creator_id') }
+    it { is_expected.to belong_to(:creator).class_name('ExternalUser') }
 
     it { is_expected.to belong_to(:court) }
-    it { is_expected.to belong_to(:transfer_court).class_name('Court').with_foreign_key('transfer_court_id') }
+    it { is_expected.to belong_to(:transfer_court).class_name('Court') }
     it { is_expected.to belong_to(:offence) }
   end
 


### PR DESCRIPTION
#### What
Remove redundant foreign_key default on belongs_to relations

#### Ticket

tech debt

#### Why
Specifying the default value for foreign_key is redundant.
raised by codeclimate/rubocop:

 - Claim::BaseClaim
 - Court
 - ExternalUser
 - TransferDetail
 - ClaimStateTransition
 - Document
 - Determination
 - Fee::FixedFeeType
 - Message