### PR TITLE
Sort error summary order according to custom sequence in error_messages.en.yml

### DIFF
--- a/app/views/external_users/claims/_error_summary.html.haml
+++ b/app/views/external_users/claims/_error_summary.html.haml
@@ -7,6 +7,6 @@
       = t('shared.errors.form_error_hint')
 
     %ul.error-summary-list
-      - ep.header_errors.sort_by { |error| error.attribute }.each do |error_detail|
+      - ep.header_errors.each do |error_detail|
         %li
           = error_detail.long_message_link


### PR DESCRIPTION
#### What
Sort error summary errors according to custom sequence in error_messages.yml

#### Ticket

[came out of error handling review related to rails 6.1 bump](https://dsdmoj.atlassian.net/browse/CFP-118)

#### Why

The header errors method returns a sorted collection of
ErrorDetail objects. These objects internally sort by sequence
numbers defined via the `_seq` values in `error_messages.en.yml`.

No further ordering should be needed.
