### PR TITLE
[CFP-126] Add litigator "no indictment" popup feature test

### DIFF
--- a/db/seeds/fee_types/csv_seeder.rb
+++ b/db/seeds/fee_types/csv_seeder.rb
@@ -21,6 +21,8 @@ module Seeds
           process_row(row)
         end
 
+        reset_pk_sequence!
+
         log "Created: #{total_created} | Updated: #{total_updated} | Error: #{total_with_error} | Processed: #{total}".yellow
       end
 
@@ -79,6 +81,10 @@ module Seeds
         self.total_with_error += 1
       ensure
         self.total += 1
+      end
+
+      def reset_pk_sequence!
+        ActiveRecord::Base.connection.reset_pk_sequence!('fee_types')
       end
 
       def log(message)

--- a/features/claims/no_indictment_warning.feature
+++ b/features/claims/no_indictment_warning.feature
@@ -1,0 +1,57 @@
+@javascript @no-seed @vat-seeds
+Feature: Evidence page "no indictment" warning
+
+  Background:
+    Given popups are enabled
+
+  Scenario: A litigator final claim for a graduated fee accepts warning when indictment not checked
+    Given I am a signed in litigator with final claim 'A20214321'
+    And I am on the 'Your claims' page
+
+    When I click the claim 'A20214321'
+    And I edit the claim's supporting evidence
+    Then I should be in the 'Supporting evidence' form page
+    And I should see a page title "Upload supporting evidence for litigator final fees claim"
+
+    When I click "Continue" in the claim form and accept "no indictment" popup
+    Then I should be on the check your claim page
+
+  Scenario: A litigator final claim for a graduated fee cancels warning and ticks indictment checkbox
+    Given I am a signed in litigator with final claim 'A20214321'
+    And I am on the 'Your claims' page
+
+    When I click the claim 'A20214321'
+    And I edit the claim's supporting evidence
+    Then I should be in the 'Supporting evidence' form page
+    And I should see a page title "Upload supporting evidence for litigator final fees claim"
+
+    When I click "Continue" in the claim form and dismiss "no indictment" popup
+    Then I should be in the 'Supporting evidence' form page
+
+    When I check the evidence boxes for 'A copy of the indictment'
+    And I click "Continue" in the claim form
+    Then I should be on the check your claim page
+
+  Scenario: An advocate final claim for a graduated fee accepts warning when indictment not checked
+    Given I am a signed in advocate with final claim 'A20214321'
+    And I am on the 'Your claims' page
+
+    When I click the claim 'A20214321'
+    And I edit the claim's supporting evidence
+    Then I should be in the 'Supporting evidence' form page
+    And I should see a page title "Upload supporting evidence for advocate final fees claim"
+
+    When I click "Continue" in the claim form and accept "no indictment" popup
+    Then I should be on the check your claim page
+
+  Scenario: An advocate final claim for a fixed fee does NOT receive a warning when indictment not checked
+    Given I am a signed in advocate with fixed fee claim 'A20214321'
+    And I am on the 'Your claims' page
+
+    When I click the claim 'A20214321'
+    And I edit the claim's supporting evidence
+    Then I should be in the 'Supporting evidence' form page
+    And I should see a page title "Upload supporting evidence for advocate final fees claim"
+
+    When I click "Continue" in the claim form
+    Then I should be on the check your claim page

--- a/features/page_objects/claim_summary_page.rb
+++ b/features/page_objects/claim_summary_page.rb
@@ -5,4 +5,5 @@ class ClaimSummaryPage < BasePage
   element :change_case_details, "#case-details-section a.link-change:nth-of-type(1)"
   element :change_defendants, "#defendants-section a.link-change:nth-of-type(1)"
   element :change_expenses, "#expenses-section a.link-change:nth-of-type(1)"
+  element :change_supporting_evidence, "#supporting-evidence-section a.link-change:nth-of-type(1)"
 end

--- a/features/step_definitions/claim_summary_steps.rb
+++ b/features/step_definitions/claim_summary_steps.rb
@@ -25,3 +25,19 @@ end
 Then("I should be in the providers claim summary page") do
   expect(@external_user_claim_show_page).to be_displayed
 end
+
+When("I edit the claim's case details") do
+  @claim_summary_page.change_case_details.click
+end
+
+When("I edit the claim's defendants") do
+  @claim_summary_page.change_defendants.click
+end
+
+When("I edit the claim's expenses") do
+  @claim_summary_page.change_expenses.click
+end
+
+When("I edit the claim's supporting evidence") do
+  @claim_summary_page.change_supporting_evidence.click
+end

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -79,6 +79,8 @@ When(/^I check the evidence boxes for\s+'([^']*)'$/) do |labels|
       @claim_form_page.evidence_checklist.check(label)
     end
   end
