### PR TITLE
[CFP-213] Fix non-sticking belongs_to_required_by_default config

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -17,4 +17,12 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
+# NOTE: this setting is not taking effect since it appears
+# that govuk_notify_rails is causing early rails loading and
+# causing it to be "lost".
 Rails.application.config.active_record.belongs_to_required_by_default = true
+
+# see https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# and this activerecord specific issue https://github.com/rails/rails/issues/27844
+ActiveRecord::Base.belongs_to_required_by_default = true


### PR DESCRIPTION
#### What
Fix non-sticking belongs_to_required_by_default config

#### Ticket
[CFP-213](https://dsdmoj.atlassian.net/browse/CFP-213)

#### Why
NOTE: this setting is not taking effect since it appears
that govuk_notify_rails is causing early rails loading and
causing it to be "lost".

This is a workaround for issue rails/rails#39855 (comment)
suggested by this issue comment rails/rails#37030 (comment)
and this activerecord specific issue https://github.com/rails/rails/issues/27844


 - [ ] check setting "sticks" on hosted environment
 - [ ] sanity test on hosted environment