### PR TITLE
[CFP-215] Enable AES-256-GCM cipher

### DIFF
--- a/config/initializers/cookie_rotation.rb
+++ b/config/initializers/cookie_rotation.rb
@@ -15,7 +15,7 @@ return unless Rails.application.secrets.old_secret_key_base.present?
 Rails.application.configure do
   # Not technically necessary, as this is the current default,
   # but it is to line up with the config below.
-  config.action_dispatch.use_authenticated_cookie_encryption = false
+  config.action_dispatch.use_authenticated_cookie_encryption = true
 
   # From:
   # https://www.gitmemory.com/issue/rails/rails/39964/668147345
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.action_dispatch.cookies_rotations.tap do |cookies|
     salt = config.action_dispatch.encrypted_cookie_salt
     signed_salt = config.action_dispatch.encrypted_signed_cookie_salt
-    cipher = config.action_dispatch.encrypted_cookie_cipher || 'aes-256-cbc'
+    cipher = config.action_dispatch.encrypted_cookie_cipher || 'aes-256-gcm'
 
     old_secret_key_base = Rails.application.secrets.old_secret_key_base
     generator = ActiveSupport::KeyGenerator.new(old_secret_key_base, iterations: 1000)

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -14,3 +14,13 @@ Rails.application.config.action_view.form_with_generates_ids = true
 # #cache_key method that is accompanied by a changing version in the
 # #cache_version method.
 Rails.application.config.active_record.cache_versioning = true
+
+# config.action_dispatch.use_authenticated_cookie_encryption controls whether
+# signed and encrypted cookies use the AES-256-GCM cipher or the older
+# AES-256-CBC cipher. It defaults to true.
+Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+
+# config.active_support.use_authenticated_message_encryption specifies whether
+# to use AES-256-GCM authenticated encryption as the default cipher for
+# encrypting messages instead of AES-256-CBC.
+Rails.application.config.active_support.use_authenticated_message_encryption = true


### PR DESCRIPTION
#### What

Rails 5.2 adopts AES-256-GCM as the default cipher for cookies and message.
Currently the old cipher is being used but this will change when the new
defaults are adopted.

This PR explicitly selects the new cipher.

See https://www.bigbinary.com/blog/rails-5-2-uses-aes-256-gcm-authenticated-encryption-as-default-cipher-for-encrypting-messages

#### Ticket

[Rails 6.1 post upgrade: handle config for Rails 5.2+](https://dsdmoj.atlassian.net/browse/CFP-215)
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### TODO

- [x] Deploy to an environment and test. For example, changing the encryption on cookies may affect currently logged in users.
