### PR TITLE
Bump mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,7 +474,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
#### What
Bump mimemagic to 0.3.6

#### Why
Previous versions yanked causing build failures.

Until rails fixes its dependency and paperclip
is removed we need to use the only compatible version
avialable.