### PR TITLE
[CBO-1754] Background job to convert evidence documents

### DIFF
--- a/app/jobs/convert_document_job.rb
+++ b/app/jobs/convert_document_job.rb
@@ -1,0 +1,38 @@
+class ConvertDocumentJob < ApplicationJob
+  queue_as :convert_document
+
+  def perform(id)
+    log "Document conversion starting for document id #{id}"
+
+    document = Document.find(id)
+    return if document.converted_preview_document.present?
+
+    if document.document.content_type == 'application/pdf'
+      copy_file document
+    else
+      convert_file document
+    end
+    document.save
+  end
+
+  private
+
+  def copy_file(document)
+    log 'Copying original PDF file to converted preview document'
+    document.converted_preview_document = document.document
+    document.as_converted_preview_document_checksum = document.as_document_checksum
+  end
+
+  def convert_file(document)
+    log 'Converting original file to PDF for converted preview document'
+    File.open("#{Dir.mktmpdir}/#{document.document_file_name}.pdf", 'wb+') do |file|
+      Libreconv.convert(Paperclip.io_adapters.for(document.document).path, file)
+      document.converted_preview_document = file
+    end
+    document.add_checksum(:converted_preview_document)
+  end
+
+  def log(message, level: :info, action: nil)
+    LogStuff.send(level, class: self.class.name, action: (action || caller_locations(1..1).first.label)) { message }
+  end
+end

--- a/app/models/concerns/document_attachment.rb
+++ b/app/models/concerns/document_attachment.rb
@@ -11,24 +11,4 @@ module DocumentAttachment
 
     validates_attachment_content_type :converted_preview_document, content_type: 'application/pdf'
   end
-
-  def generate_pdf_tmpfile
-    if File.extname(document_file_name).casecmp('.pdf').zero?
-      self.pdf_tmpfile = document # if original document is PDF, make tmpfile from original doc
-    else
-      convert_and_assign_document
-    end
-  end
-
-  def convert_and_assign_document
-    # Libreconvert performs both actions in one call
-    self.pdf_tmpfile = File.new("#{Dir.mktmpdir}/#{document_file_name}.pdf", 'wb+')
-    Libreconv.convert(Paperclip.io_adapters.for(document).path, pdf_tmpfile) # Libreoffice exe must be in PATH
-  rescue IOError
-    nil # raised if Libreoffice exe is not in PATH
-  end
-
-  def add_converted_preview_document
-    self.converted_preview_document = pdf_tmpfile if converted_preview_document_file_name.nil?
-  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -53,7 +53,7 @@ class Document < ApplicationRecord
   delegate :provider_id, to: :external_user
 
   before_save :populate_checksum
-  after_save :convert_document
+  after_create :convert_document
 
   validate :documents_count
 
@@ -63,14 +63,16 @@ class Document < ApplicationRecord
   end
 
   def save_and_verify
-    result = save
-    if result
-      result = verify_and_log
-    else
-      transform_cryptic_paperclip_error
-      log_save_error
-    end
-    result
+    self.verified = true
+    save
+    # result = save
+    # if result
+    #   result = verify_and_log
+    # else
+    #   transform_cryptic_paperclip_error
+    #   log_save_error
+    # end
+    # result
   end
 
   def verify_and_log

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -52,9 +52,8 @@ class Document < ApplicationRecord
   alias attachment document # to have a consistent interface to both Document and Message
   delegate :provider_id, to: :external_user
 
-  before_save :generate_pdf_tmpfile
-  before_save :add_converted_preview_document
   before_save :populate_checksum
+  after_save :convert_document
 
   validate :documents_count
 
@@ -137,5 +136,9 @@ class Document < ApplicationRecord
     return unless errors[:document].include?('has contents that are not what they are reported to be')
     errors[:document].delete('has contents that are not what they are reported to be')
     errors[:document] << 'The contents of the file do not match the file extension'
+  end
+
+  def convert_document
+    ConvertDocumentJob.perform_later(id)
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,6 +5,7 @@
   - [default, 2]
   - [claims, 2]
   - [stats_reports, 1]
+  - [convert_document, 1]
 development:
   :verbose: true
   :concurrency: 5

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe DocumentsController, type: :controller do
     let(:document) { create(:document, :with_preview, external_user_id: external_user.id) }
 
     it 'downloads the document' do
-      get :show, params: { id: document.id }
+      get :download, params: { id: document.id }
       expect(response.body).to eq binread(document.document.path)
     end
   end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe DocumentsController, type: :controller do
   end
 
   describe 'GET #show' do
-    let(:document) { create(:document, external_user_id: external_user.id) }
+    let(:document) { create(:document, :with_preview, external_user_id: external_user.id) }
 
     it 'downloads a preview of the document' do
       get :show, params: { id: document.id }
@@ -67,7 +67,7 @@ RSpec.describe DocumentsController, type: :controller do
   end
 
   describe 'GET #download' do
-    let(:document) { create(:document, external_user_id: external_user.id) }
+    let(:document) { create(:document, :with_preview, external_user_id: external_user.id) }
 
     it 'downloads the document' do
       get :show, params: { id: document.id }

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -29,15 +29,6 @@ FactoryBot.define do
     claim
     external_user
 
-    after(:create) do |doc|
-      # The tests very often check to see if the converted preview doc exists before
-      # it has been created, so here we just wait until it has been created up to a maximum of 1 second
-      5.times do
-        break if File.exist?(doc.converted_preview_document.path)
-        sleep 0.2
-      end
-    end
-
     trait :docx do
       document { File.open(Rails.root + 'features/examples/shorter_lorem.docx') }
       document_content_type { 'application/msword' }
