### PR TITLE
Remove the Timecop gem

### DIFF
--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -35,15 +35,17 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
   end
 
   describe "POST #{endpoint(:representation_orders)}" do
-    def post_to_create_endpoint(submission_date = Date.new(2017, 7, 1))
-      Timecop.freeze(submission_date) { post endpoint(:representation_orders), valid_params, format: :json }
+    def post_to_create_endpoint
+      post endpoint(:representation_orders), valid_params, format: :json
     end
+
+    subject { post endpoint(:representation_orders), valid_params, format: :json }
 
     include_examples "should NOT be able to amend a non-draft claim"
 
     context 'when representation_order params are valid' do
       it "should create fee, return 201 and expense JSON output including UUID" do
-        post_to_create_endpoint
+        subject
         expect(last_response.status).to eq 201
         json = JSON.parse(last_response.body)
         expect(json['id']).not_to be_nil
@@ -114,7 +116,7 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
       describe 'and the rep_order_date pre-dates the start of the scheme' do
         let(:representation_order_date) { Date.new(2018, 3, 1) }
 
-        before { post_to_create_endpoint(Date.new(2018, 5, 1)) }
+        before { travel_to(Date.new(2018, 5, 1)) { post_to_create_endpoint } }
 
         specify { expect_error_response('Check the combination of the representation order date and offence') }
       end
@@ -122,7 +124,9 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
       describe 'and the rep_order_date post-dates the start of the scheme' do
         let(:representation_order_date) { Date.new(2018, 4, 1) }
 
-        specify { expect{ post_to_create_endpoint(Date.new(2018, 5, 1)) }.to change { RepresentationOrder.count }.by(1) }
+        before { travel_to(Date.new(2018, 5, 1)) }
+
+        specify { expect{ post_to_create_endpoint }.to change { RepresentationOrder.count }.by(1) }
       end
     end
   end

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -39,13 +39,11 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
       post endpoint(:representation_orders), valid_params, format: :json
     end
 
-    subject { post endpoint(:representation_orders), valid_params, format: :json }
-
     include_examples "should NOT be able to amend a non-draft claim"
 
     context 'when representation_order params are valid' do
       it "should create fee, return 201 and expense JSON output including UUID" do
-        subject
+        post_to_create_endpoint
         expect(last_response.status).to eq 201
         json = JSON.parse(last_response.body)
         expect(json['id']).not_to be_nil

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -829,7 +829,7 @@ end
 
 def build_sortable_claims_sample(advocate)
   [:draft, :submitted, :allocated, :authorised, :rejected].each_with_index do |state, i|
-    travel(-i.days) do
+    travel_to(i.days.ago) do
       n = i+1
       claim = create("#{state}_claim".to_sym, external_user: advocate, case_number: "A2016#{(n).to_s.rjust(4,'0')}")
       claim.fees.destroy_all

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -829,7 +829,7 @@ end
 
 def build_sortable_claims_sample(advocate)
   [:draft, :submitted, :allocated, :authorised, :rejected].each_with_index do |state, i|
-    Timecop.freeze(i.days.ago) do
+    travel(-i.days) do
       n = i+1
       claim = create("#{state}_claim".to_sym, external_user: advocate, case_number: "A2016#{(n).to_s.rjust(4,'0')}")
       claim.fees.destroy_all

--- a/spec/controllers/provider_management/external_users_controller_spec.rb
+++ b/spec/controllers/provider_management/external_users_controller_spec.rb
@@ -205,17 +205,19 @@ RSpec.describe ProviderManagement::ExternalUsersController, type: :controller do
   describe "PUT #update_password" do
     let(:password) { 'password123' }
     let(:password_confirm) { password }
-    subject { put :update_password, params: { provider_id: provider, id: external_user, external_user: { user_attributes: { password: password, password_confirmation: password_confirm } } } }
+    subject(:password_update_request) do
+      put :update_password, params: { provider_id: provider, id: external_user, external_user: { user_attributes: { password: password, password_confirmation: password_confirm } } }
+    end
 
-    before(:each) { travel(-6.months) { external_user } }
+    before(:each) { travel_t0(6.months.ago) { external_user } }
 
     context 'when valid' do
       it 'does not require current password to be successful in updating the user record ' do
