### PR TITLE
[CFP-150] Refactor SlackNotifier

### DIFF
--- a/app/models/subscribers/slack.rb
+++ b/app/models/subscribers/slack.rb
@@ -10,7 +10,7 @@ module Subscribers
         message: "Stats::StatsReport.id: #{report_id}",
         status: :fail
       )
-      slack_notifier.send_message!
+      slack_notifier.send_message
     end
   end
 end

--- a/app/models/subscribers/slack.rb
+++ b/app/models/subscribers/slack.rb
@@ -3,12 +3,14 @@ module Subscribers
     def process
       report_id = event.payload[:id]
       report_name = event.payload[:name]
-      slack = SlackNotifier.new('cccd_development')
-      slack.build_generic_payload(':robot_face:',
-                                  "#{report_name} failed on #{ENV['ENV']}",
-                                  "Stats::StatsReport.id: #{report_id}",
-                                  false)
-      slack.send_message!
+      slack_notifier = SlackNotifier.new('cccd_development', formatter: SlackNotifier::Formatter::Generic.new)
+      slack_notifier.build_payload(
+        icon: ':robot_face:',
+        title: "#{report_name} failed on #{ENV['ENV']}",
+        message: "Stats::StatsReport.id: #{report_id}",
+        status: :fail
+      )
+      slack_notifier.send_message!
     end
   end
 end

--- a/app/services/injection_response_service.rb
+++ b/app/services/injection_response_service.rb
@@ -11,7 +11,7 @@ class InjectionResponseService
     return failure(action: 'run!', uuid: @response[:uuid]) unless @claim
 
     injection_attempt
-    slack_notifier.send_message! unless injection_attempt.notification_can_be_skipped?
+    slack_notifier.send_message unless injection_attempt.notification_can_be_skipped?
     true
   end
 
@@ -23,7 +23,7 @@ class InjectionResponseService
 
   def failure(options = {})
     LogStuff.info('InjectionResponseService::NonExistentClaim', options) { 'Failed to inject because no claim found' }
-    slack_notifier.send_message!
+    slack_notifier.send_message
     false
   end
 

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -9,7 +9,7 @@ class SlackNotifier
     }
   end
 
-  def send_message!
+  def send_message
     raise 'Unable to send without payload' unless @ready_to_send
 
     RestClient.post(@slack_url, @payload.to_json, content_type: :json)

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,5 +1,6 @@
 class SlackNotifier
