### PR TITLE
[CFP-150] Refactor SlackNotifier

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -870,7 +870,6 @@ RSpec/ContextWording:
     - 'spec/services/claims/update_draft_spec.rb'
     - 'spec/services/remote/http_client_spec.rb'
     - 'spec/services/simple_bill_adapter_spec.rb'
-    - 'spec/services/slack_notifier_spec.rb'
     - 'spec/services/stats/management_information_generator_spec.rb'
     - 'spec/services/transform/claim_spec.rb'
     - 'spec/support/shared_examples/models/shared_examples_for_base_claim.rb'
@@ -2134,7 +2133,6 @@ RSpec/NamedSubject:
     - 'spec/services/claims/update_draft_spec.rb'
     - 'spec/services/document_cleaner_spec.rb'
     - 'spec/services/injection_response_service_spec.rb'
-    - 'spec/services/slack_notifier_spec.rb'
     - 'spec/validators/expense_validator_spec.rb'
 
 # Offense count: 736

--- a/app/models/subscribers/slack.rb
+++ b/app/models/subscribers/slack.rb
@@ -4,10 +4,12 @@ module Subscribers
       report_id = event.payload[:id]
       report_name = event.payload[:name]
       slack = SlackNotifier.new('cccd_development', formatter: SlackNotifier::Formatter.new)
-      slack.build_generic_payload(':robot_face:',
-                                  "#{report_name} failed on #{ENV['ENV']}",
-                                  "Stats::StatsReport.id: #{report_id}",
-                                  false)
+      slack.build_payload(
+        icon: ':robot_face:',
+        title: "#{report_name} failed on #{ENV['ENV']}",
+        message: "Stats::StatsReport.id: #{report_id}",
+        status: :fail
+      )
       slack.send_message!
     end
   end

--- a/app/models/subscribers/slack.rb
+++ b/app/models/subscribers/slack.rb
@@ -3,7 +3,7 @@ module Subscribers
     def process
       report_id = event.payload[:id]
       report_name = event.payload[:name]
