### PR TITLE
Remove dependabot sidekiq bump ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,10 +37,6 @@ updates:
   - dependency-name: sdoc
     versions:
     - "> 0.4.2"
-  - dependency-name: sidekiq
-    versions:
-    - ">= 6.1.a"
-    - "< 6.2"
   - dependency-name: simplecov
     versions:
     - "> 0.17.1"


### PR DESCRIPTION
#### What
Remove dependabot sidekiq bump ignore

#### Why
Reinstate dependabot bumps for sidekiq

This was transfered over during update from version 1
to version 2 of dependabot and was probably originally
due to problems with the sidekiq dependency at the time.