### PR TITLE
[CBO-1641] Migrate claim search form to GOVUK Design System

### DIFF
--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -12,8 +12,7 @@
       %noscript
         = submit_tag t('.filter')
 
-      .search-wrapper
-        = render partial: 'shared/search_form', locals: { search_path: case_workers_admin_allocations_path(anchor: 'listanchor'), hint_text: t('hint.search'), button_text: t('search.claims') }
+      = render partial: 'shared/search_form', locals: { search_path: case_workers_admin_allocations_path(anchor: 'search-button'), hint_text: t('hint.search'), button_text: t('search.claims') }
 
     = form_for [:case_workers, :admin, @allocation] do |f|
       = hidden_field_tag :tab, params[:tab]

--- a/app/views/case_workers/admin/case_workers/index.html.haml
+++ b/app/views/case_workers/admin/case_workers/index.html.haml
@@ -6,7 +6,7 @@
 = content_for :search_html_block do
   = govuk_link_to t('.create_case_worker'), new_case_workers_admin_case_worker_path
 
-= render partial: 'shared/search_form', locals: { search_path: case_workers_admin_case_workers_path(anchor: 'listanchor'), hint_text: t('hint.search_caseworker'), button_text: t('search.caseworkers') }
+= render partial: 'shared/search_form', locals: { search_path: case_workers_admin_case_workers_path(anchor: 'search-button'), hint_text: t('hint.search_caseworker'), button_text: t('search.caseworkers') }
 
 .container.table-container
   %table.report

--- a/app/views/case_workers/claims/_search_form.html.haml
+++ b/app/views/case_workers/claims/_search_form.html.haml
@@ -1,3 +1,1 @@
-.container
-  .search-wrapper
-    = render partial: 'shared/search_form', locals: { search_path: defined?(archived) && archived ? archived_case_workers_claims_path(anchor: 'listanchor') : case_workers_claims_path(anchor: 'listanchor'), hint_text: t('case_workers.claims.hint.search'), button_text: t('search.claims') }
+= render partial: 'shared/search_form', locals: { search_path: defined?(archived) && archived ? archived_case_workers_claims_path(anchor: 'search-button') : case_workers_claims_path(anchor: 'search-button'), hint_text: t('case_workers.claims.hint.search'), button_text: t('search.claims') }

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -7,7 +7,7 @@
   .form-group
     = govuk_link_to t('.new_user'), new_external_users_admin_external_user_path
 
-= render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'listanchor'), hint_text: t('hint.search_users'), button_text: t('search.users') }
+= render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'search-button'), hint_text: t('hint.search_users'), button_text: t('search.users') }
 
 %table.report
   %thead

--- a/app/views/external_users/claims/_search_form.html.haml
+++ b/app/views/external_users/claims/_search_form.html.haml
@@ -1,3 +1,1 @@
-.container
-  .search-wrapper
-    = render partial: 'shared/search_form', locals: { search_path: defined?(archived) && archived ? archived_external_users_claims_path(anchor: 'listanchor') : external_users_claims_path(anchor: 'listanchor'), hint_text: t('hint.search'), button_text: t('search.claims')}
+= render partial: 'shared/search_form', locals: { search_path: defined?(archived) && archived ? archived_external_users_claims_path(anchor: 'search-button') : external_users_claims_path(anchor: 'search-button'), hint_text: t('hint.search'), button_text: t('search.claims')}

--- a/app/views/external_users/claims/archived.html.haml
+++ b/app/views/external_users/claims/archived.html.haml
@@ -5,8 +5,7 @@
 
 = render partial: 'external_users/shared/timed_retention_banner'
 
-.container.search-wrapper#listanchor
-  = render partial: 'search_form', locals: { archived: true }
+= render partial: 'search_form', locals: { archived: true }
 
 .container#details
   = render partial: 'main_claims_list', locals: { claims: @claims }

--- a/app/views/external_users/claims/index.html.haml
+++ b/app/views/external_users/claims/index.html.haml
@@ -11,11 +11,11 @@
     %p.heading-large
       = govuk_button_start(t('link.add_claim'), new_external_users_claim_types_path)
 
-.container.search-wrapper#listanchor
-  .grid-row
-    .column-full
-      = render partial: 'shared/scheme_filters', locals: { available_schemes: @available_schemes }
-      = render partial: 'shared/search_form', locals: { search_path: defined?(archived) && archived ? archived_external_users_claims_path(anchor: 'listanchor') : external_users_claims_path(anchor: 'listanchor'), hint_text: t('hint.search'), button_text: t('search.claims') }
+
+= render partial: 'shared/scheme_filters', locals: { available_schemes: @available_schemes }
+
+= render partial: 'shared/search_form', locals: { search_path: defined?(archived) && archived ? archived_external_users_claims_path(anchor: 'search-button') : external_users_claims_path(anchor: 'search-button'), hint_text: t('hint.search'), button_text: t('search.claims') }
+
 .container
   .importer-results{'aria-live': 'polite'}
 

--- a/app/views/shared/_search_form.html.haml
+++ b/app/views/shared/_search_form.html.haml
@@ -1,24 +1,16 @@
-.search-form
-  = form_tag search_path, method: :get do
-    = hidden_field_tag :tab, params[:tab]
-    = hidden_field_tag :sort, params[:sort]
-    = hidden_field_tag :direction, params[:direction]
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_with url: search_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+      = f.hidden_field :tab, id: :tab, value: params[:tab]
+      = f.hidden_field :sort, id: :sort, value: params[:sort]
+      = f.hidden_field :direction, id: :direction, value: params[:direction]
 
-    .form-group
-      %fieldset.inline
-        %legend.visuallyhidden
-          = t('common.search.legend')
+      = f.govuk_text_field :search,
+        label: { text: t('common.search.label'), tag: 'h2', size: 'm' },
+        hint: { text: hint_text },
+        value: params[:search]
 
-        %label.form-label-bold{ for: 'search' }
-          = t('common.search.label')
-          %span.form-hint
-            = hint_text
-        = text_field_tag :search, params[:search], class: 'form-control'
-    .form-group
-      = govuk_button(type: 'submit') do
-        - if local_assigns[:button_text]
-          = button_text
-        - else
-          = t('common.search')
+      #search-button
+        = f.govuk_submit local_assigns[:button_text] ? button_text : t('common.search.label')
 
-  = yield :search_html_block
+    = yield :search_html_block

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -27,11 +27,6 @@
   display: none;
 }
 
-.search-wrapper {
-  @include container;
-  position: relative;
-}
-
 caption {
   @include container;
 }


### PR DESCRIPTION
#### What
Migrate claim search form to the GOVUK design system formbuilder

#### Ticket
[Migrate claim search form to GOVUK design system](https://dsdmoj.atlassian.net/browse/CBO-1641)

#### Why
Part of a larger change to:

- continue migration to GOVUK Frontend
- resolve accessibility issues identified in the 2020 DAC report
- reduce then remove deprecated code