### PR TITLE
Fix artifact storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ commands:
             --out /tmp/test-results/cucumber/tests.cucumber \
             -- ${TESFILES}
       - store_artifacts:
-          path: ~/capybara
+          path: tmp/capybara
       - store_test_results:
           path: /tmp/test-results/cucumber
 


### PR DESCRIPTION
#### What
Fix artifact storage


#### Why
Currently failed feature specs screenshot images
of the failure. But their upload fails as
images are stored in tmp/capybara and should
be uploaded as artifacts from that relative path.

See `features/support/screenshot_helper.rb`

see [artifact failure example that uses this location](https://app.circleci.com/pipelines/github/ministryofjustice/Claim-for-Crown-Court-Defence/4847/workflows/02d4a7e0-41b3-4a55-9b5e-38a8516a907b/jobs/41329/artifacts)