### PR TITLE
Attempt to fix flicker with advocate_hardship_claim_submit.feature

### DIFF
--- a/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
@@ -66,8 +66,7 @@ Feature: Advocate tries to submit a hardship claim for a trial with miscellaneou
 
     And I eject the VCR cassette
 
-    When I click "Continue" in the claim form
-    Then I should be in the 'Travel expenses' form page
+    Then I click "Continue" in the claim form and move to the 'Travel expenses' form page
     And I should see a page title "Enter travel expenses for advocate hardship fees claim"
 
     When I select an expense type "Parking"

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -20,7 +20,7 @@ When(/^I select a case type of '(.*?)'$/) do |case_type|
 end
 
 When(/^I select a case stage of '(.*?)'$/) do |case_stage|
-  using_wait_time(6) do
+  patiently do
     @claim_form_page.auto_case_stage.choose_autocomplete_option(case_stage)
   end
   wait_for_ajax

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -20,7 +20,9 @@ When(/^I select a case type of '(.*?)'$/) do |case_type|
 end
 
 When(/^I select a case stage of '(.*?)'$/) do |case_stage|
-  @claim_form_page.auto_case_stage.choose_autocomplete_option(case_stage)
+  using_wait_time(6) do
+    @claim_form_page.auto_case_stage.choose_autocomplete_option(case_stage)
+  end
   wait_for_ajax
 end
 


### PR DESCRIPTION
#### What
Fix flickering feature test advocate_hardship_claim_submit.feature

After running this locally many times there seem to be two random failures. These are

```
When I select a case stage of 'Trial started but not concluded'                                                                         # features/step_definitions/common_claim_steps.rb:22
      undefined method `root_element' for nil:NilClass (NoMethodError)
      ./features/page_objects/sections/common_autocomplete_section.rb:9:in `choose_autocomplete_option'
      ./features/step_definitions/common_claim_steps.rb:23:in `/^I select a case stage of '(.*?)'$/'
      features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature:25:in `I select a case stage of 'Trial started but not concluded''
```
and

```
    When I click "Continue" in the claim form                                                                                               # features/step_definitions/common_claim_steps.rb:120
    Then I should be in the 'Travel expenses' form page                                                                                     # features/step_definitions/common_steps.rb:166
      expected to find text "Travel expenses" in "Miscellaneous fees" (RSpec::Expectations::ExpectationNotMetError)
      ./features/step_definitions/common_steps.rb:168:in `block (2 levels) in <top (required)>'
      ./features/step_definitions/common_steps.rb:167:in `/^I should be in the '(.*?)' form page$/'
      features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature:70:in `I should be in the 'Travel expenses' form page'
```

They are both quite hard to recreate as they do not happen often, perhaps 1 in every 20 runs?

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1629

#### Why
They are failing in CircleCI and delaying deployment workflows.

#### How
I have attempted to fix the first failure by using the patiently do..end functionality.

I have attempted to fix the second failure by using T`hen I click "Continue" in the claim form and move to the 'Travel expenses' form page` instead of `When I click "Continue" in the claim form
`. This includes a sleep time and attempt to deal with when the first click on Continue didn't work - and seems to be quite widely used in the features.

Since making these changes I have not seen the feature fail? (>25 runs locally)

