### PR TITLE
[CBO-1691] [AS2a]Add checksum to Paperclip attachments

### DIFF
--- a/app/models/concerns/check_summable.rb
+++ b/app/models/concerns/check_summable.rb
@@ -1,0 +1,34 @@
+module CheckSummable
+  def add_checksum(asset)
+    io = Paperclip.io_adapters.for(send(asset))
+    send("as_#{asset}_checksum=", calculate_checksum(io))
+  rescue Errno::ENOENT => e
+    checksum_log("File not found: #{send(asset).path}", e)
+  rescue Errno::ENAMETOOLONG => e
+    checksum_log("Filename too long: #{send(asset).path}", e)
+  rescue StandardError => e
+    checksum_log("Unexpected error: #{send(asset).path}", e)
+  end
+
+  def calculate_checksum(io)
+    return if io.nil?
+
+    checksum = Digest::MD5.new
+    while (chunk = io.read(5.megabytes))
+      checksum << chunk
+    end
+
+    io.rewind
+    checksum.base64digest
+  end
+
+  private
+
+  def checksum_log(message, error)
+    LogStuff.warn(
+      class: self.class.name,
+      action: 'add_checksum',
+      error: "#{error.class} - #{error.message}"
+    ) { message }
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -26,6 +26,7 @@
 class Document < ApplicationRecord
   include DocumentAttachment
   include Duplicable
+  include CheckSummable
 
   belongs_to :external_user
   belongs_to :creator, class_name: 'ExternalUser'
@@ -53,6 +54,7 @@ class Document < ApplicationRecord
 
   before_save :generate_pdf_tmpfile
   before_save :add_converted_preview_document
+  before_save :populate_checksum
 
   validate :documents_count
 
@@ -130,5 +132,10 @@ class Document < ApplicationRecord
     return unless errors[:document].include?('has contents that are not what they are reported to be')
     errors[:document].delete('has contents that are not what they are reported to be')
     errors[:document] << 'The contents of the file do not match the file extension'
+  end
+
+  def populate_checksum
+    add_checksum(:document)
+    add_checksum(:converted_preview_document)
   end
 end

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -13,6 +13,7 @@
 module Stats
   class StatsReport < ApplicationRecord
     include S3Headers
+    include CheckSummable
 
     TYPES = %w[management_information provisional_assessment rejections_refusals].freeze
 
@@ -54,10 +55,12 @@ module Stats
 
     def write_report(report_result)
       log(:info, :write_report, "Writing report #{report_name} to DB...")
+      io = StringIO.new(report_result.content)
       update(
-        document: StringIO.new(report_result.content),
+        document: io,
         document_file_name: "#{report_name}_#{started_at.to_s(:number)}.#{report_result.format}",
         document_content_type: report_result.content_type,
+        as_document_checksum: calculate_checksum(io),
         status: 'completed',
         completed_at: Time.now
       )

