### PR TITLE
Revert removal of @no-seed tag and fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,13 +177,13 @@ commands:
       - run:
           name: Run cucumber tests
           command: |
-            TESFILES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings --timings-type=filename)
+            TESTFILES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings --timings-type=filename)
 
             RUBYOPT='-W0' bundle exec cucumber \
             --format pretty \
             --format json \
             --out /tmp/test-results/cucumber/tests.cucumber \
-            -- ${TESFILES}
+            -- ${TESTFILES}
       - store_artifacts:
           path: tmp/capybara
       - store_test_results:

--- a/features/000.feature
+++ b/features/000.feature
@@ -1,9 +1,4 @@
-# Do not remove. This feature must always run first on CI.
-# Due to some obscure mechanism, sometimes cukes will start with a dirty DB state after running specs, with
-# some records already created, which causes hellish problems with VCR cassettes. This feature will reset the DB.
-# (I hate cucumber)
-#
-@javascript
+@javascript @no-seed
 Feature: This feature runs first to sanitize the database.
 
   Scenario: Logged out I see the login page. Silly test will do the magic.

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @no-seed
 Feature: Caseworker can log in while active, but not once inactive
 
   Scenario: I log in as a case worker admin and I see the allocation page

--- a/features/claims/no_indictment_warning.feature
+++ b/features/claims/no_indictment_warning.feature
@@ -1,4 +1,4 @@
-@javascript @vat-seeds
+@javascript @no-seed @vat-seeds
 Feature: Evidence page "no indictment" warning
 
   Background:

--- a/features/downtime_banner.feature
+++ b/features/downtime_banner.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @no-seed
 Feature: A downtime warning banner appears on home pages only until downtime date exceeded
 
   Background:
@@ -29,7 +29,7 @@ Feature: A downtime warning banner appears on home pages only until downtime dat
     And I refresh the page
     Then the downtime banner is not displayed
 
-  @caseworker-seed-requirements
+  @vat-seeds
   Scenario: Downtime warning active until 26 May 2021 for case workers
     Given the current date is '2021-05-19'
     And case worker "John Smith" exists

--- a/features/provider_management.feature
+++ b/features/provider_management.feature
@@ -1,4 +1,4 @@
-@javascript @caseworker-seed-requirements
+@javascript @no-seed @vat-seeds
 Feature: Case worker can manage providers
 
   Scenario: A provider Manager can create a new chamber

--- a/features/users/new_external_user.feature
+++ b/features/users/new_external_user.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @no-seed
 Feature: Create new external user
 
   Scenario: Chamber admin creates a new advocate user

--- a/features/users/user_signup_on_api_sandbox.feature
+++ b/features/users/user_signup_on_api_sandbox.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @no-seed
 Feature: User signup on api-sandbox
 
   @on-api-sandbox


### PR DESCRIPTION
#### What
Reimplement the no-seed cuke tag 
#### Why
Speeds up isolated test runs that do no require seeding.

However, the no-seed tag seemed to cause failures when followed
by scenario(s) that do require seeding. This may just have been
because of other errors.

#### How
Revert removal of no-seed tag use and convert instance var
to global var. Then run cukes several times to check for failures
based on test order.

such as
```
RUBYOPT='-W0' bundle exec cucumber \
--format pretty \
-- features/claims/no_indictment_warning.feature:7 \
 features/claims/no_indictment_warning.feature:19 \
 features/claims/no_indictment_warning.feature:35 \
 features/claims/no_indictment_warning.feature:47 \
 features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature:5 \
 features/allocation.feature:4 \
 features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature:5 \
 features/claims/litigator/hardship_claim_draft_submit.feature:5 \
 features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature:5 \
 features/fee_calculator/advocate/misc_fee_calculator.feature:5 \
 features/claims/advocate/scheme_eleven/advocate_fixed_fee_claim_submit.feature:5
 ```
--------

#### TODO (wip)

 - [x] run cukes 5 times without failure