### PR TITLE
[CFP-261] Set rails 6.0 default for `active_storage.replace_on_assign_to_many` (true)

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -31,7 +31,7 @@ Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # When assigning to a collection of attachments declared via `has_many_attached`, replace existing
 # attachments instead of appending. Use #attach to add new attachments without replacing existing ones.
-# Rails.application.config.active_storage.replace_on_assign_to_many = true
+Rails.application.config.active_storage.replace_on_assign_to_many = true
 
 # Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
 #


### PR DESCRIPTION
#### What
Set rails 6.0 default for `active_storage.replace_on_assign_to_many` (true)

#### Ticket

[CFP-261](https://dsdmoj.atlassian.net/browse/CFP-216)

#### Why

 > Determines whether assigning to a collection of attachments declared with
   `has_many_attached` replaces any existing attachments or appends to them.

We are not using `has_many_attached`, only `has_one_attached` so
should not have any impact.

#### TODO (wip)

 - [x] sanity check config sticks
 - [x] sanity test impact on file uploads add and remove