### PR TITLE
Some naming and tidying

### DIFF
--- a/docs/active_storage_migration.md
+++ b/docs/active_storage_migration.md
@@ -349,3 +349,7 @@ Paperclip can be removed.
     `converted_preview_document_file_size`,
     `converted_preview_document_updated_at`,
     `as_document_checksum`, `as_converted_preview_document_checksum`
+ * Remove unneeded (?!check) `documents.file_path` attribute. This was added as a part
+   of upload "verification" and should probably have been called `verified_file_path`.
+   It holds the full s3 path. It is, nonetheless, unclear why
+   it is needed at all.

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -116,10 +116,10 @@ namespace :db do
 
     shell_working 'recreating schema' do
       system (with_config do |_db_name, connection_opts|
-          "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -c \"drop schema public cascade\""
+          "PGPASSWORD=#{ActiveRecord::Base.connection_config[:password]} psql -q -P pager=off #{connection_opts} -c \"drop schema public cascade\""
         end)
       system (with_config do |_db_name, connection_opts|
-        "PGPASSWORD=$DB_PASSWORD psql -q -P pager=off #{connection_opts} -c \"create schema public\""
+        "PGPASSWORD=#{ActiveRecord::Base.connection_config[:password]} psql -q -P pager=off #{connection_opts} -c \"create schema public\""
       end)
     end
 

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -119,8 +119,8 @@ module Storage
     end
   end
 
-  def self.set_paperclip_checksums(relation:, model:)
-    bar = self.progress_bar title: ATTACHMENTS[model].join(', '), total: relation.count
+  def self.set_paperclip_checksums(relation:)
+    bar = self.progress_bar title: relation.table_name, total: relation.count
 
     relation.each do |record|
       bar.increment

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -119,10 +119,10 @@ module Storage
     end
   end
 
-  def self.set_paperclip_checksums(records:, model:)
-    bar = self.progress_bar title: ATTACHMENTS[model].join(', '), total: records.count
+  def self.set_paperclip_checksums(relation:, model:)
+    bar = self.progress_bar title: ATTACHMENTS[model].join(', '), total: relation.count
 
-    records.each do |record|
+    relation.each do |record|
       bar.increment
       record.populate_checksum
       record.save

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -75,8 +75,8 @@ namespace :storage do
       exit
     end
 
-    puts "Setting checksums for #{args[:model].green}"
-    Storage.set_paperclip_checksums(relation: relation, model: args[:model])
+    puts "Setting checksums for #{relation.table_name.green}"
+    Storage.set_paperclip_checksums(relation: relation)
   end
 
   desc 'Clear temporary paperclip checksums for specified model'

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -65,18 +65,18 @@ namespace :storage do
 
     case args[:model]
     when 'stats_reports'
-      records = TempStats::StatsReport.where.not(document_file_name: nil).where(as_document_checksum: nil)
+      relation = TempStats::StatsReport.where.not(document_file_name: nil).where(as_document_checksum: nil)
     when 'messages'
-      records = TempMessage.where.not(attachment_file_name: nil).where(as_attachment_checksum: nil)
+      relation = TempMessage.where.not(attachment_file_name: nil).where(as_attachment_checksum: nil)
     when 'documents'
-      records = TempDocument.where(as_document_checksum: nil)
+      relation = TempDocument.where(as_document_checksum: nil)
     else
       puts "Cannot calculate checksums for: #{args[:model]}"
       exit
     end
 
     puts "Setting checksums for #{args[:model].green}"
-    Storage.set_paperclip_checksums(records: records, model: args[:model])
+    Storage.set_paperclip_checksums(relation: relation, model: args[:model])
   end
 
   desc 'Clear temporary paperclip checksums for specified model'


### PR DESCRIPTION
The object being passed is an AR relation
so rename parameter to reflect this. And
derive table name from relation rather pass
extraneous argument.