### PR TITLE
Get Jasmine gem from Rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ group :development, :devunicorn, :test do
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'guard-webpacker', '~> 0.2.1'
-  gem 'jasmine', git: 'https://github.com/jasmine/jasmine-gem.git', branch: 'master'
+  gem 'jasmine', '> 3.0'
   gem 'jasmine_selenium_runner', require: false
   gem 'listen', '~> 3.2.1'
   gem 'meta_request'

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ group :development, :devunicorn, :test do
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'guard-webpacker', '~> 0.2.1'
-  gem 'jasmine', '> 3.0'
+  gem 'jasmine', '>= 3.5.1'
   gem 'jasmine_selenium_runner', require: false
   gem 'listen', '~> 3.2.1'
   gem 'meta_request'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -832,7 +832,7 @@ DEPENDENCIES
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
   hashie-forbidden_attributes (>= 0.1.1)
   i18n-tasks
-  jasmine (> 3.0)
+  jasmine (>= 3.5.1)
   jasmine_selenium_runner
   jquery-rails (~> 4.4.0)
   json-schema (~> 2.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,17 +9,6 @@ GIT
       eventmachine (>= 0.12.8)
       rufus-scheduler (~> 2.0.24)
 
-GIT
-  remote: https://github.com/jasmine/jasmine-gem.git
-  revision: 0f303af020000f0ced11d4652f14c42390719bba
-  branch: master
-  specs:
-    jasmine (3.5.1)
-      jasmine-core (~> 3.5.0)
-      phantomjs
-      rack (>= 1.2.1)
-      rake
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -409,7 +398,12 @@ GEM
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
     inflection (1.0.0)
-    jasmine-core (3.5.0)
+    jasmine (3.6.0)
+      jasmine-core (~> 3.6.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (3.6.0)
     jasmine_selenium_runner (3.0.0)
       jasmine (~> 3.0)
       selenium-webdriver (~> 3.8)
@@ -838,7 +832,7 @@ DEPENDENCIES
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
   hashie-forbidden_attributes (>= 0.1.1)
   i18n-tasks
-  jasmine!
+  jasmine (> 3.0)
   jasmine_selenium_runner
   jquery-rails (~> 4.4.0)
   json-schema (~> 2.8.0)


### PR DESCRIPTION
#### What

Use released versions of Jasmine instead of a version taken from the master branch on Github.

#### Ticket

N/A

#### Why

When CCCD was upgraded to Rails 6 (#3060) the latest released version of the Jasmine gem was not supported so the `Gemfile` was changed to pull the latest master from Github. [Rails 6 has subsequently been supported by Jasmine](https://github.com/jasmine/jasmine-gem/releases/tag/v3.5.1) so we can go back to using released versions. This will mean that Dependabot will be able to correctly suggest updates when they are released.

#### How

Update `Gemfile` to get the Jasmine gem from Rubygems.