### PR TITLE
[CFP-210] Send smoke tests results to alerts channel in Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,7 @@ commands:
             fi
       - slack/notify:
           title: ":smoke_it: Smoke test"
+          channel: laa-cccd-alerts
           message: $CUSTOM_SLACK_MESSAGE
           color: $CUSTOM_SLACK_COLOR
 


### PR DESCRIPTION
#### What

Put the results from the daily smoke tests into the `laa-cccd-alerts`.

#### Ticket

[CCCD alerting review](https://dsdmoj.atlassian.net/browse/CFP-210)

#### Why

Separating out alerts from other notifications (in `cccd_development`).

#### How

Update in `.circleci/config.yml`