### PR TITLE
[CFP-178] Set belongs_to_required_by_default to true

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -17,4 +17,4 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = false
+Rails.application.config.active_record.belongs_to_required_by_default = true


### PR DESCRIPTION
#### What
Set `Rails.application.config.active_record.belongs_to_required_by_default`
to true to test.

#### Ticket

[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### Details
Further reading blog here:
[Rails 5 makes belongs_to association required by default](https://www.bigbinary.com/blog/rails-5-makes-belong-to-association-required-by-default)

To adopt default/true: A search of the code base
shows this may well require a lot of remedial work
if adopted and potential breakages. We could try it
and see how the test suite reacts and then use
`optional: true` to handle on a model by model basis.
We need to consider error messaging too.

To adopt false: easier path, and could extend
to add `required: true` on a model by model basis
to implement.

--------

#### TODO (wip)

 - [x] test suite pass
 - [x] extensive sanity testing
 - [x] test archive_stale against prod like load