### PR TITLE
[CFP-216] Adopt rails 6.0 defaults for active storage queues as 6.1 defaults

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -22,6 +22,10 @@
 # Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Send Active Storage analysis and purge jobs to dedicated queues.
+# DO NOT ENABLE: since we are on 6.1 and these options are both changed
+# to default to nil (which equates to using the default queue)
+# we do not need to enable these here.
+#
 # Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
 # Rails.application.config.active_storage.queues.purge = :active_storage_purge
 

--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -48,10 +48,10 @@
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # Set the default queue name for the analysis job to the queue adapter default.
-# Rails.application.config.active_storage.queues.analysis = nil
+Rails.application.config.active_storage.queues.analysis = nil
 
 # Set the default queue name for the purge job to the queue adapter default.
-# Rails.application.config.active_storage.queues.purge = nil
+Rails.application.config.active_storage.queues.purge = nil
 
 # Set the default queue name for the incineration job to the queue adapter default.
 # Rails.application.config.action_mailbox.queues.incineration = nil

--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -47,11 +47,13 @@
 # Make `form_with` generate non-remote forms by default.
 Rails.application.config.action_view.form_with_generates_remote_forms = false
 
-# Set the default queue name for the analysis job to the queue adapter default.
-Rails.application.config.active_storage.queues.analysis = nil
+# Adopt separate queue name so we can control/lower priority
+# this is a change from default for rails 6.1 which is nil (i.e. default queue)
+Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
 
-# Set the default queue name for the purge job to the queue adapter default.
-Rails.application.config.active_storage.queues.purge = nil
+# Adopt separate queue name so we can control/lower priority
+# this is a change from default for rails 6.1 which is nil (i.e. default queue)
+Rails.application.config.active_storage.queues.purge = :active_storage_purge
 
 # Set the default queue name for the incineration job to the queue adapter default.
 # Rails.application.config.action_mailbox.queues.incineration = nil

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,6 +6,8 @@
   - [default, 2]
   - [claims, 2]
   - [stats_reports, 1]
+  - [active_storage_analysis, 1]
+  - [active_storage_purge, 1]
 development:
   :verbose: true
   :concurrency: 5


### PR DESCRIPTION
#### What
Adopt rails 6.0 defaults as 6.1 configuration for active storage queues

#### Ticket

[CFP-216](https://dsdmoj.atlassian.net/browse/CFP-216)

#### Why

- **config.active_storage.queues.purge:**
    We are not using `purge_later` so this should not make any difference.
    However we could use this, in which case the default of `active_storage_purge` 
    means it will be processed by sidekiq using the that queue. 

    see [this active storage section](https://edgeguides.rubyonrails.org/active_storage_overview.html#removing-files)    

    In testing it does appear to be backgrounded in any event but unclear where 
    from. Perhaps a rails internals behaviour I have been unable to find.

    _This sets it to `active_storage_purge` queue, which is given lowest priority!_

-   **config.active_storage.queues.analysis:**
    Active storage analyses files in the background by default and uses the `default` queue
    to do so if this option is set to `nil` - see [this issue](https://github.com/rails/rails/issues/33138).
      
    However,  looking into the [purpose of analysis](https://edgeguides.rubyonrails.org/active_storage_overview.html#analyzing-files)
      1. we do not need the attributes the analysis provides
      2. calling `analyze` on a file shows that it is skipped in any event
      
     ```
       irb$> claim.documents.last.document.analyze
        =>
        S3 Storage (131.8ms) Downloaded file from key: <blah>
       Skipping image analysis because the mini_magick gem isn't installed
     ```
    
    _This sets it to `active_storage_analysis` queue, which is given lowest priority!_

#### TODO (wip)

 - [x] sanity test a new file is analyzed
 - [x] sanity test a new file is succesfully purged
 ~- [ ] consider creating and using purge_later to background file deletion~
 - [x] consider creating and using dedicated queues for each of these

<img width="1203" alt="Screenshot 2021-07-16 at 14 16 19" src="https://user-images.githubusercontent.com/7016425/125953961-3202ffb0-f521-48b8-b6b6-154969fd3a69.png">
