### PR TITLE
Log classnames as string for zendesk failure logging

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -65,7 +65,7 @@ class Feedback
     @response_message = 'Fault reported'
   rescue ZendeskAPI::Error::ClientError => e
     @response_message = 'Unable to submit fault report'
-    LogStuff.error(class: self.class, action: 'save', error_class: e.class, error: e.to_s) do
+    LogStuff.error(class: self.class.name, action: 'save', error_class: e.class.name, error: e.to_s) do
       'Bug report submisson failed!'
     end
     false

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Feedback, type: :model do
 
         it 'logs error details' do
           bug_report.save
-          expect(LogStuff).to have_received(:error).with(class: described_class, action: 'save', error_class: ZendeskAPI::Error::ClientError, error: 'oops, something went wrong')
+          expect(LogStuff).to have_received(:error).with(class: described_class.to_s, action: 'save', error_class: 'ZendeskAPI::Error::ClientError', error: 'oops, something went wrong')
         end
       end
     end


### PR DESCRIPTION
#### What
Log classnames as string for zendesk failure logging

#### Wht
Logging the class directly does not output the name
as a string in the logs.

Example of log without explicitly retrieving the class as strings.

```
{"@source":"cccd.production.dev","@tags":[],"@fields":{"class":{},"action":"save","error_class":{},"error":"the server responded with status 401 -- post <redacted>},"@severity":"error","message":"Bug report submisson failed!","@timestamp":"2021-10-08T12:22:54.558253+00:00"}
```

On this branch the log looks like this
```
{"@source":"cccd.production.dev","@tags":[],"@fields":{"class":"Feedback","action":"save","error_class":"ZendeskAPI::Error::NetworkError","error":"the server responded with status 401 -- post ,
<redacted>},"@severity":"error","message":"Bug report submisson failed!","@timestamp":"2021-10-08T13:08:41.576973+00:00"}
```