### PR TITLE
Remove DatabaseHousekeeping.report_record_counts

### DIFF
--- a/spec/support/database_housekeeping.rb
+++ b/spec/support/database_housekeeping.rb
@@ -19,11 +19,4 @@ module DatabaseHousekeeping
       end
     end
   end
-
-  def report_record_counts
-    models = ApplicationRecord.descendants
-    models.each do |model|
-      puts "#{model} count: #{model.count}"
-    end
-  end
 end


### PR DESCRIPTION
#### What

Remove the `DatabaseHousekeeping.report_record_counts` method.

#### Ticket

N/A

#### Why

It is not used anywhere. Looking at #1002, where it was created, it may never have been used.

#### Note

I think that this whole module could be deleted and replaced by the `database_cleaner` gem which we already use in other places but that is a bigger job. I have added an item to the tech debt list.