### PR TITLE
[CFP-91] GOVUK Table component

### DIFF
--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -9,34 +9,33 @@
 
 = render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'search-button'), hint_text: t('hint.search_users'), button_text: t('search.users') }
 
-%table.report
-  %thead
-    %th{ scope: 'col' }
-      = t('.last_name')
-    %th{ scope: 'col' }
-      = t('.first_name')
-    %th{ scope: 'col' }
-      = t('.supplier_number')
-    %th{ scope: 'col' }
-      = t('.email')
-    %th{ scope: 'col' }
-      = t('.email_confirmation')
-    %th{ scope: 'col' }
-      = t('.actions')
-  %tbody
+
+= govuk_table_and_caption t('.table_caption', provider_name: "#{current_user.provider.name}"), class: 'govuk-visually-hidden' do
+
+  = govuk_table_thead_collection [t('.last_name'),
+  t('.first_name'),
+  t('.supplier_number'),
+  t('.email'),
+  t('.email_confirmation'),
+  t('.actions')]
+
+  = govuk_table_tbody do
     - @external_users.each do |advocate|
-      %tr
-        %td{ 'data-label': t('.last_name') }
-          = advocate.last_name
-        %td{ 'data-label': t('.first_name') }
-          = advocate.first_name
-        %td{ 'data-label': t('.supplier_number') }
+      = govuk_table_row do
+        = govuk_table_td advocate.last_name
+
+        = govuk_table_td advocate.first_name
+
+        = govuk_table_td do
           = advocate.supplier_number ? advocate.supplier_number : '-'
-        %td{ 'data-label': t('.email') }
+
+        = govuk_table_td do
           = govuk_mail_to advocate.email, advocate.email, { title: t('.email_title', external_user: advocate.name) }
-        %td{ 'data-label': t('.email_confirmation') }
+
+        = govuk_table_td do
           = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
-        %td.user-controls{ 'data-label': t('.actions') }
+
+        = govuk_table_td do
           - if advocate.active?
             = govuk_link_to t('.edit_html', context: advocate.name), edit_external_users_admin_external_user_path(advocate)
             = ' | '

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -10,7 +10,9 @@
 = render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'search-button'), hint_text: t('hint.search_users'), button_text: t('search.users') }
 
 
