### PR TITLE
Fix flickering test

### DIFF
--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
     end
 
     trait :with_fixed_fee_case do
-      case_type { association(:case_type, :fixed_fee) }
+      case_type { CaseType.find_by(fee_type_code: 'FXASE') || association(:case_type, :appeal_against_sentence) }
     end
 
     trait :with_graduated_fee_case do

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
 
     trait :with_fixed_fee_case do
-      case_type { association(:case_type, :fixed_fee) }
+      case_type { CaseType.find_by(fee_type_code: 'FXASE') || association(:case_type, :appeal_against_sentence) }
     end
 
     trait :with_graduated_fee_case do


### PR DESCRIPTION
#### What
Fix flickering test

#### Why
The combination of features such as this
```
cucumber \
features/claims/litigator/litigator_contempt_claim_draft_submit.feature:5 \
features/claims/no_indictment_warning.feature:47 \
features/fee_calculator/calculator_offline.feature:5
```

Was reliably erroring due to creation of the same case
type (appeal against sentence) in seeds as well as via a
factory.

This resulted in a select list with two of the same case types.
Causing:

```
And I select a case type of 'Appeal against sentence'
  Ambiguous match, found 2 elements matching visible option "Appeal against sentence"
```

This fixes by looking for and using the existing case type before
creating one.

#### Ticket

[CFP-128](https://dsdmoj.atlassian.net/browse/CFP-128)