### PR TITLE
Only execute after_initialize methods after .new

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -27,12 +27,12 @@ class Assessment < Determination
 
   has_paper_trail on: [:update], only: %i[fees expenses disbursements vat_amount total]
 
-  after_initialize :set_default_values
+  after_initialize :set_default_values, if: :new_record?
   before_save :set_paper_trail_event!
   validates :claim_id, uniqueness: { message: 'This claim already has an assessment' }
 
   def set_default_values
-    zeroize if new_record?
+    zeroize
   end
 
   def zeroize

--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -31,9 +31,7 @@ module Claim
 
     delegate :requires_cracked_dates?, to: :case_type, allow_nil: true
 
-    after_initialize do
-      instantiate_basic_fees
-    end
+    after_initialize :instantiate_basic_fees, if: :new_record?
 
     before_validation do
       set_supplier_number

--- a/app/models/claim/advocate_hardship_claim.rb
+++ b/app/models/claim/advocate_hardship_claim.rb
@@ -20,9 +20,7 @@ module Claim
                    unless: proc { |c| c.disable_for_state_transition.eql?(:all) }
     validates_with ::Claim::AdvocateHardshipClaimSubModelValidator
 
-    after_initialize do
-      instantiate_basic_fees
-    end
+    after_initialize :instantiate_basic_fees, if: :new_record?
 
     before_validation do
       set_supplier_number

--- a/app/models/fee/hardship_fee.rb
+++ b/app/models/fee/hardship_fee.rb
@@ -24,7 +24,7 @@ class Fee::HardshipFee < Fee::BaseFee
 
   validates_with Fee::HardshipFeeValidator
 
-  after_initialize :default_values
+  after_initialize :default_values, if: :new_record?
 
   def is_hardship?
     true


### PR DESCRIPTION
#### What

Change calls to the `after_initialize` hook in some models so that they only trigger after a `.new`.

#### Ticket

N/A

#### Why

`after_initialize` defines methods that are to be executed each time an object is initialized. This happens when the object is found via a search or created using `.new`. As a result, for example, when `Claim::AdvocateClaim.all` is called then the `instantiate_basic_fees` method is called on every instance in the database. This is almost certainly not what is required.

#### How

Add the argument `if: :new_record?` to calls to `after_initialize` so that the methods are only called on new instances.

* In app/models/assessment.rb; The `set_default_values` method already checks `new_record?` so this change has no real effect other than some clarity.
* In app/models/claim/advocate_claim.rb and app/models/claim/advocate_hardship_claim.rb; `instantiate_basic_fees` creates zero value basic fees for all fee types that are not explicitly included in the claim. At least one database call is made for each instance resulting in a significant overhead for a search returning a large number of claims. I am fairly sure that most of the time taken in generating MI reports is due to this.
* In app/models/fee/hardship_fee.rb; `default_values` only sets `fee_type` if it is not already set and so it should be unnecessary to call it more than at instance creation.

I have **not** changes these (even though I think it would be right to do so) because they do currently have an effect each time (either setting fields or performing a validation) so there is potential for unexpected behaviour:

* app/models/claim/base_claim.rb
* app/models/fee/base_fee_type.rb
* app/models/fee/base_fee.rb
* app/models/fee/transfer_fee.rb
* app/models/fee/warrant_fee.rb
