### PR TITLE
Standardize messages files names

### DIFF
--- a/app/controllers/external_users/admin/providers_controller.rb
+++ b/app/controllers/external_users/admin/providers_controller.rb
@@ -14,7 +14,7 @@ class ExternalUsers::Admin::ProvidersController < ExternalUsers::Admin::Applicat
     if @provider.update(provider_params.except(*filtered_params))
       redirect_to external_users_admin_provider_path, notice: 'Provider successfully updated'
     else
-      @error_presenter = ErrorPresenter.new(@provider, error_message_file)
+      @error_presenter = ErrorPresenter.new(@provider)
       render 'shared/providers/edit'
     end
   end
@@ -32,9 +32,5 @@ class ExternalUsers::Admin::ProvidersController < ExternalUsers::Admin::Applicat
   # when they change
   def filtered_params
     %i[roles provider_type]
-  end
-
-  def error_message_file
-    @error_message_file ||= Rails.root.join("config/locales/#{I18n.locale}/error_messages/provider.yml")
   end
 end

--- a/app/controllers/provider_management/providers_controller.rb
+++ b/app/controllers/provider_management/providers_controller.rb
@@ -18,7 +18,7 @@ class ProviderManagement::ProvidersController < ApplicationController
     if @provider.update(provider_params.except(*filtered_params))
       redirect_to provider_management_provider_path(@provider), notice: 'Provider successfully updated'
     else
-      @error_presenter = ErrorPresenter.new(@provider, error_message_file)
+      @error_presenter = ErrorPresenter.new(@provider)
       render 'shared/providers/edit'
     end
   end
@@ -28,7 +28,7 @@ class ProviderManagement::ProvidersController < ApplicationController
     if @provider.save
       redirect_to provider_management_root_path, notice: 'Provider successfully created'
     else
-      @error_presenter = ErrorPresenter.new(@provider, error_message_file)
+      @error_presenter = ErrorPresenter.new(@provider)
       render 'shared/providers/new'
     end
   end
@@ -41,9 +41,5 @@ class ProviderManagement::ProvidersController < ApplicationController
 
   def filtered_params
     []
-  end
-
-  def error_message_file
-    @error_message_file ||= Rails.root.join("config/locales/#{I18n.locale}/error_messages/provider.yml")
   end
 end

--- a/app/interfaces/api/error_response.rb
+++ b/app/interfaces/api/error_response.rb
@@ -46,7 +46,7 @@ module API
     private
 
     def translations
-      message_file ||= Rails.root.join('config', 'locales', "error_messages.#{I18n.locale}.yml")
+      message_file ||= Rails.root.join('config', 'locales', I18n.locale, 'error_messages', 'claim.yml')
       YAML.load_file(message_file)
     end
 

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -3,10 +3,9 @@ class ErrorPresenter
 
   attr_reader :error_details
 
-  def initialize(claim, message_file = nil)
-    @claim = claim
-    @errors = claim.errors
-    message_file ||= default_file
+  def initialize(instance, message_file = nil)
+    @errors = instance.errors
+    message_file ||= default_file_for(instance)
     @translations = YAML.load_file(message_file)
     @error_details = ErrorDetailCollection.new
     generate_messages
@@ -114,7 +113,7 @@ class ErrorPresenter
     "#{error.attribute.to_s.humanize} #{error.message.humanize.downcase}"
   end
 
-  def default_file
-    "#{Rails.root}/config/locales/#{I18n.locale}/error_messages/claim.yml"
+  def default_file_for(instance)
+    Rails.root.join('config', 'locales', I18n.locale, 'error_messages', "#{instance.class.to_s.underscore}.yml")
   end
 end


### PR DESCRIPTION
#### What

Rename the error messages file for claims to follow the same pattern as the new file for providers. Then allow the error presenter to automatically find the correct file based on the model name.

**Note:** I didn't realise that `ErrorMessageTranslator` is also used in `app/interfaces/api/error_response.rb`, and the messages file isn't just for the claims model. Therefore renaming `config/locales/error_messages.en.yml` to `config/locales/en/error_messages/claim.yml` is not clear unless it is then split up.