### PR TITLE
Anonymise Active Storage blobs

### DIFF
--- a/lib/tasks/dump.rake
+++ b/lib/tasks/dump.rake
@@ -210,7 +210,7 @@ namespace :db do
           ActiveStorage::Blob.find_each(batch_size: batch_size) do |blob|
             if (blob.attachments.map(&:record_type) - ['Stats::StatsReport']).any?
               blob.filename = fake_file_name(content_type: blob.content_type)
-              # Ex-Paperclip keys are include the filename
+              # Ex-Paperclip keys include the filename
               key_match = blob.key.match(/^(.*\d{3}\/\d{3}\/\d{3})\//)
               if key_match
                 blob.key = "#{key_match[1]}/#{blob.filename}"


### PR DESCRIPTION
#### What

Anonymise `ActiveStorage::Blob` when creating database dumps.

#### Ticket

N/A

#### Why

Active Storage blobs include the filename of messages and documents so they
are anonymised. Additionally, the keys of attachments that have been migrated
from Paperclip also includes the filename so this is modified too.

Stats reports do not need anonymising.

#### How

Add `active_storage_blobs` to the list of excluded tables and add the `db:dump:active_storage_blobs` task.