### PR TITLE
Purge attachments when records are deleted

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -52,6 +52,7 @@ class Message < ApplicationRecord
 
   before_save :populate_paperclip
   after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
+  before_destroy -> { attachment.purge }
 
   class << self
     def for(object)

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -28,6 +28,8 @@ module Stats
     scope :management_information, -> { not_errored.where(report_name: 'management_information') }
     scope :provisional_assessment, -> { not_errored.where(report_name: 'provisional_assessment') }
 
+    before_destroy -> { document.purge }
+
     has_one_attached :document
 
     def self.clean_up(report_name)

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -204,17 +204,17 @@ RSpec.describe Message, type: :model do
   describe '#destroy' do
     subject(:destroy_message) { message.destroy }
 
-    before { message }
+    let!(:message) { create(:message, trait) }
 
     context 'without an attachment' do
-      let(:message) { create(:message) }
+      let(:trait) { nil }
 
       it { expect { destroy_message }.not_to change(ActiveStorage::Attachment, :count) }
       it { expect { destroy_message }.not_to change(ActiveStorage::Blob, :count) }
     end
 
     context 'with an attachment' do
-      let(:message) { create(:message, :with_attachment) }
+      let(:trait) { :with_attachment }
 
       it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-1) }
       it { expect { destroy_message }.to change(ActiveStorage::Blob, :count).by(-1) }

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -201,6 +201,26 @@ RSpec.describe Message, type: :model do
     end
   end
 
+  describe '#destroy' do
+    subject(:destroy_message) { message.destroy }
+
+    before { message }
+
+    context 'without an attachment' do
+      let(:message) { create(:message) }
+
+      it { expect { destroy_message }.not_to change(ActiveStorage::Attachment, :count) }
+      it { expect { destroy_message }.not_to change(ActiveStorage::Blob, :count) }
+    end
+
+    context 'with an attachment' do
+      let(:message) { create(:message, :with_attachment) }
+
+      it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-1) }
+      it { expect { destroy_message }.to change(ActiveStorage::Blob, :count).by(-1) }
+    end
+  end
+
   # To allow rolling back to Paperclip
   describe '#attachment_file_name' do
     subject { message.attachment_file_name }

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -170,9 +170,7 @@ RSpec.describe Stats::StatsReport do
   describe '#destroy' do
     subject(:destroy_report) { report.destroy }
 
-    before { report }
-
-    let(:report) { create(:stats_report, :with_document) }
+    let!(:report) { create(:stats_report, :with_document) }
 
     it { expect { destroy_report }.to change(ActiveStorage::Attachment, :count).by(-1) }
     it { expect { destroy_report }.to change(ActiveStorage::Blob, :count).by(-1) }

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -167,6 +167,17 @@ RSpec.describe Stats::StatsReport do
     end
   end
 
+  describe '#destroy' do
+    subject(:destroy_report) { report.destroy }
+
+    before { report }
+
+    let(:report) { create(:stats_report, :with_document) }
+
+    it { expect { destroy_report }.to change(ActiveStorage::Attachment, :count).by(-1) }
+    it { expect { destroy_report }.to change(ActiveStorage::Blob, :count).by(-1) }
+  end
+
   describe 'housekeeping' do
     describe '.destroy_reports_older_than' do
       it 'destroys all reports for named report older than specified time' do


### PR DESCRIPTION
Active Storage does not automatically purge blobs when the attachments
are removed. This PR will configure the `Message` and `Stats::StatsReport`
models to purge any linked attachments when the record is deleted.