### PR TITLE
[CBO-1660] Migrate certification form to GOVUK design system

### DIFF
--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -58,9 +58,7 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
     params.require(:certification).permit(
       :certification_type_id,
       :certified_by,
-      :certification_date_dd,
-      :certification_date_mm,
-      :certification_date_yyyy
+      :certification_date
     )
   end
 

--- a/app/form_builders/gds_adp_form_builder.rb
+++ b/app/form_builders/gds_adp_form_builder.rb
@@ -1,0 +1,7 @@
+class GdsAdpFormBuilder < AdpFormBuilder
+  delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
+
+  include ActionView::Helpers::FormTagHelper
+  include ActionView::Context
+  include GOVUKDesignSystemFormBuilder::Builder
+end

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -18,20 +18,8 @@ class Certification < ApplicationRecord
   belongs_to :certification_type
 
   validates_with CertificationValidator
-  validate :at_least_one_boolean_selected
-
-  acts_as_gov_uk_date :certification_date, error_clash_behaviour: :override_with_gov_uk_date_field_error
 
   def perform_validation?
     true
-  end
-
-  private
-
-  def at_least_one_boolean_selected
-    return unless claim.is_a?(Claim::AdvocateClaim)
-
-    return if certification_type.present?
-    errors[:base] << 'You must select one option on this form'
   end
 end

--- a/app/validators/certification_validator.rb
+++ b/app/validators/certification_validator.rb
@@ -1,11 +1,15 @@
 class CertificationValidator < BaseValidator
   class << self
     def mandatory_fields
-      %i[certified_by certification_date]
+      %i[certification_type_id certified_by certification_date]
     end
   end
 
   private
+
+  def validate_certification_type_id
+    validate_presence(:certification_type_id, :blank) if @record&.claim&.agfs?
+  end
 
   def validate_certified_by
     validate_presence(:certified_by, :blank)

--- a/app/validators/certification_validator.rb
+++ b/app/validators/certification_validator.rb
@@ -8,7 +8,8 @@ class CertificationValidator < BaseValidator
   private
 
   def validate_certification_type_id
-    validate_presence(:certification_type_id, :blank) if @record&.claim&.agfs?
+    return unless @record&.claim&.agfs? && @record&.claim&.final?
+    validate_presence(:certification_type_id, :blank)
   end
 
   def validate_certified_by

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -1,114 +1,43 @@
 = content_for :page_title, flush: true do
   = t(".page_title.#{present(@claim).type_identifier}")
 
-= render partial: 'errors/error_summary', locals: { ep: @certification, error_summary: t('.error_summary') }
-
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
-= form_for @certification, builder: AdpFormBuilder, url: external_users_claim_certification_path(@claim) do |f|
-  .certification.normal
-    - if @claim.agfs?
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_with model: @certification, url: external_users_claim_certification_path(@claim), builder: GdsAdpFormBuilder, local: true do |f|
+      = f.govuk_error_summary
 
-      .grid-row
-        .column-two-thirds
-          %p
-            By ticking a box, you confirm you are the trial advocate (in cases where legal
-            aid was granted on or after 5 May 2015) or instructed advocate and that you
-            are entitled to submit a claim for this case. If our records show that you are
-            not the trial or instructed advocate, we may reject this claim without payment.
+      - if @claim.agfs?
+        = t('.agfs_claim_collection_html')
 
-          %p
-            Please only tick the relevant box.
+        = f.govuk_collection_radio_buttons :certification_type_id,
+          CertificationType.post_may_2015.agfs,
+          :id,
+          :name,
+          legend: { text: t('.certification_type_post_may_2015'), size: 's' }
 
-      %a#base
-      .grid-row
-        .column-two-thirds
-          %p.bold-normal
-            Final fee claims where the representation order was granted on or after 5 May 2015.
+        = f.govuk_collection_radio_buttons :certification_type_id,
+          CertificationType.pre_may_2015.agfs,
+          :id,
+          :name,
+          legend: { text: t('.certification_type_pre_may_2015'), size: 's' },
+          hint: { text: t('.certification_type_pre_may_2015_hint') }
 
-          .form-group
-            %fieldset
-              %legend
-                I certify that I am the trial advocate as:
+        = t('.agfs_claim_confirmation_info_html')
 
