### PR TITLE
Extend and refactor webapp level error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,10 @@ class ApplicationController < ActionController::Base
     redirect_to error_500_url
   end
 
+  rescue_from ActionController::InvalidAuthenticityToken do |_exception|
+    redirect_back fallback_location: unauthenticated_root_path
+  end
+
   rescue_from ActiveRecord::RecordNotFound do |_exception|
     raise unless Rails.env.production?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,14 @@ class ApplicationController < ActionController::Base
   rescue_from Exception do |exception|
     raise unless Rails.env.production?
 
-    if exception.is_a?(ActiveRecord::RecordNotFound)
-      redirect_to error_404_url
-    else
-      Sentry.capture_exception(exception)
-      redirect_to error_500_url
-    end
+    Sentry.capture_exception(exception)
+    redirect_to error_500_url
+  end
+
+  rescue_from ActiveRecord::RecordNotFound do |_exception|
+    raise unless Rails.env.production?
+
+    redirect_to error_404_url
   end
 
   rescue_from CanCan::AccessDenied do |_exception|


### PR DESCRIPTION
#### What
Add ActionController::InvalidAuthenticityToken handling.

#### Ticket

relates to [CBO-1734](https://dsdmoj.atlassian.net/browse/CBO-1734)

#### Why
`ActionController::InvalidAuthenticityToken` could be raised in certain
circumstances and go unhandled. 

Typically this would be be handled by devise's [handle_unverified_request](https://github.com/heartcombo/devise/blob/45b831c4ea5a35914037bd27fe88b76d7b3683a4/lib/devise/controllers/helpers.rb#L254-L258) but seems to be missed in some 
situations (e.g. when the form page has validation errors
and needs to redirect back to itself) causing a 500 error to be raised.

Currently this change means that when the form page has validation errors
and is rendering itself, it will 404 (instead of 500) - not sure why this does
not then redirect to a login page though?!
