### PR TITLE
Enable/disable analytics in GoogleAnalytics::DataTracking

### DIFF
--- a/app/controllers/concerns/disable_view_only_actions.rb
+++ b/app/controllers/concerns/disable_view_only_actions.rb
@@ -6,7 +6,7 @@ module DisableViewOnlyActions
   end
 
   def disable_analytics
-    @disable_analytics = true
+    GoogleAnalytics::DataTracking.active = false
   end
 
   def disable_phase_banner

--- a/app/models/google_analytics/data_tracking.rb
+++ b/app/models/google_analytics/data_tracking.rb
@@ -1,10 +1,10 @@
 module GoogleAnalytics
   class DataTracking
-    cattr_accessor :adapter, :adapter_name
+    cattr_accessor :adapter, :adapter_name, :active
 
     class << self
       def enabled?
-        adapter.present? && Rails.env.production?
+        active && adapter.present? && Rails.env.production?
       end
 
       def tag_manager?

--- a/app/views/layouts/_body_end.html.haml
+++ b/app/views/layouts/_body_end.html.haml
@@ -2,7 +2,7 @@
 
 = javascript_pack_tag "application-test" if Rails.env.test?
 
-- if GoogleAnalytics::DataTracking.analytics? && !@disable_analytics
+- if GoogleAnalytics::DataTracking.analytics?
   :javascript
     ga(function(tracker) {
       var clientId = tracker.get('clientId');

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,7 +20,7 @@
     = stylesheet_pack_tag 'govuk-frontend', media: 'all'
     = tag :meta, property: 'og:image', content: request.base_url + asset_pack_path('media/images/govuk-opengraph-image.png')
 
-    - if GoogleAnalytics::DataTracking.enabled? && !@disable_analytics
+    - if GoogleAnalytics::DataTracking.enabled?
       = render partial: 'layouts/analytics', :formats => [:js], locals: { adapter: GoogleAnalytics::DataTracking.adapter_name }
       - if GoogleAnalytics::DataTracking.analytics?
         %script
@@ -33,7 +33,7 @@
     %a.govuk-skip-link{ href: '#main-content' }
       = t('layouts.skip_content')
 
-    - if GoogleAnalytics::DataTracking.tag_manager? && !@disable_analytics
+    - if GoogleAnalytics::DataTracking.tag_manager?
       %noscript
         %iframe{ src: "https://www.googletagmanager.com/ns.html?id=#{ENV['GTM_TRACKED_ID']}", style: 'display: none; visibility:hidden', height: '0', width: '0' }
 

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -3,4 +3,5 @@
 #   :ga  -> Google Analytics
 #   :gtm -> Google Tag Manager
 #
+GoogleAnalytics::DataTracking.active = true
 GoogleAnalytics::DataTracking.adapter = ENV['GTM_TRACKER_ID'].present? ? :gtm : :ga

--- a/spec/models/google_analytics/data_tracking_spec.rb
+++ b/spec/models/google_analytics/data_tracking_spec.rb
@@ -2,22 +2,36 @@ require 'rails_helper'
 
 module GoogleAnalytics
   describe DataTracking do
+    before do
+      allow(described_class).to receive(:adapter).and_return('Adapter')
+      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      described_class.active = true
+    end
+
     describe '#enabled?' do
       subject { described_class.enabled? }
-      before do
-        allow(Rails).to receive(:env).and_return('production'.inquiry)
+
+      context 'when host is staging' do
+        before { allow(RailsHost).to receive(:env).and_return('staging') }
+
+        it { is_expected.to be_truthy }
+
+        context 'when active is false' do
+          before { described_class.active = false }
+
+          it { is_expected.to be_falsey }
+        end
       end
 
-      context 'with an adapter set' do
-        before do
-          allow(described_class).to receive(:adapter).and_return('Adapter')
-        end
+      context 'when host is production' do
+        before { allow(RailsHost).to receive(:env).and_return('production') }
 
-        %w(staging production).each do |host|
-          it "returns true when host is #{host}" do
-            allow(RailsHost).to receive(:env).and_return(host)
-            expect(described_class.enabled?).to be_truthy
-          end
+        it { is_expected.to be_truthy }
+
+        context 'when active is false' do
+          before { described_class.active = false }
+
+          it { is_expected.to be_falsey }
         end
       end
 
@@ -40,53 +54,47 @@ module GoogleAnalytics
       end
     end
 
-    describe 'type methods' do
-      before do
-        allow(described_class).to receive(:adapter).and_return('Adapter')
-        allow(Rails).to receive(:env).and_return('production'.inquiry)
+    describe '#tag_manager?' do
+      subject(:tag_manager) { described_class.tag_manager? }
+
+      context 'when the adapter is google_tag_manager' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
+
+        it { is_expected.to be true }
       end
 
-      context '#tag_manager?' do
-        subject(:tag_manager) { described_class.tag_manager? }
-        context 'when the adapter is google_tag_manager' do
-          before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
+      context 'when the adapter is google_analytics' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
 
-          it { is_expected.to be true }
-        end
-
-        context 'when the adapter is google_analytics' do
-          before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
-
-          it { is_expected.to be false }
-        end
-
-        context 'when the adapter is nil' do
-          before { allow(described_class).to receive(:adapter).and_return(nil) }
-
-          it { is_expected.to be false }
-        end
+        it { is_expected.to be false }
       end
 
-      context '#analytics?' do
-        subject(:analytics) { described_class.analytics? }
+      context 'when the adapter is nil' do
+        before { allow(described_class).to receive(:adapter).and_return(nil) }
 
-        context 'when the adapter is google_tag_manager' do
-          before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
+        it { is_expected.to be false }
+      end
+    end
 
-          it { is_expected.to be false }
-        end
+    describe '#analytics?' do
+      subject(:analytics) { described_class.analytics? }
 
-        context 'when the adapter is google_analytics' do
-          before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
+      context 'when the adapter is google_tag_manager' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:gtm) }
 
-          it { is_expected.to be true }
-        end
+        it { is_expected.to be false }
+      end
 
-        context 'when the adapter is nil' do
-          before { allow(described_class).to receive(:adapter).and_return(nil) }
+      context 'when the adapter is google_analytics' do
+        before { allow(described_class).to receive(:adapter_name).and_return(:ga) }
 
-          it { is_expected.to be false }
-        end
+        it { is_expected.to be true }
+      end
+
+      context 'when the adapter is nil' do
+        before { allow(described_class).to receive(:adapter).and_return(nil) }
+
+        it { is_expected.to be false }
       end
     end
   end


### PR DESCRIPTION
#### What

Use `GoogleAnalytics::DataTracking` to disable analytics.

#### Ticket

[Migrate layout page(s) to the GOVUK Design System](https://dsdmoj.atlassian.net/browse/CBO-1695)

#### Why

This is a small suggestion for the main PR #3754.

The `GoogleAnalytics::DataTracking` class already determines if analytics is enabled in some cases. If there needs to be a switch to turn it on or off at will then it makes sense that it should go here.

#### How

Create a new attribute `active` on the `GoogleAnalytics::DataTracking` class that allows analytics to be turned on or off at will. This attribute is set to `true` by default in `config/initializers/analytics.rb` and can be turned off with `ApplicationController#disable_analytics`.