--- a/db/migrate/20210223164419_add_attachment_checksums.rb
+++ b/db/migrate/20210223164419_add_attachment_checksums.rb
@@ -1,0 +1,8 @@
+class AddAttachmentChecksums < ActiveRecord::Migration[6.0]
+  def change
+    add_column :stats_reports, :as_document_checksum, :string
+    add_column :messages, :as_attachment_checksum, :string
+    add_column :documents, :as_document_checksum, :string
+    add_column :documents, :as_converted_preview_document_checksum, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_23_161937) do
+ActiveRecord::Schema.define(version: 2021_02_23_164419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -285,6 +285,8 @@ ActiveRecord::Schema.define(version: 2020_12_23_161937) do
     t.integer "verified_file_size"
     t.string "file_path"
     t.boolean "verified", default: false
+    t.string "as_document_checksum"
+    t.string "as_converted_preview_document_checksum"
     t.index ["claim_id"], name: "index_documents_on_claim_id"
     t.index ["creator_id"], name: "index_documents_on_creator_id"
     t.index ["document_file_name"], name: "index_documents_on_document_file_name"
@@ -430,6 +432,7 @@ ActiveRecord::Schema.define(version: 2020_12_23_161937) do
     t.string "attachment_content_type"
     t.integer "attachment_file_size"
     t.datetime "attachment_updated_at"
+    t.string "as_attachment_checksum"
     t.index ["claim_id"], name: "index_messages_on_claim_id"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
@@ -587,6 +590,7 @@ ActiveRecord::Schema.define(version: 2020_12_23_161937) do
     t.string "document_content_type"
     t.integer "document_file_size"
     t.datetime "document_updated_at"
+    t.string "as_document_checksum"
   end
 
   create_table "super_admins", id: :serial, force: :cascade do |t|

--- a/spec/models/concerns/check_summable_spec.rb
+++ b/spec/models/concerns/check_summable_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'add_checksum failure cases' do
+  before { stub_const('TestClass', test_class) }
+
+  it 'does not raise an error' do
+    expect { add_checksum }.not_to raise_error
+  end
+
+  it 'logs the error' do
+    allow(LogStuff).to receive(:warn)
+    add_checksum
+    expect(LogStuff).to have_received(:warn)
+      .with(hash_including(class: 'TestClass', action: 'add_checksum'))
+  end
+end
+
+RSpec.describe CheckSummable do
+  let(:test_object) { test_class.new }
+  let(:checksum) { Digest::MD5.new.tap { |digest| digest << 'Test document' }.base64digest }
+  let(:io) { StringIO.new('Test document') }
+  let(:test_class) do
+    Class.new do
+      include CheckSummable
+
+      attr_accessor :as_document_checksum
+
+      def document
+        @document ||= OpenStruct.new(path: 'example.pdf')
+      end
+    end
+  end
+
+  describe '#calculate_checksum' do
+    subject(:calculate_checksum) { test_object.calculate_checksum(io) }
+
+    context 'with a valid io stream' do
+      it { is_expected.to eq checksum }
+
+      it 'rewinds the io stream' do
+        expect { calculate_checksum }.not_to change(io, :readline)
+      end
+    end
+
+    context 'with a nil io stream' do
+      let(:io) { nil }
+
+      it 'is nil if the input stream is nil' do
+        expect(calculate_checksum).to be_nil
+      end
+    end
+  end
+
+  describe '#add_checksum' do
+    subject(:add_checksum) { test_object.add_checksum('document') }
+
+    let(:registry) { Paperclip::AdapterRegistry.new }
+
+    before { allow(Paperclip).to receive(:io_adapters).and_return(registry) }
+
+    context 'with a good file' do
+      before do
+        allow(registry).to receive(:for).with(test_object.document).and_return(io)
+      end
+
+      it 'sets the checksum' do
+        expect { add_checksum }.to change(test_object, :as_document_checksum).to checksum
+      end
+    end
+
+    context 'with a missing file' do
+      before do
+        allow(registry).to receive(:for).with(test_object.document).and_raise(Errno::ENOENT)
+      end
+
+      include_examples 'add_checksum failure cases'
+    end
+
+    context 'with a filename too long' do
+      before do
+        allow(registry).to receive(:for).with(test_object.document).and_raise(Errno::ENAMETOOLONG)
+      end
+
+      include_examples 'add_checksum failure cases'
+    end
+
+    context 'with an unexpected error' do
+      before do
+        allow(registry).to receive(:for).with(test_object.document).and_raise(StandardError)
+      end
+
+      include_examples 'add_checksum failure cases'
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -304,4 +304,20 @@ RSpec.describe Document, type: :model do
       expect(new_document.verified_file_size).to eq(document.verified_file_size)
     end
   end
+
+  describe '#as_document_checksum' do
+    let(:document) { create(:document) }
+
+    it 'is a checksum' do
+      expect(document.as_document_checksum).to match(/==$/)
+    end
+  end
+
+  describe '#as_converted_preview_document_checksum' do
+    let(:document) { create(:document) }
+
+    it 'is a checksum' do
+      expect(document.as_converted_preview_document_checksum).to match(/==$/)
+    end
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -17,20 +17,20 @@
 require 'rails_helper'
 
 RSpec.describe Message, type: :model do
-  it { should belong_to(:claim) }
-  it { should belong_to(:sender).class_name('User').inverse_of(:messages_sent) }
-  it { should have_many(:user_message_statuses) }
+  it { is_expected.to belong_to(:claim) }
+  it { is_expected.to belong_to(:sender).class_name('User').inverse_of(:messages_sent) }
+  it { is_expected.to have_many(:user_message_statuses) }
 
-  it { should validate_presence_of(:sender).with_message('Message sender cannot be blank') }
-  it { should validate_presence_of(:claim_id).with_message('Message claim_id cannot be blank') }
-  it { should validate_presence_of(:body).with_message('Message body cannot be blank') }
+  it { is_expected.to validate_presence_of(:sender).with_message('Message sender cannot be blank') }
+  it { is_expected.to validate_presence_of(:claim_id).with_message('Message claim_id cannot be blank') }
+  it { is_expected.to validate_presence_of(:body).with_message('Message body cannot be blank') }
 
-  it { should have_attached_file(:attachment) }
+  it { is_expected.to have_attached_file(:attachment) }
 
   it_behaves_like 'an s3 bucket'
 
   it do
-    should validate_attachment_content_type(:attachment)
+    is_expected.to validate_attachment_content_type(:attachment)
       .allowing('application/pdf',
                 'application/msword',
                 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -46,7 +46,7 @@ RSpec.describe Message, type: :model do
                  'text/html')
   end
 
-  it { should validate_attachment_size(:attachment).in(0.megabytes..20.megabytes) }
+  it { is_expected.to validate_attachment_size(:attachment).in(0.megabytes..20.megabytes) }
 
   describe '.for' do
     let(:message) { create(:message) }
@@ -54,11 +54,11 @@ RSpec.describe Message, type: :model do
     let(:user) { message.sender }
 
     it 'returns the messaages for the user' do
-      expect(Message.for(user)).to eq([message])
+      expect(described_class.for(user)).to eq([message])
     end
 
     it 'returns the messaages for the claim' do
-      expect(Message.for(claim)).to eq([message])
+      expect(described_class.for(claim)).to eq([message])
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe Message, type: :model do
     let!(:third_message) { create(:message) }
 
     it 'returns the message sorted by most recent first' do
-      expect(Message.most_recent_first).to eq([third_message, second_message, first_message])
+      expect(described_class.most_recent_first).to eq([third_message, second_message, first_message])
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe Message, type: :model do
     end
   end
 
-  context 'automotic state change of claim on message creation' do
+  context 'automatic state change of claim on message creation' do
     let(:claim)     { create :part_authorised_claim }
     let(:user)      { create :user }
 
@@ -109,7 +109,7 @@ RSpec.describe Message, type: :model do
     end
   end
 
-  context 'process written reasons' do
+  describe 'process written reasons' do
     let(:claim)     { create :part_authorised_claim }
     let(:user)      { create :user }
 
@@ -125,14 +125,14 @@ RSpec.describe Message, type: :model do
     end
   end
 
-  context 'send_email_if_required' do
+  describe 'after_create :send_email_if_required' do
     let(:claim) { create :allocated_claim }
     let(:creator) { claim.creator }
     let(:case_worker) { claim.case_workers.first }
 
     it { expect(claim.state).to eq 'allocated' }
 
-    let(:message_params) { message_params = { claim_id: claim.id, sender_id: sender.user.id, body: 'lorem ipsum' } }
+    let(:message_params) { { claim_id: claim.id, sender_id: sender.user.id, body: 'lorem ipsum' } }
 
     context 'when message created by external_user' do
       let(:sender) { creator }
@@ -142,7 +142,7 @@ RSpec.describe Message, type: :model do
         creator.save
       end
 
-      context 'set up to receive mails' do
+      context 'when set up to receive mails' do
         let(:email_notification_of_message) { 'true' }
 
         it 'does not attempt to send an email' do
@@ -151,7 +151,7 @@ RSpec.describe Message, type: :model do
         end
       end
 
-      context 'NOT set up to receive mails' do
+      context 'when NOT set up to receive mails' do
         let(:email_notification_of_message) { 'false' }
 
         it 'does not attempt to send an email' do
@@ -168,7 +168,7 @@ RSpec.describe Message, type: :model do
         creator.user.email_notification_of_message = email_notification_of_message
       end
 
-      context 'claim creator is set up to receive mails' do
+      context 'when claim creator is set up to receive mails' do
         let(:email_notification_of_message) { 'true' }
 
         it 'sends an email' do
@@ -178,7 +178,7 @@ RSpec.describe Message, type: :model do
           create(:message, message_params)
         end
 
-        context 'but has been deleted' do
+        context 'when has been deleted' do
           before do
             claim.creator.soft_delete
           end
@@ -190,7 +190,7 @@ RSpec.describe Message, type: :model do
         end
       end
 
-      context 'claim creator is not set up to receive mails' do
+      context 'when claim creator is not set up to receive mails' do
         let(:email_notification_of_message) { 'false' }
 
         it 'does not attempt to send an email' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -200,4 +200,22 @@ RSpec.describe Message, type: :model do
       end
     end
   end
+
+  describe '#as_attachment_checksum' do
+    context 'with no attachment' do
+      let(:message) { create(:message) }
+
+      it 'is nil' do
+        expect(message.as_attachment_checksum).to be_nil
+      end
+    end
+
+    context 'with an attachment' do
+      let(:message) { create(:message, :with_attachment) }
+
+      it 'is a checksum' do
+        expect(message.as_attachment_checksum).to match(/==$/)
+      end
+    end
+  end
 end

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Stats::StatsReport do
     context 'when document exists' do
       let(:report) { build(:stats_report, :with_document) }
 
-      context 'and the document storage is filesystem' do
+      context 'when the document storage is filesystem' do
         let(:options) { { storage: :filesystem } }
 
         before do
@@ -152,7 +152,7 @@ RSpec.describe Stats::StatsReport do
         end
       end
 
-      context 'and the document storage is S3' do
+      context 'when the document storage is S3' do
         let(:options) { { storage: :s3 } }
 
         before do
@@ -167,7 +167,7 @@ RSpec.describe Stats::StatsReport do
     end
   end
 
-  context 'housekeeping' do
+  describe 'housekeeping' do
     describe '.destroy_reports_older_than' do
       it 'destroys all reports for named report older than specified time' do
         _my_report_old = create :stats_report, started_at: 63.days.ago


### PR DESCRIPTION
#### What

Add checksum fields for evidence documents, message attachments and stats reports.

#### Ticket

[CCCD: migrate paperclip to active storage - migration scripts](https://dsdmoj.atlassian.net/browse/CBO-1691)

#### Why

In preparation for migrating assets from Paperclip to Active Storage we are creating checksums, required by Active Storage, for all existing assets. This PR will generate these checksums for newly created assets and a later PR will create a task to retrospectively add checksums for old assets.

#### How

The `CheckSummable` mixin is added to `Message`, `Document` and `Stats::StatsReport` to create the check sum when assets are created.

This is based on #3713.