### PR TITLE
[CFP-124] Remove commit_save_draft param

### DIFF
--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
         context 'create draft' do
           before do
             expect(Claim::AdvocateClaim.active.count).to eq(0)
-            post :create, params: { commit_save_draft: 'Save to drafts', claim: claim_params }
+            post :create, params: { claim: claim_params }
           end
 
           it 'creates the claim and sets the state to "draft"' do
@@ -416,7 +416,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
     context 'when valid' do
       context 'and deleting a rep order' do
         before {
-          put :update, params: { id: subject, claim: { defendants_attributes: { '1' => { id: subject.defendants.first, representation_orders_attributes: { '0' => { id: subject.defendants.first.representation_orders.first, _destroy: 1 } } } } }, commit_save_draft: 'Save to drafts' }
+          put :update, params: { id: subject, claim: { defendants_attributes: { '1' => { id: subject.defendants.first, representation_orders_attributes: { '0' => { id: subject.defendants.first.representation_orders.first, _destroy: 1 } } } } } }
         }
         it 'reduces the number of associated rep order by 1' do
           expect(subject.reload.defendants.first.representation_orders.count).to eq 1
@@ -429,7 +429,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
         end
 
         context 'and saving to draft' do
-          before { put :update, params: { id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' } }
+          before { put :update, params: { id: subject, claim: { additional_information: 'foo' } } }
           it 'sets API created claims source to indicate it is from API but has been edited in web' do
             expect(subject.reload.source).to eql 'api_web_edited'
           end
@@ -449,7 +449,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
         end
 
         context 'and saving to draft' do
-          before { put :update, params: { id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' } }
+          before { put :update, params: { id: subject, claim: { additional_information: 'foo' } } }
 
           it 'updates the source to indicate it was originally from JSON import but has been edited via web' do
             expect(subject.reload.source).to eql 'json_import_web_edited'
@@ -467,7 +467,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
 
       context 'and saving to draft' do
         it 'updates a claim' do
-          put :update, params: { id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' }
+          put :update, params: { id: subject, claim: { additional_information: 'foo' } }
           subject.reload
           expect(subject.additional_information).to eq('foo')
         end

--- a/spec/controllers/external_users/advocates/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/interim_claims_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
           }
 
           context 'and the form params were submitted as a draft' do
-            let(:form_action) { { } }
+            let(:form_action) { {} }
 
             it 'assigns @claim with the newly created record' do
               create_request
@@ -397,7 +397,7 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
           }
 
           context 'and the form params were submitted as a draft' do
-            let(:form_action) { { } }
+            let(:form_action) { {} }
 
             it 'assigns @claim with the existent updated record' do
               update_request

--- a/spec/controllers/external_users/advocates/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/interim_claims_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
           }
 
           context 'and the form params were submitted as a draft' do
-            let(:form_action) { { commit_save_draft: 'Save as draft' } }
+            let(:form_action) { { } }
 
             it 'assigns @claim with the newly created record' do
               create_request
@@ -397,7 +397,7 @@ RSpec.describe ExternalUsers::Advocates::InterimClaimsController, type: :control
           }
 
           context 'and the form params were submitted as a draft' do
-            let(:form_action) { { commit_save_draft: 'Save as draft' } }
+            let(:form_action) { { } }
 
             it 'assigns @claim with the existent updated record' do
               update_request

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -95,22 +95,22 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller do
         context 'create draft' do
           it 'creates a claim' do
             expect {
-              post :create, params: { commit_save_draft: 'Save to drafts', claim: claim_params }
+              post :create, params: { claim: claim_params }
             }.to change(Claim::LitigatorClaim, :count).by(1)
           end
 
           it 'redirects to claims list' do
-            post :create, params: { claim: claim_params, commit_save_draft: 'Save to drafts' }
+            post :create, params: { claim: claim_params }
             expect(response).to redirect_to(external_users_claims_path)
           end
 
           it 'sets the created claim\'s creator/"owner" to the signed in litigator' do
-            post :create, params: { claim: claim_params, commit_save_draft: 'Save to drafts' }
+            post :create, params: { claim: claim_params }
             expect(Claim::LitigatorClaim.active.first.creator).to eq(litigator)
           end
 
           it 'sets the claim\'s state to "draft"' do
-            post :create, params: { claim: claim_params, commit_save_draft: 'Save to drafts' }
+            post :create, params: { claim: claim_params }
             expect(Claim::LitigatorClaim.active.first).to be_draft
           end
         end
@@ -379,7 +379,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller do
     context 'when valid' do
       context 'and deleting a rep order' do
         before {
-          put :update, params: { id: subject, claim: { defendants_attributes: { '1' => { id: subject.defendants.first, representation_orders_attributes: { '0' => { id: subject.defendants.first.representation_orders.first, _destroy: 1 } } } } }, commit_save_draft: 'Save to drafts' }
+          put :update, params: { id: subject, claim: { defendants_attributes: { '1' => { id: subject.defendants.first, representation_orders_attributes: { '0' => { id: subject.defendants.first.representation_orders.first, _destroy: 1 } } } } } }
         }
         it 'reduces the number of associated rep orders by 1' do
           expect(subject.reload.defendants.first.representation_orders.count).to eq 1
@@ -388,7 +388,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller do
 
       context 'and saving to draft' do
         it 'updates a claim' do
-          put :update, params: { id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' }
+          put :update, params: { id: subject, claim: { additional_information: 'foo' } }
           subject.reload
           expect(subject.additional_information).to eq('foo')
         end

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -70,17 +70,17 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
         context 'create draft' do
           it 'creates a claim' do
             expect {
-              post :create, params: { commit_save_draft: 'Save to drafts', claim: claim_params }
+              post :create, params: { claim: claim_params }
             }.to change(Claim::InterimClaim, :count).by(1)
           end
 
           it 'redirects to claims list' do
-            post :create, params: { claim: claim_params, commit_save_draft: 'Save to drafts' }
+            post :create, params: { claim: claim_params }
             expect(response).to redirect_to(external_users_claims_path)
           end
 
           it 'sets the claim\'s state to "draft"' do
-            post :create, params: { claim: claim_params, commit_save_draft: 'Save to drafts' }
+            post :create, params: { claim: claim_params }
             expect(Claim::InterimClaim.active.first).to be_draft
           end
         end
@@ -263,7 +263,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
     context 'when valid' do
       context 'and deleting a rep order' do
         before {
-          put :update, params: { id: subject, claim: { defendants_attributes: { '1' => { id: subject.defendants.first, representation_orders_attributes: { '0' => { id: subject.defendants.first.representation_orders.first, _destroy: 1 } } } } }, commit_save_draft: 'Save to drafts' }
+          put :update, params: { id: subject, claim: { defendants_attributes: { '1' => { id: subject.defendants.first, representation_orders_attributes: { '0' => { id: subject.defendants.first.representation_orders.first, _destroy: 1 } } } } } }
         }
         it 'reduces the number of associated rep orders by 1' do
           expect(subject.reload.defendants.first.representation_orders.count).to eq 1
@@ -271,7 +271,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
       end
 
       context 'and saving to draft' do
-        before { put :update, params: { id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' } }
+        before { put :update, params: { id: subject, claim: { additional_information: 'foo' } } }
         it 'updates a claim' do
           expect(subject.reload.additional_information).to eq('foo')
         end

--- a/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/transfer_claims_controller_spec.rb
@@ -333,8 +333,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
                       }
                     }
                   }
-                },
-                commit_save_draft: 'Save to drafts'
+                }
               }
         }
         it 'reduces the number of associated rep orders by 1' do
