### PR TITLE
Fix defendant uplifts on supplementary claims

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
           LIVE1_DB_TASK: none
-      - image: circleci/postgres:9.6-alpine
+      - image: circleci/postgres:9.6.20
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"
@@ -130,7 +130,7 @@ executors:
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
-      - image: circleci/postgres:9.6-alpine
+      - image: circleci/postgres:9.6.20
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -5,7 +5,8 @@ class Fee::MiscFeeType < Fee::BaseFeeType
   AGFS_SUPPLEMENTARY_TYPES = (AGFS_SUPPLEMENTARY_ONLY_TYPES + AGFS_SUPPLEMENTARY_SHARED_TYPES).freeze
   TRIAL_ONLY_TYPES = %w[MIUMU MIUMO].freeze
 
-  default_scope { order(description: :asc) }
+  # default_scope { order(description: :asc) }
+  default_scope { order(Arel.sql("regexp_replace(\"fee_types\".\"description\", '[()]', '', 'g')")) }
 
   scope :without_supplementary_only, -> { where.not(unique_code: AGFS_SUPPLEMENTARY_ONLY_TYPES) }
   scope :supplementary, -> { where(unique_code: AGFS_SUPPLEMENTARY_TYPES) }

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -5,7 +5,6 @@ class Fee::MiscFeeType < Fee::BaseFeeType
   AGFS_SUPPLEMENTARY_TYPES = (AGFS_SUPPLEMENTARY_ONLY_TYPES + AGFS_SUPPLEMENTARY_SHARED_TYPES).freeze
   TRIAL_ONLY_TYPES = %w[MIUMU MIUMO].freeze
 
-  # default_scope { order(description: :asc) }
   default_scope { order(Arel.sql("regexp_replace(\"fee_types\".\"description\", '[()]', '', 'g')")) }
 
   scope :without_supplementary_only, -> { where.not(unique_code: AGFS_SUPPLEMENTARY_ONLY_TYPES) }

--- a/app/views/external_users/claims/misc_fees/advocates/supplementary/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/supplementary/_fields.html.haml
@@ -2,7 +2,7 @@
   #misc_fees.misc-fee-group-wrapper
     %h3.heading-medium
       = t('.misc_fee')
-    .form-group.fx-fee-group
+    .form-group
       %fieldset
         %legend.form-label-bold
           = t('.fee_type')

--- a/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
@@ -1,5 +1,4 @@
 - fee = present(f.object)
--# Check box input
 .multiple-choice{"data-target" => to_slug(f.object.description), "class" => "fx-hook-#{fee.fee_type_code.downcase}"}
 
   = f.check_box(:toggle, checked: !f.object.blank?, class: "fx-checkbox-hook", id: "#{to_slug(f.object.description)}-input", "aria-controls" => to_slug(f.object.description), :name => "misc_fees_checklist_#{f.object.fee_type_code.downcase}", data: { unique_code: f.object.fee_type.unique_code})

