### PR TITLE
Bug report changes on top of feedback changes

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -14,9 +14,9 @@ class FeedbackController < ApplicationController
     @feedback = Feedback.new(merged_feedback_params)
 
     if @feedback.save
-      redirect_to after_create_url, notice: 'Feedback submitted'
+      redirect_to after_create_url, notice: @feedback.response_message
     else
-      flash.now[:error] = @feedback.response_failed_message if @feedback.response_failed_message
+      flash.now[:error] = @feedback.response_message
       render "feedback/#{@feedback.type}"
     end
   end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -40,14 +40,8 @@ class FeedbackController < ApplicationController
     if current_user
       current_user.email
     else
-      email_from_user_id || params[:feedback][:email] || 'anonymous'
+      params[:feedback][:email] || 'anonymous'
     end
-  end
-
-  def email_from_user_id
-    User.active.find(params[:user_id])&.email
-  rescue ActiveRecord::RecordNotFound
-    nil
   end
 
   def after_create_url

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -64,7 +64,10 @@ class Feedback
     ZendeskSender.send!(self)
     @response_message = 'Fault reported'
   rescue ZendeskAPI::Error::ClientError => e
-    @response_message = "Unable to submit fault report [#{e}]"
+    @response_message = 'Unable to submit fault report'
+    LogStuff.error(class: self.class, action: 'save', error_class: e.class, error: e.to_s) do
+      'Bug report submisson failed!'
+    end
     false
   end
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -9,7 +9,7 @@ class Feedback
 
   attr_accessor :email, :referrer, :user_agent, :type
   attr_accessor :event, :outcome, :case_number
-  attr_accessor :task, :rating, :comment, :reason, :other_reason, :response_failed_message
+  attr_accessor :task, :rating, :comment, :reason, :other_reason, :response_message
 
   validates :type, inclusion: { in: FEEDBACK_TYPES.keys.map(&:to_s) }
   validates :event, :outcome, presence: true, if: :bug_report?
@@ -35,7 +35,7 @@ class Feedback
   end
 
   def save
-    return false unless valid?
+    return unless valid?
     return save_feedback if feedback?
     save_bug_report
   end
@@ -52,20 +52,23 @@ class Feedback
 
   def save_feedback
     response = SurveyMonkeySender.call(self)
-    @response_failed_message = "Unable to submit feedback [#{response[:error_code]}]" unless response[:success]
+    @response_message = if response[:success]
+                          'Feedback submitted'
+                        else
+                          "Unable to submit feedback [#{response[:error_code]}]"
+                        end
     response[:success]
   end
 
   def save_bug_report
-    ZendeskSender.send!(self) unless is_feedback_with_empty_comment?
-    true
+    ZendeskSender.send!(self)
+    @response_message = 'Fault reported'
+  rescue ZendeskAPI::Error::ClientError => e
+    @response_message = "Unable to submit fault report [#{e}]"
+    false
   end
 
   def feedback_type_attributes
     FEEDBACK_TYPES[type.to_sym]
-  end
-
-  def is_feedback_with_empty_comment?
-    feedback? && comment.to_s.empty?
   end
 end

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -9,8 +9,6 @@
       = f.hidden_field :type
       = f.hidden_field :referrer
       = hidden_field_tag 'ga_client_id', '', class: 'ga-client-id'
-      - if params[:user_id].present?
-        = hidden_field_tag :user_id, params[:user_id]
 
       = f.govuk_error_summary
 

