### PR TITLE
Some cleanup of `Claims::Calculations`

### DIFF
--- a/app/models/claims/calculations.rb
+++ b/app/models/claims/calculations.rb
@@ -51,10 +51,6 @@ module Claims::Calculations
     "#{net_attribute} IS NOT NULL"
   end
 
-  def calculate_expenses_total
-    Expense.where(claim_id: id).where.not(amount: nil).pluck(:amount).sum
-  end
-
   def calculate_total
     fees_total + expenses_total + disbursements_total
   end

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -689,12 +689,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
       subject.reload
     end
 
-    describe '#calculate_expenses_total' do
-      it 'calculates expenses total' do
-        expect(subject.calculate_expenses_total).to eq(146.5)
-      end
-    end
-
     describe '#update_expenses_total' do
       it 'stores the expenses total' do
         expect(subject.expenses_total).to eq(146.5)

--- a/spec/models/claims/totals_spec.rb
+++ b/spec/models/claims/totals_spec.rb
@@ -36,12 +36,6 @@ RSpec.describe Claim, type: :model do
   context 'expenses total' do
     before { expenses; claim.reload }
 
-    describe '#calculate_expenses_total' do
-      it 'calculates expenses total' do
-        expect(claim.calculate_expenses_total).to eq(146.5)
-      end
-    end
-
     describe '#update_expenses_total' do
       it 'stores the expenses total' do
         expect(claim.expenses_total).to eq(146.5)


### PR DESCRIPTION
#### What

1. Remove the `calculate_expenses_total` method from `Claims::Calculations`
2. Make some methods private

#### Ticket

N/A

#### Why

1. All uses of Claims::Calculations#calculate_expenses_total were removed in #1893 but the method itself was not deleted.
2. Methods that are not used outside of the module do not need to be public. Explicitly making them private means that it is safer to make changes in the future.