### PR TITLE
Use decompression options available on hosted env

### DIFF
--- a/lib/tasks/rake_helpers/rake_utils.rb
+++ b/lib/tasks/rake_helpers/rake_utils.rb
@@ -22,7 +22,7 @@ module RakeUtils
 
   def decompress_file(filename)
     shell_working "decompressing file #{filename}" do
-      system "gunzip -3 -f #{filename}"
+      system "gunzip #{filename}"
     end
   end
 


### PR DESCRIPTION
Was getting this error trying to restore on
a hosted env (alpine image):
```
gunzip: unrecognized option: -3
BusyBox v1.30.1 (2019-10-26 11:23:07 UTC) multi-call binary.

Usage: gunzip [-cfkt] [FILE]...

Decompress FILEs (or stdin)

  -c  Write to stdout
  -f  Force
  -k  Keep input files
  -t  Test file integrity
```