### PR TITLE
Enable new cops in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
 
 AllCops:
   DisplayCopNames: true
+  NewCops: enable
   TargetRubyVersion: 2.7
   Exclude:
     - './*'
@@ -61,101 +62,8 @@ Metrics/BlockLength:
     - trait
     - define
 
-Performance/AncestorsInclude: # (new in 1.7)
-  Enabled: true
-
-Performance/BigDecimalWithNumericArgument: # (new in 1.7)
-  Enabled: true
-
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
-
-Performance/CollectionLiteralInLoop: # (new in 1.8)
-  Enabled: true
-
-Performance/ConstantRegexp: # (new in 1.9)
-  Enabled: true
-
-Performance/MethodObjectAsBlock: # (new in 1.9)
-  Enabled: true
-
-Performance/RedundantSortBlock: # (new in 1.7)
-  Enabled: true
-
-Performance/RedundantStringChars: # (new in 1.7)
-  Enabled: true
-
-Performance/ReverseFirst: # (new in 1.7)
-  Enabled: true
-
-Performance/SortReverse: # (new in 1.7)
-  Enabled: true
-
-Performance/Squeeze: # (new in 1.7)
-  Enabled: true
-
-Performance/StringInclude: # (new in 1.7)
-  Enabled: true
-
-Performance/Sum: # (new in 1.8)
-  Enabled: true
-
-Rails/ActiveRecordCallbacksOrder: # (new in 2.7)
-  Enabled: true
-
-Rails/AfterCommitOverride: # (new in 2.8)
-  Enabled: true
-
-Rails/AttributeDefaultBlockValue: # (new in 2.9)
-  Enabled: true
-
-Rails/FindById: # (new in 2.7)
-  Enabled: true
-
-Rails/Inquiry: # (new in 2.7)
-  Enabled: true
-
-Rails/MailerName: # (new in 2.7)
-  Enabled: true
-
-Rails/MatchRoute: # (new in 2.7)
-  Enabled: true
-
-Rails/NegateInclude: # (new in 2.7)
-  Enabled: true
-
-Rails/Pluck: # (new in 2.7)
-  Enabled: true
-
-Rails/PluckInWhere: # (new in 2.7)
-  Enabled: true
-
-Rails/RenderInline: # (new in 2.7)
-  Enabled: true
-
-Rails/RenderPlainText: # (new in 2.7)
-  Enabled: true
-
-Rails/ShortI18n: # (new in 2.7)
-  Enabled: true
-
 Rails/SquishedSQLHeredocs:
   Enabled: false
-
-Rails/WhereEquals: # (new in 2.9)
-  Enabled: true
-
-Rails/WhereExists: # (new in 2.7)
-  Enabled: true
-
-Rails/WhereNot: # (new in 2.8)
-  Enabled: true
-
-Rails/EnvironmentVariableAccess: # (new in 2.10)
-  Enabled: true
-
-Rails/TimeZoneAssignment: # (new in 2.10)
-  Enabled: true
 
 RSpec/ImplicitSubject:
   EnforcedStyle: single_statement_only
@@ -175,83 +83,8 @@ Style/FrozenStringLiteralComment:
 Style/FormatStringToken:
   EnforcedStyle: template
 
-Style/StringConcatenation: # (new in 0.89)
+Style/StringConcatenation:
   Enabled: false
-
-Layout/SpaceBeforeBrackets: # (new in 1.7)
-  Enabled: true
-Lint/AmbiguousAssignment: # (new in 1.7)
-  Enabled: true
-Lint/DeprecatedConstants: # (new in 1.8)
-  Enabled: true
-Lint/DuplicateBranch: # (new in 1.3)
- Enabled: true
-Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
-  Enabled: true
-Lint/EmptyBlock: # (new in 1.1)
- Enabled: true
-Lint/EmptyClass: # (new in 1.3)
- Enabled: true
-Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
-  Enabled: true
-Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
-  Enabled: true
-Lint/RedundantDirGlobSort: # (new in 1.8)
-  Enabled: true
-Lint/ToEnumArguments: # (new in 1.1)
-  Enabled: true
-Lint/UnexpectedBlockArity: # (new in 1.5)
-  Enabled: true
-Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
-  Enabled: true
-Style/ArgumentsForwarding: # (new in 1.1)
-  Enabled: true
-Style/CollectionCompact: # (new in 1.2)
-  Enabled: true
-Style/DocumentDynamicEvalDefinition: # (new in 1.1)
- Enabled: true
-Style/EndlessMethod: # (new in 1.8)
-  Enabled: true
-Style/HashExcept: # (new in 1.7)
-  Enabled: true
-Style/NegatedIfElseCondition: # (new in 1.2)
- Enabled: true
-Style/NilLambda: # (new in 1.3)
-  Enabled: true
-Style/RedundantArgument: # (new in 1.4)
- Enabled: true
-Style/SwapValues: # (new in 1.1)
-  Enabled: true
-Lint/NumberedParameterAssignment: # (new in 1.9)
-  Enabled: true
-Lint/OrAssignmentToConstant: # (new in 1.9)
-  Enabled: true
-Lint/SymbolConversion: # (new in 1.9)
-  Enabled: true
-Lint/TripleQuotes: # (new in 1.9)
-  Enabled: true
-Style/IfWithBooleanLiteralBranches: # (new in 1.9)
-  Enabled: true
-Gemspec/DateAssignment: # (new in 1.10)
-  Enabled: true
-Style/HashConversion: # (new in 1.10)
-  Enabled: true
-Performance/RedundantEqualityComparisonBlock: # (new in 1.10)
-  Enabled: true
-Performance/RedundantSplitRegexpArgument: # (new in 1.10)
-  Enabled: true
-Performance/MapCompact: # (new in 1.11)
-  Enabled: true
-Style/StringChars: # (new in 1.12)
-  Enabled: true
-Lint/EmptyInPattern: # (new in 1.16)
-  Enabled: true
-Style/InPatternThen: # (new in 1.16)
-  Enabled: true
-Style/MultilineInPatternThen: # (new in 1.16)
-  Enabled: true
-Style/QuotedSymbols: # (new in 1.16)
-  Enabled: true
 
 # Temporarily disable while fixing spec/* directory
 Lint/RedundantCopDisableDirective:


### PR DESCRIPTION
With each update to the `rubocop` and `rubocop-*` gems we are explicitly enabling new cops to silence warnings. By setting new cops to be enabled we can reduce the size of `.rubocop.yml` and any new offences can be seen in the Dependabot PR without checking out locally.