### PR TITLE
Bump sentry-ruby, sentry-sidekiq and sentry-rails 4.5.2 to 4.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,8 @@ gem 'config',                 '~> 3.1' # this gem provides our Settings.xxx mech
 gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
 gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.git'
-gem 'sentry-rails',           '~> 4.5.2'
-gem 'sentry-sidekiq',         '~> 4.5.2'
+gem 'sentry-rails',           '~> 4.6'
+gem 'sentry-sidekiq',         '~> 4.6'
 gem 'sprockets-rails',        '~> 3.2.1'
 gem 'state_machine',          '~> 1.2.0'
 gem 'state_machines-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -638,14 +638,14 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
-    sentry-rails (4.5.2)
+    sentry-rails (4.6.1)
       railties (>= 5.0)
-      sentry-ruby-core (~> 4.5.0)
-    sentry-ruby-core (4.5.2)
+      sentry-ruby-core (~> 4.6.0)
+    sentry-ruby-core (4.6.1)
       concurrent-ruby
       faraday
-    sentry-sidekiq (4.5.2)
-      sentry-ruby-core (~> 4.5.0)
+    sentry-sidekiq (4.6.1)
+      sentry-ruby-core (~> 4.6.0)
     sexp_processor (4.12.0)
     shell-spinner (1.0.4)
       colorize
@@ -845,8 +845,8 @@ DEPENDENCIES
   ruby-progressbar
   rubyzip
   scheduler_daemon!
-  sentry-rails (~> 4.5.2)
-  sentry-sidekiq (~> 4.5.2)
+  sentry-rails (~> 4.6)
+  sentry-sidekiq (~> 4.6)
   shell-spinner (~> 1.0, >= 1.0.4)
   shoulda-matchers (>= 4.0.0.rc1)
   sidekiq (~> 6.1)


### PR DESCRIPTION
#### What
Bump all sentry dependenies at the same time
i.e. sentry-ruby, sentry-sidekiq and sentry-rails 4.5.2 to 4.6.1

#### Ticket
N/A

#### Why
This is recommended by sentry themselves on the site:
 > We recommend you update your SDK from @v4.5.2 to @v4.6.0 (All sentry packages should be updated and their versions should match)