### PR TITLE
[CFP-217] Adopt rails 6.1 default `utc_to_local_returns_utc_offset_times` (true)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -39,7 +39,7 @@ Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
 
 # Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
 # UTC offset or a UTC time.
-# ActiveSupport.utc_to_local_returns_utc_offset_times = true
+ActiveSupport.utc_to_local_returns_utc_offset_times = true
 
 # Change the default HTTP status code to `308` when redirecting non-GET/HEAD
 # requests to HTTPS in `ActionDispatch::SSL` middleware.


### PR DESCRIPTION
#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
Enables us to use `config.load_defaults "6.1"` in future

This just configures `ActiveSupport::TimeZone.utc_to_local` to return a time
with a UTC offset instead of a UTC time incorporating that offset. We do not 
make any explicit use of it so should have no impact.

#### TODO (wip)

 - [X] check config sticks