### PR TITLE
[CFP-216] Set rails 6.0 default `action_mailer.delivery_job` ("ActionMailer::MailDeliveryJob")

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -40,7 +40,7 @@ Rails.application.config.active_storage.replace_on_assign_to_many = true
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
-# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)


### PR DESCRIPTION
#### What
Set rails 6.0 default `action_mailer.delivery_job` ("ActionMailer::MailDeliveryJob")

Changes value from baseline:
```
ActionMailer::DeliveryJob --> "ActionMailer::MailDeliveryJob"
```

#### Ticket

[CFP-216](https://dsdmoj.atlassian.net/browse/CFP-216)

#### Why
Inline with rails 6.0 defaults

Not clear if this has any effect as we use govuk_notify_rails
for mail sending anyway.

 - [x] check setting "sticks"
 - [x] sanity test on hosted environment