-      slack = SlackNotifier.new('cccd_development')
+      slack = SlackNotifier.new('cccd_development', formatter: SlackNotifier::Formatter.new)
       slack.build_generic_payload(':robot_face:',
                                   "#{report_name} failed on #{ENV['ENV']}",
                                   "Stats::StatsReport.id: #{report_id}",

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -18,7 +18,7 @@ class InjectionResponseService
   private
 
   def slack
-    @slack ||= SlackNotifier.new(@channel)
+    @slack ||= SlackNotifier.new(@channel, formatter: SlackNotifier::Formatter::Injection.new)
   end
 
   def failure(options = {})

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,113 +1,23 @@
 class SlackNotifier
-  def initialize(channel)
+  def initialize(channel, formatter: nil)
+    @formatter = formatter || Formatter.new
+    @formatter.channel = channel
+    @formatter.username = Settings.slack.bot_name
     @slack_url = Settings.slack.bot_url
     @ready_to_send = false
-    @payload = {
-      channel: channel,
-      username: Settings.slack.bot_name
-    }
   end
 
   def send_message!
-    raise 'Unable to send without payload' unless @ready_to_send
+    raise 'Unable to send without payload' unless @formatter.ready_to_send
 
-    RestClient.post(@slack_url, @payload.to_json, content_type: :json)
+    RestClient.post(@slack_url, @formatter.payload.to_json, content_type: :json)
   end
 
   def build_generic_payload(message_icon, title, message, pass_fail)
-    @payload[:icon_emoji] = message_icon
-    @payload[:attachments] = [
-      {
-        fallback: message,
-        color: pass_fail_colour(pass_fail),
-        title: title,
-        text: message
-      }
-    ]
-    @ready_to_send = true
-  rescue StandardError
-    @ready_to_send = false
+    @formatter.build(message_icon, title, message, pass_fail)
   end
 
   def build_injection_payload(response)
-    @response = response.stringify_keys
-    @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
-    @payload[:icon_emoji] = message_icon
-    @payload[:attachments] = [
-      {
-        fallback: injection_fallback,
-        color: message_colour,
-        title: injection_title,
-        text: @response['uuid'],
-        fields: fields
-      }
-    ]
-    @ready_to_send = true
-  rescue StandardError
-    @ready_to_send = false
-  end
-
-  private
-
-  def injected?
-    has_no_errors? && @claim.present?
-  end
-
-  def injection_fallback
-    "#{generate_message} {#{@response['uuid']}}"
-  end
-
-  def injection_title
-    "Injection into #{app_name} #{injected? ? 'succeeded' : 'failed'}"
-  end
-
-  def app_name
-    @response['from'] || 'indeterminable system'
-  end
-
-  def has_no_errors?
-    @response['errors'].empty?
-  end
-
-  def error_message
-    @response['errors'].join(' ')
-  end
-
-  def pass_fail_colour(boolean)
-    boolean ? '#36a64f' : '#c41f1f'
-  end
-
-  def message_colour
-    pass_fail_colour(injected?)
-  end
-
-  def message_icon
-    injected? ? Settings.slack.success_icon : Settings.slack.fail_icon
-  end
-
-  def fields
-    fields = [
-      { title: 'Claim number', value: @claim&.case_number, short: true },
-      { title: 'environment', value: ENV['ENV'], short: true }
-    ]
-    errors = has_no_errors? ? [] : error_fields
-    fields + errors
-  end
-
-  def error_fields
-    errors = @response['errors'].map { |x| x['error'] }.join('\n')
-    [
-      { title: 'Errors', value: errors }
-    ]
-  end
-
-  def generate_message
-    if @claim.nil?
-      'Failed to inject because no claim found'
-    elsif injected?
-      "Claim #{@claim.case_number} successfully injected"
-    else
-      "Claim #{@claim.case_number} could not be injected"
-    end
+    @formatter.build(response)
   end
 end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -14,10 +14,10 @@ class SlackNotifier
   end
 
   def build_generic_payload(message_icon, title, message, pass_fail)
-    @formatter.build(message_icon, title, message, pass_fail)
+    @formatter.build(icon: message_icon, title: title, message: message, status: (pass_fail ? :pass : :fail))
   end
 
   def build_injection_payload(response)
-    @formatter.build(response)
+    @formatter.build(**response)
   end
 end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -4,7 +4,6 @@ class SlackNotifier
     @formatter.channel = channel
     @formatter.username = Settings.slack.bot_name
     @slack_url = Settings.slack.bot_url
-    @ready_to_send = false
   end
 
   def send_message!
@@ -13,11 +12,7 @@ class SlackNotifier
     RestClient.post(@slack_url, @formatter.payload.to_json, content_type: :json)
   end
 
-  def build_generic_payload(message_icon, title, message, pass_fail)
-    @formatter.build(icon: message_icon, title: title, message: message, status: (pass_fail ? :pass : :fail))
-  end
-
-  def build_injection_payload(response)
-    @formatter.build(**response)
+  def build_payload(*args)
+    @formatter.build(*args)
   end
 end

--- a/app/services/slack_notifier/formatter.rb
+++ b/app/services/slack_notifier/formatter.rb
@@ -6,28 +6,64 @@ class SlackNotifier
     def initialize
       @payload = {}
       @ready_to_send = false
+      @colours = {
+        pass: '#36a64f',
+        fail: '#c41f1f'
+      }
     end
 
-    def build(message_icon, title, message, pass_fail)
+    def build(**data)
+      prebuild(**data)
+
       @payload = {
         channel: @channel,
         username: @username,
         icon_emoji: message_icon,
-        attachments: [
-          {
-            fallback: message,
-            color: pass_fail_colour(pass_fail),
-            title: title,
-            text: message
-          }
-        ]  
+        attachments: [attachment]
       }
       @ready_to_send = true
     rescue StandardError
       @ready_to_send = false
-    end  
+    end
 
     private
+
+    def prebuild(**data)
+      @data = data
+    end
+
+    def attachment
+      {
+        fallback: message_fallback,
+        color: message_colour,
+        title: message_title,
+        text: message_text
+      }
+    end
+
+    def message_icon
+      @data[:icon]
+    end
+
+    def message_fallback
+      @data[:message]
+    end
+
+    def message_colour
+      @colours[status]
+    end
+
+    def status
+      @data[:status]
+    end
+
+    def message_title
+      @data[:title]
+    end
+
+    def message_text
+      @data[:message]
+    end
 
     def pass_fail_colour(boolean)
       boolean ? '#36a64f' : '#c41f1f'

--- a/app/services/slack_notifier/formatter.rb
+++ b/app/services/slack_notifier/formatter.rb
@@ -35,32 +35,8 @@ class SlackNotifier
       }
     end
 
