### PR TITLE
Revert "[CFP-61] Migrate Allocation forms to GOVUKDesignSystemFormBuilder"

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -1,48 +1,54 @@
-#allocation
-  = govuk_notification_banner('Allocation', nil, class: 'govuk-!-display-none') unless !flash.empty?
+= render partial: 'errors/error_summary', locals: { ep: @allocation, error_summary: t('.error_summary') }
+
+= govuk_notification_banner('Allocation', nil, class: 'govuk-!-display-none') unless !flash.empty?
 
 #api-key.govuk-grid-row{ data: { api_key: current_user.api_key } }
   .govuk-grid-column-two-thirds
     = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
+  .govuk-grid-column-one-third.scheme-filters
+    -# FORM
+    -# AGFS / LGFS Radios
+    = render partial: 'scheme_filters'
 
-= form_with url: case_workers_admin_allocations_path, method: :get, builder: GdsAdpFormBuilder do |f|
-  = f.hidden_field :tab, id: :tab, value: params[:tab]
-  = f.hidden_field :scheme, id: :scheme, value: params[:scheme]
-  = f.hidden_field :filter, id: :filter, value: params[:filter] if params[:filter]
-  = f.hidden_field :page, id: :page, value: params[:page]
-  = f.hidden_field :value_band_id, id: :value_band_id, value: params[:value_band_id] if params[:value_band_id]
+= form_tag case_workers_admin_allocations_path, method: :get do
+  = hidden_field_tag :tab, params[:tab]
+  = hidden_field_tag :scheme, params[:scheme]
+  = hidden_field_tag :filter, params[:filter] if params[:filter]
+  = hidden_field_tag :page, params[:page]
+  = hidden_field_tag :value_band_id, params[:value_band_id] if params[:value_band_id]
 
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds.scheme-filters
-      = render partial: 'scheme_filters', locals: { f: f }
+  %fieldset.inline
+    %legend
+      %span.heading-medium
+        = t('.allocate_claims')
+    .govuk-grid-row.js-typeahead
+      .govuk-grid-column-one-third.js-typeahead
+        = label_tag :quantity_to_allocate, t('.no_of_claims'), class: 'form-label-bold'
+        = number_field_tag :quantity_to_allocate, nil, { min: 0, size: 5, class: 'form-control form-control-full' }
+      .govuk-grid-column-one-third
+        #cc-caseworker
+          = label_tag :allocation_case_worker_id, t('dictionary.models.case_worker'), class: 'form-label-bold'
+          = collection_select :allocation, :case_worker_id, @case_workers, :id, :name, { include_blank: ''.html_safe }, { class: 'form-control form-control-full fx-autocomplete' }
+      .govuk-grid-column-one-third
+        %br/
+        = govuk_button(t('.allocate'), class: 'allocation-submit')
 
-  = f.govuk_fieldset legend: { text: t('.allocate_claims'), size: 'm' } do
+
+  %fieldset.inline
+    %legend
+      %span.heading-medium
+        = t('.filter_claims')
     .govuk-grid-row
+      .govuk-grid-column-one-third.ui-filter
+        = render partial: 'filter_tasks'
+      .govuk-grid-column-one-third.ui-filter
+        = render partial: 'filter_value_bands'
       .govuk-grid-column-one-third
-        = f.govuk_number_field :quantity_to_allocate, label: { text: t('.no_of_claims') }
+        %br/
+        = govuk_button(t('.clear_filters'), class: 'clear-filters app-button--blue')
 
-      #cc-caseworker.govuk-grid-column-one-third.fx-autocomplete-wrapper
-        = f.govuk_select :allocation_case_worker_id, label: { text: t('dictionary.models.case_worker') } do
-          = options_for_select [['', '']]
-          = options_from_collection_for_select @case_workers, :id, :name
-
-      .govuk-grid-column-one-third{ class: 'govuk-!-padding-top-6' }
-        = govuk_button t('.allocate'), class: 'allocation-submit'
-
-  = f.govuk_fieldset legend: { text: t('.filter_claims'), size: 'm' } do
-    .govuk-grid-row
-      .govuk-grid-column-one-third
-        = render partial: 'filter_tasks', locals: { f: f }
-
-      .govuk-grid-column-one-third
-        = render partial: 'filter_value_bands', locals: { f: f }
-
-      .govuk-grid-column-one-third{ class: 'govuk-!-padding-top-6' }
-        = govuk_button t('.clear_filters'), class: 'clear-filters app-button--blue'
-
-  %h2.govuk-heading-m
+  %h2.heading-medium
     = t('.allocation_queue')
-
   %table#dtAllocation
     %caption.visually-hidden
       = t('.table_summary')

--- a/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_tasks.html.haml
@@ -1,29 +1,60 @@
-#filter-tasks-agfs.dtFilter.dtFilterAGFS{ data: { scheme: 'agfs' } }
-  = f.govuk_select :filterAGFS, label: { text: t('.case_types') } do
-    = options_for_select [[t('.all'), '']]
-    = options_for_select [[t('.fixed_fee'), 'fixed_fee']]
-    = options_for_select [[t('.cracked'), 'cracked']]
-    = options_for_select [[t('.trial'), 'trial']]
-    = options_for_select [[t('.guilty_plea'), 'guilty_plea']]
-    = options_for_select [[t('.redetermination'), 'redetermination']]
-    = options_for_select [[t('.awaiting_written_reasons'), 'awaiting_written_reasons']]
-    = options_for_select [[t('.disk_evidence'), 'disk_evidence']]
-    = options_for_select [[t('.injection_errors'), 'injection_errored']]
-    = options_for_select [[t('.warrants'), 'agfs_warrants']]
-    = options_for_select [[t('.supplementary'), 'supplementary']]
-    = options_for_select [[t('.hardship'), 'agfs_hardship']]
+#filter-tasks-agfs.form-group.dtFilter.dtFilterAGFS{ data: { scheme: 'agfs' } }
+  %label.form-label-bold{ for: 'filterAGFS' }
+    = t('.case_types')
 
