### PR TITLE
[CBO-1631] Rubocop: Fix FactoryBot/FactoryClassName

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,28 +14,6 @@ FactoryBot/CreateList:
   Exclude:
     - 'spec/controllers/external_users/admin/external_users_controller_spec.rb'
 
-# Offense count: 33
-# Cop supports --auto-correct.
-FactoryBot/FactoryClassName:
-  Exclude:
-    - 'spec/factories/claim/advocate_claims.rb'
-    - 'spec/factories/claim/advocate_hardship_claims.rb'
-    - 'spec/factories/claim/advocate_interim_claims.rb'
-    - 'spec/factories/claim/advocate_supplementary_claims.rb'
-    - 'spec/factories/claim/api_claims.rb'
-    - 'spec/factories/claim/deterministic_claim.rb'
-    - 'spec/factories/claim/interim_claims.rb'
-    - 'spec/factories/claim/litigator_claims.rb'
-    - 'spec/factories/claim/litigator_hardship_claims.rb'
-    - 'spec/factories/claim/transfer_claims.rb'
-    - 'spec/factories/claim/transfer_details.rb'
-    - 'spec/factories/fee_types.rb'
-    - 'spec/factories/fees.rb'
-    - 'spec/factories/messages.rb'
-    - 'spec/factories/stats/statistics.rb'
-    - 'spec/factories/stats/stats_reports.rb'
-    - 'spec/factories/vat_rates.rb'
-
 # Offense count: 25
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -3,7 +3,7 @@
 # differentiate from other claim types.
 #
 FactoryBot.define do
-  factory :claim, aliases: [:advocate_claim, :advocate_final_claim], class: Claim::AdvocateClaim do
+  factory :claim, aliases: [:advocate_claim, :advocate_final_claim], class: 'Claim::AdvocateClaim' do
 
     # NOTE: this was introduced because it was the only way to get FactoryBot to set
     # model attributes on initialize (which seems not to be the default behaviour) and

--- a/spec/factories/claim/advocate_hardship_claims.rb
+++ b/spec/factories/claim/advocate_hardship_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :advocate_hardship_claim, class: Claim::AdvocateHardshipClaim do
+  factory :advocate_hardship_claim, class: 'Claim::AdvocateHardshipClaim' do
     advocate_base_setup
     case_type { nil }
     case_stage

--- a/spec/factories/claim/advocate_interim_claims.rb
+++ b/spec/factories/claim/advocate_interim_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :advocate_interim_claim, class: Claim::AdvocateInterimClaim do
+  factory :advocate_interim_claim, class: 'Claim::AdvocateInterimClaim' do
     advocate_base_setup
     case_type { nil }
 

--- a/spec/factories/claim/advocate_supplementary_claims.rb
+++ b/spec/factories/claim/advocate_supplementary_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :advocate_supplementary_claim, class: Claim::AdvocateSupplementaryClaim do
+  factory :advocate_supplementary_claim, class: 'Claim::AdvocateSupplementaryClaim' do
     advocate_base_setup
     offence { nil }
     case_type { nil }

--- a/spec/factories/claim/api_claims.rb
+++ b/spec/factories/claim/api_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :api_advocate_claim, class: Claim::AdvocateClaim do
+  factory :api_advocate_claim, class: 'Claim::AdvocateClaim' do
     # Attempt to create minimal API submitted claims
     # the main claim factories would have needed too much hacking to
     # remove the default values required for a web based submission

--- a/spec/factories/claim/deterministic_claim.rb
+++ b/spec/factories/claim/deterministic_claim.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :deterministic_claim, class: Claim::AdvocateClaim do
+  factory :deterministic_claim, class: 'Claim::AdvocateClaim' do
 
     before(:create) do
       Timecop.freeze(Time.new(2016, 3, 10, 11, 44, 55).utc)

--- a/spec/factories/claim/interim_claims.rb
+++ b/spec/factories/claim/interim_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :interim_claim, class: Claim::InterimClaim do
+  factory :interim_claim, class: 'Claim::InterimClaim' do
 
     litigator_base_setup
     claim_state_common_traits

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :litigator_claim, class: Claim::LitigatorClaim do
+  factory :litigator_claim, class: 'Claim::LitigatorClaim' do
 
     litigator_base_setup
     claim_state_common_traits

--- a/spec/factories/claim/litigator_hardship_claims.rb
+++ b/spec/factories/claim/litigator_hardship_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :litigator_hardship_claim, class: Claim::LitigatorHardshipClaim do
+  factory :litigator_hardship_claim, class: 'Claim::LitigatorHardshipClaim' do
     litigator_base_setup
     case_type { nil }
     case_stage { build :case_stage, :pre_ptph_or_ptph_adjourned }

