### PR TITLE
[CFP-216] Fix non-sticking `action_mailer.delivery_job`

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -48,7 +48,7 @@ Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliver
 
 # This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
 # suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
-ActionMailer::Base.delivery_job = "ActionMailer::MailDeliveryJob"
+ActionMailer::Base.delivery_job = ActionMailer::MailDeliveryJob
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)

--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -40,7 +40,15 @@ Rails.application.config.active_storage.replace_on_assign_to_many = true
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
+#
+# NOTE: this setting is not taking effect since it appears
+# that govuk_notify_rails is causing early rails loading and
+# causing it to be "lost".
 Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
+ActionMailer::Base.delivery_job = "ActionMailer::MailDeliveryJob"
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)

--- a/spec/requests/case_workers/admin/case_workers_spec.rb
+++ b/spec/requests/case_workers/admin/case_workers_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Caseworker admin', type: :request do
 
       it 'enqueues a job to send the email' do
         create_case_workers_request
-        expect(ActionMailer::DeliveryJob).to have_been_enqueued
+        expect(ActionMailer::MailDeliveryJob).to have_been_enqueued
       end
 
       describe 'if there is an issue with delivering the email' do


### PR DESCRIPTION
#### What
Fix non-sticking `action_mailer.delivery_job`

#### Ticket

[CFP-216](https://dsdmoj.atlassian.net/browse/CFP-216)

#### Why
NOTE: this setting is not taking effect since it appears
that govuk_notify_rails is causing early rails loading and
causing it to be "lost".

This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912

 - [x] check setting "sticks"
 - [x] sanity test on hosted environment