### PR TITLE
Use default url for form

### DIFF
--- a/app/views/provider_management/external_users/_form.html.haml
+++ b/app/views/provider_management/external_users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:provider_management, @provider, @external_user], url: provider_management_provider_external_user_path(@provider, @external_user), builder: GdsAdpFormBuilder do |f|
+= form_with model: [:provider_management, @provider, @external_user], builder: GdsAdpFormBuilder do |f|
 
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary


### PR DESCRIPTION


#### What

Fix the new user form for providers at `/provider_management/providers/1/external_users/new`.

#### Ticket

[Unable to add new user](https://dsdmoj.atlassian.net/browse/CFP-172)

#### Why

Currently the new user form returns an internal server error (500) so it is not possible to create new users.

#### How

The `url` parameter for `form_with` in the view overrides the default submit path for the form and for the users form it is being set to the correct path for updating an existing user. When the user does not exist (in the case of a new user) the helper to create this path fails as the id is missing.

The `url` parameter is not necessary as the default path, for both new and existing users, is correctly generated based on the value of the `model` parameter.