### PR TITLE
[CFP-30] Bump postgres for test suite 9.6 --> 13.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
           LIVE1_DB_TASK: none
-      - image: circleci/postgres:9.6.20
+      - image: circleci/postgres:13.1
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"
@@ -130,7 +130,7 @@ executors:
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
-      - image: circleci/postgres:9.6.20
+      - image: circleci/postgres:13.1
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"


### PR DESCRIPTION
#### What
Bump postgres for test suite 9.6 --> 13.1

#### Ticket

[CFP-30](https://dsdmoj.atlassian.net/browse/CFP-30)

#### Why

To run the test suite against the DB upgrade target
postres version.

PostgreSQL 13.1 is the target postgres version as
currently available in AWS for a direct/jump upgrade
from 9.6.20.

#### How
Update circleci config to use postgres images that most closely
matches target version of database for production use (via AWS)

See [circleci available service images](https://circleci.com/docs/2.0/docker-image-tags.json)
or on [dockerhub directly](https://hub.docker.com/r/circleci/postgres/tags?page=1&name=13.1&ordering=last_updated).

It looks like there is no “13.1-alpine[-ram]”, but “13.1[-ram]” should suffice since the OS of the DB
is not something we modify or have control over as far as I am aware - because it is AWS RDS default.
