### PR TITLE
[CFP-103] Remove Paperclip fields from messages

### DIFF
--- a/db/migrate/20210804123914_drop_paperclip_fields_from_messages.rb
+++ b/db/migrate/20210804123914_drop_paperclip_fields_from_messages.rb
@@ -1,0 +1,9 @@
+class DropPaperclipFieldsFromMessages < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :messages, :as_attachment_checksum, :string
+    remove_column :messages, :attachment_updated_at, :datetime
+    remove_column :messages, :attachment_file_size, :integer
+    remove_column :messages, :attachment_content_type, :string
+    remove_column :messages, :attachment_file_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_04_091216) do
+ActiveRecord::Schema.define(version: 2021_08_04_123914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -435,11 +435,6 @@ ActiveRecord::Schema.define(version: 2021_08_04_091216) do
     t.integer "sender_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "attachment_file_name"
-    t.string "attachment_content_type"
-    t.integer "attachment_file_size"
-    t.datetime "attachment_updated_at"
-    t.string "as_attachment_checksum"
     t.index ["claim_id"], name: "index_messages_on_claim_id"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end


### PR DESCRIPTION
#### What

Remove fields used by the Paperclip gem from the `messages` table.

#### Ticket

[Remove Paperclip fields from the database](https://dsdmoj.atlassian.net/browse/CFP-103)

#### Why

We moved from Paperclip to Active Storage for document storage several weeks ago and there have been no issues that would require us to roll back the change. The Paperclip specific fields can now be cleared out of the database.

#### How

A database migration that will be applied automatically when deployed to each environment; dev-lgfs, dev, staging, api-sandbox and production.