-        expect { subject }.to change { external_user.reload.user.updated_at }
+        expect { password_update_request }.to change { external_user.reload.user.updated_at }
       end
 
       it 'redirects to external_user show action' do
-        subject
+        password_update_request
         expect(response).to redirect_to(provider_management_provider_external_user_path(provider, external_user))
       end
     end
@@ -224,11 +226,11 @@ RSpec.describe ProviderManagement::ExternalUsersController, type: :controller do
       let(:password_confirm) { 'passwordxxx' }
 
       it 'does not update the user record' do
-        expect { subject }.not_to change { external_user.reload.user.updated_at }
+        expect { password_update_request }.not_to change { external_user.reload.user.updated_at }
       end
 
       it 'renders the change password template' do
-        subject
+        password_update_request
         expect(response).to render_template(:change_password)
       end
     end

--- a/spec/lib/geckoboard_publisher/providers_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/providers_report_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe GeckoboardPublisher::ProvidersReport, geckoboard: true do
       create(:provider, created_at: Date.parse('21-MAR-2017 09:00'))
     end
 
-    before { Timecop.freeze Date.parse('22-MAR-2017') }
-    after { Timecop.return }
+    before { travel_to Date.parse('22-MAR-2017') }
+    after { travel_back }
 
     include_examples 'returns valid items structure'
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1399,7 +1399,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       context 'previous redetermination record created before state was changed to redetermination' do
         it 'should be true' do
           @claim.redeterminations << Redetermination.new(fees: 12.12, expenses: 35.55, disbursements: 0)
-          travel(2.hours) do
+          travel_to(2.hours.since) do
             @claim.authorise_part!
             @claim.redetermine!
             @claim.allocate!
@@ -1410,7 +1410,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
       context 'latest redetermination created after transition to redetermination' do
         it 'should be false' do
-          travel(10.minutes) do
+          travel_to(10.minutes.since) do
             @claim.redeterminations << Redetermination.new(fees: 12.12, expenses: 35.55, disbursements: 0)
           end
           expect(@claim.requested_redetermination?).to be false

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1296,7 +1296,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     describe 'submission_date' do
       it 'should set the submission date to the date it was set to state redetermination' do
         new_time = 36.hours.from_now
-        Timecop.freeze new_time do
+        travel_to new_time do
           claim.redetermine!
         end
         expect(claim.last_submitted_at).to be_within_seconds_of(new_time, 1)
@@ -1398,21 +1398,19 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
       context 'previous redetermination record created before state was changed to redetermination' do
         it 'should be true' do
-          Timecop.freeze(Time.now - 2.hours) do
-            @claim.redeterminations << Redetermination.new(fees: 12.12, expenses: 35.55, disbursements: 0)
-            Timecop.freeze(Time.now ) do
-              @claim.authorise_part!
-              @claim.redetermine!
-              @claim.allocate!
-            end
-            expect(@claim.requested_redetermination?).to be true
+          @claim.redeterminations << Redetermination.new(fees: 12.12, expenses: 35.55, disbursements: 0)
+          travel(2.hours) do
+            @claim.authorise_part!
+            @claim.redetermine!
+            @claim.allocate!
           end
+          expect(@claim.requested_redetermination?).to be true
         end
       end
 
       context 'latest redetermination created after transition to redetermination' do
         it 'should be false' do
-          Timecop.freeze(Time.now + 10.minutes) do
+          travel(10.minutes) do
             @claim.redeterminations << Redetermination.new(fees: 12.12, expenses: 35.55, disbursements: 0)
           end
           expect(@claim.requested_redetermination?).to be false

--- a/spec/models/claims/financial_summary_spec.rb
+++ b/spec/models/claims/financial_summary_spec.rb
@@ -10,22 +10,20 @@ RSpec.describe Claims::FinancialSummary, type: :model do
     let!(:allocated_claim)  { create(:allocated_claim,) }
 
     let!(:old_part_authorised_claim) do
