### PR TITLE
[CFP-158] Fix govuk_design_system_formbuilder nested error linking

### DIFF
--- a/app/validators/base_sub_model_validator.rb
+++ b/app/validators/base_sub_model_validator.rb
@@ -50,13 +50,16 @@ class BaseSubModelValidator < BaseValidator
   end
 
   def copy_errors_to_base_record(base_record, association_name, associated_record, record_num)
-    error_prefix = "#{association_name.to_s.singularize}_#{record_num + 1}"
     associated_record.errors.each do |error|
-      error_suffix = suffix_error_fields? ? "_#{error.attribute}" : ''
-      base_record_error_key = [error_prefix, error_suffix].join.to_sym
+      base_record_error_key = associated_error_attribute(association_name, record_num, error)
       base_record.errors.add(base_record_error_key, error.message)
     end
   end
+
+  def associated_error_attribute(association_name, record_num, error)
+    "#{association_name.to_s.singularize}_#{record_num + 1}_#{error.attribute}"
+  end
+  public :associated_error_attribute
 
   def remove_unnumbered_submodel_errors_from_base_record(record)
     # DO NOT loop over `errors` because you modify the loop your are iterating over.
@@ -67,14 +70,5 @@ class BaseSubModelValidator < BaseValidator
 
   def has_many_association_names_for_errors
     has_many_association_names
-  end
-
-  # Override this method in subclasses for associations that should not generate errors in the format:
-  #   supplier_number_3_field
-  # and instead should remove the field having errors:
-  #   supplier_number_3
-  #
-  def suffix_error_fields?
-    true
   end
 end

--- a/app/validators/concerns/govuk_design_system_form_builder_errorable.rb
+++ b/app/validators/concerns/govuk_design_system_form_builder_errorable.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Include this module for validators on models that
+# are using the govuk_design_system_formbuilder
+# for their front-end forms.
+#
+# It ensures the errors are named following the convention
+# it uses and thereby enables functional links between
+# govuk_error_summary and govuk_ "field" errors.
+#
+# NOTE: Once all models are using this module then the method(s)
+# can be promoted to the superclass and this module removed
+#
+module GOVUKDesignSystemFormBuilderErrorable
+  extend ActiveSupport::Concern
+
+  included do
+    def associated_error_attribute(association_name, record_num, error)
+      "#{association_name}_attributes_#{record_num}_#{error.attribute}"
+    end
+  end
+end

--- a/app/validators/supplier_number_sub_model_validator.rb
+++ b/app/validators/supplier_number_sub_model_validator.rb
@@ -1,10 +1,8 @@
 class SupplierNumberSubModelValidator < BaseSubModelValidator
+  include GOVUKDesignSystemFormBuilderErrorable
+
   def has_many_association_names
     [:lgfs_supplier_numbers]
-  end
-
-  def suffix_error_fields?
-    true
   end
 
   def validate(record)

--- a/app/views/shared/_supplier_number_fields.html.haml
+++ b/app/views/shared/_supplier_number_fields.html.haml
@@ -17,8 +17,6 @@
         = link_to_remove_association f, wrapper_class: 'supplier-number-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
           = t('common.remove_html', context: t('.details_heading'))
 
-    -# adp_text_field does not allow to use rails defaults locales for model attributes :S
-    - attributes_scope = 'activerecord.attributes.supplier_number'
     - form_scope = 'shared.providers.form.supplier_details'
 
     = f.govuk_text_field :name,

--- a/app/views/shared/_supplier_numbers.html.haml
+++ b/app/views/shared/_supplier_numbers.html.haml
@@ -1,13 +1,13 @@
 .govuk-grid-row
   .govuk-grid-column-full
     #supplier-numbering.supplier-numbers-wrapper.fx-numberedList-hook
-      - @collection = f.object.lgfs_supplier_numbers.present? ? f.object.lgfs_supplier_numbers : [f.object.lgfs_supplier_numbers.build]
+      - @lgfs_supplier_numbers = f.object.lgfs_supplier_numbers.present? ? f.object.lgfs_supplier_numbers : [f.object.lgfs_supplier_numbers.build]
 
-      = f.fields_for :lgfs_supplier_numbers, @collection do |snf|
-        = render partial: 'shared/supplier_number_fields', locals: { f: snf, collection: @collection }
+      = f.fields_for :lgfs_supplier_numbers, @lgfs_supplier_numbers do |snf|
+        = render partial: 'shared/supplier_number_fields', locals: { f: snf }
 
     .govuk-form-group.form-actions
