### PR TITLE
[CFP-174] Send email to newly created case worker

### DIFF
--- a/app/controllers/concerns/password_helpers.rb
+++ b/app/controllers/concerns/password_helpers.rb
@@ -24,7 +24,7 @@ module PasswordHelpers
     user.reset_password_token = enc
     user.reset_password_sent_at = Time.now.utc
     user.save(validate: false)
-    DeviseMailer.reset_password_instructions(user, token, current_user.name)
+    DeviseMailer.reset_password_instructions(user, token, current_user.name).deliver_later
   rescue StandardError => e
     Rails.logger.error("DEVISE MAILER ERROR: '#{e.message}' while sending reset password mail")
   end

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -100,67 +100,8 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController, type: :controller do
     end
   end
 
-  describe 'POST #create' do
-    context 'when valid' do
-      let(:case_worker_params) {
-        {
-          case_worker: {
-            user_attributes: {
-              email: 'foo@foobar.com',
-              password: 'password',
-              password_confirmation: 'password',
-              first_name: 'John',
-              last_name: 'Smith'
-            },
-            roles: ['case_worker'],
-            location_id: create(:location).id
-          }
-        }
-      }
-
-      it 'creates a case_worker' do
-        expect {
-          post :create, params: case_worker_params
-        }.to change(User, :count).by(1)
-      end
-
-      it 'redirects to case workers index' do
-        post :create, params: case_worker_params
-        expect(response).to redirect_to(case_workers_admin_case_workers_url)
-      end
-
-      it 'attempts to deliver an email' do
-        expect(DeviseMailer).to receive(:reset_password_instructions)
-        post :create, params: case_worker_params
-      end
-
-      describe 'if there is an issue with delivering the email' do
-        let(:mailer) { double DeviseMailer }
-
-        before do
-          allow(DeviseMailer).to receive(:reset_password_instructions).and_raise(NoMethodError)
-        end
-
-        it 'raises an error' do
-          expect(Rails.logger).to receive(:error).with(/DEVISE MAILER ERROR: 'NoMethodError' while sending reset password mail/)
-          post :create, params: case_worker_params
-        end
-      end
-    end
-
-    context 'when invalid' do
-      it 'does not create a case worker' do
-        expect {
-          post :create, params: { case_worker: { roles: ['case_worker'], user_attributes: { email: 'invalidemail' } } }
-        }.to_not change(User, :count)
-      end
-
-      it 'renders the new template' do
-        post :create, params: { case_worker: { roles: ['case_worker'], user_attributes: { email: 'invalidemail' } } }
-        expect(response).to render_template(:new)
-      end
-    end
-  end
+  # POST #create test converted to requests specs
+  # See spec/requests/case_workers/admin/case_workers_spec.rb
 
   describe 'PUT #update' do
     context 'when valid' do

--- a/spec/requests/case_workers/admin/case_workers_spec.rb
+++ b/spec/requests/case_workers/admin/case_workers_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Caseworker admin', type: :request do
     let(:create_case_workers_request) { post(case_workers_admin_case_workers_path, params: case_worker_params) }
 
     context 'when valid' do
