### PR TITLE
[CFP-236] Migrate Provider tables to the Design System

### DIFF
--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -3,45 +3,20 @@
 
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading', provider_name: @provider.name) }
 
-.table-container
-  %table
-    %caption
-      = t('.table_caption')
-    %tbody
-      %tr
-        %th{ scope: 'row' }
-          = t('.provider_name')
-        %td
-          = @provider.name
-      %tr
-        %th{ scope: 'row' }
-          = t('.api_key')
-        %td#api-key
-          = @provider.api_key
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
 
+    = govuk_summary_list do
+      = govuk_summary_list_row(t('.provider_name')) { @provider.name }
+      = govuk_summary_list_row(t('.api_key')) { @provider.api_key }
       - if @provider.firm?
-        %tr
-          %th{ scope: 'row' }
-            = t('.lgfs_supplier_numbers')
-          %td
-            = @provider.lgfs_supplier_numbers.to_sentence
+        = govuk_summary_list_row(t('.lgfs_supplier_numbers')) { @provider.lgfs_supplier_numbers.to_sentence }
         - if @provider.agfs?
-          %tr
-            %th{ scope: 'row' }
-              = t('.firm_agfs_supplier_number')
-            %td
-              = @provider.firm_agfs_supplier_number
-        %tr
-          %th{ scope: 'row' }
-            = t('.vat_registered')
-          %td
-            = @provider.vat_registered == true ? 'Yes' : 'No'
+          = govuk_summary_list_row(t('.firm_agfs_supplier_number')) { @provider.firm_agfs_supplier_number }
+      = govuk_summary_list_row(t('.vat_registered')) { @provider.vat_registered == true ? t('global_yes') : t('global_no') }
 
-.form-section
-  .govuk-grid-row
-    .govuk-grid-column-one-half
+    .app-link-group
       = button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation'), module: 'govuk-button' }, class: 'govuk-button', draggable: 'false'
-    .govuk-grid-column-one-half
+
       - if can? :edit, @provider
         = govuk_link_button_secondary(t('.edit_provider'), edit_external_users_admin_provider_path(@provider))
-

--- a/app/views/geckoboard_api/statistics/index.html.haml
+++ b/app/views/geckoboard_api/statistics/index.html.haml
@@ -1,9 +1,10 @@
-.body-content
-  = govuk_inset_text do
-    %p
-      Statistics reports in tabular format.
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-l
+      = 'Statistics reports'
 
-    %table
+  .govuk-grid-column-two-thirds
+    %ul.govuk-list.govuk-list--bullet.govuk-list--spaced
       - @available_reports.each do |title, url_part|
-        %tr
-          %td= link_to(title, send("#{url_part}_geckoboard_api_widgets_path", format: 'html'))
+        %li
+          = link_to(title, send("#{url_part}_geckoboard_api_widgets_path", format: 'html'))

--- a/app/views/provider_management/external_users/index.html.haml
+++ b/app/views/provider_management/external_users/index.html.haml
@@ -1,34 +1,33 @@
 = content_for :page_title, flush: true do
   = t('.page_title', provider_name: @provider.name)
 
-= render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
+= render partial: 'layouts/header', locals: { page_heading: t('.page_heading', provider: @provider.name) }
 
-.form-group.form-buttons
-  = govuk_link_button(t('.add_provider'), new_provider_management_provider_external_user_path(@provider))
+.govuk-grid-row
+  .govuk-grid-column-full
 
-%table{ summary: t('.table_summary', provider_name: @provider.name) }
-  %caption
-    %h2.govuk-heading-m
-      = t('.caption', provider_name: @provider.name)
+    = govuk_link_button(t('.add_provider'), new_provider_management_provider_external_user_path(@provider))
 
-  %thead
-    %th{ scope: 'col' }
-      = t('.name')
-    %th{ scope: 'col' }
-      = t('.supplier_number')
-    %th{ scope: 'col' }
-      = t('.email')
-    %th{ scope: 'col' }
-      = t('.state')
+    = govuk_table(class: 'report govuk-!-margin-top-9') do
+      = govuk_table_caption(class: 'govuk-visually-hidden') do
+        = t('.caption', provider_name: @provider.name)
 
