### PR TITLE
Add feeback during migration and prevent AS record deletion

### DIFF
--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -57,12 +57,17 @@ module Storage
         UPDATE active_storage_blobs SET metadata='{}' WHERE metadata LIKE 'in-progress/%';
       SQL
 
-      puts "Creating Active Storage Blobs for #{name}"
-      connection.exec_prepared("create_active_storage_blobs_#{name}");
-      puts "Creating Active Storage Attachments for #{name}"
-      connection.exec_prepared("create_active_storage_attachments_#{name}");
-      puts "Updating Active Storage blobs metadata for #{name}"
-      connection.exec_prepared("update_active_storage_blobs_metadata_#{name}");
+      print "Creating Active Storage Blobs for #{name}..."
+      blob_result = connection.exec_prepared("create_active_storage_blobs_#{name}")
+      puts "#{blob_result.cmd_tuples.to_s.green} rows created"
+
+      print "Creating Active Storage Attachments for #{name}..."
+      attachment_result = connection.exec_prepared("create_active_storage_attachments_#{name}")
+      puts "#{attachment_result.cmd_tuples.to_s.green} rows created"
+
+      print "Updating Active Storage blobs metadata for #{name}..."
+      blob_update_result = connection.exec_prepared("update_active_storage_blobs_metadata_#{name}")
+      puts "#{blob_update_result.cmd_tuples.to_s.green} rows updated"
     end
   end
 

--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -79,7 +79,9 @@ module Storage
         DELETE FROM active_storage_attachments WHERE record_type='#{self.models(model)}' AND name='#{name}'
       SQL
 
-      connection.exec_prepared("delete_active_storage_attachments_#{name}");
+      print "Deleting #{model} active_storage_attachments called #{name}..."
+      attachment_result = connection.exec_prepared("delete_active_storage_attachments_#{name}")
+      puts "#{attachment_result.cmd_tuples.to_s.green} rows deleted"
     end
 
     # Delete blobs no longer linked to an attachment
@@ -87,7 +89,10 @@ module Storage
       DELETE FROM active_storage_blobs
         WHERE id NOT IN (SELECT blob_id FROM active_storage_attachments)
     SQL
-    connection.exec_prepared("delete_active_storage_blobs");
+
+    print "Deleting #{model} active_storage_blobs called #{name}..."
+    blob_result = connection.exec_prepared("delete_active_storage_blobs")
+    puts "#{blob_result.cmd_tuples.to_s.green} rows deleted"
   end
 
   def self.clear_paperclip_checksums(model)

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -8,6 +8,7 @@ namespace :storage do
 
   desc 'Rollback asset migration'
   task :rollback, [:model] => :environment do |_task, args|
+    production_protected
     Storage.rollback args[:model]
   end
 


### PR DESCRIPTION
#### What/Why
feedback raw sql results to console to show progress
and prevent storage:rollback being run on production
as it results in unrecoverable files.