-      Timecop.freeze(Time.now - 2.week) do
-        claim = create(:part_authorised_claim)
-        Timecop.freeze(Time.now + 1.week) do
-          claim.determinations.first.update(fees: claim.fees_total/2, expenses: claim.expenses_total)
-          claim
-        end
+      travel_to(Time.now - 2.week)
+      create(:part_authorised_claim).tap do |claim|
+        travel_to(Time.now + 1.week)
+        claim.determinations.first.update(fees: claim.fees_total/2, expenses: claim.expenses_total)
+        travel_back
       end
     end
 
     let!(:part_authorised_claim) do
-      Timecop.freeze(Time.now - 2.week) do
-        claim = create(:part_authorised_claim)
-        Timecop.freeze(Time.now + 2.week) do
-          claim.determinations.first.update(fees: claim.fees_total/2, expenses: claim.expenses_total)
-          claim
-        end
+      travel_to(Time.now - 2.week)
+      create(:part_authorised_claim).tap do |claim|
+        travel_to(Time.now + 2.week)
+        claim.determinations.first.update(fees: claim.fees_total/2, expenses: claim.expenses_total)
+        travel_back
       end
     end
 

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Claims::StateMachine, type: :model do
         claim.allocate!
         claim.refuse!
 
-        travel_to current_time + 6.months do
+        travel_to(6.months.from_now) do
           claim.await_written_reasons!
           expect(claim.last_submitted_at).to eq(current_time + 6.months)
         end

--- a/spec/models/claims/state_machine_spec.rb
+++ b/spec/models/claims/state_machine_spec.rb
@@ -265,15 +265,12 @@ RSpec.describe Claims::StateMachine, type: :model do
   end
 
   context 'set triggers' do
-    before { Timecop.freeze(Time.now) }
-    after  { Timecop.return }
-
     context 'make archive_pending_delete valid for 180 days' do
       subject(:claim) { create(:authorised_claim) }
-      let(:frozen_time) { Time.now }
+      let(:frozen_time) { Time.now.change(usec: 0) }
 
       before do
