### PR TITLE
[CFP-217] Adopt rails 6.1 defaults for active_job options

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -13,11 +13,17 @@
 # Rails.application.config.active_storage.track_variants = true
 
 # Apply random variation to the delay when retrying failed jobs.
-# Rails.application.config.active_job.retry_jitter = 0.15
+Rails.application.config.active_job.retry_jitter = 0.15
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
+ActiveJob::Base.retry_jitter = 0.15
 
 # Stop executing `after_enqueue`/`after_perform` callbacks if
 # `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
-# Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
+Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
+ActiveJob::Base.skip_after_callbacks_if_terminated = true
 
 # Specify cookies SameSite protection level: either :none, :lax, or :strict.
 #


### PR DESCRIPTION
#### What
Adopt rails 6.1 defaults for active_job options

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
This allows us to adopt config.load_defaults "6.1", but

NOTE: the config setting is not taking effect since it appears
that govuk_notify_rails is causing early rails loading and
causing it to be "lost".

 - active_job.retry_jitter to apply random job delay on retr.
   harmless!
 - active_job.skip_after_callbacks_if_terminated
   we do not use `after_enqueue` or `after_perform` so not impact

To make the setting stick we need apply directly to
`ActiveJob::Base`. This needs fixing in the future.

#### TODO (wip)

 - [X] check it sticks
 - [x] sanity test on hosted environment