### PR TITLE
[CFP-237] Migrate caseworkers table to Design System 2/3

### DIFF
--- a/app/views/case_workers/admin/case_workers/index.html.haml
+++ b/app/views/case_workers/admin/case_workers/index.html.haml
@@ -8,32 +8,32 @@
 
 = render partial: 'shared/search_form', locals: { search_path: case_workers_admin_case_workers_path(anchor: 'search-button'), hint_text: t('hint.search_caseworker'), button_text: t('search.caseworkers') }
 
-.table-container
-  %table.report
-    %caption
-      = t('.caption')
-    %thead
-      %th{ scope: 'col' }
-        = t('.surname')
-      %th{ scope: 'col' }
-        = t('.name')
-      %th{ scope: 'col' }
-        = t('.location')
-      %th{ scope: 'col' }
-        = t('.actions')
-    %tbody
-      - @case_workers.each do |case_worker|
-        %tr
-          %td
-            = case_worker.user.last_name
-          %td
-            = case_worker.user.first_name
-          %td
-            = case_worker.location.name
-          %td.user-controls
-            - if case_worker.active?
-              = govuk_link_to t('common.edit'), edit_case_workers_admin_case_worker_path(case_worker), 'aria-label': t('.edit_link_label', case_worker: case_worker.name)
-              = ' | '
-              = govuk_link_to t('common.delete'), case_workers_admin_case_worker_path(case_worker), method: :delete, data: { confirm: t('.confirmation') }, 'aria-label': t('.delete_link_label', case_worker: case_worker.name)
-            - else
-              Inactive
+
+.govuk-grid-row{class: 'govuk-!-margin-top-9'}
+  .govuk-grid-column-full
+
+    = govuk_table(class: 'report') do
+      = govuk_table_caption(class: 'govuk-visually-hidden') do
+        = t('.caption')
+
+      = govuk_table_thead_collection [t('.surname'),
+      t('.name'),
+      t('.location'),
+      t('.actions')]
+
+      = govuk_table_tbody do
+        - @case_workers.each do |case_worker|
+          = govuk_table_row do
+            = govuk_table_td('data-label': t('.surname')) { case_worker.user.last_name }
+
+            = govuk_table_td('data-label': t('.name')) { case_worker.user.first_name }
+
+            = govuk_table_td('data-label': t('.location')) { case_worker.location.name }
+
+            = govuk_table_td('data-label': t('.actions')) do
+              - if case_worker.active?
+                .app-link-group
+                  = govuk_link_to(t('.edit_caseworker_html', case_worker: case_worker.name), edit_case_workers_admin_case_worker_path(case_worker))
+                  = govuk_link_to(t('.delete_caseworker_html', case_worker: case_worker.name), case_workers_admin_case_worker_path(case_worker), method: :delete, data: { confirm: t('.confirmation') })
+              - else
+                = t('.inactive')

--- a/app/views/case_workers/admin/case_workers/show.html.haml
+++ b/app/views/case_workers/admin/case_workers/show.html.haml
@@ -2,21 +2,16 @@
   = t('.page_title', caseworker: @case_worker.name)
 
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
-%table
-  %caption
-    = t('.page_heading')
 
-  %tbody
-    %tr
-      %th{ scope: 'row' }
-        = t('.roles')
-      %td
-        = @case_worker.roles.map(&:humanize).join(', ')
+.govuk-grid-row
+  .govuk-grid-column-full
 
-- if can? :edit, @case_worker
-  .form-group
-    = govuk_link_button(t('.edit_html'), edit_case_workers_admin_case_worker_path(@case_worker))
+    = govuk_summary_list do
+      = govuk_summary_list_row(t('.roles')) { @case_worker.roles.map(&:humanize).join(', ') }
 
-- if can? :change_password, @case_worker
-  .form-group
-    = govuk_link_to t('.change_password'), change_password_case_workers_admin_case_worker_path(@case_worker)
+    .govuk-button-group
+      - if can? :edit, @case_worker
+        = govuk_link_button(t('.edit_html'), edit_case_workers_admin_case_worker_path(@case_worker))
+
+      - if can? :change_password, @case_worker
+        = govuk_link_to t('.change_password'), change_password_case_workers_admin_case_worker_path(@case_worker)

--- a/app/webpack/stylesheets/_links.scss
+++ b/app/webpack/stylesheets/_links.scss
@@ -33,3 +33,7 @@
 .delete-draft {
   color: $red;
 }
+
+.app-link-group .govuk-link {
+  @include govuk-responsive-margin(2, "right");
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2297,14 +2297,15 @@ en:
           location: Location
           actions: Manage details
           confirmation: Are you sure?
-          delete_link_label: "Delete case worker: %{case_worker}"
-          edit_link_label: "Edit case worker: %{case_worker}"
-          caption: Case worker list
+          delete_caseworker_html: 'Delete <span class="govuk-visually-hidden">case worker: %{case_worker}</span>'
+          edit_caseworker_html: 'Edit <span class="govuk-visually-hidden">case worker: %{case_worker}</span>'
+          caption: Case workers
           create_case_worker: Create a new case worker
           page_heading: Case workers
           summary: A list of case workers, ordered by surname. Edit and delete links in the last column.
           hint:
             search: for example case worker name
+          inactive: Inactive
         form:
           first_name: *first_name
           last_name: *last_name


### PR DESCRIPTION
#### What
Migrate caseworkers table markup to the GOVUK Design System Table markup.

#### Ticket
[Migrate caseworkers table markup to the GOVUK Design System Table](https://dsdmoj.atlassian.net/browse/CFP-237)

#### Why
Part of a larger change to:

- continue migration to GOVUK Frontend
- resolve accessibility issues identified in the 2020 DAC report
- reduce then remove deprecated code
