### PR TITLE
Add Makefile and amend `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+bx=bundle exec
+
+default: help
+
+help: #: Show help topics
+	@grep "#:" Makefile* | grep -v "@grep" | sort | sed "s/\([A-Za-z_ -]*\):.*#\(.*\)/$$(tput setaf 3)\1$$(tput sgr0)\2/g"
+
+rspec: #: run all or focused specs
+	${bx} rspec
+pspec: #: run all specs in parallel
+	${bx} rake parallel:spec
+cuke: #: run cucumber features tagged with @focus
+	${bx} cucumber --tag @focus
+jasmine: #: run jasmine specs
+	${bx} rake jasmine:ci
+rlint: #: run rubocop
+	rubocop
+jslint: #: lint javascript
+	yarn run validate:js
+scsslint: #: lint scss
+	yarn run validate:scss
+lint: rlint jslint scsslint #: run all linters


### PR DESCRIPTION
#### What
Add Makefile and amend `.editorconfig`

#### Why
Simplify and document basic tasks. The
`.editorconfig` has been changed as a Makefile
requires tabs for indentation, not spaces, and this
will handle this transparently.