### PR TITLE
Add delay to DocumentConvertJob call

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -95,7 +95,7 @@ class Document < ApplicationRecord
   end
 
   def convert_document
-    ConvertDocumentJob.perform_later(to_param)
+    ConvertDocumentJob.set(wait: 30.seconds).perform_later(to_param)
   end
 
   def purge_attachments


### PR DESCRIPTION
#### What

Wait at least 30 seconds before attempting to convert a document. This is related to #3897 

#### Ticket

N/A

#### Why

Many of the backgrounded document convert jobs fail on the first attempt because of a race condition. The Sidekiq process fails to find the document in the database that has just been saved.

The conversion succeeds on retry but there is a possibility that the document has genuinely been deleted, in which case we want the job to silently fail (see #3897).

#### How

Delay the conversion by adding `set(wait: 30.seconds)` to the call to `ConvertDocumentJob`.