### PR TITLE
Apply rubocop `Rails/FilePath` `argument` style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,9 @@ Metrics/BlockLength:
     - trait
     - define
 
+Rails/FilePath:
+  EnforcedStyle: arguments
+
 Rails/SquishedSQLHeredocs:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2429,28 +2429,6 @@ Rails/DynamicFindBy:
     - 'spec/models/stats/collector/claim_redeterminations_collector_spec.rb'
     - 'spec/models/stats/collector/claim_submissions_collector_spec.rb'
 
-# Offense count: 18
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: slashes, arguments
-Rails/FilePath:
-  Exclude:
-    - 'app/models/claim/transfer_brain_data_item_collection.rb'
-    - 'app/models/claim_json_schema_validator.rb'
-    - 'app/models/claim_state_transition_reason.rb'
-    - 'app/models/stats/collector/time_to_completion_collector.rb'
-    - 'lib/data_migrator/provider_suppliers_migrator.rb'
-    - 'lib/extensions/rails_module_extension.rb'
-    - 'lib/performance_platform/reports.rb'
-    - 'spec/lib/working_day_calculator_spec.rb'
-    - 'spec/models/claim/advocate_claim_spec.rb'
-    - 'spec/models/stats/collector/time_to_completion_collector_spec.rb'
-    - 'spec/presenters/error_message/presenter_spec.rb'
-    - 'spec/rails_helper.rb'
-    - 'spec/support/api/api_test_client.rb'
-    - 'spec/support/matchers/validation_matchers.rb'
-    - 'spec/support/seed_helpers.rb'
-    - 'spec/support/validation_helpers.rb'
-
 # Offense count: 12
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/app/models/claim/transfer_brain_data_item_collection.rb
+++ b/app/models/claim/transfer_brain_data_item_collection.rb
@@ -79,7 +79,7 @@ module Claim
     end
 
     def read_csv
-      file = File.join(Rails.root, 'config', 'transfer_brain_data_items.csv')
+      file = Rails.root.join('config', 'transfer_brain_data_items.csv')
       csv_content = File.read(file)
       CSV.parse(csv_content, headers: true)
     end

--- a/app/models/claim_json_schema_validator.rb
+++ b/app/models/claim_json_schema_validator.rb
@@ -1,6 +1,6 @@
 class ClaimJsonSchemaValidator
-  CCR_SCHEMA_FILE = File.join(Rails.root, 'config', 'schemas', 'ccr_claim_schema.json').freeze
-  CCLF_SCHEMA_FILE = File.join(Rails.root, 'config', 'schemas', 'cclf_claim_schema.json').freeze
+  CCR_SCHEMA_FILE = Rails.root.join('config', 'schemas', 'ccr_claim_schema.json').freeze
+  CCLF_SCHEMA_FILE = Rails.root.join('config', 'schemas', 'cclf_claim_schema.json').freeze
 
   class << self
     def ccr_schema

--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -46,7 +46,7 @@ class ClaimStateTransitionReason
 
     def translations_file
       @translations_file ||=
-        File.join(Rails.root, 'config', 'locales', "claim_state_transition_reason.#{I18n.locale}.yml")
+        Rails.root.join('config', 'locales', "claim_state_transition_reason.#{I18n.locale}.yml")
     end
 
     def disbursement_only?(claim)

--- a/app/models/stats/collector/time_to_completion_collector.rb
+++ b/app/models/stats/collector/time_to_completion_collector.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, 'lib', 'working_day_calculator')
+require Rails.root.join('lib', 'working_day_calculator')
 
 module Stats
   module Collector

--- a/lib/data_migrator/provider_suppliers_migrator.rb
+++ b/lib/data_migrator/provider_suppliers_migrator.rb
@@ -28,7 +28,7 @@ module DataMigrator
     attr_reader :seed_file, :dry_run
 
     def default_seed_file
-      File.join(Rails.root, 'db/data/providers.csv')
+      Rails.root.join('db', 'data', 'providers.csv')
     end
 
     def reset_totals

--- a/lib/extensions/rails_module_extension.rb
+++ b/lib/extensions/rails_module_extension.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, 'lib', 'rails_host.rb')
+require Rails.root.join('lib', 'rails_host.rb')
 
 module RailsModuleExtension
   def host

--- a/lib/performance_platform/reports.rb
+++ b/lib/performance_platform/reports.rb
@@ -15,7 +15,8 @@ module PerformancePlatform
     private
 
     def yaml_file
-      YAML.safe_load(ERB.new(IO.read("#{Rails.root}/config/performance_platform.yml")).result, [Symbol])
+      file = Rails.root.join('config', 'performance_platform.yml')
+      YAML.safe_load(ERB.new(IO.read(file)).result, [Symbol])
     end
   end
 end

