### PR TITLE
[CFP-150] Only report to Slack for failure

### DIFF
--- a/app/models/timed_transitions/batch_transitioner.rb
+++ b/app/models/timed_transitions/batch_transitioner.rb
@@ -65,7 +65,7 @@ module TimedTransitions
     end
 
     def log_end
-      if @notifier
+      if @notifier && @tally[:failed].positive?
         @notifier.build_payload(**@tally)
         @notifier.send_message
       end


### PR DESCRIPTION
#### What

Only report results of overnight claims archiving job when there are failures.

#### Ticket

[Alerting for errors in archive stale claims job](https://dsdmoj.atlassian.net/browse/CFP-150)

#### Why

Avoid spamming the Slack alerts channel whilst keeping watch on all the environments.

#### How

Only send the notification when failures have been found.