-    def message_icon
-      @data[:icon]
-    end
-
-    def message_fallback
-      @data[:message]
-    end
-
     def message_colour
       @colours[status]
-    end
-
-    def status
-      @data[:status]
-    end
-
-    def message_title
-      @data[:title]
-    end
-
-    def message_text
-      @data[:message]
-    end
-
-    def pass_fail_colour(boolean)
-      boolean ? '#36a64f' : '#c41f1f'
     end
   end
 end

--- a/app/services/slack_notifier/formatter.rb
+++ b/app/services/slack_notifier/formatter.rb
@@ -13,14 +13,10 @@ class SlackNotifier
     end
 
     def build(**data)
-      prebuild(**data)
+      @data = data
+      prebuild
 
-      @payload = {
-        channel: @channel,
-        username: @username,
-        icon_emoji: message_icon,
-        attachments: [attachment]
-      }
+      @payload = { channel: @channel, username: @username, icon_emoji: message_icon, attachments: [attachment] }
       @ready_to_send = true
     rescue StandardError
       @ready_to_send = false
@@ -28,9 +24,7 @@ class SlackNotifier
 
     private
 
-    def prebuild(**data)
-      @data = data
-    end
+    def prebuild; end
 
     def attachment
       {

--- a/app/services/slack_notifier/formatter.rb
+++ b/app/services/slack_notifier/formatter.rb
@@ -1,0 +1,36 @@
+class SlackNotifier
+  class Formatter
+    attr_reader :payload, :ready_to_send
+    attr_writer :channel, :username
+
+    def initialize
+      @payload = {}
+      @ready_to_send = false
+    end
+
+    def build(message_icon, title, message, pass_fail)
+      @payload = {
+        channel: @channel,
+        username: @username,
+        icon_emoji: message_icon,
+        attachments: [
+          {
+            fallback: message,
+            color: pass_fail_colour(pass_fail),
+            title: title,
+            text: message
+          }
+        ]  
+      }
+      @ready_to_send = true
+    rescue StandardError
+      @ready_to_send = false
+    end  
+
+    private
+
+    def pass_fail_colour(boolean)
+      boolean ? '#36a64f' : '#c41f1f'
+    end
+  end
+end

--- a/app/services/slack_notifier/formatter/generic.rb
+++ b/app/services/slack_notifier/formatter/generic.rb
@@ -1,0 +1,27 @@
+class SlackNotifier
+  class Formatter
+    class Generic < Formatter
+      private
+
+      def message_icon
+        @data[:icon]
+      end
+
+      def message_fallback
+        @data[:message]
+      end
+
+      def status
+        @data[:status]
+      end
+
+      def message_title
+        @data[:title]
+      end
+
+      def message_text
+        @data[:message]
+      end
+    end
+  end
+end

--- a/app/services/slack_notifier/formatter/injection.rb
+++ b/app/services/slack_notifier/formatter/injection.rb
@@ -1,0 +1,82 @@
+class SlackNotifier
+  class Formatter
+    class Injection < Formatter
+      def build(response)
+        @response = response.stringify_keys
+        @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
+
+        @payload = {
+          channel: @channel,
+          username: @username,  
+          icon_emoji: message_icon,
+          attachments: [
+            {
+              fallback: injection_fallback,
+              color: message_colour,
+              title: injection_title,
+              text: @response['uuid'],
+              fields: fields
+            }
+          ]
+        }
+        @ready_to_send = true
+      rescue StandardError
+        @ready_to_send = false
+      end
+
+      private
+
+      def message_icon
+        injected? ? Settings.slack.success_icon : Settings.slack.fail_icon
+      end
+
+      def injection_fallback
+        "#{generate_message} {#{@response['uuid']}}"
+      end
+
+      def generate_message
+        if @claim.nil?
+          'Failed to inject because no claim found'
+        elsif injected?
+          "Claim #{@claim.case_number} successfully injected"
+        else
+          "Claim #{@claim.case_number} could not be injected"
+        end
+      end
+
+      def message_colour
+        pass_fail_colour(injected?)
+      end
+
+      def injection_title
+        "Injection into #{app_name} #{injected? ? 'succeeded' : 'failed'}"
+      end
+
+      def app_name
+        @response['from'] || 'indeterminable system'
+      end
+
+      def fields
+        fields = [
+          { title: 'Claim number', value: @claim&.case_number, short: true },
+          { title: 'environment', value: ENV['ENV'], short: true }
+        ]
+        errors = has_no_errors? ? [] : error_fields
+        fields + errors
+      end
+
+      def error_fields
+        errors = @response['errors'].map { |x| x['error'] }.join('\n')
+        [{ title: 'Errors', value: errors }]
+      end
+
+      def injected?
+        has_no_errors? && @claim.present?
+      end
+
+      def has_no_errors?
+        @response['errors'].empty?
+      end
+    end
+  end
+end

--- a/app/services/slack_notifier/formatter/injection.rb
+++ b/app/services/slack_notifier/formatter/injection.rb
@@ -3,19 +3,12 @@ class SlackNotifier
     class Injection < Formatter
       private
 
-      def prebuild(**data)
-        @response = data.stringify_keys
-        @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
+      def prebuild
+        @claim = Claim::BaseClaim.find_by(uuid: @data[:uuid])
       end
 
       def attachment
-        {
-          fallback: message_fallback,
-          color: message_colour,
-          title: message_title,
-          text: @response['uuid'],
-          fields: fields
-        }
+        super.merge(fields: fields)
       end
 
       def message_icon
@@ -23,7 +16,7 @@ class SlackNotifier
       end
 
       def message_fallback
-        "#{generate_message} {#{@response['uuid']}}"
+        "#{generate_message} {#{@data[:uuid]}}"
       end
 
       def generate_message
@@ -45,7 +38,11 @@ class SlackNotifier
       end
 
       def app_name
-        @response['from'] || 'indeterminable system'
+        @data[:from] || 'indeterminable system'
+      end
+
+      def message_text
+        @data[:uuid]
       end
 
       def fields
@@ -58,7 +55,7 @@ class SlackNotifier
       end
 
       def error_fields
-        errors = @response['errors'].map { |x| x['error'] }.join('\n')
+        errors = @data[:errors].map { |x| x['error'] }.join('\n')
         [{ title: 'Errors', value: errors }]
       end
 
@@ -67,7 +64,7 @@ class SlackNotifier
       end
 
       def no_errors?
-        @response['errors'].empty?
+        @data[:errors].empty?
       end
     end
   end

--- a/app/services/slack_notifier/formatter/injection.rb
+++ b/app/services/slack_notifier/formatter/injection.rb
@@ -1,36 +1,28 @@
 class SlackNotifier
   class Formatter
     class Injection < Formatter
-      def build(response)
-        @response = response.stringify_keys
-        @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
+      private
 
-        @payload = {
-          channel: @channel,
-          username: @username,  
-          icon_emoji: message_icon,
-          attachments: [
-            {
-              fallback: injection_fallback,
-              color: message_colour,
-              title: injection_title,
-              text: @response['uuid'],
-              fields: fields
-            }
-          ]
-        }
-        @ready_to_send = true
-      rescue StandardError
-        @ready_to_send = false
+      def prebuild(**data)
+        @response = data.stringify_keys
+        @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
       end
 
-      private
+      def attachment
+        {
+          fallback: message_fallback,
+          color: message_colour,
+          title: message_title,
+          text: @response['uuid'],
+          fields: fields
+        }
+      end
 
       def message_icon
         injected? ? Settings.slack.success_icon : Settings.slack.fail_icon
       end
 
-      def injection_fallback
+      def message_fallback
         "#{generate_message} {#{@response['uuid']}}"
       end
 
@@ -44,11 +36,11 @@ class SlackNotifier
         end
       end
 
-      def message_colour
-        pass_fail_colour(injected?)
+      def status
+        injected? ? :pass : :fail
       end
 
-      def injection_title
+      def message_title
         "Injection into #{app_name} #{injected? ? 'succeeded' : 'failed'}"
       end
 
@@ -61,7 +53,7 @@ class SlackNotifier
           { title: 'Claim number', value: @claim&.case_number, short: true },
           { title: 'environment', value: ENV['ENV'], short: true }
         ]