--- a/features/bug_report.feature
+++ b/features/bug_report.feature
@@ -1,0 +1,48 @@
+@javascript @no-seed
+Feature: A user can provide a bug report
+
+  @stub_successful_zendesk_request
+  Scenario: A logged in user can successfully submit a bug report
+    Given I am a signed in advocate admin
+    And I am on the 'Your claims' page
+
+    When I click the link 'report a fault'
+    Then I should see a page title "Bug report"
+    And I should not see 'What is your email address? (Optional)'
+
+    When I fill in 'What you were doing when the fault occurred?' with 'Filling in a new claim form'
+    And I fill in 'What went wrong?' with 'Something went wrong'
+    And I click the button 'Send'
+
+    Then I see confirmation that my 'bug report' was received
+    And I should be on the your claims page
+
+  @stub_successful_zendesk_request
+  Scenario: A logged out user can successfully submit a bug report
+    Given I visit "/"
+    When I click the link 'report a fault'
+    Then I should see a page title "Bug report"
+    And the page should be accessible
+
+    When I fill in 'What you were doing when the fault occurred?' with 'Filling in a new claim form'
+    And I fill in 'What went wrong?' with 'Something went wrong'
+    And I fill in 'What is your email address? (Optional)' with 'joe.bloggs@example.com'
+    And I click the button 'Send'
+
+    Then I see confirmation that my 'bug report' was received
+    And I should be on the sign in page
+
+  @stub_failed_zendesk_request
+  Scenario: A user unsuccessfully submits a bug report
+    Given I visit "/"
+    When I click the link 'report a fault'
+    Then I should see a page title "Bug report"
+    And the page should be accessible
+
+    When I fill in 'What you were doing when the fault occurred?' with 'Filling in a new claim form'
+    And I fill in 'What went wrong?' with 'Something went wrong'
+    And I fill in 'What is your email address? (Optional)' with 'joe.bloggs@example.com'
+    And I click the button 'Send'
+
+    Then I see a warning that my bug report was not submitted successfully
+    And I should be on the bug report page

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -1,5 +1,5 @@
 @javascript @no-seed
-Feature: A user can provide feedback and bug report
+Feature: A user can provide feedback
   @stub_survey_monkey_success
   Scenario: A user can successfully submit feedback
     Given I visit "/"
@@ -33,17 +33,3 @@ Feature: A user can provide feedback and bug report
 
     Then I see a warning that my feedback was not submitted successfully
     And I should be on the feedback page
-
-  @stub_zendesk_request
-  Scenario: A user can successfully submit a bug report
-    Given I visit "/"
-    When I click the link 'report a fault'
-    Then I should see a page title "Bug report"
-    Then the page should be accessible
-
-    And I fill in 'What you were doing when the fault occurred?' with 'Filling in a new claim form'
-    And I fill in 'What went wrong?' with 'Something went wrong'
-    And I fill in 'What is your email address? (Optional)' with 'joe.bloggs@example.com'
-    And I click the button 'Send'
-    And I see confirmation that my 'bug report' was received
-    Then I should be on the sign in page

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -2,26 +2,21 @@ When(/^I have not signed in$/) do
   visit new_user_session_path
 end
 
-Then(/^I expect ZendeskSender to receive a description (with|without) an email$/) do |visibility|
-  if (visibility == 'with')
-    regex = /email:\s\w/
-  else
-    regex = /email:\s\"/
-  end
-  expect(@called_zendesk.with { |req| regex.match(req.body) }).to have_been_made.once
-end
-
-Then(/^I see confirmation that my '(.*?)' was received$/) do |payload|
-  case payload
+Then(/^I see confirmation that my '(.*?)' was received$/) do |feedback_type|
+  case feedback_type
   when 'feedback'
-    expect(page).to have_content "Feedback submitted"
+    expect(page).to have_govuk_notification_banner(key: :notice, text: 'Feedback submitted')
   when 'bug report'
-    expect(page).to have_content "Feedback submitted"
+    expect(page).to have_govuk_notification_banner(key: :notice, text: 'Fault reported')
   end
 end
 
 Then('I see a warning that my feedback was not submitted successfully') do
-  expect(page).to have_content(/Unable to submit feedback \[\d+\]/)
+  have_govuk_notification_banner(key: :error, text: /Unable to submit feedback \[\d+\]/)
+end
+
+Then('I see a warning that my bug report was not submitted successfully') do
+  expect(page).to have_govuk_notification_banner(key: :error, text: /Unable to submit fault report/)
 end
 
 Then(/^I should be informed that I have signed out$/) do
@@ -29,6 +24,10 @@ Then(/^I should be informed that I have signed out$/) do
 end
 
 Then(/^I should be on the feedback page$/) do
+  expect(current_path).to eq(feedback_index_path)
+end
+
+Then(/^I should be on the bug report page$/) do
   expect(current_path).to eq(feedback_index_path)
 end
 

--- a/features/support/stub_zendesk_requests.rb
+++ b/features/support/stub_zendesk_requests.rb
@@ -1,6 +1,19 @@
 require 'webmock/cucumber'
 
