### PR TITLE
[CBO-1754] Convert documents to PDF in a background job

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -35,6 +35,8 @@ class DocumentsController < ApplicationController
   end
 
   def show
+    raise ActiveRecord::RecordNotFound, 'Preview not found' unless document.converted_preview_document.attached?
+
     redirect_to document.converted_preview_document.blob.service_url(disposition: :inline)
   end
 

--- a/app/jobs/convert_document_job.rb
+++ b/app/jobs/convert_document_job.rb
@@ -1,0 +1,10 @@
+class ConvertDocumentJob < ApplicationJob
+  queue_as :convert_document
+
+  def perform(document_id)
+    document = Document.find(document_id)
+    DocumentConverterService.new(document.document, document.converted_preview_document).call
+    document.populate_paperclip_for :converted_preview_document
+    document.save
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -63,7 +63,9 @@ class Document < ApplicationRecord
 
   def copy_from(original)
     document.attach(original.document.blob)
-    converted_preview_document.attach(original.converted_preview_document.blob)
+    if original.converted_preview_document.attached?
+      converted_preview_document.attach(original.converted_preview_document.blob)
+    end
     self.verified = original.verified
   end
 

--- a/app/services/document_converter_service.rb
+++ b/app/services/document_converter_service.rb
@@ -24,6 +24,7 @@ class DocumentConverterService
     end
   rescue IOError => e
     log('Failed to convert document', e)
+    raise
   end
 
   def with_attached_file(document)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,11 +1,11 @@
 ---
 :logfile: ./log/sidekiq.log
 :queues:
+  - [convert_document, 3]
   - [mailers, 3]
   - [default, 2]
   - [claims, 2]
   - [stats_reports, 1]
-  - [convert_document, 1]
 development:
   :verbose: true
   :concurrency: 5

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,6 +5,7 @@
   - [default, 2]
   - [claims, 2]
   - [stats_reports, 1]
+  - [convert_document, 1]
 development:
   :verbose: true
   :concurrency: 5

--- a/spec/jobs/convert_document_job_spec.rb
+++ b/spec/jobs/convert_document_job_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe ConvertDocumentJob, type: :job do
+  let(:job) { described_class.new }
+
+  describe '#perform' do
+    subject(:perform) { job.perform(document.to_param) }
+
+    before do
+      allow(Libreconv).to receive(:convert).with(anything, anything) do |from_file, to_file|
+        if File.exist?(from_file)
+          File.open(File.expand_path('features/examples/shorter_lorem.pdf', Rails.root)) do |input_stream|
+            File.open(to_file, 'wb') do |output_stream|
+              IO.copy_stream(input_stream, output_stream)
+            end
+          end
+        end
+      end
+    end
+
+    context 'with an existing converted preview document' do
+      let(:document) { create :document, :with_preview }
+
+      it { expect { perform }.not_to(change { document.reload.converted_preview_document }) }
+      it { expect { perform }.not_to raise_error }
+    end
+
+    context 'with a pdf document' do
+      let(:document) { create :document, :pdf }
+
+      it do
+        expect { perform }
+          .to change { document.reload.converted_preview_document&.attachment&.blob }.to document.document.blob
+      end
+
+      it { expect { perform }.not_to raise_error }
+    end
+
+    context 'with a docx document' do
+      let(:document) { create :document, :docx }
+
+      it do
+        expect { perform }
+          .to change { document.reload.converted_preview_document&.attachment&.content_type }.to 'application/pdf'
+      end
+
+      it { expect { perform }.not_to raise_error }
+    end
+
+    context 'when Libreconv fails' do
+      let(:document) { create :document, :docx }
+
+      before { allow(Libreconv).to receive(:convert).and_raise(IOError) }
+
+      it { expect { perform }.to raise_error(IOError) }
+    end
+
+    context 'when allowing for Paperclip rollback' do
+      let(:document) { create :document, :docx }
+
+      it do
+        expect { perform }
+          .to change { document.reload.converted_preview_document_file_name }
+          .to "#{document.document_file_name}.pdf"
+      end
+
+      it do
+        expect { perform }
+          .to change { document.reload.converted_preview_document_content_type }
+          .to 'application/pdf'
+      end
+
+      it { expect { perform }.to(change { document.reload.converted_preview_document_updated_at }) }
+      it { expect { perform }.to(change { document.reload.converted_preview_document_file_size }) }
+      it { expect { perform }.to(change { document.reload.as_converted_preview_document_checksum }) }
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -54,51 +54,11 @@ RSpec.describe Document, type: :model do
     let(:claim) { create :claim }
     let(:trait) { :pdf }
 
