### PR TITLE
[CFP-243] Fix document upload feedback

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -23,7 +23,7 @@ class DocumentsController < ApplicationController
     @document = Document.new(document_params.merge(creator_id: current_user.id))
 
     if @document.save_and_verify
-      render json: { document: { id: @document.id, document_file_name: @document.document.filename } }, status: :created
+      render json: { document: { id: @document.id, filename: @document.document.filename } }, status: :created
     else
       render json: { error: @document.errors[:document].join(', ') }, status: :unprocessable_entity
     end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: documents
-#
-#  id                                      :integer          not null, primary key
-#  claim_id                                :integer
-#  created_at                              :datetime
-#  updated_at                              :datetime
-#  document_file_name                      :string
-#  document_content_type                   :string
-#  document_file_size                      :integer
-#  document_updated_at                     :datetime
-#  external_user_id                        :integer
-#  converted_preview_document_file_name    :string
-#  converted_preview_document_content_type :string
-#  converted_preview_document_file_size    :integer
-#  converted_preview_document_updated_at   :datetime
-#  uuid                                    :uuid
-#  form_id                                 :string
-#  creator_id                              :integer
-#  verified_file_size                      :integer
-#  file_path                               :string
-#  verified                                :boolean          default(FALSE)
-#
-
 class DocumentsController < ApplicationController
   include ActiveStorage::SetCurrent
 
@@ -48,7 +23,7 @@ class DocumentsController < ApplicationController
     @document = Document.new(document_params.merge(creator_id: current_user.id))
 
     if @document.save_and_verify
-      render json: { document: @document.reload }, status: :created
+      render json: { document: { id: @document.id, document_file_name: @document.document.filename } }, status: :created
     else
       render json: { error: @document.errors[:document].join(', ') }, status: :unprocessable_entity
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: documents
-#
-#  id                                      :integer          not null, primary key
-#  claim_id                                :integer
-#  created_at                              :datetime
-#  updated_at                              :datetime
-#  document_file_name                      :string
-#  document_content_type                   :string
-#  document_file_size                      :integer
-#  document_updated_at                     :datetime
-#  external_user_id                        :integer
-#  converted_preview_document_file_name    :string
-#  converted_preview_document_content_type :string
-#  converted_preview_document_file_size    :integer
-#  converted_preview_document_updated_at   :datetime
-#  uuid                                    :uuid
-#  form_id                                 :string
-#  creator_id                              :integer
-#  verified_file_size                      :integer
-#  file_path                               :string
-#  verified                                :boolean          default(FALSE)
-#
-
 class Document < ApplicationRecord
   include Duplicable
 

--- a/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
+++ b/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
@@ -155,12 +155,12 @@ moj.Modules.Dropzone = {
       contentType: false,
 
       success: $.proxy(function (response) {
-        const fileName = response.document.document_file_name
+        const fileName = response.document.filename
         const fileId = response.document.id
 
         this.createDocumentIdInput(response.document.id)
         tableRow.replaceWith(this.notificationHTML(fileName, 'success', 'File has been uploaded.', fileId))
-        this.status.html(response.document.document_file_name + ' has been uploaded.')
+        this.status.html(response.document.filename + ' has been uploaded.')
       }, this),
 
       error: $.proxy(function (xhr, status, error) {

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -128,9 +128,14 @@ RSpec.describe 'Document management', type: :request do
         expect(response.status).to eq(201)
       end
 
-      it 'returns the created document as JSON' do
+      it 'returns the id of the created document' do
         create_document
-        expect(JSON.parse(response.body)['document']).to eq(JSON.parse(Document.first.to_json))
+        expect(JSON.parse(response.body)['document']['id']).to eq Document.last.id
+      end
+
+      it 'returns the file name of the document' do
+        create_document
+        expect(JSON.parse(response.body)['document']['document_file_name']).to eq 'longer_lorem.pdf'
       end
     end
 

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Document management', type: :request do
 
       it 'returns the file name of the document' do
         create_document
-        expect(JSON.parse(response.body)['document']['document_file_name']).to eq 'longer_lorem.pdf'
+        expect(JSON.parse(response.body)['document']['filename']).to eq 'longer_lorem.pdf'
       end
     end
 


### PR DESCRIPTION
#### What

Following the removal of Paperclip fields (#4175) the user feedback on the evidence upload form was broken as it depended on this information.

#### Ticket

[Document upload description ) #252888](https://dsdmoj.atlassian.net/browse/CFP-243)

#### Why

The `document_file_name` field, which was one of the Paperclip fields, was used to display the filename to the user.

#### How

Instead of returning the entire document model in response to a successful upload only return the id and filename, now taken from the Active Storage attachment.

#### Before

<img width="650" alt="Screenshot 2021-08-11 at 12 41 10" src="https://user-images.githubusercontent.com/4415912/129022879-bbd374b0-f76c-4f45-b6ec-375a85ee3100.png">

#### After

<img width="647" alt="Screenshot 2021-08-11 at 12 41 19" src="https://user-images.githubusercontent.com/4415912/129022891-8e59d291-cb20-47e1-a195-e045bbe51398.png">
