### PR TITLE
Fix linting issues

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -31,6 +31,10 @@ fi
 printf '\nLinting JavaScript files...\n'
 
 yarn run validate:js
+if [[ $? -ne 0 ]]; then
+  printf 'StandardJS errors were detected. Aborting commit.\n'
+  exit 1
+fi
 
 
 ################################################################################
@@ -40,3 +44,7 @@ yarn run validate:js
 printf '\nLinting SCSS files...\n'
 
 yarn run validate:scss
+if [[ $? -ne 0 ]]; then
+  printf 'Stylelint errors were detected. Aborting commit.\n'
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence#readme",
   "scripts": {
     "validate:js": "standard",
-    "validate:scss": "stylelint app/webpack/**/*.scss"
+    "validate:scss": "stylelint **/*.scss"
   },
   "dependencies": {
     "@rails/webpacker": "5.2.1",

--- a/spec/javascripts/Modules.MangementInformation_spec.js
+++ b/spec/javascripts/Modules.MangementInformation_spec.js
@@ -72,7 +72,7 @@ describe('Modules.ManagementInformation.js', function () {
       '    </div>',
       '  </div>',
       '  <a id="provisional_assessments_date_download">link</a>',
-      '</div>',
+      '</div>'
     ]
     return html.join('')
   }


### PR DESCRIPTION
#### What

StandardJS erred with exit code 1 due to an unexpected trailing comma.
The pre-commit hook failed to stop commits due to our last lint command passing.
This commit updates pre-commit hook to immediate return an exit code should it fail and stop the commit

This commit also updates the Stylelint glob that now validates files in nested directories.

#### Ticket

n/a