-  def initialize(channel)
+  def initialize(channel, formatter: nil)
+    @formatter = formatter
     @slack_url = Settings.slack.bot_url
     @ready_to_send = false
     @payload = {
@@ -15,99 +16,20 @@ class SlackNotifier
   end
 
   def build_generic_payload(message_icon, title, message, pass_fail)
-    @payload[:icon_emoji] = message_icon
-    @payload[:attachments] = [
-      {
-        fallback: message,
-        color: pass_fail_colour(pass_fail),
-        title: title,
-        text: message
-      }
-    ]
-    @ready_to_send = true
-  rescue StandardError
-    @ready_to_send = false
+    @formatter = Formatter::Generic.new
+    build_payload(icon: message_icon, title: title, message: message, pass_fail: pass_fail)
   end
 
   def build_injection_payload(response)
-    @response = response.stringify_keys
-    @claim = Claim::BaseClaim.find_by(uuid: @response['uuid'])
-    @payload[:icon_emoji] = message_icon
-    @payload[:attachments] = [
-      {
-        fallback: injection_fallback,
-        color: message_colour,
-        title: injection_title,
-        text: @response['uuid'],
-        fields: fields
-      }
-    ]
+    @formatter = Formatter::Injection.new
+    build_payload(**response.symbolize_keys)
+  end
+
+  def build_payload(*args)
+    @payload[:attachments] = [@formatter.build(*args)]
+    @payload[:icon_emoji] = @formatter.message_icon
     @ready_to_send = true
   rescue StandardError
     @ready_to_send = false
-  end
-
-  private
-
-  def injected?
-    has_no_errors? && @claim.present?
-  end
-
-  def injection_fallback
-    "#{generate_message} {#{@response['uuid']}}"
-  end
-
-  def injection_title
-    "Injection into #{app_name} #{injected? ? 'succeeded' : 'failed'}"
-  end
-
-  def app_name
-    @response['from'] || 'indeterminable system'
-  end
-
-  def has_no_errors?
-    @response['errors'].empty?
-  end
-
-  def error_message
-    @response['errors'].join(' ')
-  end
-
-  def pass_fail_colour(boolean)
-    boolean ? '#36a64f' : '#c41f1f'
-  end
-
-  def message_colour
-    pass_fail_colour(injected?)
-  end
-
-  def message_icon
-    injected? ? Settings.slack.success_icon : Settings.slack.fail_icon
-  end
-
-  def fields
-    fields = [
-      { title: 'Claim number', value: @claim&.case_number, short: true },
-      { title: 'environment', value: ENV['ENV'], short: true }
-    ]
-    errors = has_no_errors? ? [] : error_fields
-    fields + errors
-  end
-
-  def error_fields
-    errors = @response['errors'].map { |x| x['error'] }.join('\n')
-    [
-      { title: 'Errors', value: errors }
-    ]
-  end
-
-  def generate_message
-    if @claim.nil?
-      'Failed to inject because no claim found'
-    elsif injected?
-      "Claim #{@claim.case_number} successfully injected"
-    else
-      "Claim #{@claim.case_number} could not be injected"
-    end
   end
 end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,5 +1,5 @@
 class SlackNotifier
-  def initialize(channel, formatter: nil)
+  def initialize(channel, formatter:)
     @formatter = formatter
     @slack_url = Settings.slack.bot_url
     @ready_to_send = false
@@ -16,7 +16,7 @@ class SlackNotifier
   end
 
   def build_payload(*args)
-    @payload[:attachments] = [@formatter.build(*args)]
+    @payload[:attachments] = [@formatter.attachment(*args)]
     @payload[:icon_emoji] = @formatter.message_icon
     @ready_to_send = true
   rescue StandardError

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -15,16 +15,6 @@ class SlackNotifier
     RestClient.post(@slack_url, @payload.to_json, content_type: :json)
   end
 
-  def build_generic_payload(message_icon, title, message, pass_fail)
-    @formatter = Formatter::Generic.new
-    build_payload(icon: message_icon, title: title, message: message, pass_fail: pass_fail)
-  end
-
-  def build_injection_payload(response)
-    @formatter = Formatter::Injection.new
-    build_payload(**response.symbolize_keys)
-  end
-
   def build_payload(*args)
     @payload[:attachments] = [@formatter.build(*args)]
     @payload[:icon_emoji] = @formatter.message_icon

--- a/app/services/slack_notifier/formatter.rb
+++ b/app/services/slack_notifier/formatter.rb
@@ -1,0 +1,9 @@
+class SlackNotifier
+  class Formatter
+    private
+
+    def pass_fail_colour(boolean)
+      boolean ? '#36a64f' : '#c41f1f'
+    end
+  end
+end

--- a/app/services/slack_notifier/formatter.rb
+++ b/app/services/slack_notifier/formatter.rb
@@ -1,9 +1,16 @@
 class SlackNotifier
   class Formatter
+    def initialize
+      @colours = {
+        pass: '#36a64f',
+        fail: '#c41f1f'
+      }
+    end
+
     private
 
-    def pass_fail_colour(boolean)
-      boolean ? '#36a64f' : '#c41f1f'
+    def message_colour
+      @colours[status]
     end
   end
 end

--- a/app/services/slack_notifier/formatter.rb
+++ b/app/services/slack_notifier/formatter.rb
@@ -1,10 +1,16 @@
 class SlackNotifier
   class Formatter
+    attr_reader :message_icon
+
     def initialize
       @colours = {
         pass: '#36a64f',
         fail: '#c41f1f'
       }
+    end
+
+    def attachment(*_args)
+      {}
     end
 
     private

--- a/app/services/slack_notifier/formatter/generic.rb
+++ b/app/services/slack_notifier/formatter/generic.rb
@@ -1,0 +1,18 @@
+class SlackNotifier
+  class Formatter
+    class Generic < Formatter
+      attr_reader :message_icon
+
+      def build(icon:, title:, message:, pass_fail:)
+        @message_icon = icon
+
+        {
+          fallback: message,
+          color: pass_fail_colour(pass_fail),
+          title: title,
+          text: message
+        }
+      end
+    end
+  end
+end

--- a/app/services/slack_notifier/formatter/generic.rb
+++ b/app/services/slack_notifier/formatter/generic.rb
@@ -1,9 +1,9 @@
 class SlackNotifier
   class Formatter
     class Generic < Formatter
-      attr_reader :message_icon, :status
+      attr_reader :status
 
-      def build(icon:, title:, message:, status:)
+      def attachment(icon: nil, title: nil, message: nil, status: :pass)
         @message_icon = icon
         @status = status
 
@@ -12,7 +12,7 @@ class SlackNotifier
           color: message_colour,
           title: title,
           text: message
-        }
+        }.compact
       end
     end
   end

