### PR TITLE
[CFP-155] Replace app css helpers with that of the GOV.UK Design System

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -44,7 +44,7 @@
     = t('.allocation_queue')
 
   %table#dtAllocation
-    %caption.visually-hidden
+    %caption.govuk-visually-hidden
       = t('.table_summary')
       %noscript
         = t('shared.not_available')

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -79,7 +79,7 @@
                   %tr{ id: dom_id(claim), class: claim.injection_error ? 'error injection-error' : nil }
                     %td{ 'data-label': t('.select') }
                       .error-message-container
-                        = b.label(class: 'visuallyhidden') { t('.choose_label', case_number: claim.case_number) }
+                        = b.label(class: 'govuk-visually-hidden') { t('.choose_label', case_number: claim.case_number) }
                         = b.check_box
                         - claim.injection_error do |message|
                           .error-message

--- a/app/views/external_users/claims/_date_attended_fields_condensed.html.haml
+++ b/app/views/external_users/claims/_date_attended_fields_condensed.html.haml
@@ -1,5 +1,5 @@
 %fieldset
-  %legend.visuallyhidden
+  %legend.govuk-visually-hidden
   .govuk-grid-row.extra-data.nested-fields.fee-dates
 
     - if defined?(parent_model_prefix) && defined?(submodel_count)

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -15,7 +15,7 @@
 - if local_assigns.has_key?(:fee)
   - if fee
     %table.summary
-      %caption.visuallyhidden
+      %caption.govuk-visually-hidden
         = t('.caption')
       %tbody
         = render partial: 'external_users/claims/summary_fee', locals: { fee: present(fee) }
@@ -41,7 +41,7 @@
         = t('shared.summary.basic_fees')
 
     %table.summary
-      %caption.visuallyhidden
+      %caption.govuk-visually-hidden
         = t('.caption')
 
       %thead

--- a/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
+++ b/app/views/external_users/claims/basic_fees/_basic_fee_fields_primary.html.haml
@@ -7,7 +7,7 @@
     .form-group
       = render partial: 'external_users/claims/basic_fees/offence_display', locals: { claim: @claim }
 
-    .form-group.visually-hidden{ 'aria-hidden': 'true' }
+    .form-group.govuk-visually-hidden{ 'aria-hidden': 'true' }
       = f.hidden_field :fee_type_id, value: f.object.fee_type_id, class: 'js-fee-type'
       = f.label :quantity, 'Fee calculator days', class: 'form-label-bold'
       = f.text_field :quantity, value: 1, class: 'form-control js-fee-calculator-days', readonly: true, tabindex: -1

--- a/app/views/external_users/claims/disbursements/_summary.html.haml
+++ b/app/views/external_users/claims/disbursements/_summary.html.haml
@@ -14,7 +14,7 @@
         = t('shared.summary.no_values.disbursements')
   - else
     %table.summary
-      %caption.visuallyhidden
+      %caption.govuk-visually-hidden
         = t('.caption')
 
       %thead

--- a/app/views/external_users/claims/expenses/_summary.html.haml
+++ b/app/views/external_users/claims/expenses/_summary.html.haml
@@ -17,7 +17,7 @@
 
     %table.summary
       %caption
-        %span.visually-hidden
+        %span.govuk-visually-hidden
           = t('.caption')
 
       %thead
@@ -71,7 +71,7 @@
       = t('shared.summary.expenses.travel_details')
 
     %table.summary
-      %caption.visuallyhidden
+      %caption.govuk-visually-hidden
         = t('.additional_information')
 
       %thead

--- a/app/views/external_users/claims/interim_claim_info/_fields.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_fields.html.haml
@@ -19,7 +19,7 @@
                 #interim-claim-info-details.panel.panel-border-narrow.js-hidden
                   .form-group
                     %fieldset
-                      %legend.visuallyhidden
+                      %legend.govuk-visually-hidden
                         = t('.warrant_fee')
                       .warrant-fee-issued-date-group
                         = ff.gov_uk_date_field :warrant_issued_date,

--- a/app/views/external_users/claims/interim_claim_info/_summary.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_summary.html.haml
@@ -5,7 +5,7 @@
       = t('common.warrant_fees')
 
     %table.summary
-      %caption.visuallyhidden
+      %caption.govuk-visually-hidden
         = t('.caption')
 
       %tbody