-        errors = has_no_errors? ? [] : error_fields
+        errors = no_errors? ? [] : error_fields
         fields + errors
       end
 
@@ -71,10 +63,10 @@ class SlackNotifier
       end
 
       def injected?
-        has_no_errors? && @claim.present?
+        no_errors? && @claim.present?
       end
 
-      def has_no_errors?
+      def no_errors?
         @response['errors'].empty?
       end
     end

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -13,9 +13,15 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
     subject(:process) { described_class.new(event_name, start, ending, transaction_id, payload) }
 
     it 'sends a message to slack channel with the error content' do
-      expect(SlackNotifier).to receive(:new).with('cccd_development').and_return(notifier)
-      notifier_args = [':robot_face:', 'provisional_assessment failed on test', 'Stats::StatsReport.id: 999', false]
-      expect(notifier).to receive(:build_generic_payload).with(*notifier_args)
+      expect(SlackNotifier).to receive(:new).with('cccd_development', formatter: instance_of(SlackNotifier::Formatter))
+                                            .and_return(notifier)
+      notifier_args = {
+        icon: ':robot_face:',
+        title: 'provisional_assessment failed on test',
+        message: 'Stats::StatsReport.id: 999',
+        status: :fail
+      }
+      expect(notifier).to receive(:build_payload).with(**notifier_args)
       expect(notifier).to receive(:send_message!).and_return(send_result)
       process
       expect(process).to be_kind_of(Subscribers::Base)

