### PR TITLE
Add RACK_ENV var to all environments

### DIFF
--- a/kubernetes_deploy/api-sandbox/app-config.yaml
+++ b/kubernetes_deploy/api-sandbox/app-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cccd-api-sandbox
 data:
   ENV: 'api-sandbox'
+  RACK_ENV: 'production'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://api-sandbox.claim-crown-court-defence.service.justice.gov.uk'

--- a/kubernetes_deploy/dev-lgfs/app-config.yaml
+++ b/kubernetes_deploy/dev-lgfs/app-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cccd-dev-lgfs
 data:
   ENV: 'dev'
+  RACK_ENV: 'production'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://dev-lgfs.claim-crown-court-defence.service.justice.gov.uk'

--- a/kubernetes_deploy/dev/app-config.yaml
+++ b/kubernetes_deploy/dev/app-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cccd-dev
 data:
   ENV: 'dev'
+  RACK_ENV: 'production'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://dev.claim-crown-court-defence.service.justice.gov.uk'

--- a/kubernetes_deploy/production/app-config.yaml
+++ b/kubernetes_deploy/production/app-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cccd-production
 data:
   ENV: 'production'
+  RACK_ENV: 'production'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://claim-crown-court-defence.service.gov.uk'

--- a/kubernetes_deploy/staging/app-config.yaml
+++ b/kubernetes_deploy/staging/app-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cccd-staging
 data:
   ENV: 'staging'
+  RACK_ENV: 'production'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'


### PR DESCRIPTION
#### What
Add RACK_ENV var to all environments

#### Why
This fixes an error whereby stacktraces
get displayed on production instances.

Longer term we need to understand if we
can remove this line from `application.rb`

```
config.exceptions_app = self.routes
```

see this SO thread for more:

[Rack::ShowExceptions enabled in production Rails 4.0.4](https://stackoverflow.com/questions/27113841/rackshowexceptions-enabled-in-production-rails-4-0-4)
