### PR TITLE
[CFP-240] refactor custom error handler specs

### DIFF
--- a/spec/models/supplier_number_spec.rb
+++ b/spec/models/supplier_number_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SupplierNumber, type: :model do
     let(:format_error) { ['Enter a valid LGFS supplier number'] }
 
     before do
-      allow(supplier).to receive(:supplier_number).and_return(supplier_number)
+      supplier.supplier_number = supplier_number
       supplier.validate
     end
 

--- a/spec/models/supplier_number_spec.rb
+++ b/spec/models/supplier_number_spec.rb
@@ -1,34 +1,23 @@
-# == Schema Information
-#
-# Table name: supplier_numbers
-#
-#  id              :integer          not null, primary key
-#  provider_id     :integer
-#  supplier_number :string
-#
-
-require 'rails_helper'
-
 RSpec.describe SupplierNumber, type: :model do
   subject(:supplier) { build(:supplier_number) }
 
-  context 'uniqueness' do
-    it 'fails if two records with the same suppplier number are created' do
-      create :supplier_number, supplier_number: '9X999X'
+  context 'when validating uniqueness' do
+    before { create(:supplier_number, supplier_number: '9X999X') }
+
+    specify do
       expect {
         create :supplier_number, supplier_number: '9X999X'
       }.to raise_error ActiveRecord::RecordInvalid, 'Validation failed: Supplier number has already been taken'
     end
 
-    it 'fails if the supplier number after upcasing is the same as an existing record' do
-      create :supplier_number, supplier_number: '9X999X'
+    specify do
       expect {
         create :supplier_number, supplier_number: '9x999x'
       }.to raise_error ActiveRecord::RecordInvalid, 'Validation failed: Supplier number has already been taken'
     end
   end
 
-  context 'postcode validation' do
+  context 'when validating postcode' do
     it 'is valid if postcode is nil' do
       supplier.postcode = nil
       expect(supplier).to be_valid
@@ -44,37 +33,49 @@ RSpec.describe SupplierNumber, type: :model do
       expect(supplier).to be_valid
     end
 
-    it 'is invalid if postcode is filled and has the wrong format' do
-      supplier.postcode = 'not-a-valid-postcode'
-      expect(supplier).not_to be_valid
-      expect(supplier.errors[:postcode]).to include('Enter a valid postcode')
+    context 'with wrong format' do
+      before do
+        supplier.postcode = 'not-a-valid-postcode'
+        supplier.validate
+      end
+
+      it { expect(supplier).to be_invalid }
+      it { expect(supplier.errors[:postcode]).to include('Enter a valid postcode') }
     end
   end
 
-  context 'validates supplier number format' do
+  context 'when validating supplier number' do
     let(:format_error) { ['Enter a valid LGFS supplier number'] }
 
-    it 'fails for incorrect format' do
-      allow(subject).to receive(:supplier_number).and_return('ABC123')
-      expect(subject).not_to be_valid
-      expect(subject.errors[:supplier_number]).to eq(format_error)
+    before do
+      allow(supplier).to receive(:supplier_number).and_return(supplier_number)
+      supplier.validate
     end
 
-    it 'succeeds for correct format but lowercase' do
-      allow(subject).to receive(:supplier_number).and_return('1b222z')
-      expect(subject).to be_valid
-      expect(subject.supplier_number).to eq '1B222Z'
+    context 'with invalid format' do
+      let(:supplier_number) { 'ABC123' }
+
+      it { expect(supplier.errors[:supplier_number]).to eq(format_error) }
     end
 
-    it 'pass for correct format' do
-      allow(subject).to receive(:supplier_number).and_return('1B222Z')
-      expect(subject).to be_valid
+    context 'with valid lowercase format' do
+      let(:supplier_number) { '1b222z' }
+
+      it { expect(supplier).to be_valid }
+      it { expect(supplier.supplier_number).to eq '1B222Z' }
+    end
+
+    context 'with valid format' do
+      let(:supplier_number) { '1B222Z' }
+
+      it { expect(supplier).to be_valid }
     end
   end
 
   describe '#has_non_archived_claims?' do
