### PR TITLE
Treat zero `calculate_distance` as valid

### DIFF
--- a/app/validators/expense_validator.rb
+++ b/app/validators/expense_validator.rb
@@ -66,7 +66,7 @@ class ExpenseValidator < BaseValidator
   end
 
   def validate_calculated_distance
-    return unless @record.car_travel? && @record.calculated_distance.present?
+    return unless @record.car_travel? && @record.calculated_distance.present? && !@record.calculated_distance.zero?
     validate_presence_and_numericality(:calculated_distance, minimum: 0.1)
   end
 

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe 'ExpenseValidator', type: :validator do
     end
   end
 
-  describe '#validate distance' do
+  describe '#validate_distance' do
     context 'valid' do
       it 'is valid when present for car travel' do
         car_travel_expense.distance = 33
@@ -374,7 +374,7 @@ RSpec.describe 'ExpenseValidator', type: :validator do
     end
   end
 
-  describe 'calculated distance' do
+  describe '#validate_calculated_distance' do
     context 'when the expense is not car travel' do
       subject(:expense) { hotel_accommodation_expense }
 
@@ -412,6 +412,16 @@ RSpec.describe 'ExpenseValidator', type: :validator do
         end
       end
 
+      context 'and the calculated distance is zero' do
+        before do
+          expense.calculated_distance = 0.0
+        end
+
+        it 'is valid' do
+          expect(expense).to be_valid
+        end
+      end
+
       context 'and the calculated distance is set' do
         let(:calculated_distance) { 123456 }
 
@@ -420,15 +430,6 @@ RSpec.describe 'ExpenseValidator', type: :validator do
         end
 
         it { expect(expense).to be_valid }
-
-        context 'but is not a valid number' do
-          let(:calculated_distance) { 'this-is-not-a-valid-number' }
-
-          it 'is invalid' do
-            expect(expense).not_to be_valid
-            expect(expense.errors[:calculated_distance]).to include('numericality')
-          end
-        end
 
         context 'but has a value set below the minumum acceptable' do
           let(:calculated_distance) { 0.0001 }


### PR DESCRIPTION
#### What
Treat zero `calculate_distance` as valid

#### Ticket

[CBO-1776](https://dsdmoj.atlassian.net/browse/CBO-1776)

#### Why
Currently with the google maps API broken
the request is returning nil which is converted
to zero and the expense considered invalid.

#### How
To allow for google maps API failures
without raising a validation error to the user
we must allow zeros to not be invalid.

This allows the user to enter a travel distance 
manually which case workers can then vet manually.
