### PR TITLE
[CFP-178] Set ActiveSupport.to_time_preserves_timezone to true

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -14,7 +14,7 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
+ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false


### PR DESCRIPTION
#### What
Set Rails 5.0 default to preserve timezones for ruby 2.4+

##### Note
We do not appear to be using to_time anywhere in the codebase

#### Ticket
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### Why
[Further reading](https://www.bigbinary.com/blog/to-time-preserves-time-zone-info-in-ruby-2-4)

 > Make Ruby 2.4 preserve the timezone of the receiver
In Ruby 2.4 the to_time method for both DateTime and Time will
preserve the timezone of the receiver when converting to an
instance of Time. For upgraded apps, this feature is disabled by
setting the following configuration option to false

Rails 6.1 default, true (since 5.0), current setting is false