### PR TITLE
Optimize the active_storage_blobs upsert statement

### DIFF
--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -33,10 +33,12 @@ module Storage
                  COALESCE(#{name}_updated_at, NOW())
             FROM #{model}
             WHERE #{name}_file_name IS NOT NULL
-              AND id NOT IN (
-                SELECT DISTINCT record_id FROM active_storage_attachments
-                  WHERE record_type = '#{self.models(model)}'
-                    AND name = '#{name}'
+              AND NOT EXISTS (
+                SELECT '1'
+                  FROM active_storage_attachments AS asa
+                 WHERE asa.record_type = '#{self.models(model)}'
+                   AND asa.name = '#{name}'
+                   AND asa.record_id = #{model}.id
               )
           #{self.conflict_clause_for(model)};
       SQL


### PR DESCRIPTION
#### What
Optimize the active_storage_blobs upsert statement

#### Ticket

[https://dsdmoj.atlassian.net/browse/CBO-1693](https://dsdmoj.atlassian.net/browse/CBO-1693)

#### Why
The previous use of a subquery expression
to test if the documents record already
had an associated active_storage_attachments
was meaning a second migration was taking
along time - over 6 minutes at least, probably
more.


#### How
Previous method used a NOT IN with a subquery to retrieve
all existing unique active_storage_attachments record
ids. This subquery would retrieve 200k ids and so is
not efficient.

The NOT EXISTS execution plan is more effecient, in
postgres 9.6, at least.