### PR TITLE
[CFP-108] Fix migrations after paperclip extraction

### DIFF
--- a/db/migrate/20150416144357_alter_documents_add_paperclip_attachement.rb
+++ b/db/migrate/20150416144357_alter_documents_add_paperclip_attachement.rb
@@ -1,8 +1,14 @@
 class AlterDocumentsAddPaperclipAttachement < ActiveRecord::Migration[4.2]
   def change
     change_table(:documents) do |t|
-      t.remove      :document
-      t.attachment  :document
+      t.remove :document
+      # Paperclip attachment are created using:
+      #   t.attachment :document
+      # This requires the paperclip gem, which has now been removed, so it is replaced by:
+      t.string :document_file_name
+      t.string :document_content_type
+      t.integer :document_file_size
+      t.datetime :document_updated_at
     end
     add_index :documents, :document_file_name
   end

--- a/db/migrate/20150522134938_add_attachment_converted_preview_document_to_documents.rb
+++ b/db/migrate/20150522134938_add_attachment_converted_preview_document_to_documents.rb
@@ -1,11 +1,20 @@
 class AddAttachmentConvertedPreviewDocumentToDocuments < ActiveRecord::Migration[4.2]
   def self.up
     change_table :documents do |t|
-      t.attachment :converted_preview_document
+      # Paperclip attachment are created using:
+      #   t.attachment :converted_preview_document
+      # This requires the paperclip gem, which has now been removed, so it is replaced by:
+      t.string :converted_preview_document_file_name
+      t.string :converted_preview_document_content_type
+      t.integer :converted_preview_document_file_size
+      t.datetime :converted_preview_document_updated_at
     end
   end
 
   def self.down
-    remove_attachment :documents, :converted_preview_document
+    drop_column :documents, :converted_preview_document_file_name
+    drop_column :documents, :converted_preview_document_content_type
+    drop_column :documents, :converted_preview_document_file_size
+    drop_column :documents, :converted_preview_document_updated_at
   end
 end

--- a/db/migrate/20150805144206_add_attachment_attachment_to_messages.rb
+++ b/db/migrate/20150805144206_add_attachment_attachment_to_messages.rb
@@ -1,11 +1,20 @@
 class AddAttachmentAttachmentToMessages < ActiveRecord::Migration[4.2]
   def self.up
     change_table :messages do |t|
-      t.attachment :attachment
+      # Paperclip attachment are created using:
+      #   t.attachment :attachment
+      # This requires the paperclip gem, which has now been removed, so it is replaced by:
+      t.string :attachment_file_name
+      t.string :attachment_content_type
+      t.integer :attachment_file_size
+      t.datetime :attachment_updated_at
     end
   end
 
   def self.down
-    remove_attachment :messages, :attachment
+    drop_column :messages, :attachment_file_name
+    drop_column :messages, :attachment_content_type
+    drop_column :messages, :attachment_file_size
+    drop_column :messages, :attachment_updated_at
   end
 end

--- a/db/migrate/20180718102824_add_file_to_stats_reports.rb
+++ b/db/migrate/20180718102824_add_file_to_stats_reports.rb
@@ -1,9 +1,18 @@
 class AddFileToStatsReports < ActiveRecord::Migration[5.0]
   def up
-    add_attachment :stats_reports, :document
+    # Paperclip attachment are created using:
+    #   t.attachment :document
+    # This requires the paperclip gem, which has now been removed, so it is replaced by:
+    add_column :stats_reports, :document_file_name, :string
+    add_column :stats_reports, :document_content_type, :string
+    add_column :stats_reports, :document_file_size, :integer
+    add_column :stats_reports, :document_updated_at, :datetime
   end
 
   def down
-    remove_attachment :stats_reports, :document
+    drop_column :stats_reports, :document_file_name
+    drop_column :stats_reports, :document_content_type
+    drop_column :stats_reports, :document_file_size
+    drop_column :stats_reports, :document_updated_at
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -213,8 +213,8 @@ ActiveRecord::Schema.define(version: 2021_02_23_164419) do
     t.datetime "updated_at"
     t.date "date_to"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }
-    t.integer "attended_item_id"
     t.string "attended_item_type"
+    t.integer "attended_item_id"
     t.index ["attended_item_id", "attended_item_type"], name: "index_dates_attended_on_attended_item_id_and_attended_item_type"
   end
 
@@ -636,8 +636,8 @@ ActiveRecord::Schema.define(version: 2021_02_23_164419) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
-    t.integer "persona_id"
     t.string "persona_type"
+    t.integer "persona_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "first_name"
@@ -673,6 +673,7 @@ ActiveRecord::Schema.define(version: 2021_02_23_164419) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "claims", "case_stages", name: "fk_claims_case_stage_id"
+  add_foreign_key "injection_attempts", "claims"
   add_foreign_key "offence_bands", "offence_categories"
   add_foreign_key "offences", "offence_bands"
 end


### PR DESCRIPTION
#### What

Modify database migrations that added Paperclip attachments to explicitly create the four paperclip fields.

#### Ticket

[Smoke test failure](https://dsdmoj.atlassian.net/browse/CFP-108)

#### Why

The paperclip gem provides a helper for database migration to create the required fields.

These migrations, therefore, fail when the paperclip gem is removed. The solution is to replace `attachment` with the four fields everywhere it appears.

#### How

Replace

```ruby
t.attachment document
```

with

```ruby
t.string documnet_file_name
t.string documnet_content_type
t.integer documnet_file_size
t.datetime documnet_updated_at
```

(or equivalent) wherever it appears in the database migrations.

I have added the newly created `db/schema.rb` as validation that these changes are correct. The only differences are;

* Slight column ordering change in two tables.
* Addition of a foreign key for add_foreign_key `injection_attempts` on the `claims` table. This is unrelated to this PR and I am unclear why this has appeared.