### PR TITLE
[CFP-30] Amend cronjobs to always use app-latest image

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -75,8 +75,11 @@ function _circleci_deploy() {
   # apply new image
   kubectl set image -f kubernetes_deploy/${environment}/deployment.yaml cccd-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
   kubectl set image -f kubernetes_deploy/${environment}/deployment-worker.yaml cccd-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
-  kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
-  kubectl set image -f kubernetes_deploy/cron_jobs/vacuum_db.yaml cronjob-worker=${docker_image_tag} --local -o yaml | kubectl apply -f -
+
+  # apply changes that always use app-latest tagged images
+  kubectl apply \
+  -f kubernetes_deploy/cron_jobs/archive_stale.yaml \
+  -f kubernetes_deploy/cron_jobs/vacuum_db.yaml
 
   # apply non-image specific config
   kubectl apply \

--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -20,12 +20,10 @@ spec:
           restartPolicy: Never
           containers:
           - name: cronjob-worker
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-latest
             imagePullPolicy: Always
             command:
-              - bundle
-              - exec
-              - rake
+              - rails
               - claims:archive_stale
 
             envFrom:

--- a/kubernetes_deploy/cron_jobs/vacuum_db.yaml
+++ b/kubernetes_deploy/cron_jobs/vacuum_db.yaml
@@ -20,7 +20,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: cronjob-worker
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-latest
             imagePullPolicy: Always
             command:
               - rails

--- a/kubernetes_deploy/scripts/deploy.sh
+++ b/kubernetes_deploy/scripts/deploy.sh
@@ -69,8 +69,11 @@ function _deploy() {
   # apply new image
   kubectl set image -f kubernetes_deploy/${environment}/deployment.yaml cccd-app=${docker_image_tag} --local --output yaml | kubectl apply -f -
   kubectl set image -f kubernetes_deploy/${environment}/deployment-worker.yaml cccd-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
-  kubectl set image -f kubernetes_deploy/cron_jobs/archive_stale.yaml cronjob-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
-  kubectl set image -f kubernetes_deploy/cron_jobs/vacuum_db.yaml cronjob-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
+
+  # apply changes that always use app-latest tagged images
+  kubectl apply \
+  -f kubernetes_deploy/cron_jobs/archive_stale.yaml \
+  -f kubernetes_deploy/cron_jobs/vacuum_db.yaml
 
   # apply non-image specific config
   kubectl apply \


### PR DESCRIPTION
#### What
Amend cronjobs to always use app-latest image

#### Why
Jobs pods spun up by the archvive_stale cronjob
are not being kept around.

I wonder if it is because when a new image is
applied during deploy this causes old job pods
to be removed.

We want see these logs to check archiving (or vacuuming)
was successful or not, and details thereof.

#### Ticket

[CFP-30] relates to vacuum db jobs for db upgrade

#### How
Always use the app latest image. This means the
config for the job will not be changed by the deploy
script. This means the existing completed job pods
will not be removed...hopefully - this may not be the
reason for their removal however.

It should be harmless to try this nonetheless as the
latest image should have the rake tasks that called
by the job.

[CFP-30]: https://dsdmoj.atlassian.net/browse/CFP-30