### PR TITLE
Add feature steps to excercise "Duplicate last expense"

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,8 +1,8 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip'"
-focus_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags @focus"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip' --publish-quiet"
+focus_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags @focus --publish-quiet"
 %>
 default: <%= std_opts %> features
 focus: <%= focus_opts %> features

--- a/features/claims/advocate/scheme_ten/advocate_expense_page.feature
+++ b/features/claims/advocate/scheme_ten/advocate_expense_page.feature
@@ -24,6 +24,7 @@ Feature: Advocate creates, saves, edits claims and expenses
 
     When I click the claim 'A20181234'
     And I edit the claim's expenses
+    Then I should see a page title "Enter travel expenses for advocate final fees claim"
 
     And I select an expense type "Parking"
     And I select a travel reason "View of crime scene"
@@ -39,10 +40,9 @@ Feature: Advocate creates, saves, edits claims and expenses
 
     And I select an expense type "Bike travel"
     And I select a travel reason "Other"
-    And I add an expense distance of "873"
-
     And I add an other reason of "Other reason text"
-
+    And I add an expense location of 'My other location'
+    And I add an expense distance of "873"
     And I select a mileage rate of '20p per mile'
 
     Then I should see 'Distance'
@@ -60,12 +60,11 @@ Feature: Advocate creates, saves, edits claims and expenses
     And I should not see 'Expense 2'
     But I should see 'Expense'
 
-    And I should see a page title "Enter travel expenses for advocate final fees claim"
-    And I save as draft
-
-    When I click the claim 'A20181234'
+    When I save as draft
+    Then I click the claim 'A20181234'
     Then I should see 'Bike travel'
-    Then I should see 'Other reason text'
-    Then I should see '20p'
-    Then I should see '873'
-    Then I should see '£174.60'
+    And I should see 'Destination: My other location'
+    And I should see 'Cost per mile: 20p per mile'
+    And I should see 'Distance: 873 miles'
+    And I should see 'Other reason text'
+    And I should see '£174.60'

--- a/features/claims/advocate/scheme_ten/advocate_expense_page.feature
+++ b/features/claims/advocate/scheme_ten/advocate_expense_page.feature
@@ -46,9 +46,19 @@ Feature: Advocate creates, saves, edits claims and expenses
     And I select a mileage rate of '20p per mile'
 
     Then I should see 'Distance'
-    Then I should see 'Cost per mile'
-    Then I should see '20p per mile'
-    Then I should see 'Other reason'
+    And I should see 'Cost per mile'
+    And I should see '20p per mile'
+    And I should see 'Other reason'
+
+    Given I should not see 'Expense 1'
+    When I click the link 'Duplicate last expense'
+    Then I should see 'Expense 1'
+    And I should see 'Expense 2'
+
+    When I click the first 'Remove' link
+    Then I should not see 'Expense 1'
+    And I should not see 'Expense 2'
+    But I should see 'Expense'
 
     And I should see a page title "Enter travel expenses for advocate final fees claim"
     And I save as draft

--- a/features/claims/litigator/litigator_expense_page.feature
+++ b/features/claims/litigator/litigator_expense_page.feature
@@ -24,6 +24,7 @@ Feature: Litigator expense specific page features
     Given I am later on the Your claims page
     When I click the claim 'A20161234'
     And I edit the claim's expenses
+    Then I should see a page title "Enter travel expenses for litigator final fees claim"
 
     And I select an expense type "Parking"
     And I select a travel reason "View of crime scene"
@@ -42,13 +43,25 @@ Feature: Litigator expense specific page features
 
     And I select an expense type "Bike travel"
     And I select a travel reason "Other"
+    And I add an expense location of 'My other location'
     And I add an expense distance of "873"
     And I add an other reason of "Other reason text"
 
-    Then I should see 'Location'
-    Then I should see 'Distance'
-    Then I should see 'Cost per mile'
-    Then I should see '20p per mile'
-    Then I should see 'Other reason'
+    Given I should not see 'Expense 1'
+    When I click the link 'Duplicate last expense'
+    Then I should see 'Expense 1'
+    And I should see 'Expense 2'
 
-    Then I click "Continue" in the claim form
+    When I click the first 'Remove' link
+    Then I should not see 'Expense 1'
+    And I should not see 'Expense 2'
+    But I should see 'Expense'
+
+    When I save as draft
+    Then I click the claim 'A20161234'
+    Then I should see 'Bike travel'
+    And I should see 'Destination: My other location'
+    And I should see 'Cost per mile: 20p per mile'
+    And I should see 'Distance: 873 miles'
+    And I should see 'Other reason text'
+    And I should see '£174.60'

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -74,6 +74,11 @@ When(/I click the claim '(.*?)'$/) do |case_number|
   @external_user_home_page.claim_for(case_number).case_number.click
 end
 
+When(/I click the first '(.*?)' link$/) do |text|
+  expect(page).to have_link(text)
+  click_link(text, match: :first)
+end
+
 When(/I click the link '(.*?)'$/) do |text|
   expect(page).to have_link(text)
   click_link(text)
@@ -170,8 +175,8 @@ And(/^I should be in the '(.*?)' form page$/) do |page_heading|
   wait_for_ajax
 end
 
-Then(/^I should see "([^"]*)"$/) do |arg1|
-  expect(page).to have_content(arg1)
+Then(/^I should see "([^"]*)"$/) do |string|
+  expect(page).to have_content(string)
 end
 
 And(/^I should see the field '(.*?)' with value '(.*?)' in '(.*?)'$/) do |field, value, section|

--- a/features/step_definitions/litigator_claim_steps.rb
+++ b/features/step_definitions/litigator_claim_steps.rb
@@ -114,6 +114,10 @@ Then(/^I add an other reason of "([^"]*)"$/) do |reason_text|
   @claim_form_page.expenses.last.other_reason_input.set reason_text
 end
 
+Then('I add an expense location of {string}') do |string|
+  @claim_form_page.expenses.last.destination.set string
+end
+
 Then(/^I add an expense location$/) do
   @claim_form_page.expenses.last.destination.set 'Liverpool'
 end


### PR DESCRIPTION
#### What
Add feature steps to excercise "Duplicate last expense"
expense numbering and expense removal.

#### Why
This feature was not being feature tested. The feature
itself broke due to a govuk_component change but the test
suite passed.

This also adds steps to black box test the removal
feature and its impact on expense numbering.