--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -48,7 +48,7 @@
 
 .form-group
   #offence-list.fx-view
-    .fx-results-found.visually-hidden
+    .fx-results-found.govuk-visually-hidden
       %p
     .fx-filters-display
       %p

--- a/app/views/external_users/claims/supporting_documents/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_summary.html.haml
@@ -3,7 +3,7 @@
     Evidence supplied on disk
 
   %table.summary
-    %caption.visuallyhidden
+    %caption.govuk-visually-hidden
       = "Evidence supplied on disk"
     %tbody
       %tr
@@ -16,7 +16,7 @@
   Supporting evidence documents
 
 %table.summary
-  %caption.visuallyhidden
+  %caption.govuk-visually-hidden
     = t('.caption')
   %tbody
     - claim.documents.each do |document|

--- a/app/views/external_users/claims/supporting_evidence_checklist/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_summary.html.haml
@@ -7,7 +7,7 @@
 - else
   / Table does not require summary
   %table{class:'table-summary'}
-    %caption.visuallyhidden
+    %caption.govuk-visually-hidden
       = t('.caption')
     %tbody
       - DocType.find_by_ids(claim.evidence_checklist_ids).each do |dt|

--- a/app/views/external_users/claims/transfer_detail/_summary.html.haml
+++ b/app/views/external_users/claims/transfer_detail/_summary.html.haml
@@ -11,7 +11,7 @@
     = render partial: 'external_users/claims/summary/section_status', locals: { claim: claim, section: section, step: :transfer_fee_details }
 
   %table.summary
-    %caption.visuallyhidden
+    %caption.govuk-visually-hidden
       = t('.caption')
     %tbody
       %tr

--- a/app/views/external_users/claims/warrant_fee/_fields.html.haml
+++ b/app/views/external_users/claims/warrant_fee/_fields.html.haml
@@ -5,7 +5,7 @@
   = f.fields_for :warrant_fee do |wf|
     .form-group
       %fieldset
-        %legend.visuallyhidden
+        %legend.govuk-visually-hidden
           = t('.warrant_fee')
         .warrant-fee-issued-date-group
           = wf.gov_uk_date_field :warrant_issued_date,

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -9,7 +9,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       %nav.pagination
-        %p.visually-hidden
+        %p.govuk-visually-hidden
           = t('views.pagination.title')
         %ul
           = first_page_tag unless current_page.first?

--- a/app/views/provider_management/providers/_providers.html.haml
+++ b/app/views/provider_management/providers/_providers.html.haml
@@ -4,7 +4,7 @@
 
 - else
   %table{ summary: t('.table_summary') }
-    %caption.heading-medium.visually-hidden
+    %caption.govuk-visually-hidden
       = t('.caption')
 
     %thead

--- a/app/views/shared/_certification.html.haml
+++ b/app/views/shared/_certification.html.haml
@@ -2,7 +2,7 @@
   = t('.certification_box_title')
 
 %table.table-summary
-  %caption.visuallyhidden
+  %caption.govuk-visually-hidden
     = t('.certification_caption')
 
   %tbody

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -4,7 +4,7 @@
 %h3.heading-medium
   = "Claim and case type"
 %table.table-summary
-  %caption.visuallyhidden
+  %caption.govuk-visually-hidden
     = "This section contains details of the case"
   %tbody
     - unless claim.providers_ref.blank?

--- a/app/views/shared/_determination.html.haml
+++ b/app/views/shared/_determination.html.haml
@@ -7,7 +7,7 @@
         .message-body
           = determination.event
           %table
-            %caption.visuallyhidden
+            %caption.govuk-visually-hidden
               = t('.caption')
             - determination.itemise do |item, amount|
               %tr

--- a/app/views/shared/_determinations_table.html.haml
+++ b/app/views/shared/_determinations_table.html.haml
@@ -8,7 +8,7 @@
     = t('shared.determinations_form.assessment_summary')
 
   %table#determinations
-    %caption.visuallyhidden
+    %caption.govuk-visually-hidden
       = t('.caption')
     %thead
       %tr

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -11,7 +11,7 @@
 
   - else
     %table#download-files-report
-      %caption.visually-hidden
+      %caption.govuk-visually-hidden
         = t('.caption')
       %thead
         %tr

