### PR TITLE
[CFP-73] Migrate user forms to GOVUK design system

### DIFF
--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -47,9 +47,9 @@ module Roles
 
   def roles_valid
     if roles.empty?
-      errors[:roles] << 'at least one role must be present'
+      errors[:roles] << 'Choose at least one role'
     elsif (roles - self.class::ROLES).any?
-      errors[:roles] << "must be one or more of: #{roles_string}"
+      errors[:roles] << "Must be one or more of: #{roles_string}"
     end
   end
 

--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -1,37 +1,31 @@
-= form_for [:case_workers, :admin, @case_worker], builder: AdpFormBuilder do |f|
+= form_with model: [:case_workers, :admin, @case_worker], builder: GdsAdpFormBuilder, local: true do |f|
   = f.fields_for :user do |user_fields|
-    %h2.heading-medium
-      = t('.case_worker_details')
+    = user_fields.govuk_error_summary
 
-    = user_fields.adp_text_field :first_name, label: t('.first_name')
+    = user_fields.govuk_text_field :first_name,
+      label: { text: t('.first_name') }
 
-    = user_fields.adp_text_field :last_name, label: t('.last_name')
+    = user_fields.govuk_text_field :last_name,
+      label: { text: t('.last_name') }
 
-    = user_fields.adp_text_field :email, label: t('.email')
+    = user_fields.govuk_email_field :email,
+      label: { text: t('.email') }
 
     - if @case_worker.new_record?
-      = user_fields.adp_text_field :email_confirmation, label: t('.email_confirmation')
+      = user_fields.govuk_email_field :email_confirmation,
+        label: { text: t('.email_confirmation') }
 
-    .form-group
-      %fieldset.inline{ 'aria-describedby': 'radio-control-legend-location' }
-        %legend#radio-control-legend-location
-          %span.form-label-bold
-            = t('.location')
-        = f.collection_radio_buttons(:location_id, Location.all, :id, :name) do |b|
-          .multiple-choice
-            = b.radio_button('aria-labelledby': "radio-control-legend-location #{b.text.to_css_class}")
-            = b.label(id: b.text.to_css_class) { b.object.name }
+    = f.govuk_collection_radio_buttons :location_id,
+      Location.all,
+      :id,
+      :name,
+      inline: true,
+      legend: { text: t('.location'), size: 's' }
 
+    = f.govuk_collection_check_boxes :roles,
+      CaseWorker::ROLES,
+      :to_s,
+      :humanize,
+      legend: { text: t('.roles'), size: 's' }
 
-    .form-group
-      %fieldset.inline{ 'aria-describedby': 'checkbox-control-legend-roles' }
-        %legend#checkbox-control-legend-roles
-          %span.form-label-bold
-            = t('.roles')
-
-        = f.collection_check_boxes(:roles, CaseWorker::ROLES, :to_s, :to_s) do |b|
-          .multiple-choice
-            = b.check_box("aria-labelledby": "checkbox-control-legend-roles #{b.text.to_css_class}")
-            = b.label(id: b.text.to_css_class) { b.value.humanize }
-
-    = govuk_button(t('.save'))
+    = f.govuk_submit t('.save')

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -1,27 +1,21 @@
 = content_for :page_title, flush: true do
   = t('.page_title', caseworker: @case_worker.name)
 
