### PR TITLE
[CFP-214] Remove unneeded `local: true` from form_with calls

### DIFF
--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:case_workers, :admin, @case_worker], builder: GdsAdpFormBuilder, local: true do |f|
+= form_with model: [:case_workers, :admin, @case_worker], builder: GdsAdpFormBuilder do |f|
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary
 

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path, builder: GdsAdpFormBuilder, local: true do |f|
+    = form_with model: [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path, builder: GdsAdpFormBuilder do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/cookies/new.html.haml
+++ b/app/views/cookies/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: @cookies, url: cookies_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: 'post', local: true do |f|
+    = form_with model: @cookies, url: cookies_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: 'post' do |f|
       = f.govuk_error_summary
 
       = t('.intro_html')

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: confirmation_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true) do |f|
+    = form_with(model: resource, as: resource_name, url: confirmation_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.hidden_field :confirmation_token

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true) do |f|
+    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.hidden_field :reset_password_token

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true) do |f|
+    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.govuk_email_field :email, label: { text: t('.email') }, autofocus: true, autocomplete: 'off'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,6 +1,6 @@
 %h2= t('.edit_resource', resource: resource_name.to_s.humanize)
 
-= form_with(model: resource, as: resource_name, url: registration_path(resource_name), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true) do |f|
+= form_with(model: resource, as: resource_name, url: registration_path(resource_name), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
   = f.error_notification
 
   = f.govuk_text_field :email,

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: registration_path(resource_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true) do |f|
+    = form_with(model: resource, as: resource_name, url: registration_path(resource_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
       = f.govuk_error_summary
 
       = f.govuk_check_boxes_fieldset :terms_and_conditions,

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }, builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true) do |f|
+    = form_with(model: resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
       = f.govuk_text_field :email, label: { text: t('.email') }, autofocus: true
       = f.govuk_password_field :password, label: { text: t('.password') }, autocomplete: 'off'
       = f.govuk_submit t('.sign_in')

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: unlock_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true) do |f|
+    = form_with(model: resource, as: resource_name, url: unlock_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.govuk_email_field :email, label: { text: t('.email') }, autofocus: true, autocomplete: 'off'

--- a/app/views/external_users/admin/external_users/_form.html.haml
+++ b/app/views/external_users/admin/external_users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:external_users, :admin, @external_user], builder: GdsAdpFormBuilder, local: true do |f|
+= form_with model: [:external_users, :admin, @external_user], builder: GdsAdpFormBuilder do |f|
 
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary

--- a/app/views/external_users/admin/external_users/change_password.html.haml
+++ b/app/views/external_users/admin/external_users/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path, builder: GdsAdpFormBuilder, local: true do |f|
+    = form_with model: [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path, builder: GdsAdpFormBuilder do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: @certification, url: external_users_claim_certification_path(@claim), builder: GdsAdpFormBuilder, local: true do |f|
+    = form_with model: @certification, url: external_users_claim_certification_path(@claim), builder: GdsAdpFormBuilder do |f|
       = f.govuk_error_summary
 
       - if @claim.agfs?

--- a/app/views/super_admins/admin/super_admins/_form.html.haml
+++ b/app/views/super_admins/admin/super_admins/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:super_admins, :admin, @super_admin], builder: GdsAdpFormBuilder, local: true do |f|
+= form_with model: [:super_admins, :admin, @super_admin], builder: GdsAdpFormBuilder do |f|
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary
 

--- a/app/views/super_admins/admin/super_admins/change_password.html.haml
+++ b/app/views/super_admins/admin/super_admins/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path, builder: GdsAdpFormBuilder, local: true do |f|
+    = form_with model: [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path, builder: GdsAdpFormBuilder do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 


### PR DESCRIPTION
#### What
Remove unneeded `local: true` from form_with calls

#### Ticket

relates to [CFP-214](https://dsdmoj.atlassian.net/browse/CFP-214)

#### Why
We have adopted [rails 6.1 default for form_with remote calls in this PR](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/4107)

```
form_with_generates_remote_forms = false
```

As such the `local: true` is superfluos as it is the default.
Going forward any forms that require ajax type logic will need
to explicitly add `remote: true` to their `form_with` blocks.

see https://guides.rubyonrails.org/configuring.html for details

--------

#### TODO (wip)

 - [x] sanity test