### PR TITLE
[CFP-217] Adopt rails 6.1 default for `active_record.has_many_inversing` (true)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -7,7 +7,10 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Support for inversing belongs_to -> has_many Active Record associations.
-# Rails.application.config.active_record.has_many_inversing = true
+Rails.application.config.active_record.has_many_inversing = true
+# This is a workaround for issue https://github.com/rails/rails/issues/39855#issuecomment-659670294
+# suggested by this issue comment https://github.com/rails/rails/issues/37030#issuecomment-524511912
+ActiveRecord::Base.has_many_inversing = true
 
 # Track Active Storage variants in the database.
 # Rails.application.config.active_storage.track_variants = true


### PR DESCRIPTION
#### What
Adopt rails 6.1 default for `active_record.has_many_inversing` (true)

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why
Enable easier bi-directional Primay key to foreign key
relation navigation.

 > enables setting the inverse record when traversing belongs_to
   to has_many associations.

See [this article](https://www.bigbinary.com/blog/rails-6-1-adds-support-for-belongs_to-to-has_many-inversing) for details

Since we use `inverse_of` of a lot in CCCD this should be beneficial
and mean we could remove `some_relation.reload`. Its unclear if
we need to add `inverse_of` to get this behaviour or not.

**However:**

NOTE: the config setting is not taking effect since it appears
that govuk_notify_rails is causing early rails loading and
causing it to be "lost".

Therefore to make the setting stick we need apply directly to
`ActiveRecord::Base.has_many_inversing`. This needs fixing
in the future.

#### TODO (wip)

 - [X] check it sticks
 - [x] sanity test on hosted environment
 - [x] check if can remove reloads in tests and elsewhere that handled this previously
          _possibly some can be but not in tests that I tried - out of scope_