### PR TITLE
Rake task to find unattached S3 files

### DIFF
--- a/lib/tasks/rake_helpers/storage.rb
+++ b/lib/tasks/rake_helpers/storage.rb
@@ -1,0 +1,56 @@
+module Storage
+  def self.s3_files(interactive)
+    Aws.config[:credentials] = Aws::Credentials.new(Settings.aws.s3.access, Settings.aws.s3.secret)
+    s3 = Aws::S3::Client.new
+    data = {
+      attached: {
+        rows: [],
+        total: 0,
+        size: 0
+      },
+      orphaned: {
+        rows: [],
+        total: 0,
+        size: 0
+      }
+    }
+
+    s3.list_objects(bucket: Settings.aws.s3.bucket).each_with_index do |response, i|
+      contents = response.contents
+      blobs = ActiveStorage::Blob.where(key: contents.map(&:key)).index_by(&:key)
+      keys = blobs.keys
+      good, bad = contents.partition { |c| keys.include? c.key }
+
+      self.collate data[:attached], good, blobs
+      self.collate data[:orphaned], bad
+
+      puts "#{i+1}000 processed"
+      if interactive
+        print 'Continue? [Y/n] '
+        break if $stdin.gets.strip.downcase.first == 'n'
+      end
+    end
+
+    data
+  end
+
+  private
+
+  def self.collate(data, new_data, blobs = nil)
+    data[:total] += new_data.count
+    data[:size] += new_data.sum { |content| content.size }
+    data[:rows] += new_data.map do |content|
+      (
+        blobs.nil? ? [] : [
+          blobs[content.key].id,
+          blobs[content.key].filename,
+          blobs[content.key].attachments.count
+        ]
+      ) + [
+        content.key,
+        content.last_modified,
+        content.size
+      ]
+    end
+  end
+end

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -1,0 +1,27 @@
+require 'tasks/rake_helpers/storage'
+
+namespace :storage do
+  include ActionView::Helpers::NumberHelper
+
+  desc 'Review S3 files'
+  task :s3_status, [:interactive] => :environment do |_task, args|
+    file_lists = Storage.s3_files(args[:interactive] == 'interactive')
+
+    CSV.open('tmp/s3_files.csv', 'wb') do |csv|
+      csv << %w[Blob Filename Attachments Key Modified Size]
+      file_lists[:attached][:rows].sort_by { |row| row[3] }.each { |row| csv << row }
+    end
+
+    CSV.open('tmp/s3_orphaned_files.csv', 'wb') do |csv|
+      csv << %w[Key Modified Size]
+      file_lists[:orphaned][:rows].sort_by { |row| row[3] }.each { |row| csv << row }
+    end
+
+    File.open('tmp/s3_summary.txt', 'w') do |file|
+      file.puts "Files attached to Active Storage attachments: #{file_lists[:attached][:total]}"
+      file.puts "Size of attached files: #{number_to_human_size(file_lists[:attached][:size])}"
+      file.puts "Files not attached to Active Storage attachments: #{file_lists[:orphaned][:total]}"
+      file.puts "Size of non-attached files: #{number_to_human_size(file_lists[:orphaned][:size])}"
+    end
+  end
+end


### PR DESCRIPTION
#### What

Rake task to identify S3 files that are not attached.

#### Ticket

N/A

#### Why

This allows us to see if there are files in S3 that can be deleted. This is more likely to happen on the development environments.

#### How

```bash
rails storage:s3_status
```

This will create three files;

* `tmp/s3_files.csv`: List of files with one or more `ActiveStorage::Attachment` records. Columns are; `id` in `ActiveStorage::Blob`, filename, number of attachments, key, last modified time and file size.
* `tmp/s3_orphaned_files.csv`: List of files that are not linked to an `ActiveStorage::Attachment`. Columns are; key, last modified time and file size.
* `tmp/s3_summary.txt`: Information about number of files and sum of file sizes.

The task can be executed as `rails storage:s3_status[interactive]`. This will allow the task to be stopped after each 1000 files from S3 is checked.

The summary on staging (at the moment) looks like this:

```
Files attached to Active Storage attachments: 537
Size of attached files: 269 MB
Files not attached to Active Storage attachments: 18318
Size of non-attached files: 513 MB
```