### PR TITLE
Prevent displaying empty flash for bug report

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -16,7 +16,7 @@ class FeedbackController < ApplicationController
     if @feedback.save
       redirect_to after_create_url, notice: @feedback.response_message
     else
-      flash.now[:error] = @feedback.response_message
+      flash.now[:error] = @feedback.response_message if @feedback.response_message
       render "feedback/#{@feedback.type}"
     end
   end


### PR DESCRIPTION
Prevent displaying empty flash for bug report

The flash error should not be displayed when only
model validation errors have been encountered.

Fixes this:
![Screenshot 2021-10-11 at 11 06 49](https://user-images.githubusercontent.com/7016425/136774005-0124b60e-ba5d-4608-92a5-a61a1986e99a.png)
