### PR TITLE
[CFP-103] Remove Paperclip fields from stats_reports

### DIFF
--- a/db/migrate/20210804091216_drop_paperclip_fields_from_stats_reports.rb
+++ b/db/migrate/20210804091216_drop_paperclip_fields_from_stats_reports.rb
@@ -1,0 +1,9 @@
+class DropPaperclipFieldsFromStatsReports < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :stats_reports, :as_document_checksum, :string
+    remove_column :stats_reports, :document_updated_at, :datetime
+    remove_column :stats_reports, :document_file_size, :integer
+    remove_column :stats_reports, :document_content_type, :string
+    remove_column :stats_reports, :document_file_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_134731) do
+ActiveRecord::Schema.define(version: 2021_08_04_091216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -593,11 +593,6 @@ ActiveRecord::Schema.define(version: 2021_03_05_134731) do
     t.string "status"
     t.datetime "started_at"
     t.datetime "completed_at"
-    t.string "document_file_name"
-    t.string "document_content_type"
-    t.integer "document_file_size"
-    t.datetime "document_updated_at"
-    t.string "as_document_checksum"
   end
 
   create_table "super_admins", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
#### What

Remove fields used by the Paperclip gem from the `stats_reports` table.

#### Ticket

[Remove Paperclip fields from the database](https://dsdmoj.atlassian.net/browse/CFP-103)

#### Why

We moved from Paperclip to Active Storage for document storage several weeks ago and there have been no issues that would require us to roll back the change. The Paperclip specific fields can now be cleared out of the database.

#### How

A database migration that will be applied automatically when deployed to each environment; dev-lgfs, dev, staging, api-sandbox and production.