### PR TITLE
[CFP-217] Adopt rails 6.1 default for `ssl_default_redirect_status` (308)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -43,7 +43,7 @@ ActiveSupport.utc_to_local_returns_utc_offset_times = true
 
 # Change the default HTTP status code to `308` when redirecting non-GET/HEAD
 # requests to HTTPS in `ActionDispatch::SSL` middleware.
-# Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
+Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
 
 # Use new connection handling API. For most applications this won't have any
 # effect. For applications using multiple databases, this new API provides


### PR DESCRIPTION
#### What
Adopt rails 6.1 default for ssl_default_redirect_status (308)

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
IEEE Standards application and potential security and performance
benefits related to permanent redirecting of http to https?!

 > Configures the default HTTP status code used when redirecting
   non-GET/HEAD requests from HTTP to HTTPS in the ActionDispatch::SSL middleware.
   Defaults to 308 as defined in https://tools.ietf.org/html/rfc7538.

To test locally you have to set `config.force_ssl = true` in
`environment/development.rb`, restart rails server, then
issue a curl command to POST similar to below:

```
curl -i -H 'Authorization: Token token'="blah" /
 -H "Accept: application/json" /
 -H "Content-type: application/json" /
 -X POST -d '{"user_attributes":{"first_name":"Adv","last_name":"Kate-Admin","email":"advocateadmin@example.com","email_notification_of_message":"false","id":"78"},"roles":["","admin"],"vat_registered":"true","supplier_number":""}' /
 http://localhost:3000/external_users/1 | less
 =>
HTTP/1.1 308 Permanent Redirect
Content-Type: text/html
Location: https://localhost:3000/external_users/1
Transfer-Encoding: chunked
```

#### TODO (wip)

 - [X] check it sticks
 - [x] sanity test on hosted environment
 ```
 $ curl -i -H 'Authorization: Token token'="whatever" /
-H "Accept: application/json" /
-H "Content-type: application/json" /
-X POST -d '{"user_attributes":{"first_name":"foo","last_name":"bar","email":"advocateadmin@example.com","email_notification_of_message":"false","id":"78"},"roles":["","whatever"],"vat_registered":"true","supplier_number":""}'  http://staging.claim-crown-court-defence.service.justice.gov.uk/external_users/2 | less
=>
HTTP/1.1 308 Permanent Redirect
Date: Wed, 21 Jul 2021 12:14:12 GMT
Content-Type: text/html
Content-Length: 164
Connection: keep-alive
Location: https://staging.claim-crown-court-defence.service.justice.gov.uk/external_users/2
 ```