### PR TITLE
Add cronjob to process document checksums

### DIFF
--- a/docs/active_storage_migration.md
+++ b/docs/active_storage_migration.md
@@ -338,6 +338,8 @@ Paperclip can be removed.
 * Remove `PAPERCLIP_STORAGE_OPTIONS`, `REPORTS_STORAGE_OPTIONS` and
   `REPORTS_STORAGE_OPTIONS` from the configuration files in
   `config/environments`.
+* Remove `kubernetes_deploy/cron_jobs/add_evidence_document_checksums.yml`
+* Amend ` kubernetes_deploy/scripts/cronjob.sh` to remove reference to `add_evidence_document_checksums`
 * **Note:** This step is destructive and cannot be reverted.
   Remove Paperclip related fields from the database:
   * In `stats_reports`; `document_file_name`, `document_content_type`,

--- a/kubernetes_deploy/cron_jobs/add_evidence_document_checksums.yaml
+++ b/kubernetes_deploy/cron_jobs/add_evidence_document_checksums.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cccd-add-evidence-document-checksums
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 250000
+      template:
+        metadata:
+          labels:
+            tier: worker
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: cronjob-worker
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+            imagePullPolicy: Always
+            command:
+              - bundle
+              - exec
+              - rails
+              - "storage:add_paperclip_checksums[documents,10,no_prompt]"
+
+            envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
+            env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-rds
+                  key: url

--- a/kubernetes_deploy/cron_jobs/add_evidence_document_checksums.yaml
+++ b/kubernetes_deploy/cron_jobs/add_evidence_document_checksums.yaml
@@ -40,3 +40,18 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
+            - name: SETTINGS__AWS__S3__ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: access_key_id
+            - name: SETTINGS__AWS__S3__SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: secret_access_key
+            - name: SETTINGS__AWS__S3__BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: bucket_name

--- a/kubernetes_deploy/cron_jobs/add_evidence_document_checksums.yaml
+++ b/kubernetes_deploy/cron_jobs/add_evidence_document_checksums.yaml
@@ -26,7 +26,7 @@ spec:
               - bundle
               - exec
               - rails
-              - "storage:add_paperclip_checksums[documents,10,no_prompt]"
+              - "storage:add_paperclip_checksums[documents,10000,no_prompt]"
 
             envFrom:
             - configMapRef:

--- a/kubernetes_deploy/scripts/cronjob.sh
+++ b/kubernetes_deploy/scripts/cronjob.sh
@@ -3,7 +3,7 @@ function _cronjob() {
   usage="cronjob -- apply job in the specified environment
   Usage: cronjob job environment [branch]
   Where:
-    job [archive_stale|clean_ecr]
+    job [archive_stale|clean_ecr|add_evidence_document_checksums]
     environment [dev|dev-lgfs|staging|api-sandbox|production]
     branch [<branchname>-latest|commit-sha]
 
@@ -28,7 +28,7 @@ function _cronjob() {
   fi
 
   case "$1" in
-    archive_stale)
+    archive_stale | add_evidence_document_checksums)
       job=$1
       ;;
     clean_ecr)

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -267,8 +267,8 @@ module Storage
   def self.validate(attachments:)
     attachments.each_with_object(true) do |attachment, check|
       check &&
-        attachment.blob.filename == attachment.record.send("#{attachment.name}_file_name") &&
-        attachment.blob.checksum == attachment.record.send("as_#{attachment.name}_checksum")
+        attachment.blob.filename == attachment.record&.send("#{attachment.name}_file_name") &&
+        attachment.blob.checksum == attachment.record&.send("as_#{attachment.name}_checksum")
     end ? 'OK'.green : 'Failed'.red
   end
 end


### PR DESCRIPTION
#### What
Adds a kubernetes cronjob to incrementally process
the 400k+ document for checksum

#### Ticket

[CBO-1742](https://dsdmoj.atlassian.net/browse/CBO-1742)

#### Why
Running the checksum task for documents on a worker
pod manually was failing after x (about 15-20k) records
because the process exceeded the memory request limit - 2Gi.

Increasing the memory would just have delayed the failure
as the single process would continue to "leak" memory - not
sure where this was/is happening.

#### How
This handles the "leak" by processing a limited number of
records and schedules the task to repeat every 30 minutes.

The cronjob can be applied to an environment using
```
kubernetes_deploy/scripts/cronjob.sh add_evidence_document_checksums <environment> latest
```

#### Load test results
On a pre-prod environment set up with a prod-like load this task took
approximately 8 hours to complete, processing 10K document records
every 30 minutes