### PR TITLE
[CFP-154] Replace app typography with that of the GOV.UK Design System [2 of 4]

### DIFF
--- a/app/views/external_users/claims/basic_fees/_fields.html.haml
+++ b/app/views/external_users/claims/basic_fees/_fields.html.haml
@@ -16,7 +16,7 @@
 
         .form-group
           %fieldset
-            %legend.heading-small
+            %legend.govuk-heading-s
               = t('.fee_type')
               %span.form-hint
                 Please choose all relevant options

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -18,7 +18,7 @@
 
   - unless claim.invalid_steps.empty?
     = govuk_inset_text do
-      %h2.heading-small
+      %h2.govuk-heading-s
         = t('external_users.claims.check_your_claim.missing_information.header')
       %p
         = t('external_users.claims.check_your_claim.missing_information.help_text')

--- a/app/views/external_users/claims/summary/_section_status.html.haml
+++ b/app/views/external_users/claims/summary/_section_status.html.haml
@@ -2,7 +2,7 @@
 
 - unless missing_dependencies.empty?
   = govuk_inset_text do
-    %h3.heading-small
+    %h3.govuk-heading-s
       = t('external_users.claims.check_your_claim.missing_information.header')
     %p
       = t('external_users.claims.check_your_claim.missing_information.section_help_text', section: t("external_users.claims.#{section}.summary.header"))

--- a/app/views/pages/tandcs.haml
+++ b/app/views/pages/tandcs.haml
@@ -35,18 +35,18 @@
   %p
     In these terms:
 
-  %h3.heading-small Advocate
+  %h3.govuk-heading-s Advocate
   means either a person who is an “authorised person” or an “exempt person”,
   for the purposes of exercising a “right of audience”, as defined by the
   provisions of the Legal Services Act 2007 who is instructed by an Authorising
   Organisation;
 
-  %h3.heading-small Application
+  %h3.govuk-heading-s Application
   means the CCCD application, available at
   = govuk_link_to 'https://claim-crown-court-defence.service.gov.uk/', 'https://claim-crown-court-defence.service.gov.uk/'
   \.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Authorised representative
   means:
   %ul
@@ -62,35 +62,35 @@
     %li
       a Litigator.
 
-  %h3.heading-small Authorised Signatory
+  %h3.govuk-heading-s Authorised Signatory
   means an Authorised Representative of an Authorising Organisation who meets
   our signatory requirements as set out in the AGFS and, as applicable, LGFS bill
   submission screens;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Authorising Organisation
   means an organisation or person making claims under the Standard Terms, or any
   other organisation or person who has written authority from us to use the
   Application in accordance with the Terms;
 
-  %h3.heading-small Claim
+  %h3.govuk-heading-s Claim
   means an AGFS or LGFS claim for payment, correctly made in accordance with the
   Criminal Legal Aid (Remuneration) Regulations 2013 (as amended);
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Controller
   means, where Personal Data is being processed for Law Enforcement Purposes,
   as it is defined in the Law Enforcement Directive (Directive (EU) 2016/680) (LED);
   and in all other circumstances, as defined in the Data Protection Act 2018 and the
   General Data Protection Regulation (Regulation (EU) 2016/679) (GDPR);
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Data Loss Event
   means any event that results, or may result, in unauthorised access to Personal
   Data held by you, and/or actual or potential loss and/or destruction of Personal
   Data in breach of these Terms, including any Personal Data Breach;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Data Protection Legislation
   means:
 
@@ -115,16 +115,16 @@
       practice issued by the Information Commissioner and any generally accepted
       code of good practice.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Data Security Requirements
   means our data security requirements (which can be located on our website)
   as may be amended by us from time to time;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     GDPR
   means the General Data Protection Regulation (Regulation (EU) 2016/679);
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     LAA Data
   means:
 
@@ -142,45 +142,45 @@
       any Personal Data for which we are the Controller (but not including
       the Shared Data)
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Law Enforcement Purposes
   means as it is defined in the Data Protection Act 2018;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     LED
   means the Law Enforcement Directive (Directive (EU) 2016/680);
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Legal Aid Legislation
   means the Legal Aid, Sentencing and Punishment of Offenders Act 2012 and
   statutory instruments made under that act that are relevant to the AGFS or LGFS;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Litigator
   means a solicitor, firm of solicitors or other appropriately qualified
   person referred to in a representation order as representing an assisted
   person;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Personal Data
   has the same meaning as the definition in the Data Protection Act 2018 and
   the GDPR;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Personal Data Breach
   means as it is defined in the Data Protection Act 2018 and the GDPR;
 
-  %h3.heading-small Process
+  %h3.govuk-heading-s Process
   has the same meaning as the definition in the Data Protection Legislation but,
   for the purposes of these Terms, it shall include both manual and automatic
   processing;
 
-  %h3.heading-small Processor
+  %h3.govuk-heading-s Processor
   means, where Personal Data is being Processed for Law Enforcement Purposes, as
   it is defined in the LED; and in all other circumstances, as it is defined in
   the Data Protection Act 2018 and the GDPR;
 