-#filter-tasks-lgfs.dtFilter.dtFilterLGFS.hidden{ data: { scheme: 'lgfs' } }
-  = f.govuk_select :filterLGFS, label: { text: t('.case_types') } do
-    = options_for_select [[t('.all'), '']]
-    = options_for_select [[t('.fixed_fee'), 'fixed_fee']]
-    = options_for_select [[t('.graduated_fees'), 'graduated_fees']]
-    = options_for_select [[t('.interim_fees'), 'interim_fees']]
-    = options_for_select [[t('.warrants'), 'lgfs_warrants']]
-    = options_for_select [[t('.interim_disbursements'), 'interim_disbursements']]
-    = options_for_select [[t('.risk_based_bills'), 'risk_based_bills']]
-    = options_for_select [[t('.redetermination'), 'redetermination']]
-    = options_for_select [[t('.awaiting_written_reasons'), 'awaiting_written_reasons']]
-    = options_for_select [[t('.disk_evidence'), 'disk_evidence']]
-    = options_for_select [[t('.injection_errors'), 'injection_errored']]
-    = options_for_select [[t('.hardship'), 'lgfs_hardship']]
+  %select#filterAGFS.form-control.form-control-full{ name: 'tasks' }
+    %option{ value: '' }
+      = t('.all')
+    %option{ value: 'fixed_fee' }
+      = t('.fixed_fee')
+    %option{ value: 'cracked' }
+      = t('.cracked')
+    %option{ value: 'trial' }
+      = t('.trial')
+    %option{ value: 'guilty_plea' }
+      = t('.guilty plea')
+    %option{ value: 'redetermination' }
+      = t('.redetermination')
+    %option{ value: 'awaiting_written_reasons' }
+      = t('.awaiting_written_reasons')
+    %option{ value: 'disk_evidence' }
+      = t('.disk_evidence')
+    %option{ value: 'injection_errored' }
+      = t('.injection_errors')
+    %option{ value: 'agfs_warrants' }
+      = t('.warrants')
+    %option{ value: 'supplementary' }
+      = t('.supplementary')
+    %option{ value: 'agfs_hardship' }
+      = t('.hardship')
+
+
+#filter-tasks-lgfs.form-group.dtFilter.dtFilterLGFS.hidden{ data: { scheme: 'lgfs' } }
+  %label.form-label-bold{ for: 'filterLGFS' }
+    = t('.case_types')
+
+  %select#filterLGFS.form-control.form-control-full{ name: 'tasks' }
+    %option{ value: '' }
+      = t('.all')
+    %option{ value: 'fixed_fee' }
+      = t('.fixed_fee')
+    %option{ value: 'graduated_fees' }
+      = t('.graduated_fees')
+    %option{ value: 'interim_fees' }
+      = t('.interim_fees')
+    %option{ value: 'lgfs_warrants' }
+      = t('.warrants')
+    %option{ value: 'interim_disbursements' }
+      = t('.interim_disbursements')
+    %option{ value: 'risk_based_bills' }
+      = t('.risk_based_bills')
+    %option{ value: 'redetermination' }
+      = t('.redetermination')
+    %option{ value: 'awaiting_written_reasons' }
+      = t('.awaiting_written_reasons')
+    %option{ value: 'disk_evidence' }
+      = t('.disk_evidence')
+    %option{ value: 'injection_errored' }
+      = t('.injection_errors')
+    %option{ value: 'lgfs_hardship' }
+      = t('.hardship')

--- a/app/views/case_workers/admin/allocations/_filter_value_bands.html.haml
+++ b/app/views/case_workers/admin/allocations/_filter_value_bands.html.haml
@@ -1,7 +1,15 @@
-#filter-value-bands.dtFilter
-  = f.govuk_select :filterValue, label: { text: t('.value') } do
-    = options_for_select [[t('.all'), '']]
-    = options_for_select [[t('.tier1'), 'max:25000']]
-    = options_for_select [[t('.tier2'), 'min:25000.01|max:100000']]
-    = options_for_select [[t('.tier3'), 'min:100000.01|max:150000']]
-    = options_for_select [[t('.tier4'), 'min:150000.01|max:999999.99']]
+#filter-value-bands.form-group.dtFilter
+  %label.form-label-bold{ for: 'select-box-filter-value' }
+    = t('.value')
+
+  %select#select-box-filter-value.form-control.form-control-full{ name: 'filter_value_bands' }
+    %option{ value: '' }
+      = t('.all')
+    %option{ value: 'max:25000' }
+      = t('.tier1')
+    %option{ value: 'min:25000.01|max:100000' }
+      = t('.tier2')
+    %option{ value: 'min:100000.01|max:150000' }
+      = t('.tier3')
+    %option{ value: 'min:150000.01|max:999999.99' }
+      = t('.tier4')

