### PR TITLE
Remove unused build_claim_in_state method

### DIFF
--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -822,12 +822,6 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller do
   end
 end
 
-def build_claim_in_state(state)
-  claim = FactoryBot.build :unpersisted_claim
-  allow(claim).to receive(:state).and_return(state.to_s)
-  claim
-end
-
 def build_sortable_claims_sample(advocate)
   [:draft, :submitted, :allocated, :authorised, :rejected].each_with_index do |state, i|
     travel_to(i.days.ago) do


### PR DESCRIPTION
#### What

Remove the `build_claim_in_state` method.

#### Ticket

N/A

#### Why

Dead code. The `build_claim_in_state` method is a helper for specs but all uses of it were removed in this PR: #913