### PR TITLE
[CBO-1691] [AS2b] Paperclip to Active Storage migration tasks

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -91,6 +91,11 @@ class Document < ApplicationRecord
     generate_log_stuff(:error, 'save_fail', 'Unable to save document')
   end
 
+  def populate_checksum
+    add_checksum(:document)
+    add_checksum(:converted_preview_document)
+  end
+
   private
 
   def generate_log_stuff(type, action, message)
@@ -132,10 +137,5 @@ class Document < ApplicationRecord
     return unless errors[:document].include?('has contents that are not what they are reported to be')
     errors[:document].delete('has contents that are not what they are reported to be')
     errors[:document] << 'The contents of the file do not match the file extension'
-  end
-
-  def populate_checksum
-    add_checksum(:document)
-    add_checksum(:converted_preview_document)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -65,6 +65,10 @@ class Message < ApplicationRecord
     end
   end
 
+  def populate_checksum
+    add_checksum(:attachment)
+  end
+
   private
 
   def send_email_if_required
@@ -108,9 +112,5 @@ class Message < ApplicationRecord
 
   def claim_updater
     Claims::ExternalUserClaimUpdater.new(claim, current_user: sender)
-  end
-
-  def populate_checksum
-    add_checksum(:attachment)
   end
 end

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -90,6 +90,10 @@ module Stats
       where(report_name: report_name, status: 'started', started_at: Time.at(0)..timestamp).destroy_all
     end
 
+    def populate_checksum
+      add_checksum(:document)
+    end
+
     private
 
     def log(level, action, message, error = nil)

--- a/docs/active_storage_migration.md
+++ b/docs/active_storage_migration.md
@@ -120,10 +120,10 @@ $ bundle exec rails 'storage:rollback[stats_reports]'
 ```
 
 * To delete checksums that have been calculated prior to migration use the
-  `storage:clear_checksums` task.
-  
+  `storage:clear_paperclip_checksums` task.
+
 ```bash
-$ bundle exec rails 'storage:clear_checksums[stats_reports]'
+$ bundle exec rails 'storage:clear_paperclip_checksums[stats_reports]'
 ```
 
 ## Messages
@@ -200,10 +200,10 @@ $ bundle exec rails 'storage:rollback[messages]'
 ```
 
 * To delete checksums that have been calculated prior to migration use the
-  `storage:clear_checksums` task.
-  
+  `storage:clear_paperclip_checksums` task.
+
 ```bash
-$ bundle exec rails 'storage:clear_checksums[messages]'
+$ bundle exec rails 'storage:clear_paperclip_checksums[messages]'
 ```
 
 ## Documents
@@ -247,7 +247,7 @@ AS records
 1) Generate checksums:
 
 ```bash
-$ bundle exec rails 'storage:calculate_checksums[documents]'
+$ bundle exec rails 'storage:add_paperclip_checksums[documents]'
 ```
 
 2) Ensure that the checksums have been created correctly using the
@@ -307,10 +307,10 @@ $ bundle exec rails 'storage:rollback[documents]'
 ```
 
 * To delete checksums that have been calculated prior to migration use the
-  `storage:clear_checksums` task.
-  
+  `storage:clear_paperclip_checksums` task.
+
 ```bash
