### PR TITLE
Add environment to rake task

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -59,7 +59,7 @@ namespace :db do
   task :reseed => [:clear, 'db:migrate', 'db:seed']
 
   desc 'CCCD task: clear the database, run migrations, seeds and reloads demo data'
-  task :reload do
+  task :reload => :environment do
     production_protected
 
     Rake::Task['db:clear'].invoke

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -59,7 +59,7 @@ namespace :db do
   task :reseed => [:clear, 'db:migrate', 'db:seed']
 
   desc 'CCCD task: clear the database, run migrations, seeds and reloads demo data'
-  task :reload => :environment do
+  task reload: :environment do
     production_protected
 
     Rake::Task['db:clear'].invoke


### PR DESCRIPTION
#### What
Add environment to rake task

#### Why
This was working previously but is currently broken.
Its unclear if this is a rails 6.1 issue or related
to rake version currenly bundled but the task was raising
the following error. The task should have an envn anyway.

```
bundle exec rake db:reload
=>
NoMethodError: undefined method `host' for Rails:Module
lib/tasks/rake_helpers/rake_utils.rb:30:in `production_protected'
lib/tasks/db.rake:63:in `block (2 levels) in <top (required)>'
```