### PR TITLE
[CFP-110] Revert to use custom partial for downtime notification banner

### DIFF
--- a/app/views/shared/_downtime_warning.html.haml
+++ b/app/views/shared/_downtime_warning.html.haml
@@ -1,6 +1,10 @@
 - if display_downtime_warning?
-  = govuk_notification_banner(t('.banner_title')) do
-    %h3.govuk-notification-banner__heading
-      = t('.banner_heading', date_string: Settings.downtime_warning_date.to_date.strftime('%A %d %B %Y'))
-    %p.govuk-body
-      = t('.banner_paragraph')
+  .govuk-notification-banner{'aria-labelledby': 'govuk-downtime-notification-banner-title', 'data-module': "govuk-notification-banner", role: 'alert'}
+    .govuk-notification-banner__header
+      %h2#govuk-downtime-notification-banner-title.govuk-notification-banner__title
+        = t('.banner_title')
+    .govuk-notification-banner__content
+      %h3.govuk-notification-banner__heading
+        = t('.banner_heading', date_string: Settings.downtime_warning_date.to_date.strftime('%A %d %B %Y'))
+      %p.govuk-body
+        = t('.banner_paragraph')

--- a/features/downtime_banner.feature
+++ b/features/downtime_banner.feature
@@ -11,12 +11,7 @@ Feature: A downtime warning banner appears on home pages only until downtime dat
     Then the downtime banner is displayed
     And the downtime banner should say 'This service will be unavailable on Wednesday 26 May 2021 from 5pm until midnight.'
     And the downtime banner should say 'This is to enable routine maintenance work to be carried out. Please save and close any work before this time.'
-
-    # TODO: Page not accessible at this point, i believe due to the sign in flash notification.
-    # However, even a refresh of the page, removing the sign in notification, results in
-    # a duplicate-id-aria accessibility violation. This does not occur once navigation occurs, as below.
-    #
-    # And the page should be accessible => fails
+    And the page should be accessible
 
     When I visit the fee scheme selector page
     And the downtime banner is not displayed
@@ -46,12 +41,7 @@ Feature: A downtime warning banner appears on home pages only until downtime dat
     Then the downtime banner is displayed
     And the downtime banner should say 'This service will be unavailable on Wednesday 26 May 2021 from 5pm until midnight.'
     And the downtime banner should say 'This is to enable routine maintenance work to be carried out. Please save and close any work before this time.'
-
-    # TODO: Page not accessible at this point, i believe due to the sign in flash notification.
-    # However, even a refresh of the page, removing the sign in notification, results in
-    # a duplicate-id-aria accessibility violation. This does not occur once navigation occurs, as below.
-    #
-    # And the page should be accessible => fails
+    And the page should be accessible
 
     When I click the link 'Allocation'
     And the downtime banner is not displayed


### PR DESCRIPTION
#### What
Revert to use custom partial for downtime notification banner

#### Ticket

relates to [CFP-110](https://dsdmoj.atlassian.net/browse/CFP-110)

#### Why
`duplicate-id-aria` accessibility issue caused by having a sign-in flash notification
and the downtime banner displayed at the same time.

#### How
Resolved the accessibility issue of `duplicate-id-aria` (with sign-in flash and downtime banner both displayed) by reverting to using a custom partial, with a "custom" `id` and `aria-labelledby` for the title, namely `govuk-downtime-notification-banner-title`