### PR TITLE
Correct namespace name in promethues alert

### DIFF
--- a/kubernetes_deploy/dev-lgfs/prometheus-custom-rules.yaml
+++ b/kubernetes_deploy/dev-lgfs/prometheus-custom-rules.yaml
@@ -32,7 +32,7 @@ spec:
       labels:
         severity: laa-cccd-alerts
       annotations:
-        message: cccd-dev An HTTP 5xx error has occurred
+        message: cccd-dev-lgfs An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev-lgfs),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev-lgfs,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
     - alert: DiskSpace-Threshold-Reached
       expr: container_fs_usage_bytes{namespace="cccd-dev-lgfs"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-dev-lgfs"})


### PR DESCRIPTION
#### What
Correct namespace name in promethues alert

#### Why
This alert shows up as
```
Alert: cccd-dev An HTTP 5xx error has occurred
```
but should be
```
Alert: cccd-dev-lgfs An HTTP 5xx error has occurred
```