### PR TITLE
Fix downtime feature spec

### DIFF
--- a/features/downtime_banner.feature
+++ b/features/downtime_banner.feature
@@ -6,8 +6,8 @@ Feature: A downtime warning banner appears on home pages only until downtime dat
     And the downtime date is set to '2021-05-26'
 
   Scenario: Downtime warning active until 26 May 2021 for external users
-    Given I am a signed in advocate admin
-    When the current date is '2021-05-19'
+    Given the current date is '2021-05-19'
+    When I am a signed in advocate admin
     Then the downtime banner is displayed
     And the downtime banner should say 'This service will be unavailable on Wednesday 26 May 2021 from 5pm until midnight.'
     And the downtime banner should say 'This is to enable routine maintenance work to be carried out. Please save and close any work before this time.'
@@ -31,13 +31,12 @@ Feature: A downtime warning banner appears on home pages only until downtime dat
 
   @caseworker-seed-requirements
   Scenario: Downtime warning active until 26 May 2021 for case workers
-    Given case worker "John Smith" exists
+    Given the current date is '2021-05-19'
+    And case worker "John Smith" exists
     And submitted claims exist with case numbers "T20160001, T20160002, T20160003, T20160004, T20160005"
     And I insert the VCR cassette 'features/case_workers/admin/allocation'
 
-    Given I am a signed in case worker admin
-    And the current date is '2021-05-19'
-
+    When I am a signed in case worker admin
     Then the downtime banner is displayed
     And the downtime banner should say 'This service will be unavailable on Wednesday 26 May 2021 from 5pm until midnight.'
     And the downtime banner should say 'This is to enable routine maintenance work to be carried out. Please save and close any work before this time.'

--- a/features/step_definitions/downtime_banner_steps.rb
+++ b/features/step_definitions/downtime_banner_steps.rb
@@ -15,9 +15,9 @@ Then(/^the downtime banner is (not )?displayed$/) do |negate|
 end
 
 Then('the downtime banner should say {string}') do |string|
-  expect(page).to have_selector(downtime_banner, text: string)
+  expect(page).to have_selector('.govuk-notification-banner', text: string)
 end
 
 def downtime_banner
-  'div.govuk-notification-banner'.freeze
+  'h2#govuk-downtime-notification-banner-title'.freeze
 end


### PR DESCRIPTION
#### What
Fix downtime feature spec

#### Why
The current date was being set when already on the
page to display the banner. Date must be set before
navigating to a page.

Selectors needed to change to be specific to downtime
warning, rather than any notification banner (such as
sign in success flash).