### PR TITLE
[CFP-154] Replace app typography with that of the GOV.UK Design System [3 of 4]

### DIFF
--- a/app/views/external_users/claims/defendants/_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_fields.html.haml
@@ -7,5 +7,5 @@
     = render partial: 'external_users/claims/defendants/defendant_fields', locals: { f: defendant }
 
 .form-section.form-actions.defendants-actions
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields', class: 'govuk-button app-button--blue', render_options: { }, data: { 'association-insertion-method': 'append', 'association-insertion-node': '.fx-numberedList-hook', module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -131,4 +131,4 @@
                               errors: @error_presenter,
                               value: number_with_precision(f.object.vat_amount, precision: 2)
 
-    %hr/
+    %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/external_users/claims/interim_fee/_fields.html.haml
+++ b/app/views/external_users/claims/interim_fee/_fields.html.haml
@@ -83,7 +83,7 @@
 
       = render partial: 'external_users/claims/interim_fee/calculator_help'
 
-    %hr
+    %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
     #disbursements.form-group
       .js-interim-disbursements.js-hidden

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -71,4 +71,4 @@
 
       = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: '', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
 
-  %hr/
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -39,4 +39,4 @@
                       errors: @error_presenter,
                       value: number_with_precision(f.object.amount, precision: 2)
 
-  %hr/
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -8,7 +8,7 @@
   for bugs or other problems.
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 16th June 2021
   %ul.list-bullet
     %li
@@ -31,7 +31,7 @@
       %br/
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 17th September 2020
   %ul.list-bullet
     %li
@@ -168,7 +168,7 @@
 
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 TBC
   %ul.list-bullet
     %li
@@ -180,7 +180,7 @@
       %br/
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 12th May 2020
   %ul.list-bullet
     %li
@@ -208,7 +208,7 @@
           %td GET /api/case_stages
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 15th July 2019
   %ul.list-bullet
     %li
@@ -222,7 +222,7 @@
       %br/
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 30th April 2019
   %ul.list-bullet
     %li
@@ -279,7 +279,7 @@
               WARNING: fees of an ineligible fee type added to a claim will be removed.
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 7th March 2019
   %ul.list-bullet
     %li
@@ -319,7 +319,7 @@
 
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 6th March 2019
   %ul.list-bullet
     %li
@@ -341,7 +341,7 @@
       parameter that falls within the scheme 10/11 scheme start and end date - start dates are 2018-04-01 and 2018-12-31 respectively
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 28th February 2019
   %ul.list-bullet
     %li
@@ -470,7 +470,7 @@
       finding a single fee type. Useful for testing.
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 30th January 2019
   %ul.list-bullet
     %li
@@ -484,7 +484,7 @@
       for AGFS retrial fees.
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 20th December 2018
   %ul.list-bullet
     %li
@@ -530,7 +530,7 @@
       fee amount, transfer fee amount or interim fee amount as applicable.
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 3rd December 2018
   %ul.list-bullet
     %li
@@ -559,7 +559,7 @@
       set
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 05 November 2018
   %ul.list-bullet
     %li
@@ -625,7 +625,7 @@
       Long term, API consumers should look to provide quantity and rate separately where quantity represents the number of days (in court) typically.
 
 %section.api-documentation
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 10 September 2018
   %ul.list-bullet
     %li
@@ -698,7 +698,7 @@
       %br/
       All existing fees of this type will be updated in line with these changes, but will not affect their value.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 3 September 2018
   %ul.list-bullet
     %li
@@ -839,7 +839,7 @@
     ** API consumer applications that send ineligible fixed fees will NOT error. However, when reviewing the claim's fixed fees in the web interface any ineligible fees will no longer have a type and will need to be amended to apply an eligible type.
 
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 20 April 2018
   %ul.list-bullet
     %li
@@ -889,7 +889,7 @@
       %code.code
         role
       filter to either will return all data, regardless of fee scheme.
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 12 April 2018
   %ul.list-bullet
     %li
@@ -905,7 +905,7 @@
       This change encapsulates two distinct changes, namely, Case uplifts are not applicable to LGFS
       claims and Defendant uplifts can be claimed.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 6 April 2018
   %ul.list-bullet
     %li
@@ -929,7 +929,7 @@
         \/api/external_users/claims/advocates/interim/validate
       endpoint to test your submissions against.  This will return any validation errors that will prevent the record being created on the creation endpoint.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 23 March 2018
   %ul.list-bullet
     %li
@@ -950,7 +950,7 @@
       %br/
       When submitted with a date on or after the start of scheme 10 this will return the new, scheme 10, offences.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 24 February 2018
   %ul.list-bullet
     %li
@@ -990,7 +990,7 @@
             %td
               MIEVI
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 01 November 2017
   %ul.list-bullet
     %li
@@ -1152,7 +1152,7 @@
         %em
           Note: The API will implement the validation fully on or after 1st April 2018.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 30 November 2016
   %ul.list-bullet
     %li
@@ -1166,7 +1166,7 @@
       developers when a case conclusion id is or is not required.
 
   %p
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 November 2016
   %ul.list-bullet
     %li
@@ -1198,7 +1198,7 @@
       %p
       expense_type_id and expense_type_unique_code are mutually exclusive.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 October 2016
   %ul.list-bullet
     %li
@@ -1228,7 +1228,7 @@
       %br
       fee_type_id and fee_type_unique_code are mutually exclusive so you can only provide one or the other.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 August 2016
 
   %ul.list-bullet
@@ -1237,7 +1237,7 @@
       the only offence ids that were considered valid on an LGFS claim were those that were derived from the litigator_offence_id on the relevant Offence Class.  This is no longer that case,
       any offence id may be used.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 July 2016
 
   %ul.list-bullet
@@ -1343,7 +1343,7 @@
       be one of the lgfs_offence_ids returned in the offence_classes list. You should still use the offence ids returned from the /api/offences
       endpoint for advocate claims.
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2 June 2016
 
   %ul.list-bullet
@@ -1379,7 +1379,7 @@
       Submitted dates must conform to ISO 8601, being the time information and time zone offset optional.
       Examples: 2016-12-31, 2016-12-31T11:45, 2016-12-31T11:45:30Z
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2
     February 2016
 
@@ -1396,7 +1396,7 @@
     %li retrial fields added - required for Retrial case type claims
     %li claim importer - reports specific errors for valid JSON files that contain model validation errors
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2
     October 2015
 
@@ -1404,7 +1404,7 @@
     %li
       first significant release
 
-  %hr
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
   %h2
     July 2015
 

--- a/app/views/shared/_supplier_number_fields.html.haml
+++ b/app/views/shared/_supplier_number_fields.html.haml
@@ -33,4 +33,4 @@
       hint: { text: t('hint_text.supplier_number', scope: form_scope) },
       label: { text: t('label.supplier_number', scope: form_scope) }
 
-  %hr/
+  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible


### PR DESCRIPTION
#### What

Replace app body typography with that of the GOV.UK Design System

#### Ticket

[Replace stylesheet typography](https://dsdmoj.atlassian.net/browse/CFP-153)

#### Why

To continue the migration away from the deprecated GOV.UK Elements to GOV.UK Frontend (GOV.UK Design System)

#### How

| GOV.UK Elements | GOV.UK Frontend |
| --- | ----------- |
| `lede` | `govuk-body-l` |
| `<p>`<br> `body-text` | `govuk-body` |
| `font-xsmall` | `govuk-body-s` |
| `<hr>` | `govuk-section-break`<br> `govuk-section-break--visible`<br> `govuk-section-break--xl`<br> `govuk-section-break--l`<br> `govuk-section-break--m` |
