### PR TITLE
Some cleanup of TimedTransitions

### DIFF
--- a/app/models/timed_transitions/specification.rb
+++ b/app/models/timed_transitions/specification.rb
@@ -1,9 +1,8 @@
 module TimedTransitions
   class Specification
-    attr_reader :current_state, :period_in_weeks, :method
+    attr_reader :period_in_weeks, :method
 
-    def initialize(current_state, period_in_weeks, method)
-      @current_state    = current_state
+    def initialize(period_in_weeks, method)
       @period_in_weeks  = period_in_weeks
       @method           = method
     end

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -2,14 +2,14 @@ module TimedTransitions
   class Transitioner
     attr_accessor :success
 
-    @@timed_transition_specifications = {
+    TIMED_TRANSITION_SPECIFICATIONS = {
       draft: Specification.new(Settings.timed_transition_stale_weeks, :destroy_claim),
       authorised: Specification.new(Settings.timed_transition_stale_weeks, :archive),
       part_authorised: Specification.new(Settings.timed_transition_stale_weeks, :archive),
       refused: Specification.new(Settings.timed_transition_stale_weeks, :archive),
       rejected: Specification.new(Settings.timed_transition_stale_weeks, :archive),
       archived_pending_delete: Specification.new(Settings.timed_transition_pending_weeks, :destroy_claim)
-    }
+    }.freeze
 
     def self.candidate_claims_ids
       Claim::BaseClaim.where(state: candidate_states)
@@ -21,7 +21,7 @@ module TimedTransitions
     end
 
     def self.candidate_states
-      @@timed_transition_specifications.keys
+      TIMED_TRANSITION_SPECIFICATIONS.keys
     end
 
     def initialize(claim, dummy = false)
@@ -44,7 +44,7 @@ module TimedTransitions
     end
 
     def process_stale_claim
-      specification = @@timed_transition_specifications[@claim.state.to_sym]
+      specification = TIMED_TRANSITION_SPECIFICATIONS[@claim.state.to_sym]
       last_transition = @claim.last_state_transition_time
       return unless last_transition.nil? || last_transition < specification.period_in_weeks.weeks.ago
       send(specification.method)

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -41,12 +41,8 @@ module TimedTransitions
 
     private
 
-    def is_dummy?
-      @dummy
-    end
-
     def log_level
-      is_dummy? ? :debug : :info
+      @dummy ? :debug : :info
     end
 
     def process_stale_claim
@@ -58,7 +54,7 @@ module TimedTransitions
 
     def archive
       values = @claim.hardship? ? hardship_archive_checks : archive_checks
-      @claim.send(values[:event], reason_code: ['timed_transition']) unless is_dummy?
+      @claim.send(values[:event], reason_code: ['timed_transition']) unless @dummy
       @claim.reload # not sure if needed
       log(log_level,
           action: 'archive',
@@ -92,7 +88,7 @@ module TimedTransitions
     end
 
     def destroy_claim
-      Stats::MIData.import(@claim) && @claim.destroy unless is_dummy?
+      Stats::MIData.import(@claim) && @claim.destroy unless @dummy
       log(log_level,
           action: 'destroy',
           message: 'Destroying soft-deleted claim',

--- a/app/models/timed_transitions/transitioner.rb
+++ b/app/models/timed_transitions/transitioner.rb
@@ -3,14 +3,12 @@ module TimedTransitions
     attr_accessor :success
 
     @@timed_transition_specifications = {
-      draft: Specification.new(:draft, Settings.timed_transition_stale_weeks, :destroy_claim),
-      authorised: Specification.new(:authorised, Settings.timed_transition_stale_weeks, :archive),
-      part_authorised: Specification.new(:part_authorised, Settings.timed_transition_stale_weeks, :archive),
-      refused: Specification.new(:refused, Settings.timed_transition_stale_weeks, :archive),
-      rejected: Specification.new(:rejected, Settings.timed_transition_stale_weeks, :archive),
-      archived_pending_delete: Specification.new(:archived_pending_delete,
-                                                 Settings.timed_transition_pending_weeks,
-                                                 :destroy_claim)
+      draft: Specification.new(Settings.timed_transition_stale_weeks, :destroy_claim),
+      authorised: Specification.new(Settings.timed_transition_stale_weeks, :archive),
+      part_authorised: Specification.new(Settings.timed_transition_stale_weeks, :archive),
+      refused: Specification.new(Settings.timed_transition_stale_weeks, :archive),
+      rejected: Specification.new(Settings.timed_transition_stale_weeks, :archive),
+      archived_pending_delete: Specification.new(Settings.timed_transition_pending_weeks, :destroy_claim)
     }
 
     def self.candidate_claims_ids


### PR DESCRIPTION
#### What

1. Remove the `is_dummy?` private method from `TimedTransitions::Transitioner`.
2. Remove the `current_state` attribute from `TimedTransitions:Specification`.
3. Replace `@@timed_transition_specifications` with a constant.

#### Ticket

N/A

#### Why

1. Rubocop was complaining [`Naming/PredicateName: Rename is_dummy? to dummy?`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/PredicateName) As it is a private method and is simply a wrapper for `@dummy` it can be removed completely.
2. `TimedTransitions::Specification#current_state` is not used anywhere.
3. [`Style/ClassVars`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassVars) recommends avoiding using class variables. Also, `@@timed_transition_specifications` is effectively a constant.

#### How

1. Replace `is_dummy?` with `@dummy` each time it is used.
2. Remove the `current_state` attribute and update `TimedTransitions::Transitioner` where specifications are set up.
3. Replace `@@timed_transition_specifications` by `TIMED_TRANSITION_SPECIFICATIONS`.