### PR TITLE
Fix lgfs summary fields

### DIFF
--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -51,7 +51,7 @@
         %tr
           %th{ scope: 'col' }
             = t('shared.summary.fee_type')
-          - unless claim.lgfs?
+          - unless claim.lgfs? && collection.any?(&:is_misc?)
             %th{ scope: 'col' }
               = t('shared.summary.dates')
             %th.numeric{ scope: 'col' }
@@ -73,7 +73,7 @@
         %tr
           %th{ scope: 'row' }
             = t('shared.summary.total')
-          - unless claim.lgfs?
+          - unless claim.lgfs? && collection.any?(&:is_misc?)
             %td.numeric
               = ''
             %td.numeric


### PR DESCRIPTION
#### What
Fix claim summary table layout.

#### Ticket
n/a

#### Why
Summary page, LGFS Fixed fee table was broken due to conditional logic.

Table columns (date, quantity and rate) should not be shown for LGFS misc fees but do for AGFS misc fees and AGFS/LGFS fixed fees.

| Before      | After |
| ----------- | ----------- |
| ![summary_table_error](https://user-images.githubusercontent.com/8057224/128847599-61be5f38-a982-4c1a-b364-9fe850b6ba1f.png)      | ![Screenshot 2021-08-10 at 11 21 45](https://user-images.githubusercontent.com/8057224/128851238-ba788998-6cb1-4e1b-b919-1c8e61c8695c.png)       |


