### PR TITLE
Introduce basic alerting on cccd

### DIFF
--- a/kubernetes_deploy/dev-lgfs/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/dev-lgfs/prometheus-custom-rules.yaml
@@ -1,0 +1,43 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: cccd-dev-lgfs
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-cccd
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-dev-lgfs"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-dev-lgfs"} > 0) > 90
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev-lgfs is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status="400"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev-lgfs More than a hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-dev-lgfs,type:phrase),type:phrase,value:cccd-dev-lgfs),query:(match:(kubernetes.namespace_name:(query:cccd-dev-lgfs,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status=~"5.."}[5m])) * 300 > 5
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev-lgfs),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev-lgfs,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="cccd-dev-lgfs"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="cccd-dev-lgfs"})
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev-lgfs Container disk space usage is more than 150Mb or is not reported

--- a/kubernetes_deploy/dev/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/dev/prometheus-custom-rules.yaml
@@ -1,0 +1,43 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: cccd-dev
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-cccd
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-dev"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-dev"} > 0) > 90
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev", status="400"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev More than a hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-dev,type:phrase),type:phrase,value:cccd-dev),query:(match:(kubernetes.namespace_name:(query:cccd-dev,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev", status=~"5.."}[5m])) * 300 > 5
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="cccd-dev"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="cccd-dev"})
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-dev Container disk space usage is more than 150Mb or is not reported

--- a/kubernetes_deploy/production/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/production/prometheus-custom-rules.yaml
@@ -1,0 +1,43 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: cccd-production
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-cccd
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-production"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-production"} > 0) > 90
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-production is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-production", status="400"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-production More than a hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-production,type:phrase),type:phrase,value:cccd-production),query:(match:(kubernetes.namespace_name:(query:cccd-production,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-production", status=~"5.."}[5m])) * 300 > 5
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-production An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-production),query:(match:(log_processed.kubernetes_namespace:(query:cccd-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="cccd-production"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="cccd-production"})
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-production Container disk space usage is more than 150Mb or is not reported

--- a/kubernetes_deploy/staging/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/staging/prometheus-custom-rules.yaml
@@ -1,0 +1,43 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: cccd-staging
+  labels:
+    prometheus: cloud-platform
+    role: alert-rules
+  name: prometheus-custom-rules-cccd
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-staging"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-staging"} > 0) > 90
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-staging is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-staging", status="400"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-staging More than a hundred 404 errors in one day
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-staging,type:phrase),type:phrase,value:cccd-staging),query:(match:(kubernetes.namespace_name:(query:cccd-staging,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-staging", status=~"5.."}[5m])) * 300 > 5
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-staging An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-staging),query:(match:(log_processed.kubernetes_namespace:(query:cccd-staging,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="cccd-staging"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="cccd-staging"})
+      for: 1m
+      labels:
+        severity: laa-court-get-paid
+      annotations:
+        message: cccd-staging Container disk space usage is more than 150Mb or is not reported


### PR DESCRIPTION
#### What
Introduce some basic alerting for CCCD

#### Ticket
n/a

#### Why
To help with application monitoring

#### How
Alert rules are defined in prometheus-custom-rules.yaml. Currently these are applied manually, e.g. with  `kubectl apply -f kubernetes_deploy/dev/prometheus-custom-rules.yaml -n cccd-dev`. Once we are happy the alerts are working as required the prometheus-custom-rules.yaml file should be moved to the cloud platforms environments repo (https://github.com/ministryofjustice/cloud-platform-environments) where they will be automatically applied.