-              = f.collection_radio_buttons(:certification_type_id, CertificationType.post_may_2015.agfs, :id, :name, include_hidden: false) do |b|
-                .multiple-choice
-                  = b.radio_button
-                  = b.label(class: "#{to_slug(b.object.name)}") { b.object.name }
+      - elsif @claim.is_a? Claim::LitigatorClaim
+        = t('.lgfs_claim_html')
 
-      .grid-row
-        .column-two-thirds
+      - else
+        = t('.other_claim_html')
 
-          .form-group
-            %fieldset
-              %legend
-                All other claims
-                %span.form-hint
-                  I certify that I am the instructed advocate as:
+      = f.govuk_text_field :certified_by,
+        label: { text: t('.certified_by') },
+        hint: { text: t('.certified_by_prompt_text') }
 
-              = f.collection_radio_buttons(:certification_type_id, CertificationType.pre_may_2015.agfs, :id, :name, include_hidden: false) do |b|
-                .multiple-choice
-                  = b.radio_button
-                  = b.label { b.object.name }
+      = f.govuk_date_field :certification_date,
+        legend: { text: t('.date'), size: 's' }
 
-
-      .grid-row
-        .column-two-thirds
-          %p
-            All of the above options are in accordance with relevant provision of any secondary legislation arising from the Legal Aid, Sentencing and Punishment of Offenders Act 2012.
-
-          %p.bold-normal
-            You also confirm that you certify that:
-
-          %ul.confirmation-list
-            %li
-              where you’ve represented more than one defendant in a case, you have only made, and will make, one claim for
-              all those defendants together, including where one defendant has transferred representation to another advocate.
-
-            %li
-              neither you nor any other advocate has received any interim, hardship or staged payment on any case number
-              within this matter other than the one under which this claim is made - unless fully detailed (case number, court
-              and advocate supplier number under which payment was made) within this claim.
-
-            %li
-              where there is a joined indictment, you have included all matters that you as the instructed advocate have
-              dealt with within that indictment in this claim.
-
-            %li
-              where a case has been transferred from one crown court to another, no claim has been made separately for the
-              work in the first crown court and all work in both courts is included in this claim.
-
-            %li
-              this work has not been and will not be the subject of any other claim for remuneration from criminal legal aid.
-
-            %li
-              the information you have provided is correct and that you have not made, and will not make, any other claim
-              for payment from criminal legal aid for the work you have done on this claim. You understand that you have given
-              incorrect or misleading information, your payment may be recouped.
-
-            %li
-              if you are claiming a staged payment, you will make sure that any subsequent trial advocate is advised of this
-              payment, with all necessary claim and payment details.
-
-    - elsif @claim.is_a? Claim::LitigatorClaim
-      %p
-        I certify on behalf of the payee, that the information provided is correct. This work has not been and will not be the subject of any other claim for remuneration from criminal legal aid.
-
-    - else
-      %p
-        I certify on behalf of the payee, that the information provided is correct.
-
-    .grid-row
-      .column-one-third
-        = f.adp_text_field :certified_by,
-                          label: t('.certified_by'),
-                          hint_text: t('.certified_by_prompt_text'),
-                          input_classes: 'long-input',
-                          id: 'certified_by'
-
-      .column-one-third
-        = f.gov_uk_date_field(:certification_date, form_hint_text: '', legend_text: t('.date'), legend_class: 'govuk-legend', id: 'certification_date')
-
-    .button-holder
-      = govuk_button(t('.submit'))
-      = govuk_link_button_secondary(t('.return'), edit_polymorphic_path(@claim))
+      = f.govuk_submit t('.submit')
+      = govuk_link_button_secondary t('.return'), edit_polymorphic_path(@claim)

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -290,33 +290,6 @@ form {
   }
 }
 
