### PR TITLE
Delegate each to stages array

### DIFF
--- a/app/models/stage_collection.rb
+++ b/app/models/stage_collection.rb
@@ -4,17 +4,11 @@ class StageCollection
 
   attr_reader :stages
 
-  def_delegators :@stages, :second, :last, :size
+  def_delegators :@stages, :each, :second, :last, :size
 
   def initialize(stages, object)
     @object = object
     @stages = initialize_stages(stages)
-  end
-
-  def each(&block)
-    stages.each do |stage|
-      yield(stage) if block
-    end
   end
 
   def previous_stage(stage)

--- a/spec/models/stage_collection_spec.rb
+++ b/spec/models/stage_collection_spec.rb
@@ -30,17 +30,17 @@ RSpec.describe StageCollection do
     describe '#map' do
       it { expect(collection.map(&:name)).to eql(%i[stage_1 stage_2]) }
     end
+
+    describe '#first' do
+      it 'returns the first defined stage' do
+        expect(collection.first).to eq(collection.stages.first)
+      end
+    end
   end
 
   describe '#size' do
     it 'returns the total amount of stages' do
       expect(collection.size).to eq(stages.size)
-    end
-  end
-
-  describe '#first' do
-    it 'returns the first defined stage' do
-      expect(collection.first).to eq(collection.stages.first)
     end
   end
 

--- a/spec/models/stage_collection_spec.rb
+++ b/spec/models/stage_collection_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe StageCollection do
     end
   end
 
+  context 'when enumerating' do
+    describe '#each' do
+      it { expect { |b| collection.each(&b) }.to yield_successive_args(kind_of(Stage), kind_of(Stage)) }
+    end
+
+    describe '#map' do
+      it { expect(collection.map(&:name)).to eql(%i[stage_1 stage_2]) }
+    end
+  end
+
   describe '#size' do
     it 'returns the total amount of stages' do
       expect(collection.size).to eq(stages.size)


### PR DESCRIPTION
#### What
Delegate each to stages array

#### Ticket

n/a

#### Why

This came out of a rubocop bump that
highlighted superfluos code in the
explict each method definition.

see this [PR comment](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/3625#discussion_r534985240)

For brevity and simplicity we can delegate
each instead of defining our own explictly.