### PR TITLE
Update python dependencies

### DIFF
--- a/.github/actions/delete-ecr-images/Dockerfile
+++ b/.github/actions/delete-ecr-images/Dockerfile
@@ -9,11 +9,11 @@ LABEL "com.github.actions.color"="red"
 # install dependencies
 
 RUN apk update && \
-  apk --no-cache add git python py-pip
+  apk --no-cache add git python3 py3-pip
 
-RUN pip install awscli
+RUN pip3 install awscli
 
-RUN apk --purge -v del py-pip && \
+RUN apk --purge -v del py3-pip && \
   rm /var/cache/apk/*
 
 COPY entrypoint /usr/local/bin/delete-ecr-images


### PR DESCRIPTION
#### What
Update python dependencies

#### Why
Inline with available alpine v3.13
python packages

see https://pkgs.alpinelinux.org/packages?name=py3-pip*&branch=v3.13&repo=community&arch=x86_64
for package availability.

#### How
Use python3/py3-pip instead of python/py-pip as the later
are no longer available in alpine 3.13