### PR TITLE
[CBO-1692] [AS3b] Enable Active Storage for message attachments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'geckoboard-ruby'
 gem 'posix-spawn', '~> 0.3.15'
 gem 'laa-fee-calculator-client', '~> 1.2'
 gem 'webpacker', '~> 5.2'
+gem 'active_storage_validations'
 
 group :production, :devunicorn do
   gem 'unicorn-rails', '2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       activemodel (>= 4.1, < 6.2)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
+    active_storage_validations (0.9.2)
+      rails (>= 5.2.0)
     activejob (6.0.3.5)
       activesupport (= 6.0.3.5)
       globalid (>= 0.3.6)
@@ -782,6 +784,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.12)
+  active_storage_validations
   amoeba (~> 3.1.0)
   annotate
   auto_strip_attributes (~> 2.6.0)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -15,6 +15,8 @@
 #
 
 class MessagesController < ApplicationController
+  include ActiveStorage::SetCurrent
+
   respond_to :html
 
   def create
@@ -33,11 +35,9 @@ class MessagesController < ApplicationController
   end
 
   def download_attachment
-    raise 'No attachment present on this message' if message.attachment.blank?
+    raise 'No attachment present on this message' unless message.attachment.attached?
 
-    send_file Paperclip.io_adapters.for(message.attachment).path, type: message.attachment_content_type,
-                                                                  filename: message.attachment_file_name,
-                                                                  x_sendfile: true
+    redirect_to message.attachment.blob.service_url(disposition: 'attachment')
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -24,23 +24,23 @@ class Message < ApplicationRecord
 
   attr_accessor :claim_action, :written_reasons_submitted
 
-  has_attached_file :attachment, s3_headers.merge(PAPERCLIP_STORAGE_OPTIONS)
+  has_one_attached :attachment
 
-  validates_attachment :attachment,
-                       size: { in: 0.megabytes..20.megabytes },
-                       content_type: {
-                         content_type: ['application/pdf',
-                                        'application/msword',
-                                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                                        'application/vnd.oasis.opendocument.text',
-                                        'text/rtf',
-                                        'application/rtf',
-                                        'image/jpeg',
-                                        'image/png',
-                                        'image/tiff',
-                                        'image/bmp',
-                                        'image/x-bitmap']
-                       }
+  validates :attachment,
+            size: { less_than: 20.megabytes },
+            content_type: [
+              'application/pdf',
+              'application/msword',
+              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+              'application/vnd.oasis.opendocument.text',
+              'text/rtf',
+              'application/rtf',
+              'image/jpeg',
+              'image/png',
+              'image/tiff',
+              'image/bmp',
+              'image/x-bitmap'
+            ]
 
   validates :sender, presence: { message: 'Message sender cannot be blank' }
   validates :body, presence: { message: 'Message body cannot be blank' }
@@ -50,8 +50,8 @@ class Message < ApplicationRecord
 
   scope :most_recent_last, -> { includes(:user_message_statuses).order(created_at: :asc) }
 
-  before_save :populate_checksum
   after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
+  before_save :populate_paperclip
 
   class << self
     def for(object)
@@ -112,5 +112,14 @@ class Message < ApplicationRecord
 
   def claim_updater
     Claims::ExternalUserClaimUpdater.new(claim, current_user: sender)
+  end
+
+  def populate_paperclip
+    return unless attachment.attached?
+
+    self.attachment_file_name = attachment.filename
+    self.attachment_file_size = attachment.byte_size
+    self.attachment_content_type = attachment.content_type
+    self.as_attachment_checksum = attachment.checksum
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -114,12 +114,17 @@ class Message < ApplicationRecord
     Claims::ExternalUserClaimUpdater.new(claim, current_user: sender)
   end
 
+  # High ABC Size due to setting Paperclip fields for possible revert.
+  # This 'rubocop:disable' can be removed when the Paperclip fields are removed.
+  # rubocop:disable Metrics/AbcSize
   def populate_paperclip
     return unless attachment.attached?
 
     self.attachment_file_name = attachment.filename
     self.attachment_file_size = attachment.byte_size
     self.attachment_content_type = attachment.content_type
+    self.attachment_updated_at = Time.zone.now
     self.as_attachment_checksum = attachment.checksum
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -50,8 +50,8 @@ class Message < ApplicationRecord
 
   scope :most_recent_last, -> { includes(:user_message_statuses).order(created_at: :asc) }
 
-  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
   before_save :populate_paperclip
+  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
 
   class << self
     def for(object)

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -12,6 +12,17 @@ class MessagePresenter < BasePresenter
     end
   end
 
+  def sender_name
+    return '(Case worker)' if sender_is_a?(CaseWorker) && hide_author?
+    message.sender.name
+  end
+
+  def timestamp
+    message.created_at.strftime('%H:%M')
+  end
+
+  private
+
   def attachment_field
     h.concat('Attachment: ')
     download_file_link
