### PR TITLE
[CFP-109] Ensure send message button does not appear when message box not available

### DIFF
--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -36,4 +36,4 @@
       %span.filename
       = govuk_link_to t('.remove_file_html'), '#'
 
-  = f.govuk_submit t('.send'), classes: 'app-button--blue'
+    = f.govuk_submit t('.send'), classes: 'app-button--blue'


### PR DESCRIPTION
#### What
Ensure send message button does not appear when message box not available

#### Ticket

[relates to CFP-109 redetermination/messaging bug](https://dsdmoj.atlassian.net/browse/CFP-109)

#### Why
Fixes a regression introduced by commit faa71c9e16c6f036b298dd563da35eee38d861ca

Has resulted in confusion for users since the existence of the
button without the message box/attachment means there is nothing to send
which results in an error.

This only appears to affect Litigator interim claims from the provider side as
they are not redeterminable so have no message-box/file-upload visible, but do 
have the send button.


#### How
Loss of single indentation meant that in certain situations (external user view of
refused/rejected Litigator Interim claims messaging) the send button appears without
a message box or file attachment field. Clicking send then results in an error (no message
body to send).

--------

#### TODO (wip)

 - [X] Fix regression - send button available without message box
 - [X] Consider code refactor of `#messaging_permitted?` to use `#redeterminable?` - see https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/4074
 - [X] Consider design change to make it clearer when no further messaging is possible - see [CF9-109 comment](https://dsdmoj.atlassian.net/browse/CFP-109?focusedCommentId=160382)