### PR TITLE
Add missing commits from jh/migration_task_2 PR

### DIFF
--- a/app/models/dummy_document.rb
+++ b/app/models/dummy_document.rb
@@ -1,0 +1,21 @@
+# DummyDocument: class used to shadow a real
+# Document for dummy paperclip s3 file creation.
+#
+# The "Shadow" Document object does not include callbacks
+# that would otherwise generate a pdf from the original file
+# when it has changed and is saved. This would take a long time and
+# not needed for dummy s3 file creation
+#
+# It also prevents validation of the file content and type so
+# random bytes can be used to quickly create the dummy file content
+#
+class DummyDocument < ApplicationRecord
+  include S3Headers
+  include CheckSummable
+
+  self.table_name = 'documents'
+  has_attached_file :converted_preview_document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+  has_attached_file :document, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+
+  do_not_validate_attachment_file_type :document
+end

--- a/docs/active_storage_migration.md
+++ b/docs/active_storage_migration.md
@@ -329,8 +329,10 @@ due to timeouts in Kibana logs, for example.
 After the migration to Active Storage has been completed successfully
 Paperclip can be removed.
 
+* Delete s3 dummy files, to save money (see `storage::clear_dummy_paperclip_files`)
 * Remove the `paperclip` gem from `Gemfile`
 * Delete `lib/tasks/storage.rake` and `lib/tasks/rake_helpers/storage.rb`
+* Delete `app/models/dummy_document.rb`
 * Delete `app/models/concerns/check_summable.rb` together with all instances
   `include CheckSummable`, `add_checksum` and `calculate_checksum`
 * Remove `PAPERCLIP_STORAGE_OPTIONS`, `REPORTS_STORAGE_OPTIONS` and

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -59,6 +59,8 @@ namespace :db do
 
   desc 'CCCD task: clear the database, run migrations, seeds and reloads demo data'
   task :reload do
+    production_protected
+
     Rake::Task['db:clear'].invoke
     Rake::Task['db:schema:load'].invoke
     Rake::Task['db:migrate'].invoke
@@ -158,7 +160,9 @@ namespace :db do
   # OPTIMIZE: https://stackoverflow.com/questions/148451/how-to-use-sed-to-replace-only-the-first-occurrence-in-a-file/11458836#11458836
   # required because of this change
   # https://www.postgresql.org/about/news/postgresql-103-968-9512-9417-and-9322-released-1834/
+  # NOTE: this is POSIX compliant so that BSD (osx) and GNU sed can be used
   def set_pg_search_path(dump_file)
-    `sed -i '' -e "s/SELECT pg_catalog.set_config('search_path', '', false)/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true)/" #{dump_file}`
+    `sed -e "s/SELECT pg_catalog.set_config('search_path', '', false)/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true)/" #{dump_file} > #{dump_file}.tmp`
+    `mv -- #{dump_file}.tmp #{dump_file}`
   end
 end

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -105,16 +105,67 @@ module Storage
       exit
     end
 
-    ATTACHMENTS[model].each do |name|
-      records = self.models(model).where.not("#{name}_file_name" => nil)
+    ATTACHMENTS[model].each do |attachment|
+      relation = if model.eql?('documents')
+                   DummyDocument.where.not("#{attachment}_file_name" => nil)
+                 else
+                   self.models(model).where.not("#{attachment}_file_name" => nil)
+                 end
 
-      bar = self.progress_bar title: name, total: records.count
+      bar = self.progress_bar title: attachment, total: relation.count
+
+      relation.each do |record|
+        bar.increment
+        next if record.send(attachment).exists?
+        create_or_update_dummy_file(record: record, doc_attribute: attachment, filename: File.join('tmp', record.send(attachment).path))
+      end
+    end
+  end
+
+  def self.paperclip_storage
+    PAPERCLIP_STORAGE_OPTIONS[:storage]
+  end
+
+  def self.create_or_update_dummy_file(record:, doc_attribute:, filename:)
+    FileUtils.mkdir_p File.dirname(filename)
+    file = File.open(filename, 'wb')
+    file.write(SecureRandom.random_bytes(record.send("#{doc_attribute}_file_size")))
+
+    record.send("#{doc_attribute}=", file)
+    record.save(validate: false)
+  rescue StandardError => err
+    Rails.logger.info "[#{__method__}]: #{err.class} - #{err.message}"
+  ensure
+    file.close if file
+  end
+
+  # Deleting filesystem/s3 files
+  # doc.document.destroy will delete the doc and its meta data in the doc model (not want we want)
+  # doc.document.clear wil delete the paperclip attachment file, without changing the meta data, unless you save
+  # the model object immediatley afterwards.
+
+  # NOTE: for the Document model the `doc.document.clear` message removes the "folder" (tested locally)
+  # which includes the converted_preview_document object too. However, calling `.clear` on a non-existant
+  # attachment does not raise an error.
+  #
+  def self.clear_dummy_paperclip_files_for(model)
+    if self.models(model).nil?
+      puts "Cannot clear dummy files for: #{model}"
+      exit
+    end
+
+    ATTACHMENTS[model].each do |attachment|
+      records = self.models(model).where.not("#{attachment}_file_name" => nil)
+
+      bar = self.progress_bar title: attachment, total: records.count
 
       records.each do |record|
         bar.increment
