### PR TITLE
[CFP-110] Activate downtime banner

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,7 +82,7 @@ hardship_claims_banner_enabled?: true
 
 # Feature flag to enable or disable the downtime warning
 # If enabled, all users will see it up until "downtime_warning_date"
-downtime_warning_enabled?: false
+downtime_warning_enabled?: true
 downtime_warning_date: <%= Date.new(2021, 05, 26) %>
 
 # Feature flag to enable or disable the scheme filters in the claims list page


### PR DESCRIPTION
#### NOT to be merged/released until 19/05/2021

#### What
Activate/display downtime banner on home pages


#### Ticket

activates [CFP-110](https://dsdmoj.atlassian.net/browse/CFP-110)

#### Why
To warn users of downtime from date of merge and deploy until
date specified in settings file (26th May 2021)