### PR TITLE
Set diskspace exceeded prom alert to 2Gb on CCCD prod

### DIFF
--- a/kubernetes_deploy/production/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/production/prometheus-custom-rules.yaml
@@ -35,9 +35,9 @@ spec:
         message: cccd-production An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-production),query:(match:(log_processed.kubernetes_namespace:(query:cccd-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
     - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="cccd-production"} / 1024 / 1024 > 300 or absent(container_fs_usage_bytes{namespace="cccd-production"})
+      expr: container_fs_usage_bytes{namespace="cccd-production"} / 1024 / 1024 > 2000 or absent(container_fs_usage_bytes{namespace="cccd-production"})
       for: 1m
       labels:
         severity: laa-court-get-paid
       annotations:
-        message: cccd-production Container disk space usage is more than 300Mb or is not reported
+        message: cccd-production Container disk space usage is more than 2Gb or is not reported


### PR DESCRIPTION
#### What
Set the prometheus diskspace threshold exceeded prometheus alert to 2GB (it is currently 300MB)

#### Ticket
N/A

#### Why
This alert is currently very noisy/therefore not useful. The current threshold of 300MB is being regularly exceeded and this not seem to indicate that there is a problem.

#### How
Once approved this will need to be applied with the following (until we move this to the Cloud Platforms environment repo)

kubectl apply -f kubernetes_deploy/production/prometheus-custom-rules.yaml -n cccd-production