### PR TITLE
Remove json importer code

### DIFF
--- a/app/models/claim/advocate_claim.rb
+++ b/app/models/claim/advocate_claim.rb
@@ -133,7 +133,6 @@ module Claim
       # TODO: this should return a list based on the current given fee scheme
       # rather than conditionally return scheme 10 specifically
       # TBD once all the fee scheme work is integrated
-      return Fee::BasicFeeType.all if from_json_import?
       return Fee::BasicFeeType.unscoped.agfs_scheme_10s.order(:position) if agfs_reform?
       Fee::BasicFeeType.agfs_scheme_9s
     end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -439,10 +439,6 @@ module Claim
       source == 'web'
     end
 
-    def json_import_web_edited?
-      source == 'json_import_web_edited'
-    end
-
     def api_draft?
       draft? && from_api?
     end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -439,10 +439,6 @@ module Claim
       source == 'web'
     end
 
-    def from_json_import?
-      source == 'json_import'
-    end
-
     def json_import_web_edited?
       source == 'json_import_web_edited'
     end

--- a/app/models/fee/base_fee.rb
+++ b/app/models/fee/base_fee.rb
@@ -130,11 +130,8 @@ module Fee
       false
     end
 
-    # Prevent invalid fees from being created through the JSON importer,
-    # because once created they cannot be amended on the web UI.
-    #
     def perform_validation?
-      claim&.perform_validation? || claim&.from_json_import?
+      claim&.perform_validation?
     end
 
     # where fee type not available, default calculated? to true

--- a/app/models/fee/interim_fee.rb
+++ b/app/models/fee/interim_fee.rb
@@ -37,7 +37,7 @@ class Fee::InterimFee < Fee::BaseFee
   end
 
   def perform_validation?
-    (claim&.perform_validation? && validation_required?) || claim&.from_json_import?
+    claim&.perform_validation? && validation_required?
   end
 
   def validation_required?

--- a/app/models/stats/collector/claim_creation_source_collector.rb
+++ b/app/models/stats/collector/claim_creation_source_collector.rb
@@ -3,8 +3,7 @@ module Stats
     class ClaimCreationSourceCollector < BaseCollector
       CLAIM_SOURCES = {
         web: %w[web],
-        api: %w[api api_web_edited],
-        json: %w[json_import json_import_web_edited]
+        api: %w[api api_web_edited]
       }.freeze
 
       def collect

--- a/app/services/claims/claim_actions_service.rb
+++ b/app/services/claims/claim_actions_service.rb
@@ -45,7 +45,6 @@ module Claims
 
     def update_source
       claim.source = 'api_web_edited' if claim.from_api?
-      claim.source = 'json_import_web_edited' if claim.from_json_import?
     end
 
     def rollback!

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -429,28 +429,6 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController, type: :controller do
         end
       end
 
-      context 'and editing a JSON imported claim' do
-        before do
-          subject.update(source: 'json_import')
-        end
-
-        context 'and saving to draft' do
-          before { put :update, params: { id: subject, claim: { additional_information: 'foo' } } }
-
-          it 'updates the source to indicate it was originally from JSON import but has been edited via web' do
-            expect(subject.reload.source).to eql 'json_import_web_edited'
-          end
-        end
-
-        context 'and submitted to LAA' do
-          before { put :update, params: { id: subject, claim: { additional_information: 'foo' }, summary: true, commit_submit_claim: 'Submit to LAA' } }
-
-          it 'updates the source to indicate it was originally from JSON import but has been edited via web' do
-            expect(subject.reload.source).to eql 'json_import_web_edited'
-          end
-        end
-      end
-
       context 'and saving to draft' do
         it 'updates a claim' do
           put :update, params: { id: subject, claim: { additional_information: 'foo' } }

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -793,11 +793,6 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
         expect(claim.validation_required?).to eq false
       end
 
-      it 'draft claims submitted by json importer' do
-        claim.source = 'json_import'
-        expect(claim.validation_required?).to eq false
-      end
-
       it 'archived_pending_delete claims' do
         claim = create(:archived_pending_delete_claim)
         expect(claim.validation_required?).to eq false