--- a/app/services/slack_notifier/formatter/generic.rb
+++ b/app/services/slack_notifier/formatter/generic.rb
@@ -3,8 +3,13 @@ class SlackNotifier
     class Generic < Formatter
       attr_reader :status
 
+      def initialize
+        super
+        @message_icon = ':cccd:'
+      end
+
       def attachment(icon: nil, title: nil, message: nil, status: :pass)
-        @message_icon = icon
+        @message_icon = icon if icon
         @status = status
 
         {

--- a/app/services/slack_notifier/formatter/generic.rb
+++ b/app/services/slack_notifier/formatter/generic.rb
@@ -1,14 +1,15 @@
 class SlackNotifier
   class Formatter
     class Generic < Formatter
-      attr_reader :message_icon
+      attr_reader :message_icon, :status
 
-      def build(icon:, title:, message:, pass_fail:)
+      def build(icon:, title:, message:, status:)
         @message_icon = icon
+        @status = status
 
         {
           fallback: message,
-          color: pass_fail_colour(pass_fail),
+          color: message_colour,
           title: title,
           text: message
         }

--- a/app/services/slack_notifier/formatter/injection.rb
+++ b/app/services/slack_notifier/formatter/injection.rb
@@ -1,0 +1,74 @@
+class SlackNotifier
+  class Formatter
+    class Injection < Formatter
+      def build(response)
+        @response = response
+        @claim = Claim::BaseClaim.find_by(uuid: @response[:uuid])
+
+        {
+          fallback: injection_fallback,
+          color: message_colour,
+          title: injection_title,
+          text: @response[:uuid],
+          fields: fields
+        }
+      end
+
+      def message_icon
+        injected? ? Settings.slack.success_icon : Settings.slack.fail_icon
+      end
+
+      private
+
+      def injection_fallback
+        "#{generate_message} {#{@response[:uuid]}}"
+      end
+
+      def generate_message
+        if @claim.nil?
+          'Failed to inject because no claim found'
+        elsif injected?
+          "Claim #{@claim.case_number} successfully injected"
+        else
+          "Claim #{@claim.case_number} could not be injected"
+        end
+      end
+
+      def message_colour
+        pass_fail_colour(injected?)
+      end
+
+      def injection_title
+        "Injection into #{app_name} #{injected? ? 'succeeded' : 'failed'}"
+      end
+
+      def app_name
+        @response[:from] || 'indeterminable system'
+      end
+
+      def fields
+        fields = [
+          { title: 'Claim number', value: @claim&.case_number, short: true },
+          { title: 'environment', value: ENV['ENV'], short: true }
+        ]
+        errors = no_errors? ? [] : error_fields
+        fields + errors
+      end
+
+      def error_fields
+        errors = @response[:errors].map { |x| x['error'] }.join('\n')
+        [
+          { title: 'Errors', value: errors }
+        ]
+      end
+
+      def injected?
+        no_errors? && @claim.present?
+      end
+
+      def no_errors?
+        @response[:errors].empty?
+      end
+    end
+  end
+end

--- a/app/services/slack_notifier/formatter/injection.rb
+++ b/app/services/slack_notifier/formatter/injection.rb
@@ -34,8 +34,8 @@ class SlackNotifier
         end
       end
 
-      def message_colour
-        pass_fail_colour(injected?)
+      def status
+        injected? ? :pass : :fail
       end
 
       def injection_title

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
       }
 
       expect(notifier).to receive(:build_payload).with(**notifier_args)