--- a/app/views/case_workers/admin/allocations/_scheme_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_scheme_filters.html.haml
@@ -1,7 +1,16 @@
-#allocation-filters
-  = f.govuk_collection_radio_buttons :scheme,
-    [['AGFS','agfs'], ['LGFS','lgfs']],
-    :last,
-    :first,
-    inline: true,
-    legend: { text: t('.choose_your_scheme'), size: 'm' }
+#allocation-filters.form-group
+  %fieldset.inline
+    %legend.visuallyhidden
+      = t('.choose_your_scheme')
+
+    .multiple-choice
+      %input#scheme_agfs{ name: 'scheme', type: 'radio', value: 'agfs', checked: 'checked' }
+      %label.form-label{ for: 'scheme_agfs' }
+        = t('.agfs')
+    .multiple-choice
+      %input#scheme_lgfs{ name: 'scheme', type: 'radio', value: 'lgfs' }
+      %label.form-label{ for: 'scheme_lgfs' }
+        = t('.lgfs')
+
+    %noscript
+      = submit_tag t('.submit')

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -73,7 +73,7 @@ moj.Modules.AllocationDataTable = {
 
     // dom template with custom wrappers and structure
     // =>/options/dom
-    dom: '<"govuk-grid-row"<"govuk-grid-column-one-half"<"govuk-form-group"f>><"govuk-grid-column-one-half"i>>rt<"govuk-grid-row govuk-!-margin-top-5"<"govuk-grid-column-one-third"<"govuk-form-group"l>><"govuk-grid-column-two-thirds"p>>',
+    dom: '<"form-group"<"govuk-grid-column-one-half"f><"govuk-grid-column-one-half"i>>rt<"govuk-grid-row"<"govuk-grid-column-one-third"l><"govuk-grid-column-two-thirds"p>>',
 
     // rowId can be sourced from the row data
     rowId: 'id',
@@ -166,7 +166,7 @@ moj.Modules.AllocationDataTable = {
   init: function () {
     this.$el = $('#dtAllocation')
     this.ui.$submit = $('.allocation-submit')
-    this.ui.$notificationMsg = $('#allocation .govuk-notification-banner')
+    this.ui.$notificationMsg = $('.govuk-notification-banner')
 
     this.searchConfig.key = $('#api-key').data('api-key')
 
@@ -175,12 +175,7 @@ moj.Modules.AllocationDataTable = {
     this.dataTable = moj.Modules.DataTables._init(this.options, '#dtAllocation')
 
     // :(
-    $('#dtAllocation_filter').find('input').addClass('govuk-input govuk-!-width-three-quarters')
-    $('#dtAllocation_length').find('select').addClass('govuk-select')
-
-    // circumvent radio rule "Do not pre-select radio options"
-    // plugin requires a default scheme to be set
-    $('#scheme-agfs-field').prop('checked', true)
+    $('#dtAllocation_filter').find('input').addClass('form-control')
 
     this.bindEvents()
     this.registerCustomSearch()
@@ -282,20 +277,14 @@ moj.Modules.AllocationDataTable = {
     })
 
     // EVENT: Task filter
-    $.subscribe('/filter/filterAGFS/', function (e, data) {
-      self.searchConfig.task = data.data
-      self.clearCheckboxes()
-      self.tableDraw()
-    })
-
-    $.subscribe('/filter/filterLGFS/', function (e, data) {
+    $.subscribe('/filter/tasks/', function (e, data) {
       self.searchConfig.task = data.data
       self.clearCheckboxes()
       self.tableDraw()
     })
 
     // EVENT: Value band Filter
-    $.subscribe('/filter/filterValue/', function (e, data) {
+    $.subscribe('/filter/filter_value_bands/', function (e, data) {
       const valueSelected = data.data.split('|')
       self.searchConfig.valueBands = {}
       valueSelected.forEach(function (data) {
@@ -312,15 +301,15 @@ moj.Modules.AllocationDataTable = {
 
     // EVENT: Allocate claims
     $('.allocation-submit').on('click', function (e) {
-      self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--error govuk-notification-banner--success')
+      self.ui.$notificationMsg.removeClass('govuk-!-display-none')
       self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html('Allocating.. please wait a moment..')
 
       e.preventDefault()
       self.ui.$submit.prop('disabled', true)
 
-      const quantityToAllocate = $('#quantity-to-allocate-field').val() || false
+      const quantityToAllocate = $('#quantity_to_allocate').val() || false
 
-      const allocationCaseWorkerId = $('#allocation-case-worker-id-field-select').val()
+      const allocationCaseWorkerId = $('#allocation_case_worker_id-select').val()
 
       if (!allocationCaseWorkerId) {
         // console.log('No Caseworker selected');
@@ -354,19 +343,16 @@ moj.Modules.AllocationDataTable = {
           claim_ids: data
         }
       }).success(function (data) {
-        self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--error')
+        self.ui.$notificationMsg.removeClass('govuk-!-display-none')
         self.ui.$notificationMsg.addClass('govuk-notification-banner--success')
-        self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html(data.allocated_claims.length + ' claims have been allocated to ' + $('#allocation-case-worker-id-field').val())
+        self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html(data.allocated_claims.length + ' claims have been allocated to ' + $('#allocation_case_worker_id').val())
 
         self.reloadScheme({
           scheme: self.searchConfig.scheme
         })
       }).error(function (data) {
-        self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--success')
+        self.ui.$notificationMsg.removeClass('govuk-!-display-none')
         self.ui.$notificationMsg.addClass('govuk-notification-banner--error')
-        if (data.status === 422) {
-          return self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html('Unable to allocate claim')
-        }
         self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html(data.responseJSON.errors.join(''))
       }).always(function () {
         self.ui.$submit.prop('disabled', false)

--- a/app/webpack/javascripts/modules/case_worker/Allocation.js
+++ b/app/webpack/javascripts/modules/case_worker/Allocation.js
@@ -2,7 +2,7 @@ moj.Modules.Allocation = {
   init: function () {
     // Only work on the allocation page
     if ($('.js-allocation-page').length > 0) {
-      $('.fx-autocomplete-wrapper select').is(function (idx, el) {
+      $('.fx-autocomplete').is(function (idx, el) {
         moj.Helpers.Autocomplete.new('#' + el.id, {
           showAllValues: true,
           autoselect: false,
@@ -10,7 +10,7 @@ moj.Modules.Allocation = {
         })
       })
 
-      $('#allocation-case-worker-id-field-select').attr('aria-label', 'Case worker')
+      $('#allocation_case_worker_id-select').attr('aria-label', 'Case worker')
 
       $('.dt-checkboxes-select-all input').replaceWith('<input type="checkbox" id="select-all-claim"><label for="select-all-claim" class="visually-hidden">Select all claims</label>')
     }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2444,7 +2444,6 @@ en:
           disk_evidence: Disk evidence
           fixed_fee: Fixed fee
           graduated_fees: Graduated fees
-          guilty_plea: Guilty Plea
           injection_errors: Injection errors
           interim_disbursements: Interim disbursements
           interim_fees: Interim fees

--- a/features/allocation.feature
+++ b/features/allocation.feature
@@ -7,35 +7,26 @@ Feature: Case worker admin allocates claims
 
     And I insert the VCR cassette 'features/case_workers/admin/allocation'
 
-    When I am a signed in case worker admin
+    And I am a signed in case worker admin
     Then the page should be accessible
-
     When I visit the allocation page
     Then I should see a page title "View the allocation queue"
-    And the page should be accessible
+    Then the page should be accessible
     And I should see the AGFS filters
-
-    When I select claims "T20160001, T20160002"
+    And I select claims "T20160001, T20160002"
     And I select case worker "John Smith"
     And I click Allocate
-    Then I should see '2 claims have been allocated to John Smith'
-    And claims "T20160001, T20160002" should be allocated to case worker "John Smith"
+    Then claims "T20160001, T20160002" should be allocated to case worker "John Smith"
     And claims "T20160001, T20160002" should no longer be displayed
-
-    When I enter 2 in the the number of claims field
-    And I select case worker "John Smith"
-    And I click Allocate
-    Then I should see '2 claims have been allocated to John Smith'
-    And claims "T20160003, T20160004" should no longer be displayed
-
-    When I sign out
+    And I should see '2 claims have been allocated to John Smith'
+    Then the page should be accessible
+    And I sign out
     Then I should see a page title "Help us improve this service"
-
     When I sign in as John Smith
     Then I should be on the 'Your claims' page
-    And I should see a page title "View your allocated claims list"
-    And the page should be accessible
-    And claims "T20160001, T20160002, T20160003, T20160004" should appear on the page
+    Then I should see a page title "View your allocated claims list"
+    Then the page should be accessible
+    And claims "T20160001, T20160002" should appear on the page
     And I sign out
 
     And I eject the VCR cassette

--- a/features/page_objects/allocation_page.rb
+++ b/features/page_objects/allocation_page.rb
@@ -3,8 +3,6 @@ class AllocationPage < BasePage
 
   set_url "/case_workers/admin"
 
-  element :quantity_to_allocate, '#quantity-to-allocate-field'
-
   element :allocate, "button.govuk-button.allocation-submit"
 
   section :auto_caseworker, CommonAutocomplete, "#cc-caseworker"

--- a/features/step_definitions/caseworker_claim_allocation_steps.rb
+++ b/features/step_definitions/caseworker_claim_allocation_steps.rb
@@ -91,10 +91,6 @@ When(/^I click Allocate$/) do
   wait_for_ajax
 end
 
-Then('I enter {int} in the the number of claims field') do |int|
-  @allocation_page.quantity_to_allocate.set int
-end
-
 When(/^I enter (\d+) in the quantity text field$/) do |quantity|
   within('.report') do
     @case_numbers = all('.js-test-case-number').map(&:text)
@@ -200,7 +196,7 @@ end
 
 Then(/^I should no longer see the case workers dropdown$/) do
   within '.js-case-worker-list' do
-    expect(page).to_not have_selector('#allocation-case-worker-id-field')
+    expect(page).to_not have_selector('#allocation_case_worker_id')
     expect(page).to_not have_content('Case worker')
   end
 end

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -91,7 +91,7 @@ describe('Modules.AllocationDataTable.js', function () {
     })
 
     it('...should have `dom`', function () {
-      expect(options.dom).toEqual('<"govuk-grid-row"<"govuk-grid-column-one-half"<"govuk-form-group"f>><"govuk-grid-column-one-half"i>>rt<"govuk-grid-row govuk-!-margin-top-5"<"govuk-grid-column-one-third"<"govuk-form-group"l>><"govuk-grid-column-two-thirds"p>>')
+      expect(options.dom).toEqual('<"form-group"<"govuk-grid-column-one-half"f><"govuk-grid-column-one-half"i>>rt<"govuk-grid-row"<"govuk-grid-column-one-third"l><"govuk-grid-column-two-thirds"p>>')
     })
 
     it('...should have `rowId`', function () {

--- a/spec/javascripts/Modules.Allocation_spec.js
+++ b/spec/javascripts/Modules.Allocation_spec.js
@@ -1,6 +1,6 @@
 describe('Modules.Allocation.js', function () {
   const mod = moj.Modules.Allocation
-  const filtersFixtureDOM = $('<div class="js-allocation-page"><div class="fx-autocomplete-wrapper"><select id="sampleID"><option value="1">Option 1</option></select></div></div>')
+  const filtersFixtureDOM = $('<div class="js-allocation-page"><select id="sampleID" class="fx-autocomplete"><option value="1">Option 1</option></select></div>')
 
   beforeEach(function () {
     $('body').append(filtersFixtureDOM)

--- a/vcr/cassettes/features/case_workers/admin/allocation.yml
+++ b/vcr/cassettes/features/case_workers/admin/allocation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers?api_key=bc7c74e5-ef5d-46cd-a27b-38c5f0b9e7a6
+    uri: http://localhost:3001/api/case_workers?api_key=8643b7fe-824d-47c6-933c-813c8ff4ff7d
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin19 x86_64) ruby/2.7.3p183
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -25,24 +25,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"b5f49c65e5d50c06d0d8a4985103891d"
+      - W/"c0930c386970dca6587adca24e2eaf95"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - a42cb475-7adc-4511-8b33-cd7e177cc61b
+      - 39ef2cbb-cfcb-455f-9896-e9b7c8d4234d
       X-Runtime:
-      - '0.152042'
+      - '0.023642'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '[{"id":1,"uuid":"767f2523-d544-49b9-8e9b-3320e026228b","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"},{"id":2,"uuid":"de3e2301-4409-453e-b440-879fe28f0191","first_name":"Leisha","last_name":"Rohan","email":"leisha.rohan@laa.gov.uk"}]'
-  recorded_at: Mon, 07 Jun 2021 14:08:32 GMT
+      string: '[{"id":1,"uuid":"2ce6b71e-092b-43be-b65e-99bc1fe12dad","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"},{"id":2,"uuid":"31bb00ba-fcea-4872-9ae0-b126fb31c2a6","first_name":"Polly","last_name":"Kozey","email":"polly.kozey@laa.gov.uk"}]'
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 10:10:46 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=bc7c74e5-ef5d-46cd-a27b-38c5f0b9e7a6&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
+    uri: http://localhost:3001/api/case_workers/claims?api_key=8643b7fe-824d-47c6-933c-813c8ff4ff7d&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
     body:
       encoding: US-ASCII
       string: ''
@@ -50,7 +51,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin19 x86_64) ruby/2.7.3p183
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -65,32 +66,33 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"39ae733e1dcbb4ef951acf3dc2c422fa"
+      - W/"2c3378451587e53dc15e7be048e5a927"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - bfbd95bc-6f7f-468a-9d9b-16febfd61971
+      - 7c0cdfbd-9c02-4a5a-bf15-ef365ea80e45
       X-Runtime:
-      - '0.329065'
+      - '0.103210'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":5,"limit_value":25},"items":[{"id":1,"uuid":"305e5765-32f1-4713-8df7-59e097f221c9","case_number":"T20160001","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"7a59104b-56dd-4c22-821c-4ab15a2680c4","first_name":"Johnny","last_name":"Johnson","email":"chassidy_reynolds@pouros-schneider.org"},"defendants":[{"id":1,"uuid":"759c0d83-4903-4774-93bd-40c44cf27133","first_name":"Darnell","last_name":"Rath","date_of_birth":"1991-06-07","representation_orders":[{"id":1,"uuid":"d95cb0f5-c13e-4073-aea1-d8faf8f5bea8","maat_reference":"9541971","date":"2016-01-01"},{"id":2,"uuid":"1af11569-276c-4329-85cb-e6edb3db2cd0","maat_reference":"5504274","date":"2020-05-23"}]}],"case_type":{"id":258,"name":"Case
-        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1267,"code":"XPR-1","name":"Gottlieb,
-        Lemke and Fisher-1","court_type":"crown"}},{"id":2,"uuid":"8eec378c-66de-49c9-9503-f3720c4a5870","case_number":"T20160002","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"27f6be95-1b0b-4426-800d-87ebc90619d9","first_name":"Marketta","last_name":"Crist","email":"renna@schimmel-kulas.name"},"defendants":[{"id":2,"uuid":"af44a57b-9919-4344-a974-a6868deb336e","first_name":"William","last_name":"Kihn","date_of_birth":"1991-06-07","representation_orders":[{"id":3,"uuid":"056a3b62-553b-4338-8671-62d4ce35e3df","maat_reference":"6988548","date":"2016-01-01"},{"id":4,"uuid":"15698574-990c-488a-a98b-4f5106556767","maat_reference":"9430357","date":"2020-05-23"}]}],"case_type":{"id":259,"name":"Case
-        Type 2","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1268,"code":"NJC-2","name":"Cruickshank-Bashirian-2","court_type":"crown"}},{"id":3,"uuid":"9f2de0ec-ef27-4606-9f89-f1b75ea0b134","case_number":"T20160003","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":3,"uuid":"ff4bd5d9-75f4-40ec-8e3d-4ab960649193","first_name":"Chelsea","last_name":"Howell","email":"sherri_hahn@yost.info"},"defendants":[{"id":3,"uuid":"1576538b-dd3f-41e8-b07e-80e1f034ebde","first_name":"Cleora","last_name":"Upton","date_of_birth":"1991-06-07","representation_orders":[{"id":5,"uuid":"750574e7-1d6a-4948-962e-786535f37ea2","maat_reference":"6011453","date":"2016-01-01"},{"id":6,"uuid":"302db5e1-dbd6-462b-ab21-9d59de25a0ae","maat_reference":"5023756","date":"2020-05-23"}]}],"case_type":{"id":260,"name":"Case
-        Type 3","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1269,"code":"NSY-3","name":"Lebsack,
-        Schmidt and VonRueden-3","court_type":"crown"}},{"id":4,"uuid":"845e1283-669e-46ef-9f79-3b2cf367f90c","case_number":"T20160004","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:30Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":4,"uuid":"b155b70b-0623-4de6-8c4d-52323be4bb99","first_name":"Toby","last_name":"O''Conner","email":"tamatha@maggio-dooley.net"},"defendants":[{"id":4,"uuid":"e2e861e0-37b7-49ac-b5b4-03725aa30f14","first_name":"Sang","last_name":"Thiel","date_of_birth":"1991-06-07","representation_orders":[{"id":7,"uuid":"0141fd4d-0be6-43a6-becf-beaba5407a28","maat_reference":"7227056","date":"2016-01-01"},{"id":8,"uuid":"3213c1f5-ba7e-4105-a702-9f07bb715b84","maat_reference":"7509053","date":"2020-05-23"}]}],"case_type":{"id":261,"name":"Case
-        Type 4","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1270,"code":"NWQ-4","name":"Langworth,
-        Renner and Greenfelder-4","court_type":"crown"}},{"id":5,"uuid":"95e9139c-71da-46e6-afc5-8fbd19be4604","case_number":"T20160005","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:30Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":5,"uuid":"969155d0-4eba-46b0-a667-9a03f03c6a76","first_name":"Abby","last_name":"Witting","email":"ligia_russel@bailey-miller.io"},"defendants":[{"id":5,"uuid":"559e1de3-2caf-4420-ab1f-d2b43d0fab1d","first_name":"Edna","last_name":"Jaskolski","date_of_birth":"1991-06-07","representation_orders":[{"id":9,"uuid":"91d6ed06-44ed-4b0f-adda-d328a8269ccd","maat_reference":"8606481","date":"2016-01-01"},{"id":10,"uuid":"256f00e1-d271-47e4-84c5-221f4d0fe2c3","maat_reference":"5585909","date":"2020-05-23"}]}],"case_type":{"id":262,"name":"Case
-        Type 5","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1271,"code":"DCS-5","name":"Price-D''Amore-5","court_type":"crown"}}]}'
-  recorded_at: Mon, 07 Jun 2021 14:08:32 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":5,"limit_value":25},"items":[{"id":1,"uuid":"be29d5d7-5893-4293-a24f-ce1ae83b4ebc","case_number":"T20160001","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"f0954eaa-88e4-47c5-ac20-f69b0a045d23","first_name":"Darron","last_name":"Grady","email":"daisy@mcculloughgerlach.name"},"defendants":[{"id":1,"uuid":"3df0480a-6fe6-4710-8a29-b375a4f43568","first_name":"Keith","last_name":"DuBuque","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"2b77aaa0-0780-4eec-8ad4-b819409a4639","maat_reference":"7264217","date":"2016-01-01"},{"id":2,"uuid":"2120cb77-2343-4341-b219-510c65c4a568","maat_reference":"8580707","date":"2018-08-22"}]}],"case_type":{"id":86,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":421,"code":"JUT-1","name":"Strosin-Kassulke-1","court_type":"crown"}},{"id":2,"uuid":"559ff23e-0d9e-476d-be0f-157229f111bf","case_number":"T20160002","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"17460748-d8f6-41de-8819-e544f2576638","first_name":"Harry","last_name":"Bednar","email":"hilario@ledner.name"},"defendants":[{"id":2,"uuid":"006be49a-c3d4-41e4-95fb-fe86bf6272e7","first_name":"Santiago","last_name":"Beer","date_of_birth":"1989-09-06","representation_orders":[{"id":3,"uuid":"ad129d9e-d270-4e31-97b8-431a972556d0","maat_reference":"4976373","date":"2016-01-01"},{"id":4,"uuid":"3b578759-e2a0-4d5f-ab12-275e299ae92f","maat_reference":"9115592","date":"2018-08-22"}]}],"case_type":{"id":87,"name":"Case
+        Type 2","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":422,"code":"KVA-2","name":"Kertzmann,
+        Schaefer and Russel-2","court_type":"crown"}},{"id":3,"uuid":"f455f7a8-a4d2-4c83-8d69-46e40fbfcecc","case_number":"T20160003","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":3,"uuid":"8d7518dd-d484-4699-8acd-d48614972f30","first_name":"Leon","last_name":"Mayert","email":"gregory_schroeder@bayerhamill.info"},"defendants":[{"id":3,"uuid":"aab28075-81bb-4b20-92fd-d5f8d616db1b","first_name":"Salena","last_name":"Smitham","date_of_birth":"1989-09-06","representation_orders":[{"id":5,"uuid":"3317b3ec-d3cc-4b4b-b3ee-c48045b2f0eb","maat_reference":"9416243","date":"2016-01-01"},{"id":6,"uuid":"7f228e2f-a033-4be0-ad68-997e0f360ea2","maat_reference":"7354754","date":"2018-08-22"}]}],"case_type":{"id":88,"name":"Case
+        Type 3","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":423,"code":"TWQ-3","name":"Bailey,
+        Romaguera and Sauer-3","court_type":"crown"}},{"id":4,"uuid":"81541999-935b-4e6e-a04b-ff980b6e7be5","case_number":"T20160004","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:43Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":4,"uuid":"d362248d-556e-4c22-8a4b-562fda415ace","first_name":"Tyrone","last_name":"King","email":"joannie@mitchellcrona.com"},"defendants":[{"id":4,"uuid":"d12f54c0-065c-4eb8-84dd-1faa89554517","first_name":"Pedro","last_name":"Treutel","date_of_birth":"1989-09-06","representation_orders":[{"id":7,"uuid":"0fe90abe-c6ff-4769-a709-f0c8e826e21a","maat_reference":"9672547","date":"2016-01-01"},{"id":8,"uuid":"6e8203fa-2a8f-4715-961a-1179517e456f","maat_reference":"8607172","date":"2018-08-22"}]}],"case_type":{"id":89,"name":"Case
+        Type 4","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":424,"code":"SQG-4","name":"Ledner
+        Inc-4","court_type":"crown"}},{"id":5,"uuid":"652b3f8f-ca4a-4289-bae4-5a1595297181","case_number":"T20160005","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:43Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":5,"uuid":"378b79cc-e455-466b-b501-bd014326fd2e","first_name":"Lowell","last_name":"Lynch","email":"sherrill.senger@feeneyweimann.io"},"defendants":[{"id":5,"uuid":"2d2cc2c4-76d2-4f22-bfec-86a6f50ce352","first_name":"Joane","last_name":"Hegmann","date_of_birth":"1989-09-06","representation_orders":[{"id":9,"uuid":"3b776b41-e064-415b-9ed9-66a2fb7d66e1","maat_reference":"7959620","date":"2016-01-01"},{"id":10,"uuid":"7dce4d53-80ef-4453-879d-bc58430774c5","maat_reference":"5493098","date":"2018-08-22"}]}],"case_type":{"id":90,"name":"Case
+        Type 5","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":425,"code":"PVI-5","name":"Okuneva-Adams-5","court_type":"crown"}}]}'
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 10:10:46 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers?api_key=bc7c74e5-ef5d-46cd-a27b-38c5f0b9e7a6
+    uri: http://localhost:3001/api/case_workers?api_key=8643b7fe-824d-47c6-933c-813c8ff4ff7d
     body:
       encoding: US-ASCII
       string: ''
@@ -98,7 +100,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin19 x86_64) ruby/2.7.3p183
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -113,24 +115,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"9cb732ee10074803a83623d289bf88b1"
+      - W/"c0930c386970dca6587adca24e2eaf95"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - b06ce5f5-9143-4387-b1c7-02e6f1df1f88
+      - 3fd4c14d-ff87-404f-9c09-070564bde39e
       X-Runtime:
-      - '0.011446'
+      - '0.008591'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '[{"id":1,"uuid":"767f2523-d544-49b9-8e9b-3320e026228b","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"},{"id":2,"uuid":"de3e2301-4409-453e-b440-879fe28f0191","first_name":"Leisha","last_name":"Rohan","email":"leisha.rohan@laa.gov.uk"}]'
-  recorded_at: Mon, 07 Jun 2021 14:08:35 GMT
+      string: '[{"id":1,"uuid":"2ce6b71e-092b-43be-b65e-99bc1fe12dad","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"},{"id":2,"uuid":"31bb00ba-fcea-4872-9ae0-b126fb31c2a6","first_name":"Polly","last_name":"Kozey","email":"polly.kozey@laa.gov.uk"}]'
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 10:10:46 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=bc7c74e5-ef5d-46cd-a27b-38c5f0b9e7a6&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
+    uri: http://localhost:3001/api/case_workers/claims?api_key=8643b7fe-824d-47c6-933c-813c8ff4ff7d&direction=asc&filter=all&limit=25&page=0&scheme=agfs&search=&sorting=last_submitted_at&status=unallocated&value_band_id=0
     body:
       encoding: US-ASCII
       string: ''
@@ -138,7 +141,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin19 x86_64) ruby/2.7.3p183
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -153,32 +156,33 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"4d5ddcc81906c2bf8ef48258695b497c"
+      - W/"afeb3da0862a7e633fb5e0034d7c80d3"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - a052851b-0287-4bb4-987c-67eed8ab7aee
+      - a742751a-af83-47d8-a6a8-a78799183c1f
       X-Runtime:
-      - '0.094282'
+      - '0.071878'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":5,"limit_value":25},"items":[{"id":1,"uuid":"305e5765-32f1-4713-8df7-59e097f221c9","case_number":"T20160001","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"7a59104b-56dd-4c22-821c-4ab15a2680c4","first_name":"Johnny","last_name":"Johnson","email":"chassidy_reynolds@pouros-schneider.org"},"defendants":[{"id":1,"uuid":"759c0d83-4903-4774-93bd-40c44cf27133","first_name":"Darnell","last_name":"Rath","date_of_birth":"1991-06-07","representation_orders":[{"id":1,"uuid":"d95cb0f5-c13e-4073-aea1-d8faf8f5bea8","maat_reference":"9541971","date":"2016-01-01"},{"id":2,"uuid":"1af11569-276c-4329-85cb-e6edb3db2cd0","maat_reference":"5504274","date":"2020-05-23"}]}],"case_type":{"id":258,"name":"Case
-        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1267,"code":"XPR-1","name":"Gottlieb,
-        Lemke and Fisher-1","court_type":"crown"}},{"id":2,"uuid":"8eec378c-66de-49c9-9503-f3720c4a5870","case_number":"T20160002","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"27f6be95-1b0b-4426-800d-87ebc90619d9","first_name":"Marketta","last_name":"Crist","email":"renna@schimmel-kulas.name"},"defendants":[{"id":2,"uuid":"af44a57b-9919-4344-a974-a6868deb336e","first_name":"William","last_name":"Kihn","date_of_birth":"1991-06-07","representation_orders":[{"id":3,"uuid":"056a3b62-553b-4338-8671-62d4ce35e3df","maat_reference":"6988548","date":"2016-01-01"},{"id":4,"uuid":"15698574-990c-488a-a98b-4f5106556767","maat_reference":"9430357","date":"2020-05-23"}]}],"case_type":{"id":259,"name":"Case
-        Type 2","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1268,"code":"NJC-2","name":"Cruickshank-Bashirian-2","court_type":"crown"}},{"id":3,"uuid":"9f2de0ec-ef27-4606-9f89-f1b75ea0b134","case_number":"T20160003","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":3,"uuid":"ff4bd5d9-75f4-40ec-8e3d-4ab960649193","first_name":"Chelsea","last_name":"Howell","email":"sherri_hahn@yost.info"},"defendants":[{"id":3,"uuid":"1576538b-dd3f-41e8-b07e-80e1f034ebde","first_name":"Cleora","last_name":"Upton","date_of_birth":"1991-06-07","representation_orders":[{"id":5,"uuid":"750574e7-1d6a-4948-962e-786535f37ea2","maat_reference":"6011453","date":"2016-01-01"},{"id":6,"uuid":"302db5e1-dbd6-462b-ab21-9d59de25a0ae","maat_reference":"5023756","date":"2020-05-23"}]}],"case_type":{"id":260,"name":"Case
-        Type 3","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1269,"code":"NSY-3","name":"Lebsack,
-        Schmidt and VonRueden-3","court_type":"crown"}},{"id":4,"uuid":"845e1283-669e-46ef-9f79-3b2cf367f90c","case_number":"T20160004","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:30Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":4,"uuid":"b155b70b-0623-4de6-8c4d-52323be4bb99","first_name":"Toby","last_name":"O''Conner","email":"tamatha@maggio-dooley.net"},"defendants":[{"id":4,"uuid":"e2e861e0-37b7-49ac-b5b4-03725aa30f14","first_name":"Sang","last_name":"Thiel","date_of_birth":"1991-06-07","representation_orders":[{"id":7,"uuid":"0141fd4d-0be6-43a6-becf-beaba5407a28","maat_reference":"7227056","date":"2016-01-01"},{"id":8,"uuid":"3213c1f5-ba7e-4105-a702-9f07bb715b84","maat_reference":"7509053","date":"2020-05-23"}]}],"case_type":{"id":261,"name":"Case
-        Type 4","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1270,"code":"NWQ-4","name":"Langworth,
-        Renner and Greenfelder-4","court_type":"crown"}},{"id":5,"uuid":"95e9139c-71da-46e6-afc5-8fbd19be4604","case_number":"T20160005","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:30Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":5,"uuid":"969155d0-4eba-46b0-a667-9a03f03c6a76","first_name":"Abby","last_name":"Witting","email":"ligia_russel@bailey-miller.io"},"defendants":[{"id":5,"uuid":"559e1de3-2caf-4420-ab1f-d2b43d0fab1d","first_name":"Edna","last_name":"Jaskolski","date_of_birth":"1991-06-07","representation_orders":[{"id":9,"uuid":"91d6ed06-44ed-4b0f-adda-d328a8269ccd","maat_reference":"8606481","date":"2016-01-01"},{"id":10,"uuid":"256f00e1-d271-47e4-84c5-221f4d0fe2c3","maat_reference":"5585909","date":"2020-05-23"}]}],"case_type":{"id":262,"name":"Case
-        Type 5","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":1271,"code":"DCS-5","name":"Price-D''Amore-5","court_type":"crown"}}]}'
-  recorded_at: Mon, 07 Jun 2021 14:08:35 GMT
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":5,"limit_value":25},"items":[{"id":1,"uuid":"be29d5d7-5893-4293-a24f-ce1ae83b4ebc","case_number":"T20160001","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"f0954eaa-88e4-47c5-ac20-f69b0a045d23","first_name":"Darron","last_name":"Grady","email":"daisy@mcculloughgerlach.name"},"defendants":[{"id":1,"uuid":"3df0480a-6fe6-4710-8a29-b375a4f43568","first_name":"Keith","last_name":"DuBuque","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"2b77aaa0-0780-4eec-8ad4-b819409a4639","maat_reference":"7264217","date":"2016-01-01"},{"id":2,"uuid":"2120cb77-2343-4341-b219-510c65c4a568","maat_reference":"8580707","date":"2018-08-22"}]}],"case_type":{"id":86,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":421,"code":"JUT-1","name":"Strosin-Kassulke-1","court_type":"crown"}},{"id":2,"uuid":"559ff23e-0d9e-476d-be0f-157229f111bf","case_number":"T20160002","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"17460748-d8f6-41de-8819-e544f2576638","first_name":"Harry","last_name":"Bednar","email":"hilario@ledner.name"},"defendants":[{"id":2,"uuid":"006be49a-c3d4-41e4-95fb-fe86bf6272e7","first_name":"Santiago","last_name":"Beer","date_of_birth":"1989-09-06","representation_orders":[{"id":3,"uuid":"ad129d9e-d270-4e31-97b8-431a972556d0","maat_reference":"4976373","date":"2016-01-01"},{"id":4,"uuid":"3b578759-e2a0-4d5f-ab12-275e299ae92f","maat_reference":"9115592","date":"2018-08-22"}]}],"case_type":{"id":87,"name":"Case
+        Type 2","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":422,"code":"KVA-2","name":"Kertzmann,
+        Schaefer and Russel-2","court_type":"crown"}},{"id":3,"uuid":"f455f7a8-a4d2-4c83-8d69-46e40fbfcecc","case_number":"T20160003","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":3,"uuid":"8d7518dd-d484-4699-8acd-d48614972f30","first_name":"Leon","last_name":"Mayert","email":"gregory_schroeder@bayerhamill.info"},"defendants":[{"id":3,"uuid":"aab28075-81bb-4b20-92fd-d5f8d616db1b","first_name":"Salena","last_name":"Smitham","date_of_birth":"1989-09-06","representation_orders":[{"id":5,"uuid":"3317b3ec-d3cc-4b4b-b3ee-c48045b2f0eb","maat_reference":"9416243","date":"2016-01-01"},{"id":6,"uuid":"7f228e2f-a033-4be0-ad68-997e0f360ea2","maat_reference":"7354754","date":"2018-08-22"}]}],"case_type":{"id":88,"name":"Case
+        Type 3","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":423,"code":"TWQ-3","name":"Bailey,
+        Romaguera and Sauer-3","court_type":"crown"}},{"id":4,"uuid":"81541999-935b-4e6e-a04b-ff980b6e7be5","case_number":"T20160004","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:43Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":4,"uuid":"d362248d-556e-4c22-8a4b-562fda415ace","first_name":"Tyrone","last_name":"King","email":"joannie@mitchellcrona.com"},"defendants":[{"id":4,"uuid":"d12f54c0-065c-4eb8-84dd-1faa89554517","first_name":"Pedro","last_name":"Treutel","date_of_birth":"1989-09-06","representation_orders":[{"id":7,"uuid":"0fe90abe-c6ff-4769-a709-f0c8e826e21a","maat_reference":"9672547","date":"2016-01-01"},{"id":8,"uuid":"6e8203fa-2a8f-4715-961a-1179517e456f","maat_reference":"8607172","date":"2018-08-22"}]}],"case_type":{"id":89,"name":"Case
+        Type 4","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":424,"code":"SQG-4","name":"Ledner
+        Inc-4","court_type":"crown"}},{"id":5,"uuid":"652b3f8f-ca4a-4289-bae4-5a1595297181","case_number":"T20160005","state":"submitted","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:43Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":5,"uuid":"378b79cc-e455-466b-b501-bd014326fd2e","first_name":"Lowell","last_name":"Lynch","email":"sherrill.senger@feeneyweimann.io"},"defendants":[{"id":5,"uuid":"2d2cc2c4-76d2-4f22-bfec-86a6f50ce352","first_name":"Joane","last_name":"Hegmann","date_of_birth":"1989-09-06","representation_orders":[{"id":9,"uuid":"3b776b41-e064-415b-9ed9-66a2fb7d66e1","maat_reference":"7959620","date":"2016-01-01"},{"id":10,"uuid":"7dce4d53-80ef-4453-879d-bc58430774c5","maat_reference":"5493098","date":"2018-08-22"}]}],"case_type":{"id":90,"name":"Case
+        Type 5","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"court":{"id":425,"code":"PVI-5","name":"Okuneva-Adams-5","court_type":"crown"}}]}'
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 10:10:47 GMT
 - request:
     method: get
-    uri: http://localhost:3001/api/case_workers/claims?api_key=41247cc2-043d-4299-9223-983d26c410c3&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
+    uri: http://localhost:3001/api/case_workers/claims?api_key=a2c70fa7-82c5-4c59-bbfc-55c84fcbafb3&direction=asc&limit=10&page=0&search=&sorting=last_submitted_at&status=current
     body:
       encoding: US-ASCII
       string: ''
@@ -186,7 +190,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (darwin19 x86_64) ruby/2.7.3p183
+      - rest-client/2.1.0 (darwin17.7.0 x86_64) ruby/2.6.3p62
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -201,26 +205,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Etag:
-      - W/"c29844324b8e193b2d8c4ede578214fb"
+      - W/"a6b32128fc616849b53f3a6a320d506f"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Meta-Request-Version:
       - 0.7.2
       X-Request-Id:
-      - 565ea570-a8a7-4160-8025-d5d704b2bbff
+      - b2c2587f-de9a-439e-886f-6f7a96c997a6
       X-Runtime:
-      - '0.127668'
+      - '0.054566'
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":4,"limit_value":10},"items":[{"id":1,"uuid":"305e5765-32f1-4713-8df7-59e097f221c9","case_number":"T20160001","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"7a59104b-56dd-4c22-821c-4ab15a2680c4","first_name":"Johnny","last_name":"Johnson","email":"chassidy_reynolds@pouros-schneider.org"},"defendants":[{"id":1,"uuid":"759c0d83-4903-4774-93bd-40c44cf27133","first_name":"Darnell","last_name":"Rath","date_of_birth":"1991-06-07","representation_orders":[{"id":1,"uuid":"d95cb0f5-c13e-4073-aea1-d8faf8f5bea8","maat_reference":"9541971","date":"2016-01-01"},{"id":2,"uuid":"1af11569-276c-4329-85cb-e6edb3db2cd0","maat_reference":"5504274","date":"2020-05-23"}]}],"case_type":{"id":258,"name":"Case
-        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":1,"uuid":"767f2523-d544-49b9-8e9b-3320e026228b","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"}],"court":{"id":1267,"code":"XPR-1","name":"Gottlieb,
-        Lemke and Fisher-1","court_type":"crown"}},{"id":2,"uuid":"8eec378c-66de-49c9-9503-f3720c4a5870","case_number":"T20160002","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"27f6be95-1b0b-4426-800d-87ebc90619d9","first_name":"Marketta","last_name":"Crist","email":"renna@schimmel-kulas.name"},"defendants":[{"id":2,"uuid":"af44a57b-9919-4344-a974-a6868deb336e","first_name":"William","last_name":"Kihn","date_of_birth":"1991-06-07","representation_orders":[{"id":3,"uuid":"056a3b62-553b-4338-8671-62d4ce35e3df","maat_reference":"6988548","date":"2016-01-01"},{"id":4,"uuid":"15698574-990c-488a-a98b-4f5106556767","maat_reference":"9430357","date":"2020-05-23"}]}],"case_type":{"id":259,"name":"Case
-        Type 2","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":1,"uuid":"767f2523-d544-49b9-8e9b-3320e026228b","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"}],"court":{"id":1268,"code":"NJC-2","name":"Cruickshank-Bashirian-2","court_type":"crown"}},{"id":3,"uuid":"9f2de0ec-ef27-4606-9f89-f1b75ea0b134","case_number":"T20160003","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:29Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":3,"uuid":"ff4bd5d9-75f4-40ec-8e3d-4ab960649193","first_name":"Chelsea","last_name":"Howell","email":"sherri_hahn@yost.info"},"defendants":[{"id":3,"uuid":"1576538b-dd3f-41e8-b07e-80e1f034ebde","first_name":"Cleora","last_name":"Upton","date_of_birth":"1991-06-07","representation_orders":[{"id":5,"uuid":"750574e7-1d6a-4948-962e-786535f37ea2","maat_reference":"6011453","date":"2016-01-01"},{"id":6,"uuid":"302db5e1-dbd6-462b-ab21-9d59de25a0ae","maat_reference":"5023756","date":"2020-05-23"}]}],"case_type":{"id":260,"name":"Case
-        Type 3","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":1,"uuid":"767f2523-d544-49b9-8e9b-3320e026228b","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"}],"court":{"id":1269,"code":"NSY-3","name":"Lebsack,
-        Schmidt and VonRueden-3","court_type":"crown"}},{"id":4,"uuid":"845e1283-669e-46ef-9f79-3b2cf367f90c","case_number":"T20160004","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2021-06-07T14:08:30Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":4,"uuid":"b155b70b-0623-4de6-8c4d-52323be4bb99","first_name":"Toby","last_name":"O''Conner","email":"tamatha@maggio-dooley.net"},"defendants":[{"id":4,"uuid":"e2e861e0-37b7-49ac-b5b4-03725aa30f14","first_name":"Sang","last_name":"Thiel","date_of_birth":"1991-06-07","representation_orders":[{"id":7,"uuid":"0141fd4d-0be6-43a6-becf-beaba5407a28","maat_reference":"7227056","date":"2016-01-01"},{"id":8,"uuid":"3213c1f5-ba7e-4105-a702-9f07bb715b84","maat_reference":"7509053","date":"2020-05-23"}]}],"case_type":{"id":261,"name":"Case
-        Type 4","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":1,"uuid":"767f2523-d544-49b9-8e9b-3320e026228b","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"}],"court":{"id":1270,"code":"NWQ-4","name":"Langworth,
-        Renner and Greenfelder-4","court_type":"crown"}}]}'
-  recorded_at: Mon, 07 Jun 2021 14:09:20 GMT
-recorded_with: VCR 6.0.0
+      string: '{"pagination":{"current_page":1,"total_pages":1,"total_count":2,"limit_value":10},"items":[{"id":1,"uuid":"be29d5d7-5893-4293-a24f-ce1ae83b4ebc","case_number":"T20160001","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":1,"uuid":"f0954eaa-88e4-47c5-ac20-f69b0a045d23","first_name":"Darron","last_name":"Grady","email":"daisy@mcculloughgerlach.name"},"defendants":[{"id":1,"uuid":"3df0480a-6fe6-4710-8a29-b375a4f43568","first_name":"Keith","last_name":"DuBuque","date_of_birth":"1989-09-06","representation_orders":[{"id":1,"uuid":"2b77aaa0-0780-4eec-8ad4-b819409a4639","maat_reference":"7264217","date":"2016-01-01"},{"id":2,"uuid":"2120cb77-2343-4341-b219-510c65c4a568","maat_reference":"8580707","date":"2018-08-22"}]}],"case_type":{"id":86,"name":"Case
+        Type 1","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":1,"uuid":"2ce6b71e-092b-43be-b65e-99bc1fe12dad","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"}],"court":{"id":421,"code":"JUT-1","name":"Strosin-Kassulke-1","court_type":"crown"}},{"id":2,"uuid":"559ff23e-0d9e-476d-be0f-157229f111bf","case_number":"T20160002","state":"allocated","type":"Claim::AdvocateClaim","last_submitted_at":"2019-09-06T10:10:42Z","total":0.0,"vat_amount":0.0,"opened_for_redetermination":false,"written_reasons_outstanding":false,"disk_evidence":false,"prosecution_evidence":null,"messages_count":0,"unread_messages_count":0,"external_user":{"id":2,"uuid":"17460748-d8f6-41de-8819-e544f2576638","first_name":"Harry","last_name":"Bednar","email":"hilario@ledner.name"},"defendants":[{"id":2,"uuid":"006be49a-c3d4-41e4-95fb-fe86bf6272e7","first_name":"Santiago","last_name":"Beer","date_of_birth":"1989-09-06","representation_orders":[{"id":3,"uuid":"ad129d9e-d270-4e31-97b8-431a972556d0","maat_reference":"4976373","date":"2016-01-01"},{"id":4,"uuid":"3b578759-e2a0-4d5f-ab12-275e299ae92f","maat_reference":"9115592","date":"2018-08-22"}]}],"case_type":{"id":87,"name":"Case
+        Type 2","is_fixed_fee":false,"requires_cracked_dates":false,"requires_trial_dates":false,"allow_pcmh_fee_type":false,"requires_maat_reference":true,"requires_retrial_dates":false,"roles":["agfs","lgfs"],"fee_type_code":null},"injection_attempts":[],"case_workers":[{"id":1,"uuid":"2ce6b71e-092b-43be-b65e-99bc1fe12dad","first_name":"John","last_name":"Smith","email":"john.smith@laa.gov.uk"}],"court":{"id":422,"code":"KVA-2","name":"Kertzmann,
+        Schaefer and Russel-2","court_type":"crown"}}]}'
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 10:11:09 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
**Reverts** ministryofjustice/Claim-for-Crown-Court-Defence#3989

Issue appears to be browser cache related and was resolved for myself by clearing the site data. A hard refresh was not tried. It is therefore likely this will resolve itself once browser caches expire.

To investigate why this may have happened I am looking into cache-expiry limits on grape APIs. 

Symptoms when broken were that the fee scheme was not selected and when any filter was selected nothing changed. If you selected a fee scheme the filtering remained non-functional.
