### PR TITLE
[CFP-214] Set unknown_asset_fallback to false

### DIFF
--- a/config/initializers/new_framework_defaults_5_1.rb
+++ b/config/initializers/new_framework_defaults_5_1.rb
@@ -1,0 +1,6 @@
+# From https://edgeguides.rubyonrails.org/configuring.html#configuring-assets
+# config.assets.unknown_asset_fallback allows you to modify the behavior of
+# the asset pipeline when an asset is not in the pipeline, if you use
+# sprockets-rails 3.2.0 or newer.
+
+Rails.application.config.assets.unknown_asset_fallback = false


### PR DESCRIPTION
#### What

```ruby
Rails.application.config.assets.unknown_asset_fallback = false
```

is the default for Rails 5.1+. CCCD is not using sprockets so this does not have any effect.

#### Ticket

[Rails 6.1 post upgrade: handle config for Rails 5.1+](https://dsdmoj.atlassian.net/browse/CFP-214)
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)