-      = link_to_add_association t('.add_supplier'), f, :lgfs_supplier_numbers, partial: 'shared/supplier_number_fields', render_options: { locals: { collection: @collection } }, class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.supplier-numbers-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
+      = link_to_add_association t('.add_supplier'), f, :lgfs_supplier_numbers, partial: 'shared/supplier_number_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.supplier-numbers-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
 
     = govuk_detail t('.postcode_help.heading') do
       = t('.postcode_help.text_html')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,8 @@ en:
               incompatible_case_type: Fixed fee invalid on non-fixed fee case types
         supplier_number:
           attributes:
+            postcode:
+              invalid: Enter a valid postcode
             supplier_number:
               invalid: Enter a valid LGFS supplier number
         provider:

--- a/features/provider_management.feature
+++ b/features/provider_management.feature
@@ -62,7 +62,7 @@ Feature: Case worker can manage providers
     And I fill in 'Supplier number' with '11111'
 
     When I click the button 'Save details'
-    Then the following error details should exist:
+    Then the following govuk error details should exist:
       | field_type | field_locator | error_text | linked_id |
       | field | Provider name| Enter a provider name | provider-name-field-error |
       | field | Supplier number | Enter a valid LGFS supplier number | provider-lgfs-supplier-numbers-attributes-0-supplier-number-field-error |

--- a/features/provider_management.feature
+++ b/features/provider_management.feature
@@ -30,11 +30,9 @@ Feature: Case worker can manage providers
     Then the page should be accessible
     When I click the link 'Providers'
     Then I should be on the provider index page
-    And the page should be accessible
 
     When I click the link 'Add a provider'
     Then I should be on the new provider page
-    And the page should be accessible skipping 'aria-allowed-attr'
 
     When I fill in 'Provider name' with 'Test Chambers'
     And I choose govuk radio 'Firm' for 'Provider type'

--- a/features/provider_management.feature
+++ b/features/provider_management.feature
@@ -42,11 +42,37 @@ Feature: Case worker can manage providers
     And I click govuk checkbox 'LGFS'
     And I fill in 'Supplier number' with '1A234B'
     And I choose govuk radio 'Yes' for 'Is the provider VAT registered?'
-    Then the page should be accessible skipping 'aria-allowed-attr'
 
     When I click the button 'Save details'
     Then I should see 'Provider successfully created'
+
+    And I eject the VCR cassette
+
+  Scenario: A Provider manager creates a new firm with errors and corrects
+    When I insert the VCR cassette 'features/provider_management'
+    Given I am a signed in case worker provider manager
     Then the page should be accessible
+    When I click the link 'Providers'
+
+    When I click the link 'Add a provider'
+    Then I should be on the new provider page
+
+    When I choose govuk radio 'Firm' for 'Provider type'
+    And I click govuk checkbox 'LGFS'
+    And I fill in 'Supplier number' with '11111'
+
+    When I click the button 'Save details'
+    Then the following error details should exist:
+      | field_type | field_locator | error_text | linked_id |
+      | field | Provider name| Enter a provider name | provider-name-field-error |
+      | field | Supplier number | Enter a valid LGFS supplier number | provider-lgfs-supplier-numbers-attributes-0-supplier-number-field-error |
+      | fieldset | Is the provider VAT registered? | Choose VAT registration state | provider-vat-registered-field-error |
+
+    When I fill in 'Provider name' with 'Test firm'
+    And I fill in 'Supplier number' with '1A234B'
+    And I choose govuk radio 'Yes' for 'Is the provider VAT registered?'
+    And I click the button 'Save details'
+    Then I should see 'Provider successfully created'
 
     And I eject the VCR cassette
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -205,16 +205,6 @@ And('I fill in {string} with {string}') do |label, text|
   fill_in label, with: text
 end
 
-And('I click govuk checkbox {string}') do |label|
-  find('.govuk-checkboxes__item label', text: label).click
-end
-
-And('I choose govuk radio {string} for {string}') do |label, legend|
-  find('.govuk-fieldset__legend', text: legend)
-    .find(:xpath, '..')
-    .find('.govuk-radios__item label', text: label).click
-end
-
 And('the text field {string} should be filled with {string}') do |label, value|
   actual_value = find_field(label).value
   expect(actual_value).to eql(value)

