### PR TITLE
[CFP-118] Fix validation error preventing claim creation

### DIFF
--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe API::V2::CCLFClaim, feature: :injection do
     # TODO: this should not require build + save + reload
     # understand what the factory is doing to solve this
     claim = build(*args)
-    claim.save
+    claim.save!
     claim.reload
   end
 
@@ -277,7 +277,8 @@ RSpec.describe API::V2::CCLFClaim, feature: :injection do
           end
 
           context 'when miscellaneous fees exists' do
-            let(:claim) { create_claim(:litigator_claim, :submitted, :without_fees, misc_fees: [misc_fee]) }
+            let(:claim) { create_claim(:litigator_claim, :submitted, :without_fees, case_type: case_type, misc_fees: [misc_fee]) }
+            let(:case_type) { build(:case_type, :trial) }
             let(:misc_fee) { build(:misc_fee, :lgfs, fee_type: fee_type) }
 
             before do


### PR DESCRIPTION
#### What
Fix validation error preventing claim creation on rails 6.1 bump

#### Ticket

relates to [CFP-118](https://dsdmoj.atlassian.net/browse/CFP-118)

#### Why
see individual commits but this spec breaks on rails 6.1 with the following
error

```
Failure/Error: claim.reload

ActiveRecord::RecordNotFound:
  Couldn't find Claim::LitigatorClaim without an ID
./spec/api/v2/cclf_claim_spec.rb:88:in `create_claim'
./spec/api/v2/cclf_claim_spec.rb:280:in `block (7 levels) in <top (required)>'
./spec/api/v2/cclf_claim_spec.rb:305:in `block (8 levels) in <top (required)>'
./spec/vcr_helper.rb:84:in `block (3 levels) in <top (required)>'
./spec/vcr_helper.rb:83:in `block (2 levels) in <top (required)>'
```

The fix is, however, to correct the validation error - which was
caused by not having a case type to which you can add an unused materials
fee.