### PR TITLE
[CFP-198] add AGFS and LGFS management information reports

### DIFF
--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -18,8 +18,7 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
     record = Stats::StatsReport.most_recent_by_type(params[:report_type])
 
     if record.document.attached?
-      # TODO: Change service_url to url when moving to Rails 6.1
-      redirect_to record.document.blob.service_url(disposition: 'attachment')
+      redirect_to record.document.blob.url(disposition: 'attachment')
     else
       redirect_to case_workers_admin_management_information_url, alert: t('.missing_report')
     end

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -1,6 +1,11 @@
 module Stats
   class StatsReport < ApplicationRecord
-    TYPES = %w[management_information provisional_assessment rejections_refusals submitted_claims].freeze
+    TYPES = %w[management_information
+               agfs_management_information
+               lgfs_management_information
+               provisional_assessment
+               rejections_refusals
+               submitted_claims].freeze
 
     validates :status, inclusion: { in: %w[started completed error] }
 

--- a/app/presenters/concerns/management_information_reportable.rb
+++ b/app/presenters/concerns/management_information_reportable.rb
@@ -65,7 +65,7 @@ module ManagementInformationReportable
 
     def completed_at
       completion_steps = @journey.select { |step| COMPLETED_STATES.include?(step.to) }
-      completion_steps.present? ? completion_steps.first.created_at.strftime('%d/%m/%Y %H:%M') : 'n/a'
+      completion_steps.present? ? completion_steps.first.created_at.strftime('%d/%m/%Y') : 'n/a'
     end
 
     def current_or_end_state

--- a/app/services/stats/management_information_generator.rb
+++ b/app/services/stats/management_information_generator.rb
@@ -10,6 +10,7 @@ module Stats
 
     def initialize(options = {})
       @format = options.fetch(:format, DEFAULT_FORMAT)
+      @claim_scope = options.fetch(:claim_scope, :all)
     end
 
     def call
@@ -25,8 +26,8 @@ module Stats
       Settings.claim_csv_headers.map { |header| header.to_s.humanize }
     end
 
-    def active_non_draft_claims
-      Claim::BaseClaim.active.non_draft
+    def claims
+      Claim::BaseClaim.active.non_draft.send(@claim_scope)
     end
 
     # TODO: separate data retrieval from exporting the data itself
@@ -35,7 +36,7 @@ module Stats
       log_info('Report generation started...')
       content = CSV.generate do |csv|
         csv << headers
-        active_non_draft_claims.find_each do |claim|
+        claims.find_each do |claim|
           ManagementInformationPresenter.new(claim, 'view').present! do |claim_journeys|
             claim_journeys.each { |journey| csv << journey } if claim_journeys.any?
           end

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -29,8 +29,7 @@ module Stats
     attr_reader :report_type, :options
 
     def validate_report_type
-      return if StatsReport::TYPES.include?(report_type.to_s)
-      raise InvalidReportType
+      raise InvalidReportType unless StatsReport::TYPES.include?(report_type.to_s)
     end
 
     def generate_new_report

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -34,15 +34,26 @@ module Stats
     end
 
     def generate_new_report
-      return ManagementInformationGenerator.call(options) if report_type.to_sym == :management_information
+      return management_information_generator if report_type.include?('management_information')
 
       ReportGenerator.call(report_type, **options)
     end
 
+    def management_information_generator
+      case report_type.to_sym
+      when :agfs_management_information
+        options[:claim_scope] = :agfs
+      when :lgfs_management_information
+        options[:claim_scope] = :lgfs
+      end
+
+      ManagementInformationGenerator.call(options)
+    end
+
     def notify_error(report_record, error)
       return unless Settings.notify_report_errors
-      ActiveSupport::Notifications.instrument 'call_failed.stats_report',
-                                              id: report_record&.id, name: report_type, error: error
+      ActiveSupport::Notifications.instrument('call_failed.stats_report',
+                                              id: report_record&.id, name: report_type, error: error)
     end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/helpers/application_helper.rb",
