### PR TITLE
[CFP-213] set ssl_options defaults

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,9 +3,11 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # default from rails 5.0
+  # see https://edgeguides.rubyonrails.org/configuring.html#for-5-0-baseline-defaults-from-below-and
+  config.ssl_options = { hsts: { subdomains: true } }
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # Excluding some endpoints due to ELB only talking HTTP on port 80 and not following redirects to https.
-  # config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck|ping/ } } }
   config.force_ssl = true
 
   # Code is not reloaded between requests.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # Excluding some endpoints due to ELB only talking HTTP on port 80 and not following redirects to https.
-  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck|ping/ } } }
+  # config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck|ping/ } } }
   config.force_ssl = true
 
   # Code is not reloaded between requests.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,9 +50,6 @@ Rails.application.configure do
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
-
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = :info


### PR DESCRIPTION
#### What
review ssl_options and adopt defaults explicitly* and remove unneeded exclusions

#### Ticket

[CFP-213](https://dsdmoj.atlassian.net/browse/CFP-213)

#### Why
 - _Rails.application.config.ssl_options: Options passed to
ActionDispatch::SSL if it is enabled with config.force_ssl_
- Baseline default: {}
- Current setting: { redirect: { exclude: -> request { request.path =~ /healthcheck|ping/ } } }`
- Rails 5.0 default { hsts: { subdomains: true } }

See [ActionDispatch::SSL](https://api.rubyonrails.org/v6.1.3.2/classes/ActionDispatch/SSL.html) for details

**Exclusions:** On investigation of the exclusions for ping and healthcheck it appears as though we do not need them as they are using https, and the k8s probes that call them do too, as below:
```
          readinessProbe:
            httpGet:
              path: /ping.json
              port: 3000
              httpHeaders:
                - name: X-Forwarded-Proto
                  value: https
                - name: X-Forwarded-Ssl
                  value: "on"
```
**_Therefore I have removed the exclusions_**

***Defaults:** On investigation of the ssl_options available and the default for rails 5 that we are not explicitly setting:
```
 config.ssl_options = { hsts: { subdomains: true } }
```
It turns out the header below is added irrespective of whether this config option is explicitly set (tested in chrome and IE9)
as 
```
Strict-Transport-Security:	max-age=15724800; includeSubDomains
```

This correlates to 180 days which is the default expiry specified in [rails 5 ssl docs](https://api.rubyonrails.org/v5.0/classes/ActionDispatch/SSL.html) but [not rails 6.1 (2 years)](https://api.rubyonrails.org/v6.1.3.2/classes/ActionDispatch/SSL.html)

**_Therefore we can explicitly set defaults for now, and use load defaults later without any obvious impact that i can see._**

#### TODO (wip)

 - [x] test removal of exclusions for ping and healthcheck
 - [x] try HSTS with subdomains
 - [x] test HSTS on oldest IE browser supported?!
 - [x] consider preload option 
 
#### Preload option
 Not clear there is much advantage setting `{ preload: true }` and requires submitting our domain. On [checking the preload site for production](https://hstspreload.org/?domain=claim-crown-court-defence.service.gov.uk). it appears it is already preloaded
 
 