-$ bundle exec rails 'storage:clear_checksums[documents]'
+$ bundle exec rails 'storage:clear_paperclip_checksums[documents]'
 ```
 
 ## Redrafting bug

--- a/docs/active_storage_migration.md
+++ b/docs/active_storage_migration.md
@@ -1,0 +1,355 @@
+# Active Storage migration plan
+
+## Contents
+
+* [Overview](#Overview)
+* [Stats Reports](#Stats-Reports)
+* [Messages](#Messages)
+* [Documents](#Documents)
+* [Clean up](#Clean-up)
+
+## Overview
+
+These notes outline the plan for migrating CCCD assets from Paperclip to
+Active Storage. Assets exist in three different places:
+
+* Stats reports
+* Attachments on messages
+* Evidence documents
+
+and each of these is dealt with separately. The process is similar for each but
+with some small differences and can be summarised as:
+
+1) Generate checksums for all existing assets. The Checksum is required by
+   Active Storage and is time consuming to generate. However, it can be done in
+   advance of the migration to avoid disruption.
+2) Test that checksums have been created correctly.
+3) Copy information in the database about the assets from where Paperclip has
+   them to where they need to be for Active Storage.
+4) Test that document information has been copied correctly.
+5) Update the application to use Active Storage to create and access assets.
+6) Test that existing assets can be accessed and new assets can be created.
+
+The current status of the storage migration can be seen using the
+`storage:status` task:
+
+```bash
+$ bundle exec rails storage:status
+Stats Reports
+=============
+Total records:      58
+Total unique files: 42
+Missing checksums:  58
+AS records:         0
+AS records checked: OK
+(etc)
+```
+
+## Stats Reports
+
+The 'Stats Reports' section of the `storage:status` task output contains:
+
+```bash
+Total records:      58  <-- Total number of stats reports records. Each record
+                            includes a Paperclip attachment, although some
+                            files are attached to multiple records.
+Total unique files: 42  <-- Total number excluding duplicate Paperclip
+                            attachments.
+Missing checksums:  58  <-- Number of records without a checksum. On completion
+                            this should be zero.
+AS records:         0   <-- Number of Active Storage attachments for stats
+                            reports. On completion this should be the same as
+                            the total number of stats reports records excluding
+                            duplicates.
+AS records checked: OK  <-- Check that each Active Storage record is linked to
+                            the same file and has the same checksum as the
+                            corresponding Paperclip attachment.
+```
+
+1) Generate checksums:
+
+```bash
+$ bundle exec rails 'storage:add_paperclip_checksums[stats_reports]'
+```
+
+2) Ensure that the checksums have been created correctly using the
+`storage:status` task (see above). The `Missing checksum` count should be zero.
+
+3) Migrate assets details from Paperclip to Active Storage:
+
+```bash
+$ bundle exec rails 'storage:migrate[stats_reports]'
+```
+
+4) Confirm that all records have been migrated using the `storage:status` task
+(see above). The `AS records` count should be the same as the `Total unique
+files` count and `AS records checked` should be `OK`.
+
+5) Test that a sample document can be downloaded via Active Storage (this will only work when S3 is used for storage):
+
+```ruby
+# Get a download url for a sample document
+rails> ActiveStorage::Attachment.where(record_type: 'Stats::StatsReport').sample.service_url
+# => "https://cloud-platform-..."
+# Paste this url into a browser and confirm that it can be downloaded
+# Note that this url will expire in 5 minutes
+```
+
+6) (Final step) Activate Active Storage for stats reports by deploying PR #3722 (CBO-1683)
+
+### Testing
+
+1) After the final step above has been completed the first test is to download
+   the reports at `case_workers/admin/management_information` without
+   regenerating.
+2) Next, regenerate the report and download again. Confirm that the new
+   document is different from the previous.
+
+### Rollback
+
+**Note:** This rollback should not be attempted after
+[CBO-1683](https://dsdmoj.atlassian.net/browse/CBO-1683) has been completed
+as this will delete assets from Active Storage that do not exist in Paperclip.
+
+* To roll back the migration of assets from Paperclip to Active Storage use the
+  `storage:rollback` task. This will delete records from the
+  `active_storage_attachments` and `active_storage_blobs` tables.
+
+```bash
+$ bundle exec rails 'storage:rollback[stats_reports]'
+```
+
+* To delete checksums that have been calculated prior to migration use the
+  `storage:clear_checksums` task.
+  
+```bash
+$ bundle exec rails 'storage:clear_checksums[stats_reports]'
+```
+
+## Messages
+
+The 'Messages' section of the `storage:status` task output contains:
+
+```bash
+Total records:      117587  <-- Total number of messages records. Each message
+                                record has an optional Paperclip attachment.
+Total attachments:  20715   <-- Total number of message records that have a
+                                Paperclip attachment.
+Missing checksums:  20715   <-- Number of records with Paperclip attachments
+                                without a checksum. On completion this should
+                                be zero.
+AS records:         0       <-- Number of Active Storage attachments for
+                                messages. On completion this should be the same
+                                as the total number of Paperclip attachments.
+AS records checked: OK      <-- Check that each Active Storage record for
+                                messages is linked to the same for and has the
+                                same checksum as the corresponding Paperclip
+                                attachment.
+```
+
+1) Generate checksums:
+
+```bash
+$ bundle exec rails 'storage:add_paperclip_checksums[messages]'
+```
+
+2) Ensure that the checksums have been created correctly using the
+`storage:status` task (see above). The `Missing checksum` count should be zero.
+
+3) Migrate assets details from Paperclip to Active Storage:
+
+```bash
+$ bundle exec rails 'storage:migrate[messages]'
+```
+
+4) Confirm that all records have been migrated using the `storage:status` task
+(see above). The `AS records` count should be the same as the `Total
+attachments` count and `AS records checked` should be `OK`.
+
+5) Test that a sample message attachment can be downloaded via Active Storage (this will only work when S3 is used for storage):
+
+```ruby
+# Get a download url for a sample attachment
+rails> ActiveStorage::Attachment.where(record_type: 'Message').sample.service_url
+# => "https://cloud-platform-..."
+# Paste this url into a browser and confirm that it can be downloaded
+# Note that this url will expire in 5 minutes
+```
+
+6) (Final step) Activate Active Storage for stats reports by deploying PR #3735 (CBO-1692)
+
+### Testing
+
+1) Find an existing case with a message attachment. Confirm that the attachment
+   can be downloaded correctly.
+2) Add a new message to a case and add an attachment. Confirm that the
+   attachment can be downloaded correctly.
+
+### Rollback
+
+**Note:** This rollback should not be attempted after
+[CBO-1692](https://dsdmoj.atlassian.net/browse/CBO-1692) has been completed
+as this will delete assets from Active Storage that do not exist in Paperclip.
+
+* To roll back the migration of assets from Paperclip to Active Storage use the
+  `storage:rollback` task. This will delete records from the
+  `active_storage_attachments` and `active_storage_blobs` tables.
+
+```bash
+$ bundle exec rails 'storage:rollback[messages]'
+```
+
+* To delete checksums that have been calculated prior to migration use the
+  `storage:clear_checksums` task.
+  
+```bash
+$ bundle exec rails 'storage:clear_checksums[messages]'
+```
+
+## Documents
+
+
+The 'Documents' section of the `storage:status` task output contains:
+
+```
+Total records:      204432 <-- Total number of document records. Each document
+                               includes two Paperclip attachments, for the
+                               original document and the converted preview. If
+                               the original document is a PDF then both
+                               Paperclip attachments will link to the same
+                               file.
+Missing checksums
+  Document:         204432 <-- Number of document records for which the
+                               checksum for the original document is missing.
+                               On completion this should be zero.
+  Preview:          204432 <-- Number of document records for which the
+                               checksum for the converted preview is missing.
+                               On completion this should be zero.
+AS records
+  Document:         0      <-- Number of Active Storage attachments for the
+                               original documents. On completion this should be
+                               the same as the total number of document
+                               records.
+  Document checked: OK     <-- Check that each Active Storage record for the
+                               original documents is linked to the same file
+                               and has the same checksum as the corresponding
+                               Paperclip attachment.
+  Preview:          0      <-- Number of Active Storage attachments for the
+                               converted previews. On completion this should be
+                               the same as the total number of document
+                               records.
+  Preview checked:  OK     <-- Check that each Active Storage record for the
+                               converted previews is linked to the same file
+                               and has the same checksum as the corresponding
+                               Paperclip attachment.
+```
+
+1) Generate checksums:
+
+```bash
+$ bundle exec rails 'storage:calculate_checksums[documents]'
+```
+
+2) Ensure that the checksums have been created correctly using the
+`storage:status` task (see above). The `Missing checksum` count for both
+document and preview should be zero.
+
+3) Migrate assets details from Paperclip to Active Storage:
+
+```bash
+$ bundle exec rails 'storage:migrate[documents]'
+```
+
+4) Confirm that all records have been migrated using the `storage:status` task
+(see above). The `AS records` count should be the same as the `Total records`
+count for `Document` and `Preview`, and `Document checked` and `Preview
+checked` should both be `OK`.
+
+5) Test that a sample document can be downloaded via Active Storage (this will only work when S3 is used for storage):
+
+```ruby
+# Get a download url for a sample document
+rails> ActiveStorage::Attachment.where(record_type: 'Document', name: 'document').sample.service_url
+# => "https://cloud-platform-..."
+# Paste this url into a browser and confirm that it can be downloaded
+
+# Get a download preview url for a sample document
+rails> ActiveStorage::Attachment.where(record_type: 'Document', name: 'converted_preview_document').sample.service_url(disposition: 'inline')
+# => "https://cloud-platform-..."
+# Paste this url into a browser and confirm that it can be previewed in the browser
+
+# Note that these url will expire in 5 minutes
+```
+
+6) (Final step) Activate Active Storage for documents by deploying PR #3739 (CBO-1693)
+
+### Testing
+
+1) Find an case with a message attachment. Confirm that evidence documents can
+   be downloaded and viewed in browser.
+2) As a caseworker, confirm that all documents can be downloaded as a zip file.
+   can be downloaded correctly.
+3) Add a new case and confirm that documents can be accessed as in steps (1)
+   and (2)
+
+### Rollback
+
+**Note:** This rollback should not be attempted after
+[CBO-1693](https://dsdmoj.atlassian.net/browse/CBO-1693) has been completed
+as this will delete assets from Active Storage that do not exist in Paperclip.
+
+* To roll back the migration of assets from Paperclip to Active Storage use the
+  `storage:rollback` task. This will delete records from the
+  `active_storage_attachments` and `active_storage_blobs` tables.
+
+```bash
+$ bundle exec rails 'storage:rollback[documents]'
+```
+
+* To delete checksums that have been calculated prior to migration use the
+  `storage:clear_checksums` task.
+  
+```bash
+$ bundle exec rails 'storage:clear_checksums[documents]'
+```
+
+## Redrafting bug
+
+There is a bug with the redrafting of claims that may be related to how
+documents are stored in Paperclip. See
+[CBO-1233,](https://dsdmoj.atlassian.net/browse/CBO-1233)
+[CBO-1393](https://dsdmoj.atlassian.net/browse/CBO-1393) and
+[CBO-1679.](https://dsdmoj.atlassian.net/browse/CBO-1569) After the Active
+Storage migration is complete this last ticket needs to be reviewed to see if
+the issue has been resolved. This can be done by checking for redraft failures
+due to timeouts in Kibana logs, for example.
+
+## Clean up
+
+After the migration to Active Storage has been completed successfully
+Paperclip can be removed.
+
+* Remove the `paperclip` gem from `Gemfile`
+* Delete `lib/tasks/storage.rake` and `lib/tasks/rake_helpers/storage.rb`
+* Delete `app/models/concerns/check_summable.rb` together with all instances
+  `include CheckSummable`, `add_checksum` and `calculate_checksum`
+* Remove `PAPERCLIP_STORAGE_OPTIONS`, `REPORTS_STORAGE_OPTIONS` and
+  `REPORTS_STORAGE_OPTIONS` from the configuration files in
+  `config/environments`.
+* **Note:** This step is destructive and cannot be reverted.
+  Remove Paperclip related fields from the database:
+  * In `stats_reports`; `document_file_name`, `document_content_type`,
+    `document_file_size`, `document_updated_at`, `as_document_checksum`
+  * In `messages`; `attachment_file_name`, `attachment_content_type`,
+    `attachment_file_size`, `attachment_updated_at`, `as_attachment_checksum`
+  * In `documents`; `document_file_name`, `document_content_type`
+    `document_file_size`, `document_updated_at`,
+    `converted_preview_document_file_name`,
+    `converted_preview_document_content_type`
+    `converted_preview_document_file_size`,
+    `converted_preview_document_updated_at`,
+    `as_document_checksum`, `as_converted_preview_document_checksum`
+ * Remove unneeded (?!check) `documents.file_path` attribute. This was added as a part
+   of upload "verification" and should probably have been called `verified_file_path`.
+   It holds the full s3 path. It is, nonetheless, unclear why
+   it is needed at all.

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -36,7 +36,7 @@ namespace :db do
 
       shell_working "importing static data dump file #{dump_file}" do
         system (with_config do |_db_name, connection_opts|
-          "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -f #{dump_file} >/dev/null"
+          "PGPASSWORD=#{ActiveRecord::Base.connection_config[:password]} psql -q -P pager=off #{connection_opts} -f #{dump_file} >/dev/null"
         end)
       end
     end
@@ -78,7 +78,7 @@ namespace :db do
 
     shell_working "anonymising data in place" do
       system (with_config do |_db_name, connection_opts|
-        "PGPASSWORD=$DB_PASSWORD psql -v translation=\\'#{translation}\\' #{connection_opts} -f #{Rails.root}/db/data/anonymise_db.sql"
+        "PGPASSWORD=#{ActiveRecord::Base.connection_config[:password]} psql -v translation=\\'#{translation}\\' #{connection_opts} -f #{Rails.root}/db/data/anonymise_db.sql"
       end)
     end
   end
@@ -116,16 +116,16 @@ namespace :db do
 
     shell_working 'recreating schema' do
       system (with_config do |_db_name, connection_opts|
-          "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -c \"drop schema public cascade\""
+          "PGPASSWORD=#{ActiveRecord::Base.connection_config[:password]} psql -q -P pager=off #{connection_opts} -c \"drop schema public cascade\""
         end)
       system (with_config do |_db_name, connection_opts|
-        "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -c \"create schema public\""
+        "PGPASSWORD=#{ActiveRecord::Base.connection_config[:password]} psql -q -P pager=off #{connection_opts} -c \"create schema public\""
       end)
     end
 
     shell_working "importing dump file #{dump_file}" do
       system (with_config do |_db_name, connection_opts|
-        "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -f #{dump_file} > /dev/null"
+        "PGPASSWORD=#{ActiveRecord::Base.connection_config[:password]} psql -q -P pager=off #{connection_opts} -f #{dump_file} > /dev/null"
       end)
     end
   end

--- a/lib/tasks/rake_helpers/rake_utils.rb
+++ b/lib/tasks/rake_helpers/rake_utils.rb
@@ -22,7 +22,7 @@ module RakeUtils
 
   def decompress_file(filename)
     shell_working "decompressing file #{filename}" do
-      system "gunzip -3 -f #{filename}"
+      system "gunzip #{filename}"
     end
   end
 

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -1,0 +1,221 @@
+module Storage
+  ATTACHMENTS = {
+    'stats_reports' => ['document'],
+    'messages' => ['attachment'],
+    'documents' => ['document', 'converted_preview_document']
+  }.freeze
+
+  def self.migrate(model)
+    connection = ActiveRecord::Base.connection.raw_connection
+    ATTACHMENTS[model].each do |name|
+      # Insert reference information for attachments into ActiveStorage::Blob
+      # Set the asset key correctly in ActiveStorage::Blob
+      key = self.s3_path_pattern(model).split('/')
+        .map do |part|
+          case part
+          when ':id_partition'
+            "TO_CHAR(id, 'fm000/000/000/')"
+          when ':filename'
+            "#{name}_file_name"
+          else
+            "'#{part}/'"
+          end
+        end.join(', ')
+
+      connection.prepare("create_active_storage_blobs_#{name}", <<~SQL)
+        INSERT INTO active_storage_blobs (key, filename, content_type, metadata, byte_size, checksum, created_at)
+          SELECT CONCAT(#{key}),
+                 #{name}_file_name,
+                 #{name}_content_type,
+                 CONCAT('in-progress/', CAST(id AS CHARACTER VARYING)),
+                 #{name}_file_size,
+                 as_#{name}_checksum,
+                 #{name}_updated_at
+            FROM #{model}
+            WHERE #{name}_file_name IS NOT NULL
+              AND id NOT IN (
+                SELECT DISTINCT record_id FROM active_storage_attachments
+                  WHERE record_type = '#{self.models(model)}'
+                    AND name = '#{name}'
+              )
+          #{self.conflict_clause_for(model)};
+      SQL
+
+      # Link ActiveStorage::Blob objects to the correct records with ActiveStorage::Attachment
+      connection.prepare("create_active_storage_attachments_#{name}", <<~SQL)
+        INSERT INTO active_storage_attachments (name, record_type, record_id, blob_id, created_at)
+          SELECT '#{name}',
+                 '#{self.models(model)}',
+                 CAST(SPLIT_PART(metadata, '/', 2) AS INTEGER),
+                 id,
+                 created_at
+          FROM active_storage_blobs
+          WHERE metadata LIKE 'in-progress/%';
+      SQL
+
+      connection.prepare("update_active_storage_blobs_metadata_#{name}", <<~SQL)
+        UPDATE active_storage_blobs SET metadata='{}' WHERE metadata LIKE 'in-progress/%';
+      SQL
+
+      puts "Creating Active Storage Blobs for #{name}"
+      connection.exec_prepared("create_active_storage_blobs_#{name}");
+      puts "Creating Active Storage Attachments for #{name}"
+      connection.exec_prepared("create_active_storage_attachments_#{name}");
+      puts "Updating Active Storage blobs metadata for #{name}"
+      connection.exec_prepared("update_active_storage_blobs_metadata_#{name}");
+    end
+  end
+
+  def self.rollback(model)
+    connection = ActiveRecord::Base.connection.raw_connection
+    ATTACHMENTS[model].each do |name|
+      # Delete active storage attachments for the model
+      connection.prepare("delete_active_storage_attachments_#{name}", <<~SQL)
+        DELETE FROM active_storage_attachments WHERE record_type='#{self.models(model)}' AND name='#{name}'
+      SQL
+
+      connection.exec_prepared("delete_active_storage_attachments_#{name}");
+    end
+
+    # Delete blobs no longer linked to an attachment
+    connection.prepare("delete_active_storage_blobs", <<~SQL)
+      DELETE FROM active_storage_blobs
+        WHERE id NOT IN (SELECT blob_id FROM active_storage_attachments)
+    SQL
+    connection.exec_prepared("delete_active_storage_blobs");
+  end
+
+  def self.clear_checksums(model)
+    connection = ActiveRecord::Base.connection.raw_connection
+    ATTACHMENTS[model].each do |name|
+      # Clear checksums
+      connection.prepare("clear_checksums_#{name}", <<~SQL)
+        UPDATE #{model} SET as_#{name}_checksum=NULL
+      SQL
+
+      connection.exec_prepared("clear_checksums_#{name}");
+    end
+  end
+
+  def self.make_dummy_files_for(model)
+    if self.models(model).nil?
+      puts "Cannot create dummy files for: #{model}"
+      exit
+    end
+
+    ATTACHMENTS[model].each do |name|
+      records = self.models(model).where.not("#{name}_file_name" => nil)
+
+      bar = self.progress_bar title: name, total: records.count
+
+      records.each do |record|
+        bar.increment
+        filename = File.absolute_path(record.send(name).path)
+        FileUtils.mkdir_p File.dirname(filename)
+        File.open(filename, 'wb') { |file| file.write(SecureRandom.random_bytes(record.send("#{name}_file_size"))) }
+      end
+    end
+  end
+
+  def self.set_checksums(records:, model:)
+    bar = self.progress_bar title: ATTACHMENTS[model].join(', '), total: records.count
+
+    records.each do |record|
+      bar.increment
+      record.populate_checksum
+      record.save
+    end
+  end
+
+  def self.progress_bar(title:, total:)
+    ProgressBar.create(
+      title: title,
+      format: "%a [%e] %b\u{15E7}%i %c/%C",
+      progress_mark: '#'.green,
+      remainder_mark: "\u{FF65}".yellow,
+      starting_at: 0,
+      total: total
+    )
+  end
+
+  def self.status(model)
+    checksum_formats = { good: [0], bad: (1..) }
+
+    puts model.titlecase
+    puts "="*model.length
+
+    all = self.models(model).all
+    puts "Total records:      #{all.count.to_s.green}"
+
+    case model
+    when 'stats_reports'
+      sr_unique = all.distinct.count(:document_file_name)
+      puts "Total unique files: #{sr_unique.to_s.green}"
+      puts "Missing checksums:  #{self.highlight(all.where(as_document_checksum: nil).count, **checksum_formats)}"
+      as = ActiveStorage::Attachment.where(record_type: 'Stats::StatsReport')
+      puts "AS records:         #{self.highlight(as.count, bad: (0..sr_unique-1), good: [sr_unique], warning: (sr_unique+1..))}"
+      puts "AS records checked: #{self.validate(attachments: as)}"
+    when 'messages'
+      ms_attachments = all.where.not(attachment_file_name: nil)
+      ms_attachments_count = ms_attachments.count
+      puts "Total attachments:  #{ms_attachments_count.to_s.green}"
+      puts "Missing checksums:  #{self.highlight(ms_attachments.where(as_attachment_checksum: nil).count, **checksum_formats)}"
+      as = ActiveStorage::Attachment.where(record_type: 'Message')
+      puts "AS records:         #{self.highlight(as.count, bad: (0..ms_attachments_count-1), good: [ms_attachments_count], warning: (ms_attachments_count+1..))}"
+      puts "AS records checked: #{self.validate(attachments: as)}"
+    when 'documents'
+      ds_count = all.count
+      migrated_formats = { bad: (0..ds_count-1), good: [ds_count], warning: (ds_count+1..) }
+      puts 'Missing checksums'
+      puts "  Document:         #{self.highlight(all.where(as_document_checksum: nil).count, **checksum_formats)}"
+      puts "  Preview:          #{self.highlight(all.where(as_converted_preview_document_checksum: nil).count, **checksum_formats)}"
+      as_doc = ActiveStorage::Attachment.where(record_type: 'Document', name: 'document')
+      as_preview = ActiveStorage::Attachment.where(record_type: 'Document', name: 'converted_preview_document')
+      puts 'AS records'
+      puts "  Document:         #{self.highlight(as_doc.count, **migrated_formats)}"
+      puts "  Document checked: #{self.validate(attachments: as_doc)}"
+      puts "  Preview:          #{self.highlight(as_preview.count, **migrated_formats)}"
+      puts "  Preview checked:  #{self.validate(attachments: as_preview)}"
+    end
+  end
+
+  private
+
+  def self.models(model)
+    {
+      'stats_reports' => Stats::StatsReport,
+      'messages' => Message,
+      'documents' => Document
+    }[model]
+  end
+
+  def self.s3_path_pattern(model)
+    {
+      'stats_reports' => REPORTS_STORAGE_OPTIONS[:path],
+      'messages' => PAPERCLIP_STORAGE_OPTIONS[:path],
+      'documents' => PAPERCLIP_STORAGE_OPTIONS[:path]
+    }[model]
+  end
+
+  def self.conflict_clause_for(model)
+    return 'ON CONFLICT (key) DO UPDATE SET metadata=EXCLUDED.metadata' if model == 'documents'
+
+    'ON CONFLICT DO NOTHING'
+  end
+
+  def self.highlight(n, good: nil, warning: nil, bad: nil)
+    return n.to_s.green if good&.include? n
+    return n.to_s.yellow if warning&.include? n
+    return n.to_s.red if bad&.include? n
+
+    n.to_s
+  end
+
+  def self.validate(attachments:)
+    attachments.each_with_object(true) do |attachment, check|
+      check &&
+        attachment.blob.filename == attachment.record.send("#{attachment.name}_file_name") &&
+        attachment.blob.checksum == attachment.record.send("as_#{attachment.name}_checksum")
+    end ? 'OK'.green : 'Failed'.red
+  end
+end

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -91,9 +91,11 @@ module Storage
       # Clear checksums
       connection.prepare("clear_paperclip_checksums_#{name}", <<~SQL)
         UPDATE #{model} SET as_#{name}_checksum=NULL
+        WHERE as_#{name}_checksum IS NOT NULL
       SQL
 
-      connection.exec_prepared("clear_paperclip_checksums_#{name}");
+      result = connection.exec_prepared("clear_paperclip_checksums_#{name}")
+      puts "Updated #{result.cmd_tuples.to_s.green} rows"
     end
   end
 

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -119,8 +119,8 @@ module Storage
     end
   end
 
-  def self.set_paperclip_checksums(relation:, model:)
-    bar = self.progress_bar title: ATTACHMENTS[model].join(', '), total: relation.count
+  def self.set_paperclip_checksums(relation:)
+    bar = self.progress_bar title: relation.table_name, total: relation.count
 
     relation.each do |record|
       bar.increment

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -85,19 +85,19 @@ module Storage
     connection.exec_prepared("delete_active_storage_blobs");
   end
 
-  def self.clear_checksums(model)
+  def self.clear_paperclip_checksums(model)
     connection = ActiveRecord::Base.connection.raw_connection
     ATTACHMENTS[model].each do |name|
       # Clear checksums
-      connection.prepare("clear_checksums_#{name}", <<~SQL)
+      connection.prepare("clear_paperclip_checksums_#{name}", <<~SQL)
         UPDATE #{model} SET as_#{name}_checksum=NULL
       SQL
 
-      connection.exec_prepared("clear_checksums_#{name}");
+      connection.exec_prepared("clear_paperclip_checksums_#{name}");
     end
   end
 
-  def self.make_dummy_files_for(model)
+  def self.create_dummy_paperclip_files_for(model)
     if self.models(model).nil?
       puts "Cannot create dummy files for: #{model}"
       exit
@@ -117,10 +117,10 @@ module Storage
     end
   end
 
-  def self.set_checksums(records:, model:)
-    bar = self.progress_bar title: ATTACHMENTS[model].join(', '), total: records.count
+  def self.set_paperclip_checksums(relation:, model:)
+    bar = self.progress_bar title: ATTACHMENTS[model].join(', '), total: relation.count
 
-    records.each do |record|
+    relation.each do |record|
       bar.increment
       record.populate_checksum
       record.save

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -20,8 +20,8 @@ namespace :storage do
   end
 
   desc 'Add file checksums to paperclip columns'
-  task :add_paperclip_checksums, [:model] => :environment do |_task, args|
-    continue?("Set paperclip checksums for all records of #{args[:model]}?")
+  task :add_paperclip_checksums, [:model, :count] => :environment do |_task, args|
+    continue?("Set #{args[:count] || 'all'} paperclip checksums for all records of #{args[:model]}?")
 
     module TempStats
       class StatsReport < ApplicationRecord
@@ -74,6 +74,7 @@ namespace :storage do
       puts "Cannot calculate checksums for: #{args[:model]}"
       exit
     end
+    relation = relation.limit(args[:count]) if args[:count]
 
     puts "Setting checksums for #{relation.table_name.green}"
     Storage.set_paperclip_checksums(relation: relation)

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -75,8 +75,8 @@ namespace :storage do
       exit
     end
 
-    puts "Setting checksums for #{args[:model].green}"
-    Storage.set_paperclip_checksums(relation: relation, model: args[:model])
+    puts "Setting checksums for #{relation.table_name.green}"
+    Storage.set_paperclip_checksums(relation: relation)
   end
 
   desc 'Clear temporary paperclip checksums for specified model'

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -21,6 +21,8 @@ namespace :storage do
 
   desc 'Add file checksums to paperclip columns'
   task :add_paperclip_checksums, [:model] => :environment do |_task, args|
+    continue?("Set paperclip checksums for all records of #{args[:model]}?")
+
     module TempStats
       class StatsReport < ApplicationRecord
         include S3Headers
@@ -79,6 +81,7 @@ namespace :storage do
 
   desc 'Clear temporary paperclip checksums for specified model'
   task :clear_paperclip_checksums, [:model] => :environment do |_task, args|
+    continue?("Clear paperclip checksums for all records of #{args[:model]}?")
     Storage.clear_paperclip_checksums args[:model]
   end
 

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -1,0 +1,93 @@
+require 'tasks/rake_helpers/storage.rb'
+
+namespace :storage do
+  desc 'Migrate assets from Paperclip to Active Storage'
+  task :migrate, [:model] => :environment do |_task, args|
+    Storage.migrate args[:model]
+  end
+
+  desc 'Rollback asset migration'
+  task :rollback, [:model] => :environment do |_task, args|
+    Storage.rollback args[:model]
+  end
+
+  desc 'Create dummy assets files'
+  task :dummy_files, [:model] => :environment do |_task, args|
+    production_protected
+
+    Storage.make_dummy_files_for args[:model]
+  end
+
+  desc 'Calculate checksums'
+  task :calculate_checksums, [:model] => :environment do |_task, args|
+    module TempStats
+      class StatsReport < ApplicationRecord
+        include S3Headers
+        include CheckSummable
+
+        self.table_name = 'stats_reports'
+        has_attached_file :document, s3_headers.merge(REPORTS_STORAGE_OPTIONS)
+
+        def populate_checksum
+          add_checksum(:document) unless document_file_name.nil?
+        end
+      end
+    end
+
+    class TempMessage < ApplicationRecord
+      include S3Headers
+      include CheckSummable
+
+      self.table_name = 'messages'
+      has_attached_file :attachment, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+
+      def populate_checksum
+        add_checksum(:attachment) unless attachment_file_name.nil?
+      end
+    end
+
+    class TempDocument < ApplicationRecord
+      include S3Headers
+      include CheckSummable
+
+      self.table_name = 'documents'
+      has_attached_file :converted_preview_document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+      has_attached_file :document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+
+      def populate_checksum
+        add_checksum(:document) unless document_file_name.nil?
+        add_checksum(:converted_preview_document) unless converted_preview_document.nil?
+      end
+    end
+
+    case args[:model]
+    when 'stats_reports'
+      records = TempStats::StatsReport.where.not(document_file_name: nil).where(as_document_checksum: nil)
+    when 'messages'
+      records = TempMessage.where.not(attachment_file_name: nil).where(as_attachment_checksum: nil)
+    when 'documents'
+      records = TempDocument.where(as_document_checksum: nil)
+    else
+      puts "Cannot calculate checksums for: #{args[:model]}"
+      exit
+    end
+
+    puts "Setting checksums for #{args[:model].green}"
+    Storage.set_checksums(records: records, model: args[:model])
+  end
+
+  desc 'Clear temporary checksums'
+  task :clear_checksums, [:model] => :environment do |_task, args|
+    Storage.clear_checksums args[:model]
+  end
+
+  desc 'Show status of storage migration'
+  task status: :environment do
+
+    Storage.status('stats_reports')
+    puts
+    Storage.status('messages')
+    puts
+    Storage.status('documents')
+  end
+end


### PR DESCRIPTION
#### What

Documentation for the Paperclip to Active Storage migration plan.

Add tasks for:

* Creating checksums for all Paperclip assets in preparation for migration
* Migrate Paperclip assets database fields to Active Storage fields

Also tasks for:

* Creating dummy files for testing
* Rollback migration and checksum calculation

#### Ticket

[CCCD: migrate paperclip to active storage - migration scripts](https://dsdmoj.atlassian.net/browse/CBO-1691)

#### Why

Before switching over the Document, Message and Stats::StatsReport models to use Active Storage we need to copy over details of existing assets so that they can still be accessed.

#### How

Full details are given in the [migration plan.](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/0b814a812be9b684dc798e50d424d9a63d2d552d/docs/active_storage_migration.md)

The Rake tasks that are created are:

* `rails 'storage:add_paperclip_checksums[model]'`: Calculate checksums for assets where it is missing
* `rails 'storage:migrate[model]'`: Migrate assets from Paperclip to Active Storage
* `rails 'storage:rollback[model]'`: Rollback asset migration. Note that this will remove Active Storage details and clear checksums for all assets. **Note:** this includes assets created directly in Active Storage, after the relevant model has been updated
* `rails 'storage:clear_paperclip_checksums[model]'`: Clear checksums created by `storage:calculate_checksums`
* `rails 'storage:create_dummy_paperclip_files[model]'`: Create dummy assets files (for testing)
* `rails storage:status`: Display the current status of migration

In each case `model` should be one of; `stats_reports`, `messages` or `documents`. 