### PR TITLE
Exclude storage directory from Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
     - 'old_features/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
+    - 'storage/**/*'
 
 Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true


### PR DESCRIPTION
#### What

Exclude the contents of the `storage/` directory when running Rubocop.

#### Ticket

N/A

#### Why

Rubocop will scan all files but there are none in `storage/` that need to be checked so these will unnecessarily slow down the check.

#### How

Add `storage/**/*` to the exclusion list in `.rubocop.yml`.