--- a/spec/factories/claim/transfer_claims.rb
+++ b/spec/factories/claim/transfer_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :transfer_claim, aliases: [:litigator_transfer_claim], class: Claim::TransferClaim do
+  factory :transfer_claim, aliases: [:litigator_transfer_claim], class: 'Claim::TransferClaim' do
     litigator_base_setup
     claim_state_common_traits
     case_type { nil }
@@ -75,7 +75,7 @@ FactoryBot.define do
     end
   end
 
-  factory :bare_bones_transfer_claim, class: Claim::TransferClaim do
+  factory :bare_bones_transfer_claim, class: 'Claim::TransferClaim' do
     creator { build :external_user, :litigator }
     external_user { creator }
   end

--- a/spec/factories/claim/transfer_details.rb
+++ b/spec/factories/claim/transfer_details.rb
@@ -1,6 +1,6 @@
 
 FactoryBot.define do
-  factory :transfer_detail, class: Claim::TransferDetail do
+  factory :transfer_detail, class: 'Claim::TransferDetail' do
     litigator_type { 'original' }
     elected_case { false }
     transfer_stage_id { 10 }

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -17,7 +17,7 @@
 #
 
 FactoryBot.define do
-  factory :basic_fee_type, class: Fee::BasicFeeType do
+  factory :basic_fee_type, class: 'Fee::BasicFeeType' do
     sequence(:description) { |n| "AGFS, Basic fee type, basic fee -#{n}" }
     code { random_safe_code }
     calculated { true }
@@ -187,7 +187,7 @@ FactoryBot.define do
       npw
     end
 
-    factory :misc_fee_type, class: Fee::MiscFeeType do
+    factory :misc_fee_type, class: 'Fee::MiscFeeType' do
       sequence(:description) { |n| "AGFS, Misc fee type, Noting brief - #{n}" }
       code { random_safe_code }
       calculated { true }
@@ -349,7 +349,7 @@ FactoryBot.define do
       end
     end
 
-    factory :fixed_fee_type, class: Fee::FixedFeeType do
+    factory :fixed_fee_type, class: 'Fee::FixedFeeType' do
       sequence(:description) { |n| "AGFS, Fixed fee type, Contempt - #{n}" }
       code { random_safe_code }
       calculated { true }
@@ -429,7 +429,7 @@ FactoryBot.define do
       end
     end
 
-    factory :graduated_fee_type, class: Fee::GraduatedFeeType do
+    factory :graduated_fee_type, class: 'Fee::GraduatedFeeType' do
       sequence(:description) { |n| "LGFS, Fixed fee, Elected case not proceeded - #{n}" }
       code { 'GTRL' }
       calculated { false }
@@ -444,7 +444,7 @@ FactoryBot.define do
       end
     end
 
-    factory :interim_fee_type, class: Fee::InterimFeeType do
+    factory :interim_fee_type, class: 'Fee::InterimFeeType' do
       sequence(:description) { |n| "#{Faker::Lorem.word}-#{n}" }
       code { 'ITRS' }
       calculated { false }
@@ -487,7 +487,7 @@ FactoryBot.define do
       end
     end
 
-    factory :transfer_fee_type, class: Fee::TransferFeeType do
+    factory :transfer_fee_type, class: 'Fee::TransferFeeType' do
       calculated { false }
       code { 'TRANS' }
       unique_code { 'TRANS' }
@@ -495,7 +495,7 @@ FactoryBot.define do
       roles { ['lgfs'] }
     end
 
-    factory :warrant_fee_type, class: Fee::WarrantFeeType do
+    factory :warrant_fee_type, class: 'Fee::WarrantFeeType' do
       description { 'Warrant Fee' }
       code { 'XWAR' }
       calculated { false }
@@ -506,14 +506,14 @@ FactoryBot.define do
       end
     end
 
-    factory :hardship_fee_type, class: Fee::HardshipFeeType do
+    factory :hardship_fee_type, class: 'Fee::HardshipFeeType' do
       description { 'Hardship Fee' }
       code { 'HARDSHIP' }
       calculated { false }
       roles { ['lgfs'] }
     end
 
-    factory :child_fee_type, class: Fee::FixedFeeType do
+    factory :child_fee_type, class: 'Fee::FixedFeeType' do
       description { 'Child' }
       roles { ['lgfs'] }
 

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -20,7 +20,7 @@
 #
 
 FactoryBot.define do
-  factory :fixed_fee, class: Fee::FixedFee do
+  factory :fixed_fee, class: 'Fee::FixedFee' do
     claim { build(:advocate_claim, :with_fixed_fee_case) }
     fee_type { build :fixed_fee_type }
     quantity { 1 }
