### PR TITLE
[CFP-213] Adopt rails 5.0 default of true for `belongs_to_required_by_default`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,14 +42,11 @@ module AdvocateDefencePayments
     #
     config.autoloader = :classic
     config.action_mailer.deliver_later_queue_name = :mailers
-    config.active_record.belongs_to_required_by_default = false
     config.active_storage.queues.analysis = :active_storage_analysis
     config.active_storage.queues.purge = :active_storage_purge
 
     config.autoload_paths << config.root.join('lib')
-
     config.eager_load_paths << config.root.join('lib')
-
     config.exceptions_app = self.routes
 
     config.to_prepare do


### PR DESCRIPTION
#### What
Adopt rails 5.0 default of true for `belongs_to_required_by_default`

#### Ticket

[came out of CFP-213](https://dsdmoj.atlassian.net/browse/CFP-213)

#### Why

This will require quite a bit of remedial work to
implement but would be nice to adopt this new
default.

By removing the config we accept the default,
since rails 5.0 of `true`.

[Relevant rails config documentation](https://guides.rubyonrails.org/configuring.html#for-5-0-baseline-defaults-from-below-and)