--- a/spec/services/slack_notifier/formatter/generic_spec.rb
+++ b/spec/services/slack_notifier/formatter/generic_spec.rb
@@ -1,46 +1,45 @@
 require 'rails_helper'
 
-RSpec.describe SlackNotifier::Formatter do
+RSpec.describe SlackNotifier::Formatter::Generic do
   subject(:formatter) { described_class.new }
 
-  describe '#ready_to_send' do
-    subject { formatter.ready_to_send }
-
-    context 'when #build has not been called' do
-      it { is_expected.to be_falsey }
-    end
+  let(:valid_build_parameters) do
+    {
+      icon: ':sign-roadworks:',
+      message: 'Test message',
+      title: 'Test title',
+      status: :pass
+    }
   end
+
+  it_behaves_like 'a slack notifier formatter'
 
   describe '#payload' do
     subject(:payload) { formatter.payload }
 
-    let(:build_parameters) do
-      {
-        icon: ':sign-roadworks:',
-        message: 'Test message',
-        title: 'Test title',
-        status: :pass
-      }
-    end
     let(:first_attachment) { payload[:attachments].first }
 
     before { formatter.build(**build_parameters) }
 
-    it { expect(payload[:icon_emoji]).to eq ':sign-roadworks:' }
-    it { expect(first_attachment[:fallback]).to eq 'Test message' }
-    it { expect(first_attachment[:title]).to eq 'Test title' }
-    it { expect(first_attachment[:text]).to eq 'Test message' }
-    it { expect(first_attachment[:color]).to eq '#36a64f' }
-    it { expect(formatter.ready_to_send).to be_truthy }
+    context 'with valid build parameters' do
+      let(:build_parameters) { valid_build_parameters }
+
+      it { expect(payload[:icon_emoji]).to eq ':sign-roadworks:' }
+      it { expect(first_attachment[:fallback]).to eq 'Test message' }
+      it { expect(first_attachment[:title]).to eq 'Test title' }
+      it { expect(first_attachment[:text]).to eq 'Test message' }
+      it { expect(first_attachment[:color]).to eq '#36a64f' }
+      it { expect(formatter.ready_to_send).to be_truthy }
+    end
 
     context 'with a failing status' do
-      let(:build_parameters) { super().merge(status: :fail) }
+      let(:build_parameters) { valid_build_parameters.merge(status: :fail) }
 
       it { expect(first_attachment[:color]).to eq '#c41f1f' }
     end
 
     context 'without icon parameter' do
-      let(:build_parameters) { super().except(:icon) }
+      let(:build_parameters) { valid_build_parameters.except(:icon) }
 
       # TODO: Default icon?
       it { expect(payload[:icon_emoji]).to be_nil }
@@ -48,7 +47,7 @@ RSpec.describe SlackNotifier::Formatter do
     end
 
     context 'without status parameter' do
-      let(:build_parameters) { super().except(:status) }
+      let(:build_parameters) { valid_build_parameters.except(:status) }
 
       it { expect(first_attachment[:color]).to be_nil }
 
@@ -59,7 +58,7 @@ RSpec.describe SlackNotifier::Formatter do
     end
 
     context 'without message parameter' do
-      let(:build_parameters) { super().except(:message) }
+      let(:build_parameters) { valid_build_parameters.except(:message) }
 
       it { expect(first_attachment[:fallback]).to be_nil }
       it { expect(first_attachment[:text]).to be_nil }
@@ -77,7 +76,7 @@ RSpec.describe SlackNotifier::Formatter do
     end
 
     context 'without title parameter' do
