### PR TITLE
Update bundler to 2.2.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -897,4 +897,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.11


### PR DESCRIPTION
#### What

Update the version of Bundler used to 2.2.11.

#### Ticket

N/A

#### Why

This version of Bundler fixes a recently discovered dependency vulnerability. See [here](https://bundler.io/blog/2021/02/15/a-more-secure-bundler-we-fixed-our-source-priorities.html) for more details.

#### How

```bash
gem install bundler
bundle update --bundler
```