-Before('@stub_zendesk_request') do
+Before('@stub_successful_zendesk_request') do
   stub_request(:post, %r{\Ahttps://.*ministryofjustice.zendesk.com/api/v2/tickets\z})
-    .to_return(status: 200, body: "stubbed response", headers: {})
+    .to_return(status: 201, body: successful_zendesk_body, headers: { 'Content-Type' => 'application/json'})
+end
+
+Before('@stub_failed_zendesk_request') do
+  stub_request(:post, %r{\Ahttps://.*ministryofjustice.zendesk.com/api/v2/tickets\z})
+    .to_return(status: 403, body: unsuccessful_zendesk_body, headers: { 'Content-Type' => 'application/json'})
+end
+
+def successful_zendesk_body
+  { item: {} }.to_json
+end
+
+def unsuccessful_zendesk_body
+  { error: 'RecordInvalid' }.to_json
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -107,13 +107,19 @@ RSpec.describe Feedback, type: :model do
       context 'when zendesk submission fails' do
         before do
           allow(ZendeskAPI::Ticket).to receive(:create!).and_raise ZendeskAPI::Error::ClientError, 'oops, something went wrong'
+          allow(LogStuff).to receive(:error)
         end
 
         it { expect(bug_report.save).to be_falsey }
 
         it 'stores failure message on object' do
           bug_report.save
-          expect(bug_report.response_message).to eq('Unable to submit fault report [oops, something went wrong]')
+          expect(bug_report.response_message).to eq('Unable to submit fault report')
+        end
+
+        it 'logs error details' do
+          bug_report.save
+          expect(LogStuff).to have_received(:error).with(class: described_class, action: 'save', error_class: ZendeskAPI::Error::ClientError, error: 'oops, something went wrong')
         end
       end
     end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Feedback, type: :model do
   let(:params) do
     {
-      email: 'example@example.com',
       user_agent: 'Firefox',
       referrer: '/index'
     }
@@ -12,7 +11,7 @@ RSpec.describe Feedback, type: :model do
   it { is_expected.to validate_inclusion_of(:type).in_array(%w(feedback bug_report)) }
 
   context 'feedback' do
-    subject(:feedback) { Feedback.new(feedback_params) }
+    subject(:feedback) { described_class.new(feedback_params) }
 
     let(:feedback_params) do
       params.merge(type: 'feedback', task: '1', rating: '4', comment: 'lorem ipsum', reason: ['', '1', '2'], other_reason: 'dolor sit')
@@ -40,114 +39,104 @@ RSpec.describe Feedback, type: :model do
     end
 
     describe '#is?' do
-      context 'feedback' do
-        it 'is true for feedback' do
-          expect(feedback.is?(:feedback)).to eq(true)
-        end
+      context 'with feedback type' do
+        it { expect(feedback.is?(:feedback)).to be true }
       end
 
-      context 'bug report' do
-        it 'is false for feedback' do
-          expect(feedback.is?(:bug_report)).to eq(false)
-        end
+      context 'with bug report type' do
+        it { expect(feedback.is?(:bug_report)).to be false }
       end
     end
   end
 
   context 'bug report' do
+    subject(:bug_report) { described_class.new(bug_report_params) }
+
     let(:bug_report_params) do
-      params.merge(type: 'bug_report', case_number: 'XXX', event: 'lorem', outcome: 'ipsum')
+      params.merge(type: 'bug_report', case_number: 'XXX', event: 'lorem', outcome: 'ipsum', email: 'example@example.com')
     end
 
-    subject { Feedback.new(bug_report_params) }
+    it { expect(bug_report.email).to eq('example@example.com') }
+    it { expect(bug_report.case_number).to eq('XXX') }
+    it { expect(bug_report.event).to eq('lorem') }
+    it { expect(bug_report.outcome).to eq('ipsum') }
+    it { expect(bug_report.user_agent).to eq('Firefox') }
+    it { expect(bug_report.referrer).to eq('/index') }
 
     it { is_expected.to_not validate_inclusion_of(:rating).in_array(('1'..'5').to_a) }
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:outcome) }
     it { is_expected.to_not validate_presence_of(:case_number) }
-
-    describe '#initialize' do
-      it 'sets the email' do
-        expect(subject.email).to eq('example@example.com')
-      end
-
-      it 'sets the case_number' do
-        expect(subject.case_number).to eq('XXX')
-      end
-
-      it 'sets the event' do
-        expect(subject.event).to eq('lorem')
-      end
-
-      it 'sets the outcome' do
-        expect(subject.outcome).to eq('ipsum')
-      end
-
-      it 'sets the user_agent' do
-        expect(subject.user_agent).to eq('Firefox')
-      end
-
-      it 'sets the referrer' do
-        expect(subject.referrer).to eq('/index')
-      end
-    end
+    it { is_expected.to be_bug_report }
+    it { is_expected.not_to be_feedback }
 
     describe '#save' do
-      before do
-        allow(ZendeskAPI::Ticket).to receive(:create!).and_return(true)
-      end
+      context 'when valid and successful' do
+        let(:ticket) { instance_double(ZendeskAPI::Ticket) }
 
-      context 'when valid' do
-        it 'creates zendesk ticket and returns true' do
-          expect(ZendeskSender).to receive(:send!)
-          expect(subject.save).to eq(true)
+        before do
+          allow(ZendeskAPI::Ticket).to receive(:create!).and_return(ticket)
+          allow(ZendeskSender).to receive(:send!)
+        end
+
+        it 'calls zendesk sender' do
+          bug_report.save
+          expect(ZendeskSender).to have_received(:send!)
+        end
+
+        it { expect(bug_report.save).to be_truthy }
+
+        it 'stores success message on object' do
+          bug_report.save
+          expect(bug_report.response_message).to eq('Fault reported')
         end
       end
 
-      context 'when invalid' do
-        it 'returns false' do
-          subject.event = nil
-          subject.outcome = nil
-          expect(subject.save).to eq(false)
+      context 'when bug report has no outcome' do
+        before { bug_report.outcome = nil }
+
+        it { expect(bug_report.save).to be_falsey }
+      end
+
+      context 'when bug report has no event' do
+        before { bug_report.event = nil }
+
+        it { expect(bug_report.save).to be_falsey }
+      end
+
+      context 'when zendesk submission fails' do
+        before do
+          allow(ZendeskAPI::Ticket).to receive(:create!).and_raise ZendeskAPI::Error::ClientError, 'oops, something went wrong'
+        end
+
+        it { expect(bug_report.save).to be_falsey }
+
+        it 'stores failure message on object' do
+          bug_report.save
+          expect(bug_report.response_message).to eq('Unable to submit fault report [oops, something went wrong]')
         end
       end
     end
 
     describe '#subject' do
       it 'returns the subject heading' do
-        expect(subject.subject).to eq('Bug report (test)')
+        expect(bug_report.subject).to eq('Bug report (test)')
       end
     end
 
     describe '#description' do
       it 'returns the description' do
-        expect(subject.description).to eq('case_number: XXX - event: lorem - outcome: ipsum - email: example@example.com')
+        expect(bug_report.description).to eq('case_number: XXX - event: lorem - outcome: ipsum - email: example@example.com')
       end
     end
 
     describe '#is?' do
-      context 'feedback' do
-        it 'is false for bug report' do
-          expect(subject.is?(:feedback)).to eq(false)
-        end
+      context 'with feedback type' do
+        it { expect(bug_report.is?(:feedback)).to be false }
       end
 
-      context 'bug report' do
-        it 'is true for bug report' do
-          expect(subject.is?(:bug_report)).to eq(true)
-        end
-      end
-    end
-
-    describe '#feedback?' do
-      it 'is not feedback' do
-        expect(subject).to_not be_feedback
-      end
-    end
-
-    describe '#bug_report?' do
-      it 'is a bug report' do
-        expect(subject).to be_bug_report
+      context 'with bug report type' do
+        it { expect(bug_report.is?(:bug_report)).to be true }
       end
     end
   end

--- a/spec/support/capybara_extensions/govuk_component/matchers.rb
+++ b/spec/support/capybara_extensions/govuk_component/matchers.rb
@@ -25,8 +25,13 @@ module CapybaraExtensions
         has_selector?('h1.govuk-heading-xl', **options)
       end
 
-      def has_govuk_flash?(options = {})
-        has_selector?('.govuk-error-summary', **options)
+      def has_govuk_notification_banner?(**options)
+        key = options.delete(:key)
+
+        [
+          has_selector?(".govuk-notification-banner.govuk-notification-banner--#{key}"),
+          has_selector?('.govuk-notification-banner__content', **options)
+        ].all?
       end
 
       def has_govuk_warning?(text = nil)


### PR DESCRIPTION
Add success and failure for bug report submission

Inline with feedback form changes this changes the
bug report to handle success and failure in a similar
manner.

**Also**, removes code which is no longer needed
or was already "dead". And breaks out
feature tests for the bug report and extends to include
the logged in and logged out workflows.