-  %tbody
-    - @external_users.each do |advocate|
-      %tr
-        %td
-          = advocate.active? ? govuk_link_to(advocate.name, provider_management_provider_external_user_path(@provider, advocate), 'aria-label': t('.view_details', text: advocate.name)) : advocate.name
-        %td
-          = advocate.supplier_number
-        %td
-          = govuk_mail_to advocate.email, advocate.email, 'aria-label': t('.title', provider: advocate.name)
-        %td
-          = advocate.active? ? t('.live') : t('.inactive')
+      = govuk_table_thead_collection [t('.name'),
+        t('.supplier_number'),
+        t('.email'),
+        t('.state')]
+
+      = govuk_table_tbody do
+        - @external_users.each do |advocate|
+          = govuk_table_row do
+            = govuk_table_td('data-label': t('.name')) do
+              = advocate.active? ? govuk_link_to(advocate.name, provider_management_provider_external_user_path(@provider, advocate), 'aria-label': t('.view_details', text: advocate.name)) : advocate.name
+
+            = govuk_table_td('data-label': t('.supplier_number')) do
+              = advocate.supplier_number
+
+            = govuk_table_td('data-label': t('.email')) do
+              = govuk_mail_to advocate.email, advocate.email, 'aria-label': t('.title', provider: advocate.name)
+
+            = govuk_table_td('data-label': t('.state')) do
+              = advocate.active? ? t('.live') : t('.inactive')

--- a/app/views/provider_management/external_users/show.html.haml
+++ b/app/views/provider_management/external_users/show.html.haml
@@ -1,48 +1,31 @@
 = content_for :page_title, flush: true do
   = t('.page_title', external_user: @external_user.name)
 
-= render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
+= render partial: 'layouts/header', locals: { page_heading: t('.page_heading', external_user: @external_user.name) }
 
-.form-group
-  %table{ summary: t('.table_summary', external_user: @external_user.name) }
-    %caption
-      %h2.govuk-heading-m
-        = t('.caption')
-    %tbody
-      %tr
-        %th{ scope: 'row' }
-          = t('.provider')
-        %td
-          = govuk_link_to @external_user.provider.name, provider_management_provider_path(@provider), 'aria-label': t('.edit_provider')
-      %tr
-        %th{ scope: 'row' }
-          = t('.email')
-        %td
-          = @external_user.email
-      %tr
-        %th{ scope: 'row' }
-          = t('.name')
-        %td
-          = @external_user.name
-      %tr
-        %th{ scope: 'row' }
-          = t('.supplier_number')
-        %td
-          = @external_user.supplier_number
-      %tr
-        %th{ scope: 'row' }
-          = t('.vat_registered')
-        %td
-          = @external_user.vat_registered? ? t('.answer_yes') : t('.answer_no')
-      %tr
-        %th{ scope: 'row' }
-          = t('.role')
-        %td
-          = @external_user.roles.map(&:humanize).join(', ')
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
 
-.form-group
-  - if can? :edit, @external_user
-    = govuk_link_button(t('.edit'), edit_provider_management_provider_external_user_path(@provider, @external_user))
+    = govuk_summary_list do
+      = govuk_summary_list_row(t('.provider')) do
+        = govuk_link_to @external_user.provider.name, provider_management_provider_path(@provider), 'aria-label': t('.edit_provider')
 
-  - if can? :change_password, @external_user
-    = govuk_link_button(t('.change_password'), change_password_provider_management_provider_external_user_path(@provider, @external_user))
+      = govuk_summary_list_row(t('.email')) do
+        = govuk_mail_to @external_user.email, @external_user.email
+
+      = govuk_summary_list_row(t('.name')) { @external_user.name }
+
+      = govuk_summary_list_row(t('.supplier_number')) { @external_user.supplier_number }
+
+      = govuk_summary_list_row(t('.vat_registered')) do
+        = @external_user.vat_registered? ? t('.answer_yes') : t('.answer_no')
+
+      = govuk_summary_list_row(t('.role')) do
+        = @external_user.roles.map(&:humanize).join(', ')
+
+    .govuk-button-group
+      - if can? :edit, @external_user
+        = govuk_link_button(t('.edit'), edit_provider_management_provider_external_user_path(@provider, @external_user))
+
+      - if can? :change_password, @external_user
+        = govuk_link_button_secondary(t('.change_password'), change_password_provider_management_provider_external_user_path(@provider, @external_user))

