### PR TITLE
Add ability/docs to run specs in parallel

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,6 @@
+--require spec_helper
+--format progress
+--format ParallelTests::RSpec::SummaryLogger --out tmp/spec_summary.log
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log
+

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
 gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.git'
 gem 'sentry-rails',           '~> 4.1.7'
-gem 'sentry-sidekiq',         '~> 4.1.2' 
+gem 'sentry-sidekiq',         '~> 4.1.2'
 gem 'sprockets-rails',        '~> 3.2.1'
 gem 'state_machine',          '~> 1.2.0'
 gem 'state_machines-activerecord'
@@ -88,6 +88,7 @@ group :development, :devunicorn, :test do
   gem 'jasmine_selenium_runner', require: false
   gem 'listen', '~> 3.2.1'
   gem 'meta_request'
+  gem 'parallel_tests'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,6 +506,8 @@ GEM
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
     parallel (1.20.1)
+    parallel_tests (3.5.2)
+      parallel
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
@@ -847,6 +849,7 @@ DEPENDENCIES
   nokogiri (~> 1.11)
   paper_trail (~> 11.1.0)
   paperclip (~> 6.1.0)
+  parallel_tests
   pg (~> 1.2.3)
   posix-spawn (~> 0.3.15)
   pry-byebug

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ devunicorn:
 
 test: &test
   <<: *default
-  database: <%= ENV['CBO_BASE_DATABASE_DATABASE'] || 'cccd_test' %>
+  database: <%= "cccd_test#{ENV['TEST_ENV_NUMBER']}" %>
 
 production:
   <<: *default

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,45 @@ To execute unit tests
 bundle exec rspec
 bundle exec rake jasmine:ci
 ```
+
+### Javascript Unit Testing
+
+Run it using the `guard` command. Jasmine output available here: [http://localhost:8888](http://localhost:8888)
+
+## Features tests
+
+To execute cucumber feature tests
+
+```
+bundle exec cucumber
+```
+
+## Parallel spec running
+
+There are over 10k of rspec examples. This can take in excess of an hour to run locally in a single process. To run rspec examples in parallel, in as many processes as you have cores, you can use the following setup and execution. It should reduce the runtime to
+approximately 15 minutes on an 8 core machine.
+
+- One time setup
+  ```
+  rake parallel:create
+  rake parallel:prepare
+  rake parallel:migrate # needed after each migration
+  ```
+  *see [parallet_test setup for rails](https://github.com/grosser/parallel_tests#setup-for-rails) for more*
+
+
+- Then to execute...
+  ```
+  rake parallel:spec
+  ```
+  *see [parallel_test running](https://github.com/grosser/parallel_tests#run) for more*
+
+## Parallel feature running
+
+While `rake parallel:features` will run the cucumber features in parallel they will error for various reasons. See [parallel_test getting stuff running wiki](https://github.com/grosser/parallel_tests/wiki) for various potential fixes.
+
+## Linting
+
 ### Sass Linting
 
 To ensure code quality and consistency in our Sass files we check that certain
@@ -26,18 +65,6 @@ You can manually run it using `$ yarn run validate:scss`
 CCCD uses [standardjs](http://standardjs.com/), an opinionated JavaScript linter. All JavaScript (except vendor files) files follow its conventions, and it runs on git pre-commit to ensure that commits are in line with them.
 
 You can manually run it using `$ yarn run validate:js`
-
-### Javascript Unit Testing
-
-Run it using the `guard` command. Jasmine output available here: [http://localhost:8888](http://localhost:8888)
-
-## Features tests
-
-To execute cucumber feature tests
-
-```
-bundle exec cucumber
-```
 
 ## How we test external services
 

--- a/spec/parallel_spec_helper.rb
+++ b/spec/parallel_spec_helper.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |config|
+  # mute noise for parallel tests
+  config.silence_filter_announcements = true if ENV['TEST_ENV_NUMBER']
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,10 +59,12 @@ ENV['ADP_API_PASS'] = 'api_password'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'shoulda/matchers'
 require 'paperclip/matchers'
 require 'webmock/rspec'
+require 'parallel_spec_helper'
 require 'vcr_helper'
 require 'sidekiq/testing'
 


### PR DESCRIPTION
#### What
Add ability/docs to run specs in parallel, locally

#### Why
The are 10k+ specs that take approx 1 hour
to run locally in a single process.

This enables them to be run in parallel in
as many processes as the machine has cores.
On an 8 core machine it took ~15 minutes.

#### How
To install, prepare and run:
```
bundle
rake parallel:create
rake parallel:prepare
rake parallel:migrate # needed after each migration
rake parallel:spec
```
Note, feature specs not working and alot of setup and customization
needed it looks like