### PR TITLE
gitignore public/assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 public/system/documents
 public/paperclip
 public/uploads
+public/assets
 public/assets/test
 public/assets/dev
 features/examples/000


### PR DESCRIPTION
#### What
gitignore public/assets

#### Ticket

n/a

#### Why

`bundle exec rails assets:precompile` can generate various
files directly under public/assets that we do no want or need
in the repo. assets are precompiled as part of docker build
process in nay event.