--- a/app/views/shared/_history_items_list.html.haml
+++ b/app/views/shared/_history_items_list.html.haml
@@ -5,7 +5,7 @@
   - else
     - claim.history_items_by_date.each do |date, history_items|
       %fieldset.single-date
-        %legend.visuallyhidden
+        %legend.govuk-visually-hidden
           = casual_date(date)
         .event-date
           = casual_date(date)

--- a/app/views/shared/_summary.html.haml
+++ b/app/views/shared/_summary.html.haml
@@ -8,7 +8,7 @@
     - else
       / table does noe require summary
       %table
-        %caption.visually-hidden
+        %caption.govuk-visually-hidden
           = t('.fees.caption')
         %thead
           %tr
@@ -63,7 +63,7 @@
     - else
       / table does noe require summary
       %table
-        %caption.visually-hidden
+        %caption.govuk-visually-hidden
           = t('.expenses.caption')
 
         %thead
@@ -128,7 +128,7 @@
       - else
         / table does noe require summary
         %table
-          %caption.visually-hidden
+          %caption.govuk-visually-hidden
             = t('.disbursements.caption')
 
           %thead

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -9,7 +9,7 @@
     - else
       / table does not require summary
       %table.figures
-        %caption.visually-hidden
+        %caption.govuk-visually-hidden
           = t('.fees.caption')
         %thead
           %tr

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -8,7 +8,7 @@
     - else
       / table does noe require summary
       %table.figures
-        %caption.visually-hidden
+        %caption.govuk-visually-hidden
           = t('.fees.caption')
         %thead
           %tr
@@ -102,7 +102,7 @@
           %h3.heading-medium
             = t('shared.disbursements_gross')
           %table.figures
-            %caption.visually-hidden
+            %caption.govuk-visually-hidden
               = t('.disbursements.caption')
             %thead
               %tr
@@ -140,7 +140,7 @@
           %h3.heading-medium
             = t('shared.disbursements_no_vat')
           %table.figures
-            %caption.visually-hidden
+            %caption.govuk-visually-hidden
               = t('.disbursements.caption')
             %thead
               %tr

--- a/app/views/shared/summary/expenses/index.html.haml
+++ b/app/views/shared/summary/expenses/index.html.haml
@@ -3,7 +3,7 @@
     = t(".header_#{vat ? 'with_vat' : 'without_vat'}")
 
   %table.figures{ class: (current_user.case_worker? ? 'expenses-data-table' : nil) }
-    %caption.visually-hidden
+    %caption.govuk-visually-hidden
       = t('.caption')
 
     %thead

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -121,7 +121,7 @@ moj.Modules.AllocationDataTable = {
         selectAllPages: false
       },
       render: function (data, type, row) {
-        return '<input type="checkbox" class="dt-checkboxes" id="claim-' + data + '"><label for="claim-' + data + '" class="visually-hidden">claim id ' + data + '</label>'
+        return '<input type="checkbox" class="dt-checkboxes" id="claim-' + data + '"><label for="claim-' + data + '" class="govuk-visually-hidden">claim id ' + data + '</label>'
       }
     }, {
       targets: 1,

--- a/app/webpack/javascripts/modules/case_worker/Allocation.js
+++ b/app/webpack/javascripts/modules/case_worker/Allocation.js
@@ -12,7 +12,7 @@ moj.Modules.Allocation = {
 
       $('#allocation-case-worker-id-field-select').attr('aria-label', 'Case worker')
 
-      $('.dt-checkboxes-select-all input').replaceWith('<input type="checkbox" id="select-all-claim"><label for="select-all-claim" class="visually-hidden">Select all claims</label>')
+      $('.dt-checkboxes-select-all input').replaceWith('<input type="checkbox" id="select-all-claim"><label for="select-all-claim" class="govuk-visually-hidden">Select all claims</label>')
     }
   }
 }

