### PR TITLE
Only check existence of persisted documents

### DIFF
--- a/app/views/external_users/claims/supporting_documents/_existing.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_existing.html.haml
@@ -1,4 +1,4 @@
-- if @claim.documents.any?
+- if @claim.documents.any?(&:persisted?)
   %table.previously-uploaded
     %caption
       = t('.previously_uploaded_docs')


### PR DESCRIPTION
`ExternalUsers::ClaimsController#build_nested_resource` adds an empty instance of `Document` to `@claim.documents` if it is empty and this ensures that `@claim.document.any?` is true while `@claim.document.count` is zero (as this checks with an additional query to the database).

`@claim.document.any?(&:persisted?)` can be used to excluded the extra instance added by the controller.

## Before

<img width="655" alt="Screenshot 2021-06-21 at 15 35 47" src="https://user-images.githubusercontent.com/4415912/122780163-81dbc580-d2a6-11eb-8b79-9c4c0c69f696.png">

## After

<img width="662" alt="Screenshot 2021-06-21 at 15 34 24" src="https://user-images.githubusercontent.com/4415912/122780172-843e1f80-d2a6-11eb-81f6-c079caa877b2.png">
