### PR TITLE
[CFP-217] Adopt rails 6.1 default urlsafe_csrf_tokens (true)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -35,7 +35,7 @@ ActiveJob::Base.skip_after_callbacks_if_terminated = true
 #
 # This change is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.1.
-# Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+Rails.application.config.action_controller.urlsafe_csrf_tokens = true
 
 # Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
 # UTC offset or a UTC time.


### PR DESCRIPTION
#### What
Adopt rails 6.1 default urlsafe_csrf_tokens (true)

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why

Improved CSRF protection

Configures whether generated CSRF tokens are URL-safe.

Uses `Base64.urlsafe_encode64` to encode the token

#### TODO (wip)

 - [X] check config sticks
 - [x] Have FE consider/review impact