### PR TITLE
Ensure that a test unique code has letters

### DIFF
--- a/spec/factories/case_stages.rb
+++ b/spec/factories/case_stages.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :case_stage do
     case_type { association(:case_type) }
-    unique_code { Faker::Lorem.unique.characters(number: 5..7).upcase }
+    unique_code { Faker::Lorem.unique.characters(number: 5..7, min_alpha: 1).upcase }
     sequence(:description) { |n| "Case stage #{n}" }
     sequence(:position) { |n| n }
     roles { %w[agfs lgfs] }


### PR DESCRIPTION
`Faker::Lorem.characters` generates a random alphanumeric string which can, with a small probability, be entirely numeric. The Shoulda matcher used in the `#unique_code` tests in `spec/models/case_stage_spec.rb` fails if the test value does not contain letters as it cannot check case sensitivity. Adding the `min_alpha: 1` parameter to `Faker::Lorem.characters` will ensure that case sensitively can be checked.