### PR TITLE
Standardise formatting options across supported editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# see https://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_style = tab
+indent_size = 2
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
#### What
Apply some standard formattting across supported editors

VS Code is supported and sublimetext has a plugin

see https://editorconfig.org/ for list of
editors with built in support or others
that require a plugin.


#### Why
To apply consistent standards across diffeerent
editors used by developers.

These default settings are the recommended
by the sublimetext plugin and allow for indent
being specified by tab width. editors should
set their tab width to 2 spaces.

https://packagecontrol.io/packages/EditorConfig