### PR TITLE
Remove simple_form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus
 gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.git'
 gem 'sentry-rails',           '~> 4.1.7'
 gem 'sentry-sidekiq',         '~> 4.1.2' 
-gem 'simple_form',            '~> 5.1.0'
 gem 'sprockets-rails',        '~> 3.2.1'
 gem 'state_machine',          '~> 1.2.0'
 gem 'state_machines-activerecord'


### PR DESCRIPTION
#### What

Remove `simple_form` from `Gemfile`.

#### Ticket

N/A

#### Why

This gem was remove (#3751) but it was re-introduced into `Gemfile` accidentally as a result of a merge conflict.