### PR TITLE
[CFP-216] Set `config.autoloader` :classic

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,9 @@ module AdvocateDefencePayments
 
     config.assets.enabled = true
 
+    # TODO: move to :zeitwork mode
+    config.autoloader = :classic
+
     config.autoload_paths << config.root.join('lib')
 
     config.eager_load_paths << config.root.join('lib')

--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -6,11 +6,6 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-# see https://guides.rubyonrails.org/autoloading_and_reloading_constants.html
-# There is a separate ticket to handle upgrade to zeitwork, we should stick
-# to :classic for the time being.
-# Rails.application.config.autoloader = :zeitwerk
-
 # Determines whether forms are generated with a hidden tag that forces older versions of Internet Explorer to submit forms encoded in UTF-8.
 Rails.application.config.action_view.default_enforce_utf8 = false
 


### PR DESCRIPTION
#### What
Set `config.autoloader` to  `:classic` explicitly

#### Ticket

[board ticket description](link)

#### Why
Specify `:classic` autoloader explicitly as rails 6.0
default of `:zeitwork` breaks the app. There is a
separate ticket to adopt `:zeitwork` autoloading.

See [CFP-179](https://dsdmoj.atlassian.net/browse/CFP-179)

:classic is the current autoloading mechanism so this
will not have any effect but will allow us to
use `config.load_defaults "6.1"` without breakages.

 - [x] check config "sticks"
 - [x] sanity test on hosted environment