### PR TITLE
[Security] Selectively Bump jquery from 2.2.4 through to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "resolutions": {
     "hosted-git-info": "^3.0.8",
     "is-svg": "^4.3.1",
+    "jquery": "^3.6.0",
     "node-forge": "^0.10.0",
     "ssri": "^8.0.1",
     "webpack": "^4.44.2"
@@ -52,10 +53,5 @@
     "env": [ "jasmine", "jquery" ],
     "globals": [ "GOVUK", "moj" ],
     "ignore": [ "app/webpack/javascripts/vendor/", "spec/javascripts/helpers/" ]
-  },
-  "@comments": {
-    "@dependencies": {
-      "jquery": "exact version required due to older API usage within app"
-    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4799,10 +4799,10 @@ jquery@2.2.4:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
   integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
 
-"jquery@>= 1.0.0", jquery@>=1.0.0, jquery@>=1.8.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+"jquery@>= 1.0.0", jquery@>=1.0.0, jquery@>=1.8.0, jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
#### What
Selective version resolution of jquery

#### Why
Vulnerabilities

CVE-2015-9251 High severity
CVE-2016-10707 Moderate severity
CVE-2019-11358 Moderate severity
CVE-2020-11023 Moderate severity
CVE-2020-11022 Moderate severity


