### PR TITLE
[CFP-215] Set method for generating non-sensitive digests

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -1,0 +1,3 @@
+# config.active_support.hash_digest_class allows configuring the digest class
+# to use to generate non-sensitive digests, such as the ETag header.
+Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA1


### PR DESCRIPTION
#### What

config.active_support.hash_digest_class allows configuring the digest class to use to generate non-sensitive digests, such as the ETag header.

The default method changes with Rails 5.2 to OpenSSL::Digest::SHA1. This PR prepares for the Rails 5.2 defaults being adopted.

#### Ticket

[Rails 6.1 post upgrade: handle config for Rails 5.2+](https://dsdmoj.atlassian.net/browse/CFP-215)
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### TODO

- [x] Deploy to an environment and test.