### PR TITLE
[CBO-1664] Migrate axe-matchers to axe-core-cucumber

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ group :development, :devunicorn, :test do
 end
 
 group :test do
-  gem 'axe-matchers', '~> 2.6'
+  gem 'axe-core-cucumber', '~> 4.1'
   gem 'capybara-selenium'
   gem 'capybara', '~> 3.34'
   gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,9 +108,16 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    axe-matchers (2.6.1)
-      dumb_delegator (~> 0.8)
-      virtus (~> 1.0)
+    axe-core-api (4.1.0)
+      capybara
+      dumb_delegator
+      selenium-webdriver
+      virtus
+      watir
+    axe-core-cucumber (4.1.0)
+      axe-core-api
+      dumb_delegator
+      virtus
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -257,7 +264,7 @@ GEM
       dry-equalizer (~> 0.2)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.5, >= 1.5.2)
-    dumb_delegator (0.8.1)
+    dumb_delegator (1.0.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -749,6 +756,9 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
+    watir (6.17.0)
+      regexp_parser (~> 1.2)
+      selenium-webdriver (~> 3.6)
     webdrivers (4.4.2)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -788,7 +798,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   aws-sdk-sns (~> 1)
   aws-sdk-sqs (~> 1)
-  axe-matchers (~> 2.6)
+  axe-core-cucumber (~> 4.1)
   better_errors
   binding_of_caller
   bootsnap

--- a/features/claims/hardship_claims_banner.feature
+++ b/features/claims/hardship_claims_banner.feature
@@ -9,7 +9,7 @@ Feature: A hardship claims banner will appear on the claims list, until the user
 
     And I click 'Start a claim'
     Then The hardship claims banner is visible
-    And the page should be accessible within "#content"
+    Then the page should be accessible within "#content"
 
     When I click the link 'Do not show hardship claims information again'
     Then The hardship claims banner is not visible

--- a/features/step_definitions/accessibility.rb
+++ b/features/step_definitions/accessibility.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Then('the page should be accessible within {string}') do |selector|
+  steps %(Then the page should be axe clean within "#{selector}")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ require 'sidekiq/testing'
 require_relative '../page_objects/base_page'
 require_relative '../../spec/vcr_helper'
 require_relative '../../spec/support/factory_helpers'
-require 'axe/cucumber/step_definitions'
+require 'axe-cucumber-steps'
 
 # enable forgery protection in feature tests so as not to obscure
 # loss of signed in user


### PR DESCRIPTION
#### What
The package axe-matchers has been moved to axe-core-gems. We need to migrate to the new package and update our assertions.

#### Ticket
[Migrate axe-matchers to axe-core-cucumber](https://dsdmoj.atlassian.net/browse/CBO-1664)

#### Why
Because the package axe-matchers has been deprecated.
