### PR TITLE
[CFP-92] Allow zip files with duplicate filenames

### DIFF
--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -14,11 +14,10 @@ class S3ZipDownloader
   private
 
   def build_zip_file(documents, bundle)
-    filename_counts = {}
     Dir.mktmpdir("#{@claim.case_number}-") do |tmp_dir|
       Zip::File.open(bundle, Zip::File::CREATE) do |zip_file|
-        documents.map(&:document).each do |document|
-          zip_file.add(get_filename(document.filename, filename_counts), local_file(document, tmp_dir))
+        documents.map(&:document).each_with_index do |document, i|
+          zip_file.add("#{i}_#{document.filename}", local_file(document, tmp_dir))
         end
       end
     end
@@ -27,18 +26,6 @@ class S3ZipDownloader
   def local_file(document, folder)
     File.join(folder, document.filename.to_s).tap do |local_path|
       document.open { |tmp_file| FileUtils.copy(tmp_file, local_path) }
-    end
-  end
-
-  def get_filename(original, filename_counts)
-    original = original.to_s
-    if filename_counts.key? original
-      filename_counts[original] += 1
-      extension = File.extname(original)
-      "#{File.basename(original, extension)} (#{filename_counts[original]})#{extension}"
-    else
-      filename_counts[original] = 0
-      original
     end
   end
 end

--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -14,10 +14,11 @@ class S3ZipDownloader
   private
 
   def build_zip_file(documents, bundle)
+    filename_counts = {}
     Dir.mktmpdir("#{@claim.case_number}-") do |tmp_dir|
       Zip::File.open(bundle, Zip::File::CREATE) do |zip_file|
         documents.map(&:document).each do |document|
-          zip_file.add(document.filename, local_file(document, tmp_dir))
+          zip_file.add(get_filename(document.filename, filename_counts), local_file(document, tmp_dir))
         end
       end
     end
@@ -26,6 +27,18 @@ class S3ZipDownloader
   def local_file(document, folder)
     File.join(folder, document.filename.to_s).tap do |local_path|
       document.open { |tmp_file| FileUtils.copy(tmp_file, local_path) }
+    end
+  end
+
+  def get_filename(original, filename_counts)
+    original = original.to_s
+    if filename_counts.key? original
+      filename_counts[original] += 1
+      extension = File.extname(original)
+      "#{File.basename(original, extension)} (#{filename_counts[original]})#{extension}"
+    else
+      filename_counts[original] = 0
+      original
     end
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -25,11 +25,16 @@
 
 FactoryBot.define do
   factory :document do
+    transient do
+      sequence(:filename) { |n| "testfile#{n}.pdf" }
+    end
+
     document do
-      Rack::Test::UploadedFile.new(
-        File.expand_path('features/examples/longer_lorem.pdf', Rails.root),
-        'application/pdf'
-      )
+      Dir.mktmpdir do |tmp|
+        temp_file = File.expand_path(filename, tmp)
+        FileUtils.cp(File.expand_path('features/examples/longer_lorem.pdf', Rails.root), temp_file)
+        Rack::Test::UploadedFile.new(temp_file, 'application/pdf')
+      end
     end
     claim
     external_user
@@ -37,26 +42,38 @@ FactoryBot.define do
     trait :pdf # default
 
     trait :docx do
+      transient do
+        sequence(:filename) { |n| "testfile#{n}.docx" }
+      end
+
       document do
-        Rack::Test::UploadedFile.new(
-          File.expand_path('features/examples/shorter_lorem.docx', Rails.root),
-          'application/msword'
-        )
+        Dir.mktmpdir do |tmp|
+          temp_file = File.expand_path(filename, tmp)
+          FileUtils.cp(File.expand_path('features/examples/shorter_lorem.docx', Rails.root), temp_file)
+          Rack::Test::UploadedFile.new(temp_file, 'application/msword')
+        end
       end
     end
 
     trait :with_preview do
-      document do
-        Rack::Test::UploadedFile.new(
-          File.expand_path('features/examples/shorter_lorem.docx', Rails.root),
-          'application/msword'
-        )
+      transient do
+        sequence(:filename) { |n| "testfile#{n}.docx" }
       end
+
+      document do
+        Dir.mktmpdir do |tmp|
+          temp_file = File.expand_path(filename, tmp)
+          FileUtils.cp(File.expand_path('features/examples/shorter_lorem.docx', Rails.root), temp_file)
+          Rack::Test::UploadedFile.new(temp_file, 'application/msword')
+        end
+      end
+
       converted_preview_document do
