### PR TITLE
[CBO-1686] Remove sass-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem 'rubyzip'
 gem 'config',                 '~> 2.2' # this gem provides our Settings.xxx mechanism
 gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
-gem 'sass-rails',             '~> 6.0.0'
 gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.git'
 gem 'susy',                   '~> 2.2.14'
 gem 'sentry-raven',           '~> 2.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -652,16 +652,6 @@ GEM
     rufus-scheduler (2.0.24)
       tzinfo (>= 0.3.22)
     sass (3.4.25)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -882,7 +872,6 @@ DEPENDENCIES
   rubocop-rspec
   ruby-progressbar
   rubyzip
-  sass-rails (~> 6.0.0)
   scheduler_daemon!
   sentry-raven (~> 2.13.0)
   shell-spinner (~> 1.0, >= 1.0.4)


### PR DESCRIPTION
#### What
Remove sass-rails gem.

#### Ticket
[Remove sass-rails gem](https://dsdmoj.atlassian.net/browse/CBO-1686)

#### Why
Leftover technical debt when we move asset management from [Sprockets to Webpacker ](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/3363)