--- a/lib/rule.rb
+++ b/lib/rule.rb
@@ -1,1 +1,1 @@
-Dir[Rails.root.join('lib/rule/**/*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('lib', 'rule', '**', '*.rb')].sort.each { |f| require f }

--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec::Matchers.define :be_valid_cclf_claim_json do
   match do |response|
-    schema_path = ClaimJsonSchemaValidator::CCLF_SCHEMA_FILE
-    @errors = JSON::Validator.fully_validate(schema_path, response.respond_to?(:body) ? response.body : response)
+    schema = ClaimJsonSchemaValidator.cclf_schema
+    @errors = JSON::Validator.fully_validate(schema, response.respond_to?(:body) ? response.body : response)
     @errors.empty?
   end
 

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec::Matchers.define :be_valid_ccr_claim_json do
   match do |response|
-    schema_path = ClaimJsonSchemaValidator::CCR_SCHEMA_FILE
-    @errors = JSON::Validator.fully_validate(schema_path, response.respond_to?(:body) ? response.body : response)
+    schema = ClaimJsonSchemaValidator.ccr_schema
+    @errors = JSON::Validator.fully_validate(schema, response.respond_to?(:body) ? response.body : response)
     @errors.empty?
   end
 

--- a/spec/lib/working_day_calculator_spec.rb
+++ b/spec/lib/working_day_calculator_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require File.join(Rails.root, 'lib', 'working_day_calculator')
+require Rails.root.join('lib', 'working_day_calculator')
 
 describe WorkingDayCalculator do
   let(:tue_19_jul) { Date.new(2016, 7, 19) }

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -883,7 +883,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
 
   describe 'Case type scopes' do
     before(:all) do
-      @case_types = load("#{Rails.root}/db/seeds/case_types.rb")
+      load(Rails.root.join('db', 'seeds', 'case_types.rb'))
       @trials = create_list(:submitted_claim, 2, case_type: CaseType.by_type('Trial'))
       @retrials = create_list(:submitted_claim, 2, case_type: CaseType.by_type('Retrial'))
       @cracked_trials = create_list(:submitted_claim, 2, case_type: CaseType.by_type('Cracked Trial'))

--- a/spec/models/stats/collector/time_to_completion_collector_spec.rb
+++ b/spec/models/stats/collector/time_to_completion_collector_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require File.join(Rails.root, 'lib', 'demo_data', 'claim_state_advancer')
+require Rails.root.join('lib', 'demo_data', 'claim_state_advancer')
 
 module Stats
   module Collector

--- a/spec/presenters/error_message_spec.rb
+++ b/spec/presenters/error_message_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ErrorMessage do
   describe '.default_translation_file' do
     subject { described_class.default_translation_file }
 
-    it { is_expected.to eq(Rails.root.join('config/locales/en/error_messages/claim.yml')) }
+    it { is_expected.to eq(Rails.root.join('config', 'locales', 'en', 'error_messages', 'claim.yml')) }
   end
 
   describe '.translation_file_for' do
@@ -13,7 +13,7 @@ RSpec.describe ErrorMessage do
     let(:model_name) { 'claim' }
 
     context 'with default locale' do
-      it { is_expected.to eq(Rails.root.join('config/locales/en/error_messages/claim.yml')) }
+      it { is_expected.to eq(Rails.root.join('config', 'locales', 'en', 'error_messages', 'claim.yml')) }
     end
 
     context 'with welsh locale and `provider`' do
@@ -21,7 +21,7 @@ RSpec.describe ErrorMessage do
 
       let(:model_name) { 'provider' }
 
-      it { is_expected.to eq(Rails.root.join('config/locales/cy/error_messages/provider.yml')) }
+      it { is_expected.to eq(Rails.root.join('config', 'locales', 'cy', 'error_messages', 'provider.yml')) }
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,7 +77,7 @@ require 'sidekiq/testing'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -170,10 +170,10 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     # to delete files from filesystem that were generated during rspec tests
-    FileUtils.rm_rf('./public/assets/test/images/')
+    FileUtils.rm_rf(Rails.root.join('public', 'assets', 'test', 'images'))
     # Deletes report files created during the test suite run
-    FileUtils.rm_rf("#{Rails.root}/tmp/test/reports/")
-    FileUtils.rm_rf(Dir["#{Rails.root}/tmp/[^.]*documents.zip"])
+    FileUtils.rm_rf(Rails.root.join('tmp', 'test', 'reports'))
+    FileUtils.rm_rf(Dir[Rails.root.join('tmp', '[^.]*documents.zip')])
     VatRate.delete_all
   end
 

--- a/spec/support/api/api_test_client.rb
+++ b/spec/support/api/api_test_client.rb
@@ -21,7 +21,7 @@
 
 require 'caching/api_request'
 require 'rest-client'
-Dir[File.join(Rails.root, 'spec', 'support', 'api', 'claims', '*.rb')].each { |file| require file }
+Dir[Rails.root.join('spec', 'support', 'api', 'claims', '*.rb')].each { |file| require file }
 
 class ApiTestClient
   include Debuggable


### PR DESCRIPTION
#### What
Apply rubocop `Rails/FilePath` `argument` style

#### Why

To adhere to one style throughout the app, which mainly
uses the argument style, baring these examples.

Also rely on Pathname object to be usable everywhere a
string path is usable. This should be generally true
and tests should seriously fail if not but will need sanity
testing.