-        filename = File.absolute_path(record.send(name).path)
-        FileUtils.mkdir_p File.dirname(filename)
-        File.open(filename, 'wb') { |file| file.write(SecureRandom.random_bytes(record.send("#{name}_file_size"))) }
+        record.send(attachment).clear
+        record.send(attachment).save
+
+        # IMPORTANT: do not save the record itself or it will clear meta data
+        record.update_column("as_#{attachment}_checksum", nil)
       end
     end
   end

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -11,12 +11,20 @@ namespace :storage do
     Storage.rollback args[:model]
   end
 
-  desc 'Create/replace dummy paperclip asset files'
+  desc 'Create/replace dummy paperclip asset files, based on attachment metadata'
   task :create_dummy_paperclip_files, [:model] => :environment do |_task, args|
     production_protected
     continue?("Warning: this will overwrite existing files for #{args[:model]} with random bytes! Are you sure?")
 
-    Storage.create_dummy_paperclip_files_for args[:model]
+    Storage.create_dummy_paperclip_files_for(args[:model])
+  end
+
+  desc 'Clear dummy paperclip asset files, but leave attachment meta data in place'
+  task :clear_dummy_paperclip_files, [:model] => :environment do |_task, args|
+    production_protected
+    continue?("Warning: this will delete existing files for #{args[:model]}! Are you sure?")
+
+    Storage.clear_dummy_paperclip_files_for(args[:model])
   end
 
   desc 'Add file checksums to paperclip columns'


### PR DESCRIPTION
This was generated as follow
```
git checkout master
git pull
git co -b temp_migration_task2
git merge --squash jsugarman/migration_tasks_2
# Then resolve any conflicts arising from above command (thankfully few and easy)
git add .
git commit -v
git push -u origin temp_migration_task_2
```

Squashed commit of the following:

commit 53ce838fa21aa2bfd594b1444da8843b12303c1c
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 9 21:11:44 2021 +0000

    Reduce use of local vars to save memory

    2Gi limit means that heap size is getting eaten up
    and killing the porcess before it can complete.

    This can be handled by increasing the memory
    allocation to the environment or by
    attempting to reduce amount of memory used
    in the loop.

    This is an attempt at the latter.

commit 1ece957481c3fae84db1f73bac40bfcb3622144c
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 9 15:17:12 2021 +0000

    Log paperclip errors using rails logger

    This is consistent with the current paperclip
    logger.

    This is an attempt to capture and unknown error
    causing dummy file creation to cease after a
    certain, unknown, point.

commit 128824a1d22ea3259735aa2161519f96521add1f
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 9 07:43:56 2021 +0000

    Ensure we close the file