--- a/app/views/provider_management/providers/_providers.html.haml
+++ b/app/views/provider_management/providers/_providers.html.haml
@@ -1,34 +1,35 @@
-- if providers.none?
-  %p
-    = t('.no_provider')
+.govuk-grid-row{class: 'govuk-!-margin-top-9'}
+  .govuk-grid-column-full
 
-- else
-  %table{ summary: t('.table_summary') }
-    %caption.govuk-visually-hidden
-      = t('.caption')
+    - if providers.none?
+      %p
+        = t('.no_provider')
 
-    %thead
-      %th{ scope: 'col' }
-        = t('.provider_name')
-      %th{ scope: 'col' }
-        = t('.provider_type')
-      %th{ scope: 'col' }
-        = t('.fee_schemes')
-      %th{ scope: 'col' }
-        = t('.vat_registered')
-      %th{ scope: 'col' }
-        = t('.users')
+    - else
+      = govuk_table(class: 'report') do
+        = govuk_table_caption(class: 'govuk-visually-hidden') do
+          = t('.caption')
 
-    %tbody
-      - providers.each do |provider|
-        %tr{ id: dom_id(provider) }
-          %td
-            = govuk_link_to provider.name, provider_management_provider_path(provider)
-          %td
-            = provider.provider_type.humanize
-          %td
-            = provider.roles.map(&:upcase) * ', '
-          %td
-            = provider.vat_registered == true ? t('global_yes') : t('global_no')
-          %td
-            = govuk_link_to t('.manage_user'), provider_management_provider_external_users_path(provider)
+        = govuk_table_thead_collection [t('.provider_name'),
+        t('.provider_type'),
+        t('.fee_schemes'),
+        t('.vat_registered'),
+        t('.users')]
+
+        = govuk_table_tbody do
+          - providers.each do |provider|
+            = govuk_table_row(id: dom_id(provider)) do
+              = govuk_table_td('data-label': t('.provider_name')) do
+                = govuk_link_to provider.name, provider_management_provider_path(provider)
+
+              = govuk_table_td('data-label': t('.provider_type')) do
+                = provider.provider_type.humanize
+
+              = govuk_table_td('data-label': t('.fee_schemes')) do
+                = provider.roles.map(&:upcase) * ', '
+
+              = govuk_table_td('data-label': t('.vat_registered')) do
+                = provider.vat_registered == true ? t('global_yes') : t('global_no')
+
+              = govuk_table_td('data-label': t('.users')) do
+                = govuk_link_to t('.manage_user_html', context: provider.name), provider_management_provider_external_users_path(provider)

--- a/app/views/provider_management/providers/index.html.haml
+++ b/app/views/provider_management/providers/index.html.haml
@@ -3,9 +3,10 @@
 
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
-.form-section
-  .form-group.form-buttons
-    = govuk_link_button(t('.add_a_provider'), new_provider_management_provider_path)
-    = govuk_link_button_secondary(t('.find_provider_by_email'), provider_management_external_users_find_path)
+.govuk-grid-row
+  .govuk-grid-column-full
+    .govuk-button-group
+      = govuk_link_button(t('.add_a_provider'), new_provider_management_provider_path)
+      = govuk_link_button_secondary(t('.find_provider_by_email'), provider_management_external_users_find_path)
 
 = render partial: 'providers', locals: { providers: @providers }

--- a/app/views/provider_management/providers/show.html.haml
+++ b/app/views/provider_management/providers/show.html.haml
@@ -1,46 +1,23 @@
 = content_for :page_title, flush: true do
   = t('.page_title', provider_name: @provider.name)
 
-= render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
+= render partial: 'layouts/header', locals: { page_heading: t('.page_heading', provider_name: @provider.name) }
 
-.form-group
-  %table{ summary: t('.table_summary', provider_name: @provider.name) }
-    %caption
-      %h2.govuk-heading-m
-        = @provider.name
-    %tbody
-      %tr
-        %th{ scope: 'row' }
-          = t('.provider_type')
-        %td
-          = @provider.provider_type.capitalize
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
 