-// certification.SCSS
-.certification {
-  ul,
-  ol {
-    list-style-type: initial;
-  }
-
-  ul {
-    margin-left: 7%;
-  }
-
-  .confirmation-list {
-    li {
-      margin-bottom: $gutter;
-    }
-  }
-
-  strong {
-    font-weight: 700;
-  }
-
-  .radio-wrapper {
-    margin-left: 5%;
-    @include clearfix;
-  }
-}
-
 // claims-table.SCSS
 .totals {
   padding-top: $gutter-two-thirds;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,8 +180,6 @@ en:
         supplier_number: 'Supplier number'
       case_worker:
         roles: *roles
-      certification:
-        certified_by: 'Name of person certifying'
       user:
         email: *email
         password: *password
@@ -214,11 +212,6 @@ en:
               blank: "can't be blank"
             claim_ids:
               blank: "can't be blank"
-        certification:
-          attributes:
-            certification_date:
-              after_claim_creation: "must be same day or after claim submission day"
-              not_in_the_future: "can't be in the future"
         fee/graduated_fee:
           attributes:
             claim:
@@ -778,27 +771,6 @@ en:
     your_claims: Your claims
     claim_heading: Claim for Crown Court fees
 
-    certifications:
-      new:
-        submit: Certify and submit claim
-        return: Return to claim
-        error_summary: This claim certification has
-        certified_by: 'Name of person certifying'
-        certified_by_prompt_text: 'Enter full name'
-        certification_date: 'Date'
-        date: 'Date'
-        page_title_transfer_claim: Certify and submit the litigator transfer fees claim
-        page_title_advocate_claim: advocate claim
-        page_heading: Certification
-        page_title:
-          agfs_final: Certify and submit the advocate final fees claim
-          agfs_interim: Certify and submit the advocate warrant fees claim
-          agfs_hardship: Certify and submit the advocate hardship fees claim
-          agfs_supplementary: Certify and submit the advocate supplementary fees claim
-          lgfs_final: Certify and submit the litigator final fees claim
-          lgfs_interim: Certify and submit the litigator interim fees claim
-          lgfs_transfer: Certify and submit the litigator transfer fees claim
-          lgfs_hardship: Certify and submit the litigator hardship fees claim
     claim_types:
       new:
         continue: Continue

--- a/config/locales/en/views/certifications.yml
+++ b/config/locales/en/views/certifications.yml
@@ -1,0 +1,28 @@
+---
+en:
+  external_users:
+    certifications:
+      new:
+        agfs_claim_collection_html:
+          <p class="govuk-body">By ticking a box, you confirm you are the trial advocate (in cases where legal aid was granted on or after 5 May 2015) or instructed advocate and that you are entitled to submit a claim for this case. If our records show that you are not the trial or instructed advocate, we may reject this claim without payment.</p>
+          <p class="govuk-body">Please only tick the relevant box.</p>
+          <p class="govuk-body">Final fee claims where the representation order was granted on or after 5 May 2015.</p>
+        agfs_claim_confirmation_info_html:
+          <p class="govuk-body">All of the above options are in accordance with relevant provision of any secondary legislation arising from the Legal Aid, Sentencing and Punishment of Offenders Act 2012.</p>
+          <p class="govuk-body">You also confirm that you certify that:</p>
+          <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+          <li>where you’ve represented more than one defendant in a case, you have only made, and will make, one claim for all those defendants together, including where one defendant has transferred representation to another advocate.</li>
+          <li>neither you nor any other advocate has received any interim, hardship or staged payment on any case number within this matter other than the one under which this claim is made - unless fully detailed (case number, court and advocate supplier number under which payment was made) within this claim.</li>
+          <li>where there is a joined indictment, you have included all matters that you as the instructed advocate have dealt with within that indictment in this claim.</li>
+          <li>where a case has been transferred from one crown court to another, no claim has been made separately for the work in the first crown court and all work in both courts is included in this claim.</li>
+          <li>this work has not been and will not be the subject of any other claim for remuneration from criminal legal aid.</li>
+          <li>the information you have provided is correct and that you have not made, and will not make, any other claim for payment from criminal legal aid for the work you have done on this claim. You understand that you have given incorrect or misleading information, your payment may be recouped.</li>
+          <li>if you are claiming a staged payment, you will make sure that any subsequent trial advocate is advised of this payment, with all necessary claim and payment details.</li>
+          </ul>
+        certification_type_post_may_2015: "I certify that I am the trial advocate as:"
+        certification_type_pre_may_2015: All other claims
+        certification_type_pre_may_2015_hint: "I certify that I am the instructed advocate as:"
+        lgfs_claim_html:
+          <p class="govuk-body">I certify on behalf of the payee, that the information provided is correct. This work has not been and will not be the subject of any other claim for remuneration from criminal legal aid.</p>
+        other_claim_html:
+          <p class="govuk-body">I certify on behalf of the payee, that the information provided is correct.</p>

--- a/config/locales/en/views/certifications.yml
+++ b/config/locales/en/views/certifications.yml
@@ -1,5 +1,19 @@
 ---
 en:
+  activerecord:
+    errors:
+      models:
+        certification:
+          attributes:
+            certification_date:
+              after_claim_creation: Certification date must be same day or after claim submission day
+              blank: Enter certifying date
+              not_in_the_future: Certification date cannot be in the future
+            certification_type_id:
+              blank: Choose a certification type
+            certified_by:
+              blank: Enter the name of person certifying
+
   external_users:
     certifications:
       new:
@@ -26,3 +40,22 @@ en:
           <p class="govuk-body">I certify on behalf of the payee, that the information provided is correct. This work has not been and will not be the subject of any other claim for remuneration from criminal legal aid.</p>
         other_claim_html:
           <p class="govuk-body">I certify on behalf of the payee, that the information provided is correct.</p>
+        submit: Certify and submit claim
+        return: Return to claim
+        error_summary: This claim certification has
+        certified_by: 'Name of person certifying'
+        certified_by_prompt_text: 'Enter full name'
+        certification_date: 'Date'
+        date: 'Date'
+        page_title_transfer_claim: Certify and submit the litigator transfer fees claim
+        page_title_advocate_claim: advocate claim
+        page_heading: Certification
+        page_title:
+          agfs_final: Certify and submit the advocate final fees claim
+          agfs_interim: Certify and submit the advocate warrant fees claim
+          agfs_hardship: Certify and submit the advocate hardship fees claim
+          agfs_supplementary: Certify and submit the advocate supplementary fees claim
+          lgfs_final: Certify and submit the litigator final fees claim
+          lgfs_interim: Certify and submit the litigator interim fees claim
+          lgfs_transfer: Certify and submit the litigator transfer fees claim
+          lgfs_hardship: Certify and submit the litigator hardship fees claim

--- a/features/page_objects/certification_page.rb
+++ b/features/page_objects/certification_page.rb
@@ -1,6 +1,6 @@
 class CertificationPage < BasePage
   set_url "/external_users/claims/{id}/certification/new"
 
-  element :attended_main_hearing, "label.i-attended-the-main-hearing-1st-day-of-trial"
-  element :certify_and_submit_claim, "div.certification > div.button-holder > button"
+  element :attended_main_hearing, "label.govuk-radios__label", text: "I attended the main hearing (1st day of trial)"
+  element :certify_and_submit_claim, "input[value='Certify and submit claim']"
 end

--- a/features/page_objects/confirmation_page.rb
+++ b/features/page_objects/confirmation_page.rb
@@ -1,5 +1,5 @@
 class ConfirmationPage < BasePage
   set_url "/external_users/claims/{id}/confirmation"
 
-  element :view_your_claims, "div.button-holder > a:nth-of-type(2)"
+  element :view_your_claims, 'a.govuk-button--secondary'
 end

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -159,7 +159,6 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller do
         params['certification']['certification_type_id'] = nil
         post :create, params: params
         expect(response).to render_template(:new)
-        expect(assigns(:certification).errors.messages[:certification_type_id]).to eq(['Choose a certification type'])
       end
     end
   end

--- a/spec/controllers/external_users/certifications_controller_spec.rb
+++ b/spec/controllers/external_users/certifications_controller_spec.rb
@@ -156,10 +156,10 @@ RSpec.describe ExternalUsers::CertificationsController, type: :controller do
     context 'invalid certification' do
       it 'redirects to new' do
         params = valid_certification_params(claim, certification_type)
-        params['certification']['certification_type_id'] = 9999
+        params['certification']['certification_type_id'] = nil
         post :create, params: params
         expect(response).to render_template(:new)
-        expect(assigns(:certification).errors.full_messages).to eq(['You must select one option on this form'])
+        expect(assigns(:certification).errors.messages[:certification_type_id]).to eq(['Choose a certification type'])
       end
     end
   end
@@ -183,9 +183,9 @@ def valid_certification_params(claim, certification_type)
       'certification_type_id' => certification_type.id,
       'certified_by' => 'David Cameron',
       'main_hearing' => 'true',
-      'certification_date_dd' => certification_date.day,
-      'certification_date_mm' => certification_date.month,
-      'certification_date_yyyy' => certification_date.year
+      'certification_date(3i)' => certification_date.day,
+      'certification_date(2i)' => certification_date.month,
+      'certification_date(1i)' => certification_date.year
     }
   }
 end

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :litigator_claim, class: 'Claim::LitigatorClaim' do
+  factory :litigator_claim, aliases: [:litigator_final_claim], class: 'Claim::LitigatorClaim' do
     litigator_base_setup
     claim_state_common_traits
 

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -21,46 +21,5 @@ RSpec.describe Certification, type: :model do
   it { is_expected.to belong_to(:claim) }
   it { is_expected.to belong_to(:certification_type) }
 
