### PR TITLE
[CFP-215] Set cache_versioning to true

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -9,3 +9,8 @@ Rails.application.config.action_controller.default_protect_from_forgery = true
 # config.action_view.form_with_generates_ids determines whether form_with
 # generates ids on inputs.
 Rails.application.config.action_view.form_with_generates_ids = true
+
+# config.active_record.cache_versioning indicates whether to use a stable
+# #cache_key method that is accompanied by a changing version in the
+# #cache_version method.
+Rails.application.config.active_record.cache_versioning = true


### PR DESCRIPTION
#### What

See https://www.bigbinary.com/blog/rails-adds-support-for-recyclable-cache-keys

Set `Rails.application.config.active_record.cache_versioning` to true. This will be the default when the defaults for Rails 5.2 are loaded so this PR prepares for this change.

#### Ticket

[Rails 6.1 post upgrade: handle config for Rails 5.2+](https://dsdmoj.atlassian.net/browse/CFP-215)
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### TODO

- [x] Deploy to an environment and test.