-= govuk_table_and_caption t('.table_caption', provider_name: "#{current_user.provider.name}"), class: 'govuk-visually-hidden' do
+= govuk_table(class: 'report') do
+  = govuk_table_caption(class: 'govuk-visually-hidden') do
+    = t('.table_caption', provider_name: "#{current_user.provider.name}")
 
   = govuk_table_thead_collection [t('.last_name'),
   t('.first_name'),
@@ -22,20 +24,20 @@
   = govuk_table_tbody do
     - @external_users.each do |advocate|
       = govuk_table_row do
-        = govuk_table_td advocate.last_name
+        = govuk_table_td('data-label': t('.last_name')) { advocate.last_name }
 
-        = govuk_table_td advocate.first_name
+        = govuk_table_td('data-label': t('.first_name')) { advocate.first_name }
 
-        = govuk_table_td do
+        = govuk_table_td('data-label': t('.supplier_number')) do
           = advocate.supplier_number ? advocate.supplier_number : '-'
 
-        = govuk_table_td do
+        = govuk_table_td('data-label': t('.email')) do
           = govuk_mail_to advocate.email, advocate.email, { title: t('.email_title', external_user: advocate.name) }
 
-        = govuk_table_td do
+        = govuk_table_td('data-label': t('.email_confirmation')) do
           = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
 
-        = govuk_table_td do
+        = govuk_table_td('data-label': t('.actions')) do
           - if advocate.active?
             = govuk_link_to t('.edit_html', context: advocate.name), edit_external_users_admin_external_user_path(advocate)
             = ' | '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -677,10 +677,10 @@ en:
           advocates: 'Users'
           add_advocate: 'Add User'
           edit: *edit
-          edit_html: Edit <span class="govuk-visually-hidden">user %{context}</span>
+          edit_html: Edit<span class="govuk-visually-hidden"> user %{context}</span>
           email: 'Email'
           delete: *delete
-          delete_html: Delete <span class="govuk-visually-hidden">user %{context}</span>
+          delete_html: Delete<span class="govuk-visually-hidden"> user %{context}</span>
           confirm_delete: 'Are you sure?'
           first_name: 'Name'
           last_name: 'Surname'
@@ -694,6 +694,7 @@ en:
           email_title: Email %{external_user}
           email_confirmation: Email notifications of messages?
           confirmation: Are you sure?
+          table_caption: "%{provider_name} users"
         new:
           error: 'error'
           page_heading: Add a new user to %{provider_name}

--- a/features/page_objects/external_user_manage_users_page.rb
+++ b/features/page_objects/external_user_manage_users_page.rb
@@ -1,7 +1,7 @@
 class ExternalUserManageUsersPage < BasePage
   set_url "/external_users/admin/external_users"
 
-  section :user_table, 'table.report' do
+  section :user_table, 'table' do
     sections :rows, 'tbody > tr' do
     end
   end

--- a/features/step_definitions/manage_users_steps.rb
+++ b/features/step_definitions/manage_users_steps.rb
@@ -18,7 +18,7 @@ Then('the following user details are displayed:') do |table|
   expect(@external_user_manage_users_page).to be_displayed
   table.hashes.each do |row|
     row.each do |data_label, text|
-      actual_text_values = @external_user_manage_users_page.all("td[data-label='#{data_label}']").map(&:text)
+      actual_text_values = @external_user_manage_users_page.all('td').map(&:text)
       expect(actual_text_values).to include(text)
     end
   end

--- a/lib/govuk_component/railtie.rb
+++ b/lib/govuk_component/railtie.rb
@@ -40,6 +40,10 @@ module GovukComponent
       ActiveSupport.on_load(:action_view) { include GovukComponent::SummaryListHelpers }
     end
 
+    initializer 'govuk_component.table_helpers' do
+      ActiveSupport.on_load(:action_view) { include GovukComponent::TableHelpers }
+    end
+
     initializer 'govuk_component.tag_helpers' do
       ActiveSupport.on_load(:action_view) { include GovukComponent::TagHelpers }
     end

--- a/lib/govuk_component/shared_helpers.rb
+++ b/lib/govuk_component/shared_helpers.rb
@@ -10,5 +10,9 @@ module GovukComponent
       options[:class] = classes.join(' ')
       options
     end
+
+    def capture_or_arg(data = nil, &block)
+      block ? capture(&block) : data
+    end
   end
 end

--- a/lib/govuk_component/shared_helpers.rb
+++ b/lib/govuk_component/shared_helpers.rb
@@ -10,9 +10,5 @@ module GovukComponent
       options[:class] = classes.join(' ')
       options
     end
-
-    def capture_or_arg(data = nil, &block)
-      block ? capture(&block) : data
-    end
   end
 end

--- a/lib/govuk_component/table_helpers.rb
+++ b/lib/govuk_component/table_helpers.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Component Reference: https://design-system.service.gov.uk/components/table/
+
+module GovukComponent
+  module TableHelpers
+    def govuk_table(tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table', tag_options)
+      capture_block = capture(&block)
+
+      tag.table(capture_block, tag_options)
+    end
+
+    def govuk_table_caption(caption = nil, tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__caption', tag_options)
+      content = capture_or_arg(caption, &block)
+
+      tag.caption(content, tag_options)
+    end
+
+    def govuk_table_thead(tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__head', tag_options)
+      capture_block = capture(&block)
+
+      tag.thead(capture_block, tag_options)
+    end
+
+    def govuk_table_tbody(tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__body', tag_options)
+      capture_block = capture(&block)
+
+      tag.tbody(capture_block, tag_options)
+    end
+
+    def govuk_table_row(tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__row', tag_options)
+      capture_block = capture(&block)
+
+      tag.tr(capture_block, tag_options)
+    end
+
+    def govuk_table_th(data = nil, scope = 'col', tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__header', tag_options)
+      tag_options[:scope] = scope
+      content = capture_or_arg(data, &block)
+
+      tag.th(content, tag_options)
+    end
+
+    def govuk_table_td(data = nil, tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__cell', tag_options)
+      content = capture_or_arg(data, &block)
+
+      tag.td(content, tag_options)
+    end
+
+    def govuk_table_and_caption(caption = nil, tag_options = {}, &block)
+      govuk_table do
+        concat govuk_table_caption(caption, tag_options)
+        concat capture(&block)
+      end
+    end
+
+    def govuk_table_thead_collection(headers, _tag_options = {})
+      govuk_table_thead do
+        govuk_table_row do
+          headers.each do |header|
+            concat govuk_table_th(header)
+          end
+        end
+      end
+    end
+
+    def govuk_table_tbody_collection(data_collections, _tag_options = {})
+      govuk_table_tbody do
+        table_rows = data_collections.map do |data|
+          data.map do |datum|
+            govuk_table_td(datum)
+          end.join
+        end
+
+        table_rows.each do |table_cell|
+          # rubocop:disable Rails/OutputSafety
+          concat tag.tr(table_cell.html_safe, class: 'govuk-table__row')
+          # rubocop:enable Rails/OutputSafety
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_component/table_helpers.rb
+++ b/lib/govuk_component/table_helpers.rb
@@ -6,83 +6,82 @@ module GovukComponent
   module TableHelpers
     def govuk_table(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table', tag_options)
-      capture_block = capture(&block)
 
-      tag.table(capture_block, tag_options)
+      tag.table(capture(&block), tag_options)
     end
 
-    def govuk_table_caption(caption = nil, tag_options = {}, &block)
+    def govuk_table_caption(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__caption', tag_options)
-      content = capture_or_arg(caption, &block)
 
-      tag.caption(content, tag_options)
+      tag.caption(capture(&block), tag_options)
     end
 
     def govuk_table_thead(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__head', tag_options)
-      capture_block = capture(&block)
 
-      tag.thead(capture_block, tag_options)
+      tag.thead(capture(&block), tag_options)
     end
 
     def govuk_table_tbody(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__body', tag_options)
-      capture_block = capture(&block)
 
-      tag.tbody(capture_block, tag_options)
+      tag.tbody(capture(&block), tag_options)
     end
 
     def govuk_table_row(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__row', tag_options)
-      capture_block = capture(&block)
 
-      tag.tr(capture_block, tag_options)
+      tag.tr(capture(&block), tag_options)
     end
 
-    def govuk_table_th(data = nil, scope = 'col', tag_options = {}, &block)
+    def govuk_table_th(scope = 'col', tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__header', tag_options)
       tag_options[:scope] = scope
-      content = capture_or_arg(data, &block)
 
-      tag.th(content, tag_options)
+      tag.th(capture(&block), tag_options)
     end
 
-    def govuk_table_td(data = nil, tag_options = {}, &block)
+    def govuk_table_td(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__cell', tag_options)
-      content = capture_or_arg(data, &block)
 
-      tag.td(content, tag_options)
+      tag.td(capture(&block), tag_options)
     end
 
     def govuk_table_and_caption(caption = nil, tag_options = {}, &block)
       govuk_table do
-        concat govuk_table_caption(caption, tag_options)
-        concat capture(&block)
+        concat(govuk_table_caption(tag_options) { caption })
+        concat(capture(&block))
       end
     end
 
-    def govuk_table_thead_collection(headers, _tag_options = {})
+    def govuk_table_thead_collection(data_collections)
       govuk_table_thead do
         govuk_table_row do
-          headers.each do |header|
-            concat govuk_table_th(header)
+          data_collections.each do |datum|
+            concat(govuk_table_th { datum })
           end
         end
       end
     end
 
-    def govuk_table_tbody_collection(data_collections, _tag_options = {})
+    def govuk_table_tbody_collection(data_collections)
       govuk_table_tbody do
-        table_rows = data_collections.map do |data|
-          data.map do |datum|
-            govuk_table_td(datum)
+        table_rows = data_collections.map do |row|
+          row.map do |data_cell|
+            govuk_table_td { data_cell }
           end.join
         end
 
-        table_rows.each do |table_cell|
-          # rubocop:disable Rails/OutputSafety
-          concat tag.tr(table_cell.html_safe, class: 'govuk-table__row')
-          # rubocop:enable Rails/OutputSafety
+        table_rows.each do |table_row|
+          concat(govuk_table_row { sanitize(table_row, tags: %w[td]) })
+        end
+      end
+    end
+
+    def govuk_table_row_collection(data_collections)
+      govuk_table_row do
+        data_collections.each do |datum|
+          concat(govuk_table_td { datum })
         end
       end
     end

--- a/spec/lib/govuk_component/table_helpers_spec.rb
+++ b/spec/lib/govuk_component/table_helpers_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
   end
 
   describe '#govuk_table_caption' do
-    subject(:markup) { helper.govuk_table_caption('My table caption', class: 'my-custom-class') }
+    subject(:markup) { helper.govuk_table_caption(class: 'my-custom-class') { 'My table caption' } }
 
     it 'adds a govuk table caption' do
       is_expected.to have_tag(:caption, with: { class: 'govuk-table__caption my-custom-class' },
@@ -46,7 +46,7 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
 
   describe '#govuk_table_th' do
     context 'with col scope' do
-      subject(:markup) { helper.govuk_table_th('table head') }
+      subject(:markup) { helper.govuk_table_th { 'table head' } }
 
       it 'adds a govuk table header cell' do
         is_expected.to have_tag(:th, with: { class: 'govuk-table__header', scope: 'col' }, text: 'table head')
@@ -54,7 +54,7 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
     end
 
     context 'with row scope' do
-      subject(:markup) { helper.govuk_table_th('table head', 'row') }
+      subject(:markup) { helper.govuk_table_th('row') { 'table head' } }
 
       it 'adds a govuk table header cell' do
         is_expected.to have_tag(:th, with: { class: 'govuk-table__header', scope: 'row' }, text: 'table head')
@@ -62,7 +62,7 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
     end
 
     context 'with custom class' do
-      subject(:markup) { helper.govuk_table_th('table head', 'row', class: 'my-custom-class') }
+      subject(:markup) { helper.govuk_table_th('row', class: 'my-custom-class') { 'table head' } }
 
       it 'adds a govuk table header cell' do
         is_expected.to have_tag(:th, with: { class: 'govuk-table__header my-custom-class', scope: 'row' },
@@ -72,7 +72,7 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
   end
 
   describe '#govuk_table_td' do
-    subject(:markup) { helper.govuk_table_td('table cell', class: 'my-custom-class') }
+    subject(:markup) { helper.govuk_table_td(class: 'my-custom-class') { 'table cell' } }
 
     it 'adds a govuk table cell' do
       is_expected.to have_tag(:td, with: { class: 'govuk-table__cell my-custom-class' }, text: 'table cell')
@@ -113,6 +113,18 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
         with_tag(:tr, with: { class: 'govuk-table__row' }, count: 2) do
           with_tag(:td, with: { class: 'govuk-table__cell' }, count: 4, text: /data cell/)
         end
+      end
+    end
+  end
+
+  describe '#govuk_table_row_collection' do
+    subject(:markup) do
+      helper.govuk_table_row_collection(['data cell 1', 'data cell 2'])
+    end
+
+    it 'adds a nested table cells in govuk table row' do
+      is_expected.to have_tag(:tr, with: { class: 'govuk-table__row' }) do
+        with_tag(:td, with: { class: 'govuk-table__cell' }, count: 2, text: /data cell/)
       end
     end
   end

--- a/spec/lib/govuk_component/table_helpers_spec.rb
+++ b/spec/lib/govuk_component/table_helpers_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukComponent::TableHelpers, type: :helper do
+  include RSpecHtmlMatchers
+
+  describe '#govuk_table' do
+    subject(:markup) { helper.govuk_table(class: 'my-custom-class') { nil } }
+
+    it 'adds a govuk table' do
+      is_expected.to have_tag(:table, with: { class: 'govuk-table my-custom-class' })
+    end
+  end
+
+  describe '#govuk_table_caption' do
+    subject(:markup) { helper.govuk_table_caption('My table caption', class: 'my-custom-class') }
+
+    it 'adds a govuk table caption' do
+      is_expected.to have_tag(:caption, with: { class: 'govuk-table__caption my-custom-class' },
+                                        text: 'My table caption')
+    end
+  end
+
+  describe '#govuk_table_thead' do
+    subject(:markup) { helper.govuk_table_thead(class: 'my-custom-class') { nil } }
+
+    it 'adds a govuk table thead' do
+      is_expected.to have_tag(:thead, with: { class: 'govuk-table__head my-custom-class' })
+    end
+  end
+
+  describe '#govuk_table_tbody' do
+    subject(:markup) { helper.govuk_table_tbody(class: 'my-custom-class') { nil } }
+
+    it 'adds a govuk table tbody' do
+      is_expected.to have_tag(:tbody, with: { class: 'govuk-table__body my-custom-class' })
+    end
+  end
+
+  describe '#govuk_table_row' do
+    subject(:markup) { helper.govuk_table_row(class: 'my-custom-class') { nil } }
+
+    it 'adds a govuk table row' do
+      is_expected.to have_tag(:tr, with: { class: 'govuk-table__row my-custom-class' })
+    end
+  end
+
+  describe '#govuk_table_th' do
+    context 'with col scope' do
+      subject(:markup) { helper.govuk_table_th('table head') }
+
+      it 'adds a govuk table header cell' do
+        is_expected.to have_tag(:th, with: { class: 'govuk-table__header', scope: 'col' }, text: 'table head')
+      end
+    end
+
+    context 'with row scope' do
+      subject(:markup) { helper.govuk_table_th('table head', 'row') }
+
+      it 'adds a govuk table header cell' do
+        is_expected.to have_tag(:th, with: { class: 'govuk-table__header', scope: 'row' }, text: 'table head')
+      end
+    end
+
+    context 'with custom class' do
+      subject(:markup) { helper.govuk_table_th('table head', 'row', class: 'my-custom-class') }
+
+      it 'adds a govuk table header cell' do
+        is_expected.to have_tag(:th, with: { class: 'govuk-table__header my-custom-class', scope: 'row' },
+                                     text: 'table head')
+      end
+    end
+  end
+
+  describe '#govuk_table_td' do
+    subject(:markup) { helper.govuk_table_td('table cell', class: 'my-custom-class') }
+
+    it 'adds a govuk table cell' do
+      is_expected.to have_tag(:td, with: { class: 'govuk-table__cell my-custom-class' }, text: 'table cell')
+    end
+  end
+
+  describe '#govuk_table_and_caption' do
+    subject(:markup) { helper.govuk_table_and_caption('My table caption', class: 'my-custom-class') { nil } }
+
+    it 'adds a nested caption in govuk table' do
+      is_expected.to have_tag(:table, with: { class: 'govuk-table' }) do
+        with_tag(:caption, with: { class: 'govuk-table__caption my-custom-class' }, text: 'My table caption')
+      end
+    end
+  end
+
+  describe '#govuk_table_thead_collection' do
+    subject(:markup) do
+      helper.govuk_table_thead_collection(['table head 1', 'table head 2'])
+    end
+
+    it 'adds a nested table header cell in govuk table head' do
+      is_expected.to have_tag(:thead, with: { class: 'govuk-table__head' }) do
+        with_tag(:tr, with: { class: 'govuk-table__row' }) do
+          with_tag(:th, with: { class: 'govuk-table__header', scope: 'col' }, count: 2, text: /table head/)
+        end
+      end
+    end
+  end
+
+  describe '#govuk_table_tbody_collection' do
+    subject(:markup) do
+      helper.govuk_table_tbody_collection([['data cell 1', 'data cell 2'], ['data cell 3', 'data cell 4']])
+    end
+
+    it 'adds a nested table cell in govuk table body' do
+      is_expected.to have_tag(:tbody, with: { class: 'govuk-table__body' }) do
+        with_tag(:tr, with: { class: 'govuk-table__row' }, count: 2) do
+          with_tag(:td, with: { class: 'govuk-table__cell' }, count: 4, text: /data cell/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Implementation of [GOVUK's Design System Table component](https://design-system.service.gov.uk/components/table/)

#### Ticket
[GOVUK component - Table](https://dsdmoj.atlassian.net/browse/CFP-91)

#### Why
Migration to the GOVUK Design System to:

- enable a consistent user experience
- improve accessibility
- use the current supported markup and remove deprecate designs

#### How
Create a custom table helper that reflects the table markup of the [GOVUK's Design System Table component](https://design-system.service.gov.uk/components/table/)

Migrate the external_users index table to use the new table helper
