### PR TITLE
Remove unneeded rake task

### DIFF
--- a/lib/tasks/api.rake
+++ b/lib/tasks/api.rake
@@ -38,22 +38,6 @@ namespace :api do
     end
   end
 
-  desc 'Run specific api test to reproduce reported bugs'
-  task :debug => :environment do
-    require "#{Rails.root.join('lib','api','api_test_client')}"
-    api_client = ApiTestClient.new
-    api_client.run_debug_session
-
-    if api_client.success
-      puts "[+] success"
-      puts api_client.messages.join("\n")
-    else
-      puts "[-] errors"
-      puts api_client.full_error_messages.join("\n")
-      raise "API Error: ADP RESTful API smoke test failure!"
-    end
-  end
-
   desc 'display useful api keys in dev'
   task :keys => :environment do
     if Rails.env.development?

--- a/spec/support/api/api_test_client.rb
+++ b/spec/support/api/api_test_client.rb
@@ -47,10 +47,6 @@ class ApiTestClient
     LitigatorHardshipClaimTest.new(client: self).test_creation!
   end
 
-  def run_debug_session
-    DebugFinalClaimTest.new(client: self).test_creation!
-  end
-
   def failure
     !@success
   end


### PR DESCRIPTION
#### What
Remove unneeded rake task

#### Why
This task no longer works and is unclear what it aimed to do
as there is no longer a DebugFinalClaimTest class. IMO it is not
needed anyway as debugging is easy enough.