### PR TITLE
Add email confirmation on create

### DIFF
--- a/app/controllers/external_users/registrations_controller.rb
+++ b/app/controllers/external_users/registrations_controller.rb
@@ -28,7 +28,7 @@ class ExternalUsers::RegistrationsController < Devise::RegistrationsController
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i[terms_and_conditions first_name last_name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[terms_and_conditions first_name last_name email_confirmation])
   end
 
   def notify_resource

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
 
   attribute :terms_and_conditions_required, :boolean, default: false
   attribute :terms_and_conditions, :boolean
-  attr_accessor :email_confirmation
+  attribute :email_confirmation, :string
 
   belongs_to :persona, polymorphic: true
   has_many :messages_sent, foreign_key: 'sender_id', class_name: 'Message'
@@ -52,6 +52,7 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, presence: true, length: { maximum: 40 }
   validates :email, confirmation: true, length: { maximum: 80 }
+  validates :email_confirmation, presence: true, on: :create
   validates :terms_and_conditions,
             acceptance: ['1', true],
             allow_nil: false,

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -25,6 +25,7 @@
       = f.govuk_text_field :first_name, label: { text: t('.first_name') }
       = f.govuk_text_field :last_name, label: { text: t('.last_name') }
       = f.govuk_text_field :email, label: { text: t('.email') }
+      = f.govuk_text_field :email_confirmation, label: { text: t('.email_confirmation') }
       = f.govuk_password_field :password, label: { text: t('.password') }
       = f.govuk_password_field :password_confirmation, label: { text: t('.password_confirmation') }
       = f.govuk_submit t('.sign_up')

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -2,6 +2,7 @@
 
 en:
   email: &email Email
+  email_confirmation: &email_confirmation Email confirmation
   password: &password Password
   password_confirmation: &password_confirmation Password confirmation
 
@@ -70,6 +71,7 @@ en:
         submit: Update
       new:
         email: *email
+        email_confirmation: *email_confirmation
         first_name: First name
         last_name: Last name
         page_title: Sign up

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,8 +250,8 @@ en:
               taken: Email address is already registered
               too_long: Email must be 80 characters or less
             email_confirmation:
-              confirmation: Email and confirmation must match
               blank: Enter an email confirmation
+              confirmation: Email and confirmation must match
             current_password:
               blank: Enter the currrent password
               invalid: Enter the current password

--- a/features/page_objects/api_landing_page.rb
+++ b/features/page_objects/api_landing_page.rb
@@ -1,0 +1,3 @@
+class ApiLandingPage < BasePage
+  set_url "/api/landing"
+end

--- a/features/page_objects/new_user_sign_up_page.rb
+++ b/features/page_objects/new_user_sign_up_page.rb
@@ -1,0 +1,3 @@
+class NewUserSignUpPage < BasePage
+  set_url "/users/sign_up"
+end

--- a/features/page_objects/vendor_tandcs_page.rb
+++ b/features/page_objects/vendor_tandcs_page.rb
@@ -1,0 +1,3 @@
+class VendorTandcsPage < BasePage
+  set_url "/vendor_tandcs"
+end

--- a/features/step_definitions/api_landing_steps.rb
+++ b/features/step_definitions/api_landing_steps.rb
@@ -1,0 +1,3 @@
+Then('I am on the api landing page') do
+  expect(@api_landing_page).to be_displayed
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -241,3 +241,11 @@ And('the text field {string} should be filled with {string}') do |label, value|
   actual_value = find_field(label).value
   expect(actual_value).to eql(value)
 end
+
+Then('I should see link {string}') do |string|
+  expect(page).to have_link(string)
+end
+
+When('I go back') do
+  page.go_back
+end

--- a/features/step_definitions/new_user_sign_up_steps.rb
+++ b/features/step_definitions/new_user_sign_up_steps.rb
@@ -1,0 +1,7 @@
+Then('I am on the new user sign up page') do
+  expect(@new_user_sign_up_page).to be_displayed
+end
+
+Then('I am on the software vendor terms and conditions page') do
+  expect(@vendor_tandcs_page).to be_displayed
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -55,6 +55,20 @@ Before('not @no-seed') do
   end
 end
 
+Before('@on-api-sandbox') do
+  allow(ENV).to receive(:[]).and_call_original
+  allow(ENV).to receive(:[]).with('ENV').and_return 'api-sandbox'
+
+  @api_landing_page = ApiLandingPage.new
+  @new_user_sign_up_page = NewUserSignUpPage.new
+  @vendor_tandcs_page = VendorTandcsPage.new
+  @external_user_home_page = ExternalUserHomePage.new
+end
+
+After('@on-api-sandbox') do
+  allow(ENV).to receive(:[]).with('ENV').and_call_original
+end
+
 AfterConfiguration do
   # Possible values are :truncation and :transaction
   # The :transaction strategy is faster, but might give you threading problems.

--- a/features/users/new_external_user.feature
+++ b/features/users/new_external_user.feature
@@ -1,4 +1,4 @@
-@javascript @no-seed
+@javascript @no-seed @focus
 Feature: Create new external user
 
   Scenario: Chamber admin creates a new advocate user

