### PR TITLE
[CBO-1685] Remove Susy gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
 gem 'sass-rails',             '~> 6.0.0'
 gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.git'
-gem 'susy',                   '~> 2.2.14'
 gem 'sentry-raven',           '~> 2.13.0'
 gem 'simple_form',            '~> 5.0.3'
 gem 'sprockets-rails',        '~> 3.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,8 +713,6 @@ GEM
       state_machines-activemodel (>= 0.8.0)
     state_machines-audit_trail (2.0.2)
       state_machines
-    susy (2.2.14)
-      sass (>= 3.3.0, < 3.5)
     sys-uname (1.2.1)
       ffi (>= 1.0.0)
     temple (0.8.1)
@@ -898,7 +896,6 @@ DEPENDENCIES
   state_machine (~> 1.2.0)
   state_machines-activerecord
   state_machines-audit_trail
-  susy (~> 2.2.14)
   test-prof
   timecop
   tzinfo-data

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,8 +2,6 @@ require_relative 'boot'
 
 require 'rails/all'
 
-require 'susy'
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
#### What
Remove susy gem.

#### Ticket
[Remove susy gem](https://dsdmoj.atlassian.net/browse/CBO-1685)

#### Why
Leftover technical debt when we move asset management from [Sprockets to Webpacker ](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/3363)
