### PR TITLE
[CFP-217] Adopt rails 6.1 default of cookies_same_site_protection (:lax)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -29,7 +29,7 @@ ActiveJob::Base.skip_after_callbacks_if_terminated = true
 #
 # This change is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.1.
-# Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
 
 # Generate CSRF tokens that are encoded in URL-safe Base64.
 #


### PR DESCRIPTION
#### What
Adopt rails 6.1 default of cookies_same_site_protection (:lax)

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why

Improved CSRF protection

 > Configures the default value of the SameSite attribute
   when setting cookies. When set to nil, the SameSite
   attribute is not added.

see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
for more.

#### TODO (wip)

 - [X] check config sticks (SameSite header exists on any page)
 - [x] Have FE consider/review impact