-      "line": 76,
+      "line": 78,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.except(:page).merge(:sort => column, :direction => ((\"desc\" or \"asc\")), :anchor => column).permit!",
       "render_path": null,
@@ -63,24 +63,24 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "fc469a28ef113fae0ef0022ac73c65a4867936f8aaa0299100108f00c9f195d7",
+      "fingerprint": "f864ab7fd11658900179de410a865664137731863114daba2062981f29df068f",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/case_workers/admin/management_information_controller.rb",
-      "line": 22,
+      "line": 21,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.service_url(:disposition => \"attachment\"))",
+      "code": "redirect_to(Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\"))",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "CaseWorkers::Admin::ManagementInformationController",
         "method": "download"
       },
-      "user_input": "Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.service_url(:disposition => \"attachment\")",
+      "user_input": "Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\")",
       "confidence": "High",
-      "note": ""
+      "note": "params[:report_type] is validated to be one of the acceptable values in a controller before_action"
     }
   ],
-  "updated": "2021-05-07 11:52:13 +0100",
-  "brakeman_version": "5.0.1"
+  "updated": "2021-09-21 12:55:57 +0100",
+  "brakeman_version": "5.1.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2462,6 +2462,8 @@ en:
           year: Year
           example_date: "For example, 31 3 1980"
           report_types:
+            agfs_management_information: AGFS management information
+            lgfs_management_information: LGFS management information
             management_information: Management information
             provisional_assessment: Provisional assessment
             rejections_refusals: 'Rejections/Refusals'

--- a/scheduled_tasks/agfs_management_information_generation_task.rb
+++ b/scheduled_tasks/agfs_management_information_generation_task.rb
@@ -1,0 +1,14 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class AgfsManagementInformationGenerationTask < Scheduler::SchedulerTask
+  every '1d', first_at: Chronic.parse('next 2:00 am')
+
+  def run
+    LogStuff.info { 'AGFS Management Information Generation started' }
+    Stats::StatsReportGenerator.call('agfs_management_information')
+    LogStuff.info { 'AGFS Management Information Generation finished' }
+  rescue StandardError => e
+    LogStuff.error { 'AGFS Management Information Generation error: ' + e.message }
+  end
+end

--- a/scheduled_tasks/lgfs_management_information_generation_task.rb
+++ b/scheduled_tasks/lgfs_management_information_generation_task.rb
@@ -1,0 +1,14 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class LgfsManagementInformationGenerationTask < Scheduler::SchedulerTask
+  every '1d', first_at: Chronic.parse('next 2:30 am')
+
+  def run
+    LogStuff.info { 'LGFS Management Information Generation started' }
+    Stats::StatsReportGenerator.call('lgfs_management_information')
+    LogStuff.info { 'LGFS Management Information Generation finished' }
+  rescue StandardError => e
+    LogStuff.error { 'LGFS Management Information Generation error: ' + e.message }
+  end
+end

--- a/spec/controllers/case_workers/admin/management_information_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/management_information_controller_spec.rb
@@ -7,7 +7,14 @@ RSpec.describe CaseWorkers::Admin::ManagementInformationController, type: :contr
     let(:persona) { create(:case_worker, :admin) }
 
     describe 'GET #index' do
-      let(:expected_report_types) { %w[management_information provisional_assessment rejections_refusals submitted_claims] }
+      let(:expected_report_types) do
+        %w[management_information
+           agfs_management_information
+           lgfs_management_information
+           provisional_assessment
+           rejections_refusals
+           submitted_claims]
+      end
 
       before { get :index }
 

--- a/spec/controllers/case_workers/admin/management_information_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/management_information_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CaseWorkers::Admin::ManagementInformationController, type: :contr
         before do
           stats_report = create(:stats_report, :with_document, report_name: report_type)
           allow(Stats::StatsReport).to receive(:most_recent_by_type).and_return(stats_report)
-          allow(stats_report.document.blob).to receive(:service_url).and_return(test_url)
+          allow(stats_report.document.blob).to receive(:url).and_return(test_url)
 
           download
         end

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -75,6 +75,14 @@ FactoryBot.define do
       end
     end
 
+    trait :draft do
+      # NOTE: remove the certification that general build would have added
+      # as only submitted+ states need certifying
+      after(:build) do |claim|
+        claim.certification = nil if claim.certification
+      end
+    end
+
     #
     # states: initial/default state is draft
     # - alphabetical list
@@ -83,11 +91,20 @@ FactoryBot.define do
       after(:create) { |claim| allocate_claim(claim); claim.reload }
     end
 
+    trait :allocated do
+      after(:create) { |claim| allocate_claim(claim); claim.reload }
+    end
+
     factory :archived_pending_delete_claim do
       after(:create) { |claim| advance_to_pending_delete(claim) }
     end
 
     factory :authorised_claim do
+      offence { create :offence, :with_fee_scheme, offence_class: create(:offence_class) }
+      after(:create) { |claim| authorise_claim(claim) }
+    end
+
+    trait :authorised do
       offence { create :offence, :with_fee_scheme, offence_class: create(:offence_class) }
       after(:create) { |claim| authorise_claim(claim) }
     end
@@ -109,12 +126,25 @@ FactoryBot.define do
       after(:create) { |claim| claim.submit!; claim.allocate!; assign_fees_and_expenses_for(claim); claim.authorise_part! }
     end
 
+    trait :part_authorised do
+      offence { create :offence, :with_fee_scheme, offence_class: create(:offence_class) }
+      after(:create) { |claim| allocate_claim(claim); claim.reload; assign_fees_and_expenses_for(claim); claim.authorise_part! }
+    end
+
     factory :refused_claim do
       after(:create) { |claim| claim.submit!; claim.allocate!; claim.refuse! }
     end
 
+    trait :refused do
+      after(:create) { |claim| claim.submit!; allocate_claim(claim); claim.refuse! }
+    end
+
     factory :rejected_claim do
       after(:create) { |claim| claim.submit!; claim.allocate!; claim.reject! }
+    end
+
+    trait :rejected do
+      after(:create) { |claim| claim.submit!; allocate_claim(claim); claim.reject! }
     end
 
     factory :submitted_claim do
@@ -131,6 +161,10 @@ FactoryBot.define do
           create(:injection_attempt, :with_errors, claim: claim)
         end
       end
+    end
+
+    trait :submitted do
+      after(:create, &:submit!)
     end
   end
 end

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -140,7 +140,7 @@ def publicise_errors(claim)
     claim.defendants.each do |defendant|
       ap defendant
       puts defendant.errors.full_messages
-      d.representation_orders.each do |rep|
+      defendant.representation_orders.each do |rep|
         ap rep
         puts '>>> rep order'
         puts rep.errors.full_messages

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -71,5 +71,13 @@ FactoryBot.define do
     trait :submitted do
       after(:create) { |c| c.submit! }
     end
+
+    trait :rejected do
+      after(:create) do |claim|
+        claim.submit!
+        allocate_claim(claim)
+        claim.reject!
+      end
+    end
   end
 end

--- a/spec/presenters/management_information_presenter_spec.rb
+++ b/spec/presenters/management_information_presenter_spec.rb
@@ -365,21 +365,21 @@ RSpec.describe ManagementInformationPresenter do
         end
       end
 
-      it 'date allocated' do
+      it 'date allocated_at' do
         presenter.present! do |claim_journeys|
           expect(claim_journeys.first).to include((Time.zone.now - 2.day).strftime('%d/%m/%Y'))
           expect(claim_journeys.second).to include('n/a', 'n/a')
         end
       end
 
-      it 'date of last assessment' do
+      it 'date last assessment completed_at' do
         presenter.present! do |claim_journeys|
-          expect(claim_journeys.first).to include((Time.zone.now - 1.day).strftime('%d/%m/%Y %H:%M'))
+          expect(claim_journeys.first).to include((Time.zone.now - 1.day).strftime('%d/%m/%Y'))
           expect(claim_journeys.second).to include('n/a', 'n/a')
         end
       end
 
-      it 'current/end state' do
+      it 'current or end state' do
         presenter.present! do |claim_journeys|
           expect(claim_journeys.first).to include('authorised')
           expect(claim_journeys.second).to include('submitted')

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Stats::ManagementInformationGenerator do
-  subject(:result) { described_class.call }
-
   let(:frozen_time) { Time.new(2015, 3, 10, 11, 44, 55) }
   let(:report_columns) do
     [
@@ -33,11 +31,14 @@ RSpec.describe Stats::ManagementInformationGenerator do
     ]
   end
 
-  context 'when generating data' do
-    subject(:contents) { result.content.split("\n") }
+  describe '#call' do
+    subject(:call) { described_class.new.call }
+
+    let(:rows) { call.content.split("\n") }
 
     let!(:valid_claims) {
       [
+        create(:submitted_claim),
         create(:allocated_claim),
         create(:authorised_claim),
         create(:part_authorised_claim)
@@ -46,34 +47,30 @@ RSpec.describe Stats::ManagementInformationGenerator do
     let!(:draft_claim) { create(:draft_claim) }
     let!(:non_active_claim) { travel_to(frozen_time) { create(:allocated_claim) } }
 
-    it 'returns CSV content with a header and a row for all active non-draft claims' do
-      expect(contents.size).to eq(valid_claims.size + 1)
+    it 'returns a row for all active non-draft claims' do
+      expect(rows.size).to eq(valid_claims.size + 1)
     end
 
-    it 'has expected columns' do
-      expect(contents.first.split(',')).to match_array(report_columns)
+    it 'has expected headers' do
+      expect(rows.first.split(',')).to match_array(report_columns)
     end
   end
 
-  context 'For logging' do
-    let(:error) { StandardError.new('test error') }
+  context 'when logging without errors' do
+    it 'log start and end' do
+      expect(LogStuff).to receive(:info).twice
+      described_class.call
+    end
+  end
 
-    context 'when successful' do
-      it 'uses LogStuff to log start and end' do
-        expect(LogStuff).to receive(:info).twice
-        described_class.call
-      end
+  context 'when logging errors' do
+    before do
+      allow(CSV).to receive(:generate).and_raise(StandardError)
     end
 
-    context 'when error raised' do
-      before do
-        allow(CSV).to receive(:generate).and_raise error
-      end
-
-      it 'uses LogStuff to log error' do
-        expect(LogStuff).to receive(:error).once
-        described_class.call
-      end
+    it 'uses LogStuff to log error' do
+      expect(LogStuff).to receive(:error).once
+      described_class.call
     end
   end
 end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
 
     let(:report_type) { 'management_information' }
 
-    context 'when the report type is not valid' do
+    context 'with an invalid report type' do
       let(:report_type) { 'some-report-type' }
 
       before { allow(Settings).to receive(:notify_report_errors).and_return(false) }
@@ -20,7 +20,9 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       end
     end
 
-    context 'when there is already a report of that type in progress' do
+    context 'with a valid report type that is already in progress' do
+      let(:report_type) { 'management_information' }
+
       before { Stats::StatsReport.create(report_name: report_type, status: 'started') }
 
       it 'does not create a new report' do
@@ -28,54 +30,55 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
       end
     end
 
-    context 'when there is no report of that type in progress' do
+    context 'with a valid report type that is not already in progress' do
+      let(:report_type) { 'management_information' }
       let(:mocked_result) { Stats::Result.new('some new content', 'csv') }
 
       before { allow(Stats::ManagementInformationGenerator).to receive(:call).and_return(mocked_result) }
 
-      it 'adds a new completed report' do
+      it 'marks report as completed' do
         expect { call_report_generator }
           .to change(Stats::StatsReport.where(report_name: report_type).completed, :count).by 1
       end
 
-      it 'puts data into the new report' do
+      it 'generates report content' do
         call_report_generator
-        new_record = Stats::StatsReport.where(report_name: report_type).completed.last
-        file_path = ActiveStorage::Blob.service.path_for(new_record.document.blob.key)
+        record = Stats::StatsReport.where(report_name: report_type).completed.last
+        file_path = ActiveStorage::Blob.service.path_for(record.document.blob.key)
         expect(File.open(file_path).read).to eq('some new content')
       end
     end
 
-    context 'when an error happens during the generation of the report' do
+    context 'with an unexpected error' do
       before do
         allow(Stats::ManagementInformationGenerator).to receive(:call).and_raise(StandardError)
+      end
+
+      it 'marks report as errored' do
+        expect {
+          call_report_generator rescue nil
+        }.to change { Stats::StatsReport.where(report_name: report_type).errored.count }.from(0).to(1)
       end
 
       it 'raises the error' do
         expect { call_report_generator }.to raise_error(StandardError)
       end
 
-      it 'creates a new report marked as errored' do
-        expect {
-          call_report_generator rescue nil
-        }.to change { Stats::StatsReport.where(report_name: report_type).errored.count }.from(0).to(1)
-      end
-
-      context 'when the error notifications are enabled' do
+      context 'with notifications enabled' do
         before do
           allow(Settings).to receive(:notify_report_errors).and_return(true)
-        end
-
-        it 'sends an error notification' do
           allow(ActiveSupport::Notifications).to receive(:instrument)
           call_report_generator rescue nil
+        end
+
+        it 'sends an error notification with expected args' do
           record = Stats::StatsReport.where(report_name: report_type).errored.first
           args = ['call_failed.stats_report', id: record.id, name: report_type, error: instance_of(StandardError)]
           expect(ActiveSupport::Notifications).to have_received(:instrument).with(*args)
         end
       end
 
-      context 'when the error notifications are disabled' do
+      context 'with notifications disabled' do
         before do
           allow(Settings).to receive(:notify_report_errors).and_return(false)
           allow(ActiveSupport::Notifications).to receive(:instrument)

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -19,8 +19,8 @@ module FactoryHelpers
 
   def allocate_claim(claim)
     publicise_errors(claim) { claim.submit! }
-    case_worker = create :case_worker
-    case_worker_admin = create :case_worker, :admin
+    case_worker = create(:case_worker)
+    case_worker_admin = create(:case_worker, :admin)
     allocator_options = {
       current_user: case_worker_admin.user,
       case_worker_id: case_worker.id,


### PR DESCRIPTION
#### What
Provide 2 additional MI reports, only AGFS and only LGFS

#### Ticket

[CFP-198](https://dsdmoj.atlassian.net/browse/CFP-198)

#### Why
The number of returned by the existing MI report is
prohibitively large, making the case worker use of it
,including fitlering and extracting to other reports
difficult and cumbersome.

The report is used by 2 distinct teams, one for AGFS
claims and one for LGFS so providing two separate
reports, split by scheme, provides more applicable datasets
of a smaller size and thereby thereby easing case worker
manipulation of the data.

#### How
Pass in scheme as an optional scope on the base relational
query.