### PR TITLE
Ensure surver_monkey_bearer_token is string

### DIFF
--- a/config/initializers/survey_monkey.rb
+++ b/config/initializers/survey_monkey.rb
@@ -1,6 +1,6 @@
 SurveyMonkey.configure do |config|
   config.root_url = 'https://api.eu.surveymonkey.com/v3/'
-  config.bearer = Rails.application.secrets.survey_monkey_bearer_token
+  config.bearer = Rails.application.secrets.survey_monkey_bearer_token.to_s
   config.collector_id = ENV['SURVEY_MONKEY_COLLECTOR_ID']
   config.logger = Rails.logger
   config.verbose_logging = true


### PR DESCRIPTION
#### What

Convert the survey_monkey_bearer_token to a string.

#### Ticket

[User satisfaction form changes](https://dsdmoj.atlassian.net/browse/CFP-194)

#### Why

Not all environments have have Survey Monkey configured. A nil bearer token results in a 500 error. By ensuring that the token is a string then the user will at least get an error message.