@@ -28,20 +39,11 @@ class MessagePresenter < BasePresenter
   end
 
   def attachment_file_name
-    message.attachment.original_filename
+    message.attachment.filename.to_s
   end
 
   def attachment_file_size
-    h.number_to_human_size(message.attachment_file_size)
-  end
-
-  def sender_name
-    return '(Case worker)' if sender_is_a?(CaseWorker) && hide_author?
-    message.sender.name
-  end
-
-  def timestamp
-    message.created_at.strftime('%H:%M')
+    h.number_to_human_size(message.attachment.byte_size)
   end
 
   def hide_author?

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -76,18 +76,16 @@ RSpec.describe MessagesController, type: :controller do
       subject(:download_attachment) { get :download_attachment, params: { id: message.id } }
 
       context 'when message has attachment' do
-        let(:disk_service_prefix) { 'rails/active_storage/disk' }
-        let(:filename) { 'test_document.docx' }
         let(:message) { create(:message) }
+        let(:test_url) { 'https://example/com/attachment.doc#123abc' }
 
         before do
-          message.attachment.attach(io: StringIO.new, filename: filename)
-          download_attachment
+          message.attachment.attach(io: StringIO.new, filename: 'attachment.doc')
+          allow(Message).to receive(:find).with(message[:id].to_s).and_return(message)
+          allow(message.attachment.blob).to receive(:service_url).and_return(test_url)
         end
 
-        it 'redirects to the attachment' do
-          expect(response.location).to match %r{#{disk_service_prefix}/.*/#{filename}}
-        end
+        it { is_expected.to redirect_to test_url }
       end
 
       context 'when message does not have attachment' do

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -31,7 +31,11 @@ FactoryBot.define do
   end
 
   trait :with_attachment do
-    attachment { File.open(Rails.root + 'features/examples/shorter_lorem.docx') }
-    attachment_content_type { 'application/msword' }
+    attachment do
+      Rack::Test::UploadedFile.new(
+        File.expand_path('features/examples/shorter_lorem.docx', Rails.root),
+        'application/msword'
+      )
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Ability do
 
     it { should be_able_to(:create, Message.new) }
     it { should be_able_to(:download_attachment, Message.new) }
-    it { should be_able_to(:download_attachment, Message.new) }
     it { should be_able_to(:index, UserMessageStatus) }
     it { should be_able_to(:update, UserMessageStatus.new) }
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -250,6 +250,25 @@ RSpec.describe Message, type: :model do
     end
   end
 
+  describe '#attachment_updated_at' do
+    subject { message.attachment_updated_at }
+
+    context 'with no attachment' do
+      let(:message) { create(:message) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with an attachment' do
+      let(:message) { create(:message, :with_attachment) }
+      let(:time) { Time.zone.parse('19 January 2021, 11:05:00') }
+
+      before { travel_to time }
+
+      it { is_expected.to eq time }
+    end
+  end
+
   describe '#as_attachment_checksum' do
     subject { message.as_attachment_checksum }
 

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe MessagePresenter, type: :helper do
+  subject(:presenter) { described_class.new message, helper }
+
+  let(:attachment) { nil }
+  let(:message) { build :message, attachment: attachment }
+
+  describe '#body' do
+    context 'without an attachment' do
+      it 'does not include a download link for the attachment' do
+        expect(presenter.body).not_to match(%r{Attachment:\s*<a.*>.*</a>})
+      end
+    end
+
+    context 'with an attachment' do
+      let(:file) { File.expand_path('features/examples/shorter_lorem.docx', Rails.root) }
+      let(:file_size) { number_to_human_size(File.size(file)) }
+      let(:attachment) { Rack::Test::UploadedFile.new(file) }
+
+      before do
+        allow(message.attachment).to receive(:service_url).and_return('http://example.com')
+      end
+
+      it 'includes a download link to the attachment' do
+        expect(presenter.body)
+          .to match(%r{Attachment:\s*<a.*>shorter_lorem.docx \(#{file_size}\)</a>})
+      end
+    end
+  end
+end

--- a/spec/support/active_storage_validations.rb
+++ b/spec/support/active_storage_validations.rb
@@ -1,0 +1,5 @@
+require 'active_storage_validations/matchers'
+
+RSpec.configure do |config|
+  config.include ActiveStorageValidations::Matchers
+end


### PR DESCRIPTION
#### What

Switch over to using Active Storage for attachments of claim messages.

#### Ticket

[Migrate paperclip to active storage - enable for messages](https://dsdmoj.atlassian.net/browse/CBO-1692)

#### Why

We need to switch over to using Active Storage everywhere we have documents in CCCD. Following on from the PR to turn this on for stats report the next step is for attachments of messages.

#### How

There are some notes on how document storage is deals with using Active Storage: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/jh/use-active-storage/docs/document_storage.md