-      expect(notifier).to receive(:send_message!).and_return(send_result)
+      expect(notifier).to receive(:send_message).and_return(send_result)
       process
       expect(process).to be_kind_of(Subscribers::Base)
     end

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -13,9 +13,19 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
     subject(:process) { described_class.new(event_name, start, ending, transaction_id, payload) }
 
     it 'sends a message to slack channel with the error content' do
-      expect(SlackNotifier).to receive(:new).with('cccd_development').and_return(notifier)
-      notifier_args = [':robot_face:', 'provisional_assessment failed on test', 'Stats::StatsReport.id: 999', false]
-      expect(notifier).to receive(:build_generic_payload).with(*notifier_args)
+      expect(SlackNotifier)
+        .to receive(:new)
+        .with('cccd_development', formatter: an_instance_of(SlackNotifier::Formatter::Generic))
+        .and_return(notifier)
+
+      notifier_args = {
+        icon: ':robot_face:',
+        title: 'provisional_assessment failed on test',
+        message: 'Stats::StatsReport.id: 999',
+        status: :fail
+      }
+
+      expect(notifier).to receive(:build_payload).with(**notifier_args)
       expect(notifier).to receive(:send_message!).and_return(send_result)
       process
       expect(process).to be_kind_of(Subscribers::Base)

--- a/spec/services/slack_notifier/formatter/generic_spec.rb
+++ b/spec/services/slack_notifier/formatter/generic_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotifier::Formatter::Generic do
+  subject(:formatter) { described_class.new }
+
+  let(:valid_build_parameters) do
+    {
+      icon: ':sign-roadworks:',
+      message: 'Test message',
+      title: 'Test title',
+      status: :pass
+    }
+  end
+
+  describe '#attachment' do
+    subject(:attachment) { formatter.attachment(**build_parameters) }
+
+    context 'with valid build parameters' do
+      let(:build_parameters) { valid_build_parameters }
+
+      it { expect(attachment[:fallback]).to eq 'Test message' }
+      it { expect(attachment[:title]).to eq 'Test title' }
+      it { expect(attachment[:text]).to eq 'Test message' }
+      it { expect(attachment[:color]).to eq '#36a64f' }
+      it { expect { attachment }.to change(formatter, :message_icon).to ':sign-roadworks:' }
+    end
+
+    context 'without an icon' do
+      let(:build_parameters) { valid_build_parameters.except(:icon) }
+
+      # TODO: Default icon?
+      it { expect { attachment }.not_to change(formatter, :message_icon) }
+    end
+
+    context 'with a failing status' do
+      let(:build_parameters) { valid_build_parameters.merge(status: :fail) }
+
+      it { expect(attachment[:color]).to eq '#c41f1f' }
+    end
+
+    context 'without status parameter' do
+      let(:build_parameters) { valid_build_parameters.except(:status) }
+
+      it { expect(attachment[:color]).to eq '#36a64f' }
+    end
+
+    context 'without message parameter' do
+      let(:build_parameters) { valid_build_parameters.except(:message) }
+
+      it { expect(attachment).not_to have_key(:fallback) }
+      it { expect(attachment).not_to have_key(:text) }
+    end
+
+    context 'without title parameter' do
+      let(:build_parameters) { valid_build_parameters.except(:title) }
+
+      it { expect(attachment).not_to have_key(:title) }
+    end
+  end
+end

