### PR TITLE
Add default dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
   open-pull-requests-limit: 5
   reviewers:
   - ministryofjustice/crime-billing-online
+  - "naseberry"
   ignore:
   - dependency-name: govuk_frontend_toolkit
     versions:
@@ -34,6 +35,9 @@ updates:
   rebase-strategy: "disabled"
   reviewers:
   - ministryofjustice/crime-billing-online
+  - "jsugarman"
+  - "kmahern"
+  - "jrmhaig"
   ignore:
   - dependency-name: govuk_frontend_toolkit
     versions:


### PR DESCRIPTION
#### What
Add default dependabot reviewers for its PRs

#### Why
So we do not have to assign reviewers manually