### PR TITLE
[CFP-103] Remove report field from stats_reports table

### DIFF
--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: stats_reports
-#
-#  id           :integer          not null, primary key
-#  report_name  :string
-#  report       :string
-#  status       :string
-#  started_at   :datetime
-#  completed_at :datetime
-#
-
 module Stats
   class StatsReport < ApplicationRecord
     TYPES = %w[management_information provisional_assessment rejections_refusals submitted_claims].freeze

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -60,10 +60,6 @@ module Stats
       raise
     end
 
-    def write_error(report_contents)
-      update(report: report_contents, status: 'error', completed_at: nil)
-    end
-
     def download_filename
       "#{report_name}_#{started_at.to_s(:number)}.csv"
     end

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -19,7 +19,7 @@ module Stats
       report_contents = generate_new_report
       report_record.write_report(report_contents)
     rescue StandardError => e
-      report_record.update(status: 'error') if report_record
+      report_record&.update(status: 'error')
       notify_error(report_record, e)
       raise
     end

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -19,7 +19,7 @@ module Stats
       report_contents = generate_new_report
       report_record.write_report(report_contents)
     rescue StandardError => e
-      handle_error(e, report_record)
+      notify_error(report_record, e)
       raise
     end
 
@@ -36,12 +36,6 @@ module Stats
       return ManagementInformationGenerator.call(options) if report_type.to_sym == :management_information
 
       ReportGenerator.call(report_type, **options)
-    end
-
-    def handle_error(error, record)
-      contents = "#{error.class} - #{error.message} \n #{error.backtrace}"
-      record&.write_error(contents)
-      notify_error(record, error)
     end
 
     def notify_error(report_record, error)

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -19,6 +19,7 @@ module Stats
       report_contents = generate_new_report
       report_record.write_report(report_contents)
     rescue StandardError => e
+      report_record.update(status: 'error') if report_record
       notify_error(report_record, e)
       raise
     end

--- a/db/migrate/20210805124942_remove_report_from_stats_reports.rb
+++ b/db/migrate/20210805124942_remove_report_from_stats_reports.rb
@@ -1,0 +1,5 @@
+class RemoveReportFromStatsReports < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :stats_reports, :report, :string, after: :report_name
+  end
+end

--- a/db/migrate/20210805124942_remove_report_from_stats_reports.rb
+++ b/db/migrate/20210805124942_remove_report_from_stats_reports.rb
@@ -1,5 +1,5 @@
 class RemoveReportFromStatsReports < ActiveRecord::Migration[6.1]
   def change
-    remove_column :stats_reports, :report, :string, after: :report_name
+    remove_column :stats_reports, :report, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_04_151307) do
+ActiveRecord::Schema.define(version: 2021_08_05_124942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -573,7 +573,6 @@ ActiveRecord::Schema.define(version: 2021_08_04_151307) do
 
   create_table "stats_reports", id: :serial, force: :cascade do |t|
     t.string "report_name"
-    t.string "report"
     t.string "status"
     t.datetime "started_at"
     t.datetime "completed_at"

--- a/spec/factories/stats/stats_reports.rb
+++ b/spec/factories/stats/stats_reports.rb
@@ -1,25 +1,11 @@
-# == Schema Information
-#
-# Table name: stats_reports
-#
-#  id           :integer          not null, primary key
-#  report_name  :string
-#  report       :string
-#  status       :string
-#  started_at   :datetime
-#  completed_at :datetime
-#
-
 FactoryBot.define do
   factory :stats_report, class: 'Stats::StatsReport' do
     report_name { 'management_information' }
-    report { 'report contents' }
     status { 'completed' }
     started_at { 2.minutes.ago }
     completed_at { 2.seconds.ago }
 
     trait :with_document do
-      report { nil }
       document do
         Rack::Test::UploadedFile.new(
           File.expand_path('spec/fixtures/files/report.csv', Rails.root),

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe Stats::StatsReport do
           expect(record.report_name).to eq 'my_new_report'
           expect(record.started_at).to eq frozen_time
           expect(record.completed_at).to be_nil
-          expect(record.report).to be_nil
         end
       end
     end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
     end
 
     context 'when there is already a report of that type in progress' do
-      before { Stats::StatsReport.create(report_name: report_type, status: 'started', report: 'some content') }
+      before { Stats::StatsReport.create(report_name: report_type, status: 'started') }
 
       it 'does not create a new report' do
         expect { call_report_generator }.not_to change { Stats::StatsReport.count }.from(1)


### PR DESCRIPTION
#### What

Remove the `report` field from the `stats_reports` table.

#### Ticket

Related to: [Remove Paperclip fields from the database](https://dsdmoj.atlassian.net/browse/CFP-103)

#### Why

The `report` field in the `Stats::StatsReport` model used to contain the data of the report but that was moved into AWS a long time ago. This field is therefore unused now, although errors from failed report generation may get written there.

#### How

Remove the field from the database and stop attempting to write errors to it.