+  wait_for_ajax
+  sleep 1 # can't find a way around need for this when popups enabled.
 end
 
 When("I answer {string} to was prosecution evidence served on this case?") do |string|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -87,18 +87,6 @@ When(/I edit this claim/) do
   @external_user_claim_show_page.edit_this_claim.click
 end
 
-When(/^I edit the claim's case details$/) do
-  @claim_summary_page.change_case_details.click
-end
-
-When(/^I edit the claim's defendants$/) do
-  @claim_summary_page.change_defendants.click
-end
-
-When(/^I edit the claim's expenses$/) do
-  @claim_summary_page.change_expenses.click
-end
-
 Then(/^I should be on the certification page$/) do
   expect(@certification_page).to be_displayed
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -231,3 +231,8 @@ end
 When('I go back') do
   page.go_back
 end
+
+Given('popups are enabled') do
+  overwrite_constant :ENABLED, false, Rack::NoPopups
+end
+

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -56,8 +56,8 @@ When(/^I select the offence category '(.*?)'$/) do |offence_cat|
   wait_for_ajax
 end
 
-And(/^I sleep for '(.*?)' second$/) do |num_seconds|
-  sleep num_seconds.to_f
+And('I sleep for {int} seconds') do |seconds|
+  sleep seconds.to_i
 end
 
 Given(/^I am later on the Your claims page$/) do

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -34,6 +34,22 @@ Given(/^I am a signed in advocate$/) do
   sign_in(@advocate.user, 'password')
 end
 
+Given('I am a signed in advocate with final claim {string}') do |case_number|
+  @advocate = create(:external_user, :advocate)
+  create(:advocate_claim, creator: @advocate, external_user: @advocate, case_number: case_number)
+  visit new_user_session_path
+  switch_to_chrome_window
+  sign_in(@advocate.user, 'password')
+end
+
+Given('I am a signed in advocate with fixed fee claim {string}') do |case_number|
+  @advocate = create(:external_user, :advocate)
+  create(:advocate_claim, :with_fixed_fee_case, creator: @advocate, external_user: @advocate, case_number: case_number)
+  visit new_user_session_path
+  switch_to_chrome_window
+  sign_in(@advocate.user, 'password')
+end
+
 Given(/^I am a signed in advocate admin$/) do
   @advocate = create(:external_user, :advocate_and_admin)
   visit new_user_session_path
@@ -43,6 +59,14 @@ end
 
 Given(/^I am a signed in litigator$/) do
   @litigator = create(:external_user, :litigator)
+  visit new_user_session_path
+  switch_to_chrome_window
+  sign_in(@litigator.user, 'password')
+end
+
+Given('I am a signed in litigator with final claim {string}') do |case_number|
+  @litigator = create(:external_user, :litigator)
+  create(:litigator_claim, creator: @litigator, external_user: @litigator, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
   sign_in(@litigator.user, 'password')

--- a/features/step_definitions/supporting_evidence_steps.rb
+++ b/features/step_definitions/supporting_evidence_steps.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+When('I click "Continue" in the claim form and accept "no indictment" popup') do
+  accept_confirm(no_indictment_message) do
+    @claim_form_page.continue_button.click
+  end
+end
+
+When('I click "Continue" in the claim form and dismiss "no indictment" popup') do
+  dismiss_confirm(no_indictment_message) do
+    @claim_form_page.continue_button.click
+  end
+end
+
+def no_indictment_message
+  @no_indictment_message ||= "The evidence checklist suggests that no indictment has been attached.\n" +
+                             "This can lead to your claim being rejected.\n\n" +
+                             "Do you wish to proceed without attaching an indictment?"
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -48,10 +48,10 @@ Before('not @no-seed') do
     load "#{Rails.root}/db/seeds/certification_types.rb"
     load "#{Rails.root}/db/seeds/disbursement_types.rb"
     load "#{Rails.root}/db/seeds/expense_types.rb"
-    load "#{Rails.root}/db/seeds/vat_rates.rb" unless @caseworker_seed_done
+    load "#{Rails.root}/db/seeds/vat_rates.rb" unless @vat_seed_done
     load "#{Rails.root}/db/seeds/establishments.rb"
 
-    @caseworker_seed_done = true
+    @vat_seed_done = true
     $seed_done = true
   end
 end
@@ -59,10 +59,10 @@ end
 # minimum seeding necessary for case worker functionality
 # to avoid long start up time for basic case worker features
 #
-Before('@caseworker-seed-requirements') do
-  unless (@caseworker_seed_done ||= false)
+Before('@caseworker-seed-requirements or @vat-seeds') do
+  unless (@vat_seed_done ||= false)
     load "#{Rails.root}/db/seeds/vat_rates.rb"
-    @caseworker_seed_done = true
+    @vat_seed_done = true
   end
 end
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -94,7 +94,7 @@ After do |scenario|
 
   # screenshot failure for storage as artifcate in circleCI
   name = scenario.location.file.gsub('features/','').gsub(/\.|\//, '-')
-  screenshot_image(name) if scenario.failed?
+  screenshot_image(name) if scenario.failed? && ENV['CI']
 
   # Following a local ruby and various dependecy updates cucumber no longer
   # appears to have been shutting down the chromedriver automatically.

--- a/features/support/overwrite_constants.rb
+++ b/features/support/overwrite_constants.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Idea from
+# https://makandracards.com/makandra/6125-how-to-overwrite-and-reset-constants-within-cucumber-features
+#
+module ConstantsHelper
+  def saved_constants
+    @saved_constants ||= {}
+  end
+
+  def undefined_constants
+    @undefined_constants ||= {}
+  end
+
+  def overwrite_constant(constant, value, object = Object)
+    constant = constant.to_sym
+    if object.const_defined?(constant)
+      saved_constants[object] ||= {}
+      saved_constants[object][constant] = object.const_get(constant) unless saved_constants[object].has_key?(constant)
+    else
+      undefined_constants[object] ||= []
+      undefined_constants[object] << constant
+    end
+
+    silence_warnings { object.const_set(constant, value) }
+  end
+
+  def overwrite_constants(constants = {}, object = Object)
+    constants.each do |constant, value|
+      overwrite_constant constant, value, object
+    end
+  end
+
+  def reset_constant(constant, object = Object)
+    silence_warnings do
+      if undefined_constants[object] && undefined_constants[object].include?(constant)
+        object.instance_eval { remove_const(constant) }
+        undefined_constants[object].delete(constant)
+      else
+        object.const_set(constant, saved_constants[object].delete(constant))
+      end
+    end
+  end
+
+  def reset_constants(constants = nil, object = Object)
+    constants ||= (saved_constants[object].keys | undefined_constants.fetch(object, []))
+    constants.each do |constant|
+      reset_constant(constant, object)
+    end
+  end
+
+  def reset_all_constants
+    (saved_constants.keys | undefined_constants.keys).each do |object|
+      reset_constants(nil, object)
+    end
+  end
+end
+
+World(ConstantsHelper)
+
+After do
+  reset_all_constants
+end

--- a/features/support/screenshot_helper.rb
+++ b/features/support/screenshot_helper.rb
@@ -6,12 +6,16 @@ module ScreenshotHelper
   end
 
   def screenshot_image(name = 'capybara-screenshot')
-    window = Capybara.current_session.driver.browser.manage.window
-    window.resize_to(*dimensions)
+    resize_window_to_fit
     screenshot_name = "#{name}-#{Time.now.utc.iso8601.gsub('-', '').gsub(':', '')}.#{SecureRandom.hex}.png"
     file_path = Rails.root.join("tmp/capybara/#{screenshot_name}").to_s
     save_screenshot(file_path)
     file_path
+  end
+
+  def resize_window_to_fit
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(*dimensions)
   end
 
   def dimensions

--- a/lib/rack/no_popups.rb
+++ b/lib/rack/no_popups.rb
@@ -4,6 +4,8 @@ module Rack
   class NoPopups
     include Injectable
 
+    ENABLED = true
+
     DISABLE_POPUPS_HTML = <<~HTML.freeze
       <script type="text/javascript">
         window.alert = function() { };
@@ -13,8 +15,12 @@ module Rack
 
     private
 
+    def enabled?
+      ENABLED
+    end
+
     def fragment
-      DISABLE_POPUPS_HTML
+      enabled? ? DISABLE_POPUPS_HTML : ''
     end
   end
 end


### PR DESCRIPTION
#### What
Add litigator "no indictment" popup feature test


#### Ticket
[CFP-126](https://dsdmoj.atlassian.net/browse/CFP-126)

#### Why
This feature had been indvertently broken for while
due to suttle view/frontend changes that impacted it.

Jasmine unit tests had not picked this up as we need
an "integration" test to cover the functionality.

#### How
Modal popups are disabled by custom rack middleware
during test runs (rspec and cucumber) to prevent
the need to interact with them.

Since this feature needs to test/interact with a modal dialog
it re-enables modal dialogs/popups just for this particular
scenario. The step then verifies the text of the message and
accepts it to proceed. It will fail if no modal dialog
pops up or the modal does not have the expected text.