### PR TITLE
Prefetch blob and record to avoid N+1 problem

### DIFF
--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -265,7 +265,7 @@ module Storage
   end
 
   def self.validate(attachments:)
-    attachments.each_with_object(true) do |attachment, check|
+    attachments.includes(:blob, :record).each_with_object(true) do |attachment, check|
       check &&
         attachment.blob.filename == attachment.record&.send("#{attachment.name}_file_name") &&
         attachment.blob.checksum == attachment.record&.send("as_#{attachment.name}_checksum")


### PR DESCRIPTION
#### What

Pre-fetch `ActiveStorage::Blob` and `Document`/`Message`/`Stats::StatsReport` when validating migration data.

#### Ticket

N/A

#### Why

The `storage:status` Rake task checks each Active Storage attachment to make sure that the values in the `ActiveStorage::Blob` records match the corresponding Paperclip data.

#### How

Add `includes(:blob, :record)`