### PR TITLE
Basic claim search

### DIFF
--- a/app/interfaces/api/v2/case_workers/claim.rb
+++ b/app/interfaces/api/v2/case_workers/claim.rb
@@ -57,18 +57,17 @@ module API
               current_user.claims.where(id: generic_claims)
             end
 
-            def archived_claims
+            def unallocated_claims
               generic_claims
-            end
-
-            def allocated_claims
-              generic_claims.public_send(scheme)
+                .filter_by(filter)
+                .value_band(value_band_id)
             end
 
             def generic_claims
               ClaimSearchService.call(
                 state: states_for_status,
                 term: search_terms,
+                scheme: scheme,
                 user: current_user.persona
               )
             end
@@ -84,14 +83,9 @@ module API
               end
             end
 
-            def unallocated_claims
-              generic_claims
-                .__send__(scheme)
-                .filter_by(filter)
-                .value_band(value_band_id)
-            end
-
             def claims_scope
+              return generic_claims if %w[archived allocated].include? params[:status]
+
               send("#{params[:status]}_claims")
             end
 

--- a/app/interfaces/api/v2/case_workers/claim.rb
+++ b/app/interfaces/api/v2/case_workers/claim.rb
@@ -60,7 +60,6 @@ module API
             def unallocated_claims
               generic_claims
                 .filter_by(filter)
-                .value_band(value_band_id)
             end
 
             def generic_claims
@@ -69,7 +68,8 @@ module API
                 term: search_terms,
                 scheme: scheme,
                 user: current_user.persona,
-                current_user_claims: current_user_claims
+                current_user_claims: current_user_claims,
+                value_band_id: value_band_id
               )
             end
 

--- a/app/interfaces/api/v2/case_workers/claim.rb
+++ b/app/interfaces/api/v2/case_workers/claim.rb
@@ -53,8 +53,8 @@ module API
               params[:value_band_id]
             end
 
-            def current_claims
-              current_user.claims.where(id: generic_claims)
+            def current_user_claims
+              params[:status] == 'current'
             end
 
             def unallocated_claims
@@ -68,7 +68,8 @@ module API
                 state: states_for_status,
                 term: search_terms,
                 scheme: scheme,
-                user: current_user.persona
+                user: current_user.persona,
+                current_user_claims: current_user_claims
               )
             end
 
@@ -84,9 +85,9 @@ module API
             end
 
             def claims_scope
-              return generic_claims if %w[archived allocated].include? params[:status]
+              return unallocated_claims if params[:status] == 'unallocated'
 
-              send("#{params[:status]}_claims")
+              generic_claims
             end
 
             def claims

--- a/app/services/claim_search_service.rb
+++ b/app/services/claim_search_service.rb
@@ -1,7 +1,8 @@
 class ClaimSearchService
   FILTERS = [
     ClaimSearchService::State,
-    ClaimSearchService::Keyword
+    ClaimSearchService::Keyword,
+    ClaimSearchService::Scheme
   ].freeze
 
   def self.call(params)

--- a/app/services/claim_search_service.rb
+++ b/app/services/claim_search_service.rb
@@ -1,0 +1,19 @@
+class ClaimSearchService
+  FILTERS = [
+    ClaimSearchService::State
+  ].freeze
+
+  def self.call(params)
+    new(params).call
+  end
+
+  def initialize(params = {})
+    @search = FILTERS.inject(ClaimSearchService::Base.new) do |partial_search, filter|
+      filter.decorate(partial_search, params)
+    end
+  end
+
+  def call
+    @search.run
+  end
+end

--- a/app/services/claim_search_service.rb
+++ b/app/services/claim_search_service.rb
@@ -2,7 +2,9 @@ class ClaimSearchService
   FILTERS = [
     ClaimSearchService::State,
     ClaimSearchService::Keyword,
-    ClaimSearchService::Scheme
+    ClaimSearchService::Scheme,
+    # This needs to be last because of how it is implemented
+    ClaimSearchService::CurrentUser
   ].freeze
 
   def self.call(params)

--- a/app/services/claim_search_service.rb
+++ b/app/services/claim_search_service.rb
@@ -3,6 +3,7 @@ class ClaimSearchService
     ClaimSearchService::State,
     ClaimSearchService::Keyword,
     ClaimSearchService::Scheme,
+    ClaimSearchService::ValueBand,
     # This needs to be last because of how it is implemented
     ClaimSearchService::CurrentUser
   ].freeze