--- a/spec/services/slack_notifier/formatter/generic_spec.rb
+++ b/spec/services/slack_notifier/formatter/generic_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe SlackNotifier::Formatter::Generic do
     context 'without an icon' do
       let(:build_parameters) { valid_build_parameters.except(:icon) }
 
-      # TODO: Default icon?
-      it { expect { attachment }.not_to change(formatter, :message_icon) }
+      it { expect { attachment }.not_to change(formatter, :message_icon).from ':cccd:' }
     end
 
     context 'with a failing status' do

--- a/spec/services/slack_notifier/formatter/injection_spec.rb
+++ b/spec/services/slack_notifier/formatter/injection_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotifier::Formatter::Injection do
+  subject(:formatter) { described_class.new }
+
+  let(:claim) { create :claim }
+  let(:valid_build_parameters) do
+    {
+      uuid: claim.uuid,
+      from: 'external application',
+      errors: []
+    }
+  end
+
+  describe '#attachment' do
+    subject(:attachment) { formatter.attachment(**build_parameters) }
+
+    before do
+      allow(Settings.slack).to receive(:success_icon).and_return ':tada:'
+      allow(Settings.slack).to receive(:fail_icon).and_return ':sad:'
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('ENV').and_return 'test_environment'
+    end
+
+    context 'with valid build parameters' do
+      let(:build_parameters) { valid_build_parameters }
+
+      it { expect(attachment[:fallback]).to eq "Claim #{claim.case_number} successfully injected {#{claim.uuid}}" }
+      it { expect(attachment[:title]).to eq 'Injection into external application succeeded' }
+      it { expect(attachment[:text]).to eq claim.uuid }
+      it { expect(attachment[:color]).to eq '#36a64f' }
+      it { expect(attachment[:fields].count).to eq 2 }
+      it { expect { attachment }.to change(formatter, :message_icon).to ':tada:' }
+    end
+
+    context 'with errors' do
+      let(:build_parameters) do
+        valid_build_parameters.merge(errors: [{ 'error' => "No defendant found for Rep Order Number: '123'." }])
+      end
+
+      it { expect(attachment[:fallback]).to eq "Claim #{claim.case_number} could not be injected {#{claim.uuid}}" }
+      it { expect(attachment[:title]).to eq 'Injection into external application failed' }
+      it { expect(attachment[:text]).to eq claim.uuid }
+      it { expect(attachment[:color]).to eq '#c41f1f' }
+      it { expect(attachment[:fields].count).to eq 3 }
+    end
+
+    context 'without an errors parameter' do
+      let(:build_parameters) { valid_build_parameters.except(:errors) }
+
+      it { expect(attachment[:fields].count).to eq 2 }
+    end
+
+    context 'with an unknown claim' do
+      let(:build_parameters) { valid_build_parameters.merge(uuid: 'bad-uuid') }
+
+      it { expect(attachment[:fallback]).to eq 'Failed to inject because no claim found {bad-uuid}' }
+      it { expect(attachment[:title]).to eq 'Injection into external application failed' }
+      it { expect(attachment[:text]).to eq 'bad-uuid' }
+      it { expect(attachment[:color]).to eq '#c41f1f' }
+      it { expect(attachment[:fields].count).to eq 2 }
+      it { expect { attachment }.to change(formatter, :message_icon).to ':sad:' }
+    end
+
+    context 'without a from parameter' do
+      let(:build_parameters) { valid_build_parameters.except(:from) }
+
+      it { expect(attachment[:title]).to eq 'Injection into indeterminable system succeeded' }
+    end
+  end
+end

--- a/spec/services/slack_notifier/formatter/injection_spec.rb
+++ b/spec/services/slack_notifier/formatter/injection_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SlackNotifier::Formatter::Injection do
       it { expect(attachment[:title]).to eq 'Injection into external application succeeded' }
       it { expect(attachment[:text]).to eq claim.uuid }
       it { expect(attachment[:color]).to eq '#36a64f' }
-      it { expect(attachment[:fields].count).to eq 2 }
+      it { expect(attachment[:fields].pluck(:title)).to match_array(['Claim number', 'environment']) }
       it { expect { attachment }.to change(formatter, :message_icon).to ':tada:' }
     end
 
