### PR TITLE
[CFP-215] Fix non-sticking cache_versioning config

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -13,7 +13,15 @@ Rails.application.config.action_view.form_with_generates_ids = true
 # config.active_record.cache_versioning indicates whether to use a stable
 # #cache_key method that is accompanied by a changing version in the
 # #cache_version method.
+#
+# NOTE: this setting is not taking effect since it appears
+# that govuk_notify_rails is causing early rails loading and
+# causing it to be "lost".
+# see https://github.com/rails/rails/issues/39855#issuecomment-659670294
 Rails.application.config.active_record.cache_versioning = true
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
+ActiveRecord::Base.cache_versioning = true
 
 # config.action_dispatch.use_authenticated_cookie_encryption controls whether
 # signed and encrypted cookies use the AES-256-GCM cipher or the older


### PR DESCRIPTION
#### What
Fix non-sticking cache_versioning config

#### Ticket

[CFP-215](https://dsdmoj.atlassian.net/browse/CFP-215)

#### Why
`cache_versioning` setting is not taking effect since it appears
that govuk_notify_rails is causing early rails loading and
causing it to be "lost".

This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912


 - [X] check setting "sticks" on hosted environment
 - [X] sanity test on hosted environment