### PR TITLE
[CFP-137] Signpost unused material fees on claim summary

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -52,7 +52,7 @@ module ClaimsHelper
     end
   end
 
-  def misc_fees_locals(claim, args = {})
+  def misc_fees_summary_locals(claim, args = {})
     {
       claim: claim, header: t('external_users.claims.misc_fees.summary.header'),
       collection: claim.misc_fees, step: :miscellaneous_fees,

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -46,7 +46,9 @@ module ClaimsHelper
       page_header: t('page_header', scope: scope),
       page_hint: t('page_hint', scope: scope)
     }.tap do |headings|
-      headings[:page_notice] = t('unused_materials.notice', scope: scope) if display_unused_materials_notice_for(claim)
+      if display_unused_materials_notice_for(claim)
+        headings[:page_notice] = t('unused_materials.notice.short', scope: scope)
+      end
     end
   end
 
@@ -57,7 +59,7 @@ module ClaimsHelper
       **args
     }.tap do |locals|
       if display_unused_materials_notice_for(claim)
-        locals[:unclaimed_fees_notice] = t('external_users.claims.misc_fees.unused_materials.notice_long')
+        locals[:unclaimed_fees_notice] = t('external_users.claims.misc_fees.unused_materials.notice.long')
       end
     end
   end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -46,7 +46,19 @@ module ClaimsHelper
       page_header: t('page_header', scope: scope),
       page_hint: t('page_hint', scope: scope)
     }.tap do |headings|
-      headings[:page_notice] = t('unused_materials_notice', scope: scope) if display_unused_materials_notice_for(claim)
+      headings[:page_notice] = t('unused_materials.notice', scope: scope) if display_unused_materials_notice_for(claim)
+    end
+  end
+
+  def misc_fees_locals(claim, args = {})
+    {
+      claim: claim, header: t('external_users.claims.misc_fees.summary.header'),
+      collection: claim.misc_fees, step: :miscellaneous_fees,
+      **args
+    }.tap do |locals|
+      if display_unused_materials_notice_for(claim)
+        locals[:unclaimed_fees_notice] = t('external_users.claims.misc_fees.unused_materials.notice_long')
+      end
     end
   end
 

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -1,6 +1,9 @@
 %h2.govuk-heading-l
   = local_assigns.has_key?(:header) ? header : t('common.fees')
 
+- if local_assigns.has_key?(:unclaimed_fees_notice)
+  = govuk_warning_text(unclaimed_fees_notice)
+
 - if local_assigns[:editable]
   = govuk_link_to t('common.change_html', context: t('common.fees')), edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change'
 

--- a/app/views/external_users/claims/misc_fees/_summary.html.haml
+++ b/app/views/external_users/claims/misc_fees/_summary.html.haml
@@ -1,5 +1,5 @@
 #miscellaneous-fees-section.app-summary-section
-  = render partial: 'summary_fees', locals: { claim: claim, header: t('external_users.claims.misc_fees.summary.header'), collection: claim.misc_fees, editable: editable, section: section, step: :miscellaneous_fees }
+  = render partial: 'summary_fees', locals: misc_fees_locals(claim, editable: editable, section: section)
 
   - if claim.requires_interim_claim_info?
     = render partial: 'external_users/claims/interim_claim_info/summary', locals: { claim: claim }

--- a/app/views/external_users/claims/misc_fees/_summary.html.haml
+++ b/app/views/external_users/claims/misc_fees/_summary.html.haml
@@ -1,5 +1,5 @@
 #miscellaneous-fees-section.app-summary-section
-  = render partial: 'summary_fees', locals: misc_fees_locals(claim, editable: editable, section: section)
+  = render partial: 'summary_fees', locals: misc_fees_summary_locals(claim, editable: editable, section: section)
 
   - if claim.requires_interim_claim_info?
     = render partial: 'external_users/claims/interim_claim_info/summary', locals: { claim: claim }

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -10,9 +10,8 @@
     = govuk_warning_text(t('external_users.claims.misc_fees.unused_materials.heading')) do
       = t('external_users.claims.misc_fees.unused_materials.notice')
       %br