--- a/app/webpack/javascripts/vendor/typeahead-aria.js
+++ b/app/webpack/javascripts/vendor/typeahead-aria.js
@@ -1931,7 +1931,7 @@
     var Status = function() {
         "use strict";
         function Status(options) {
-            this.el = '<span role="status" aria-live="polite" class="visuallyhidden"></span>';
+            this.el = '<span role="status" aria-live="polite" class="govuk-visually-hidden"></span>';
             this.$el = $(this.el);
             options.$input.after(this.$el);
             _.each(options.menu.datasets, _.bind(function(dataset) {

--- a/app/webpack/stylesheets/_buttons.scss
+++ b/app/webpack/stylesheets/_buttons.scss
@@ -31,7 +31,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 }
 
 .button-holder {
-  @include clearfix;
+  @include govuk-clearfix;
 
   margin-top: $gutter;
 }

--- a/app/webpack/stylesheets/_claims_importer.scss
+++ b/app/webpack/stylesheets/_claims_importer.scss
@@ -11,7 +11,7 @@
   .js-enabled & {
     input[type="file"],
     .no-file-selected [type="submit"] {
-      @include visually-hidden;
+      @include govuk-visually-hidden;
     }
   }
 

--- a/app/webpack/stylesheets/_messages.scss
+++ b/app/webpack/stylesheets/_messages.scss
@@ -76,10 +76,6 @@
           width: $half;
           margin-left: auto;
 
-          .visuallyhidden {
-            display: none;
-          }
-
           td {
             border-top: 1px solid $border-colour;
           }

--- a/app/webpack/stylesheets/_project-helpers.scss
+++ b/app/webpack/stylesheets/_project-helpers.scss
@@ -1,21 +1,5 @@
 // HELPERS
 
-@mixin clearfix {
-  zoom: 1;
-
-  &:before,
-  &:after {
-    content: "";
-    display: block;
-    height: 0;
-    overflow: hidden;
-  }
-
-  &:after {
-    clear: both;
-  }
-}
-
 .hidden,
 .js-enabled .js-hidden {
   display: none;

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -494,7 +494,7 @@ form {
 
 // Ported from v1 stylesheets
 .search-form {
-  @include clearfix;
+  @include govuk-clearfix;
 
   .heading-medium {
     margin-top: 0;

--- a/app/webpack/stylesheets/_tables.scss
+++ b/app/webpack/stylesheets/_tables.scss
@@ -241,7 +241,7 @@ table {
       }
 
       &.mobile-sort {
-        @include clearfix;
+        @include govuk-clearfix;
         display: inline-block;
         width: $full-width;
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,12 +83,12 @@ en:
   views:
     pagination:
       title: "Pagination navigation"
-      first_html: "First <span class='visually-hidden'>page</span>"
-      last_html: "Last <span class='visually-hidden'>page</span>"
-      previous_html: "Previous <span class='visually-hidden'>page</span>"
-      next_html: "Next <span class='visually-hidden'>page</span>"
+      first_html: "First <span class='govuk-visually-hidden'>page</span>"
+      last_html: "Last <span class='govuk-visually-hidden'>page</span>"
+      previous_html: "Previous <span class='govuk-visually-hidden'>page</span>"
+      next_html: "Next <span class='govuk-visually-hidden'>page</span>"
       truncate: "&hellip;"
-      page_html: "<span class='visually-hidden'>Page </span>%{count}"
+      page_html: "<span class='govuk-visually-hidden'>Page </span>%{count}"
   helpers:
     page_entries_info:
       one_page:
@@ -1430,8 +1430,8 @@ en:
       financial_summary:
         total_outstanding: 'Total outstanding:'
         total_authorised: 'Total authorised:'
-        view_details_outstanding_html: 'View details <span class="visuallyhidden">for total outstanding</span>'
-        view_details_authorised_html: 'View details <span class="visuallyhidden">for total authorised</span>'
+        view_details_outstanding_html: 'View details <span class="govuk-visually-hidden">for total outstanding</span>'
+        view_details_authorised_html: 'View details <span class="govuk-visually-hidden">for total authorised</span>'
         outstanding_claim_details_label: View outstanding claims details
         authorised_claim_details_label: View authorised claims details
       graduated_fees:


### PR DESCRIPTION
#### What

Replace app css helpers with that of the GOV.UK Design System

#### Ticket

[Replace stylesheet helper classes](https://dsdmoj.atlassian.net/browse/CFP-155)

#### Why

To continue the migration away from the deprecated GOV.UK Elements to GOV.UK Frontend (GOV.UK Design System)

#### How

| GOV.UK Elements | GOV.UK Frontend |
| --- | ----------- |
| visually-hidden, visuallyhidden | govuk-visually-hidden, govuk-visually-hidden-focusable |
| clearfix | govuk-clearfix |