-      let(:build_parameters) { super().except(:title) }
+      let(:build_parameters) { valid_build_parameters.except(:title) }
 
       it { expect(first_attachment[:title]).to be_nil }
       it { expect(formatter.ready_to_send).to be_truthy }
@@ -86,23 +85,6 @@ RSpec.describe SlackNotifier::Formatter do
         pending 'TODO: Remove keys with nil value from payload sent to Slack'
         expect(first_attachment).not_to have_key(:title)
       end
-    end
-  end
-
-  describe '#build' do
-    subject(:build) { formatter.build(**build_parameters) }
-
-    context 'with valid parameters' do
-      let(:build_parameters) do
-        {
-          icon: ':sign-roadworks:',
-          message: 'Test message',
-          title: 'Test title',
-          status: :pass
-        }
-      end
-
-      it { expect { build }.to change(formatter, :ready_to_send).to true }
     end
   end
 end

--- a/spec/services/slack_notifier/formatter/injection_spec.rb
+++ b/spec/services/slack_notifier/formatter/injection_spec.rb
@@ -3,17 +3,20 @@ require 'rails_helper'
 RSpec.describe SlackNotifier::Formatter::Injection do
   subject(:formatter) { described_class.new }
 
+  let(:claim) { create :claim }
+  let(:valid_build_parameters) do
+    {
+      uuid: claim.uuid,
+      from: 'external application',
+      errors: []
+    }
+  end
+
+  it_behaves_like 'a slack notifier formatter'
+
   describe '#payload' do
     subject(:payload) { formatter.payload }
 
-    let(:claim) { create :claim }
-    let(:build_parameters) do
-      {
-        uuid: claim.uuid,
-        from: 'external application',
-        errors: []
-      }
-    end
     let(:first_attachment) { payload[:attachments].first }
 
     before do
@@ -25,17 +28,21 @@ RSpec.describe SlackNotifier::Formatter::Injection do
       formatter.build(**build_parameters)
     end
 
-    it { expect(payload[:icon_emoji]).to eq ':tada:' }
-    it { expect(first_attachment[:fallback]).to eq "Claim #{claim.case_number} successfully injected {#{claim.uuid}}" }
-    it { expect(first_attachment[:title]).to eq 'Injection into external application succeeded' }
-    it { expect(first_attachment[:text]).to eq claim.uuid }
-    it { expect(first_attachment[:color]).to eq '#36a64f' }
-    it { expect(first_attachment[:fields].count).to eq 2 }
-    it { expect(formatter.ready_to_send).to be_truthy }
+    context 'with valid build parameters' do
+      let(:build_parameters) { valid_build_parameters }
+
+      it { expect(payload[:icon_emoji]).to eq ':tada:' }
+      it { expect(first_attachment[:fallback]).to eq "Claim #{claim.case_number} successfully injected {#{claim.uuid}}" }
+      it { expect(first_attachment[:title]).to eq 'Injection into external application succeeded' }
+      it { expect(first_attachment[:text]).to eq claim.uuid }
+      it { expect(first_attachment[:color]).to eq '#36a64f' }
+      it { expect(first_attachment[:fields].count).to eq 2 }
+      it { expect(formatter.ready_to_send).to be_truthy }
+    end
 
     context 'with errors' do
       let(:build_parameters) do
-        super().merge(errors: [{ 'error' => "No defendant found for Rep Order Number: '123'." }])
+        valid_build_parameters.merge(errors: [{ 'error' => "No defendant found for Rep Order Number: '123'." }])
       end
 
       it { expect(payload[:icon_emoji]).to eq ':sad:' }
@@ -48,7 +55,7 @@ RSpec.describe SlackNotifier::Formatter::Injection do
     end
 
     context 'with an unknown claim' do
-      let(:build_parameters) { super().merge(uuid: 'bad-uuid') }
+      let(:build_parameters) { valid_build_parameters.merge(uuid: 'bad-uuid') }
 
       it { expect(payload[:icon_emoji]).to eq ':sad:' }
       it { expect(first_attachment[:fallback]).to eq 'Failed to inject because no claim found {bad-uuid}' }
@@ -60,7 +67,7 @@ RSpec.describe SlackNotifier::Formatter::Injection do
     end
 
     context 'without a from parameter' do
-      let(:build_parameters) { super().except(:from) }
+      let(:build_parameters) { valid_build_parameters.except(:from) }
 
       it { expect(first_attachment[:title]).to eq 'Injection into indeterminable system succeeded' }
     end