-    context 'with a pdf document' do
-      before { document_save }
+    before { ActiveJob::Base.queue_adapter = :test }
 
-      it 'creates the preview as a copy of the original' do
-        expect(document.converted_preview_document.checksum).to eq document.document.checksum
-      end
-    end
-
-    context 'with a docx document' do
-      let(:trait) { :docx }
-      let(:checksum) { 'LmC+AfCP6+Q69vCYuAt7rQ==' } # Checksum of shorter_lorem.pdf
-
-      before do
-        allow(Libreconv).to receive(:convert).with(anything, anything) do |from_file, to_file|
-          if File.exist?(from_file)
-            File.open(File.expand_path('features/examples/shorter_lorem.pdf', Rails.root)) do |input_stream|
-              File.open(to_file, 'wb') do |output_stream|
-                IO.copy_stream(input_stream, output_stream)
-              end
-            end
-          end
-        end
-
-        document_save
-      end
-
-      it 'creates a preview using Libreconv' do
-        expect(document.converted_preview_document.checksum).to eq checksum
-      end
-
-      it 'creates a preview of type application/pdf' do
-        expect(document.converted_preview_document.content_type).to eq 'application/pdf'
-      end
-
-      it 'creates a preview with name based on the orginal' do
-        expect(document.converted_preview_document.filename).to eq "#{document.document.filename}.pdf"
-      end
-    end
-
-    context 'when Libreconv fails' do
-      let(:trait) { :docx }
-
-      before { allow(Libreconv).to receive(:convert).and_raise(IOError) }
-
-      it { expect { document_save }.not_to raise_error }
+    it 'schedules a ConvertDocumentJob' do
+      expect { document_save }
+        .to(have_enqueued_job(ConvertDocumentJob).with { |id| expect(id).to eq document.reload.to_param })
     end
 
     context 'when the maximum document limit is reached' do
@@ -112,6 +72,10 @@ RSpec.describe Document, type: :model do
       it 'reports a sensible error' do
         document_save
         expect(document.errors[:document]).to include('Total documents exceed maximum of 2. This document has not been uploaded.')
+      end
+
+      it 'does not schedule a ConvertDocumentJob' do
+        expect { document_save }.not_to have_enqueued_job(ConvertDocumentJob)
       end
     end
 
@@ -136,26 +100,6 @@ RSpec.describe Document, type: :model do
 
       it 'sets as_document_checksum' do
         expect(document.as_document_checksum).to eq document.document.checksum
-      end
-
-      it 'sets converted_preview_document_file_name' do
-        expect(document.converted_preview_document_file_name).to eq document.converted_preview_document.filename.to_s
-      end
-
-      it 'sets converted_preview_document_file_size' do
-        expect(document.converted_preview_document_file_size).to eq document.converted_preview_document.byte_size
-      end
-
-      it 'sets converted_preview_document_content_type' do
-        expect(document.converted_preview_document_content_type).to eq document.converted_preview_document.content_type
-      end
-
-      it 'sets converted_preview_document_updated_at' do
-        expect(document.converted_preview_document_updated_at).not_to be_nil
-      end
-
-      it 'sets as_converted_preview_document_checksum' do
-        expect(document.as_converted_preview_document_checksum).to eq document.converted_preview_document.checksum
       end
     end
   end


### PR DESCRIPTION
#### What

When an evidence document is uploaded, use a background job to convert it to PDF instead of doing it inline.

#### Ticket

[Background task for creating converted preview documents](https://dsdmoj.atlassian.net/browse/CBO-1754)

#### Why

There are some problems with converting documents before sending a response back to the user:

* If the conversion fails then it cannot be retried and so the download needs to be repeated.
* To the user the download does not appear to complete until the conversion has finished and this can be several seconds. This is an unnecessary delay.

#### How

Create a new background job, `ConvertDocumentJob`.

--------

#### TODO (wip)

 - [x] Fix any tests that are broken due to newly created documents not having a converted preview
 - [x] Replace tests related to the conversion process, as appropriate
 - [x] Test that conversion job is being created and performed
 - [x] Cater for attempting to view a preview if a preview has not been created yet
   - [x] Do not display the 'preview' link if the preview does not exist