### PR TITLE
Fix disallowed sql in migrations run by smoke test

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -69,7 +69,7 @@ namespace :data do
     desc 'Migrate offence data for scheme 9 to have unique code based on description and class letter'
     task :offence_unique_code_scheme_9 => :environment do
       require Rails.root.join('lib','data_migrator','offence_unique_code_migrator')
-      offences = Offence.joins(:offence_class).where.not(offence_class: nil).unscope(:order).order('offences.description COLLATE "C", offence_classes.class_letter COLLATE "C"')
+      offences = Offence.joins(:offence_class).where.not(offence_class: nil).unscope(:order).order(Arel.sql('offences.description COLLATE "C", offence_classes.class_letter COLLATE "C"'))
       migrator = DataMigrator::OffenceUniqueCodeMigrator.new(relation: offences)
       migrator.migrate!
     end
@@ -77,7 +77,7 @@ namespace :data do
     desc 'Migrate offence data for scheme 10 offences to have unique code based on description and offence category/band'
     task :offence_unique_code_scheme_10 => :environment do
       require Rails.root.join('lib','data_migrator','offence_unique_code_migrator')
-      offences = Offence.joins(:offence_band).where(offence_class: nil).unscope(:order).order('offences.description COLLATE "C", offences.contrary COLLATE "C", offence_bands.description COLLATE "C"')
+      offences = Offence.joins(:offence_band).where(offence_class: nil).unscope(:order).order(Arel.sql('offences.description COLLATE "C", offences.contrary COLLATE "C", offence_bands.description COLLATE "C"'))
       migrator = DataMigrator::OffenceUniqueCodeMigrator.new(relation: offences)
       migrator.migrate!
     end


### PR DESCRIPTION
#### What
Fix disallowed sql in migrations run by smoke test

#### Why

Was raising udring smoke test run, following rails 6.1 bump
```
Query method called with non-attribute argument(s): "offences.description COLLATE \"C\", offence_classes.class_letter COLLATE \"C\""
```