### PR TITLE
Do not delete py-pip3

### DIFF
--- a/.github/actions/delete-ecr-images/Dockerfile
+++ b/.github/actions/delete-ecr-images/Dockerfile
@@ -14,8 +14,7 @@ RUN apk update \
 RUN pip3 install --upgrade pip \
     && pip install awscli
 
-RUN apk --purge -v del py3-pip \
-    && rm -rf /var/cache/apk/*
+RUN apk --purge && rm -rf /var/cache/apk/*
 
 RUN aws --version
 


### PR DESCRIPTION
Do not delete py-pip3

Looks like awscli relies on it. but delete modified config
and clean cache to reduce image size.