### PR TITLE
Do not use include ActionDispatch::TestProcess

### DIFF
--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -242,13 +242,6 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
         let(:invalid_claim_params)      { valid_claim_fee_params.reject { |k, _v| k == 'advocate_category' } }
 
         context 'non fixed fee case types' do
-          before do
-            @file = Rack::Test::UploadedFile.new(
-                      File.expand_path('spec/fixtures/files/repo_order_1.pdf', Rails.root),
-                      'text/csv'
-                    )
-          end
-
           context 'valid params' do
             it 'creates a claim with all basic fees and specified miscellaneous but NOT the fixed fees' do
               post :create, params: { claim: claim_params }

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -243,7 +243,10 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
 
         context 'non fixed fee case types' do
           before do
-            @file = fixture_file_upload('files/repo_order_1.pdf', 'application/pdf')
+            @file = Rack::Test::UploadedFile.new(
+                      File.expand_path('spec/fixtures/files/repo_order_1.pdf', Rails.root),
+                      'text/csv'
+                    )
           end
 
           context 'valid params' do

--- a/spec/factories/stats/stats_reports.rb
+++ b/spec/factories/stats/stats_reports.rb
@@ -20,7 +20,11 @@ FactoryBot.define do
 
     trait :with_document do
       report { nil }
-      document { fixture_file_upload "#{Rails.root}/spec/fixtures/files/report.csv", 'text/csv' }
+      document {
+        Rack::Test::UploadedFile.new(
+          File.expand_path('spec/fixtures/files/report.csv', Rails.root),
+          'text/csv')
+      }
     end
 
     trait :incomplete do

--- a/spec/factories/stats/stats_reports.rb
+++ b/spec/factories/stats/stats_reports.rb
@@ -20,11 +20,12 @@ FactoryBot.define do
 
     trait :with_document do
       report { nil }
-      document {
+      document do
         Rack::Test::UploadedFile.new(
           File.expand_path('spec/fixtures/files/report.csv', Rails.root),
-          'text/csv')
-      }
+          'text/csv'
+        )
+      end
     end
 
     trait :incomplete do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,8 +68,6 @@ require 'parallel_spec_helper'
 require 'vcr_helper'
 require 'sidekiq/testing'
 
-include ActionDispatch::TestProcess # required for fixture_file_upload
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
#### What
Do not use include ActionDispatch::TestProcess for file
fixtures

#### Why
Not sure if this is preferable but some commentators
have argued against using this lib.

https://collectiveidea.com/blog/archives/2017/01/16/testing-an-uploaded-file-in-rspec

An alternative may be to just include the FixtureFile aspect
```
include ActionDispatch::TestProcess::FixtureFile
```