-        Rack::Test::UploadedFile.new(
-          File.expand_path('features/examples/longer_lorem.pdf', Rails.root),
-          'application/pdf'
-        )
+        Dir.mktmpdir do |tmp|
+          temp_file = File.expand_path("#{filename}.pdf", tmp)
+          FileUtils.cp(File.expand_path('features/examples/longer_lorem.pdf', Rails.root), temp_file)
+          Rack::Test::UploadedFile.new(temp_file, 'application/pdf')
+        end
       end
     end
 
@@ -67,12 +84,6 @@ FactoryBot.define do
 
     trait :verified do
       verified_file_size { 2663 }
-      document do
-        Rack::Test::UploadedFile.new(
-          File.expand_path('features/examples/longer_lorem.pdf', Rails.root),
-          'application/pdf'
-        )
-      end
       verified { true }
     end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -50,9 +50,8 @@ RSpec.describe Document, type: :model do
   describe '#save' do
     subject(:document_save) { document.save }
 
-    let(:document) { build :document, trait, claim: claim, form_id: claim.form_id }
+    let(:document) { build :document, :pdf, claim: claim, form_id: claim.form_id }
     let(:claim) { create :claim }
-    let(:trait) { :pdf }
 
     before { ActiveJob::Base.queue_adapter = :test }
 

--- a/spec/models/timed_transitions/transitioner_spec.rb
+++ b/spec/models/timed_transitions/transitioner_spec.rb
@@ -305,11 +305,7 @@ RSpec.describe TimedTransitions::Transitioner do
 
           context 'with an associated document' do
             let(:file) do
-              Rake::Test::UploadedFile.new(
-                File.expand_path('features/examples/longer_lorem.pdf'),
-                'application/pdf'
-              )
-              let(:document) { create :document, document: file, verified: true }
+              let(:document) { create :document, verified: true }
 
               before { claim.update(documents: [document]) }
 
@@ -486,24 +482,18 @@ RSpec.describe TimedTransitions::Transitioner do
           end
 
           context 'with an associated document' do
-            let(:file) do
-              Rake::Test::UploadedFile.new(
-                File.expand_path('features/examples/longer_lorem.pdf'),
-                'application/pdf'
-              )
-              let(:document) { create :document, document: file, verified: true }
+            let(:document) { create :document, verified: true }
 
-              before { claim.update(documents: [document]) }
+            before { claim.update(documents: [document]) }
 
-              it 'does not destroy associated documents' do
-                expect { run_transitioner }.not_to change(Document, :count)
-              end
+            it 'does not destroy associated documents' do
+              expect { run_transitioner }.not_to change(Document, :count)
+            end
 
-              it 'does not delete the file from storage' do
-                file_on_disk = ActiveStorage::Blob.service.send(:path_for, claim.documents.first.document.blob.key)
+            it 'does not delete the file from storage' do
+              file_on_disk = ActiveStorage::Blob.service.send(:path_for, claim.documents.first.document.blob.key)
 
-                expect { run_transitioner }.not_to(change { File.exist? file_on_disk })
-              end
+              expect { run_transitioner }.not_to(change { File.exist? file_on_disk })
             end
           end
 

--- a/spec/services/s3_zip_downloader_spec.rb
+++ b/spec/services/s3_zip_downloader_spec.rb
@@ -4,12 +4,20 @@ RSpec.describe S3ZipDownloader do
   let(:s3_zip_downloader) { described_class.new(claim) }
   let(:claim) { create :claim }
 
-  before { create :document, :verified, claim: claim }
-
   describe '#generate!' do
     subject(:generated_file) { s3_zip_downloader.generate! }
 
-    it { is_expected.to be_a String }
-    it { expect(File).to exist(generated_file) }
+    context 'with evidence documents' do
+      before { create :document, :verified, claim: claim }
+
+      it { is_expected.to be_a String }
+      it { expect(File).to exist(generated_file) }
+    end
+
+    context 'with two files with the same name' do
+      before { create_list :document, 2, :verified, claim: claim, filename: 'testfile.pdf' }
+
+      it { expect { generated_file }.not_to raise_error }
+    end
   end
 end


### PR DESCRIPTION
#### What

Append an index to evidence documents when added to a zip file for caseworkers to download.

#### Ticket

[Duplicate file names causes failure to download zip file](https://dsdmoj.atlassian.net/browse/CFP-92)

#### Why

The creation of a zip file fails if two files have the same name. Appending a file number avoids this.

#### How

If there are two files named `filename.doc` then they will be added to the zip file as `filename.doc` and `filename (1).doc`.