+    subject { described_class.new(supplier_number: '6X666X').has_non_archived_claims? }
+
     let(:relation) { double(ActiveRecord::Relation) }
-    subject { described_class.new(supplier_number: '6X666X') }
 
     before do
       expect(Claim::BaseClaim).to receive(:non_archived_pending_delete).and_return(relation)
@@ -84,17 +85,13 @@ RSpec.describe SupplierNumber, type: :model do
     context 'when there are claims' do
       let(:claims) { [double('Claim')] }
 
-      it 'returns true' do
-        expect(subject.has_non_archived_claims?).to be true
-      end
+      it { is_expected.to be_truthy }
     end
 
     context 'when there are no claims' do
       let(:claims) { [] }
 
-      it 'returns false' do
-        expect(subject.has_non_archived_claims?).to be false
-      end
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/presenters/data/error_messages.en.yml
+++ b/spec/presenters/data/error_messages.en.yml
@@ -29,5 +29,5 @@ defendant:
     _seq: 10
     blank:
       long: "Enter a first name for the #{defendant}"
-      short: Enter a name
+      short: Enter a first name
       api: "The first name for the #{defendant} must not be blank"

--- a/spec/presenters/error_message_translator_spec.rb
+++ b/spec/presenters/error_message_translator_spec.rb
@@ -86,8 +86,6 @@ RSpec.describe ErrorMessageTranslator do
     }
   end
 
-  it { is_expected.to respond_to(:long_message, :short_message, :api_message) }
-
   describe '.association_key' do
     subject(:association_key) { described_class.association_key(key) }
 

--- a/spec/presenters/error_message_translator_spec.rb
+++ b/spec/presenters/error_message_translator_spec.rb
@@ -88,6 +88,47 @@ RSpec.describe ErrorMessageTranslator do
 
   it { is_expected.to respond_to(:long_message, :short_message, :api_message) }
 