-  it { is_expected.to validate_presence_of(:certified_by) }
-  it { is_expected.to validate_presence_of(:certification_date) }
-
-  context 'validations' do
-    it 'is invalid without certification type' do
-      certification.certification_type_id = nil
-      expect(certification).to be_invalid
-      expect(certification.errors.messages[:certification_type_id]).to include('Choose a certification type')
-    end
-
-    it 'is invalid without certification by' do
-      certification.certified_by = nil
-      expect(certification).to be_invalid
-      expect(certification.errors.messages[:certified_by]).to include('Enter the name of person certifying')
-    end
-
-    context 'certification date' do
-      context 'when is before the claim creation date' do
-        let(:claim) { build(:claim, created_at: 2.days.ago) }
-
-        before do
-          certification.certification_date = 3.days.ago
-        end
-
-        it 'is invalid' do
-          expect(certification).to be_invalid
-          expect(certification.errors.messages[:certification_date]).to include('Certification date must be same day or after claim submission day')
-        end
-      end
-
-      context 'when is in the future' do
-        before do
-          certification.certification_date = 10.days.from_now
-        end
-
-        it 'is invalid' do
-          expect(certification).to be_invalid
-          expect(certification.errors.messages[:certification_date]).to include('Certification date cannot be in the future')
-        end
-      end
-    end
-  end
+  it { is_expected.to validate_with(CertificationValidator) }
 end

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -28,7 +28,13 @@ RSpec.describe Certification, type: :model do
     it 'is invalid without certification type' do
       certification.certification_type_id = nil
       expect(certification).to be_invalid
