### PR TITLE
[CBO-1683] [AS3a] Use Active Storage for stats reports

### DIFF
--- a/app/models/stats/result.rb
+++ b/app/models/stats/result.rb
@@ -8,10 +8,14 @@ module Stats
     end
 
     def content_type
-      {
+      @content_type ||= {
         csv: 'text/csv',
         json: 'application/json'
       }[format.to_sym]
+    end
+
+    def io
+      @io ||= StringIO.new(content)
     end
   end
 end

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -64,6 +64,7 @@ module Stats
         document_file_name: filename,
         document_file_size: document.byte_size,
         document_content_type: report_result.content_type,
+        document_updated_at: document.created_at,
         as_document_checksum: document.checksum
       )
     rescue StandardError => e

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -51,15 +51,26 @@ module Stats
       create!(report_name: report_name, status: 'started', started_at: Time.now)
     end
 
+    # High ABC Size due to setting Paperclip fields for possible revert.
+    # This 'rubocop:disable' can be removed when the Paperclip fields are removed.
+    # rubocop:disable Metrics/AbcSize
     def write_report(report_result)
       filename = "#{report_name}_#{started_at.to_s(:number)}.#{report_result.format}"
       log(:info, :write_report, "Writing report #{report_name} to #{filename}")
       document.attach(io: report_result.io, filename: filename, content_type: report_result.content_type)
-      update(status: 'completed', completed_at: Time.zone.now)
+      update(
+        status: 'completed',
+        completed_at: Time.zone.now,
+        document_file_name: filename,
+        document_file_size: document.byte_size,
+        document_content_type: report_result.content_type,
+        as_document_checksum: document.checksum
+      )
     rescue StandardError => e
       log(:error, :write_report, "error writing report #{report_name}...", e)
       raise
     end
+    # rubocop:enable Metrics/AbcSize
 
     def write_error(report_contents)
       update(report: report_contents, status: 'error', completed_at: nil)

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -54,7 +54,7 @@ module Stats
     def write_report(report_result)
       filename = "#{report_name}_#{started_at.to_s(:number)}.#{report_result.format}"
       log(:info, :write_report, "Writing report #{report_name} to #{filename}")
-      document.attach(io: StringIO.new(report_result.content), filename: filename)
+      document.attach(io: report_result.io, filename: filename, content_type: report_result.content_type)
       update(status: 'completed', completed_at: Time.zone.now)
     rescue StandardError => e
       log(:error, :write_report, "error writing report #{report_name}...", e)

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,11 +14,6 @@ require_relative '../lib/govuk_component'
 
 module AdvocateDefencePayments
   class Application < Rails::Application
-    # remove active storage routes - not used (yet)
-    initializer(:remove_activestorage_routes, after: :add_routing_paths) do |app|
-      app.routes_reloader.paths.delete_if {|path| path =~ /activestorage/}
-    end
-
     config.middleware.use Rack::Deflater
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -5,9 +5,9 @@
       "warning_code": 70,
       "fingerprint": "068f21e75ff2347f986c43eed66f00d0be08ce368dc2b5a2927f198e4f519547",
       "check_name": "MassAssignment",
-      "message": "Parameters should be whitelisted for mass assignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/helpers/application_helper.rb",
-      "line": 85,
+      "line": 76,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.except(:page).merge(:sort => column, :direction => ((\"desc\" or \"asc\")), :anchor => column).permit!",
       "render_path": null,
@@ -39,8 +39,28 @@
       "user_input": "Claim::BaseClaim.active.find(params[:id])",
       "confidence": "Weak",
       "note": "Caseworkers need to identify the downloads correspond to the cases they are processing"
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "fc469a28ef113fae0ef0022ac73c65a4867936f8aaa0299100108f00c9f195d7",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/case_workers/admin/management_information_controller.rb",
+      "line": 22,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.service_url(:disposition => \"attachment\"))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CaseWorkers::Admin::ManagementInformationController",
+        "method": "download"
+      },
+      "user_input": "Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.service_url(:disposition => \"attachment\")",
+      "confidence": "High",
+      "note": ""
     }
   ],
-  "updated": "2019-07-11 10:02:57 +0100",
-  "brakeman_version": "4.5.1"
+  "updated": "2021-03-03 16:39:39 +0000",
+  "brakeman_version": "5.0.0"
 }

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_storage.service_urls_expire_in = 5.minutes # default

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2474,6 +2474,7 @@ en:
           invalid_report_type: &invalid_report_type The requested report type is not supported
         download:
           invalid_report_type: *invalid_report_type
