### PR TITLE
[CFP-244] Automatically remove graduated fees that are incorrectly added to transfer claims

### DIFF
--- a/app/models/claim/transfer_claim.rb
+++ b/app/models/claim/transfer_claim.rb
@@ -215,6 +215,10 @@ module Claim
       provider
     end
 
+    def cleaner
+      Cleaners::TransferClaimCleaner.new(self)
+    end
+
     def assign_total_attrs
       # TODO: understand if this check is really needed
       # left it here mostly to ensure the new changes do

--- a/app/services/cleaners/transfer_claim_cleaner.rb
+++ b/app/services/cleaners/transfer_claim_cleaner.rb
@@ -1,0 +1,13 @@
+module Cleaners
+  class TransferClaimCleaner < BaseClaimCleaner
+    def call
+      destroy_invalid_fees
+    end
+
+    private
+
+    def destroy_invalid_fees
+      fees.where(type: 'Fee::GraduatedFee').destroy_all
+    end
+  end
+end

--- a/spec/models/claim/transfer_claim_spec.rb
+++ b/spec/models/claim/transfer_claim_spec.rb
@@ -1,74 +1,10 @@
-# == Schema Information
-#
-# Table name: claims
-#
-#  id                       :integer          not null, primary key
-#  additional_information   :text
-#  apply_vat                :boolean
-#  state                    :string
-#  last_submitted_at        :datetime
-#  case_number              :string
-#  advocate_category        :string
-#  first_day_of_trial       :date
-#  estimated_trial_length   :integer          default(0)
-#  actual_trial_length      :integer          default(0)
-#  fees_total               :decimal(, )      default(0.0)
-#  expenses_total           :decimal(, )      default(0.0)
-#  total                    :decimal(, )      default(0.0)
-#  external_user_id         :integer
-#  court_id                 :integer
-#  offence_id               :integer
-#  created_at               :datetime
-#  updated_at               :datetime
-#  valid_until              :datetime
-#  cms_number               :string
-#  authorised_at            :datetime
-#  creator_id               :integer
-#  evidence_notes           :text
-#  evidence_checklist_ids   :string
-#  trial_concluded_at       :date
-#  trial_fixed_notice_at    :date
-#  trial_fixed_at           :date
-#  trial_cracked_at         :date
-#  trial_cracked_at_third   :string
-#  source                   :string
-#  vat_amount               :decimal(, )      default(0.0)
-#  uuid                     :uuid
-#  case_type_id             :integer
-#  form_id                  :string
-#  original_submission_date :datetime
-#  retrial_started_at       :date
-#  retrial_estimated_length :integer          default(0)
-#  retrial_actual_length    :integer          default(0)
-#  retrial_concluded_at     :date
-#  type                     :string
-#  disbursements_total      :decimal(, )      default(0.0)
-#  case_concluded_at        :date
-#  transfer_court_id        :integer
-#  supplier_number          :string
-#  effective_pcmh_date      :date
-#  legal_aid_transfer_date  :date
-#  allocation_type          :string
-#  transfer_case_number     :string
-#  clone_source_id          :integer
-#  last_edited_at           :datetime
-#  deleted_at               :datetime
-#  providers_ref            :string
-#  disk_evidence            :boolean          default(FALSE)
-#  fees_vat                 :decimal(, )      default(0.0)
-#  expenses_vat             :decimal(, )      default(0.0)
-#  disbursements_vat        :decimal(, )      default(0.0)
-#  value_band_id            :integer
-#  retrial_reduction        :boolean          default(FALSE)
-#
-
 require 'rails_helper'
 require_relative 'shared_examples_for_lgfs_claim'
 
 describe Claim::TransferClaim, type: :model do
   let(:claim) { build :transfer_claim }
 
-  it_behaves_like 'uses claim cleaner', Cleaners::NullClaimCleaner
+  it_behaves_like 'uses claim cleaner', Cleaners::TransferClaimCleaner
 
   it { is_expected.not_to delegate_method(:requires_trial_dates?).to(:case_type) }
   it { is_expected.not_to delegate_method(:requires_retrial_dates?).to(:case_type) }

--- a/spec/services/cleaners/transfer_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/transfer_claim_cleaner_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require 'services/cleaners/cleaner_shared_examples'
+
+RSpec.describe Cleaners::TransferClaimCleaner do
+  subject(:cleaner) { described_class.new(claim) }
+
+  let(:claim) { create(:transfer_claim) }
+
+  describe '#call' do
+    subject(:call_cleaner) { cleaner.call }
+
+    context 'when a graduated fee is added to the claim' do
+      before { create(:graduated_fee, claim: claim) }
+
+      it { expect { call_cleaner }.to change(claim.fees, :count).from(2).to 1 }
+
+      it do
+        call_cleaner
+        expect(claim.fees.map(&:class)).to match_array([Fee::TransferFee])
+      end
+    end
+
+    context 'when a non-graduated fee is added to the claim' do
+      before { create(:misc_fee, claim: claim) }
+
+      it { expect { call_cleaner }.not_to change(claim.fees, :count).from 2 }
+
+      it do
+        call_cleaner
+        expect(claim.fees.map(&:class)).to match_array([Fee::TransferFee, Fee::MiscFee])
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

Automatically delete any graduate fees from transfer claims.

#### Ticket

[Incorrect fee on transfer claim (#252755)](https://dsdmoj.atlassian.net/browse/CFP-244)

#### Why

Transfer claims cannot have graduated fees but some vendor clients are adding them automatically. Ideally the API would return an error to the client if an invalid fee is added to a claim but the current behaviour is to silently clean up the input and changing this could cause problems for vendors.

#### How

Create a new cleaner class for transfer claims that will delete any attached graduated fees that are found.