### PR TITLE
Amend add_paperclip_checksums for cronjob

### DIFF
--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -28,8 +28,8 @@ namespace :storage do
   end
 
   desc 'Add file checksums to paperclip columns'
-  task :add_paperclip_checksums, [:model, :count] => :environment do |_task, args|
-    continue?("Set #{args[:count] || 'all'} paperclip checksums for all records of #{args[:model]}?")
+  task :add_paperclip_checksums, [:model, :limit, :prompt] => :environment do |_task, args|
+    continue?("Set paperclip checksums for #{args[:limit] || 'all'} records of #{args[:model]}?") unless args[:prompt].eql?('no_prompt')
 
     module TempStats
       class StatsReport < ApplicationRecord
@@ -82,10 +82,12 @@ namespace :storage do
       puts "Cannot calculate checksums for: #{args[:model]}"
       exit
     end
-    relation = relation.limit(args[:count]) if args[:count]
+    relation = relation.limit(args[:limit]) if args[:limit]
 
-    puts "Setting checksums for #{relation.table_name.green}"
+    puts "Setting paperclip checksums for #{args[:limit] || 'all'} records of #{relation.table_name.green}"
     Storage.set_paperclip_checksums(relation: relation)
+
+    Rake::Task['storage:status'].invoke
   end
 
   desc 'Clear temporary paperclip checksums for specified model'


### PR DESCRIPTION
#### What
Amend add_paperclip_checksums for cronjob

#### Ticket
[CBO-1742](https://dsdmoj.atlassian.net/browse/CBO-1742)

#### Why
* Add condition for prompting to add_paperclip_checksums
  So it can be run unattended via a k8s cronjob.

* Amend output to include "limit" applied to relation
  So running this task with 'no_prompt' argument will
  output the record limit to logs.

* Call storage:status task after adding checksums
  So cronjob outputs results after running the
  add checksums task. This is useful for cronjobs
  that are only intended to run a singular
  command and it is hacky to get them
  to run a separate command afterward.

  The cronjob can now just run the command below
  to add the checksums and report on the result.

  ```
  bundle exec rails "storage:add_paperclip_checksums[documents,10000,no_prompt]"
  ```