-      let(:case_worker_params) {
+      let(:case_worker_params) do
         {
           case_worker: {
             user_attributes: {
@@ -21,7 +21,7 @@ RSpec.describe 'Caseworker admin', type: :request do
             location_id: create(:location).id
           }
         }
-      }
+      end
 
       it 'creates a case_worker' do
         expect { create_case_workers_request }.to change(User, :count).by(1)
@@ -33,29 +33,34 @@ RSpec.describe 'Caseworker admin', type: :request do
       end
 
       it 'attempts to deliver an email' do
-        expect(DeviseMailer).to receive(:reset_password_instructions)
+        allow(DeviseMailer).to receive(:reset_password_instructions)
         create_case_workers_request
+        expect(DeviseMailer).to have_received(:reset_password_instructions)
       end
 
       describe 'if there is an issue with delivering the email' do
-        let(:mailer) { double DeviseMailer }
+        let(:mailer) { instance_double DeviseMailer }
 
         before do
           allow(DeviseMailer).to receive(:reset_password_instructions).and_raise(NoMethodError)
         end
 
         it 'raises an error' do
-          expect(Rails.logger).to receive(:error).with(/DEVISE MAILER ERROR: 'NoMethodError' while sending reset password mail/)
+          allow(Rails.logger).to receive(:error)
           create_case_workers_request
+          expect(Rails.logger).to have_received(:error)
+            .with(/DEVISE MAILER ERROR: 'NoMethodError' while sending reset password mail/)
         end
       end
     end
 
     context 'when invalid' do
-      let(:case_worker_params) { { case_worker: { roles: ['case_worker'], user_attributes: { email: 'invalidemail' } } } }
+      let(:case_worker_params) do
+        { case_worker: { roles: ['case_worker'], user_attributes: { email: 'invalidemail' } } }
+      end
 
       it 'does not create a case worker' do
-        expect { create_case_workers_request }.to_not change(User, :count)
+        expect { create_case_workers_request }.not_to change(User, :count)
       end
 
       it 'renders the new template' do

--- a/spec/requests/case_workers/admin/case_workers_spec.rb
+++ b/spec/requests/case_workers/admin/case_workers_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe 'Caseworker admin', type: :request do
+  let(:admin) { create(:case_worker, :admin) }
+
+  before { sign_in admin.user }
+
+  describe 'POST /case_workers/admin/case_workers' do
+    let(:create_case_workers_request) { post(case_workers_admin_case_workers_path, params: case_worker_params) }
+
+    context 'when valid' do
+      let(:case_worker_params) {
+        {
+          case_worker: {
+            user_attributes: {
+              email: 'foo@foobar.com',
+              password: 'password',
+              password_confirmation: 'password',
+              first_name: 'John',
+              last_name: 'Smith'
+            },
+            roles: ['case_worker'],
+            location_id: create(:location).id
+          }
+        }
+      }
+
+      it 'creates a case_worker' do
+        expect { create_case_workers_request }.to change(User, :count).by(1)
+      end
+
+      it 'redirects to case workers index' do
+        create_case_workers_request
+        expect(response).to redirect_to(case_workers_admin_case_workers_url)
+      end
+
+      it 'attempts to deliver an email' do
+        expect(DeviseMailer).to receive(:reset_password_instructions)
+        create_case_workers_request
+      end
+
+      describe 'if there is an issue with delivering the email' do
+        let(:mailer) { double DeviseMailer }
+
+        before do
+          allow(DeviseMailer).to receive(:reset_password_instructions).and_raise(NoMethodError)
+        end
+
+        it 'raises an error' do
+          expect(Rails.logger).to receive(:error).with(/DEVISE MAILER ERROR: 'NoMethodError' while sending reset password mail/)
+          create_case_workers_request
+        end
+      end
+    end
+
+    context 'when invalid' do
+      let(:case_worker_params) { { case_worker: { roles: ['case_worker'], user_attributes: { email: 'invalidemail' } } } }
+
+      it 'does not create a case worker' do
+        expect { create_case_workers_request }.to_not change(User, :count)
+      end
+
+      it 'renders the new template' do
+        create_case_workers_request
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

Send an email with the password reset link to a newly case worker.

#### Ticket

[https://dsdmoj.atlassian.net/browse/CFP-174](https://dsdmoj.atlassian.net/browse/CFP-174)

This ticket identifies issues on creation of new case workers as well as a password reset. This PR fixes the former issue but I have not been able to recreate the latter.

#### Why

The email is required to enable new users to set the password before the account can be used.

#### How

The email notification is being prepared but, due to a [previous commit,](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/commit/41b129c50061e9fdcb1080205fa8d01cf73dcbef) the job to send it was not being enqueued.