@@ -350,7 +349,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
       #   end
       #
       #   context 'and saving to draft' do
-      #     before { put :update, id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' }
+      #     before { put :update, id: subject, claim: { additional_information: 'foo' } }
       #     it 'sets API created claims source to indicate it is from API but has been edited in web' do
       #       expect(subject.reload.source).to eql 'api_web_edited'
       #     end
@@ -366,7 +365,7 @@ RSpec.describe ExternalUsers::Litigators::TransferClaimsController, type: :contr
 
       context 'and saving to draft' do
         it 'updates a claim' do
-          put :update, params: { id: subject, claim: { additional_information: 'foo' }, commit_save_draft: 'Save to drafts' }
+          put :update, params: { id: subject, claim: { additional_information: 'foo' } }
           subject.reload
           expect(subject.additional_information).to eq('foo')
         end


### PR DESCRIPTION
#### What
Remove commit_save_draft param

#### Ticket

[CFP-124](https://dsdmoj.atlassian.net/browse/CFP-124)

#### Why
Controller does not rely on this value so
it is irrelevant and confusing to keep in
there.

This came out of discovering a indirectly related
bug. The same commit(s) that had caused the bug
had removed the name: :commit_save_draft name
from the button.

I appears as this is not used by any controllers in
question in any event, but was at some point (TBC: a commit
link to when and where).

#### TODO
There is still a JS dependency in a jasmine test to remove
`spec/javascripts/supporting-evidence_spec.js`