### PR TITLE
[CFP-210] Change slack channel for prometheus alerts

### DIFF
--- a/kubernetes_deploy/api-sandbox/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/api-sandbox/prometheus-custom-rules.yaml
@@ -14,7 +14,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-api-sandbox"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-api-sandbox"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-api-sandbox is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -22,7 +22,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-api-sandbox", status="400"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-api-sandbox More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-api-sandbox,type:phrase),type:phrase,value:cccd-api-sandbox),query:(match:(kubernetes.namespace_name:(query:cccd-api-sandbox,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -30,7 +30,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-api-sandbox", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-api-sandbox An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-api-sandbox),query:(match:(log_processed.kubernetes_namespace:(query:cccd-api-sandbox,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -38,6 +38,6 @@ spec:
       expr: container_fs_usage_bytes{namespace="cccd-api-sandbox"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-api-sandbox"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-api-sandbox Container disk space usage is more than 1Gi or is not reported

--- a/kubernetes_deploy/dev-lgfs/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/dev-lgfs/prometheus-custom-rules.yaml
@@ -14,7 +14,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-dev-lgfs"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-dev-lgfs"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev-lgfs is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -22,7 +22,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status="400"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev-lgfs More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-dev-lgfs,type:phrase),type:phrase,value:cccd-dev-lgfs),query:(match:(kubernetes.namespace_name:(query:cccd-dev-lgfs,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -30,7 +30,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev-lgfs),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev-lgfs,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -38,6 +38,6 @@ spec:
       expr: container_fs_usage_bytes{namespace="cccd-dev-lgfs"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-dev-lgfs"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev-lgfs Container disk space usage is more than 1Gi or is not reported

--- a/kubernetes_deploy/dev/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/dev/prometheus-custom-rules.yaml
@@ -14,7 +14,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-dev"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-dev"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -22,7 +22,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev", status="400"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-dev,type:phrase),type:phrase,value:cccd-dev),query:(match:(kubernetes.namespace_name:(query:cccd-dev,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -30,7 +30,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -38,6 +38,6 @@ spec:
       expr: container_fs_usage_bytes{namespace="cccd-dev"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-dev"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-dev Container disk space usage is more than 1Gi or is not reported

--- a/kubernetes_deploy/production/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/production/prometheus-custom-rules.yaml
@@ -14,7 +14,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-production"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-production"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-production is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -22,7 +22,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-production", status="400"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-production More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-production,type:phrase),type:phrase,value:cccd-production),query:(match:(kubernetes.namespace_name:(query:cccd-production,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -30,7 +30,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-production", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-production An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-production),query:(match:(log_processed.kubernetes_namespace:(query:cccd-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -38,6 +38,6 @@ spec:
       expr: container_fs_usage_bytes{namespace="cccd-production"} / 1024 / 1024 > 2048 or absent(container_fs_usage_bytes{namespace="cccd-production"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-production Container disk space usage is more than 2Gi or is not reported

--- a/kubernetes_deploy/staging/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/staging/prometheus-custom-rules.yaml
@@ -14,7 +14,7 @@ spec:
       expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-staging"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-staging"} > 0) > 90
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-staging is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
@@ -22,7 +22,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-staging", status="400"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-staging More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-staging,type:phrase),type:phrase,value:cccd-staging),query:(match:(kubernetes.namespace_name:(query:cccd-staging,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
@@ -30,7 +30,7 @@ spec:
       expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-staging", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-staging An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-staging),query:(match:(log_processed.kubernetes_namespace:(query:cccd-staging,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
@@ -38,6 +38,6 @@ spec:
       expr: container_fs_usage_bytes{namespace="cccd-staging"} / 1024 / 1024 > 2048 or absent(container_fs_usage_bytes{namespace="cccd-staging"})
       for: 1m
       labels:
-        severity: laa-court-get-paid
+        severity: laa-cccd-alerts
       annotations:
         message: cccd-staging Container disk space usage is more than 2Gi or is not reported


### PR DESCRIPTION
#### What
Change slack channel for prometheus alerts

#### Ticket

[relates to CFP-210](https://dsdmoj.atlassian.net/browse/CFP-210)

#### Why

The `severity` entry is used by cloud platforms
infrastructure in some way that is obscured from us
to route alerts to the "receiver" (the webhook I guess)

#### How
We just need to change the "severity" level (can also call it
a "slack channel receiver").

See this PR that creates a "severity" called laa-cccd-alerts
that points to a webhook that sends output to the
 \#laa-cccd-alerts channel

https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/1347


### TODO

- [x] apply to dev
- [x] apply to dev-lgfs
- [x] apply to staging
- [x] apply to api-sandbox
- [x] apply to production
- [ ] merge PR 


**Note**: merging this PR won't actually do anything since we do not apply `prometheusrules` via the pipeline. we can do it manually on the console

```
# describe rules in namespace
kubectl describe prometheusrules prometheus-custom-rules-cccd -n <namespace>

# apply rule
kubectl apply -f kubernetes_deploy/<env>/prometheus-custom-rules.yaml -n <namespace>
e.g. k apply -f kubernetes_deploy/staging/prometheus-custom-rules.yaml -n cccd-staging
```
