### PR TITLE
[CFP-232] Remove moj_template config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,21 +32,6 @@ module AdvocateDefencePayments
       g.helper_specs false
     end
 
-    # Application Title (Populates <title>)
-    config.app_title = 'Claim for crown court defence'
-    # Proposition Title (Populates proposition header)
-    config.proposition_title = 'Claim for crown court defence'
-    # Current Phase (Sets the current phase and the colour of phase tags)
-    # Presumed values: alpha, beta, live
-    config.phase = 'BETA'
-    # Product Type (Adds class to body based on service type)
-    # Presumed values: information, service
-    config.product_type = 'not_set'
-    # Feedback URL (URL for feedback link in phase banner)
-    config.feedback_url = 'not_set'
-    # Google Analytics ID (Tracking ID for the service)
-    config.ga_id = 'not_set'
-
     config.assets.enabled = true
 
     # TODO: move to :zeitwork mode


### PR DESCRIPTION
#### What
Remove moj_template config

#### Ticket

Came out of [CFP-232](https://dsdmoj.atlassian.net/browse/CFP-232)

#### Why
Remove unused config!

The [moj_template gem](https://github.com/ministryofjustice/moj_template) was removed some time ago and this config relates [to this gem specifically](https://github.com/ministryofjustice/moj_template#gem-config).

See this commit 4c31fa6.