### PR TITLE
[CFP-217] Adopt rails 6.1 default `action_view.preload_links_header` (true)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -72,4 +72,4 @@ Rails.application.config.action_mailbox.queues.routing = nil
 
 # Generate a `Link` header that gives a hint to modern browsers about
 # preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.
-# Rails.application.config.action_view.preload_links_header = true
+Rails.application.config.action_view.preload_links_header = true


### PR DESCRIPTION
#### What
Adopt rails 6.1 default `action_view.preload_links_header` (true)

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
Ca improve page render time by preloading assets

 > Determines whether `javascript_include_tag` and `stylesheet_link_tag`
   will generate a Link header that preload assets.

Note: the config is removed once it sets
`ActionView::Helpers::AssetTagHelper.preload_links_header`
to true. see [this line in action view lib]( https://github.com/rails/rails/blob/70470d7eed2086169881cc3328693a0f014b03f8/actionview/lib/action_view/railtie.rb#L53)

#### What it does
When enabled this will generate a Link "header" with `preload` browser hints in any page that includes a `stylesheet_link_tag`
or `javascript_include_tag`, similar to this:

```
# Example response header for preload_link_header of true
Link: </packs/css/application-00e3fe6f.css>; rel=preload; as=style; nopush,</packs/css/govuk-frontend-9401f477.css>; rel=preload; as=style; nopush,</packs/js/application.bundle.js>; rel=preload; as=script; nopush
```

#### TODO (wip)

 - [X] check it sticks
 - [x] sanity test on hosted environment
 - [x] sanity grape swagger docs (that use javascript_include_tag & stylesheet_link_tag )