@@ -42,13 +42,16 @@ RSpec.describe SlackNotifier::Formatter::Injection do
       it { expect(attachment[:title]).to eq 'Injection into external application failed' }
       it { expect(attachment[:text]).to eq claim.uuid }
       it { expect(attachment[:color]).to eq '#c41f1f' }
-      it { expect(attachment[:fields].count).to eq 3 }
+
+      it {
+        expect(attachment[:fields].pluck(:title)).to match_array(['Claim number', 'environment', 'Errors'])
+      }
     end
 
     context 'without an errors parameter' do
       let(:build_parameters) { valid_build_parameters.except(:errors) }
 
-      it { expect(attachment[:fields].count).to eq 2 }
+      it { expect(attachment[:fields].pluck(:title)).to match_array(['Claim number', 'environment']) }
     end
 
     context 'with an unknown claim' do

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe SlackNotifier, slack_bot: true do
   subject(:slack_notifier) { described_class.new('test-channel', formatter: formatter) }
 
+  let(:formatter) { SlackNotifier::Formatter.new }
+
   describe '#send_message!' do
     subject(:send_message) { slack_notifier.send_message! }
-
-    let(:formatter) { SlackNotifier::Formatter::Generic.new }
 
     context 'when a payload has not been generated' do
       it 'raises an error' do
@@ -14,112 +14,28 @@ RSpec.describe SlackNotifier, slack_bot: true do
       end
     end
 
-    context 'when a generic payload has been generated' do
-      let(:valid_parameters) { { icon: ':robot-face:', title: 'Test title', message: 'Test message', status: :pass } }
-      let(:expected_attachment) do
-        {
-          fallback: 'Test message',
-          color: '#36a64f',
-          title: 'Test title',
-          text: 'Test message'
-        }
-      end
-
+    context 'when a payload has been generated' do
       before do
-        slack_notifier.build_payload(**valid_parameters)
+        allow(formatter).to receive(:attachment).with(hash_including(key: 'value')).and_return({ title: 'Test title' })
+        allow(formatter).to receive(:message_icon).and_return ':sign-roadworks:'
+        slack_notifier.build_payload(key: 'value')
         send_message
       end
 
       it 'calls the slack api' do
-        expect(a_request(:post, 'https://hooks.slack.com/services/fake/endpoint')).to have_been_made.times(1)
+        expect(a_request(:post, 'https://hooks.slack.com/services/fake/endpoint')).to have_been_made.once
       end
 
       it 'sets the channel' do
         expect(WebMock)
           .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
-          .with(body: hash_including(channel: 'test-channel'))
+          .with(body: hash_including(channel: 'test-channel', icon_emoji: ':sign-roadworks:'))
       end
 
       it 'sets the attachments' do
         expect(WebMock)
           .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
