### PR TITLE
[CFP-210] Enable performance monitoring in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,5 +4,8 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
    Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
     config.breadcrumbs_logger = [:active_support_logger]
+
+    # Send 10% of transactions for performance monitoring
+    config.traces_sample_rate = 0.1
   end
 end


### PR DESCRIPTION
#### What

Enable performance monitoring in Sentry

#### Ticket

[CCCD alerting review](https://dsdmoj.atlassian.net/browse/CFP-210)

#### Why

Performance monitoring was added to Sentry with the move from `sentry-raven` to `sentry-rails`.

#### How

A trace sample rate needs to be configured for transactions to be submitted to Sentry. Initially, 10% of transactions will be sent (sample rate = 0.1).

Sentry documentation is here: https://docs.sentry.io/platforms/ruby/guides/rails/performance/