### PR TITLE
Rename and extend external user management feature

### DIFF
--- a/features/page_objects/edit_user_page.rb
+++ b/features/page_objects/edit_user_page.rb
@@ -1,0 +1,3 @@
+class EditUserPage < BasePage
+  set_url_matcher(/external_users\/admin\/external_users\/\d+\/edit/)
+end

--- a/features/page_objects/manage_users_page.rb
+++ b/features/page_objects/manage_users_page.rb
@@ -1,3 +1,8 @@
 class ManageUsersPage < BasePage
   set_url "/external_users/admin/external_users"
+
+  section :user_table, 'table.report' do
+    sections :rows, 'tbody > tr' do
+    end
+  end
 end

--- a/features/step_definitions/external_user_management_steps.rb
+++ b/features/step_definitions/external_user_management_steps.rb
@@ -1,0 +1,7 @@
+Then('I am on the new user page') do
+  expect(@new_user_page).to be_displayed
+end
+
+Then('I am on the edit user page') do
+  expect(@edit_user_page).to be_displayed
+end

--- a/features/step_definitions/manage_users_steps.rb
+++ b/features/step_definitions/manage_users_steps.rb
@@ -8,6 +8,12 @@ Then('I am on the manage users page') do
   expect(@manage_users_page).to be_displayed
 end
 
+And('I click the link {string} for user {string} on the manage users page') do |label, email|
+  row = @manage_users_page.user_table.rows.find {|row| row.text.include?(email) }
+  expect(row).not_to be_nil, "Could not find row containing email '#{email}'"
+  row.find_link(label).click
+end
+
 Then('the following user details are displayed:') do |table|
   expect(@manage_users_page).to be_displayed
   table.hashes.each do |row|

--- a/features/step_definitions/new_user_steps.rb
+++ b/features/step_definitions/new_user_steps.rb
@@ -1,3 +1,0 @@
-Then('I am on the new users page') do
-  expect(@new_user_page).to be_displayed
-end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -9,6 +9,7 @@ Before('not @no-site-prism') do
   @case_worker_claim_show_page = CaseWorkerClaimShowPage.new
   @manage_users_page = ManageUsersPage.new
   @new_user_page = NewUserPage.new
+  @edit_user_page = EditUserPage.new
 
   @claim_form_page = ClaimFormPage.new
   @advocate_hardship_claim_form_page = AdvocateHardshipClaimFormPage.new

--- a/features/users/external_user_management.feature
+++ b/features/users/external_user_management.feature
@@ -1,14 +1,14 @@
 @javascript @no-seed
-Feature: Create new external user
+Feature: Create new and update existing external users
 
-  Scenario: Chamber admin creates a new advocate user
+  Scenario: Chamber admin creates and updates an advocate user
     Given I am a signed in advocate admin
     When I click the link 'Manage users'
     Then I am on the manage users page
     And the page should be accessible
 
     When I click the link 'Create a new user'
-    Then I am on the new users page
+    Then I am on the new user page
     And I should see 'Add a new user to'
     And the page should be accessible skipping 'aria-allowed-attr'
 
@@ -35,6 +35,19 @@ Feature: Create new external user
       | Surname | Name | Supplier number | Email | Email notifications of messages? |
       | Bob | Jim | BAR2A | jim.bob@example.com | Yes |
 
+    When I click the link 'Edit' for user 'jim.bob@example.com' on the manage users page
+    Then I am on the edit user page
+    And the page should be accessible skipping 'aria-allowed-attr'
+
+    When I fill in 'First name' with 'John'
+    And I fill in 'Email' with 'john.bob@example.com'
+    And I click the button 'Save'
+    Then I am on the manage users page
+    And I should see 'User successfully updated'
+    And the following user details are displayed:
+      | Surname | Name | Supplier number | Email | Email notifications of messages? |
+      | Bob | John | BAR2A | john.bob@example.com | Yes |
+
   Scenario: LGFS Firm admin creates a new litigator user
     Given I am a signed in litigator admin
     When I click the link 'Manage users'
@@ -42,7 +55,7 @@ Feature: Create new external user
     And the page should be accessible
 
     When I click the link 'Create a new user'
-    Then I am on the new users page
+    Then I am on the new user page
     And I should see 'Add a new user to'
     And the page should be accessible
 
@@ -70,7 +83,7 @@ Feature: Create new external user
     And the page should be accessible
 
     When I click the link 'Create a new user'
-    Then I am on the new users page
+    Then I am on the new user page
     And I should see 'Add a new user to'
     And the page should be accessible
 


### PR DESCRIPTION
#### What
Rename and extend external user management feature

#### Ticket

relates to [CFP-159 nested error linking](https://dsdmoj.atlassian.net/browse/CFP-159)

#### Why
Happy path coverage for basic functionality to prevent
regressions.

#### How
 - Rename file to more closely reflect the intention (along
 with step files used).

- Extend to cover basic happy path for an external user
admin to edit an existing user to cover regressions.