### PR TITLE
[CFP-215] Set form_with_generates_ids to true

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -7,7 +7,6 @@
 
 = form_with url: case_workers_admin_allocations_path, method: :get, builder: GdsAdpFormBuilder do |f|
   = f.hidden_field :tab, id: :tab, value: params[:tab]
-  = f.hidden_field :scheme, id: :scheme, value: params[:scheme]
   = f.hidden_field :filter, id: :filter, value: params[:filter] if params[:filter]
   = f.hidden_field :page, id: :page, value: params[:page]
   = f.hidden_field :value_band_id, id: :value_band_id, value: params[:value_band_id] if params[:value_band_id]

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -5,3 +5,7 @@ Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA
 # config.action_controller.default_protect_from_forgery determines whether
 # forgery protection is added on ActionController::Base.
 Rails.application.config.action_controller.default_protect_from_forgery = true
+
+# config.action_view.form_with_generates_ids determines whether form_with
+# generates ids on inputs.
+Rails.application.config.action_view.form_with_generates_ids = true


### PR DESCRIPTION
#### What

The default value of `Rails.application.config.action_view.form_with_generates_ids` for Rails 5.2 is true. This commit sets it to true in preparation for updating `config.load_defaults` to 5.2.

As explained in [this Stack Overflow question](https://stackoverflow.com/questions/66049667/what-is-the-reasoning-for-having-form-with-not-generate-any-ids) this is the more sensible setting, and problems are more likely to occur if it is set to false.

#### Ticket

[Rails 6.1 post upgrade: handle config for Rails 5.2+](https://dsdmoj.atlassian.net/browse/CFP-215)
[Epic](https://dsdmoj.atlassian.net/browse/CFP-178)
[Related ticket](https://dsdmoj.atlassian.net/browse/CFP-176)

#### TODO

- [x] Deploy to an environment and test. In particular, check that forms are not affected.
- [x] Also check on new/edit provider page.