### PR TITLE
Add babel env preset 'loose' option

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -32,7 +32,8 @@ module.exports = function (api) {
           useBuiltIns: 'entry',
           corejs: 3,
           modules: false,
-          exclude: ['transform-typeof-symbol']
+          exclude: ['transform-typeof-symbol'],
+          loose: true
         }
       ]
     ].filter(Boolean),


### PR DESCRIPTION
#### What
Silence webpacker warning by explicitly adding `loose: true` option to @babel/preset-env

#### Why
Webpacker warning arose in relation to babels `loose` option after recent dependency updates.

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled)...
```
