### PR TITLE
[CFP-217] Adopt rails 6.1 defaults for action mailbox queues

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -56,10 +56,10 @@ Rails.application.config.active_storage.queues.analysis = :active_storage_analys
 Rails.application.config.active_storage.queues.purge = :active_storage_purge
 
 # Set the default queue name for the incineration job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.incineration = nil
+Rails.application.config.action_mailbox.queues.incineration = nil
 
 # Set the default queue name for the routing job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.routing = nil
+Rails.application.config.action_mailbox.queues.routing = nil
 
 # Set the default queue name for the mail deliver job to the queue adapter default.
 # Rails.application.config.action_mailer.deliver_later_queue_name = nil


### PR DESCRIPTION
#### What
Adopt rails 6.1 defaults for action mailbox queues

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
These rails 6.1 defaults have no effect but enable us to use
config.load_defaults "6.1" eventually.

We do not use action mailbox (not to be confused
with action mailer). Action mailbox is for inbound
email and these options handle routing and
incineration/deletion of inbound mail.

The default of nil results in these tasks using
the "default" queue

--------

#### TODO (wip)

 - [x] check config sticks
 - [x] sanity test on hosted environment