### PR TITLE
Undo MI report's completed_at format change

### DIFF
--- a/app/presenters/concerns/management_information_reportable.rb
+++ b/app/presenters/concerns/management_information_reportable.rb
@@ -65,7 +65,7 @@ module ManagementInformationReportable
 
     def completed_at
       completion_steps = @journey.select { |step| COMPLETED_STATES.include?(step.to) }
-      completion_steps.present? ? completion_steps.first.created_at.strftime('%d/%m/%Y') : 'n/a'
+      completion_steps.present? ? completion_steps.first.created_at.strftime('%d/%m/%Y %H:%M') : 'n/a'
     end
 
     def current_or_end_state

--- a/spec/presenters/management_information_presenter_spec.rb
+++ b/spec/presenters/management_information_presenter_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe ManagementInformationPresenter do
 
       it 'date last assessment completed_at' do
         presenter.present! do |claim_journeys|
-          expect(claim_journeys.first).to include((Time.zone.now - 1.day).strftime('%d/%m/%Y'))
+          expect(claim_journeys.first).to include((Time.zone.now - 1.day).strftime('%d/%m/%Y %H:%M'))
           expect(claim_journeys.second).to include('n/a', 'n/a')
         end
       end


### PR DESCRIPTION
#### What
Partial reversion of [commit](f9d369c3f2cf0091a86d0d1f81751ba4f3a15581)

#### Ticket

relates to MI report split ticket [CFP-198](https://dsdmoj.atlassian.net/browse/CFP-198)

#### Why
A couple of caseworkers have come back to say they need the timestamp.

Needs to be confirmed with BAs first **[confirmed]**