### PR TITLE
[CFP-178] Set rails 5+ defaults for additional csrf protection

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -10,7 +10,7 @@
 Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+Rails.application.config.action_controller.forgery_protection_origin_check = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -7,7 +7,7 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
 Rails.application.config.action_controller.forgery_protection_origin_check = false


### PR DESCRIPTION
#### What
set rails 5+ defaults related to CSRF protection

#### Ticket

[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### Why
Additional CSRF protection

- [x] sanity test on staging (successful advocate final claim submission, allocation and assessment)