-      expect(certification.errors.full_messages).to include('You must select one option on this form')
+      expect(certification.errors.messages[:certification_type_id]).to include('Choose a certification type')
+    end
+
+    it 'is invalid without certification by' do
+      certification.certified_by = nil
+      expect(certification).to be_invalid
+      expect(certification.errors.messages[:certified_by]).to include('Enter the name of person certifying')
     end
 
     context 'certification date' do
@@ -41,7 +47,7 @@ RSpec.describe Certification, type: :model do
 
         it 'is invalid' do
           expect(certification).to be_invalid
-          expect(certification.errors.full_messages).to include('Certification date must be same day or after claim submission day')
+          expect(certification.errors.messages[:certification_date]).to include('Certification date must be same day or after claim submission day')
         end
       end
 
@@ -52,7 +58,7 @@ RSpec.describe Certification, type: :model do
 
         it 'is invalid' do
           expect(certification).to be_invalid
-          expect(certification.errors.full_messages).to include("Certification date can't be in the future")
+          expect(certification.errors.messages[:certification_date]).to include('Certification date cannot be in the future')
         end
       end
     end

--- a/spec/support/matchers/validate_with_matcher.rb
+++ b/spec/support/matchers/validate_with_matcher.rb
@@ -1,0 +1,24 @@
+# RSpec matcher for validates_with.
+# Usage:
+#
+#  describe User do
+#    it { is_expected.to validate_with CustomValidator }
+#  end
+
+RSpec::Matchers.define :validate_with do |validator|
+  match do |subject|
+    subject.class.validators.map(&:class).include? validator
+  end
+
+  description do
+    "validate with #{validator}"
+  end
+
+  failure_message do
+    "expected to validate with #{validator}"
+  end
+
+  failure_message_when_negated do
+    "expected not to validate with #{validator}"
+  end
+end

