### PR TITLE
Reduce the sampling rate for Sentry to 5%.

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,7 +5,7 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
     config.dsn = ENV['SENTRY_DSN']
     config.breadcrumbs_logger = [:active_support_logger]
 
-    # Send 10% of transactions for performance monitoring
-    config.traces_sample_rate = 0.1
+    # Send 5% of transactions for performance monitoring
+    config.traces_sample_rate = 0.05
   end
 end


### PR DESCRIPTION
#### What
Reduce the sampling rate for Sentry to 5%.

#### Ticket
N/A

#### Why
The Sentry performance monitoring is rate limited and [Ops-Eng suggest having a sample rate of 5%.](https://ministryofjustice.github.io/operations-engineering/documentation/services/sentry.html#sentry-io) I had originally set it to 10% before I knew that it was rate limited.

#### How

Update in `config/initializers/sentry.rb`.