### PR TITLE
[CFP-215] Set default_protect_from_forgery to true

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery prepend: true, with: :exception unless ENV['DISABLE_CSRF'] == '1'
+  skip_forgery_protection if ENV['DISABLE_CSRF'] == '1'
 
   include CookieConcern
   before_action :set_default_cookie_usage

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
 class ErrorsController < ApplicationController
   skip_load_and_authorize_resource only: %i[not_endpoint not_found internal_server_error dummy_exception]
-  protect_from_forgery prepend: true, except: %i[not_endpoint not_found internal_server_error]
+  skip_forgery_protection only: %i[not_endpoint not_found internal_server_error]
 
   def not_endpoint
     logger.info("Data POSTed to root with API key: #{not_endpoint_params[:api_key]}") if params.present?

--- a/app/controllers/geckoboard_api/application_controller.rb
+++ b/app/controllers/geckoboard_api/application_controller.rb
@@ -1,5 +1,4 @@
 class GeckoboardApi::ApplicationController < ActionController::Base
-  protect_from_forgery prepend: true, with: :exception
   before_action :authenticate_token!
 
   private

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -1,3 +1,7 @@
 # config.active_support.hash_digest_class allows configuring the digest class
 # to use to generate non-sensitive digests, such as the ETag header.
 Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA1
+
+# config.action_controller.default_protect_from_forgery determines whether
+# forgery protection is added on ActionController::Base.
+Rails.application.config.action_controller.default_protect_from_forgery = true


### PR DESCRIPTION
#### What

Prior to 5.2 the `ApplicationController` required

```
protect_from_forgery prepend: true, with: :exception
```

This is now added to `ActionController::Base`, but only if default_protect_from_forgery is set to true. This becomes the default setting when the 5.2 defaults are loaded. This commit prepares for this by setting it explicitly and updating the controllers accordingly.

#### Ticket

[Rails 6.1 post upgrade: handle config for Rails 5.2+](https://dsdmoj.atlassian.net/browse/CFP-215)
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### TODO

- [x] Deploy to an environment and test. Specifically,
  - check that form submission with an invalid CSRF token fails
  - check that the API, and any other urls that do not need require CSRF, still works