### PR TITLE
Remove nil assignement expense adaptor bug

### DIFF
--- a/app/services/ccr/expenses_adapter.rb
+++ b/app/services/ccr/expenses_adapter.rb
@@ -71,7 +71,7 @@ module CCR
     end
 
     def description
-      parts = [(expense.location ||= expense.expense_type.name)]
+      parts = [(expense.location || expense.expense_type.name)]
       parts << expense.reason_text || ''
       parts.join(' ').strip
     end


### PR DESCRIPTION
The check should not be an assignment as this
is purely for "presenting" or adapting the data
as expected by CCR.