-          .with(body: hash_including(attachments: [expected_attachment]))
-      end
-    end
-
-    context 'when an injection payload has been generated' do
-      let(:claim) { create :claim }
-      let(:json_response) do
-        {
-          from: 'external application',
-          errors: [],
-          uuid: claim.uuid,
-          messages: [{ message: 'Claim injected successfully.' }]
-        }
-      end
-      let(:expected_attachment) do
-        {
-          fallback: "Claim #{claim.case_number} successfully injected {#{claim.uuid}}",
-          color: '#36a64f',
-          title: 'Injection into external application succeeded',
-          text: claim.uuid,
-          fields: [
-            { title: 'Claim number', value: claim.case_number, short: true },
-            { title: 'environment', value: 'test', short: true }
-          ]
-        }
-      end
-      let(:formatter) { SlackNotifier::Formatter::Injection.new }
-
-      before do
-        slack_notifier.build_payload(**json_response)
-        send_message
-      end
-
-      it 'calls the slack api' do
-        expect(a_request(:post, 'https://hooks.slack.com/services/fake/endpoint')).to have_been_made.times(1)
-      end
-
-      it 'sets the channel' do
-        expect(WebMock)
-          .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
-          .with(body: hash_including(channel: 'test-channel'))
-      end
-
-      it 'sets the attachments' do
-        expect(WebMock)
-          .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
-          .with(body: hash_including(attachments: [expected_attachment]))
-      end
-
-      context 'with errors' do
-        let(:json_response) do
-          {
-            from: 'external application',
-            errors: [{ error: "No defendant found for Rep Order Number: '123456432'." }],
-            uuid: claim.uuid,
-            messages: []
-          }
-        end
-        let(:expected_attachment) do
-          {
-            fallback: "Claim #{claim.case_number} could not be injected {#{claim.uuid}}",
-            color: '#c41f1f',
-            title: 'Injection into external application failed',
-            text: claim.uuid,
-            fields: [
-              { title: 'Claim number', value: claim.case_number, short: true },
-              { title: 'environment', value: 'test', short: true },
-              { title: 'Errors', value: '' }
-            ]
-          }
-        end
-
-        it 'sets the attachments' do
-          expect(WebMock)
-            .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
-            .with(body: hash_including(attachments: [expected_attachment]))
-        end
+          .with(body: hash_including(attachments: [{ title: 'Test title' }]))
       end
     end
   end

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe SlackNotifier, slack_bot: true do
 
   let(:formatter) { SlackNotifier::Formatter.new }
 
-  describe '#send_message!' do
-    subject(:send_message) { slack_notifier.send_message! }
+  describe '#send_message' do
+    subject(:send_message) { slack_notifier.send_message }
 
     context 'when a payload has not been generated' do
       it 'raises an error' do

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -1,47 +1,131 @@
 require 'rails_helper'
 
 RSpec.describe SlackNotifier, slack_bot: true do
-  subject(:slack_notifier) { described_class.new(claim) }
-
-  let(:claim) { create :claim }
-  let(:valid_json_on_success) do
-    {
-      from: 'external application',
-      errors: [],
-      uuid: claim.uuid,
-      messages: [{ message: 'Claim injected successfully.' }]
-    }
-  end
-  # TODO: This isn't used. Is there a missing test or is it redundant?
-  let(:valid_json_on_failure) do
-    {
-      from: 'external application',
-      errors: [{ error: "No defendant found for Rep Order Number: '123456432'." }],
-      uuid: claim.uuid,
-      messages: []
-    }
-  end
-
-  it { is_expected.to be_a described_class }
-
-  it { is_expected.to respond_to :build_injection_payload }
-  it { is_expected.to respond_to :send_message! }
+  subject(:slack_notifier) { described_class.new('test-channel') }
 
   describe '#send_message!' do
-    subject(:send_message!) { slack_notifier.send_message! }
+    subject(:send_message) { slack_notifier.send_message! }
 
-    context 'before message payload is set' do
+    context 'when a payload has not been generated' do
       it 'raises an error' do
-        expect { subject }.to raise_error(RuntimeError, 'Unable to send without payload')
+        expect { send_message }.to raise_error(RuntimeError, 'Unable to send without payload')
       end
     end
 
-    context 'after payload set' do
-      before { slack_notifier.build_injection_payload(valid_json_on_success) }
+    context 'when a generic payload has been generated' do
+      let(:valid_parameters) { [':robot-face:', 'Test title', 'Test message', true] }
+      let(:expected_attachment) do
+        {
+          fallback: 'Test message',
+          color: '#36a64f',
+          title: 'Test title',
+          text: 'Test message'
+        }
+      end
+
+      before do
+        slack_notifier.build_generic_payload(*valid_parameters)
+        send_message
+      end
 
       it 'calls the slack api' do
-        subject
         expect(a_request(:post, 'https://hooks.slack.com/services/fake/endpoint')).to have_been_made.times(1)
