### PR TITLE
Remove simplecov-multi gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,6 @@ group :test do
   gem 'rspec-html-matchers', '~> 0.9.4'
   gem 'rspec-mocks'
   gem 'shoulda-matchers', '>= 4.0.0.rc1'
-  gem 'simplecov-multi', require: false
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -664,10 +664,7 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-csv (0.1.3)
-      simplecov
     simplecov-html (0.10.2)
-    simplecov-multi (0.0.1)
     site_prism (3.7.1)
       addressable (~> 2.5)
       capybara (~> 3.8)
@@ -858,8 +855,6 @@ DEPENDENCIES
   sidekiq (~> 6.1)
   sidekiq-failures (~> 1.0)
   simplecov
-  simplecov-csv
-  simplecov-multi
   site_prism (~> 3.7)
   sprockets-rails (~> 3.2.1)
   state_machine (~> 1.2.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,6 @@ require 'simplecov'
 # $ open coverage/index.html)
 # ```
 #
-SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 
 SimpleCov.configure do
   add_filter '_spec.rb'


### PR DESCRIPTION
The `simplecov-multi` gem is unused so can be removed. Also, it appears that it is now included in `simplecov`. See:

https://github.com/simplecov-ruby/simplecov#using-multiple-formatters

Also also, the HTML formatter is the default so it does not need to be set explicitly.