### PR TITLE
[CFP-217] Remove unneeded devise mailer layout

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,14 +47,8 @@ module AdvocateDefencePayments
     config.active_storage.queues.purge = :active_storage_purge
 
     config.autoload_paths << config.root.join('lib')
-
     config.eager_load_paths << config.root.join('lib')
-
     config.exceptions_app = self.routes
-
-    config.to_prepare do
-      Devise::Mailer.layout "email" # email.haml or email.erb
-    end
 
     config.active_job.queue_adapter = :sidekiq
   end


### PR DESCRIPTION
#### What
Remove unneeded devise mailer layout

#### Ticket

[came out of CFP-217](https://dsdmoj.atlassian.net/browse/CFP-217)

#### Why

We no longer use devise mailer. This was
replaced by [GOV UK notify service](https://www.notifications.service.gov.uk/) that stores
templates for email on their service.

See [this commit](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/commit/926629f7c7a2f32c79cbd50fedc126d55c117179) that added the custom template
and configured it in 2016

#### TODO (wip)

 - [x] sanity test mailer on staging
    _password reset works fine_