--- a/spec/services/slack_notifier/formatter/injection_spec.rb
+++ b/spec/services/slack_notifier/formatter/injection_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotifier::Formatter::Injection do
+  subject(:formatter) { described_class.new }
+
+  describe '#payload' do
+    subject(:payload) { formatter.payload }
+
+    let(:claim) { create :claim }
+    let(:build_parameters) do
+      {
+        uuid: claim.uuid,
+        from: 'external application',
+        errors: []
+      }
+    end
+    let(:first_attachment) { payload[:attachments].first }
+
+    before do
+      allow(Settings.slack).to receive(:success_icon).and_return ':tada:'
+      allow(Settings.slack).to receive(:fail_icon).and_return ':sad:'
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('ENV').and_return 'test_environment'
+
+      formatter.build(**build_parameters)
+    end
+
+    it { expect(payload[:icon_emoji]).to eq ':tada:' }
+    it { expect(first_attachment[:fallback]).to eq "Claim #{claim.case_number} successfully injected {#{claim.uuid}}" }
+    it { expect(first_attachment[:title]).to eq 'Injection into external application succeeded' }
+    it { expect(first_attachment[:text]).to eq claim.uuid }
+    it { expect(first_attachment[:color]).to eq '#36a64f' }
+    it { expect(first_attachment[:fields].count).to eq 2 }
+    it { expect(formatter.ready_to_send).to be_truthy }
+
+    context 'with errors' do
+      let(:build_parameters) do
+        super().merge(errors: [{ 'error' => "No defendant found for Rep Order Number: '123'." }])
+      end
+
+      it { expect(payload[:icon_emoji]).to eq ':sad:' }
+      it { expect(first_attachment[:fallback]).to eq "Claim #{claim.case_number} could not be injected {#{claim.uuid}}" }
+      it { expect(first_attachment[:title]).to eq 'Injection into external application failed' }
+      it { expect(first_attachment[:text]).to eq claim.uuid }
+      it { expect(first_attachment[:color]).to eq '#c41f1f' }
+      it { expect(first_attachment[:fields].count).to eq 3 }
+      it { expect(formatter.ready_to_send).to be_truthy }
+    end
+
+    context 'with an unknown claim' do
+      let(:build_parameters) { super().merge(uuid: 'bad-uuid') }
+
+      it { expect(payload[:icon_emoji]).to eq ':sad:' }
+      it { expect(first_attachment[:fallback]).to eq 'Failed to inject because no claim found {bad-uuid}' }
+      it { expect(first_attachment[:title]).to eq 'Injection into external application failed' }
+      it { expect(first_attachment[:text]).to eq 'bad-uuid' }
+      it { expect(first_attachment[:color]).to eq '#c41f1f' }
+      it { expect(first_attachment[:fields].count).to eq 2 }
+      it { expect(formatter.ready_to_send).to be_truthy }
+    end
+
+    context 'without a from parameter' do
+      let(:build_parameters) { super().except(:from) }
+
+      it { expect(first_attachment[:title]).to eq 'Injection into indeterminable system succeeded' }
+    end
+  end
+end