@@ -58,6 +49,15 @@ FactoryBot.define do
       document { nil }
       verified_file_size { 0 }
       verified { false }
+    end
+
+    trait :pdf # Default
+
+    trait :with_preview do
+      document { File.open(Rails.root + 'features/examples/longer_lorem.png') }
+      document_content_type { 'image/png' }
+      converted_preview_document { File.open(Rails.root + 'features/examples/longer_lorem.pdf') }
+      converted_preview_document_content_type { 'application/pdf' }
     end
   end
 end

--- a/spec/jobs/convert_document_job_spec.rb
+++ b/spec/jobs/convert_document_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ConvertDocumentJob, type: :job do
       before do
         allow(Libreconv).to receive(:convert).with(any_args) do |_file_in, file_out|
           File.open(Rails.root + 'features/examples/longer_lorem.pdf', 'rb') do |input|
-            while buff = input.read(4096)
+            while (buff = input.read(4096))
               file_out.write(buff)
             end
           end

--- a/spec/jobs/convert_document_job_spec.rb
+++ b/spec/jobs/convert_document_job_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe ConvertDocumentJob, type: :job do
+  subject(:job) { described_class.new }
+
+  describe '#perform' do
+    subject(:perform) { job.perform(document.id) }
+
+    context 'with an existing converted preview document' do
+      let(:document) { create :document, :with_preview }
+
+      it { expect { perform }.not_to(change { document.reload.converted_preview_document_file_name }) }
+      it { expect { perform }.not_to raise_error }
+    end
+
+    context 'with a pdf document' do
+      let(:document) { create :document, :pdf }
+
+      it { expect { perform }.to change { document.reload.converted_preview_document.path }.to(document.document.path) }
+      it { expect { perform }.not_to raise_error }
+
+      it do
+        expect { perform }
+          .to change { document.reload.as_converted_preview_document_checksum }
+          .to(document.as_document_checksum)
+      end
+    end
+
+    context 'with a docx document' do
+      let(:document) { create :document, :docx }
+
+      it do
+        expect { perform }
+          .to change { document.reload.converted_preview_document_file_name }.to(document.document_file_name + '.pdf')
+      end
+
+      it do
+        expect { perform }
+          .to change { document.reload.converted_preview_document_content_type }.to('application/pdf')
+      end
+
+      it { expect { perform }.not_to raise_error }
+
+      it { expect { perform }.to change { document.reload.as_converted_preview_document_checksum.to_s[-2..] }.to('==') }
+    end
+
+    context 'when Libreconv fails' do
+      let(:document) { create :document, :docx }
+
+      before { allow(Libreconv).to receive(:convert).and_raise(IOError) }
+
+      it { expect { perform }.to raise_error(IOError) }
+    end
+  end
+end

--- a/spec/jobs/convert_document_job_spec.rb
+++ b/spec/jobs/convert_document_job_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe ConvertDocumentJob, type: :job do
     context 'with a docx document' do
       let(:document) { create :document, :docx }
 
+      before do
+        allow(Libreconv).to receive(:convert).with(any_args) do |_file_in, file_out|
+          File.open(Rails.root + 'features/examples/longer_lorem.pdf', 'rb') do |input|
+            while buff = input.read(4096)
+              file_out.write(buff)
+            end
+          end
+        end
+      end
+
       it do
         expect { perform }
           .to change { document.reload.converted_preview_document_file_name }.to(document.document_file_name + '.pdf')
@@ -41,7 +51,11 @@ RSpec.describe ConvertDocumentJob, type: :job do
 
       it { expect { perform }.not_to raise_error }
 
-      it { expect { perform }.to change { document.reload.as_converted_preview_document_checksum.to_s[-2..] }.to('==') }
+      it do
+        expect { perform }
+          .to change { document.reload.as_converted_preview_document_checksum }
+          .to('VJnssr9u1aT2uVBaTtQ7eQ==')
+      end
     end
 
     context 'when Libreconv fails' do

--- a/spec/models/timed_transitions/transitioner_spec.rb
+++ b/spec/models/timed_transitions/transitioner_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe TimedTransitions::Transitioner do
             2.times { @claim.messages << create(:message, claim: @claim) }
             @claim.injection_attempts << create(:injection_attempt, claim: @claim)
             @claim.expenses.first.dates_attended << DateAttended.new
-            @claim.documents << create(:document, claim: @claim, verified: true)
+            @claim.documents << create(:document, :with_preview, claim: @claim, verified: true)
             @claim.certification = create(:certification, claim: @claim)
             @claim.save!
             @claim.reload


### PR DESCRIPTION
#### What

Create a backgrounded job to convert evidence documents to PDF.

#### Ticket

[Background task for creating converted preview documents](https://dsdmoj.atlassian.net/browse/CBO-1754)

#### Why

Currently evidence documents are converted as they are uploaded. This results in the uploads to take several seconds to complete. By creating a background job the user will see documents uploaded much quicker and, additionally, failed conversions can be retried.

#### How

Create a new job `ConvertDocumentJob` that is enqueued when a document is saved.

--------

#### TODO (wip)

 - [ ] Fix any tests that are broken due to newly created documents not having a converted preview
 - [ ] Replace tests related to the conversion process, as appropriate
 - [ ] Test that conversion job is being created, performed and retried
 - [ ] Cater for attempting to view a preview if a preview has not been created yet