### PR TITLE
[CFP-216] Adopt rails 6.0 default of true for use_cookies_with_metadata

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -19,7 +19,7 @@
 #
 # This option is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.0.
-# Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Send Active Storage analysis and purge jobs to dedicated queues.
 # Rails.application.config.active_storage.queues.analysis = :active_storage_analysis


### PR DESCRIPTION
#### What
Adopt default of true for use_cookies_with_metadata

#### Ticket

[CFP-216](https://dsdmoj.atlassian.net/browse/CFP-216)

#### Why
New config in rails 6.0 to improve security

Since we are already stable on rails 6.1 this should
be adoptable with no side-effects.

see [rails upgrade guide section](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#purpose-and-expiry-metadata-is-now-embedded-inside-signed-and-encrypted-cookies-for-increased-security)
and [this article](https://blog.saeloun.com/2019/11/12/rails-6-adds-purpose-metadata-to-cookies.html) for details.

 > To improve security, Rails embeds the purpose and expiry metadata inside encrypted or signed cookies value.
 > Rails can then thwart attacks that attempt to copy the signed/encrypted value of a cookie and use it as the value of another cookie.
 > This new embed metadata make those cookies incompatible with versions of Rails older than 6.0.

 #### TODO

  - [x] sanity test on hosted environment