### PR TITLE
[CFP-94] Add backtrace to redrafting logging

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -189,7 +189,10 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
       documents: @claim.documents.count,
       total_size: helpers.number_to_human_size(@claim.documents.sum { |doc| doc.document.byte_size })
     }
-    log_data[:error] = "#{error.class}: #{error.message}" if error
+    if error
+      log_data[:error] = "#{error.class}: #{error.message}"
+      log_data[:backtrace] = error.backtrace
+    end
     LogStuff.send(level, 'ExternalUsers::ClaimsController', **log_data) { message }
   end
 

--- a/app/models/claims/cloner.rb
+++ b/app/models/claims/cloner.rb
@@ -108,8 +108,6 @@ module Claims::Cloner
     draft = duplicate
     draft.transition_clone_to_draft!(author_id: author_id)
     draft
-  rescue StandardError => e
-    raise("Claims::Cloner.clone_rejected_to_new_draft failed with error '#{e.message}'")
   end
 
   # `other_claim` can be a draft instance of any kind of claim scheme (agfs or lgfs).

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -601,13 +601,11 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller do
         end
 
         it 'logs an error' do
-          expect(LogStuff).to \
-            have_received(:error).with('ExternalUsers::ClaimsController',
-                                       action: 'clone',
-                                       claim_id: claim.id,
-                                       documents: 2,
-                                       total_size: "#{longer_lorem_size * 2} KB",
-                                       error: 'Timeout::Error: execution expired')
+          expect(LogStuff).to have_received(:error)
+            .with(
+              'ExternalUsers::ClaimsController',
+              hash_including(:action, :claim_id, :documents, :total_size, :error, :backtrace)
+            )
         end
 
         it 'displays a flash alert' do
@@ -625,14 +623,11 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller do
       end
 
       it 'logs an error' do
-        expect(LogStuff).to \
-          have_received(:error)
-          .with('ExternalUsers::ClaimsController',
-                action: 'clone',
-                claim_id: claim.id,
-                documents: 0,
-                total_size: '0 Bytes',
-                error: 'RuntimeError: Claims::Cloner.clone_rejected_to_new_draft failed with error \'Can only clone claims in state "rejected"\'')
+        expect(LogStuff).to have_received(:error)
+          .with(
+            'ExternalUsers::ClaimsController',
+            hash_including(:action, :claim_id, :documents, :total_size, :error, :backtrace)
+          )
       end
 
       it 'redirects to advocates dashboard' do

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -185,9 +185,7 @@ RSpec.describe Claims::Cloner, type: :model do
 
         before { allow_any_instance_of(Claim::BaseClaim).to receive(:transition_clone_to_draft!).and_raise(RuntimeError) }
 
-        it 'raises the correct error' do
-          expect { clone_fail }.to raise_error("Claims::Cloner.clone_rejected_to_new_draft failed with error 'RuntimeError'")
-        end
+        it { expect { clone_fail }.to raise_error(RuntimeError) }
       end
     end
   end

--- a/spec/services/claims/external_user_claim_updater_spec.rb
+++ b/spec/services/claims/external_user_claim_updater_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Claims::ExternalUserClaimUpdater do
       let(:claim) { create :submitted_claim }
 
       it 'raises an appropriate error' do
-        expect { subject.clone_rejected }.to raise_error('Claims::Cloner.clone_rejected_to_new_draft failed with error \'Can only clone claims in state "rejected"\'')
+        expect { subject.clone_rejected }.to raise_error('Can only clone claims in state "rejected"')
       end
     end
   end


### PR DESCRIPTION
#### What

Add the backtrace to the logging of a failed redrafting.

#### Ticket

[Fix bug preventing redrafting after a rejection](https://dsdmoj.atlassian.net/browse/CFP-94)

#### Why

Occasionally providers get an error when attempting to redraft a rejected claim and they are then required to re-create the claim from scratch. It is not clear what is causing the error other than a `ActiveStorage::FileNotFoundError` exception without context.

#### How

Add `error.backtrace` to the log that is reported in Kibana. Also, remove the 'rescue' in `ExternalUsers::ClaimsController#clone_rejected_to_new_draft' as this effectively resets the error's backtrace and makes it appear as though the error occurred in this method.