-  %h3.heading-small Protective Measures
+  %h3.govuk-heading-s Protective Measures
   means the appropriate technical and organisational measures which may include:
   pseudonymising and encrypting Personal Data, ensuring confidentiality, integrity,
   availability and resilience of systems and services, ensuring that availability of
@@ -188,12 +188,12 @@
   and regularly assessing and evaluating the effectiveness of the such measures
   adopted by it;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Shared Data
   means data (including Personal Data) on the Application for which you are the
   Controller, either alone or jointly with us;
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Standard Terms
   means, as applicable:
 
@@ -227,11 +227,11 @@
     subordinate legislation made under it and includes any new legal aid
     legislation in force on or after the date of these Terms.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     We, us, our
   means the Lord Chancellor acting through the LAA.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     You, your
   refers to (unless expressly indicated otherwise) you as an Authorised
   Representative, whom an Authorising Organisation has authorised to
@@ -262,7 +262,7 @@
   %h2.govuk-heading-m
     4. Licence to use the Application
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Authorised representatives
 
   %p
@@ -270,7 +270,7 @@
     and revocable licence to use the Application in accordance with the purposes
     set out in the Standard Terms.
 
-  %h3.heading-small Advocates
+  %h3.govuk-heading-s Advocates
 
   %p
     Subject to section 13 below, we grant you a non-exclusive, non-transferable
@@ -278,7 +278,7 @@
     obligations under Part 1 of the Legal Aid, Sentencing and Punishment of Offenders
     Act 2012 relating to the legal aid scheme.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Litigators
 
   %p
@@ -430,7 +430,7 @@
   %h2.govuk-heading-m
     9. Users and Passwords
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Advocate user
 
   %p
@@ -438,7 +438,7 @@
     However, the Advocate user can only create, edit, submit, view, manage
     and delete their own bills.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Advocate administrator user
 
   %p
@@ -640,7 +640,7 @@
   %h2.govuk-heading-m
     16. Information About You and Your Visits to Our Site
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Your information
 
   %p
@@ -648,7 +648,7 @@
     and your IP address) in accordance with these Terms. By using the Application,
     you consent to this.
 
-  %h3.heading-small Cookies
+  %h3.govuk-heading-s Cookies
 
   %p
     We may use information obtained about you from cookies (files that your
@@ -658,7 +658,7 @@
   %p
     There are different kinds of cookies with different functions:
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Session cookies:
   these cookies are only stored on your computer during your web session.
   They are automatically deleted when the browser is closed. They
@@ -666,7 +666,7 @@
   website without having to log in to each page. They do not collect
   any information from your computer.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Persistent cookies:
   a persistent cookie is stored as a file on your computer, and it
   remains there when you close your web browser. The cookie can be read
@@ -674,7 +674,7 @@
   do not use persistent cookies other than for Google Analytics (please
   see below for information on Google Analytics).
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Google Analytics:
   The Application uses Google Analytics, a web analytics service provided
   by Google. Google Analytics uses cookies to analyse how the Application
@@ -689,7 +689,7 @@
   to Google processing your Personal Data in the manner and for the purposes
   set out above.
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Deleting cookies:
 
   %p
@@ -722,7 +722,7 @@
     of or in connection with these terms or their subject matter or
     formation (including non-contractual disputes or claims).
 
-  %h3.heading-small
+  %h3.govuk-heading-s
     Contact Us
 
   %p

--- a/app/views/shared/summary/_expenses.html.haml
+++ b/app/views/shared/summary/_expenses.html.haml
@@ -6,7 +6,7 @@
 
 - if claim.travel_expense_additional_information.present?
   = govuk_inset_text do
-    %h3.heading-small
+    %h3.govuk-heading-s
       = t('.travel_expense_additional_information')
     %p
       = claim.travel_expense_additional_information

--- a/app/views/shared/summary/expenses/index.html.haml
+++ b/app/views/shared/summary/expenses/index.html.haml
@@ -1,5 +1,5 @@
 .table-container
-  %h3.heading-small
+  %h3.govuk-heading-s
     = t(".header_#{vat ? 'with_vat' : 'without_vat'}")
 
   %table.figures{ class: (current_user.case_worker? ? 'expenses-data-table' : nil) }


### PR DESCRIPTION
#### What

Replace app headings typography with that of the GOV.UK Design System

#### Ticket

[Replace stylesheet typography](https://dsdmoj.atlassian.net/browse/CFP-153)

#### Why

To continue the migration away from the deprecated GOV.UK Elements to GOV.UK Frontend (GOV.UK Design System)

#### How

| GOV.UK Elements | GOV.UK Frontend |
| --- | ----------- |
| `heading-xlarge` | `govuk-heading-xl` |
| `heading-large` | `govuk-heading-l` |
| `heading-medium` | `govuk-heading-m` |
| `heading-small` | `govuk-heading-s` |
