### PR TITLE
[CFP-214] Set form_with_generates_remote_forms to false

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -45,7 +45,7 @@
 # Rails.application.config.active_record.legacy_connection_handling = false
 
 # Make `form_with` generate non-remote forms by default.
-# Rails.application.config.action_view.form_with_generates_remote_forms = false
+Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # Set the default queue name for the analysis job to the queue adapter default.
 # Rails.application.config.active_storage.queues.analysis = nil


### PR DESCRIPTION
#### What

Set rails 6.1+ default related to remote forms with `form_with`.

Explicitly set:

```ruby
Rails.application.config.action_view.form_with_generates_remote_forms = false
```

This setting is introduced in Rails 5.1, where the default is true. The default is changed to false in 6.1. As we never adopted the 5.1 defaults it is simplest to keep it as false.

This does not change the setting now but it will ensure that the setting remains false when `config.load_defaults` is used in `config/application.rb` for 5.1, 5.2 and 6.0.

#### Ticket

[Rails 6.1 post upgrade: handle config for Rails 5.1+](https://dsdmoj.atlassian.net/browse/CFP-214)
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)