--- a/app/services/claim_search_service.rb
+++ b/app/services/claim_search_service.rb
@@ -8,7 +8,7 @@ class ClaimSearchService
     new(params).call
   end
 
-  def initialize(params = {})
+  def initialize(**params)
     @search = FILTERS.inject(ClaimSearchService::Base.new) do |partial_search, filter|
       filter.decorate(partial_search, params)
     end

--- a/app/services/claim_search_service.rb
+++ b/app/services/claim_search_service.rb
@@ -1,6 +1,7 @@
 class ClaimSearchService
   FILTERS = [
-    ClaimSearchService::State
+    ClaimSearchService::State,
+    ClaimSearchService::Keyword
   ].freeze
 
   def self.call(params)

--- a/app/services/claim_search_service/base.rb
+++ b/app/services/claim_search_service/base.rb
@@ -5,7 +5,7 @@ class ClaimSearchService
     end
 
     def run
-      Claim::BaseClaim.active
+      Claim::BaseClaim.active.distinct
     end
   end
 end

--- a/app/services/claim_search_service/base.rb
+++ b/app/services/claim_search_service/base.rb
@@ -1,0 +1,11 @@
+class ClaimSearchService
+  class Base
+    def initialize(search = nil, _options = {})
+      @search = search || self
+    end
+
+    def run
+      Claim::BaseClaim.active
+    end
+  end
+end

--- a/app/services/claim_search_service/current_user.rb
+++ b/app/services/claim_search_service/current_user.rb
@@ -1,0 +1,19 @@
+class ClaimSearchService
+  class CurrentUser < Base
+    def initialize(search, user:)
+      super
+
+      @user = user
+    end
+
+    def run
+      @user.claims.where(id: @search.run)
+    end
+
+    def self.decorate(search, user: nil, current_user_claims: false, **_params)
+      return search unless user && current_user_claims
+
+      new(search, user: user)
+    end
+  end
+end

--- a/app/services/claim_search_service/keyword.rb
+++ b/app/services/claim_search_service/keyword.rb
@@ -1,0 +1,47 @@
+class ClaimSearchService
+  class Keyword < Base
+    STATUSES = %w[archived allocated current].freeze
+
+    def initialize(search, term:)
+      super
+
+      @term = "%#{term}%"
+    end
+
+    def run
+      @search.run.merge(or_chain)
+    end
+
+    def self.decorate(claim_search, status: nil, search: nil, **_params)
+      return claim_search unless STATUSES.include?(status) && search.present?
+
+      new(claim_search, term: search)
+    end
+
+    private
+
+    def or_chain
+      fields.inject(stub.none) do |partial_search, field|
+        partial_search.or(stub.where(field.matches(@term)))
+      end
+    end
+
+    def fields
+      [
+        Claim::BaseClaim.arel_table[:case_number],
+        Defendant.arel_table[:first_name],
+        Defendant.arel_table[:last_name],
+        User.arel_table[:first_name],
+        User.arel_table[:last_name],
+        RepresentationOrder.arel_table[:maat_reference]
+      ]
+    end
+
+    def stub
+      @stub ||= Claim::BaseClaim.joins(
+        defendants: :representation_orders,
+        external_user: :user
+      )
+    end
+  end
+end

--- a/app/services/claim_search_service/scheme.rb
+++ b/app/services/claim_search_service/scheme.rb
@@ -1,0 +1,11 @@
+class ClaimSearchService
+  class Scheme < Scope
+    SCHEMAS = %w[agfs lgfs].freeze
+
+    def self.decorate(search, scheme: nil, **_params)
+      return search unless SCHEMAS.include? scheme
+
+      new(search, scope: scheme)
+    end
+  end
+end

--- a/app/services/claim_search_service/scope.rb
+++ b/app/services/claim_search_service/scope.rb
@@ -1,0 +1,13 @@
+class ClaimSearchService
+  class Scope < Base
+    def initialize(search, scope:)
+      super
+
+      @scope = scope
+    end
+
+    def run
+      @search.run.send(@scope)
+    end
+  end
+end

--- a/app/services/claim_search_service/state.rb
+++ b/app/services/claim_search_service/state.rb
@@ -1,25 +1,19 @@
 class ClaimSearchService
   class State < Base
-    STATES = {
-      archived: Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES,
-      allocated: Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES
-    }.freeze
-
-    def initialize(search, status:)
+    def initialize(search, state:)
       super
 
-      @status = status
+      @state = state
     end
 
     def run
-      @search.run.where(state: STATES[@status])
+      @search.run.where(state: @state)
     end
 
