### PR TITLE
[CFP-216] Adopt rails 6.0 default_enforce_utf8  default of false

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -12,7 +12,7 @@
 # Rails.application.config.autoloader = :zeitwerk
 
 # Determines whether forms are generated with a hidden tag that forces older versions of Internet Explorer to submit forms encoded in UTF-8.
-# Rails.application.config.action_view.default_enforce_utf8 = false
+Rails.application.config.action_view.default_enforce_utf8 = false
 
 # Embed purpose and expiry metadata inside signed and encrypted
 # cookies for increased security.


### PR DESCRIPTION
#### What
Determines whether forms are generated with a hidden tag that
forces older versions of Internet Explorer to submit forms encoded
in UTF-8.

#### Ticket

[CFP-216](https://dsdmoj.atlassian.net/browse/CFP-216)

#### Why
To accept rails 6.0 default

This is new config in 6.0 and is disabled by default  meaning it changes
the current behaviour.

**current behaviour:**
all forms get `<input name="utf8" type="hidden" value="✓">` to force IE7/8 to encode using UTF-8

**new behaviour:**
the hidden input above is removed from all forms. There are possible edge cases 
therefore where IE7/8 could error when submitting forms with non-UTF-8 chars.
Since we do not technically support IE browsers below IE9 this is becomes academic.

#### TODO
  - [x] sanity test on hosted environment
  - [x] sanity tested on IE7/8 - thanks @naseberry 