--- a/spec/models/fee/interim_fee_spec.rb
+++ b/spec/models/fee/interim_fee_spec.rb
@@ -106,19 +106,10 @@ RSpec.describe Fee::InterimFee do
 
     before do
       allow(claim).to receive(:perform_validation?).and_return(false)
-      allow(claim).to receive(:from_json_import?).and_return(false)
       allow(fee).to receive(:validation_required?).and_return(false)
     end
 
     specify { is_expected.to be_falsey }
-
-    context 'when the associated claim is from a JSON import' do
-      before do
-        allow(claim).to receive(:from_json_import?).and_return(true)
-      end
-
-      specify { is_expected.to be_truthy }
-    end
 
     context 'when the associated claim needs validation' do
       before do

--- a/spec/models/stats/collector/claim_creation_source_collector_spec.rb
+++ b/spec/models/stats/collector/claim_creation_source_collector_spec.rb
@@ -8,9 +8,6 @@ module Stats
           create(:draft_claim, source: 'web')
           create(:submitted_claim, source: 'api_web_edited')
           create(:draft_claim, source: 'api')
-          create(:submitted_claim, source: 'json_import')
-          create(:submitted_claim, source: 'json_import_web_edited')
-          create(:draft_claim, source: 'json_import')
         end
       end
 

--- a/spec/models/stats/collector/claim_creation_source_collector_spec.rb
+++ b/spec/models/stats/collector/claim_creation_source_collector_spec.rb
@@ -35,15 +35,6 @@ module Stats
           expect(stat.claim_type).to eq 'Claim::BaseClaim'
           expect(stat.value_1).to eq 2
         end
-
-        it 'counts the created claims on that day for source json' do
-          stats = Statistic.find_by_date_and_report_name(report_day, 'creations_source_json').to_a
-          expect(stats.size).to eq 1
-
-          stat = stats.first
-          expect(stat.claim_type).to eq 'Claim::BaseClaim'
-          expect(stat.value_1).to eq 3
-        end
       end
 
       def report_day

--- a/spec/services/claims/update_claim_spec.rb
+++ b/spec/services/claims/update_claim_spec.rb
@@ -31,12 +31,6 @@ describe Claims::UpdateClaim do
         expect(subject.claim.source).to eq('api_web_edited')
       end
 
-      it 'updates the source when editing a JSON imported claim' do
-        allow(subject.claim).to receive(:from_json_import?).and_return(true)
-        subject.call
-        expect(subject.claim.source).to eq('json_import_web_edited')
-      end
-
       it 'is successful' do
         expect(subject.claim.case_number).to eq('A20161234')
         expect(subject.claim).to receive(:update_claim_document_owners)

--- a/spec/services/claims/update_draft_spec.rb
+++ b/spec/services/claims/update_draft_spec.rb
@@ -46,12 +46,6 @@ RSpec.describe Claims::UpdateDraft do
         expect(subject.claim.source).to eq('api_web_edited')
       end
 
-      it 'updates the source when editing a JSON imported claim' do
-        allow(subject.claim).to receive(:from_json_import?).and_return(true)
-        subject.call
-        expect(subject.claim.source).to eq('json_import_web_edited')
-      end
-
       it 'is successful' do
         expect(subject.claim.case_number).to eq('A20161234')
 

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -19,22 +19,6 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
     claim.force_validation = true
   end
 
-  context 'for a JSON imported claim (and no forced validation)' do
-    before do
-      claim.force_validation = false
-    end
-
-    let(:claim) { build :advocate_claim, source: 'json_import' }
-
-    it 'does not perform claim validation' do
-      expect(claim.perform_validation?).to be_falsey
-    end
-
-    it 'performs fee validation' do
-      expect(ppe_fee.perform_validation?).to be_truthy
-    end
-  end
-
   describe '#validate_claim' do
     it { should_error_if_not_present(fee, :claim, 'blank') }
   end


### PR DESCRIPTION
#### What
Remove `json_import` and `json_import_web_edited` and all references to it

#### Ticket
[original ticket for removing JSON importer/uploader](https://dsdmoj.atlassian.net/browse/CBO-608)

#### Why
System no longer has json imports and there are
no claims on production that have this as a `claim#source`
value any longer. We can therefore safely delete the code.

This is a follow up to https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/2879