### PR TITLE
[CFP-120] Add environment variables to archive_stale cronjob

### DIFF
--- a/kubernetes_deploy/cron_jobs/archive_stale.yaml
+++ b/kubernetes_deploy/cron_jobs/archive_stale.yaml
@@ -38,3 +38,23 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
+            - name: SETTINGS__AWS__S3__ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: access_key_id
+            - name: SETTINGS__AWS__S3__SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: secret_access_key
+            - name: SETTINGS__AWS__S3__BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: bucket_name
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-elasticache-redis
+                  key: url


### PR DESCRIPTION
#### What

Add environment variables for accessing S3 and Redis to the configuration of the `archive_stale` cronjob.

#### Ticket

[Archiving stale claims errors](https://dsdmoj.atlassian.net/browse/CFP-120)

#### Why

When deleting archived claims the documents also need to be removed from S3. This requires access to the AWS S3 credentials. Redis access is also required as the job to delete the files it added to a background job.

#### How

Add the environment variable configuration to `kubernetes_deploy/cron_jobs/archive_stale.yaml`