### PR TITLE
Simplify call to form_with in provider management

### DIFF
--- a/app/views/shared/providers/_form.html.haml
+++ b/app/views/shared/providers/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: @provider, url: form_url, builder: GdsAdpFormBuilder, html: { novalidate: true } do |f|
+= form_with model: [:provider_management, @provider], builder: GdsAdpFormBuilder do |f|
   = f.govuk_error_summary
 
   = f.govuk_text_field :name,

--- a/app/views/shared/providers/edit.html.haml
+++ b/app/views/shared/providers/edit.html.haml
@@ -5,4 +5,4 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render partial: 'shared/providers/form', locals: { form_url: url_for(controller: params[:controller], action: 'update', id: @provider.id) }
+    = render partial: 'shared/providers/form'

--- a/app/views/shared/providers/new.html.haml
+++ b/app/views/shared/providers/new.html.haml
@@ -5,4 +5,4 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render partial: 'shared/providers/form', locals: { form_url: url_for(controller: params[:controller], action: 'create') }
+    = render partial: 'shared/providers/form'


### PR DESCRIPTION
#### What
Simplify call to form_with in provider management

#### Why
Pass namespaced model from which rails can
determine correct controller and action.

Also remove html novalidate option which
does not appear to have any effect.