### PR TITLE
Fix BigDecimal.new calls

### DIFF
--- a/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocate_claim.rb
@@ -27,7 +27,7 @@ module API::V1::ExternalUsers
       namespace '/' do
         desc 'DEPRECATED: Create an Advocate final claim. see advocates/final endpoint'
         post do
-          deprecate(datetime: Time.new(2021, 3, 31), link: "#{request.base_url}/api/release_notes")
+          deprecate(datetime: Time.new(2021, 4, 30), link: "#{request.base_url}/api/release_notes")
           create_resource(::Claim::AdvocateClaim)
           status api_response.status
           api_response.body
@@ -35,7 +35,7 @@ module API::V1::ExternalUsers
 
         desc 'DEPRECATED: Validate an Advocate final claim. see advocates/final/validate endpoint'
         post '/validate' do
-          deprecate(datetime: Time.new(2021, 3, 31), link: "#{request.base_url}/api/release_notes")
+          deprecate(datetime: Time.new(2021, 4, 30), link: "#{request.base_url}/api/release_notes")
           validate_resource(::Claim::AdvocateClaim)
           status api_response.status
           api_response.body

--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -35,7 +35,7 @@ module Claims::Calculations
              .where(claim_id: claim_id)
              .where(attribute_is_null_to_s(net_attribute))
              .pluck(vat_attribute, net_attribute)
-    { vat: values.map { |v| v.first || BigDecimal.new(0.0, 8) }.sum, net: values.map(&:last).sum }
+    { vat: values.map { |v| v.first || BigDecimal(0.0, 8) }.sum, net: values.map(&:last).sum }
   end
 
   # NOTE: This is meant to reproduce the same behaviour as totalize_for_claim
@@ -44,7 +44,7 @@ module Claims::Calculations
     records = public_send(association_name)
     records.each_with_object(vat: 0, net: 0) do |record, memo|
       next if record.marked_for_destruction? || record.public_send(net_attribute).nil?
-      memo[:vat] += (record.public_send(vat_attribute) || BigDecimal.new(0.0, 8))
+      memo[:vat] += (record.public_send(vat_attribute) || BigDecimal(0.0, 8))
       memo[:net] += record.public_send(net_attribute)
     end
   end

--- a/spec/api/v1/external_users/claims/advocate_final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocate_final_claim_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::AdvocateClaim do
   it_behaves_like 'a claim endpoint', relative_endpoint: :advocate
   it_behaves_like 'a claim validate endpoint', relative_endpoint: :advocate
   it_behaves_like 'a claim create endpoint', relative_endpoint: :advocate
-  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :validate, deprecation_datetime: Time.new(2021, 3, 31)
-  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :create, deprecation_datetime: Time.new(2021, 3, 31)
+  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :validate, deprecation_datetime: Time.new(2021, 4, 30)
+  it_behaves_like 'a deprecated claim endpoint', relative_endpoint: :advocate, action: :create, deprecation_datetime: Time.new(2021, 4, 30)
 
   # TODO: write a generic date error handling spec and share
   describe "POST #{ClaimApiEndpoints.for(:advocate).validate}" do


### PR DESCRIPTION
#### What
Fix BigDecimal.new calls

#### Why
This should fix [sentry errors we have been getting](https://sentry.io/organizations/ministryofjustice/issues/2303416769/?project=5436820&query=is%3Aunresolved)

#### How
Ruby 2.6 deprecated and ruby 2.7 broke
calls to `.new`

see the ruby 2.6 definition for which
also contains the fix.

```
def BigDecimal.new(*args, **kwargs)
  warn "BigDecimal.new is deprecated; use BigDecimal() method instead.", uplevel: 1
  BigDecimal(*args, **kwargs)
end
```