### PR TITLE
Prevent convert retry if document deleted

### DIFF
--- a/app/jobs/convert_document_job.rb
+++ b/app/jobs/convert_document_job.rb
@@ -2,7 +2,9 @@ class ConvertDocumentJob < ApplicationJob
   queue_as :convert_document
 
   def perform(document_id)
-    document = Document.find(document_id)
+    document = Document.find_by(id: document_id)
+    return if document.nil?
+
     DocumentConverterService.new(document.document, document.converted_preview_document).call
     document.populate_paperclip_for :converted_preview_document
     document.save

--- a/spec/jobs/convert_document_job_spec.rb
+++ b/spec/jobs/convert_document_job_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe ConvertDocumentJob, type: :job do
       it { expect { perform }.to raise_error(IOError) }
     end
 
+    context 'when the document has been deleted' do
+      subject(:perform) { job.perform(999) }
+
+      it { expect { perform }.not_to raise_error }
+    end
+
     context 'when allowing for Paperclip rollback' do
       let(:document) { create :document, :docx }
 


### PR DESCRIPTION
#### What

Silently terminate a document convert job if the document cannot be found.

#### Ticket

N/A

#### Why

If a document is uploaded and then deleted before the convert job has been performed this causes an error, as the document cannot be found, resulting in the job being retried. This is unnecessary.

#### How

Prevent the convert job from raising a 'record not found' error.