### PR TITLE
Remove vat_registered? logging and use a fallback

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -502,16 +502,9 @@ module Claim
     end
 
     def vat_registered?
-      if provider_delegator.nil?
-        LogStuff.send(:error, 'vat_registration',
-                      action: 'vat_registration',
-                      provider_id: provider&.id,
-                      creator_id: creator&.id,
-                      claim_id: id) do
-          "calculating VAT for #{id}"
-        end
-      end
       provider_delegator.vat_registered?
+    rescue NoMethodError
+      true
     end
 
     def trial_length

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -765,30 +765,26 @@ RSpec.describe MockBaseClaim do
 
     before do
       allow(claim).to receive(:provider_delegator).and_return(mock_provider_delegator)
-      allow(LogStuff).to receive(:error)
     end
 
     context 'when the provider exists' do
-      let(:provider_delegator) { double(:provider_delegator, vat_registered?: true) }
+      context 'with vat_registered true' do
+        let(:provider_delegator) { double(:provider_delegator, vat_registered?: true) }
 
-      it 'does not log error' do
-        registered
-        expect(LogStuff).not_to have_received(:error)
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with vat_registered false' do
+        let(:provider_delegator) { double(:provider_delegator, vat_registered?: false) }
+
+        it { is_expected.to be_falsey }
       end
     end
 
     context 'when the provider is nil' do
-      # this should never happen but the logger is implemented to trace errors in live
       let(:provider_delegator) { nil }
 
-      it 'logs error' do
-        expect{ registered }.to raise_error NoMethodError # spy on, call and swallow error
-        expect(LogStuff).to have_received(:error).once
-      end
-
-      it 'raises error' do
-        expect{ registered }.to raise_error NoMethodError
-      end
+      it { is_expected.to be_truthy }
     end
   end
 end


### PR DESCRIPTION
#### What
Remove vat_registered? logging and use a fallback of true

#### Ticket

n/a

#### Why
A very occasional sentry error exists whereby
the provider_delegator is nil. Rather than stop
user processing in such situations with a 500
we will swallow the error and default to true as
most providers are vat registered (**need to check this).

Fix swallow sentry error and fallback to default of true
for vat_registered? for a provider.