### PR TITLE
CFP-288 mitigate connection timeouts

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,4 +13,4 @@ development:
   :concurrency: 5
 production:
   :verbose: true
-  :concurrency: 10
+  :concurrency: 5


### PR DESCRIPTION
#### What
Reduce sidekiq concurrency inline with available ActiveRecord pool size settings.

#### Ticket
[relates to CFP-288](https://dsdmoj.atlassian.net/browse/CFP-288)

#### Why
We are regularly seeing `ActiveRecord::ConnectionTimeoutError` in
sentry which are therefore not processing jobs.

Hopefully this will address the issue. There are other
issues such as number of queues being used which can be addressed
separately - we should reduce them.

#### How
Reduce sidekiq concurrent processes inline with DB pool size.

Having up to 10 sidekiq processes potentially each consuming
a connection from the pool (1 per process) means if a dearth
of jobs are received they could each be processed at the
same time, potentially exceeding the 5 DB connections. Once 5
DB connections are reached it waits for 5.0 seconds then timesout.

We could increase DB pool size to 10 instead but that has
implications for the app generally which need to be considered
(should be fine).

see [heroku config comments here](https://devcenter.heroku.com/articles/concurrency-and-database-connections#background-workers)