### PR TITLE
Amend places where we should be using `#redeterminable?`

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -35,9 +35,7 @@ module ClaimsHelper
 
   def messaging_permitted?(message)
     return true if message.claim_action.present?
-    if current_user_is_external_user?
-      return Claims::StateMachine::VALID_STATES_FOR_REDETERMINATION.exclude?(message.claim.state)
-    end
+    return !message.claim.redeterminable? if current_user_is_external_user?
     false
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -87,7 +87,7 @@ class Message < ApplicationRecord
   end
 
   def process_claim_action
-    return unless Claims::StateMachine::VALID_STATES_FOR_REDETERMINATION.include?(claim.state)
+    return unless claim.redeterminable?
 
     case claim_action
     when /Apply for redetermination/

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -6,7 +6,7 @@
   }
   moj.Modules.Messaging.processMsg(data);
 
-  <% unless Claim::BaseClaim::VALID_STATES_FOR_REDETERMINATION.include?(@message.claim.state) %>
+  <% unless @message.claim.redeterminable? %>
     $('.js-hide-status').hide();
   <% end %>
 


### PR DESCRIPTION
#### What
Amend places where we should be using `#redeterminable?`

#### Ticket

[came out of/relates to CFP-109, redetermination messaging bugs](https://dsdmoj.atlassian.net/browse/CFP-109)

#### Why
The `#redeterminable?` method below applies the logic
used in these place plus the additional consideration of
not permitting redeterminations on Litigator interim claims,
which we PROBABLY should be applying everywhere.

```
def redeterminable?
  VALID_STATES_FOR_REDETERMINATION.include?(state) && !(lgfs? && interim?)
end
```

#### TODO (wip)

 - [x] pass test suite
 - [ ] test messaging functionality on all claim types is unchanged
       or write features tests to cover