+      end
+
+      it 'sets the channel' do
+        expect(WebMock)
+          .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
+          .with(body: hash_including(channel: 'test-channel'))
+      end
+
+      it 'sets the attachments' do
+        expect(WebMock)
+          .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
+          .with(body: hash_including(attachments: [expected_attachment]))
+      end
+    end
+
+    context 'when an injection payload has been generated' do
+      let(:claim) { create :claim }
+      let(:json_response) do
+        {
+          from: 'external application',
+          errors: [],
+          uuid: claim.uuid,
+          messages: [{ message: 'Claim injected successfully.' }]
+        }
+      end
+      # TODO: This isn't used. Is there a missing test or is it redundant?
+      let(:valid_json_on_failure) do
+        {
+          from: 'external application',
+          errors: [{ error: "No defendant found for Rep Order Number: '123456432'." }],
+          uuid: claim.uuid,
+          messages: []
+        }
+      end
+      let(:expected_attachment) do
+        {
+          fallback: "Claim #{claim.case_number} successfully injected {#{claim.uuid}}",
+          color: '#36a64f',
+          title: 'Injection into external application succeeded',
+          text: claim.uuid,
+          fields: [
+            { title: 'Claim number', value: claim.case_number, short: true },
+            { title: 'environment', value: 'test', short: true }
+          ]
+        }
+      end
+
+      before do
+        slack_notifier.build_injection_payload(json_response)
+        send_message
+      end
+
+      it 'calls the slack api' do
+        expect(a_request(:post, 'https://hooks.slack.com/services/fake/endpoint')).to have_been_made.times(1)
+      end
+
+      it 'sets the channel' do
+        expect(WebMock)
+          .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
+          .with(body: hash_including(channel: 'test-channel'))
+      end
+
+      it 'sets the attachments' do
+        expect(WebMock)
+          .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
+          .with(body: hash_including(attachments: [expected_attachment]))
+      end
+
+      context 'with errors' do
+        let(:json_response) do
+          {
+            from: 'external application',
+            errors: [{ error: "No defendant found for Rep Order Number: '123456432'." }],
+            uuid: claim.uuid,
+            messages: []
+          }
+        end
+        let(:expected_attachment) do
+          {
+            fallback: "Claim #{claim.case_number} could not be injected {#{claim.uuid}}",
+            color: '#c41f1f',
+            title: 'Injection into external application failed',
+            text: claim.uuid,
+            fields: [
+              { title: 'Claim number', value: claim.case_number, short: true },
+              { title: 'environment', value: 'test', short: true },
+              { title: 'Errors', value: '' }
+            ]
+          }
+        end
+
+        it 'sets the attachments' do
+          expect(WebMock)
+            .to have_requested(:post, 'https://hooks.slack.com/services/fake/endpoint')
+            .with(body: hash_including(attachments: [expected_attachment]))
+        end
       end
     end
   end


### PR DESCRIPTION
#### What

Prepare for creating Slack alerts for the archive stale claims job by refactoring the Slack Notifier service by extracting the formatting of the payload sent to Slack into strategies.

#### Ticket

[Alerting for errors in archive stale claims job](https://dsdmoj.atlassian.net/browse/CFP-150)

#### Why

The Slack Notifier service, `app/services/slack_notifier.rb`, is already set up and is used to send alerts to Slack when stats reports fail and for claim injections. Although there is one `SlackNotifier` class these two use cases have their own methods for generating the payload.

#### How

Rather than adding more complexity to `SlackNotifier` for the archive stale claims job alerts, I have extracted the generators of the payloads into separate strategies;

* `SlackNotifier::Formatter::Generic`; For formatting generic payloads given an icon, message, title and status. This replaces `SlackNotifier#build_generic_payload`.
* `SlackNotifier::Formatter::Injection`; Used for formatting payloads for injection alerts given a claim uuid, application name and list of errors. This replaces `SlackNotifier#build_injection_payload`.

I have also expanded the tests to test that the payload is generated correctly based on the input parameters.

#### TODO (wip)

 - [x] Pass instances of `SlackNotifier::Formatter::*` into the `SlackNotifier` when it is instantiated, and remove the obsolete `build_generic_payload` and `build_injection_payload`
 - [x] Move tests from `spec/services/slack_notifier_spec.rb` into `spec/services/slack_notifier/formatter/*`, as appropriate, and expand.
