### PR TITLE
Typeahead specs

### DIFF
--- a/app/webpack/stylesheets/_autocomplete.scss
+++ b/app/webpack/stylesheets/_autocomplete.scss
@@ -15,7 +15,7 @@
 
 // scss-lint:disable QualifyingElement, ImportantRule
 .js-enabled select.typeahead { // stylelint-disable-line selector-no-qualifying-type
-  @include visually-hidden;
+  display: none;
 }
 
 .typeahead.fixedwidth {

--- a/spec/javascripts/Modules.Autocomplete_spec.js
+++ b/spec/javascripts/Modules.Autocomplete_spec.js
@@ -80,19 +80,5 @@ describe('Modules.Autocomplete', function () {
         expect($.fn.typeahead).toHaveBeenCalled()
       })
     })
-
-    describe('...typeaheadInit', function () {
-      it('should throw and error if either param is undefined', function () {
-        expect(function () {
-          module.typeaheadInit()
-        }).toThrowError('Missing params')
-      })
-
-      it('should call $.fn.typeahead', function () {
-        spyOn($.fn, 'typeahead')
-        module.typeaheadInit($('<input />'), [])
-        expect($.fn.typeahead).toHaveBeenCalled()
-      })
-    })
   })
 })


### PR DESCRIPTION
#### What
The typeahead function duplicates the default element (`select`) classes to a dynamically created input.

If the type selector (`select`) is removed from the css, both elements become visually hidden, the test would still pass, as the spec could still interact with both elements, however users could not.

Now, the selector will be completely hidden, if the type selector (`select`) is removed, the spec cannot interact with it, the test will fail and engineers will be informed.

#### Ticket
[Test typeahead functionality](https://dsdmoj.atlassian.net/browse/CBO-1632)
