### PR TITLE
Migrate to sentry-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,9 @@ gem 'config',                 '~> 2.2' # this gem provides our Settings.xxx mech
 gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
 gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.git'
-gem 'sentry-raven',           '~> 2.13.0'
+gem 'sentry-rails',           '~> 4.1.7'
+gem 'sentry-sidekiq',         '~> 4.1.2' 
+gem 'simple_form',            '~> 5.1.0'
 gem 'sprockets-rails',        '~> 3.2.1'
 gem 'state_machine',          '~> 1.2.0'
 gem 'state_machines-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -655,8 +655,14 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.0)
-    sentry-raven (2.13.0)
-      faraday (>= 0.7.6, < 1.0)
+    sentry-rails (4.1.7)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.1.2)
+    sentry-ruby-core (4.1.6)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.1.3)
+      sentry-ruby-core (~> 4.1.2)
     sexp_processor (4.12.0)
     shell-spinner (1.0.4)
       colorize
@@ -867,7 +873,8 @@ DEPENDENCIES
   ruby-progressbar
   rubyzip
   scheduler_daemon!
-  sentry-raven (~> 2.13.0)
+  sentry-rails (~> 4.1.7)
+  sentry-sidekiq (~> 4.1.2)
   shell-spinner (~> 1.0, >= 1.0.4)
   shoulda-matchers (>= 4.0.0.rc1)
   sidekiq (~> 6.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
     if exception.is_a?(ActiveRecord::RecordNotFound)
       redirect_to error_404_url
     else
-      Raven.capture_exception(exception)
+      Sentry.capture_exception(exception)
       redirect_to error_500_url
     end
   end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,9 +1,0 @@
-require 'raven'
-
-if %w( production ).include?(Rails.env) && ENV['SENTRY_DSN'].present?
-  Raven.configure do |config|
-    config.dsn = ENV['SENTRY_DSN']
-    config.environments = %w( production )
-    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  end
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
+   Sentry.init do |config|
+    config.dsn = ENV['SENTRY_DSN']
+    config.breadcrumbs_logger = [:active_support_logger]
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe ApplicationController, type: :controller do
       it 'does not report the exception, and redirect to the 404 error page' do
         routes.draw { get 'record_not_found' => 'anonymous#record_not_found' }
 
-        expect(Raven).not_to receive(:capture_exception)
+        expect(Sentry).not_to receive(:capture_exception)
 
         get :record_not_found
         expect(response).to redirect_to(error_404_url)
@@ -162,7 +162,7 @@ RSpec.describe ApplicationController, type: :controller do
       it 'reports the exception, and redirect to the 500 error page' do
         routes.draw { get 'another_exception' => 'anonymous#another_exception' }
 
-        expect(Raven).to receive(:capture_exception)
+        expect(Sentry).to receive(:capture_exception)
 
         get :another_exception
         expect(response).to redirect_to(error_500_url)


### PR DESCRIPTION

#### What
Migrate sentry-raven gem to sentry-ruby gem

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1662

#### Why
Sentry-raven is now in maintenance mode and it is recommended to migrate to sentry-ruby/sentry-rails.

#### How
Updated Gemfile, config and associated spec.
