### PR TITLE
Remove test-prof gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,6 @@ group :test do
   gem 'simplecov-csv', require: false
   gem 'simplecov-multi', require: false
   gem 'simplecov', require: false
-  gem 'test-prof'
   gem 'timecop'
   gem 'vcr'
   gem 'webdrivers', '~> 4.6', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -712,7 +712,6 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
-    test-prof (1.0.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -886,7 +885,6 @@ DEPENDENCIES
   state_machine (~> 1.2.0)
   state_machines-activerecord
   state_machines-audit_trail
-  test-prof
   timecop
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
#### What
Remove test-prof gem

#### Why
We are not using it, though perhaps
we should. But unitl such time as we
work on speeding tests up this is not needed.