### PR TITLE
[CFP-217] Adopt rails 6.1 default for `legacy_connection_handling` (false)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -48,7 +48,10 @@ ActiveSupport.utc_to_local_returns_utc_offset_times = true
 # Use new connection handling API. For most applications this won't have any
 # effect. For applications using multiple databases, this new API provides
 # support for granular connection swapping.
-# Rails.application.config.active_record.legacy_connection_handling = false
+Rails.application.config.active_record.legacy_connection_handling = false
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
+ActiveRecord::Base.legacy_connection_handling = false
 
 # Make `form_with` generate non-remote forms by default.
 Rails.application.config.action_view.form_with_generates_remote_forms = false


### PR DESCRIPTION
#### What
Adopt rails 6.1 default for `legacy_connection_handling` (false)

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
Rails 6. Default of false enables use of new DB connection handling API.

 > For applications using multiple databases, this new API provides
   support for granular connection swapping.

Although we do not use multiple databases the new API should be
adopted going forward and allows us to use `config.load_defaults "6.1"`
in the future.

**However:**

NOTE: the config setting is not taking effect since it appears
that govuk_notify_rails is causing early rails loading and
causing it to be "lost".

Therefore to make the setting stick we need apply directly to
`ActiveRecord::Base.legacy_connection_handling`. This needs fixing
in the future.

#### TODO (wip)

 - [X] check it sticks
 - [x] sanity test on hosted environment