-= render partial: 'errors/error_summary', locals: { ep: @case_worker, error_summary: t('.prohibited_save') }
-
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
-.main-section.container
-  .body-content
-    = form_for [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path do |f|
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_with model: [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path, builder: GdsAdpFormBuilder, local: true do |f|
       = f.fields_for :user do |user_fields|
-        .form-fields
-          %fieldset
-            %legend.visually-hidden
-              = t('.change_password')
-            .form-group
-              .form-group.input
-                = user_fields.label :current_password, t('.current_password'), class: 'form-label'
-                = user_fields.password_field :current_password, class: 'form-control'
-              .form-group.input
-                = user_fields.label :password, t('.password'), class: 'form-label'
-                = user_fields.password_field :password, class: 'form-control'
-              .form-group.input
-                = user_fields.label :password_confirmation, t('.password_confirmation'), class: 'form-label'
-                = user_fields.password_field :password_confirmation, class: 'form-control'
+        = user_fields.govuk_error_summary
 
-      = govuk_button(t('.submit'))
+        = user_fields.govuk_password_field :current_password,
+          label: { text: t('.current_password') }
+
+        = user_fields.govuk_password_field :password,
+          label: { text: t('.password') }
+
+        = user_fields.govuk_password_field :password_confirmation,
+          label: { text: t('.password_confirmation') }
+
+        = f.govuk_submit t('.submit')

--- a/app/views/case_workers/admin/case_workers/edit.html.haml
+++ b/app/views/case_workers/admin/case_workers/edit.html.haml
@@ -1,10 +1,8 @@
 = content_for :page_title, flush: true do
   = t('.page_title', caseworker: @case_worker.name)
 
-= render partial: 'errors/error_summary', locals: { ep: @case_worker, error_summary: t('.error_summary') }
-
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
-.main-section.container
-  .body-content
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
     = render 'form'

--- a/app/views/case_workers/admin/case_workers/new.html.haml
+++ b/app/views/case_workers/admin/case_workers/new.html.haml
@@ -1,8 +1,8 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'errors/error_summary', locals:{ ep: @case_worker, error_summary: t('.error_summary')}
-
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
-= render 'form'
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = render 'form'

--- a/app/views/external_users/admin/external_users/_form.html.haml
+++ b/app/views/external_users/admin/external_users/_form.html.haml
@@ -1,62 +1,50 @@
-= form_for [:external_users, :admin, @external_user] do |f|
+= form_with model: [:external_users, :admin, @external_user], builder: GdsAdpFormBuilder, local: true do |f|
 
   = f.fields_for :user do |user_fields|
-    .form-group
-      %a{ name: 'first_name' }
-      = user_fields.label :first_name, t('.first_name'), class: 'form-label-bold'
-      = user_fields.text_field :first_name, class: 'form-control'
-    .form-group
-      %a{ name: 'last_name' }
-      = user_fields.label :last_name, t('.last_name'), class: 'form-label-bold'
-      = user_fields.text_field :last_name, class: 'form-control'
+    = user_fields.govuk_error_summary
 
-    .form-group
-      %a{ name: 'email' }
-      = user_fields.label :email, t('.email'), class: 'form-label-bold'
-      = user_fields.email_field :email, class: 'form-control'
+    = user_fields.govuk_text_field :first_name,
+      label: { text: t('.first_name') }
+
+    = user_fields.govuk_text_field :last_name,
+      label: { text: t('.last_name') }
+
+    = user_fields.govuk_email_field :email,
+      label: { text: t('.email') }
+
     - if @external_user.new_record?
-      .form-group
-        %a{ name: 'email_confirmation' }
-        = user_fields.label :email_confirmation, t('.email_confirmation'), class: 'form-label-bold'
-        = user_fields.email_field :email_confirmation, class: 'form-control'
+      = user_fields.govuk_email_field :email_confirmation,
+        label: { text: t('.email_confirmation') }
 
-    .form-group
-      %fieldset.inline{ 'aria-describedby': 'radio-control-legend-email' }
-        %legend#radio-control-legend-email
-          %span.heading-medium
-            = t('.email_notification')
-
-        = user_fields.collection_radio_buttons(:email_notification_of_message, [true, false], :to_s, :to_s) do |b|
-          .multiple-choice
-            = b.radio_button('aria-labelledby': "radio-control-legend-email #{b.text.to_css_class}")
-            = b.label { (b.value.to_s == 'true' ? t('.answer_yes') : t('.answer_no')) }
+    = f.govuk_collection_radio_buttons :email_notification_of_message,
+      [['Yes','true'],['No','false']],
+      :last,
+      :first,
+      inline: true,
+      legend: { text: t('.email_notification'), size: 's' }
 
     - if current_user.persona.admin?
-      .form-group
-        %fieldset.inline.js-advocate-roles{ 'aria-describedby': 'checkbox-control-legend-roles' }
-          %legend#checkbox-control-legend-roles
-            %span.heading-medium
-              = t('.roles')
+      = f.govuk_check_boxes_fieldset :roles, legend: { text: t('.roles'), size: 's' } do
 
-          = f.collection_check_boxes(:roles, @external_user.available_roles, :to_s, :to_s) do |b|
-            .multiple-choice
-              = b.check_box('aria-labelledby': "checkbox-control-legend-roles #{b.text.to_css_class}")
-              = b.label(id: b.text.to_css_class) { b.value.humanize }
+        = f.govuk_check_box :roles,
+          @external_user.available_roles.first,
+          label: { text: 'Admin' },
+          link_errors: true
 
-    - if current_user.persona.provider.chamber?
-      .form-group.js-chamber-advocates-only
-        %fieldset.inline{ 'aria-describedby': 'checkbox-control-legend-vat' }
-          %legend#checkbox-control-legend-vat
-            = t('.vat_registered')
+        = f.govuk_check_box :roles,
+          @external_user.available_roles.last,
+          label: { text: 'Advocate' } do
 
-          = f.collection_radio_buttons(:vat_registered, [true, false], :to_s, :to_s) do |b|
-            .multiple-choice
-              = b.radio_button('aria-labelledby': "checkbox-control-legend-vat #{b.text.to_css_class}")
-              = b.label { (b.value.to_s == 'true' ? t('.answer_yes') : t('.answer_no')) }
+          - if current_user.persona.provider.chamber?
+            = f.govuk_collection_radio_buttons :vat_registered,
+              [['Yes','true'],['No','false']],
+              :last,
+              :first,
+              inline: true,
+              legend: { text: t('.vat_registered'), size: 's' }
 
-      .form-group
-        = f.label :supplier_number, t('.supplier_number'), class: 'form-label-bold'
-        = f.text_field :supplier_number, class: 'form-control'
+    = f.govuk_text_field :supplier_number,
+      hint: { text: t('.supplier_number_hint') },
+      label: { text: t('.supplier_number') }
 
-  .form-group
-    = govuk_button(t('.save'))
+    = f.govuk_submit t('.save')

--- a/app/views/external_users/admin/external_users/change_password.html.haml
+++ b/app/views/external_users/admin/external_users/change_password.html.haml
@@ -1,30 +1,21 @@
 = content_for :page_title, flush: true do
   = t('.page_title')
 
-= render partial: 'errors/error_summary', locals: { ep: @external_user.user, error_summary: t('.error_summary') }
-
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_with model: [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path, builder: GdsAdpFormBuilder, local: true do |f|
+      = f.fields_for :user do |user_fields|
+        = user_fields.govuk_error_summary
 
-= form_for [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path do |f|
-  = f.fields_for :user do |user_fields|
-    .form-fields
-      %fieldset
-        %legend.visually-hidden
-          = t('.change_password')
-        .form-group
-          .form-group.input
-            %a{ name: 'current_password' }
-            = user_fields.label :current_password, t('.current_password'), class: 'form-label'
-            = user_fields.password_field :current_password, class: 'form-control'
-          .form-group.input
-            %a{ name: 'password' }
-            = user_fields.label :password, t('.password'), class: 'form-label'
-            = user_fields.password_field :password, class: 'form-control'
-          .form-group.input
-            %a{ name: 'password_confirmation' }
-            = user_fields.label :password_confirmation, t('.password_confirmation'), class: 'form-label'
-            = user_fields.password_field :password_confirmation, class: 'form-control'
+        = user_fields.govuk_password_field :current_password,
+          label: { text: t('.current_password') }
 
-        .form-group
-          = govuk_button(t('.submit'))
+        = user_fields.govuk_password_field :password,
+          label: { text: t('.password') }
+
+        = user_fields.govuk_password_field :password_confirmation,
+          label: { text: t('.password_confirmation') }
+
+        = f.govuk_submit t('.submit')

--- a/app/views/external_users/admin/external_users/edit.html.haml
+++ b/app/views/external_users/admin/external_users/edit.html.haml
@@ -1,8 +1,8 @@
 = content_for :page_title, flush: true do
   = t('.page_title', external_user: @external_user.user.name)
 
-= render partial: 'errors/error_summary', locals:{ ep: @external_user.user, error_summary: t('.error_summary')}
-
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading', external_user: @external_user.user.name)}
 
-= render 'form'
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = render 'form'

--- a/app/views/external_users/admin/external_users/new.html.haml
+++ b/app/views/external_users/admin/external_users/new.html.haml
@@ -1,8 +1,8 @@
 = content_for :page_title, flush: true do
   = t(".page_title_#{@current_provider.provider_type}")
 
-= render partial: 'errors/error_summary', locals: { ep: @external_user.user, error_summary: t('.error_summary') }
-
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading', provider_name: "#{current_user.provider.name}") }
 
-= render 'form'
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = render 'form'

--- a/app/views/super_admins/admin/super_admins/_form.html.haml
+++ b/app/views/super_admins/admin/super_admins/_form.html.haml
@@ -1,30 +1,17 @@
-= form_for [:super_admins, :admin, @super_admin] do |f|
-
-  - if @super_admin.errors.any?
-    .error-summary{"aria-labelledby" => "error-summary-heading", :role => "alert", :tabindex => "-1"}
-      %h2#error-summary-heading.heading-medium.error-summary-heading
-        = "#{t('.prohibited_save')} #{pluralize(@super_admin.errors.count, t('.error'))}"
-      %ul.error-summary-list
-        - @super_admin.errors.full_messages.each do |msg|
-          %li
-            = msg
-
+= form_with model: [:super_admins, :admin, @super_admin], builder: GdsAdpFormBuilder, local: true do |f|
   = f.fields_for :user do |user_fields|
-    %fieldset.user-form
-      .form-group
-        = user_fields.label t('.first_name'), class: 'form-label-bold', for: 'super_admin_user_attributes_first_name'
-        = user_fields.text_field :first_name, class: 'form-control'
+    = user_fields.govuk_error_summary
 
-      .form-group
-        = user_fields.label t('.last_name'), class: 'form-label-bold', for: 'super_admin_user_attributes_last_name'
-        = user_fields.text_field :last_name, class: 'form-control'
+    = user_fields.govuk_text_field :first_name,
+      label: { text: t('.first_name') }
 
-      .form-group
-        = user_fields.label t('.email'), class: 'form-label-bold', for: 'super_admin_user_attributes_email'
-        = user_fields.email_field :email, class: 'form-control'
+    = user_fields.govuk_text_field :last_name,
+      label: { text: t('.first_name') }
 
-      .form-group
-        = user_fields.label t('.email_confirmation'), class: 'form-label-bold', for: 'super_admin_user_attributes_email_confirmation'
-        = user_fields.email_field :email_confirmation, class: 'form-control'
+    = user_fields.govuk_email_field :email,
+      label: { text: t('.email') }
 
-  = f.submit t('.submit'), class: "button"
+    = user_fields.govuk_email_field :email_confirmation,
+      label: { text: t('.email_confirmation') }
+
+    = f.govuk_submit t('.submit')

--- a/app/views/super_admins/admin/super_admins/change_password.html.haml
+++ b/app/views/super_admins/admin/super_admins/change_password.html.haml
@@ -3,29 +3,19 @@
 
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
-= form_for [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path do |f|
-  - if @super_admin.user.errors.any?
-    .error-summary{"aria-labelledby" => "error-summary-heading", :role => "alert", :tabindex => "-1"}
-      %h2#error-summary-heading.heading-medium.error-summary-heading
-        = "#{t('.prohibited_save')} #{pluralize(@super_admin.user.errors.count, 'error')}"
-      %ul.error-summary-list
-        - @super_admin.user.errors.full_messages.each do |msg|
-          %li
-            = msg
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_with model: [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path, builder: GdsAdpFormBuilder, local: true do |f|
+      = f.fields_for :user do |user_fields|
+        = user_fields.govuk_error_summary
 
-  = f.fields_for :user do |user_fields|
-    %fieldset.user-form
+        = user_fields.govuk_password_field :current_password,
+          label: { text: t('.current_password') }
 
-      .form-group
-        = user_fields.label t(".current_password"), class: "form-label-bold", for: 'super_admin_user_attributes_current_password'
-        = user_fields.password_field :current_password, class: "form-control"
+        = user_fields.govuk_password_field :password,
+          label: { text: t('.password') }
 
-      .form-group
-        = user_fields.label t(".password"), class: "form-label-bold", for: 'super_admin_user_attributes_password'
-        = user_fields.password_field :password, class: "form-control"
+        = user_fields.govuk_password_field :password_confirmation,
+          label: { text: t('.password_confirmation') }
 
-      .form-group
-        = user_fields.label t(".password_confirmation"), class: "form-label-bold", for: 'super_admin_user_attributes_password_confirmation'
-        = user_fields.password_field :password_confirmation, class: "form-control"
-
-  = f.submit t(".submit"), class: "button"
+        = f.govuk_submit t('.submit')

--- a/app/views/super_admins/admin/super_admins/edit.html.haml
+++ b/app/views/super_admins/admin/super_admins/edit.html.haml
@@ -3,4 +3,6 @@
 
 = render partial: 'layouts/header', locals: {page_heading: t('.page_heading')}
 
-= render 'form'
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = render 'form'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,11 +233,11 @@ en:
         external_user:
           attributes:
             roles:
-              blank: cannot be blank
+              blank: Choose at least one role
               inclusion: *inclusion
             supplier_number:
-              blank: cannot be blank
-              invalid: 'must be 5 alpha-numeric uppercase characters'
+              blank: Enter a supplier number
+              invalid: Enter a valid supplier number
         case_worker:
           attributes:
             roles:
@@ -246,17 +246,21 @@ en:
           attributes:
             email:
               blank: Enter an email
+              invalid: Enter a valid email
               taken: Email address is already registered
               too_long: Email must be 80 characters or less
             email_confirmation:
-              confirmation: email and confirmation must match
+              confirmation: Email and confirmation must match
               blank: Enter an email confirmation
+            current_password:
+              blank: Enter the currrent password
+              invalid: Enter the current password
             password:
               blank: Enter a password
               too_short: Email must be at least 8 characters
             password_confirmation:
               blank: Enter a password confirmation
-              confirmation: password and confirmation must match
+              confirmation: Password and confirmation must match
             first_name:
               blank: Enter a first name
               too_long: First name must be 40 characters or less
@@ -702,6 +706,7 @@ en:
           first_name: *first_name
           last_name: *last_name
           supplier_number: 'Supplier number'
+          supplier_number_hint: must be 5 alpha-numeric uppercase characters
           roles: *roles
           submit: 'Create user'
           answer_yes: *global_yes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,7 +257,7 @@ en:
               invalid: Enter the current password
             password:
               blank: Enter a password
-              too_short: Email must be at least 8 characters
+              too_short: Password must be at least 8 characters
             password_confirmation:
               blank: Enter a password confirmation
               confirmation: Password and confirmation must match

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ExternalUser, type: :model do
       context 'for advocate' do
         before { subject.roles = ['advocate'] }
 
-        let(:format_error) { ['must be 5 alpha-numeric uppercase characters'] }
+        let(:format_error) { ['Enter a valid supplier number'] }
 
         it { should validate_presence_of(:supplier_number) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe User, type: :model do
   it { is_expected.to validate_length_of(:email).is_at_most(80).with_message('Email must be 80 characters or less') }
   it { is_expected.to allow_value('email@addresse.foo').for(:email) }
   it { is_expected.not_to allow_value('foo').for(:email) }
-  it { is_expected.to validate_length_of(:password).is_at_least(8).with_message('Email must be at least 8 characters') }
+  it { is_expected.to validate_length_of(:password).is_at_least(8).with_message('Password must be at least 8 characters') }
 
   context 'when host is not api-sandbox' do
     around do |example|

--- a/spec/support/shared_examples_for_roles.rb
+++ b/spec/support/shared_examples_for_roles.rb
@@ -16,12 +16,12 @@ RSpec.shared_examples_for 'roles' do |klass, roles|
     it 'is not valid with an invalid role' do
       assigned_roles << [roles.first, 'foobar123xyz']
       expect(subject).to_not be_valid
-      expect(subject.errors[:roles]).to include("must be one or more of: #{roles.map { |r| r.humanize.downcase }.join(', ')}")
+      expect(subject.errors[:roles]).to include("Must be one or more of: #{roles.map { |r| r.humanize.downcase }.join(', ')}")
     end
 
     it 'is not valid without a role' do
       expect(subject).to_not be_valid
-      expect(subject.errors[:roles]).to include('at least one role must be present')
+      expect(subject.errors[:roles]).to include('Choose at least one role')
     end
   end
 


### PR DESCRIPTION
#### What
Migrate certification form to the GOVUK design system form builder

#### Ticket
[Migrate user forms to the GOVUK design system form builder](https://dsdmoj.atlassian.net/browse/CFP-73)

#### Why
Part of a larger change to:

- continue migration to GOVUK Frontend
- resolve accessibility issues identified in the 2020 DAC report
- reduce then remove deprecated code