### PR TITLE
Enable writing to s3 for hosted envs

### DIFF
--- a/app/models/dummy_document.rb
+++ b/app/models/dummy_document.rb
@@ -1,21 +1,21 @@
-  # DummyDocument: class used to shadow a real
-  # Document for dummy paperclip s3 file creation.
-  #
-  # The "Shadow" Document object does not include callbacks
-  # that would otherwise generate a pdf from the original file
-  # when it has changed and is saved. This would take a long time and
-  # not needed for dummy s3 file creation
-  #
-  # It also prevents validation of the file content and type so
-  # random bytes can be used to quickly create the dummy file content
-  #
-  class DummyDocument < ApplicationRecord
-    include S3Headers
-    include CheckSummable
+# DummyDocument: class used to shadow a real
+# Document for dummy paperclip s3 file creation.
+#
+# The "Shadow" Document object does not include callbacks
+# that would otherwise generate a pdf from the original file
+# when it has changed and is saved. This would take a long time and
+# not needed for dummy s3 file creation
+#
+# It also prevents validation of the file content and type so
+# random bytes can be used to quickly create the dummy file content
+#
+class DummyDocument < ApplicationRecord
+  include S3Headers
+  include CheckSummable
 
-    self.table_name = 'documents'
-    has_attached_file :converted_preview_document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
-    has_attached_file :document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+  self.table_name = 'documents'
+  has_attached_file :converted_preview_document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+  has_attached_file :document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
 
-    do_not_validate_attachment_file_type :document
-  end
+  do_not_validate_attachment_file_type :document
+end

--- a/app/models/dummy_document.rb
+++ b/app/models/dummy_document.rb
@@ -18,11 +18,4 @@
     has_attached_file :document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
 
     do_not_validate_attachment_file_type :document
-
-    before_save :populate_checksum
-
-    def populate_checksum
-      add_checksum(:document) unless document_file_name.nil?
-      add_checksum(:converted_preview_document) unless converted_preview_document.nil?
-    end
   end

--- a/app/models/dummy_document.rb
+++ b/app/models/dummy_document.rb
@@ -1,0 +1,28 @@
+  # DummyDocument: class used to shadow a real
+  # Document for dummy paperclip s3 file creation.
+  #
+  # The "Shadow" Document object does not include callbacks
+  # that would otherwise generate a pdf from the original file
+  # when it has changed and is saved. This would take a long time and
+  # not needed for dummy s3 file creation
+  #
+  # It also prevents validation of the file content and type so
+  # random bytes can be used to quickly create the dummy file content
+  #
+  class DummyDocument < ApplicationRecord
+    include S3Headers
+    include CheckSummable
+
+    self.table_name = 'documents'
+    has_attached_file :converted_preview_document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+    has_attached_file :document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+
+    do_not_validate_attachment_file_type :document
+
+    before_save :populate_checksum
+
+    def populate_checksum
+      add_checksum(:document) unless document_file_name.nil?
+      add_checksum(:converted_preview_document) unless converted_preview_document.nil?
+    end
+  end

--- a/docs/active_storage_migration.md
+++ b/docs/active_storage_migration.md
@@ -331,6 +331,7 @@ Paperclip can be removed.
 
 * Remove the `paperclip` gem from `Gemfile`
 * Delete `lib/tasks/storage.rake` and `lib/tasks/rake_helpers/storage.rb`
+* Delete `app/models/dummy_document.rb`
 * Delete `app/models/concerns/check_summable.rb` together with all instances
   `include CheckSummable`, `add_checksum` and `calculate_checksum`
 * Remove `PAPERCLIP_STORAGE_OPTIONS`, `REPORTS_STORAGE_OPTIONS` and

--- a/docs/active_storage_migration.md
+++ b/docs/active_storage_migration.md
@@ -329,6 +329,7 @@ due to timeouts in Kibana logs, for example.
 After the migration to Active Storage has been completed successfully
 Paperclip can be removed.
 
+* Delete s3 dummy files, to save money (see `storage::clear_dummy_paperclip_files`)
 * Remove the `paperclip` gem from `Gemfile`
 * Delete `lib/tasks/storage.rake` and `lib/tasks/rake_helpers/storage.rb`
 * Delete `app/models/dummy_document.rb`

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -59,6 +59,8 @@ namespace :db do
 
   desc 'CCCD task: clear the database, run migrations, seeds and reloads demo data'
   task :reload do
+    production_protected
+
     Rake::Task['db:clear'].invoke
     Rake::Task['db:schema:load'].invoke
     Rake::Task['db:migrate'].invoke

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -160,7 +160,9 @@ namespace :db do
   # OPTIMIZE: https://stackoverflow.com/questions/148451/how-to-use-sed-to-replace-only-the-first-occurrence-in-a-file/11458836#11458836
   # required because of this change
   # https://www.postgresql.org/about/news/postgresql-103-968-9512-9417-and-9322-released-1834/
+  # NOTE: this is POSIX compliant so that BSD (osx) and GNU sed can be used
   def set_pg_search_path(dump_file)
-    `sed -i '' -e "s/SELECT pg_catalog.set_config('search_path', '', false)/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true)/" #{dump_file}`
+    `sed -e "s/SELECT pg_catalog.set_config('search_path', '', false)/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true)/" #{dump_file} > #{dump_file}.tmp`
+    `mv -- #{dump_file}.tmp #{dump_file}`
   end
 end

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -11,12 +11,20 @@ namespace :storage do
     Storage.rollback args[:model]
   end
 
-  desc 'Create/replace dummy paperclip asset files'
+  desc 'Create/replace dummy paperclip asset files, based on attachment metadata'
   task :create_dummy_paperclip_files, [:model] => :environment do |_task, args|
     production_protected
     continue?("Warning: this will overwrite existing files for #{args[:model]} with random bytes! Are you sure?")
 
-    Storage.create_dummy_paperclip_files_for args[:model]
+    Storage.create_dummy_paperclip_files_for(args[:model])
+  end
+
+  desc 'Clear dummy paperclip asset files, but leave attachment meta data in place'
+  task :clear_dummy_paperclip_files, [:model] => :environment do |_task, args|
+    production_protected
+    continue?("Warning: this will delete existing files for #{args[:model]}! Are you sure?")
+
+    Storage.clear_dummy_paperclip_files_for(args[:model])
   end
 
   desc 'Add file checksums to paperclip columns'


### PR DESCRIPTION
To load test the adding of checksums we need
to create a production like amount of s3 hosted
files.

These files should also be deleted once we are done with
them to avoid costs.