### PR TITLE
Exclude public folder from rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - 'features/**/*'
     - 'node_modules/**/*'
     - 'old_features/**/*'
+    - 'public/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
 


### PR DESCRIPTION
#### What
Exclude public folder from rubocop

#### Why
Unnecessary to lint this folder, plus
if using for disk storage if can get very
large and cause slow startup for rubocop.