### PR TITLE
[CFP-217] Adopt rails 6.1 default for `active_storage.track_variants` (true)

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -10,7 +10,7 @@
 # Rails.application.config.active_record.has_many_inversing = true
 
 # Track Active Storage variants in the database.
-# Rails.application.config.active_storage.track_variants = true
+Rails.application.config.active_storage.track_variants = true
 
 # Apply random variation to the delay when retrying failed jobs.
 Rails.application.config.active_job.retry_jitter = 0.15


### PR DESCRIPTION
#### What
Adopt rails 6.1 default for active_storage.track_variants (true)

#### Ticket

[CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why

Has no impact on CCCD.

 > determines whether variants are recorded in the database. The default is true.

Enables tracking of uploaded file variants (if there are any) in the
database rather than by querying s3. see [this article for more](https://www.bigbinary.com/blog/rails-6-1-tracks-active-storage-variant-in-the-database)

We do not generate variants therefore this setting has no impact. This
is an on-demand service provided out of the box by rails if needed.
Typically this is, for example, storing resized image version such
as thumbnails. We do, however, have the DB tables to do so if needed
and therefore this setting will not break existing functionality and
could be used if needed.

#### TODO (wip)

 - [X] check it sticks
 - [x] sanity test on hosted environment