-    def self.decorate(search, status: nil, **_params)
-      status = status&.to_sym
-      return search if STATES[status].blank?
+    def self.decorate(search, state: nil, **_params)
+      return search if state.blank?
 
-      new(search, status: status)
+      new(search, state: Array(state))
     end
   end
 end

--- a/app/services/claim_search_service/state.rb
+++ b/app/services/claim_search_service/state.rb
@@ -1,0 +1,25 @@
+class ClaimSearchService
+  class State < Base
+    STATES = {
+      archived: Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES,
+      allocated: Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES
+    }.freeze
+
+    def initialize(search, status:)
+      super
+
+      @status = status
+    end
+
+    def run
+      @search.run.where(state: STATES[@status])
+    end
+
+    def self.decorate(search, status: nil, **_params)
+      status = status&.to_sym
+      return search if STATES[status].blank?
+
+      new(search, status: status)
+    end
+  end
+end

--- a/app/services/claim_search_service/value_band.rb
+++ b/app/services/claim_search_service/value_band.rb
@@ -1,0 +1,21 @@
+class ClaimSearchService
+  class ValueBand < Base
+    def initialize(search, value_band_id:)
+      super
+
+      @value_band_id = value_band_id
+    end
+
+    def run
+      @search.run.where(value_band_id: @value_band_id)
+    end
+
+    def self.decorate(search, value_band_id: nil, **_params)
+      # N.B. Originally a zero value_band_id would result in a where.not(value_band_id: nil) but this doesn't seem to
+      # have any effect
+      return search if value_band_id.blank? || value_band_id.zero?
+
+      new(search, value_band_id: value_band_id)
+    end
+  end
+end

--- a/spec/factories/case_workers.rb
+++ b/spec/factories/case_workers.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     after(:build) do |case_worker, evaluator|
       if evaluator.build_user
         case_worker.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, password: 'password', password_confirmation: 'password')
-        case_worker.user.email = "#{case_worker.first_name}.#{case_worker.last_name}@laa.gov.uk"
+        case_worker.user.email ||= "#{case_worker.first_name}.#{case_worker.last_name}@laa.gov.uk"
       end
     end
 