--- a/features/users/user_signup_on_api_sandbox.feature
+++ b/features/users/user_signup_on_api_sandbox.feature
@@ -1,0 +1,31 @@
+@javascript @no-seed
+Feature: User signup on api-sandbox
+
+  @on-api-sandbox
+  Scenario: User signs up on the api-sandbox
+    Given I visit "/"
+    Then I should see link 'API Sign up and documentation'
+    And I should see link 'software vendor terms and conditions'
+
+    When I click the link 'API Sign up and documentation'
+    Then I am on the api landing page
+
+    When I click the link 'complete a short registration form'
+    Then I am on the new user sign up page
+    And the page should be accessible
+    And I should see 'Our software vendor terms and conditions contain important information you must agree to'
+
+    When I click the first 'software vendor terms and conditions' link
+    Then I am on the software vendor terms and conditions page
+    And I go back
+
+    When I click govuk checkbox 'I agree to the terms and conditions'
+    Then I fill in 'First name' with 'Jim'
+    And I fill in 'Last name' with 'Bob'
+    And I fill in 'Email' with 'jim.bob@example.com'
+    And I fill in 'Password' with 'my-password'
+    And I fill in 'Password confirmation' with 'my-password'
+    And I click the button 'Sign up'
+
+    Then My new claim should be displayed
+    And I should see 'Welcome! You have signed up successfully.'

--- a/features/users/user_signup_on_api_sandbox.feature
+++ b/features/users/user_signup_on_api_sandbox.feature
@@ -1,4 +1,4 @@
-@javascript @no-seed
+@javascript @no-seed @focus
 Feature: User signup on api-sandbox
 
   @on-api-sandbox
@@ -23,9 +23,12 @@ Feature: User signup on api-sandbox
     Then I fill in 'First name' with 'Jim'
     And I fill in 'Last name' with 'Bob'
     And I fill in 'Email' with 'jim.bob@example.com'
+    And I fill in 'Email confirmation' with 'jim.bob@example.com'
     And I fill in 'Password' with 'my-password'
     And I fill in 'Password confirmation' with 'my-password'
+    And I save and open screenshot
     And I click the button 'Sign up'
+    And I save and open screenshot
 
     Then My new claim should be displayed
     And I should see 'Welcome! You have signed up successfully.'

--- a/lib/demo_data/external_user_seeder.rb
+++ b/lib/demo_data/external_user_seeder.rb
@@ -31,6 +31,7 @@ module DemoData
           first_name: 'Barry',
           last_name: 'Stir',
           email: 'advocate@example.com',
+          email_confirmation: 'advocate@example.com',
           password: ENV.fetch('ADVOCATE_PASSWORD'),
           password_confirmation: ENV.fetch('ADVOCATE_PASSWORD'),
         )
@@ -45,6 +46,7 @@ module DemoData
           first_name: 'Advo',
           last_name: 'Kate-Admin',
           email: 'advocateadmin@example.com',
+          email_confirmation: 'advocateadmin@example.com',
           password: ENV.fetch('ADMIN_PASSWORD'),
           password_confirmation: ENV.fetch('ADMIN_PASSWORD')
         )
@@ -70,6 +72,7 @@ module DemoData
           first_name: 'Liti',
           last_name: 'Gator',
           email: 'litigator@example.com',
+          email_confirmation: 'litigator@example.com',
           password: ENV['ADVOCATE_PASSWORD'],
           password_confirmation: ENV['ADVOCATE_PASSWORD']
         )
@@ -84,6 +87,7 @@ module DemoData
           first_name: 'Liti',
           last_name: 'Gator-Admin',
           email: 'litigatoradmin@example.com',
+          email_confirmation: 'litigatoradmin@example.com',
           password: ENV['ADMIN_PASSWORD'],
           password_confirmation: ENV['ADMIN_PASSWORD']
         )
@@ -112,6 +116,7 @@ module DemoData
           first_name: 'Adi',
           last_name: 'Firmstein',
           email: 'advocate@agfslgfs.com',
+          email_confirmation: 'advocate@agfslgfs.com',
           password: ENV['ADVOCATE_PASSWORD'],
           password_confirmation: ENV['ADVOCATE_PASSWORD']
         )
@@ -127,6 +132,7 @@ module DemoData
           first_name: 'Adliti',
           last_name: 'Vogator-Admin',
           email: 'admin@agfslgfs.com',
+          email_confirmation: 'admin@agfslgfs.com',
           password: ENV['ADMIN_PASSWORD'],
           password_confirmation: ENV['ADMIN_PASSWORD']
         )
@@ -141,6 +147,7 @@ module DemoData
             first_name: 'Adliti',
             last_name: 'Gator',
             email: 'litigator@agfslgfs.com',
+            email_confirmation: 'litigator@agfslgfs.com',
             password: ENV['ADMIN_PASSWORD'],
             password_confirmation: ENV['ADMIN_PASSWORD']
         )

--- a/spec/factories/external_users.rb
+++ b/spec/factories/external_users.rb
@@ -20,8 +20,16 @@ FactoryBot.define do
     end
 
     after(:build) do |eu, evaluator|
+
       if evaluator.build_user
-        eu.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.email, password: 'password', password_confirmation: 'password')
+        email = Faker::Internet.email
+        eu.user ||= build(:user,
+                          first_name: Faker::Name.first_name,
+                          last_name: Faker::Name.last_name,
+                          email: email,
+                          email_confirmation: email,
+                          password: 'password',
+                          password_confirmation: 'password')
       end
     end
 


### PR DESCRIPTION
#### What
Add email confirmation on create

#### Why
Since we do not confirm a users sign up email
by sending them an activation email (TBC), we
can, at least, have them confirm their address
in the form, as for passwords.