### PR TITLE
Fix smoke test

### DIFF
--- a/spec/support/api/claims/advocate_claim_test.rb
+++ b/spec/support/api/claims/advocate_claim_test.rb
@@ -9,7 +9,7 @@ class AdvocateClaimTest < BaseClaimTest
     puts 'starting'
 
     # create a claim
-    response = client.post_to_endpoint('claims', claim_data)
+    response = client.post_to_endpoint('claims/advocates/final', claim_data)
     return if client.failure
 
     self.claim_uuid = id_from_json(response)


### PR DESCRIPTION
#### What
Fix smoke test inline with removal of dprecated endpoint

#### Why
Failing with
```
[-] errors
claims Endpoint raised error - not found
rake aborted!
API Error: ADP RESTful API smoke test failure!
/usr/src/app/lib/tasks/api.rake:37:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/cli/exec.rb:63:in `load'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/cli/exec.rb:63:in `kernel_load'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/cli.rb:494:in `exec'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/cli.rb:30:in `dispatch'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/cli.rb:24:in `start'
/usr/local/bundle/gems/bundler-2.2.16/exe/bundle:49:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.2.16/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.2.16/exe/bundle:37:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'
```