-      %tr
-        %th{ scope: 'row' }
-          = t('.fee_schemes')
-        %td
-          = @provider.roles.map(&:upcase) * ', '
+    = govuk_summary_list do
+      = govuk_summary_list_row(t('.provider_type')) { @provider.provider_type.capitalize }
+
+      = govuk_summary_list_row(t('.fee_schemes')) { @provider.roles.map(&:upcase) * ', ' }
 
       - if @provider.lgfs_supplier_numbers.any?
-        %tr
-          %th{ scope: 'row' }
-            = t('.lgfs_supplier_numbers')
-          %td
-            = @provider.lgfs_supplier_numbers.to_sentence
+        = govuk_summary_list_row(t('.lgfs_supplier_numbers')) { @provider.lgfs_supplier_numbers.to_sentence }
 
       - if @provider.firm? && @provider.agfs?
-        %tr
-          %th{ scope: 'row' }
-            = t('.firm_agfs_supplier_number')
-          %td
-            = @provider.firm_agfs_supplier_number
+        = govuk_summary_list_row(t('.firm_agfs_supplier_number')) { @provider.firm_agfs_supplier_number }
 
-      %tr
-        %th{ scope: 'row' }
-          = t('.vat_registered')
-        %td
-          = @provider.vat_registered == true ? t('.answer_yes') : t('.answer_no')
+      = govuk_summary_list_row(t('.vat_registered')) { @provider.vat_registered == true ? t('.answer_yes') : t('.answer_no') }
 
-- if can? :edit, @provider
-  .form-group
-    = govuk_link_button(t('.edit'), edit_provider_management_provider_path(@provider))
+    - if can? :edit, @provider
+      = govuk_link_button(t('.edit'), edit_provider_management_provider_path(@provider))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,7 +571,7 @@ en:
         caption: Users in %{provider_name}
         state: Account state
         add_provider: Add user to provider
-        page_heading: Manage Users
+        page_heading: Manage %{provider} Users
         title: Click to email %{provider}
         live: Live
         inactive: Inactive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -546,7 +546,7 @@ en:
         caption: Provider list
         table_summary: A list of providers. Includes links to the provider page and to manage users
         users: Users
-        manage_user: "Manage users in provider"
+        manage_user_html: Manage users in provider <span class="govuk-visually-hidden">%{context}</span>
         no_provider: "No providers found"
       form:
         cancel_button: Cancel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -527,7 +527,7 @@ en:
         lgfs_supplier_numbers: 'LGFS supplier numbers'
         firm_agfs_supplier_number: 'AGFS supplier number'
         page_title: "View %{provider_name}'s details"
-        page_heading: Providers
+        page_heading: "Provider: %{provider_name}"
         edit: Edit
         answer_yes: *global_yes
         answer_no:  *global_no

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,7 +591,7 @@ en:
         answer_yes: *global_yes
         answer_no:  *global_no
         manage_user: Manage user
-        page_heading: Manage user
+        page_heading: Manage user %{external_user}
         table_summary: A list of user details for %{external_user}
         edit_provider: edit the provider
       edit:


### PR DESCRIPTION
#### What
Migrate Provider tables to the Design System

#### Ticket
[Migrate Provider tables to the Design System](https://dsdmoj.atlassian.net/browse/CFP-236)

#### Why
Part of a larger change to:

- continue migration to GOVUK Frontend
- resolve accessibility issues identified in the 2020 DAC report
- reduce then remove deprecated code

#### How
Migrate old table markup to match the Design System table markup by means of CCCD's table helpers
The `*:id` routes displayed a single thing, therefore these were changed from tables to a summary list component in order to summarise the information.
The `/statistics` route was changed from a table to a list component

--------

#### Routes TODO (wip)
 - [x] /provider_management
 - [x] /provider_management/providers
 - [x] /provider_management/providers/:id
 - [x] /provider_management/providers/:provider_id/external_users
 - [x] /provider_management/providers/:provider_id/external_users/:id
 - [x] /statistics
 - [x] /external_users/admin/providers/:provider_id