@@ -71,7 +71,7 @@ FactoryBot.define do
     end
   end
 
-  factory :misc_fee, class: Fee::MiscFee do
+  factory :misc_fee, class: 'Fee::MiscFee' do
     claim
     fee_type { build :misc_fee_type }
     quantity { 1 }
@@ -125,7 +125,7 @@ FactoryBot.define do
     end
   end
 
-  factory :warrant_fee, class: Fee::WarrantFee do
+  factory :warrant_fee, class: 'Fee::WarrantFee' do
     claim
     fee_type { build :warrant_fee_type }
     warrant_issued_date { Fee::WarrantFeeValidator::MINIMUM_PERIOD_SINCE_ISSUED.ago }
@@ -144,7 +144,7 @@ FactoryBot.define do
     end
   end
 
-  factory :interim_fee, class: Fee::InterimFee do
+  factory :interim_fee, class: 'Fee::InterimFee' do
     claim { build :interim_claim }
     fee_type { build :interim_fee_type }
     quantity { 2 }
@@ -187,7 +187,7 @@ FactoryBot.define do
     end
   end
 
-  factory :basic_fee, class: Fee::BasicFee do
+  factory :basic_fee, class: 'Fee::BasicFee' do
     claim
     fee_type { build :basic_fee_type }
     quantity { 1 }
@@ -266,7 +266,7 @@ FactoryBot.define do
     trait :banpw_fee do npw_fee end
   end
 
-  factory :transfer_fee, class: Fee::TransferFee do
+  factory :transfer_fee, class: 'Fee::TransferFee' do
     claim { build :transfer_claim }
     fee_type { build :transfer_fee_type }
     quantity { 0 }
@@ -274,7 +274,7 @@ FactoryBot.define do
     amount { 25 }
   end
 
-  factory :graduated_fee, class: Fee::GraduatedFee do
+  factory :graduated_fee, class: 'Fee::GraduatedFee' do
     claim
     fee_type { build :graduated_fee_type }
     quantity { 1 }
@@ -291,7 +291,7 @@ FactoryBot.define do
     end
   end
 
-  factory :hardship_fee, class: Fee::HardshipFee do
+  factory :hardship_fee, class: 'Fee::HardshipFee' do
     claim
     fee_type { build :hardship_fee_type }
     quantity { 1 }

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
   end
 
-  factory :unpersisted_message, class: Message do
+  factory :unpersisted_message, class: 'Message' do
     body            { Faker::Lorem.paragraph }
     claim           { FactoryBot.build :unpersisted_claim }
     sender          { FactoryBot.build :user }

--- a/spec/factories/stats/statistics.rb
+++ b/spec/factories/stats/statistics.rb
@@ -1,6 +1,6 @@
 
 FactoryBot.define do
-  factory :statistic, class: Stats::Statistic do
+  factory :statistic, class: 'Stats::Statistic' do
     date { Date.today }
     report_name { 'my_report' }
     claim_type { 'Claim::AdvocateClaim' }

--- a/spec/factories/stats/stats_reports.rb
+++ b/spec/factories/stats/stats_reports.rb
@@ -11,7 +11,7 @@
 #
 
 FactoryBot.define do
-  factory :stats_report, class: Stats::StatsReport do
+  factory :stats_report, class: 'Stats::StatsReport' do
     report_name { 'management_information' }
     report { 'report contents' }
     status { 'completed' }

--- a/spec/factories/vat_rates.rb
+++ b/spec/factories/vat_rates.rb
@@ -10,7 +10,7 @@
 #
 
 FactoryBot.define do
-  factory :vat_rate, class: VatRate do
+  factory :vat_rate, class: 'VatRate' do
     rate_base_points { 1750 }
     effective_date { Date.new(2001, 1, 4) }
 


### PR DESCRIPTION
#### What

Bring the RSpec tests into line with our Ruby coding standards. In this case, fix the RSpec factory files so that they satisfy the [Fix FactoryBot/FactoryClassName](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName) in Rubocop.

#### Ticket

[CCCD: RSpecs rubocop adherence](https://dsdmoj.atlassian.net/browse/CBO-1631)

#### Why

A consistent coding standard makes it easier to understand a large code base.

#### What

From the FactoryBot/FactoryClassName documentation:

> Use string value when setting the class attribute explicitly.
> 
> This cop would promote faster tests by lazy-loading of application files. Also, this could help you suppress potential bugs in combination with external libraries by avoiding a preload of application files from the factory files.

Whether or not the tests are faster as a result of lazy-loading can be seen by comparing the RSpec run time in Circle CI with the same run time of the parent PR, #3650 (There doesn't seem to be a significant improvement)