--- a/spec/services/slack_notifier/formatter_spec.rb
+++ b/spec/services/slack_notifier/formatter_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotifier::Formatter do
+  subject(:formatter) { described_class.new }
+
+  describe '#ready_to_send' do
+    subject { formatter.ready_to_send }
+
+    context 'when #build has not been called' do
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#payload' do
+    subject(:payload) { formatter.payload }
+
+    let(:build_parameters) do
+      {
+        icon: ':sign-roadworks:',
+        message: 'Test message',
+        title: 'Test title',
+        status: :pass
+      }
+    end
+    let(:first_attachment) { payload[:attachments].first }
+
+    before { formatter.build(**build_parameters) }
+
+    it { expect(payload[:icon_emoji]).to eq ':sign-roadworks:' }
+    it { expect(first_attachment[:fallback]).to eq 'Test message' }
+    it { expect(first_attachment[:title]).to eq 'Test title' }
+    it { expect(first_attachment[:text]).to eq 'Test message' }
+    it { expect(first_attachment[:color]).to eq '#36a64f' }
+    it { expect(formatter.ready_to_send).to be_truthy }
+
+    context 'with a failing status' do
+      let(:build_parameters) { super().merge(status: :fail) }
+
+      it { expect(first_attachment[:color]).to eq '#c41f1f' }
+    end
+
+    context 'without icon parameter' do
+      let(:build_parameters) { super().except(:icon) }
+
+      # TODO: Default icon?
+      it { expect(payload[:icon_emoji]).to be_nil }
+      it { expect(formatter.ready_to_send).to be_truthy }
+    end
+
+    context 'without status parameter' do
+      let(:build_parameters) { super().except(:status) }
+
+      it { expect(first_attachment[:color]).to be_nil }
+
+      it do
+        pending 'TODO: Remove keys with nil value from payload sent to Slack'
+        expect(first_attachment).not_to have_key(:color)
+      end
+    end
+
+    context 'without message parameter' do
+      let(:build_parameters) { super().except(:message) }
+
+      it { expect(first_attachment[:fallback]).to be_nil }
+      it { expect(first_attachment[:text]).to be_nil }
+      it { expect(formatter.ready_to_send).to be_truthy }
+
+      it do
+        pending 'TODO: Remove keys with nil value from payload sent to Slack'
+        expect(first_attachment).not_to have_key(:fallback)
+      end
+
+      it do
+        pending 'TODO: Remove keys with nil value from payload sent to Slack'
+        expect(first_attachment).not_to have_key(:text)
+      end
+    end
+
+    context 'without title parameter' do
+      let(:build_parameters) { super().except(:title) }
+
+      it { expect(first_attachment[:title]).to be_nil }
+      it { expect(formatter.ready_to_send).to be_truthy }
+
+      it do
+        pending 'TODO: Remove keys with nil value from payload sent to Slack'
+        expect(first_attachment).not_to have_key(:title)
+      end
+    end
+  end
+
+  describe '#build' do
+    subject(:build) { formatter.build(**build_parameters) }
+
+    context 'with valid parameters' do
+      let(:build_parameters) do
+        {
+          icon: ':sign-roadworks:',
+          message: 'Test message',
+          title: 'Test title',
+          status: :pass
+        }
+      end
+
+      it { expect { build }.to change(formatter, :ready_to_send).to true }
+    end
+  end
+end

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe SlackNotifier, slack_bot: true do
-  subject(:slack_notifier) { described_class.new('test-slack-channel') }
+  subject(:slack_notifier) { described_class.new('test-slack-channel', formatter: formatter) }
+
+  let(:formatter) { SlackNotifier::Formatter.new }
 
   describe '#send_message!' do
     subject(:send_message) { slack_notifier.send_message! }
@@ -44,6 +46,7 @@ RSpec.describe SlackNotifier, slack_bot: true do
     end
 
     context 'with an injection payload' do
+      let(:formatter) { SlackNotifier::Formatter::Injection.new }
       let(:valid_json_on_success) do
         {
           from: 'external application',

--- a/spec/support/shared_examples/services/slack_notifier_formatter.rb
+++ b/spec/support/shared_examples/services/slack_notifier_formatter.rb
@@ -1,0 +1,15 @@
+RSpec.shared_examples 'a slack notifier formatter' do
+  describe '#ready_to_send' do
+    subject { formatter.ready_to_send }
+
+    context 'when #build has not been called' do
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#build' do
+    subject(:build) { formatter.build(**valid_build_parameters) }
+
+    it { expect { build }.to change(formatter, :ready_to_send).to true }
+  end
+end


### PR DESCRIPTION
Do not merge. Superseded by #4207

#### What

Prepare for creating Slack alerts for the archive stale claims job by refactoring the Slack Notifier service by extracting the formatting of the payload sent to Slack into strategies.

#### Ticket

[Alerting for errors in archive stale claims job](https://dsdmoj.atlassian.net/browse/CFP-150)

#### Why

The Slack Notifier service, `app/services/slack_notifier.rb`, is already set up and is used to send alerts to Slack when stats reports fail and for claim injections. Although there is one `SlackNotifier` class these two use cases have their own methods for generating the payload.

#### How

Rather than adding more complexity to `SlackNotifier` for the archive stale claims job alerts, I have extracted the generators of the payloads into separate strategies;

* `SlackNotifier::Formatter::Generic`; For formatting generic payloads given an icon, message, title and status. This replaces `SlackNotifier#build_generic_payload`.
* `SlackNotifier::Formatter::Injection`; Used for formatting payloads for injection alerts given a claim uuid, application name and list of errors. This replaces `SlackNotifier#build_injection_payload`.

I have also expanded the tests to test that the payload is generated correctly based on the input parameters.