-        Timecop.freeze(frozen_time) { claim.archive_pending_delete! }
+        travel_to(frozen_time) { claim.archive_pending_delete! }
       end
 
       it {
@@ -282,6 +279,9 @@ RSpec.describe Claims::StateMachine, type: :model do
     end
 
     context 'make last_submitted_at attribute equal now' do
+      before { freeze_time }
+      after  { travel_back }
+
       it 'sets the last_submitted_at to the current time' do
         current_time = Time.now
         claim.submit!
@@ -297,24 +297,24 @@ RSpec.describe Claims::StateMachine, type: :model do
 
     context 'update last_submitted_at on redetermination or await_written_reasons' do
       it 'set the last_submitted_at to the current time for redetermination' do
-        current_time = Time.now
+        current_time = Time.now.change(usec: 0)
         claim.submit!
         claim.allocate!
         claim.refuse!
 
-        Timecop.freeze 6.months.from_now do
+        travel_to current_time + 6.months do
           claim.redetermine!
           expect(claim.last_submitted_at).to eq(current_time + 6.months)
         end
       end
 
       it 'set the last_submitted_at to the current time for awaiting_written_reasons' do
-        current_time = Time.now
+        current_time = Time.now.change(usec: 0)
         claim.submit!
         claim.allocate!
         claim.refuse!
 
-        Timecop.freeze 6.months.from_now do
+        travel_to current_time + 6.months do
           claim.await_written_reasons!
           expect(claim.last_submitted_at).to eq(current_time + 6.months)
         end
@@ -327,8 +327,8 @@ RSpec.describe Claims::StateMachine, type: :model do
       it {
         claim.assessment.update(fees: 100.00, expenses: 23.45)
 
-        frozen_time = Time.now + 1.month
-        Timecop.freeze(frozen_time) { claim.authorise! }
+        frozen_time = Time.now.change(usec: 0) + 1.month
+        travel_to(frozen_time) { claim.authorise! }
 
         expect(claim.authorised_at).to eq(frozen_time)
       }
@@ -340,8 +340,8 @@ RSpec.describe Claims::StateMachine, type: :model do
       it {
         claim.assessment.update(fees: 100.00, expenses: 23.45)
 
-        frozen_time = Time.now + 1.month
-        Timecop.freeze(frozen_time) { claim.authorise_part! }
+        frozen_time = Time.now.change(usec: 0) + 1.month
+        travel_to(frozen_time) { claim.authorise_part! }
 
         expect(claim.authorised_at).to eq(frozen_time)
       }

--- a/spec/models/redetermination_spec.rb
+++ b/spec/models/redetermination_spec.rb
@@ -74,14 +74,14 @@ RSpec.describe Redetermination do
 
       # Given a number of redeterminations written at various times
       [date_3, date_1, date_2].each do |date|
-        Timecop.freeze(date) do
+        travel_to(date) do
           create(:redetermination, claim: claim)
         end
       end
       # when I call claim.redeterminations
       rds = claim.redeterminations
 
-      # it should return them in created_at order - con vert to integer to remove precesion pproblems on travis
+      # it should return them in created_at order - convert to integer to remove precesion pproblems on travis
       expect(rds.map(&:created_at).map(&:to_i)).to eq( [ date_1.to_i, date_2.to_i, date_3.to_i ])
     end
   end

--- a/spec/models/stats/collector/claim_creation_source_collector_spec.rb
+++ b/spec/models/stats/collector/claim_creation_source_collector_spec.rb
@@ -5,12 +5,14 @@ module Stats
     describe ClaimCreationSourceCollector do
 
       before(:all) do
-        create_claim(:draft, report_day, source: 'web')
-        create_claim(:submitted, report_day, source: 'api_web_edited')
-        create_claim(:draft, report_day, source: 'api')
-        create_claim(:submitted, report_day, source: 'json_import')
-        create_claim(:submitted, report_day, source: 'json_import_web_edited')
-        create_claim(:draft, report_day, source: 'json_import')
+        travel_to report_day do
+          create(:draft_claim, source: 'web')
+          create(:submitted_claim, source: 'api_web_edited')
+          create(:draft_claim, source: 'api')
+          create(:submitted_claim, source: 'json_import')
+          create(:submitted_claim, source: 'json_import_web_edited')
+          create(:draft_claim, source: 'json_import')
+        end
       end
 
       after(:all) { clean_database }
@@ -49,17 +51,7 @@ module Stats
       end
 
       def report_day
-        Timecop.freeze(Time.new(2018, 3, 10, 11, 44, 55)) { 5.days.ago }
-      end
-
-      def create_claim(state, date, attributes = {})
-        travel_to(date) do
-          FactoryBot.create(factory_name(state), attributes)
-        end
-      end
-
-      def factory_name(state)
-        "#{state}_claim".to_sym
+        Time.new(2018, 3, 5, 11, 44, 55)
       end
     end
   end

--- a/spec/models/stats/collector/claim_redeterminations_collector_spec.rb
+++ b/spec/models/stats/collector/claim_redeterminations_collector_spec.rb
@@ -38,7 +38,7 @@ module Stats
 
 
       def create_claim(state, date)
-        Timecop.freeze(date) do
+        travel_to(date) do
           create factory_name(state)
         end
       end

--- a/spec/models/stats/collector/claim_submissions_collector_spec.rb
+++ b/spec/models/stats/collector/claim_submissions_collector_spec.rb
@@ -43,7 +43,7 @@ module Stats
 
 
       def create_claim(state, date)
-        Timecop.freeze(date) do
+        travel_to(date) do
           create factory_name(state)
         end
       end

--- a/spec/models/stats/gecko_widgets/line_graph_spec.rb
+++ b/spec/models/stats/gecko_widgets/line_graph_spec.rb
@@ -77,7 +77,7 @@ module Stats
       describe '#to_a' do
         context 'without specifying x-axis labels' do
           it 'should produce an array of arrays suitable for displaying in a tabular format' do
-            Timecop.freeze(Date.new(2016, 7, 13)) do
+            travel_to(Date.new(2016, 7, 13)) do
               array = [
                 ['Sun 10 Jul 2016', 33, 22, 5],
                 ['Mon 11 Jul 2016', 5, 24, 8],

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Stats::StatsReport do
     describe '.record_start' do
       it 'creates and incomplete record' do
         frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
-        Timecop.freeze(frozen_time) do
+        travel_to(frozen_time) do
           record = described_class.record_start('my_new_report')
           expect(record.report_name).to eq 'my_new_report'
           expect(record.started_at).to eq frozen_time
@@ -89,11 +89,11 @@ RSpec.describe Stats::StatsReport do
       it 'updates with report contents and completed_at time' do
         frozen_time = Time.new(2015, 3, 16, 13, 36, 12)
         record = nil
-        Timecop.freeze(frozen_time) do
+        travel_to(frozen_time) do
           record = described_class.record_start('my_new_report')
         end
 
-        Timecop.freeze(frozen_time + 2.minutes) do
+        travel_to(frozen_time + 2.minutes) do
           record.write_report(Stats::Result.new('The contents of my new report', 'csv'))
         end
 

--- a/spec/presenters/claim_history_presenter_spec.rb
+++ b/spec/presenters/claim_history_presenter_spec.rb
@@ -6,32 +6,32 @@ RSpec.describe ClaimHistoryPresenter do
 
   describe '#history_items_by_date' do
     let(:first_message) do
-      Timecop.travel(Time.zone.local(2015, 9, 21, 13, 0, 0)) do
+      travel_to(Time.zone.local(2015, 9, 21, 13, 0, 0)) do
         create(:message, claim: claim, body: 'Hello world')
       end
     end
 
     let(:second_message) do
-      Timecop.travel(Time.zone.local(2015, 9, 21, 14, 0, 0)) do
+      travel_to(Time.zone.local(2015, 9, 21, 14, 0, 0)) do
         create(:message, claim: claim, body: 'Lorem ipsum')
       end
     end
 
     let(:third_message) do
-      Timecop.travel(Time.zone.local(2015, 9, 23, 14, 0, 0)) do
+      travel_to(Time.zone.local(2015, 9, 23, 14, 0, 0)) do
         create(:message, claim: claim, body: 'Lorem ipsum')
       end
     end
 
     let(:first_redetermination) do
-      Timecop.travel(Time.zone.local(2015, 9, 25, 14, 0, 0)) do
+      travel_to(Time.zone.local(2015, 9, 25, 14, 0, 0)) do
         claim.redeterminations.create(fees: 500, expenses: 300, disbursements: 0)
         claim.redeterminations.last.versions.last
       end
     end
 
     let(:assessment) do
-      Timecop.travel(Time.zone.local(2015, 9, 24, 14, 0, 0)) do
+      travel_to(Time.zone.local(2015, 9, 24, 14, 0, 0)) do
         claim.assessment.fees = 100
         claim.assessment.expenses = 200
         claim.assessment.disbursements = 0
@@ -41,7 +41,7 @@ RSpec.describe ClaimHistoryPresenter do
     end
 
     let!(:expected_hash) do
-      Timecop.travel(Time.zone.local(2015, 9, 21, 13, 50, 9)) do
+      travel_to(Time.zone.local(2015, 9, 21, 13, 50, 9)) do
         claim.submit!
       end
 

--- a/spec/services/claim_reporter_spec.rb
+++ b/spec/services/claim_reporter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ClaimReporter do
 
   describe '#completion_rate' do
     before do
-      Timecop.freeze(5.weeks.ago) do
+      travel -5.weeks do
         create(:claim_intention, form_id: @submitted_claim_1.form_id)
         create(:claim_intention, form_id: @allocated_claim_1.form_id)
 

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
       ]
     }
     let!(:draft_claim) { create(:draft_claim) }
-    let!(:non_active_claim) { Timecop.freeze(frozen_time) { create(:allocated_claim) } }
+    let!(:non_active_claim) { travel_to(frozen_time) { create(:allocated_claim) } }
 
     it 'returns CSV content with a header and a row for all active non-draft claims' do
       expect(contents.size).to eq(valid_claims.size + 1)


### PR DESCRIPTION
#### What

Replace Timecop with time helpers.

#### Ticket

N/A

#### Why

The time helpers that are built into Rails provide the same functionality as the Timecop gem so the gem could be removed.

#### How

I have updated many references to Timecop in the tests to use the time helpers instead. In some cases I have also cleaned up the tests.

--------

#### TODO (wip)

 - [ ] Timecop is still used in three factories; `spec/factories/claim/advocate_claims.rb`, `spec/factories/claim/base_claims.rb' and`spec/factories/claim/deterministic_claim.rb`. I am still trying to work out the correct way to use time helpers inside FactoryBot.