### PR TITLE
Add default dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   open-pull-requests-limit: 5
   reviewers:
   - "naseberry"
-  - "imtiazahmd"
+  - "imtiazAhmd"
   ignore:
   - dependency-name: jquery
     versions:


### PR DESCRIPTION
#### What
Add default dependabot reviewers for its PRs, case sensitive resolution.

#### Why
So we do not have to assign reviewers manually