### PR TITLE
Revert jQuery 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "resolutions": {
     "hosted-git-info": "^3.0.8",
     "is-svg": "^4.3.1",
-    "jquery": "^3.6.0",
     "node-forge": "^0.10.0",
     "ssri": "^8.0.1",
     "webpack": "^4.44.2"
@@ -53,5 +52,10 @@
     "env": [ "jasmine", "jquery" ],
     "globals": [ "GOVUK", "moj" ],
     "ignore": [ "app/webpack/javascripts/vendor/", "spec/javascripts/helpers/" ]
+  },
+  "@comments": {
+    "@dependencies": {
+      "jquery": "exact version required due to older API usage within app"
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4797,10 +4797,10 @@ jquery@2.2.4:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
   integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
 
-"jquery@>= 1.0.0", jquery@>=1.0.0, jquery@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+"jquery@>= 1.0.0", jquery@>=1.0.0, jquery@>=1.8.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
#### What
Revert "Selectively bump jQuery from 2.2.4 to 3.6.0", commit 1ad2f1e

#### Why
Selectively bumping provides a dependency version range to our application, in most instances this resolves our dependant issue, however this does not resolve our jQuery security issues.

#### TODO
A new ticket will be created to;

 - Bump the core jQuery version to the latest
 - Update all deprecated methods
 - Remove deprecated JS code
 - Sanity check application
 - Where possible replace jQuery with vanilla JS (nice to have)
