### PR TITLE
[CFP-217] Do not adopt rails 6.1 default `action_mailer.deliver_later_queue_name`

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -62,7 +62,10 @@ Rails.application.config.action_mailbox.queues.incineration = nil
 Rails.application.config.action_mailbox.queues.routing = nil
 
 # Set the default queue name for the mail deliver job to the queue adapter default.
-# Rails.application.config.action_mailer.deliver_later_queue_name = nil
+Rails.application.config.action_mailer.deliver_later_queue_name = :mailers
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
+ActionMailer::Base.deliver_later_queue_name = :mailers
 
 # Generate a `Link` header that gives a hint to modern browsers about
 # preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.


### PR DESCRIPTION
#### What
Do not adopt rails 6.1 default `action_mailer.deliver_later_queue_name`

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
Continue using "mailers" queue for mail processing to keep
its priority lower than default - its quick enough! - and isloate
mail to its own queue

Baseline default is `:mailers` which is what we currently
use. Rails 6.1 default of `nil` results in using `active_job.default_queue_name`,
which is the "default" queue, which has a hight priority.

**However:**

NOTE: the config setting is not taking effect since it appears
that govuk_notify_rails is causing early rails loading and
causing it to be "lost". Therefore to make the setting stick we
need apply directly via `ActionMailer::Base.deliver_later_queue_name`. 
This needs fixing in the future.

#### TODO (wip)

 - [X] check it sticks
 - [x] sanity test on hosted environment