### PR TITLE
Add mechanism for low impact secret rotation

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -108,5 +108,4 @@ Rails.application.configure do
   #   authentication:       :login,
   #   enable_starttls_auto: true
   # }
-
 end

--- a/config/initializers/cookie_rotation.rb
+++ b/config/initializers/cookie_rotation.rb
@@ -1,0 +1,36 @@
+# See `docs/cookie_rotation.md` for details.
+#
+# This initializer can be kept for future
+# rotation or it can be deleted.
+#
+# It will only take action if there is an
+# `old_secret_key_base` secret in `config/secrets.yml`.
+#
+# NOTE: any changes to rails `action_dispatch` encryption config will
+# impact this functionality, rendering it in need of revisiting - manual
+# testing.
+#
+return unless Rails.application.secrets.old_secret_key_base.present?
+
+Rails.application.configure do
+  # Not technically necessary, as this is the current default,
+  # but it is to line up with the config below.
+  config.action_dispatch.use_authenticated_cookie_encryption = false
+
+  # From:
+  # https://www.gitmemory.com/issue/rails/rails/39964/668147345
+  # --------------------------------------------------------------------------------
+  config.action_dispatch.cookies_rotations.tap do |cookies|
+    salt = config.action_dispatch.encrypted_cookie_salt
+    signed_salt = config.action_dispatch.encrypted_signed_cookie_salt
+    cipher = config.action_dispatch.encrypted_cookie_cipher || 'aes-256-cbc'
+
+    old_secret_key_base = Rails.application.secrets.old_secret_key_base
+    generator = ActiveSupport::KeyGenerator.new(old_secret_key_base, iterations: 1000)
+    len = ActiveSupport::MessageEncryptor.key_len(cipher)
+    secret = generator.generate_key(salt, len)
+    sign_secret = generator.generate_key(signed_salt)
+
+    cookies.rotate :encrypted, secret, sign_secret
+  end
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,7 +11,8 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: ee63f015ce225c840bf33a4f40e4890398221b394ca5f93e7ca6d4a491acf2f35bedcca677f146b22a6fa212099af990a16a80c7e8c8a8ac28927daa84e091a3
+  old_secret_key_base: ee63f015ce225c840bf33a4f40e4890398221b394ca5f93e7ca6d4a491acf2f35bedcca677f146b22a6fa212099af990a16a80c7e8c8a8ac28927daa84e091a3
+  secret_key_base: ce448bd7c975ec94f925bf2a24dee48427d11f2b81f5944b6dcc541f9d330dc0d60fda8fc1bb6e5c942b86f5a2726161d58cdaa8ebba3ab8088cd31c92094c55
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
   currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>
 
@@ -29,6 +30,7 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
+  old_secret_key_base: <%= ENV["OLD_SECRET_KEY_BASE"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
   currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>

--- a/docs/cookie_rotation.md
+++ b/docs/cookie_rotation.md
@@ -1,0 +1,82 @@
+## Session cookie rotation
+
+### About
+The session cookie, amongst others, is encrypted based on the value of the `secret_key_base` secret. If this
+secret changes then all existing session cookies become invalid and users would be forced to login again or
+encounter errors. To rotate the `secret_key_base` secret, for security reasons, while mitigating the impact
+on users you can follow this guide.
+
+### Guide
+Encrypted cookie rotation is performed by the `config/initializers/cookie_rotation.rb` initializer
+but it will only take action if there is an `old_secret_key_base` secret in `config/secrets.yml`.
+
+To rotate the `secret_key_base` without inconveniencing users you must:
+
+1. add an old_secret_key_base to `config/secrets.yml`
+   and assign its value to that of the current secret
+   you wish to rotate.
+
+2. generate a new secret at a terminal rooted in the
+   (or any rails) repo using `rails secret` and assign
+   the existing `secret_key_base`'s value to be that
+   of the new secret
+   example:
+   ```
+   # config/secrets.yml
+   development:
+     old_secret_key_base: my-current-local-secret-key-base-secret
+     secret_key_base: my-new-local-secret-key-base-secret
+   ....
+   production:
+     old_secret_key_base: ENV["OLD_SECRET_KEY_BASE"]
+     secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+   ```
+
+3. For production, as in the above example, you will need to
+   add an OLD_SECRET_KEY_BASE env variable to each namespace/host,
+   add the current secret to that and modify the existing
+   SECRET_KEY_BASE to hold the new secret.
+
+   Note: secret env vars are kept in `kubernetes_deploy/<environment>/secrets.yaml`
+   , where `environment` can be dev, staging, production or
+   any other "namespace".
+
+4. Deploy the application, ensuring the new secrets
+   are applied first. The `kubernetes_deploy/scripts/deploy.sh`
+   or `.circleci/deploy.sh` scripts will apply the secrets
+   before the image, thereby ensuring this.
+
+5. Leave the rotation in place for x, where x is however
+   long (days?!) we think it will take the majority of
+   users to have visited the site and have their cookies rotated.
+
+6. After x amount of time you should then delete the
+   `old_secret_key_base` secret entry from `config/secrets.yml`
+   and any matching `OLD_SECRET_KEY_BASE` env variable. You
+   should do this at time of low traffic to minimise
+   inconvenience for users.
+
+### How it works:
+  The process above will add a fallback encryptor that uses
+  the `old_secret_key_base` secret to verify session cookies
+  are valid if the "primary" encryptor (that uses `secret_key_base`)
+  determines it to be invalid.
+
+  Nonetheless, a new session cookie will be generated using
+  the new `secret_key_base` secret.
+
+  Anyone visiting the site using an old session cookie
+  will not be considered invalid AND will transparently generate
+  themselves a new session cookie using the new secret.
+  Once the old key is deleted those who have visited the site in
+  the interim will already have a valid session cookie in any event
+  and those who do not will be logged out.
+
+  A futher mitigation of the impact would therefore be to do
+  the deploy that deletes the old key at a time of low traffic
+  to avoid inconveniencing as few people as possible. The inconvenience
+  for these individuals would be, at best, a redirect to login, but could
+  possibly cause form input loss if the input is not yet saved, and in
+  some cases a 500 may occur. This last might typically happen if they
+  are on a form page with validation errors displaying and they
+  attempt to resubmit with more validation errors.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,9 @@
 - [Anonymised database dump and restore](#anonymised-database-dump-and-restore)
 - [A note on architecture](#a-note-on-architecture)
 
+## Other links:
+- [Cookie rotation](cookie_rotation.md)
+
 ## Setting up development environment
 
 - Install dependencies


### PR DESCRIPTION
#### What
Adds deactivated configuration that enables
rotation of the `secret_key_base` without
logging users out.

#### Ticket

[CBO-1734](https://dsdmoj.atlassian.net/browse/CBO-1734)

#### Why
To prevent users being logged out when the `secret_key_base`
secret is rotated, which in turn would be an inconvenience
with some potetntial for input field data loss, as well
as edges cases for error being encountered by the app.

#### How
 See `docs/cookie_rotation.md` for details.