### PR TITLE
[CFP-170] Task to create report of number of claims submitted

### DIFF
--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -141,4 +141,11 @@ namespace :claims do
     RakeHelpers::ArchivedClaims.write args[:filename]
     puts 'Done'.green
   end
+
+  desc 'Create a report of submitted claims'
+  task :submitted_claims_report, [:filename] => :environment do |_task, args|
+    require_relative 'rake_helpers/submitted_claims'
+
+    RakeHelpers::SubmittedClaims.write args[:filename]
+  end
 end

--- a/lib/tasks/rake_helpers/submitted_claims.rb
+++ b/lib/tasks/rake_helpers/submitted_claims.rb
@@ -1,19 +1,18 @@
 module RakeHelpers
   module SubmittedClaims
     def self.write(filename)
-      truncate = Arel.sql("date_trunc('week', created_at)")
+      truncate = Arel.sql("date_trunc('week', original_submission_date::date)")
 
       end_date = Time.zone.now.monday
       start_date = end_date - 12.weeks
 
       CSV.open(filename, 'wb') do |csv|
         csv << ['Week starting', 'Submitted claims']
-        ClaimStateTransition
-          .where(ClaimStateTransition.arel_table[:created_at].between(start_date..end_date))
-          .where(to: 'submitted')
-          .group(truncate).count
-          .sort_by { |row| row.first }.reverse
-          .each { |row| csv << [row[0].strftime('%d/%m/%Y'), row[1]] }
+        claims = Claim::BaseClaim
+          .where(original_submission_date: start_date..end_date)
+          .group(truncate).order(truncate).count
+          .transform_keys { |key| key.strftime('%d/%m/%Y') }
+          .to_a.each { |row| csv << row }
       end
     end
   end

--- a/lib/tasks/rake_helpers/submitted_claims.rb
+++ b/lib/tasks/rake_helpers/submitted_claims.rb
@@ -1,0 +1,20 @@
+module RakeHelpers
+  module SubmittedClaims
+    def self.write(filename)
+      truncate = Arel.sql("date_trunc('week', created_at)")
+
+      end_date = Time.zone.now.monday
+      start_date = end_date - 12.weeks
+
+      CSV.open(filename, 'wb') do |csv|
+        csv << ['Week starting', 'Submitted claims']
+        ClaimStateTransition
+          .where(ClaimStateTransition.arel_table[:created_at].between(start_date..end_date))
+          .where(to: 'submitted')
+          .group(truncate).count
+          .sort_by { |row| row.first }.reverse
+          .each { |row| csv << [row[0].strftime('%d/%m/%Y'), row[1]] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

Create a Rake task to generate a report of submitted claims per week.

#### Ticket

[Last 3 months submitted claims](https://dsdmoj.atlassian.net/browse/CFP-170)

#### Why

One of the outputs of spike [CFP-141](https://dsdmoj.atlassian.net/browse/CFP-141) is to pull the last 3 months submitted claims this will allow us to calculate the cost per transaction. This will give us an idea of the efficiency of our product this links directly to the current LAA digital strategy. 

#### How

To create a CSV file containing the total number of claims set to 'submitted' each week for the past 12 weeks:

```bash
rails claims:submitted_claims_report[filename]
```