### PR TITLE
Remove linting from pre-commit githook

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -22,29 +22,3 @@ if [[ $? -ne 0 ]]; then
 else
   printf "none found!"
 fi
-
-
-################################################################################
-# JavaScript linting using standardJS
-#
-
-printf '\nLinting JavaScript files...\n'
-
-yarn run validate:js
-if [[ $? -ne 0 ]]; then
-  printf 'StandardJS errors were detected. Aborting commit.\n'
-  exit 1
-fi
-
-
-################################################################################
-# SCSS linting using styleLint
-#
-
-printf '\nLinting SCSS files...\n'
-
-yarn run validate:scss
-if [[ $? -ne 0 ]]; then
-  printf 'Stylelint errors were detected. Aborting commit.\n'
-  exit 1
-fi


### PR DESCRIPTION
#### What
Remove linting from pre-commit githook

#### Why

These are taking a long time and the test
suite/ci is really the place for linting
and these linters are run as part of that now.

Having them in the githook:

1. means they run on every commit and amend

2. they take 12+ seconds each time
  ```
  Linting JavaScript files...
  yarn run v1.22.10
  $ standard
  ✨  Done in 1.59s.

  Linting SCSS files...
  yarn run v1.22.10
  $ stylelint **/*.scss
  ✨  Done in 12.12s.
  ```

3. it does not matter if lint errors are committed and pushed
   to github as they are caught by the CI anyway now.

4. most commits, for most devs, don't touch css/javascript