--- a/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -260,7 +260,7 @@
       const self = this
       $(document).ready(function () {
         // TODO: this loop is causing multiple init procedures
-        // limiting it for now to at least one visible
+        // limiting it for now to, at most, one visible
         $('.calculated-unit-fee:visible:first').each(function () {
           self.calculateUnitPrice()
         })

--- a/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
@@ -29,10 +29,10 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I should see the advocate categories 'Junior,Leading junior,QC'
     And the following miscellaneous fee checkboxes should exist:
       | section | fee_description |
-      | miscellaneous | Confiscation hearings (half day uplift) |
       | miscellaneous | Confiscation hearings (half day) |
-      | miscellaneous | Confiscation hearings (whole day uplift) |
+      | miscellaneous | Confiscation hearings (half day uplift) |
       | miscellaneous | Confiscation hearings (whole day) |
+      | miscellaneous | Confiscation hearings (whole day uplift) |
       | miscellaneous | Deferred sentence hearings |
       | miscellaneous | Deferred sentence hearings uplift |
       | miscellaneous | Plea and trial preparation hearing |
@@ -44,16 +44,16 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
       | miscellaneous | Wasted preparation fee |
 
     When I select an advocate category of 'Junior'
-    And I choose the 'Confiscation hearings (half day uplift)' miscellaneous fee with quantity of '1'
     And I choose the 'Confiscation hearings (half day)' miscellaneous fee with quantity of '2'
+    And I choose the 'Confiscation hearings (half day uplift)' miscellaneous fee with quantity of '1'
     And I choose the 'Standard appearance fee' miscellaneous fee with quantity of '2'
     And I choose the 'Standard appearance fee uplift' miscellaneous fee with quantity of '1'
     And I choose the 'Wasted preparation fee' miscellaneous fee with quantity of '1'
 
     Then the following supplementary fee details should exist:
       | section | fee_description | rate | hint | help |
-      | miscellaneous | Confiscation hearings (half day uplift) | 52.40 | Number of additional defendants | true |
       | miscellaneous | Confiscation hearings (half day) | 131.00 | Number of half days | true |
+      | miscellaneous | Confiscation hearings (half day uplift) | 52.40 | Number of additional defendants | true |
       | miscellaneous | Standard appearance fee | 91.00 | Number of days | true |
       | miscellaneous | Standard appearance fee uplift | 36.40 | Number of additional defendants | true |
       | miscellaneous | Wasted preparation fee | 39.39 | Number of hours | true |

--- a/spec/models/fee/misc_fee_type_spec.rb
+++ b/spec/models/fee/misc_fee_type_spec.rb
@@ -30,10 +30,13 @@ RSpec.describe Fee::MiscFeeType do
         create(:misc_fee_type, description: 'A')
         create(:misc_fee_type, description: 'C')
         create(:misc_fee_type, description: 'B')
+        create(:misc_fee_type, description: 'C (a)')
+        create(:misc_fee_type, description: 'C (a )')
+        create(:misc_fee_type, description: 'C (a a)')
       end
 
-      it 'orders by description ascending' do
-        is_expected.to eq ['A', 'B', 'C']
+      it 'orders by description ascending, ignoring parentheses' do
+        is_expected.to eq ['A', 'B', 'C', 'C (a)', 'C (a )', 'C (a a)']
       end
     end
 


### PR DESCRIPTION
#### What
Ensure feature test behave as prod, which currently has fee calc
edge case bug, and fix that bug.

#### To duplicate bug
On staging
 - Create a scheme 11 supplementary claim
 - Add two defendants
 - Add Misc fee of "Confiscation hearing (half day)" with quantity of one - rate: £131
 - Add Misc fee of "Confiscation hearing (half day uplift)" with quantity of one - rate £52.40
 Last fee should have a rate of £26.20 (this works on local machine)

#### Ticket

[https://dsdmoj.atlassian.net/browse/CFP-105](https://dsdmoj.atlassian.net/browse/CFP-105)

#### Why
Invalid calculations for the Supplementary claim
"Confiscation hearing (half day uplift)" are causing
invalid amounts to be calculated and thereby potentially
claimed.

#### How
Suttle differences in ordering of strings with braces between local hosted postgres,
circleci alpine postgres images and AWS RDS DB instances are causing an ordering difference.
This would be fine except that a minor javascript oversight then causes a double counting of the first
fee type on the page - which happens to be the non-uplift fee quantity "Confiscation hearing (half day)".
This doubling then causes a doubling of the fee types defendant uplift "Confiscation hearing (half day uplift)"
if it is claimed/visible.

This Javascript bug has no impact if the uplift is the first fee type on the page.

Local postgres 9.6.21 on darwin puts the uplift above the non-uplift equivalent so no doubling occurs. The test
suite used alpine hosted postgres which also puts put the uplift above the non-uplift so no doubling occurs, however
when a postgres image hosted on debian is used the reverse ordering happens and the bug occurs, and the feature test
fails.

So this PR uses a debian version of postgres to match prod-like environments as closely as possible. This PR also
enforces the ordering of fee types so that postgres versions will not have an impact in any event. The result being
that non-uplift fee types should always appear above there uplift fee type.

Finally the javascript bug is fixed by removing a misplaced class, `.fx-fee-group`, on the outer container
for all the fee type checkboxes. This is causing the first fee type to be double-counted because of line
`231` of `app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js`