--- a/spec/services/claim_search_service/current_user_spec.rb
+++ b/spec/services/claim_search_service/current_user_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ClaimSearchService::CurrentUser do
+  describe '#decorate' do
+    subject(:decorate) { described_class.decorate(base, **params) }
+
+    let(:base) { ClaimSearchService::Base.new }
+    let(:user) { create :case_worker }
+
+    context 'when no user is given' do
+      let(:params) { { current_user_claims: true } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when the current user claims flag is missing' do
+      let(:params) { { user: user } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when the user is present and the current user claims flag is false' do
+      let(:params) { { user: user, current_user_claims: false } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when the user is present and the current user claims flag is true' do
+      let(:params) { { user: user, current_user_claims: true } }
+
+      it { is_expected.to be_a described_class }
+    end
+  end
+end

--- a/spec/services/claim_search_service/keyword_spec.rb
+++ b/spec/services/claim_search_service/keyword_spec.rb
@@ -6,28 +6,16 @@ RSpec.describe ClaimSearchService::Keyword do
 
     let(:base) { ClaimSearchService::Base.new }
 
-    context 'when no status is given' do
-      let(:params) { { search: 'T20200101' } }
-
-      it { is_expected.not_to be_a described_class }
-    end
-
     context 'when no search term is given' do
-      let(:params) { { status: 'allocated' } }
+      let(:params) { {} }
 
       it { is_expected.not_to be_a described_class }
     end
 
-    context 'when the status is allocated and there is a search term' do
-      let(:params) { { status: 'archived', search: 'T20200101' } }
+    context 'when a search term is provided' do
+      let(:params) { { term: 'T20200101' } }
 
       it { is_expected.to be_a described_class }
-    end
-
-    context 'when no status is unknown' do
-      let(:params) { { status: 'boo', search: 'T20200101' } }
-
-      it { is_expected.not_to be_a described_class }
     end
   end
 end

--- a/spec/services/claim_search_service/keyword_spec.rb
+++ b/spec/services/claim_search_service/keyword_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ClaimSearchService::Keyword do
+  describe '#decorate' do
+    subject(:decorate) { described_class.decorate(base, **params) }
+
+    let(:base) { ClaimSearchService::Base.new }
+
+    context 'when no status is given' do
+      let(:params) { { search: 'T20200101' } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when no search term is given' do
+      let(:params) { { status: 'allocated' } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when the status is allocated and there is a search term' do
+      let(:params) { { status: 'archived', search: 'T20200101' } }
+
+      it { is_expected.to be_a described_class }
+    end
+
+    context 'when no status is unknown' do
+      let(:params) { { status: 'boo', search: 'T20200101' } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+  end
+end

--- a/spec/services/claim_search_service/state_spec.rb
+++ b/spec/services/claim_search_service/state_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ClaimSearchService::State do
+  describe '#decorate' do
+    subject(:decorate) { described_class.decorate(base, **params) }
+
+    let(:base) { ClaimSearchService::Base.new }
+
+    context 'when no status is given' do
+      let(:params) { {} }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when the status is archived' do
+      let(:params) { { status: 'archived' } }
+
+      it { is_expected.to be_a described_class }
+    end
+
+    context 'when the status is allocated' do
+      let(:params) { { status: 'allocated' } }
+
+      it { is_expected.to be_a described_class }
+    end
+
+    context 'when no status is unknown' do
+      let(:params) { { status: 'boo' } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+  end
+end

--- a/spec/services/claim_search_service/state_spec.rb
+++ b/spec/services/claim_search_service/state_spec.rb
@@ -6,28 +6,22 @@ RSpec.describe ClaimSearchService::State do
 
     let(:base) { ClaimSearchService::Base.new }
 
-    context 'when no status is given' do
+    context 'when no states are given' do
       let(:params) { {} }
 
       it { is_expected.not_to be_a described_class }
     end
 
-    context 'when the status is archived' do
-      let(:params) { { status: 'archived' } }
+    context 'when there is a single state' do
+      let(:params) { { state: 'authorised' } }
 
       it { is_expected.to be_a described_class }
     end
 
-    context 'when the status is allocated' do
-      let(:params) { { status: 'allocated' } }
+    context 'when there are multiple states' do
+      let(:params) { { state: %w[authorised part_authorised rejected] } }
 
       it { is_expected.to be_a described_class }
-    end
-
-    context 'when no status is unknown' do
-      let(:params) { { status: 'boo' } }
-
-      it { is_expected.not_to be_a described_class }
     end
   end
 end

--- a/spec/services/claim_search_service/value_band_spec.rb
+++ b/spec/services/claim_search_service/value_band_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ClaimSearchService::ValueBand do
+  describe '#decorate' do
+    subject(:decorate) { described_class.decorate(base, **params) }
+
+    let(:base) { ClaimSearchService::Base.new }
+
+    context 'when no value band id is given' do
+      let(:params) { {} }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when the value band id is 0' do
+      let(:params) { { value_band_id: 0 } }
+
+      it { is_expected.not_to be_a described_class }
+    end
+
+    context 'when the value band id is 10' do
+      let(:params) { { value_band_id: 10 } }
+
+      it { is_expected.to be_a described_class }
+    end
+  end
+end

--- a/spec/services/claim_search_service_spec.rb
+++ b/spec/services/claim_search_service_spec.rb
@@ -187,4 +187,16 @@ RSpec.describe ClaimSearchService, type: :service do
 
     it { is_expected.to match_array expected_search }
   end
+
+  context 'with a current user claims search' do
+    let(:current_case_worker) { build :case_worker }
+    let(:other_case_worker) { build :case_worker }
+    let(:params) { { user: current_case_worker, current_user_claims: true } }
+
+    let!(:expected_search) { [create(:allocated_claim, case_workers: [current_case_worker])] }
+
+    before { create(:allocated_claim, case_workers: [other_case_worker]) }
+
+    it { is_expected.to match_array expected_search }
+  end
 end

--- a/spec/services/claim_search_service_spec.rb
+++ b/spec/services/claim_search_service_spec.rb
@@ -145,4 +145,46 @@ RSpec.describe ClaimSearchService, type: :service do
       it { is_expected.not_to include claim }
     end
   end
+
+  context 'with an agfs scheme' do
+    let(:params) { { scheme: 'agfs' } }
+    let(:expected_search) do
+      [
+        create(:advocate_claim),
+        create(:advocate_interim_claim),
+        create(:advocate_supplementary_claim),
+        create(:advocate_hardship_claim)
+      ]
+    end
+
+    before do
+      create :litigator_claim
+      create :interim_claim
+      create :transfer_claim
+      create :litigator_hardship_claim
+    end
+
+    it { is_expected.to match_array expected_search }
+  end
+
+  context 'with an lgfs scheme' do
+    let(:params) { { scheme: 'lgfs' } }
+    let(:expected_search) do
+      [
+        create(:litigator_claim),
+        create(:interim_claim),
+        create(:transfer_claim),
+        create(:litigator_hardship_claim)
+      ]
+    end
+
+    before do
+      create :advocate_claim
+      create :advocate_interim_claim
+      create :advocate_supplementary_claim
+      create :advocate_hardship_claim
+    end
+
+    it { is_expected.to match_array expected_search }
+  end
 end

--- a/spec/services/claim_search_service_spec.rb
+++ b/spec/services/claim_search_service_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe ClaimSearchService, type: :service do
+  subject(:result) { described_class.call(**params) }
+
+  context 'when there are no options' do
+    let(:params) { {} }
+    let(:expected_search) do
+      [
+        create(:authorised_claim),
+        create(:authorised_claim)
+      ]
+    end
+
+    it 'returns all the claims' do
+      expect(result).to match_array expected_search
+    end
+
+    it 'does not return a deleted claim' do
+      expected_search.first.delete
+      expect(result).not_to include expected_search.first
+    end
+  end
+
+  context 'when the status is archived' do
+    let(:params) { { status: 'archived' } }
+    let(:expected_search) do
+      [
+        create(:authorised_claim),
+        create(:part_authorised_claim),
+        create(:rejected_claim),
+        create(:refused_claim),
+        create(:archived_pending_delete_claim),
+        create(:hardship_archived_pending_review_claim)
+      ]
+    end
+
+    before do
+      create :allocated_claim
+      create :submitted_claim
+      create :redetermination_claim
+      create :awaiting_written_reasons_claim
+    end
+
+    it { is_expected.to match_array expected_search }
+  end
+
+  context 'when the status is allocated' do
+    let(:params) { { status: 'allocated' } }
+    let(:expected_search) { [create(:allocated_claim)] }
+
+    before do
+      create :submitted_claim
+      create :redetermination_claim
+      create :awaiting_written_reasons_claim
+      create :authorised_claim
+      create :part_authorised_claim
+      create :rejected_claim
+      create :refused_claim
+      create :archived_pending_delete_claim
+      # create :hardship_archived_pending_review_claim
+    end
+
+    it { is_expected.to match_array expected_search }
+  end
+end

--- a/spec/services/claim_search_service_spec.rb
+++ b/spec/services/claim_search_service_spec.rb
@@ -63,4 +63,49 @@ RSpec.describe ClaimSearchService, type: :service do
 
     it { is_expected.to match_array expected_search }
   end
+
+  context 'with a case number search' do
+    let(:params) { { status: 'allocated', search: 'T202001' } }
+    let!(:expected_search) { [create(:allocated_claim, case_number: 'T20200101')] }
+
+    before { create :allocated_claim, case_number: 'T20209999' }
+
+    it { is_expected.to match_array expected_search }
+  end
+
+  context 'with a case-insensitive case number search' do
+    let(:params) { { status: 'allocated', search: 't202001' } }
+    let!(:expected_search) { [create(:allocated_claim, case_number: 'T20200101')] }
+
+    it { is_expected.to match_array expected_search }
+  end
+
+  context 'with a defendants forename search' do
+    let(:params) { { status: 'allocated', search: 'mic' } }
+    let(:expected_search) { [create(:allocated_claim, defendants: [build(:defendant, first_name: 'Michael')])] }
+
+    before { create :allocated_claim, defendants: [build(:defendant, first_name: 'Tom', last_name: 'Cruise')] }
+
+    it { is_expected.to match_array expected_search }
+  end
+
+  context 'with a defendants surname search' do
+    let(:params) { { status: 'allocated', search: 'cai' } }
+    let(:expected_search) { [create(:allocated_claim, defendants: [build(:defendant, last_name: 'Caine')])] }
+
+    before { create :allocated_claim, defendants: [build(:defendant, first_name: 'Tom', last_name: 'Cruise')] }
+
+    it { is_expected.to match_array expected_search }
+  end
+
+  context 'with a MAAT reference search' do
+    let(:params) { { status: 'allocated', search: '5123' } }
+    let(:representation_order) { build :representation_order, maat_reference: 5_123_456 }
+    let(:defendant) { build :defendant, representation_orders: [representation_order] }
+    let(:expected_search) { [create(:allocated_claim, defendants: [defendant])] }
+
+    before { create :allocated_claim, defendants: [build(:defendant)] }
+
+    it { is_expected.to match_array expected_search }
+  end
 end

--- a/spec/services/claim_search_service_spec.rb
+++ b/spec/services/claim_search_service_spec.rb
@@ -8,7 +8,15 @@ RSpec.describe ClaimSearchService, type: :service do
     let(:expected_search) do
       [
         create(:authorised_claim),
-        create(:authorised_claim)
+        create(:authorised_claim),
+        create(:rejected_claim),
+        create(:refused_claim),
+        create(:part_authorised_claim),
+        create(:archived_pending_delete_claim),
+        create(:allocated_claim),
+        create(:submitted_claim),
+        create(:redetermination_claim),
+        create(:awaiting_written_reasons_claim)
       ]
     end
 
@@ -22,43 +30,23 @@ RSpec.describe ClaimSearchService, type: :service do
     end
   end
 
-  context 'when the status is archived' do
-    let(:params) { { status: 'archived' } }
+  context 'when there is a state filter' do
+    let(:params) { { state: [:authorised, :rejected, :refused] } }
     let(:expected_search) do
       [
         create(:authorised_claim),
-        create(:part_authorised_claim),
         create(:rejected_claim),
         create(:refused_claim),
-        create(:archived_pending_delete_claim),
-        create(:hardship_archived_pending_review_claim)
       ]
     end
 
     before do
+      create :part_authorised_claim
+      create :archived_pending_delete_claim
       create :allocated_claim
       create :submitted_claim
       create :redetermination_claim
       create :awaiting_written_reasons_claim
-    end
-
-    it { is_expected.to match_array expected_search }
-  end
-
-  context 'when the status is allocated' do
-    let(:params) { { status: 'allocated' } }
-    let(:expected_search) { [create(:allocated_claim)] }
-
-    before do
-      create :submitted_claim
-      create :redetermination_claim
-      create :awaiting_written_reasons_claim
-      create :authorised_claim
-      create :part_authorised_claim
-      create :rejected_claim
-      create :refused_claim
-      create :archived_pending_delete_claim
-      # create :hardship_archived_pending_review_claim
     end
 
     it { is_expected.to match_array expected_search }

--- a/spec/services/claim_search_service_spec.rb
+++ b/spec/services/claim_search_service_spec.rb
@@ -195,8 +195,20 @@ RSpec.describe ClaimSearchService, type: :service do
 
     let!(:expected_search) { [create(:allocated_claim, case_workers: [current_case_worker])] }
 
-    before { create(:allocated_claim, case_workers: [other_case_worker]) }
+    before { create :allocated_claim, case_workers: [other_case_worker] }
 
     it { is_expected.to match_array expected_search }
   end
+
+  # TODO: Fix these. value_band_id is set when the claim is saved based on the
+  #       total, which is calculated in Claims::Calculations.
+  # context 'with a value band id search' do
+  #   let(:params) { { value_band_id: 10 } }
+  #
+  #   let!(:expected_search) { [create(:allocated_claim, value_band_id: 10)] }
+  #
+  #   before { create :allocated_claim, value_band_id: 20 }
+  #
+  #   it { is_expected.to match_array expected_search }
+  # end
 end


### PR DESCRIPTION
#### What

Rewriting of the claim search, currently in `app/models/claims/search.rb` and `app/interfaces/api/v2/case_workers/claim.rb`.

#### Ticket

N/A

#### Why

Some of the logic for the search is contained in the claim interface for Grape API and some in `Claims::Search` module. Additionally, the `search` method in `Claims::Search` deals with both the state filter and the keyword search in one place. It would be easier to understand and extend (if necessary) with a better separation of concerns.

#### How

Create a new claim search service that takes the search parameters and returns the required results:

```ruby
ClaimSearchService.new(params).call
# => Claim::BaseClaim::ActiveRecord_Relation
```

Inside `ClaimSearchService`, the search is built up using decorators that each behave as follows:

```ruby
# Build the search
search = ClaimSearchService::Base
search = ClaimSearchService::FilterOne.decorate(search, params)
search = ClaimSearchService::FilterTwo.decorate(search, params)
...
# Execute the search
search.run
```

--------

#### TODO (wip)

 - [X] State filter
 - [x] Keyword search
 - [x] Current user
 - [ ] Unallocated claims
 - [x] Scheme filter
 - [ ] 'Filter' filter; all, redetermination, awaiting written reasons, fixed fee, cracked, trial, guilty plea, graduated fees, interim fees, warrants, interim disbursements, risk based bills
 - [ ] Sort and pagination
