### PR TITLE
[CFP-216] Adopt rails 6.0 default for `collection_cache_versioning` (true)

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -45,4 +45,4 @@ Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
 # of the relation's cache key into the cache version to support recycling cache key.
-# Rails.application.config.active_record.collection_cache_versioning = true
+Rails.application.config.active_record.collection_cache_versioning = true


### PR DESCRIPTION
#### Warning
This setting has no effect because the govuk_notify_rails gems
(by the looks of it) is misbehaving and causing the rails framework
to load too early - see this [issue comment](https://github.com/rails/rails/issues/39855#issuecomment-659670294) and this
[useful debugging issue comment](https://github.com/rails/rails/issues/37030#issuecomment-524511912) for more information and details.

#### What
Set rails 6.0 default for `collection_cache_versioning` (true)

#### Ticket

[CFP-216](https://dsdmoj.atlassian.net/browse/CFP-216)

#### Why
Improved caching for SQL queries

Enables the same cache key to be reused when the object being
cached of type ActiveRecord::Relation changes by moving the
volatile information (max updated at and count) of the relation's
cache key into the cache version to support recycling cache key.