### PR TITLE
[CFP-154] Replace app typography with that of the GOV.UK Design System [4 of 4]

### DIFF
--- a/app/views/external_users/claims/_financial_summary.html.haml
+++ b/app/views/external_users/claims/_financial_summary.html.haml
@@ -1,14 +1,14 @@
 .govuk-grid-column-one-third
-  %p.heading-large
-    %span.heading-secondary
+  %p.govuk-heading-l
+    %span.govuk-caption-l
       = t('.total_outstanding')
     = number_to_currency(financial_summary.total_outstanding_claim_value)
   %p
     = link_to t('.view_details_outstanding_html'), outstanding_external_users_claims_path, id: 'outstanding_claim_details', 'aria-label': t('.outstanding_claim_details_label')
 
 .govuk-grid-column-one-third
-  %p.heading-large
-    %span.heading-secondary
+  %p.govuk-heading-l
+    %span.govuk-caption-l
       = t('.total_authorised')
     = number_to_currency(financial_summary.total_authorised_claim_value)
   %p

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -1,43 +1,50 @@
 .claim-hgroup
-  .govuk-grid-row{ class: 'govuk-!-margin-bottom-3' }
+  .govuk-grid-row
     .govuk-grid-column-one-third
-      %h1
-        = t('.case_number')
-        %span.case-number-header
-          = claim.formatted_case_number
-          %span.unique-id-small= claim.unique_id
-    .govuk-grid-column-one-third
-      .claim-status
-        = t('.status')
-        .govuk-grid-row
-          .govuk-grid-column-full
-            = govuk_tag claim.state.humanize, class: "app-tag--#{claim.state}"
+      %h1.govuk-heading-l
+        %span.govuk-caption-l
+          = t('.case_number')
+
+        = claim.formatted_case_number
+        %span.govuk-caption-l
+          = claim.unique_id
+
+    .govuk-grid-column-one-third.claim-status
+      %p.govuk-heading-l
+        %span.govuk-caption-l
+          = t('.status')
+        = govuk_tag claim.state.humanize, class: "app-tag--#{claim.state}"
 
     .govuk-grid-column-one-third
-      %h2
-        = t('.assessment_date')
-        %span.case-number-header
-          = claim.assessment_date
+      %p.govuk-heading-l
+        %span.govuk-caption-l
+          = t('.assessment_date')
 
-  .govuk-grid-row{ class: 'govuk-!-margin-bottom-3' }
-    .govuk-grid-column-one-third
-      %h2
-        = t('.defendant_names')
-        %span.case-number-header
-          = claim.defendant_name_and_initial
-        %span
-          = claim.other_defendant_summary
-    .govuk-grid-column-one-third
-      %h2
-        = t('.provider_type')
-        %span.case-number-header
-          = claim.provider.name
+        = claim.assessment_date
 
+  .govuk-grid-row
+    .govuk-grid-column-one-third
+      %p.govuk-heading-l
+        %span.govuk-caption-l
+          = t('.defendant_names')
+
+        = claim.defendant_name_and_initial
+        = claim.other_defendant_summary
+
+    .govuk-grid-column-one-third
+      %p.govuk-heading-l
+        %span.govuk-caption-l
+          = t('.provider_type')
+
+        = claim.provider.name
 
     .govuk-grid-column-one-third.claim-detail-actions
       - if current_user.persona.is_a?(ExternalUser)
         - if claim.editable?
-          = t('.actions')
+          %p.govuk-heading-l
+            %span.govuk-caption-l
+              = t('.actions')
+
           .action-wrapper
             = govuk_link_button(t('buttons.edit_draft'), edit_polymorphic_path(claim), class: 'edit-claim')
 
@@ -50,7 +57,10 @@
             = govuk_link_button(t('buttons.delete_draft'), external_users_claim_path(claim), class: 'delete-draft', 'data-method': 'delete', 'data-confirm': t('.confirm_text'))
 
         - if claim.archivable?
-          = t('.actions')
+          %p.govuk-heading-l
+            %span.govuk-caption-l
+              = t('.actions')
+
           .action-wrapper
             - if claim.rejected?
               = button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: 'patch', class: 'govuk-button resubmit-claim', form_class: 'inline-form', data: { module: 'govuk-button' }, role: 'button', draggable: 'false'
@@ -58,6 +68,9 @@
             = govuk_link_button(t('.archive'), external_users_claim_path(claim), 'data-method': 'delete', 'data-confirm': t('.confirm_text'))
 
         - if claim.archived_pending_delete? || claim.archived_pending_review?
-          = t('.actions')
+          %p.govuk-heading-l
+            %span.govuk-caption-l
+              = t('.actions')
+
           .action-wrapper
             = button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: 'patch', class: 'govuk-button', form_class: 'inline-form', data: { module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -1,4 +1,7 @@
-// Typography Settings
+html {
+  font-family: $govuk-font-family-gds-transport;
+}
+
 .bold-xsmall {
   @include bold-14;
 }

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -16,10 +16,6 @@ html {
   font-size: 12px;
 }
 
-.case-number-header .unique-id-small {
-  display: inline-block;
-}
-
 .sub-header {
   margin-bottom: $gutter-half;
 }
@@ -41,30 +37,6 @@ html {
 
 .claim-hgroup {
   margin-bottom: $gutter-one-third;
-
-  h1 {
-    @include core-19;
-    display: inline-block;
-    margin-left: 0;
-    padding-top: 0;
-  }
-
-  .case-number-header {
-    @include core-36;
-    display: block;
-    font-weight: 700;
-    word-wrap: break-word;
-    word-break: break-word;
-    hyphens: auto;
-    overflow-wrap: break-word;
-  }
-
-  .claim-status {
-    @include core-19;
-    display: block;
-    margin-bottom: $gutter-one-third;
-    float: none;
-  }
 
   .claim-detail-actions {
     margin-bottom: $gutter-one-third;

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -4,9 +4,7 @@ $path: '~images/';
 
 // GOV.UK Frontend Toolkit (alphagov/govuk_frontend_toolkit)
 @import '~govuk_frontend_toolkit/stylesheets/colours';
-@import '~govuk_frontend_toolkit/stylesheets/font_stack';
 @import '~govuk_frontend_toolkit/stylesheets/measurements';
-@import '~govuk_frontend_toolkit/stylesheets/typography';
 @import '~govuk_frontend_toolkit/stylesheets/shims';
 
 @import '~govuk_frontend_toolkit/stylesheets/design-patterns/alpha-beta';
@@ -18,7 +16,6 @@ $path: '~images/';
 @import '~govuk-elements-sass/public/sass/elements/reset';
 
 // Components (chunks of UI)
-@import '~govuk-elements-sass/public/sass/elements/elements-typography';
 @import '~govuk-elements-sass/public/sass/elements/buttons';
 @import '~govuk-elements-sass/public/sass/elements/icons';
 @import '~govuk-elements-sass/public/sass/elements/lists';


### PR DESCRIPTION
#### What

Replace app's deprecated typography with that of the GOV.UK Design System

#### Ticket

[Replace stylesheet typography](https://dsdmoj.atlassian.net/browse/CFP-153)

#### Why

To continue the migration away from the deprecated GOV.UK Elements to GOV.UK Frontend (GOV.UK Design System)

#### How

Tidy-up of the task to replace the deprecated typography style from the app;

- Remove deprecated typography related css imports