--- a/spec/validators/certification_validator_spec.rb
+++ b/spec/validators/certification_validator_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+RSpec.describe CertificationValidator, type: :validator do
+  subject(:certification) { build(:certification, certification_type: certification_type, claim: claim) }
+
+  let(:certification_type) { create(:certification_type) }
+  let(:claim) { build(:claim) }
+
+  describe '#validate_certification_type_id' do
+    context 'when agfs final claim' do
+      let(:claim) { build(:advocate_final_claim) }
+
+      context 'with certification type' do
+        before { certification.certification_type_id = certification_type.id }
+
+        it { expect(certification).to be_valid }
+      end
+
+      context 'with no certification type' do
+        before { certification.certification_type_id = nil }
+
+        it { expect(certification).to be_invalid }
+
+        it {
+          certification.valid?
+          expect(certification.errors.messages[:certification_type_id]).to include('Choose a certification type')
+        }
+      end
+    end
+
+    context 'with advocate interim claim' do
+      let(:claim) { build(:advocate_interim_claim) }
+
+      context 'with no certification type' do
+        before { certification.certification_type_id = nil }
+
+        it { expect(certification).to be_valid }
+      end
+    end
+
+    context 'with litigator claim' do
+      let(:claim) { build(:litigator_final_claim) }
+
+      context 'with no certification type' do
+        before { certification.certification_type_id = nil }
+
+        it { expect(certification).to be_valid }
+      end
+    end
+  end
+
+  describe '#validate_certified_by' do
+    before { certification.certified_by = nil }
+
+    it { expect(certification).to be_invalid }
+
+    it {
+      certification.valid?
+      expect(certification.errors.messages[:certified_by]).to include('Enter the name of person certifying')
+    }
+  end
+
+  describe '#validate_certification_date' do
+    context 'when before the claim creation date' do
+      let(:claim) { build(:claim, created_at: 2.days.ago) }
+
+      before do
+        certification.certification_date = 3.days.ago
+      end
+
+      it { expect(certification).to be_invalid }
+
+      it {
+        certification.valid?
+        expect(certification.errors.messages[:certification_date]).to include('Certification date must be same day or after claim submission day')
+      }
+    end
+
+    context 'when in the future' do
+      before do
+        certification.certification_date = 10.days.from_now
+      end
+
+      it { expect(certification).to be_invalid }
+
+      it {
+        certification.valid?
+        expect(certification.errors.messages[:certification_date]).to include('Certification date cannot be in the future')
+      }
+    end
+  end
+end

--- a/spec/validators/certification_validator_spec.rb
+++ b/spec/validators/certification_validator_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe CertificationValidator, type: :validator do
 
     it {
       certification.valid?
-      expect(certification.errors.messages[:certified_by]).to include('Enter the name of person certifying')
+      expect(certification.errors.messages[:certified_by])
+        .to include('Enter the name of person certifying')
     }
   end
 
@@ -72,7 +73,8 @@ RSpec.describe CertificationValidator, type: :validator do
 
       it {
         certification.valid?
-        expect(certification.errors.messages[:certification_date]).to include('Certification date must be same day or after claim submission day')
+        expect(certification.errors.messages[:certification_date])
+          .to include('Certification date must be same day or after claim submission day')
       }
     end
 
@@ -85,7 +87,8 @@ RSpec.describe CertificationValidator, type: :validator do
 
       it {
         certification.valid?
-        expect(certification.errors.messages[:certification_date]).to include('Certification date cannot be in the future')
+        expect(certification.errors.messages[:certification_date])
+          .to include('Certification date cannot be in the future')
       }
     end
   end


### PR DESCRIPTION
#### What
Migrate certification form to the GOVUK design system form builder

#### Ticket
[Migrate certification form to the GOVUK design system form builder](https://dsdmoj.atlassian.net/browse/CBO-1660)

#### Why
Part of a larger change to:

- continue migration to GOVUK Frontend
- resolve accessibility issues identified in the 2020 DAC report
- reduce then remove deprecated code

