### PR TITLE
[CFP-158] Move capybara config to own file and extend

### DIFF
--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Load custom capybara extensions
+#
+# Idea comes from:
+# https://github.com/DavyJonesLocker/capybara-extensions
+#
+require Rails.root.join('spec','support','capybara_extensions','matchers')
+
+module Capybara
+  module DSL
+    CapybaraExtensions::Matchers.instance_methods.each do |method|
+      define_method method do |*args, &block|
+        page.send method, *args, &block
+      end
+    end
+  end
+
+  class Session
+    CapybaraExtensions::Matchers.instance_methods.each do |method|
+      define_method method do |*args, &block|
+        current_scope.send method, *args, &block
+      end
+    end
+  end
+
+  Node::Base.include CapybaraExtensions::Matchers
+  Node::Simple.include CapybaraExtensions::Matchers
+end
+
+# set minimum threads to 0 (to allow shutdown?!)
+# and max threads to 5 (duplicate default development
+# settings)
+#
+Capybara.register_server :puma do |app, port, host|
+  require 'rack/handler/puma'
+  Rack::Handler::Puma.run(app, Host: host, Port: port, Threads: "0:5")
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu window-size=1366,768) }
+  )
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+end
+
+# use headless chrome for javascript
+Capybara.javascript_driver = :headless_chrome
+
+Capybara.configure do |config|
+  config.default_max_wait_time = 10 # seconds
+end
+
+if ENV['BROWSER'] == 'chrome'
+  Capybara.register_driver :chrome do |app|
+    Capybara::Selenium::Driver.new(app, browser: :chrome)
+  end
+
+  Capybara.configure do |config|
+    config.default_max_wait_time = 10 # seconds
+    config.javascript_driver = :chrome
+  end
+end
+
+
+# Capybara defaults to CSS3 selectors rather than XPath.
+# If you'd prefer to use XPath, just uncomment this line and adjust any
+# selectors in your step definitions to use the XPath syntax.
+# Capybara.default_selector = :xpath

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -48,45 +48,6 @@ allowed_sites = [
 ]
 WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
 
-# set minimum threads to 0 (to allow shutdown?!)
-# and max threads to 5 (duplicate default development
-# settings)
-#
-Capybara.register_server :puma do |app, port, host|
-  require 'rack/handler/puma'
-  Rack::Handler::Puma.run(app, Host: host, Port: port, Threads: "0:5")
-end
-
-Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu window-size=1366,768) }
-  )
-  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
-end
-
-# use headless chrome for javascript
-Capybara.javascript_driver = :headless_chrome
-
-Capybara.configure do |config|
-  config.default_max_wait_time = 10 # seconds
-end
-
-if ENV['BROWSER'] == 'chrome'
-  Capybara.register_driver :chrome do |app|
-    Capybara::Selenium::Driver.new(app, browser: :chrome)
-  end
-
-  Capybara.configure do |config|
-    config.default_max_wait_time = 10 # seconds
-    config.javascript_driver = :chrome
-  end
-end
-
-# Capybara defaults to CSS3 selectors rather than XPath.
-# If you'd prefer to use XPath, just uncomment this line and adjust any
-# selectors in your step definitions to use the XPath syntax.
-# Capybara.default_selector = :xpath
-
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how
 # your application behaves in the production environment, where an error page will

--- a/spec/support/capybara_extensions/govuk_component_matchers.rb
+++ b/spec/support/capybara_extensions/govuk_component_matchers.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# rubocop:disable Naming/PredicateName
+module CapybaraExtensions
+  module GOVUKComponent
+    module Matchers
+      def has_govuk_page_title?(options = {})
+        has_selector?('h1.govuk-heading-xl', **options)
+      end
+
+      def has_govuk_flash?(options = {})
+        has_selector?('.govuk-error-summary', **options)
+      end
+
+      def has_govuk_warning?(text = nil)
+        [
+          has_selector?('.govuk-warning-text strong.govuk-warning-text__text', text: text),
+          has_selector?('.govuk-warning-text span.govuk-warning-text__icon', text: '!'),
+          has_selector?('.govuk-warning-text span.govuk-warning-text__assistive', text: 'Warning')
+        ].all?
+      end
+
+      def has_govuk_error_summary?(error_text = nil)
+        summary = find('.govuk-error-summary[role="alert"]')
+        [
+          summary.has_selector?('#error-summary-title', text: 'There is a problem'),
+          summary.has_link?(error_text)
+        ].all?
+      end
+
+      def has_govuk_error_field?(model, field, error_text = nil)
+        model = model.to_s.tr('_', '-')
+        field = field.to_s.tr('_', '-')
+        has_selector?(".govuk-error-message##{model}-#{field}-error", text: error_text)
+      end
+
+      def has_govuk_detail_summary?(text, options = {})
+        has_selector?(detail_summary_selector, **options.merge(text: text))
+      end
+
+      def has_no_govuk_detail_summary?(text, options = {})
+        has_no_selector?(detail_summary_selector, **options.merge(text: text))
+      end
+
+      def click_govuk_detail_summary(text, options = {})
+        detail_summary = find(detail_summary_selector, **options.merge(text: text))
+        detail_summary.click
+      end
+
+      def detail_summary_selector
+        'details.govuk-details summary.govuk-details__summary span.govuk-details__summary-text'
+      end
+    end
+  end
+end
+# rubocop:enable Naming/PredicateName

--- a/spec/support/capybara_extensions/matchers.rb
+++ b/spec/support/capybara_extensions/matchers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Extensions to capybara can be written here
+# and they will be mixed into existing
+# helpers/matchers by the `features/support/capybara.rb`
+#
+# Idea comes from:
+# https://github.com/DavyJonesLocker/capybara-extensions
+#
+
+require_relative 'govuk_component_matchers'
+
+module CapybaraExtensions
+  module Matchers
+    include GOVUKComponent::Matchers
+  end
+end


### PR DESCRIPTION
#### What
Move capybara config to own file and extend

#### Ticket
relates to [CFP-158](https://dsdmoj.atlassian.net/browse/CFP-158)

#### Why
There is a lot of capybara config for cucumber so this separates
it out to its own file as a first step. 

It would be useful to extend capybara with govuk component 
helpers as we migrate to using the form builder and apply its styling. To 
assist with this we can mixin extensions using composition via the config.

The matcher file that is mixed in here is just using using some tweaked
extensions taken from VCD.