-      = t('external_users.claims.misc_fees.unused_materials.hint_start')
-      = govuk_link_to t('external_users.claims.misc_fees.unused_materials.hint_link'), edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary)
-      = t('external_users.claims.misc_fees.unused_materials.hint_end')
+      - misc_fee_link = govuk_link_to t('external_users.claims.misc_fees.unused_materials.hint_link'), edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary)
+      = t('external_users.claims.misc_fees.unused_materials.hint_html', link: misc_fee_link)
 
 
   %p

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -6,6 +6,15 @@
 
 - present(@claim) do |claim|
 
+  - if display_unused_materials_notice_for(claim)
+    = govuk_warning_text(t('external_users.claims.misc_fees.unused_materials.heading')) do
+      = t('external_users.claims.misc_fees.unused_materials.notice')
+      %br
+      = t('external_users.claims.misc_fees.unused_materials.hint_start')
+      = govuk_link_to t('external_users.claims.misc_fees.unused_materials.hint_link'), edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary)
+      = t('external_users.claims.misc_fees.unused_materials.hint_end')
+
+
   %p
     = t('external_users.claims.check_your_claim.help_text')
 

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -8,7 +8,7 @@
 
   - if display_unused_materials_notice_for(claim)
     = govuk_warning_text(t('external_users.claims.misc_fees.unused_materials.heading')) do
-      = t('external_users.claims.misc_fees.unused_materials.notice')
+      = t('external_users.claims.misc_fees.unused_materials.notice.short')
       %br
       - misc_fee_link = govuk_link_to t('external_users.claims.misc_fees.unused_materials.hint_link'), edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary)
       = t('external_users.claims.misc_fees.unused_materials.hint_html', link: misc_fee_link)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1374,7 +1374,13 @@ en:
           <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" class="govuk-link" rel="noreferrer noopener" target="_blank">appropriate special prep form <span class="govuk-visually-hidden">(opens in new tab)</span></a>
           or <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" class="govuk-link" rel="noreferrer noopener" target="_blank">unused materials (over 3 hours) form <span class="govuk-visually-hidden">(opens in new tab)</span></a>
           and attach to the claim.
-        unused_materials_notice: This claim should be eligible for unused materials fees (up to 3 hours)
+        unused_materials:
+          heading: Unclaimed fees
+          notice: This claim should be eligible for unused materials fees (up to 3 hours)
+          notice_long: This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed
+          hint_start: Go to
+          hint_link: miscellaneous fees
+          hint_end: to add this to your claim
         advocates:
           fields:
             add_misc_fee: Add another fee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1378,9 +1378,8 @@ en:
           heading: Unclaimed fees
           notice: This claim should be eligible for unused materials fees (up to 3 hours)
           notice_long: This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed
-          hint_start: Go to
+          hint_html: Go to %{link} to add this to your claim
           hint_link: miscellaneous fees
-          hint_end: to add this to your claim
         advocates:
           fields:
             add_misc_fee: Add another fee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1376,8 +1376,9 @@ en:
           and attach to the claim.
         unused_materials:
           heading: Unclaimed fees
-          notice: This claim should be eligible for unused materials fees (up to 3 hours)
-          notice_long: This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed
+          notice:
+            short: This claim should be eligible for unused materials fees (up to 3 hours)
+            long: This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed
           hint_html: Go to %{link} to add this to your claim
           hint_link: miscellaneous fees
         advocates:

--- a/lib/govuk_component/warning_text_helpers.rb
+++ b/lib/govuk_component/warning_text_helpers.rb
@@ -2,7 +2,7 @@
 
 module GovukComponent
   module WarningTextHelpers
-    def govuk_warning_text(body = nil, assistive_text = t('common.warning'), **tag_options)
+    def govuk_warning_text(body = nil, assistive_text = t('common.warning'), **tag_options, &block)
       tag_options = prepend_classes('govuk-warning-text', tag_options)
 
       text__assistive = tag.span(assistive_text, class: 'govuk-warning-text__assistive')
@@ -10,7 +10,17 @@ module GovukComponent
       tag.div(**tag_options) do
         concat tag.span('!', class: 'govuk-warning-text__icon', 'aria-hidden': true)
         concat tag.strong(text__assistive + content, class: 'govuk-warning-text__text')
+        govuk_warning_text_description(&block)
       end
