### PR TITLE
Amend calculated_distance minimum validation

### DIFF
--- a/app/validators/expense_validator.rb
+++ b/app/validators/expense_validator.rb
@@ -66,8 +66,8 @@ class ExpenseValidator < BaseValidator
   end
 
   def validate_calculated_distance
-    return unless @record.car_travel? && @record.calculated_distance.present? && !@record.calculated_distance.zero?
-    validate_presence_and_numericality(:calculated_distance, minimum: 0.1)
+    return unless @record.car_travel? && @record.calculated_distance.present?
+    validate_presence_and_numericality(:calculated_distance, minimum: 0.0)
   end
 
   def validate_mileage_rate_id

--- a/spec/validators/expense_validator_spec.rb
+++ b/spec/validators/expense_validator_spec.rb
@@ -432,10 +432,10 @@ RSpec.describe 'ExpenseValidator', type: :validator do
         it { expect(expense).to be_valid }
 
         context 'but has a value set below the minumum acceptable' do
-          let(:calculated_distance) { 0.0001 }
+          let(:calculated_distance) { -0.0001 }
 
           it 'is invalid' do
-            expect(expense).not_to be_valid
+            expect(expense).to be_invalid
             expect(expense.errors[:calculated_distance]).to include('numericality')
           end
         end


### PR DESCRIPTION
#### What
Amend calculated_distance minimum validation

#### Ticket

N/A

#### Why
A simpler, and IMO clearer, way to loosen
the validation that causes Maps API failures to
prevent users proceeding.

#### How
Rather than ensure a non-zero value before attempting
to validate we can just set the minimum to be 0.0. A
failed API call, returning 0, would then be considered valid,
while a negative decimal would be invalid. In addition this
validates upper limit by default (of 200_000).