### PR TITLE
Remove unused includes_state? method

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -9,11 +9,6 @@ module ClaimsHelper
     awaiting_written_reasons
   ].freeze
 
-  def includes_state?(claims, states)
-    states.gsub(/\s+/, '').split(',').to_a unless states.is_a?(Array)
-    claims.map(&:state).uniq.any? { |s| states.include?(s) }
-  end
-
   def claim_allocation_checkbox_helper(claim, case_worker)
     checked = claim.is_allocated_to_case_worker?(case_worker) ? 'checked="checked"' : nil
     element_id = "id=\"case_worker_claim_ids_#{claim.id}\""

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -23,25 +23,6 @@ RSpec.describe ClaimsHelper do
     end
   end
 
-  describe '#includes_state?' do
-    let(:only_allocated_claims) { create_list(:allocated_claim, 5) }
-
-    it 'returns true if state included as array' do
-      states_as_arr = ['draft', 'allocated']
-      expect(includes_state?(only_allocated_claims, states_as_arr)).to eql(true)
-    end
-
-    it 'returns true if state included as comma delimited string' do
-      states_as_comma_delimited_string = 'draft,allocated'
-      expect(includes_state?(only_allocated_claims, states_as_comma_delimited_string)).to eql(true)
-    end
-
-    it 'returns false if state NOT included' do
-      invalid_states = 'draft,submitted'
-      expect(includes_state?(only_allocated_claims, invalid_states)).to eql(false)
-    end
-  end
-
   describe '#display_downtime_warning?' do
     subject { helper.display_downtime_warning? }
 


### PR DESCRIPTION
#### What

Remove the `includes_state?` method from the `ClaimsHelper` module.

#### Ticket

N/A

#### Why

The method is no longer being used anywhere.

#### How

Remove the method together with its unit tests.