--- a/features/step_definitions/govuk_component_steps.rb
+++ b/features/step_definitions/govuk_component_steps.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+When('I click govuk checkbox {string}') do |label|
+  find('.govuk-checkboxes__item label', text: label).click
+end
+
+When('I choose govuk radio {string} for {string}') do |label, legend|
+  find('.govuk-fieldset__legend', text: legend)
+    .find(:xpath, '..')
+    .find('.govuk-radios__item label', text: label).click
+end
+
 Then('I should see govuk error summary with {string}') do |text|
   expect(page).to have_govuk_error_summary(text)
 end
@@ -16,7 +26,7 @@ Then('I should see govuk error fieldset for {string} with error {string} and id 
   expect(page).to have_govuk_error_fieldset(locator, text: text, id: id)
 end
 
-Then('the following error details should exist:') do |table|
+Then('the following govuk error details should exist:') do |table|
   table.hashes.each do |row|
     type, locator, text, id = row['field_type'], row['field_locator'], row['error_text'], row['linked_id']
 

--- a/features/step_definitions/govuk_component_steps.rb
+++ b/features/step_definitions/govuk_component_steps.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Then('I should see govuk error summary with {string}') do |text|
+  expect(page).to have_govuk_error_summary(text)
+end
+
+Then('I should see govuk error summary with {string} linking to {string}') do |text, href|
+  expect(page).to have_govuk_error_summary(text, href: href)
+end
+
+Then('I should see govuk error field for {string} with error {string} and id {string}') do |locator, text, id|
+  expect(page).to have_govuk_error_field(locator, text: text, id: id)
+end
+
+Then('I should see govuk error fieldset for {string} with error {string} and id {string}') do |locator, text, id|
+  expect(page).to have_govuk_error_fieldset(locator, text: text, id: id)
+end
+
+Then('the following error details should exist:') do |table|
+  table.hashes.each do |row|
+    type, locator, text, id = row['field_type'], row['field_locator'], row['error_text'], row['linked_id']
+
+    expect(page).to have_govuk_error_summary(text, href: "##{id}")
+    expect(page).to send("have_govuk_error_#{type}", locator, text: text, id: id)
+  end
+end
+

--- a/spec/models/supplier_number_spec.rb
+++ b/spec/models/supplier_number_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SupplierNumber, type: :model do
     it 'is invalid if postcode is filled and has the wrong format' do
       supplier.postcode = 'not-a-valid-postcode'
       expect(supplier).not_to be_valid
-      expect(supplier.errors[:postcode]).to include('is invalid')
+      expect(supplier.errors[:postcode]).to include('Enter a valid postcode')
     end
   end
 

--- a/spec/support/capybara_extensions/govuk_component_matchers.rb
+++ b/spec/support/capybara_extensions/govuk_component_matchers.rb
@@ -20,18 +20,30 @@ module CapybaraExtensions
         ].all?
       end
 
-      def has_govuk_error_summary?(error_text = nil)
+      def has_govuk_error_summary?(error_text = nil, options = {})
         summary = find('.govuk-error-summary[role="alert"]')
         [
           summary.has_selector?('#error-summary-title', text: 'There is a problem'),
-          summary.has_link?(error_text)
+          summary.has_link?(error_text, options)
         ].all?
       end
 
-      def has_govuk_error_field?(model, field, error_text = nil)
-        model = model.to_s.tr('_', '-')
-        field = field.to_s.tr('_', '-')
-        has_selector?(".govuk-error-message##{model}-#{field}-error", text: error_text)
+      def has_govuk_error_fieldset?(locator, text: nil, id: nil)
+        fieldset = find('.govuk-fieldset__legend', text: locator).find(:xpath, '..')
+
+        [
+          fieldset.find('.govuk-error-message').has_text?(text),
+          fieldset.first('label')[:for].eql?(id || fieldset.first('label')[:for])
+        ].all?
+      end
+
+      def has_govuk_error_field?(locator, text: nil, id: nil)
+        field = find_field(locator)
+
+        [
+          field.sibling('.govuk-error-message').has_text?(text),
+          field[:id].eql?(id || field[:id])
+        ].all?
       end
 
       def has_govuk_detail_summary?(text, options = {})