+  describe '.association_key' do
+    subject(:association_key) { described_class.association_key(key) }
+
+    context 'with unnumbered key' do
+      let(:key) { 'foo.bar_1_baz' }
+
+      it { is_expected.to eq('foo_0_bar_0_baz') }
+    end
+
+    context 'with numbered key' do
+      let(:key) { 'foo_0_bar_0_baz' }
+
+      it { is_expected.to eq('foo_0_bar_0_baz') }
+    end
+  end
+
+  describe '#translation_found?' do
+    subject { emt.translation_found? }
+
+    context 'when key and error exists' do
+      let(:key) { :name }
+      let(:error) { 'cannot_be_blank' }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when key does not exist' do
+      let(:key) { :foo }
+      let(:error) { 'cannot_be_blank' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when message does not exist' do
+      let(:key) { :name }
+      let(:error) { 'bar' }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   context 'with single level translations' do
     context 'when key and error exists' do
       let(:key) { :name }

--- a/spec/presenters/error_message_translator_spec.rb
+++ b/spec/presenters/error_message_translator_spec.rb
@@ -1,6 +1,25 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+RSpec.shared_examples 'translation not found' do
+  it { expect(emt).not_to be_translation_found }
+  it { expect(emt.long_message).to be_nil }
+  it { expect(emt.short_message).to be_nil }
+  it { expect(emt.api_message).to be_nil }
+end
+
+RSpec.shared_examples 'translation found' do |options|
+  it { expect(emt).to be_translation_found }
+  it { expect(emt.long_message).to eq(options[:long]) }
+  it { expect(emt.short_message).to eq(options[:short]) }
+  it { expect(emt.api_message).to eq(options[:api]) }
+end
 
 RSpec.describe ErrorMessageTranslator do
+  subject(:emt) { described_class.new(translations, key, error) }
+
+  let(:key) { :name }
+  let(:error) { 'cannot_be_blank' }
+
   let(:translations) do
     {
       'name' => {
@@ -67,171 +86,119 @@ RSpec.describe ErrorMessageTranslator do
     }
   end
 
-  let(:emt) { ErrorMessageTranslator.new(translations, key, error) }
+  it { is_expected.to respond_to(:long_message, :short_message, :api_message) }
 
-  context 'provides readble message attributes' do
-    let(:key)   { :name }
-    let(:error) { 'cannot_be_blank' }
+  context 'with single level translations' do
+    context 'when key and error exists' do
+      let(:key) { :name }
+      let(:error) { 'cannot_be_blank' }
 
-    it 'responds to long_message, short_message, api_message' do
-      expect(emt).to respond_to :long_message
-      expect(emt).to respond_to :short_message
-      expect(emt).to respond_to :api_message
+      it_behaves_like 'translation found',
+                      long: 'The claimant name must not be blank, please enter a name',
+                      short: 'Enter a name',
+                      api: 'The claimant name must not be blank'
+    end
+
+    context 'when key does not exist' do
+      let(:key) { :stepmother }
+      let(:error) { 'too_long' }
+
+      it_behaves_like 'translation not found'
+    end
+
+    context 'when key exists but error does not exist' do
+      let(:key) { :name }
+      let(:error) { 'rubbish' }
+
+      it_behaves_like 'translation not found'
     end
   end
 
-  context 'single_level_translations' do
-    let(:key)           { :name }
-    let(:error)         { 'cannot_be_blank' }
+  context 'with has_many sub-model translations' do
+    context 'when key and error exist' do
+      let(:key) { :defendant_2_first_name }
+      let(:error) { 'blank' }
 
-    context 'key and error exists in translations table' do
-      it 'returns top level long and short messages' do
-        expect(emt.translation_found?).to be true
-        expect(emt.long_message).to eq 'The claimant name must not be blank, please enter a name'
-        expect(emt.short_message).to eq 'Enter a name'
-        expect(emt.api_message).to eq 'The claimant name must not be blank'
-      end
+      it_behaves_like 'translation found',
+                      long: 'Enter a first name for the second defendant',
+                      short: 'Cannot be blank',
+                      api: 'The first name for the second defendant must not be blank'
     end
 
-    context 'key does not exist in translations table' do
-      let(:key)           { :stepmother }
-      let(:error)         { 'too_long' }
-      it 'returns nil and responds true to unable_to_find_translation' do
-        expect_translation_not_found(emt)
-      end
+    context 'when key for submodel does not exist in base model' do
+      let(:key) { :person_2_first_name }
+      let(:error) { 'blank' }
+
+      it_behaves_like 'translation not found'
     end
 
-    context 'key exists but error does not exist in translations table' do
-      let(:key)           { :name }
-      let(:error)         { 'rubbish' }
-      it 'returns nil and responds true to unable_to_find_translation' do
-        expect_translation_not_found(emt)
-      end
+    context 'when key for submodel exists but key for field in submodel does not' do
+      let(:key) { :defendant_2_age }
+      let(:error) { 'blank' }
+
+      it_behaves_like 'translation not found'
+    end
+
+    context 'when key for submodel and field on submodel exists but error does not' do
+      let(:key) { :defendant_2_first_name }
+      let(:error) { 'foo' }
+
+      it_behaves_like 'translation not found'
     end
   end
 
-  context 'sub-model translations' do
-    context 'has_many relations' do
-      context 'key and error exist in translations table' do
-        let(:key)           { :defendant_2_first_name }
-        let(:error)         { 'blank' }
-        it 'returns defendant 2 error messages' do
-          expect(emt.translation_found?).to be true
-          expect(emt.long_message).to eq 'Enter a first name for the second defendant'
-          expect(emt.short_message).to eq 'Cannot be blank'
-          expect(emt.api_message).to eq 'The first name for the second defendant must not be blank'
-        end
-      end
-
-      context 'key for submodel does not exist in base model' do
-        let(:key) { :person_2_first_name }
-        let(:error) { 'blank' }
-        it 'returns defendant 2 error messages' do
-          expect_translation_not_found(emt)
-        end
-      end
-
-      context 'key for submodel exists but key for field in submodel does not' do
-        let(:key) { :defendant_2_age }
-        let(:error) { 'blank' }
-        it 'returns defendant 2 error messages' do
-          expect_translation_not_found(emt)
-        end
-      end
-
-      context 'key for submodel and field on submodel exists but error does not' do
-        let(:key) { :defendant_2_first_name }
-        let(:error) { 'baslderdash' }
-        it 'returns defendant 2 error messages' do
-          expect_translation_not_found(emt)
-        end
-      end
-    end
-
-    context 'has_one relations' do
+  context 'with has_one sub-model translations' do
+    context 'when nested key and error exists' do
       let(:key) { 'fixed_fee.quantity' }
       let(:error) { 'invalid' }
-      it 'returns error defaulting error message' do
-        expect(emt.translation_found?).to be true
-        expect(emt.long_message).to eq 'Enter a valid quantity for the fixed fee'
-      end
+
+      it_behaves_like 'translation found',
+                      long: 'Enter a valid quantity for the fixed fee',
+                      short: 'Enter a valid quantity',
+                      api: 'Enter a valid quantity for the fixed fee'
     end
   end
 
-  context 'sub-sub-model translations' do
-    context 'all keys and errors exist' do
-      let(:key)           { :defendant_5_representation_order_2_maat_reference }
-      let(:error)         { 'blank' }
-      it 'returns defendant 5 reporder 2 errors' do
-        expect(emt.translation_found?).to be true
-        expect(emt.long_message).to   eq 'The MAAT Reference must be 7-10 numeric digits for the second representation order of the fifth defendant'
-        expect(emt.short_message).to  eq 'Invalid format'
-        expect(emt.api_message).to    eq 'The MAAT Reference must be 7-10 numeric digits for the second representation order of the fifth defendant'
-      end
+  context 'with has_many sub-sub-model translations' do
+    context 'when nested keys and errors exist' do
+      let(:key) { :defendant_5_representation_order_2_maat_reference }
+      let(:error) { 'blank' }
+
+      it_behaves_like 'translation found',
+                      long: 'The MAAT Reference must be 7-10 numeric digits for the second representation order of the fifth defendant',
+                      short: 'Invalid format',
+                      api: 'The MAAT Reference must be 7-10 numeric digits for the second representation order of the fifth defendant'
     end
 
-    context 'key for sub sub model does not exist' do
-      let(:key)           { :defendant_5_court_order_2_maat_reference }
-      let(:error)         { 'blank' }
-      it 'returns defendant 5 reporder 2 errors' do
-        expect_translation_not_found(emt)
-      end
+    context 'when key for sub-sub-model does not exist' do
+      let(:key) { :defendant_5_court_order_2_maat_reference }
+      let(:error) { 'blank' }
+
+      it_behaves_like 'translation not found'
     end
 
-    context 'key for field on sub sub model does not exist' do
-      let(:key)           { :defendant_5_representation_order_2_court }
-      let(:error)         { 'blank' }
-      it 'returns defendant 5 reporder 2 errors' do
-        expect_translation_not_found(emt)
-      end
+    context 'when key for field on sub sub model does not exist' do
+      let(:key) { :defendant_5_representation_order_2_court }
+      let(:error) { 'blank' }
+
+      it_behaves_like 'translation not found'
     end
 
-    context 'key for error on sub sub model does not exist' do
-      let(:key)           { :defendant_5_representation_order_2_maat_reference }
-      let(:error)         { 'no_such_error' }
-      it 'returns defendant 5 reporder 2 errors' do
-        expect_translation_not_found(emt)
-      end
+    context 'when key for error on sub sub model does not exist' do
+      let(:key) { :defendant_5_representation_order_2_maat_reference }
+      let(:error) { 'no_such_error' }
+
+      include_examples 'translation not found'
     end
   end
 
-  describe 'to_ordinal' do
-    let(:key)           { :defendant_5_representation_order_2_maat_reference }
-    let(:error)         { 'no_such_error' }
-
-    it 'returns empty string for 0' do
-      expect(emt.send(:to_ordinal, 0)).to be_empty
-      expect(emt.send(:to_ordinal, '0')).to be_empty
-    end
-
-    it 'returns words for 1 to 10' do
-      expect(emt.send(:to_ordinal, '1')).to eq 'first'
-      expect(emt.send(:to_ordinal, '2')).to eq 'second'
-      expect(emt.send(:to_ordinal, '3')).to eq 'third'
-      expect(emt.send(:to_ordinal, '4')).to eq 'fourth'
-      expect(emt.send(:to_ordinal, '5')).to eq 'fifth'
-      expect(emt.send(:to_ordinal, '6')).to eq 'sixth'
-      expect(emt.send(:to_ordinal, '7')).to eq 'seventh'
-      expect(emt.send(:to_ordinal, '8')).to eq 'eighth'
-      expect(emt.send(:to_ordinal, '9')).to eq 'ninth'
-      expect(emt.send(:to_ordinal, '10')).to eq 'tenth'
-    end
-
-    it 'returns ordinals for 11+' do
-      expect(emt.send(:to_ordinal, '11')).to eq '11th'
-      expect(emt.send(:to_ordinal, '12')).to eq '12th'
-      expect(emt.send(:to_ordinal, '21')).to eq '21st'
-      expect(emt.send(:to_ordinal, '43')).to eq '43rd'
-      expect(emt.send(:to_ordinal, '67')).to eq '67th'
-    end
-  end
-
-  # local helpers
-  # -------------
-  def expect_translation_not_found(emt)
-    expect(emt.translation_found?).to be false
-    expect(emt.long_message).to   be_nil
-    expect(emt.short_message).to  be_nil
-    expect(emt.api_message).to    be_nil
+  describe '#to_ordinal' do
+    it { expect(emt.send(:to_ordinal, 0)).to be_empty }
+    it { expect(emt.send(:to_ordinal, '0')).to be_empty }
+    it { expect(emt.send(:to_ordinal, '1')).to eq 'first' }
+    it { expect(emt.send(:to_ordinal, '10')).to eq 'tenth' }
+    it { expect(emt.send(:to_ordinal, '11')).to eq '11th' }
+    it { expect(emt.send(:to_ordinal, '42')).to eq '42nd' }
+    it { expect(emt.send(:to_ordinal, '63')).to eq '63rd' }
   end
 end

--- a/spec/presenters/error_presenter_spec.rb
+++ b/spec/presenters/error_presenter_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ErrorPresenter do
       it do
         is_expected.to eq(
           [
-            ErrorDetail.new(:defendant_2_first_name, 'Enter a first name for the second defendant', 'Enter a name', 'The first name for the second defendant must not be blank')
+            ErrorDetail.new(:defendant_2_first_name, 'Enter a first name for the second defendant', 'Enter a first name', 'The first name for the second defendant must not be blank')
           ]
         )
       end
@@ -114,12 +114,46 @@ RSpec.describe ErrorPresenter do
       it { is_expected.to eq('Foo bar') }
     end
 
-    context 'without attribute present in translation file' do
-      before { claim.errors.add(attribute, 'foo_bar_too') }
+    context 'with nested error and message present in translations' do
+      before do
+        claim.errors.add(attribute, 'blank')
+      end
 
-      let(:attribute) { :defendant_2_name }
+      let(:attribute) { :defendant_2_first_name }
 
-      it { is_expected.to eq('Foo bar too') }
+      it { is_expected.to eq('Enter a first name') }
+    end
+
+    context 'with nested error and message NOT present in translations' do
+      before do
+        claim.errors.add(attribute, 'foo_bar')
+      end
+
+      let(:attribute) { :defendant_2_first_name }
+
+      it { is_expected.to eq('Foo bar') }
+    end
+
+    context 'with multiple errors on attribute and message present in translations' do
+      before do
+        claim.errors.add(:name, 'cannot_be_blank')
+        claim.errors.add(:name, 'too_long')
+      end
+
+      let(:attribute) { :name }
+
+      it { is_expected.to eq('Enter a name, Too long') }
+    end
+
+    context 'with multiple errors on attribute and message NOT present in translations' do
+      before do
+        claim.errors.add(:name, 'cannot_be_blank')
+        claim.errors.add(:name, 'foo_bar')
+      end
+
+      let(:attribute) { :name }
+
+      it { is_expected.to eq('Enter a name, Foo bar') }
     end
   end
 end

--- a/spec/presenters/error_presenter_spec.rb
+++ b/spec/presenters/error_presenter_spec.rb
@@ -1,9 +1,9 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
 RSpec.describe ErrorPresenter do
-  subject(:presenter) { ErrorPresenter.new(claim, filename) }
+  subject(:presenter) { described_class.new(claim, filename) }
 
-  let(:claim) { FactoryBot.build :claim }
+  let(:claim) { FactoryBot.build(:claim) }
   let(:filename) { File.dirname(__FILE__) + '/data/error_messages.en.yml' }
 
   it { is_expected.to delegate_method(:errors_for?).to(:error_details) }
@@ -14,13 +14,13 @@ RSpec.describe ErrorPresenter do
   it { expect(presenter.method(:field_level_error_for)).to eq(presenter.method(:short_messages_for)) }
 
   describe '#generate_sequence' do
-    context 'when fieldname present' do
+    context 'when attribute present' do
       it 'returns the value from the error messages file' do
         expect(presenter.send(:generate_sequence, 'name')).to eq 50
       end
     end
 
-    context 'when fieldname not present' do
+    context 'when attribute not present' do
       it 'returns 99999' do
         expect(presenter.send(:generate_sequence, 'nokey')).to eq 99999
       end
@@ -30,7 +30,7 @@ RSpec.describe ErrorPresenter do
   describe '#header_errors' do
     subject { presenter.header_errors }
 
-    context 'with fieldname and message present in translations' do
+    context 'with attribute and message present in translations' do
       before { claim.errors.add(:date_of_birth, 'too_early') }
 
       it do
@@ -42,7 +42,7 @@ RSpec.describe ErrorPresenter do
       end
     end
 
-    context 'with fieldname but without message present in translations' do
+    context 'with attribute but without message present in translations' do
       before { claim.errors.add(:date_of_birth, 'foo_bar') }
 
       it do
@@ -54,7 +54,7 @@ RSpec.describe ErrorPresenter do
       end
     end
 
-    context 'without fieldname present in translation file' do
+    context 'without attribute present in translation file' do
       before { claim.errors.add(:defendant_2_name, 'is invalid') }
 
       it do
@@ -66,7 +66,7 @@ RSpec.describe ErrorPresenter do
       end
     end
 
-    context 'with nested submodel fieldname and message present in translations' do
+    context 'with nested submodel attribute and message present in translations' do
       before { claim.errors.add(:defendant_2_first_name, 'blank') }
 
       it do
@@ -98,26 +98,24 @@ RSpec.describe ErrorPresenter do
   describe '#field_level_error_for' do
     subject { presenter.field_level_error_for(attribute) }
 
-    context 'with fieldname and message present in translations' do
-      before { claim.errors.add(:date_of_birth, 'too_early') }
+    context 'with attribute and message present in translations' do
+      before { claim.errors.add(attribute, 'too_early') }
 
       let(:attribute) { :date_of_birth }
 
-      it 'returns the short message' do
-        is_expected.to eq('Enter a valid date')
-      end
+      it { is_expected.to eq('Enter a valid date') }
     end
 
-    context 'with fieldname but without message present in translations' do
-      before { claim.errors.add(:date_of_birth, 'foo_bar') }
+    context 'with attribute but without message present in translations' do
+      before { claim.errors.add(attribute, 'foo_bar') }
 
       let(:attribute) { :date_of_birth }
 
       it { is_expected.to eq('Foo bar') }
     end
 
-    context 'without fieldname present in translation file' do
-      before { claim.errors.add(:defendant_2_name, 'foo_bar_too') }
+    context 'without attribute present in translation file' do
+      before { claim.errors.add(attribute, 'foo_bar_too') }
 
       let(:attribute) { :defendant_2_name }
 


### PR DESCRIPTION
#### What
Refactor unit tests for custom error handling code

#### Ticket

[relates to CFP-240](https://dsdmoj.atlassian.net/browse/CFP-240)

#### Why
The error message translator and error presenter specs can be improved:
 - for clarity following [betterspecs](https://www.betterspecs.org/) practices.
 - to cover missing cases
 - to facilitate refactoring of the translater and presenters in particular