+    end
+
+    def govuk_warning_text_description(&block)
+      return unless block
+
+      concat tag.div(
+        capture(&block),
+        class: 'govuk-warning-text__text govuk-!-font-weight-regular govuk-!-margin-top-4'
+      )
     end
   end
 end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -203,8 +203,8 @@ RSpec.describe ClaimsHelper do
     end
   end
 
-  describe '#misc_fees_locals' do
-    subject(:locals) { misc_fees_locals(claim) }
+  describe '#misc_fees_summary_locals' do
+    subject(:locals) { misc_fees_summary_locals(claim) }
 
     let(:claim) { build :claim }
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe ClaimsHelper do
     context 'with a claim eligible for unused materials fees' do
       before { allow(claim).to receive(:unused_materials_applicable?).and_return true }
 
-      it { expect(locals[:unclaimed_fees_notice]).not_to be_nil }
+      it { expect(locals[:unclaimed_fees_notice]).to eq "This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed" }
 
       context 'when unused material fees have already been claimed' do
         before { create :misc_fee, :miumu_fee, claim: claim, quantity: 1 }

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -202,4 +202,28 @@ RSpec.describe ClaimsHelper do
       it { expect(headings.keys).not_to include(:page_notice) }
     end
   end
+
+  describe '#misc_fees_locals' do
+    subject(:locals) { misc_fees_locals(claim) }
+
+    let(:claim) { build :claim }
+
+    context 'with a claim eligible for unused materials fees' do
+      before { allow(claim).to receive(:unused_materials_applicable?).and_return true }
+
+      it { expect(locals[:unclaimed_fees_notice]).not_to be_nil }
+
+      context 'when unused material fees have already been claimed' do
+        before { create :misc_fee, :miumu_fee, claim: claim, quantity: 1 }
+
+        it { expect(locals.keys).not_to include(:unclaimed_fees_notice) }
+      end
+    end
+
+    context 'with a claim ineligible for unused materials fees' do
+      before { allow(claim).to receive(:unused_materials_applicable?).and_return false }
+
+      it { expect(locals.keys).not_to include(:unclaimed_fees_notice) }
+    end
+  end
 end

--- a/spec/lib/govuk_component/warning_text_helpers_spec.rb
+++ b/spec/lib/govuk_component/warning_text_helpers_spec.rb
@@ -62,4 +62,18 @@ RSpec.describe GovukComponent::WarningTextHelpers, type: :helper do
       end
     end
   end
+
+  describe '#govuk_warning_text_description' do
+    context 'when called with a block' do
+      subject(:markup) { helper.govuk_warning_text_description { 'You can be fined up to £5,000 if you do not register.' } }
+
+      it { is_expected.to have_tag(:div, with: { class: 'govuk-warning-text__text govuk-\!-font-weight-regular govuk-\!-margin-top-4' }) }
+    end
+
+    context 'when called without a block' do
+      subject(:markup) { helper.govuk_warning_text_description }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/lib/govuk_component/warning_text_helpers_spec.rb
+++ b/spec/lib/govuk_component/warning_text_helpers_spec.rb
@@ -47,5 +47,19 @@ RSpec.describe GovukComponent::WarningTextHelpers, type: :helper do
         is_expected.to have_tag(:div, with: { class: 'govuk-warning-text my-custom-class1 my-custom-class2' })
       end
     end
+
+    context 'when called with a block' do
+      subject(:markup) do
+        helper.govuk_warning_text('You can be fined up to £5,000 if you do not register.', class: 'my-custom-class1 my-custom-class2') do
+          'Some extra information'
+        end
+      end
+
+      it 'adds tag with custom classes, prepended by govuk class' do
+        is_expected.to have_tag(:div) do
+          with_tag(:div, with: { class: 'govuk-warning-text__text govuk-\!-font-weight-regular govuk-\!-margin-top-4' })
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What

Add a notice on the claim summary for qualifying claims to indicate that an unused material fee may be claimed.

#### Ticket

[Unused material fee flag on summary page](https://dsdmoj.atlassian.net/browse/CFP-137)

#### Why

Providers are being underpaid for work they are entitled to claim for.

#### How

Following on from #4011, add the notices to the summary page based on the same rules.