commit ceac0df0cade9a63474a4614121c0d75cc9060b6
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 8 18:08:55 2021 +0000

    Prevent overwritting of existing files

    Creation of dummy files for evidence documents
    failed cease with an unknown error after 20
    minutes and having created some 6 thousdand.

    Not sure of the cause (could be a timeout issue
    on runniing the command unattended) but
    don't want to have to recreate dummy files again
    so putting a check if doc exists. This adds overhead
    however :(

commit d320e73ebacc416bbad2b50fecdc4b04aec28a39
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 8 09:50:41 2021 +0000

    Use POSIX compliant sed command

    For portability of script.

    BSD (osx) sed uses `-i ''` to name the temporary
    file sed generates. GBU sed uses `-i.tmp` or similar.

    To avoid the probelm we are ceasing using `-i` as it is
    not POSIX compliant. instead use output redirection
    itself for portability across `sed` flavours.

commit 996dbc2160ef1cfd6cc3df66578574a2bfb163cb
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 8 08:15:35 2021 +0000

    Add missing production protected to reload

    The reload task is destructive and should
    never be run on production

commit 495749cab61809f6b18f2ecee27f85bb49c9d59e
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 8 07:51:15 2021 +0000

    correct indentation

commit da10e53a9be3e397e71ab8a74f2a029632aaa68f
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 8 07:48:16 2021 +0000

    Add readme notes for restore on remote host

    As part of load testing s3 checksum additions
    we will need to restore a prod like load
    onto a remote host.

commit dca22b3d663e4f13813f8b07210c5971904b4e21
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Thu Mar 4 17:42:19 2021 +0000

    Move methods to be below caller

commit ef3358799efac04a2a0a65e09dcdc3a11c91660b
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Thu Mar 4 17:40:05 2021 +0000

    Remove population of checksum from dummy_document

    Since we want to load the creation of checksums
    on a prod-like load we don't ant to generate them

commit 85ca71c6e13699c7b6b73d6aaafa9bac7ea4d647
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Thu Mar 4 10:31:03 2021 +0000

    update migration cleanup to cover deleting dummy s3 files

commit 636e2c642558f11cec4fc5d54266dba246f887ac
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Thu Mar 4 09:53:50 2021 +0000

    Add a clear dummy paper clip files options

    So we can delete objects in s3 to save money
    once we are done.

commit 9a49827b4729411788be75dcef94f04983bb376e
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Thu Mar 4 08:40:21 2021 +0000

    Update cleanup readme regardin dummy_document model

    This model class can be deleted after we are done

commit 9173b2e13d1b3d54f4cdd89e2c3bd6b13a29cf28
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Thu Mar 4 08:31:26 2021 +0000

    Handle "Specified key does not exist errors" for dummy file creation

    When creating a dummy file on s3 paperclip writes
    to STDOUT a warning that the "specified key does not exist".

    This is because while the paperclip meta
    data exists from the DB restore the actual
    file does not YET exist. This is just noise
    in the context of dummy file creation so
    we can ignore.

commit e2d24ecabde445b79170eebaaf0fef345d28e9e0
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 2 19:23:00 2021 +0000

    Handle writing to s3 for hosted envs

    * add shadow document class to circumnavigate
      unnecesary callbacks for Document model objects

    * prevent validations firing on all paperclip objects
      to enable invalid byte data for quick file generation

commit a2d57a924571e255c7b8b918febd38115a8880cc
Merge: 3cf9554f2 d629c534a
Author: Joseph Haig <jrmhaig@users.noreply.github.com>
Date:   Wed Mar 3 09:56:15 2021 +0000

    Merge pull request #3779 from ministryofjustice/jsugarman/migration_tasks_2

    More DB_PASSWORD replacements

commit d629c534a03c43421e5cea7a5538102d20b8697a
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 2 15:59:08 2021 +0000

    Replace all instances of DB_PASSWORD

    Not available on hosted envs

commit 3cf9554f2f0509a8e8875145166ca61f138672ce
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Tue Mar 2 15:40:17 2021 +0000

    Allow a limit on the checksum creation task

commit 8ee1cf618bbe3f9e1c3f524b66a238251205d615
Merge: df6b4e6a0 439aeee32
Author: Joseph Haig <jrmhaig@users.noreply.github.com>
Date:   Tue Mar 2 15:38:20 2021 +0000

    Merge pull request #3778 from ministryofjustice/jsugarman/migration_tasks_2

    Use decompression options available on hosted env

commit 439aeee329fe3fdea9889db76981cd746c3044bb
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 2 15:06:42 2021 +0000

    Use decompression options available on hosted env

    Was getting this error trying to restore on
    a hosted env (alpine image):
    ```
    gunzip: unrecognized option: -3
    BusyBox v1.30.1 (2019-10-26 11:23:07 UTC) multi-call binary.

    Usage: gunzip [-cfkt] [FILE]...

    Decompress FILEs (or stdin)

      -c  Write to stdout
      -f  Force
      -k  Keep input files
      -t  Test file integrity
    ```

commit df6b4e6a0b310258aa04c4ec96b56ac79806c67a
Merge: 53092c151 7f96f6a22
Author: Joseph Haig <jrmhaig@users.noreply.github.com>
Date:   Tue Mar 2 14:36:41 2021 +0000

    Merge pull request #3777 from ministryofjustice/jsugarman/migration_tasks_2

    Some naming and tidying

commit 7f96f6a22f43605fb7cce4cb9b408e9808f7d857
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 2 14:27:38 2021 +0000

    Amend DB password retrieval for hosted environments

    The current restore relies on $DB_PASSWORD but this
    is not available on hosted environments sine they
    rely on $DATABASE_URL alone for connection details.

    Using `ActiveRecord::Base.connection_config[:password]`
    should work both locally and on hosts.

commit bdb0b3ee5726e9cee309d39ceb47947ed8b50e87
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 2 12:20:17 2021 +0000

    Derive table_name from relation instead of argument

    No need to pass extra argument to identify the
    table being amended as the relation has that info.

commit f20dc25c85d8adeef7f19185deedec32ebfde6a8
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 2 12:08:29 2021 +0000

    Change arg name records --> relation

    It is a relation object.

commit 08b611e4ab02d9bc9e3e694dfa1398b059080b47
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Tue Mar 2 11:18:38 2021 +0000

    Note potential cleanup to remove `documents.file_path` attribute

commit 53092c151526cd58532f568349fdf2843cf7f0cf
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Tue Mar 2 10:30:13 2021 +0000

    Update steps using `storage:status`

commit 29bb567980e12b602aa758d99b842814ae7c4a44
Merge: 3cb2a5512 0365e262f
Author: Joseph Haig <jrmhaig@users.noreply.github.com>
Date:   Tue Mar 2 09:09:06 2021 +0000

    Merge pull request #3775 from ministryofjustice/jsugarman/migration_tasks_2

    Rename some rake tasks and their methods

commit 0365e262f310a17fe536c54e75dfaed3ca6d2832
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 1 17:47:02 2021 +0000

    Rename make_dummy_files_for --> create_dummy_paperclip_files

    For clarity

commit 3cb2a55125915aaac48f8b6e49e18316e0bd108d
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Mon Mar 1 16:12:59 2021 +0000

    Typo

commit e1df3b31bf18d730872b2892295a30708158ff92
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Mon Mar 1 15:59:11 2021 +0000

    Fix conflict clause for documents

commit bb5983a6cdb359065e3ba44c6bdf46537daab6bb
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 1 15:41:49 2021 +0000

    Avoid updating to null unnecessarily and add output

    Updating null to null is superfluos. Not much impact
    beyond reporting though.

    Output number of records updated for info and
    feedback purposes.

commit 9fdae59dd8ec713e9f0da9233e6b00eca95e0e78
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 1 15:40:03 2021 +0000

    Add prompting to Set and clear checksums

    An optional extra to avoid fat finger
    impact. Can remove but is pretty harmless
    unles we want to run this unattendded.

commit 73ab39c42fa5f07ee11e2b8af0f687e5df151cf3
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 1 15:06:36 2021 +0000

    Rename clear_checksums --> clear_paperclip_checksums

    For clarity

commit 68e402523e1d860694f13290412849c622a00ed1
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 1 14:51:08 2021 +0000

    Rename set_checksums --> set_paperclip_checksums

    For clarity, to differentiate from AS checksum
    table data setting.

commit 915c4f013c17960ed16bda6e3fd0b3764be10ebd
Author: jsugarman <joel.sugarman@digital.justice.gov.uk>
Date:   Mon Mar 1 14:21:41 2021 +0000

    Rename calculate_checksums --> add_paperclip_checksums

    For clarity. calculate checksums is a generic term
    that does not encapsulate the purpose.

commit 44276b096c9e6111a0ca7eddd3a7e56e9f1ab783
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Mon Mar 1 13:51:39 2021 +0000

    Add extra check to status

commit ac4c44c876ef9475f252373ce5f40ad7d5adfedc
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Mon Mar 1 09:42:26 2021 +0000

    Use Rake tasks for rollback steps

commit f0e6e0975748933a6e0ff770c77a368f32105776
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Mon Mar 1 09:41:56 2021 +0000

    Split rollback task

commit 0b814a812be9b684dc798e50d424d9a63d2d552d
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Fri Feb 26 10:25:49 2021 +0000

    Fix to correctly migrate converted preview documents

commit 9dcc2fc7e2faf7862a9f0f3379a63952c2db6604
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Thu Feb 25 16:50:47 2021 +0000

    Rollback task

commit 05cc6ecf1891771a8c4bb8014c3de188abe5b6bd
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Thu Feb 25 09:19:01 2021 +0000

    Active Storage migration documentation

commit 5c73fc06404872de8b54b0d8c3815f2f978fbcbb
Author: Joe Haig <joseph.haig@digital.justice.gov.uk>
Date:   Thu Feb 25 09:18:41 2021 +0000

    Rake tasks for active storage migration
