### PR TITLE
Remove requested_redetermination? method

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -304,12 +304,6 @@ module Claim
       @force_validation
     end
 
-    # if allocated, and the last state was redetermination
-    # and happened since the last redetermination record was created
-    def requested_redetermination?
-      allocated? ? redetermination_since_allocation? : false
-    end
-
     def redetermination_since_allocation?
       if last_state_transition.from == 'redetermination'
         last_state_transition_later_than_redetermination?(last_state_transition)

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1361,57 +1361,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     end
   end
 
-  describe '#requested_redetermination?' do
-    context 'allocated state from redetermination' do
-      before do
-        @claim = FactoryBot.create :redetermination_claim
-        @claim.allocate!
-      end
-
-      context 'no previous redetermination' do
-        it 'is true' do
-          expect(@claim.redeterminations).to be_empty
-          expect(@claim.requested_redetermination?).to be true
-        end
-      end
-
-      context 'previous redetermination record created before state was changed to redetermination' do
-        it 'is true' do
-          @claim.redeterminations << Redetermination.new(fees: 12.12, expenses: 35.55, disbursements: 0)
-          travel_to(2.hours.since) do
-            @claim.authorise_part!
-            @claim.redetermine!
-            @claim.allocate!
-          end
-          expect(@claim.requested_redetermination?).to be true
-        end
-      end
-
-      context 'latest redetermination created after transition to redetermination' do
-        it 'is false' do
-          travel_to(10.minutes.since) do
-            @claim.redeterminations << Redetermination.new(fees: 12.12, expenses: 35.55, disbursements: 0)
-          end
-          expect(@claim.requested_redetermination?).to be false
-        end
-      end
-    end
-
-    context 'allocated state where the previous state was not redetermination' do
-      it 'is false' do
-        claim = FactoryBot.create :allocated_claim
-        expect(claim.requested_redetermination?).to be false
-      end
-    end
-
-    context 'not allocated state' do
-      it 'is false' do
-        claim = FactoryBot.create :redetermination_claim
-        expect(claim.requested_redetermination?).to be false
-      end
-    end
-  end
-
   describe '#amount_assessed' do
     let(:external_user) { build(:external_user, vat_registered: false) }
     let!(:claim) { create(:claim, state: 'draft', external_user: external_user) }


### PR DESCRIPTION
#### What

Remove `Claim::BaseClaim#requested_redetermination?`.

#### Ticket

N/A

#### Why

This method is no longer used after #1203.

#### How

Remove the method together with its unit tests.