### PR TITLE
Remove awesome_print gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'aws-sdk-costexplorer',   '~> 1'
 gem 'aws-sdk-s3',             '~> 1'
 gem 'aws-sdk-sns',            '~> 1'
 gem 'aws-sdk-sqs',            '~> 1'
-gem 'awesome_print'
 gem 'bootsnap', require: false
 gem 'cancancan',              '~> 3.2'
 gem 'cocoon',                 '~> 1.2.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
     ast (2.4.1)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    awesome_print (1.8.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.417.0)
     aws-sdk-core (3.111.2)
@@ -793,7 +792,6 @@ DEPENDENCIES
   amoeba (~> 3.1.0)
   annotate
   auto_strip_attributes (~> 2.6.0)
-  awesome_print
   aws-sdk-costexplorer (~> 1)
   aws-sdk-s3 (~> 1)
   aws-sdk-sns (~> 1)

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -135,23 +135,23 @@ def publicise_errors(claim, &block)
     block.call
   rescue => e
     puts "***************** DEBUG validation errors #{__FILE__}::#{__LINE__} **********"
-    ap claim
+    pp claim
     puts claim.errors.full_messages
     claim.defendants.each do |defendant|
-      ap defendant
+      pp defendant
       puts defendant.errors.full_messages
       d.representation_orders.each do |rep|
-        ap rep
+        pp rep
         puts '>>> rep order'
         puts rep.errors.full_messages
       end
     end
     claim.fees.each do |fee|
-      ap fee
+      pp fee
       puts fee.errors.full_messages
     end
     claim.expenses.each do |expense|
-      ap expense
+      pp expense
       puts expense.errors.full_messages
     end
     raise e


### PR DESCRIPTION
#### What

Remove the [Awesome Print](https://github.com/awesome-print/awesome_print) gem.

#### Ticket

N/A

#### Why

As far as I can see, Awesome Print is only used in one place and that is for debugging that should probably have been deleted. This is not a massive saving in disk space or memory but it does (slightly) clear the list of libraries that we are pulling in.

#### How

Remove `awesome_print` from `Gemfile` and replace any instances of `ap` in the code with `pp` (which probably didn't exist when the was added).

#### Important notes for reviewers

* Am I right in my assumption that this gem is not being used elsewhere? Are you aware of anywhere else it appears?
* Is that `rescue` block in spec/factories/claim/base_claims.rb actually adding any value or can it be deleted? See comments on #512