### PR TITLE
Load scheme date helpers

### DIFF
--- a/lib/demo_data/base_claim_generator.rb
+++ b/lib/demo_data/base_claim_generator.rb
@@ -3,6 +3,8 @@ require_relative 'document_generator'
 require_relative 'basic_fee_generator'
 require_relative 'fee_generator'
 require_relative 'expense_generator'
+require Rails.root.join('spec', 'support', 'scheme_date_helpers')
+FactoryBot::SyntaxRunner.include(SchemeDateHelpers)
 
 module DemoData
 


### PR DESCRIPTION
#### What

Load the `SchemeDateHelpers' module into Factory Bot.

#### Ticket

N/A

#### Why

The rake task to reload the sample data (`rails db:reload`) fails when using the defendants factory because the `scheme_date_for` is missing.