### PR TITLE
[CFP-153] Replace app media queries with that of the GOV.UK Design System

### DIFF
--- a/app/webpack/stylesheets/_autocomplete.scss
+++ b/app/webpack/stylesheets/_autocomplete.scss
@@ -1,4 +1,4 @@
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   // stylelint-disable selector-id-pattern
   #case_details,
   #transfer-detail {
@@ -31,7 +31,7 @@
   background-color: $page-colour;
 }
 
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   .tt-menu {
     width: $half;
   }

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -40,10 +40,6 @@
   margin-bottom: $gutter-one-third;
 
   h1 {
-    @include media(desktop) {
-      margin-left: 0;
-    }
-
     @include core-19;
     display: inline-block;
     margin-left: 0;
@@ -68,8 +64,10 @@
   }
 
   .claim-detail-actions {
-    @include media(mobile) {
-      margin-bottom: $gutter-one-third;
+    margin-bottom: $gutter-one-third;
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: 0;
     }
 
     @include core-19;

--- a/app/webpack/stylesheets/_cocoon.scss
+++ b/app/webpack/stylesheets/_cocoon.scss
@@ -1,6 +1,6 @@
 .remove_fields {
   @include govuk-responsive-margin(4, "bottom");
-  @include govuk-media-query ($from: desktop) {
+  @include govuk-media-query($from: desktop) {
     position: absolute;
     top: 0;
     right: 0;

--- a/app/webpack/stylesheets/_datatables.scss
+++ b/app/webpack/stylesheets/_datatables.scss
@@ -535,7 +535,7 @@ table.dataTable td {
   height: 0
 }
 
-@media screen and (max-width: 767px) {
+@include govuk-media-query($until: desktop) {
 
   .dataTables_wrapper .dataTables_info,
   .dataTables_wrapper .dataTables_paginate {
@@ -548,7 +548,7 @@ table.dataTable td {
   }
 }
 
-@media screen and (max-width: 640px) {
+@include govuk-media-query($until: tablet) {
 
   .dataTables_wrapper .dataTables_length,
   .dataTables_wrapper .dataTables_filter {
@@ -868,7 +868,7 @@ div.dt-button-background {
   z-index: 2001
 }
 
-@media screen and (max-width: 640px) {
+@include govuk-media-query($until: tablet) {
   div.dt-buttons {
     float: none !important;
     text-align: center
@@ -919,7 +919,7 @@ table.fixedHeader-locked {
   background-color: white
 }
 
-@media print {
+@include govuk-media-query($media-type: print) {
   table.fixedHeader-floating {
     display: none
   }
@@ -1059,7 +1059,7 @@ div.dataTables_wrapper span.select-item {
   margin-left: 0.5em
 }
 
-@media screen and (max-width: 640px) {
+@include govuk-media-query($until: tablet) {
 
   div.dataTables_wrapper span.select-info,
   div.dataTables_wrapper span.select-item {
@@ -1090,7 +1090,7 @@ div.dataTables_wrapper span.select-item {
   font-weight: 700;
 }
 
-@media screen and (max-width: 640px) {
+@include govuk-media-query($until: tablet) {
 
   div.dataTables_wrapper span.select-info,
   div.dataTables_wrapper span.select-item {

--- a/app/webpack/stylesheets/_denote.scss
+++ b/app/webpack/stylesheets/_denote.scss
@@ -6,7 +6,7 @@
   background-color: $grey-3;
   line-height: 1.1;
 
-  @media (min-width: 641px) {
+  @include govuk-media-query($from: tablet) {
     padding: $gutter-one-sixth + 2 $gutter-one-third + 2;
   }
 }
@@ -24,7 +24,7 @@
   color: $white;
   background-color: $error-colour;
 
-  @media (min-width: 641px) {
+  @include govuk-media-query($from: tablet) {
     padding: $gutter-one-sixth + 3 $gutter-one-third + 2;
   }
 }

--- a/app/webpack/stylesheets/_forms.scss
+++ b/app/webpack/stylesheets/_forms.scss
@@ -12,7 +12,7 @@ fieldset {
   }
 
   legend {
-    @include govuk-media-query ($from: desktop) {
+    @include govuk-media-query($from: desktop) {
       float: left;
     }
     width: $full-width;
@@ -60,10 +60,6 @@ input.form-control:read-only {  // stylelint-disable-line selector-no-qualifying
 
 .form-control-full {
   width: $full-width;
-
-  @include media(tablet) {
-    width: $full-width;
-  }
 }
 
 .inline-form {

--- a/app/webpack/stylesheets/_links.scss
+++ b/app/webpack/stylesheets/_links.scss
@@ -2,7 +2,7 @@
 .link-change,
 .download-all-link {
   @include govuk-responsive-margin(4, "bottom");
-  @include govuk-media-query ($from: desktop) {
+  @include govuk-media-query($from: desktop) {
     position: absolute;
     top: 0;
     right: 0;

--- a/app/webpack/stylesheets/_messages.scss
+++ b/app/webpack/stylesheets/_messages.scss
@@ -2,7 +2,7 @@
 
 @mixin normalize-bubble($direction:left) {
   @if $direction == "left" {
-    @media print {
+    @include govuk-media-query($media-type: print) {
       margin-right: 95px;
     }
 
@@ -13,7 +13,7 @@
   }
 
   @if $direction == "right" {
-    @media print {
+    @include govuk-media-query($media-type: print) {
       margin-left: 95px;
     }
 
@@ -22,7 +22,7 @@
     }
   }
 
-  @media print {
+  @include govuk-media-query($media-type: print) {
     .message-audit {
       color: $black;
       font-weight: 700;

--- a/app/webpack/stylesheets/_print.scss
+++ b/app/webpack/stylesheets/_print.scss
@@ -2,7 +2,7 @@
   page-break-before: always;
 }
 
-@media print {
+@include govuk-media-query($media-type: print) {
   @page {
     size: 216mm 280mm;
   }

--- a/app/webpack/stylesheets/_related.scss
+++ b/app/webpack/stylesheets/_related.scss
@@ -58,13 +58,13 @@
 .related .return-to-top {
   @include core-16;
 
-  @media (min-width: 769px) {
+  @include govuk-media-query($from: tablet) {
     position: absolute;
     left: -9999em;
   }
 }
 
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   .page-header div {
     margin-top: $gutter;
     margin-bottom: $gutter;

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -493,18 +493,6 @@ form {
 }
 
 // Ported from v1 stylesheets
-.contactus-link {
-  @include core-19;
-  @include clearfix;
-  margin-top: $gutter * 2;
-  margin-bottom: -($gutter * 2);
-
-  @include media($max-width: 768px) {
-    margin-top: $gutter-half;
-    margin-bottom: $gutter-half;
-  }
-}
-
 .search-form {
   @include clearfix;
 

--- a/app/webpack/stylesheets/_tables.scss
+++ b/app/webpack/stylesheets/_tables.scss
@@ -54,7 +54,7 @@ table {
           width: 320px;
           color: $error-colour;
 
-          @media (max-width: 1018px) {
+          @include govuk-media-query($until: desktop) {
             width: auto;
           }
         }
@@ -78,7 +78,7 @@ table {
           color: $orange;
           font-weight: 700;
 
-          @media (max-width: 1018px) {
+          @include govuk-media-query($until: desktop) {
             width: auto;
           }
         }
@@ -212,7 +212,7 @@ table {
   }
 }
 
-@include media($max-width: 1018px) {
+@include govuk-media-query($until: desktop) {
   .report {
     border: 0;
 

--- a/app/webpack/stylesheets/accessible-autocomplete.scss
+++ b/app/webpack/stylesheets/accessible-autocomplete.scss
@@ -130,7 +130,7 @@
 .autocomplete__option {
   padding: 4px;
 }
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   .autocomplete__hint,
   .autocomplete__input,
   .autocomplete__option {

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -6,8 +6,6 @@ $path: '~images/';
 @import '~govuk_frontend_toolkit/stylesheets/colours';
 @import '~govuk_frontend_toolkit/stylesheets/font_stack';
 @import '~govuk_frontend_toolkit/stylesheets/measurements';
-@import '~govuk_frontend_toolkit/stylesheets/conditionals';
-@import '~govuk_frontend_toolkit/stylesheets/device-pixels';
 @import '~govuk_frontend_toolkit/stylesheets/typography';
 @import '~govuk_frontend_toolkit/stylesheets/shims';
 


### PR DESCRIPTION
#### What

Replace app media queries with that of the GOV.UK Design System

#### Ticket

[Replace stylesheet media queries](https://dsdmoj.atlassian.net/browse/CFP-153)

#### Why

To continue the migration away from the deprecated GOV.UK Frontend toolkit to GOV.UK Frontend (GOV.UK Design System)

#### How

| GOV.UK Frontend Toolkit | GOV.UK Frontend |
| --- | ----------- |
| `@include media(...)`, `@media`,  `@media print` | `@include govuk-media-query(...)` |