--- a/spec/support/shared_examples/validators/shared_examples_for_error_handling.rb
+++ b/spec/support/shared_examples/validators/shared_examples_for_error_handling.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with associated error handler setup' do
+  let(:association_name) { 'foos' }
+  let(:record_num) { 0 }
+  let(:error) { instance_double(ActiveModel::Error) }
+
+  before { allow(error).to receive(:attribute).and_return('bar') }
+end
+
+RSpec.shared_examples 'a govuk design system associated error handler' do
+  describe '#associated_error_attribute' do
+    subject { validator.associated_error_attribute(association_name, record_num, error) }
+
+    include_context 'with associated error handler setup'
+
+    it { is_expected.to eql('foos_attributes_0_bar') }
+  end
+end
+
+RSpec.shared_examples 'a custom CCCD associated error handler' do
+  describe '#associated_error_attribute' do
+    subject { validator.associated_error_attribute(association_name, record_num, error) }
+
+    include_context 'with associated error handler setup'
+
+    it { is_expected.to eql('foo_1_bar') }
+  end
+end

--- a/spec/validators/claim/base_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/base_claim_sub_model_validator_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Claim::BaseClaimSubModelValidator, type: :validator do
+  subject(:validator) { described_class.new }
+
   let(:claim) { FactoryBot.create :claim }
   let(:defendant) { claim.defendants.first }
 
@@ -8,6 +10,8 @@ RSpec.describe Claim::BaseClaimSubModelValidator, type: :validator do
     claim.force_validation = true
     claim.form_step = :defendants
   end
+
+  it_behaves_like 'a custom CCCD associated error handler'
 
   it 'calls the validators on all the defendants' do
     expect(claim.defendants).to have(1).members

--- a/spec/validators/defendant_sub_model_validator_spec.rb
+++ b/spec/validators/defendant_sub_model_validator_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe DefendantSubModelValidator, type: :validator do
+  subject(:validator) { described_class.new }
+
+  it_behaves_like 'a custom CCCD associated error handler'
+
+  describe '#has_many_association_names' do
+    subject { validator.has_many_association_names }
+
+    it { is_expected.to match_array([:representation_orders]) }
+  end
+end

--- a/spec/validators/fee/fee_sub_model_validator_spec.rb
+++ b/spec/validators/fee/fee_sub_model_validator_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe FeeSubModelValidator, type: :validator do
+  subject(:validator) { described_class.new }
+
+  it_behaves_like 'a custom CCCD associated error handler'
+
+  describe '#has_many_association_names' do
+    subject { validator.has_many_association_names }
+
+    it { is_expected.to match_array([:dates_attended]) }
+  end
+end

--- a/spec/validators/supplier_number_sub_model_validator_spec.rb
+++ b/spec/validators/supplier_number_sub_model_validator_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe SupplierNumberSubModelValidator, type: :validator do
+  subject(:validator) { described_class.new }
+
+  it_behaves_like 'a govuk design system associated error handler'
+
+  describe '#has_many_association_names' do
+    subject { validator.has_many_association_names }
+
+    it { is_expected.to match_array([:lgfs_supplier_numbers]) }
+  end
+
+  describe '#validate' do
+    subject(:validate) { validator.validate(record) }
+
+    let(:record) { build(:provider, :lgfs) }
+
+    context 'with an LGFS supplier number' do
+      before { record.lgfs_supplier_numbers << build(:supplier_number) }
+
+      specify { expect { validate }.to change(record.errors, :count).by(0) }
+    end
+
+    context 'without an LGFS supplier number' do
+      specify { expect { validate }.to change(record.errors, :count).by(1) }
+
+      specify do
+        validate
+        expect(record.errors.details).to eql({ base: [{ error: :blank_supplier_numbers }] })
+      end
+
+      specify do
+        validate
+        expect(record.errors[:base]).to include('You must specify at least one LGFS supplier number')
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Fix govuk_design_system_formbuilder nested error linking

#### Ticket

[CFP-156](https://dsdmoj.atlassian.net/browse/CFP-156)

#### Why
error linking between summary and field are broken nested fields when using the govuk formbuilder

#### How
- [X] Name nested errors following expectations from form builder
- [X] Use concern to override nested error attribute naming for validators on models using formbuilder on FE
- [X] Use DfE formbuilder 2.7.2

#### TODO
- [x] use new version of govuk formbuilder once [fix-multiple-captures](https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/301) is merged and released
- [x] unit spec error naming via composition and inheritance
- [x] feature spec unhappy path for provider supplier number error linking?!