### PR TITLE
Attempt to optimise dummy file creation

### DIFF
--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -137,15 +137,18 @@ module Storage
   def self.create_or_update_dummy_file(record:, doc_attribute:, filename:)
     FileUtils.mkdir_p File.dirname(filename)
     File.open(filename, 'wb') { |file| file.write(SecureRandom.random_bytes(record.send("#{doc_attribute}_file_size"))) }
+    file = File.open(filename)
 
-    record.send("#{doc_attribute}=", File.open(filename))
+    record.send("#{doc_attribute}=", file)
     record.save(validate: false)
-  rescue Paperclip::Error => err
+  rescue StandardError => err
     LogStuff.warn(
       module: self.name,
       action: "#{__method__} for #{record.class.table_name}",
       error: "#{err.class} - #{err.message}"
     ) { err.message }
+  ensure
+    file.close if file
   end
 
   # Deleting filesystem/s3 files

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -117,6 +117,8 @@ module Storage
       records.each do |record|
         bar.increment
 
+        next if record.send(attachment).exists?
+
         filename = if paperclip_storage.eql?(:s3)
                      File.join('tmp', record.send(attachment).path)
                    else

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -142,11 +142,7 @@ module Storage
     record.send("#{doc_attribute}=", file)
     record.save(validate: false)
   rescue StandardError => err
-    LogStuff.warn(
-      module: self.name,
-      action: "#{__method__} for #{record.class.table_name}",
-      error: "#{err.class} - #{err.message}"
-    ) { err.message }
+    Rails.logger.info "[#{__method__}]: #{err.class} - #{err.message}"
   ensure
     file.close if file
   end


### PR DESCRIPTION
Evidence document dummy file creation is
failing due to process being killed after
it reaches 2Gi of memory consumption.

Memory consumption also causes checksum addition to
fail.