### PR TITLE
[CFP-33] Add vacuum DB cronjob

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -76,6 +76,7 @@ function _circleci_deploy() {
   kubectl set image -f kubernetes_deploy/${environment}/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
   kubectl set image -f kubernetes_deploy/${environment}/deployment-worker.yaml cccd-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
   kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
+  kubectl set image -f kubernetes_deploy/cron_jobs/vacuum_db.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
 
   # apply non-image specific config
   kubectl apply \

--- a/docs/build_and_deploy.md
+++ b/docs/build_and_deploy.md
@@ -30,7 +30,7 @@ kubernetes_deploy/scripts/deploy.sh dev latest
 
 #### Cronjobs
 
-There are two cronjobs, `clean_ecr` and `archive_stale`. Any change to the `archive_stale` jobs config (`kubernetes_deploy/cron_jobs/archive_stale.yml`) are applied as part of the deployment process (because it relies on the app image), but any changes to the standalone `clean_ecr` job need to be applied from the commandline, as below
+There are three cronjobs, `clean_ecr`, `archive_stale` and `vacuum_db`. Their config can be found in the `kubernetes_deploy/cron_jobs` directory. Any change to the `archive_stale` and `vacuum_db` jobs config are applied as part of the deployment process because it relies on the app image, but any changes to the standalone `clean_ecr` job need to be applied from the commandline, as below.
 
 ```
 # apply changes to made to `kubernetes_deploy/cron_jobs/clean_ecr.yml`

--- a/kubernetes_deploy/cron_jobs/vacuum_db.yaml
+++ b/kubernetes_deploy/cron_jobs/vacuum_db.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cccd-vacuum-db
+spec:
+  schedule: "5 1 * * 0"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 250000
+      template:
+        metadata:
+          labels:
+            tier: worker
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: cronjob-worker
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+            imagePullPolicy: Always
+            command:
+              - rails
+              - db:vacuum
+
+            envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
+            env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-rds
+                  key: url

--- a/kubernetes_deploy/cron_jobs/vacuum_db.yaml
+++ b/kubernetes_deploy/cron_jobs/vacuum_db.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   schedule: "5 1 * * 0"
   concurrencyPolicy: Forbid
-  startingDeadlineSeconds: 300
+  startingDeadlineSeconds: 120
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
-      backoffLimit: 0
+      backoffLimit: 3
       ttlSecondsAfterFinished: 250000
       template:
         metadata:

--- a/kubernetes_deploy/scripts/cronjob.sh
+++ b/kubernetes_deploy/scripts/cronjob.sh
@@ -3,7 +3,7 @@ function _cronjob() {
   usage="cronjob -- apply job in the specified environment
   Usage: cronjob job environment [branch]
   Where:
-    job [archive_stale|clean_ecr]
+    job [archive_stale|clean_ecr|vacuum_db]
     environment [dev|dev-lgfs|staging|api-sandbox|production]
     branch [<branchname>-latest|commit-sha]
 
@@ -28,7 +28,7 @@ function _cronjob() {
   fi
 
   case "$1" in
-    archive_stale)
+    archive_stale | vacuum_db)
       job=$1
       ;;
     clean_ecr)

--- a/kubernetes_deploy/scripts/deploy.sh
+++ b/kubernetes_deploy/scripts/deploy.sh
@@ -70,6 +70,7 @@ function _deploy() {
   kubectl set image -f kubernetes_deploy/${environment}/deployment.yaml cccd-app=${docker_image_tag} --local --output yaml | kubectl apply -f -
   kubectl set image -f kubernetes_deploy/${environment}/deployment-worker.yaml cccd-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
   kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
+  kubectl set image -f kubernetes_deploy/cron_jobs/vacuum_db.yaml cronjob-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
 
   # apply non-image specific config
   kubectl apply \

--- a/lib/tasks/vacuum.rake
+++ b/lib/tasks/vacuum.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc 'Perform a full vacuum of the postgres database'
+  task :vacuum => :environment do
+    puts "[#{DateTime.current}]".yellow
+    ActiveRecord::Base.connection.execute('VACUUM (VERBOSE, ANALYZE);')
+    puts "[#{DateTime.current}]".yellow
+  end
+end


### PR DESCRIPTION
Add vacuum DB cronjob

#### What
Reclaim storage on postgres DB every week

#### Ticket

relates to [CFP-33](https://dsdmoj.atlassian.net/browse/CFP-33) - DB upgrade

#### Why
- Preparation for DB upgrade
- free operation to improve performance of DB
- free operation to remove unneeded space and reduce hosting costs

#### How
Run a kubernetes cronjob once a week (can be changed) to VACUUM the 
postgres database. RDS does apply [autovacuum](https://aws.amazon.com/blogs/database/understanding-autovacuum-in-amazon-rds-for-postgresql-environments/) config but this is not as
effective in reclaiming storage.

We run vacuum with analyze to update the DB statistics to improve execution
plans.
