### PR TITLE
Remove the climate_control gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,6 @@ group :test do
   gem 'axe-core-cucumber', '~> 4.1'
   gem 'capybara-selenium'
   gem 'capybara', '~> 3.35'
-  gem 'climate_control'
   gem 'codeclimate-test-reporter', require: false
   gem 'cucumber-rails', '~> 2.2.0', require: false
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -797,7 +797,6 @@ DEPENDENCIES
   cancancan (~> 3.2)
   capybara (~> 3.35)
   capybara-selenium
-  climate_control
   cocoon (~> 1.2.15)
   codeclimate-test-reporter
   colorize


### PR DESCRIPTION
#### What

Remove the `climate_control` gem.

#### Ticket

N/A

#### Why

This gem is no longer being used.

#### How

Remove from `Gemfile` and recreate `Gemfile.lock`.