+          missing_report: The requested report is missing
         generate:
           invalid_report_type: *invalid_report_type
         index:

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -244,9 +244,9 @@ module Storage
 
   def self.s3_path_pattern(model)
     {
-      'stats_reports' => REPORTS_STORAGE_OPTIONS[:path],
-      'messages' => PAPERCLIP_STORAGE_OPTIONS[:path],
-      'documents' => PAPERCLIP_STORAGE_OPTIONS[:path]
+      'stats_reports' => REPORTS_STORAGE_PATH,
+      'messages' => PAPERCLIP_STORAGE_PATH,
+      'documents' => PAPERCLIP_STORAGE_PATH
     }[model]
   end
 

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -30,7 +30,7 @@ module Storage
                  CONCAT('in-progress/', CAST(id AS CHARACTER VARYING)),
                  #{name}_file_size,
                  as_#{name}_checksum,
-                 #{name}_updated_at
+                 COALESCE(#{name}_updated_at, NOW())
             FROM #{model}
             WHERE #{name}_file_name IS NOT NULL
               AND id NOT IN (

--- a/spec/controllers/case_workers/admin/management_information_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/management_information_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CaseWorkers::Admin::ManagementInformationController, type: :contr
         end
 
         it 'redirects to the service url of the document' do
-          expect(response.location).to match %{#{disk_service_prefix}/.*/#{filename}}
+          expect(response.location).to match %(#{disk_service_prefix}/.*/#{filename})
         end
       end
 

--- a/spec/models/stats/result_spec.rb
+++ b/spec/models/stats/result_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Stats::Result do
+  let(:result) { described_class.new(lines.join("\n"), format) }
+  let(:lines) { ['Col 1,Col2', '3,6'] }
+  let(:format) { 'csv' }
+
+  describe '#io' do
+    subject(:io) { result.io }
+
+    it 'is an IO stream for the content' do
+      expect(io.readlines.map(&:chomp)).to eq lines
+    end
+  end
+
+  describe '#content_type' do
+    subject(:content_type) { result.content_type }
+
+    context 'when csv' do
+      it { is_expected.to eq 'text/csv' }
+    end
+
+    context 'when json' do
+      let(:format) { 'json' }
+
+      it { is_expected.to eq 'application/json' }
+    end
+  end
+end

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -160,6 +160,10 @@ RSpec.describe Stats::StatsReport do
       it 'sets the paperclip checksum' do
         expect { write_report }.to change(report, :as_document_checksum).to checksum
       end
+
+      it 'sets the paperclip updated at' do
+        expect { write_report }.to change(report, :document_updated_at).from(nil)
+      end
     end
   end
 

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Stats::StatsReport do
 
       it 'copies the document to the document storage' do
         write_report
-        expect(File.open(report.document.path).read).to eq document_content
+        expect(File.open(ActiveStorage::Blob.service.path_for(report.document.blob.key)).read).to eq document_content
       end
 
       it 'does not change the started_at time' do
@@ -136,47 +136,6 @@ RSpec.describe Stats::StatsReport do
         expect { write_report }
           .to change { described_class.completed.where(report_name: 'my_new_report').first }
           .to report
-      end
-
-      it 'sets the checksum' do
-        expect { write_report }.to change(report, :as_document_checksum).to(checksum)
-      end
-    end
-  end
-
-  describe '#document_url' do
-    context 'when document is nil' do
-      let(:report) { build(:stats_report, report: nil, document: nil) }
-
-      it { expect(report.document_url).to be_nil }
-    end
-
-    context 'when document exists' do
-      let(:report) { build(:stats_report, :with_document) }
-
-      context 'when the document storage is filesystem' do
-        let(:options) { { storage: :filesystem } }
-
-        before do
-          allow(report.document).to receive(:options).and_return(options)
-        end
-
-        it 'returns the document path' do
-          expect(report.document_url).to eq('tmp/test/reports/report.csv')
-        end
-      end
-
-      context 'when the document storage is S3' do
-        let(:options) { { storage: :s3 } }
-
-        before do
-          original_options = report.document.options
-          allow(report.document).to receive(:options).and_return(original_options.merge(options))
-        end
-
-        it 'returns the an expiring url for the document' do
-          expect(report.document_url).to match(%r{tmp/test/reports/report.csv\?([0-9])+})
-        end
       end
     end
   end

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -124,6 +124,11 @@ RSpec.describe Stats::StatsReport do
         expect(File.open(ActiveStorage::Blob.service.path_for(report.document.blob.key)).read).to eq document_content
       end
 
+      it 'names the document based on the report type and timestamp' do
+        write_report
+        expect(report.document.filename).to eq "my_new_report_#{start_time.to_s(:number)}.csv"
+      end
+
       it 'does not change the started_at time' do
         expect { write_report }.not_to change(report, :started_at)
       end
@@ -136,6 +141,24 @@ RSpec.describe Stats::StatsReport do
         expect { write_report }
           .to change { described_class.completed.where(report_name: 'my_new_report').first }
           .to report
+      end
+
+      # These are to allow reverting back to Paperclip if necessary
+      it 'sets the paperclip filename' do
+        expect { write_report }
+          .to change(report, :document_file_name).to "my_new_report_#{start_time.to_s(:number)}.csv"
+      end
+
+      it 'sets the paperclip file size' do
+        expect { write_report }.to change(report, :document_file_size)
+      end
+
+      it 'sets the paperclip content type' do
+        expect { write_report }.to change(report, :document_content_type).to 'text/csv'
+      end
+
+      it 'sets the paperclip checksum' do
+        expect { write_report }.to change(report, :as_document_checksum).to checksum
       end
     end
   end

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -163,44 +163,6 @@ RSpec.describe Stats::StatsReport do
     end
   end
 
-  describe '#document#path' do
-    let(:report) { create :stats_report, document_file_name: 'test_file.csv' }
-
-    before do
-      stub_const 'REPORTS_STORAGE_PATH', 'reports/:filename'
-    end
-
-    context 'without an Active Storage attachment' do
-      it 'has a path based on the filename' do
-        expect(report.document.path).to eq 'reports/test_file.csv'
-      end
-    end
-
-    context 'with an Active Storage attachment in disk storage' do
-      require 'active_storage/service/disk_service'
-
-      include_context 'add active storage record assets for stats reports' do
-        let(:service) { ActiveStorage::Service::DiskService.new(root: '/root/') }
-      end
-
-      it 'has the path for disk storage' do
-        expect(report.document.path).to eq '/root/te/st/test_key'
-      end
-    end
-
-    context 'with an Active Storage attachment in S3' do
-      require 'active_storage/service/s3_service'
-
-      include_context 'add active storage record assets for stats reports' do
-        let(:service) { ActiveStorage::Service::S3Service.new(bucket: 'bucket') }
-      end
-
-      it 'has the path for disk storage' do
-        expect(report.document.path).to eq 'test_key'
-      end
-    end
-  end
-
   describe 'housekeeping' do
     describe '.destroy_reports_older_than' do
       it 'destroys all reports for named report older than specified time' do

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -2,88 +2,83 @@ require 'rails_helper'
 
 RSpec.describe Stats::StatsReportGenerator, type: :service do
   describe '.call' do
-    context 'when the report type is not valid' do
-      before do
-        allow(Settings).to receive(:notify_report_errors).and_return(false)
-      end
+    subject(:call_report_generator) { described_class.call(report_type) }
 
+    let(:report_type) { 'management_information' }
+
+    context 'when the report type is not valid' do
       let(:report_type) { 'some-report-type' }
 
+      before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
+
       it 'raises an invalid report type error' do
-        expect { described_class.call(report_type) }.to raise_error(Stats::StatsReportGenerator::InvalidReportType)
+        expect { call_report_generator }.to raise_error(Stats::StatsReportGenerator::InvalidReportType)
       end
 
       it 'does not create a new report' do
-        expect {
-          described_class.call(report_type) rescue nil
-        }.not_to change { Stats::StatsReport.count }.from(0)
+        expect { call_report_generator rescue nil }.not_to change { Stats::StatsReport.count }.from(0)
       end
     end
 
     context 'when there is already a report of that type in progress' do
-      let(:report_type) { 'management_information' }
-      let!(:report) { Stats::StatsReport.create(report_name: report_type, status: 'started', report: 'some content') }
+      before { Stats::StatsReport.create(report_name: report_type, status: 'started', report: 'some content') }
 
       it 'does not create a new report' do
-        expect {
-          described_class.call(report_type)
-        }.not_to change { Stats::StatsReport.count }.from(1)
+        expect { call_report_generator }.not_to change { Stats::StatsReport.count }.from(1)
       end
     end
 
     context 'when there is no report of that type in progress' do
-      let(:report_type) { 'management_information' }
-      let!(:report) { Stats::StatsReport.create(report_name: report_type, status: 'completed', report: 'some content') }
       let(:mocked_result) { Stats::Result.new('some new content', 'csv') }
 
-      it 'creates a new report marked as completed with the generated content' do
-        expect(Stats::ManagementInformationGenerator).to receive(:call).and_return(mocked_result)
-        expect {
-          described_class.call(report_type)
-        }.to change { Stats::StatsReport.where(report_name: report_type).completed.count }.from(1).to(2)
-        new_record = Stats::StatsReport.where(report_name: report_type).completed.last
-        expect(new_record.document).to be_kind_of(Paperclip::Attachment)
-        expect(open(new_record.document.path).read).to eq('some new content')
+      before { allow(Stats::ManagementInformationGenerator).to receive(:call).and_return(mocked_result) }
+
+      it 'adds a new completed report' do
+        expect { call_report_generator }.to change(Stats::StatsReport.where(report_name: report_type).completed, :count).by 1
       end
 
-      context 'but an error happens during the generation of the report' do
+      it 'puts data into the new report' do
+        call_report_generator
+        new_record = Stats::StatsReport.where(report_name: report_type).completed.last
+        expect(open(new_record.document.path).read).to eq('some new content')
+      end
+    end
+
+    context 'when an error happens during the generation of the report' do
+      before do
+        allow(Stats::ManagementInformationGenerator).to receive(:call).and_raise(StandardError)
+      end
+
+      it 'raises the error' do
+        expect { call_report_generator }.to raise_error(StandardError)
+      end
+
+      it 'creates a new report marked as errored' do
+        expect {
+          call_report_generator rescue nil
+        }.to change { Stats::StatsReport.where(report_name: report_type).errored.count }.from(0).to(1)
+      end
+
+      context 'when when the error notifications are enabled' do
         before do
-          expect(Stats::ManagementInformationGenerator).to receive(:call).and_raise(StandardError)
+          allow(Settings).to receive(:notify_report_errors).and_return(true)
         end
 
-        it 'raises the error' do
-          expect { described_class.call(report_type) }.to raise_error(StandardError)
+        it 'sends an error notification' do
+          allow(ActiveSupport::Notifications).to receive(:instrument)
+          call_report_generator rescue nil
+          record = Stats::StatsReport.where(report_name: report_type).errored.first
+          args = ['call_failed.stats_report', id: record.id, name: report_type, error: instance_of(StandardError)]
+          expect(ActiveSupport::Notifications).to have_received(:instrument).with(*args)
         end
+      end
 
-        it 'creates a new report marked as errored' do
-          expect {
-            described_class.call(report_type) rescue nil
-          }.to change { Stats::StatsReport.where(report_name: report_type).errored.count }.from(0).to(1)
-        end
+      context 'when when the error notifications are disabled' do
+        before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
 
-        context 'and when the error notifications are enabled' do
-          before do
-            allow(Settings).to receive(:notify_report_errors).and_return(true)
-          end
-
-          it 'sends an error notification' do
-            allow(ActiveSupport::Notifications).to receive(:instrument)
-            described_class.call(report_type) rescue nil
-            record = Stats::StatsReport.where(report_name: report_type).errored.first
-            args = ['call_failed.stats_report', id: record.id, name: report_type, error: instance_of(StandardError)]
-            expect(ActiveSupport::Notifications).to have_received(:instrument).with(*args)
-          end
-        end
-
-        context 'and when the error notifications are disabled' do
-          before do
-            allow(Settings).to receive(:notify_report_errors).and_return(false)
-          end
-
-          it 'does not sends an error notification' do
-            expect(ActiveSupport::Notifications).not_to receive(:instrument)
-            described_class.call(report_type) rescue nil
-          end
+        it 'does not sends an error notification' do
+          expect(ActiveSupport::Notifications).not_to receive(:instrument)
+          call_report_generator rescue nil
         end
       end
     end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
         }.to change { Stats::StatsReport.where(report_name: report_type).errored.count }.from(0).to(1)
       end
 
-      context 'when when the error notifications are enabled' do
+      context 'when the error notifications are enabled' do
         before do
           allow(Settings).to receive(:notify_report_errors).and_return(true)
         end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
         before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
 
         it 'does not sends an error notification' do
+          allow(ActiveSupport::Notifications).to receive(:instrument)
           call_report_generator rescue nil
           expect(ActiveSupport::Notifications).not_to have_received(:instrument)
         end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
         end
       end
 
-      context 'when when the error notifications are disabled' do
+      context 'when the error notifications are disabled' do
         before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
 
         it 'does not sends an error notification' do

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       before do
         allow(Stats::ManagementInformationGenerator).to receive(:call).and_raise(StandardError)
       end
+    end
 
       it 'raises the error' do
         expect { call_report_generator }.to raise_error(StandardError)

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       before { allow(Stats::ManagementInformationGenerator).to receive(:call).and_return(mocked_result) }
 
       it 'adds a new completed report' do
-        expect { call_report_generator }.to change(Stats::StatsReport.where(report_name: report_type).completed, :count).by 1
+        expect { call_report_generator }
+          .to change(Stats::StatsReport.where(report_name: report_type).completed, :count).by 1
       end
 
       it 'puts data into the new report' do

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
         before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
 
         it 'does not sends an error notification' do
-          expect(ActiveSupport::Notifications).not_to receive(:instrument)
           call_report_generator rescue nil
+          expect(ActiveSupport::Notifications).not_to have_received(:instrument)
         end
       end
     end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       context 'when the error notifications are disabled' do
         before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
 
-        it 'does not sends an error notification' do
+        it 'does not send an error notification' do
           allow(ActiveSupport::Notifications).to receive(:instrument)
           call_report_generator rescue nil
           expect(ActiveSupport::Notifications).not_to have_received(:instrument)

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       before do
         allow(Stats::ManagementInformationGenerator).to receive(:call).and_raise(StandardError)
       end
-    end
 
       it 'raises the error' do
         expect { call_report_generator }.to raise_error(StandardError)

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -76,10 +76,12 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       end
 
       context 'when the error notifications are disabled' do
-        before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
+        before do
+          allow(Settings).to receive(:notify_report_errors).and_return(false)
+          allow(ActiveSupport::Notifications).to receive(:instrument)
+        end
 
         it 'does not send an error notification' do
-          allow(ActiveSupport::Notifications).to receive(:instrument)
           call_report_generator rescue nil
           expect(ActiveSupport::Notifications).not_to have_received(:instrument)
         end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       it 'puts data into the new report' do
         call_report_generator
         new_record = Stats::StatsReport.where(report_name: report_type).completed.last
-        expect(open(new_record.document.path).read).to eq('some new content')
+        file_path = ActiveStorage::Blob.service.path_for(new_record.document.blob.key)
+        expect(File.open(file_path).read).to eq('some new content')
       end
     end
 


### PR DESCRIPTION
#### What

Switch over to using Active Storage for stats reports.

#### Ticket

[Migrate Paperclip to Active Storage](https://dsdmoj.atlassian.net/browse/CBO-1630)

#### Why

We need to switch over to using Active Storage everywhere we have documents in CCCD. The simplest of these, and the place with the least risk, is for the stats reports and so this is being done first.

#### How

| How to ... | Paperclip | Active Storage |
|---|---|---|
| Configure an attachment for reports | `has_attached_file :document` | `has_one_attached :document` |
| Attach a report file | `update(...)` | `document.attach(...)` |
| Download a report | Fetch file to the server and then stream with `send_data` | Redirect to `document.blob.service_url` |

This is based on #3722, which is now closed.