### PR TITLE
[CFP-299] MI report version 2

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -352,6 +352,7 @@ Metrics/ModuleLength:
     - 'app/helpers/application_helper.rb'
     - 'app/models/claims/calculations.rb'
     - 'app/models/claims/state_machine.rb'
+    - 'app/services/stats/management_information/concerns/journey_queryable.rb'
     - 'spec/models/fee/base_fee_spec.rb'
     - 'spec/support/validation_helpers.rb'
 

--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -27,7 +27,7 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
   def generate
     StatsReportGenerationJob.perform_later(params[:report_type])
     message = t('case_workers.admin.management_information.job_scheduled')
-    redirect_to case_workers_admin_management_information_url, alert: message
+    redirect_to case_workers_admin_management_information_url, flash: { notification: message }
   end
 
   private

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -247,6 +247,10 @@ module Claim
       will_save_change_to_case_transferred_from_another_court?
     end
 
+    def self.claim_types
+      agfs_claim_types | lgfs_claim_types
+    end
+
     def self.agfs_claim_types
       [Claim::AdvocateClaim,
        Claim::AdvocateInterimClaim,

--- a/app/models/stats/stats_report.rb
+++ b/app/models/stats/stats_report.rb
@@ -3,6 +3,9 @@ module Stats
     TYPES = %w[management_information
                agfs_management_information
                lgfs_management_information
+               management_information_v2
+               agfs_management_information_v2
+               lgfs_management_information_v2
                provisional_assessment
                rejections_refusals
                submitted_claims].freeze

--- a/app/presenters/concerns/management_information_reportable.rb
+++ b/app/presenters/concerns/management_information_reportable.rb
@@ -38,7 +38,7 @@ module ManagementInformationReportable
     end
 
     def claim_total
-      total_including_vat.to_s
+      format('%.2f', total_including_vat)
     end
 
     def submission_type
@@ -76,7 +76,7 @@ module ManagementInformationReportable
     def state_reason_code
       reason_code = @journey.last.reason_code
       reason_code = reason_code.flatten.join(', ') if reason_code.is_a?(Array)
-      reason_code
+      reason_code.presence
     end
 
     def rejection_reason
@@ -106,11 +106,12 @@ module ManagementInformationReportable
     end
 
     def af1_lf1_processed_by
-      previous_redetermination_steps.present? ? previous_redetermination_steps.last.author_name : ''
+      previous_redetermination_steps.present? ? previous_redetermination_steps.last.author_name : nil
     end
 
     def misc_fees
-      claim.misc_fees.map { |f| f.fee_type.description.tr(',', '') }.join(' ')
+      misc_fees = claim.misc_fees.map { |f| f.fee_type.description.tr(',', '') }.join(' ')
+      misc_fees.presence
     end
 
     def redetermination_steps

--- a/app/presenters/concerns/management_information_reportable.rb
+++ b/app/presenters/concerns/management_information_reportable.rb
@@ -38,7 +38,7 @@ module ManagementInformationReportable
     end
 
     def claim_total
-      format('%.2f', total_including_vat)
+      format('%.2f', total_including_vat.round(4))
     end
 
     def submission_type

--- a/app/presenters/concerns/management_information_reportable.rb
+++ b/app/presenters/concerns/management_information_reportable.rb
@@ -22,7 +22,7 @@ module ManagementInformationReportable
     end
 
     def case_type_name
-      case_type&.name || ''
+      case_type&.name
     end
 
     def bill_type

--- a/app/presenters/management_information_presenter.rb
+++ b/app/presenters/management_information_presenter.rb
@@ -23,6 +23,20 @@ class ManagementInformationPresenter < BasePresenter
   def sorted_and_filtered_state_transitions
     claim_state_transitions.sort.reject do |transition|
       SORTED_AND_FILTERED_STATES.include?(transition.to) ||
+        # This is equivalent to
+        #   `Time.zone.now - 6.months >= transition.created_at`
+        #
+        # TODO: This is very brittle and confusing as it means:
+        # 1. it is based on what TIME the report is run.
+        # 2. it will not include transitions that occured exactly 6 months ago
+        # 3. it will not include transitions 6 months before the time the report is run (to the second/sub-second)
+        # 4. makes testing it time sensitive (to when the test is run, to the nearest micro-second potentially)
+        #
+        # Instead we should truncate the datetime to date and compare to `6.months.ago.beginning_of_day`
+        # i.e. transition.created_at.beginning_of_day < 6.months.ago.beginning_of_day
+        #
+        # I am leaving for now to emulate this behaviour in SQL as is, using a diff of v1 and v2
+        # against prod-like data set
         transition.created_at < Time.zone.now - 6.months
     end
   end

--- a/app/presenters/management_information_presenter.rb
+++ b/app/presenters/management_information_presenter.rb
@@ -23,21 +23,7 @@ class ManagementInformationPresenter < BasePresenter
   def sorted_and_filtered_state_transitions
     claim_state_transitions.sort.reject do |transition|
       SORTED_AND_FILTERED_STATES.include?(transition.to) ||
-        # This is equivalent to
-        #   `Time.zone.now - 6.months >= transition.created_at`
-        #
-        # TODO: This is very brittle and confusing as it means:
-        # 1. it is based on what TIME the report is run.
-        # 2. it will not include transitions that occured exactly 6 months ago
-        # 3. it will not include transitions 6 months before the time the report is run (to the second/sub-second)
-        # 4. makes testing it time sensitive (to when the test is run, to the nearest micro-second potentially)
-        #
-        # Instead we should truncate the datetime to date and compare to `6.months.ago.beginning_of_day`
-        # i.e. transition.created_at.beginning_of_day < 6.months.ago.beginning_of_day
-        #
-        # I am leaving for now to emulate this behaviour in SQL as is, using a diff of v1 and v2
-        # against prod-like data set
-        transition.created_at < Time.zone.now - 6.months
+        transition.created_at.beginning_of_day < 6.months.ago.beginning_of_day
     end
   end
 

--- a/app/presenters/management_information_presenter.rb
+++ b/app/presenters/management_information_presenter.rb
@@ -9,6 +9,13 @@ class ManagementInformationPresenter < BasePresenter
     yield parsed_journeys if block_given?
   end
 
+  def parsed_journeys
+    journeys.map do |journey|
+      @journey = clean_deallocations(journey)
+      Settings.claim_csv_headers.map { |method_call| send(method_call) } if @journey.any?
+    end
+  end
+
   def journeys
     sorted_and_filtered_state_transitions.slice_after { |transition| COMPLETED_STATES.include?(transition.to) }
   end
@@ -17,13 +24,6 @@ class ManagementInformationPresenter < BasePresenter
     claim_state_transitions.sort.reject do |transition|
       SORTED_AND_FILTERED_STATES.include?(transition.to) ||
         transition.created_at < Time.zone.now - 6.months
-    end
-  end
-
-  def parsed_journeys
-    journeys.map do |journey|
-      @journey = clean_deallocations(journey)
-      Settings.claim_csv_headers.map { |method_call| send(method_call) } if @journey.any?
     end
   end
 

--- a/app/services/stats/management_information/concerns/claim_type_filterable.rb
+++ b/app/services/stats/management_information/concerns/claim_type_filterable.rb
@@ -9,9 +9,9 @@ module Stats
         delegate :claim_types, :agfs_claim_types, :lgfs_claim_types, to: :'::Claim::BaseClaim'
 
         def claim_type_filter
-          return in_statement_for(claim_types) if scheme.blank?
           return in_statement_for(agfs_claim_types) if scheme.eql?('AGFS')
-          in_statement_for(lgfs_claim_types)
+          return in_statement_for(lgfs_claim_types) if scheme.eql?('LGFS')
+          in_statement_for(claim_types)
         end
 
         def in_statement_for(arr)

--- a/app/services/stats/management_information/concerns/claim_type_filterable.rb
+++ b/app/services/stats/management_information/concerns/claim_type_filterable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Stats
+  module ManagementInformation
+    module ClaimTypeQueryable
+      extend ActiveSupport::Concern
+
+      included do
+        delegate :claim_types, :agfs_claim_types, :lgfs_claim_types, to: :'::Claim::BaseClaim'
+
+        def claim_type_filter
+          return in_statement_for(claim_types) if scheme.blank?
+          return in_statement_for(agfs_claim_types) if scheme.eql?('AGFS')
+          in_statement_for(lgfs_claim_types)
+        end
+
+        def in_statement_for(arr)
+          arr.map(&:to_s).join('\', \'').prepend('(\'').concat('\')')
+        end
+      end
+    end
+  end
+end

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -95,7 +95,10 @@ module Stats
               c.*,
               c2.scheme as scheme,
               p.name as organisation,
-              ct.name as case_type_name,
+              coalesce(ct.name, (select ct2.name
+                                   from case_types ct2
+                                  where ct2.id = cs.case_type_id)
+              ) as case_type_name,
               c2.scheme || ' ' || c2.sub_type as bill_type,
               round(c.total + c.vat_amount, 2)::varchar as claim_total,
               main_defendant.name as main_defendant,
@@ -111,6 +114,8 @@ module Stats
               ON p.id = creator.provider_id
             LEFT OUTER JOIN case_types AS ct
               ON ct.id = c.case_type_id
+            LEFT OUTER JOIN case_stages cs
+              ON cs.id = c.case_stage_id
             LEFT JOIN LATERAL journeys(c.id) j
               ON TRUE
             LEFT JOIN LATERAL (

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -139,7 +139,7 @@ module Stats
               from representation_orders r, defendants d2
               where d2.claim_id = c.id
                 and r.defendant_id = d2.id
-              order by r.representation_order_date asc
+              order by r.representation_order_date, r.created_at asc
               fetch first row only
             ) earliest_representation_order ON TRUE
             LEFT JOIN LATERAL (

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -97,7 +97,7 @@ module Stats
               p.name as organisation,
               ct.name as case_type_name,
               c2.scheme || ' ' || c2.sub_type as bill_type,
-              (c.total + c.vat_amount)::varchar as claim_total,
+              round(c.total + c.vat_amount, 2)::varchar as claim_total,
               main_defendant.name as main_defendant,
               earliest_representation_order.maat_reference as maat_reference,
               earliest_representation_order.representation_order_date as rep_order_issued_date,
@@ -153,7 +153,7 @@ module Stats
               fetch first row only
             ) previous_redetermined_decision ON TRUE
             LEFT JOIN LATERAL (
-              select string_agg(ft.description, ' ') as descriptions
+              select string_agg(ft.description, ' ' order by f.id) as descriptions
               from fees f, fee_types ft
               where f.claim_id = c.id
                 and f.fee_type_id = ft.id

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -51,14 +51,7 @@ module Stats
                     on t.subject_id = subjects.id
                   where t.claim_id = in_claim_id
                   and t.to not in (select * from unnest(filtered_states))
-                  and t.created_at >= (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London'
-                  --
-                  -- postgres created_at is utc, now is utc
-                  -- to gain MI report v1 equivalent we need to compare created_at to now() Europe/London
-                  -- to do this more simply we need to change MI report v1 to truncate dates to midnight (see old version 1)
-                  -- and truncate these dates in this statement, as below
-                  -- "and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')"
-                  --
+                  and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')
                 )
                 select t.claim_id,
                        jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -101,6 +101,7 @@ module Stats
               ) as case_type_name,
               c2.scheme || ' ' || c2.sub_type as bill_type,
               round(c.total + c.vat_amount, 2)::varchar as claim_total,
+              c.last_submitted_at at time zone 'utc' at time zone 'Europe/London' as last_submitted_at,
               main_defendant.name as main_defendant,
               earliest_representation_order.maat_reference as maat_reference,
               earliest_representation_order.representation_order_date as rep_order_issued_date,

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -51,7 +51,14 @@ module Stats
                     on t.subject_id = subjects.id
                   where t.claim_id = in_claim_id
                   and t.to not in (select * from unnest(filtered_states))
-                  and DATE_TRUNC('day', t.created_at) > DATE_TRUNC('day', current_date - '6 months'::interval)
+                  and t.created_at at time zone 'utc' at time zone 'Europe/London' >= (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London'
+                  --
+                  -- postgres created_at is utc, now is utc
+                  -- to gain MI report v1 equivalent we need to compare created_at Europe/London to now() Europe/London
+                  -- to do this more simply we need to change MI report v1 to truncate dates to midnight (see old version 1)
+                  -- and truncate these dates in this statement, as below
+                  -- "and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')"
+                  --
                 )
                 select t.claim_id,
                        jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -51,10 +51,10 @@ module Stats
                     on t.subject_id = subjects.id
                   where t.claim_id = in_claim_id
                   and t.to not in (select * from unnest(filtered_states))
-                  and t.created_at at time zone 'utc' at time zone 'Europe/London' >= (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London'
+                  and t.created_at >= (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London'
                   --
                   -- postgres created_at is utc, now is utc
-                  -- to gain MI report v1 equivalent we need to compare created_at Europe/London to now() Europe/London
+                  -- to gain MI report v1 equivalent we need to compare created_at to now() Europe/London
                   -- to do this more simply we need to change MI report v1 to truncate dates to midnight (see old version 1)
                   -- and truncate these dates in this statement, as below
                   -- "and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')"

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -62,7 +62,7 @@ module Stats
 
                 for transition in (select jsonb_array_elements(rec.transitions))
                 loop
-                  -- remove "deallocated" allocations as not important for report
+                  -- remove "deallocated" allocations as not wanted for report
                   if transition ->> 'to' = 'deallocated' then
                     slice := slice - -1;
                   else

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require_relative 'claim_type_filterable'
+
+module Stats
+  module ManagementInformation
+    module JourneyQueryable
+      extend ActiveSupport::Concern
+
+      included do
+        def prepare
+          ActiveRecord::Base.connection.execute(drop_journeys_func)
+          ActiveRecord::Base.connection.execute(create_journeys_func)
+        end
+
+        def drop_journeys_func
+          <<~SQL
+            DROP FUNCTION IF EXISTS journeys(integer);
+          SQL
+        end
+
+        def create_journeys_func
+          <<~SQL
+            CREATE OR REPLACE FUNCTION journeys(in_claim_id int)
+            RETURNS TABLE(journey jsonb)
+            COST 100
+            STABLE
+            AS
+            $BODY$
+            DECLARE
+              rec record;
+              transition jsonb;
+              slice jsonb := '[]'::jsonb;
+              filtered_states constant varchar[] := array['draft', 'archived_pending_delete' , 'archived_pending_review'];
+              completed_states constant varchar[] := array['rejected', 'refused', 'authorised', 'part_authorised'];
+            BEGIN
+              for rec in (
+                with transitions as (
+                  select t.claim_id,
+                         t.from,
+                         t.to,
+                         t.created_at,
+                         t.reason_code,
+                         t.reason_text,
+                         (authors.first_name || ' ' || authors.last_name) as author_name,
+                         (subjects.first_name || ' ' || subjects.last_name) as subject_name
+                  from claim_state_transitions t
+                  left outer join users as authors
+                    on t.author_id = authors.id
+                  left outer join users as subjects
+                    on t.subject_id = subjects.id
+                  where t.claim_id = in_claim_id
+                  and t.to not in (select * from unnest(filtered_states))
+                  and DATE_TRUNC('day', t.created_at) > DATE_TRUNC('day', current_date - '6 months'::interval)
+                )
+                select t.claim_id,
+                       jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions
+                from transitions t
+                group by t.claim_id
+              ) loop
+                slice := '[]'::jsonb;
+
+                for transition in (select jsonb_array_elements(rec.transitions))
+                loop
+                  -- remove "deallocated" allocations as not important for report
+                  if transition ->> 'to' = 'deallocated' then
+                    slice := slice - -1;
+                  else
+                    slice := slice || transition;
+                  end if;
+
+                  -- pipe out completed slice as row
+                  if transition ->> 'to' in (select * from unnest(completed_states)) then
+                    journey := slice;
+                    return next;
+                    slice := '[]'::jsonb;
+                  end if;
+                end loop;
+
+                -- pipe out last slice for claim unless it already has been above (because it has a completed status)
+                if transition ->> 'to' not in (select * from unnest(completed_states)) then
+                  journey := slice;
+                  return next;
+                end if;
+              end loop;
+            END
+            $BODY$
+            LANGUAGE plpgsql;
+          SQL
+        end
+
+        def journeys_query
+          <<~SQL
+            SELECT
+              c.*,
+              c2.scheme as scheme,
+              p.name as organisation,
+              ct.name as case_type_name,
+              c2.scheme || ' ' || c2.sub_type as bill_type,
+              (c.total + c.vat_amount)::varchar as claim_total,
+              main_defendant.name as main_defendant,
+              earliest_representation_order.maat_reference as maat_reference,
+              earliest_representation_order.representation_order_date as rep_order_issued_date,
+              previous_redetermined_decision.author_name as af1_lf1_processed_by,
+              misc_fees.descriptions as misc_fees,
+              j.journey as journey
+            FROM claims c
+            LEFT OUTER JOIN external_users AS creator
+              ON c.creator_id = creator.id
+            LEFT OUTER JOIN providers AS p
+              ON p.id = creator.provider_id
+            LEFT OUTER JOIN case_types AS ct
+              ON ct.id = c.case_type_id
+            LEFT JOIN LATERAL journeys(c.id) j
+              ON TRUE
+            LEFT JOIN LATERAL (
+              select first_name || ' ' || last_name as name
+              from defendants
+              where claim_id = c.id
+              fetch first row only
+            ) main_defendant ON TRUE
+            LEFT JOIN LATERAL (
+              select maat_reference,
+                     representation_order_date
+              from representation_orders r, defendants d2
+              where d2.claim_id = c.id
+                and r.defendant_id = d2.id
+              order by r.representation_order_date asc
+              fetch first row only
+            ) earliest_representation_order ON TRUE
+            LEFT JOIN LATERAL (
+              select
+                case
+                  when type in #{in_statement_for(agfs_claim_types)} then 'AGFS'
+                  when type in #{in_statement_for(lgfs_claim_types)} then 'LGFS'
+                  else 'Unknown'
+                end as scheme,
+                case
+                  when regexp_replace(type, 'Claim|::|Advocate|Litigator|\s+', '', 'g') = '' then 'Final'
+                  else regexp_replace(type, 'Claim|::|Advocate|Litigator|\s+', '', 'g')
+                end as sub_type
+              from claims
+              where id = c.id
+              ) c2 ON TRUE
+            LEFT JOIN LATERAL (
+              select transitions ->> 'author_name' as author_name
+              from journeys(c.id) j2,
+                   jsonb_array_elements(j2.journey) transitions
+              where j.journey -> 0 ->> 'to' = 'redetermination'
+                and transitions ->> 'to' = j.journey -> 0 ->> 'from'
+                and (transitions ->> 'created_at')::timestamp < (j.journey -> 0 ->> 'created_at')::timestamp
+              order by (transitions ->> 'created_at')::timestamp desc
+              fetch first row only
+            ) previous_redetermined_decision ON TRUE
+            LEFT JOIN LATERAL (
+              select string_agg(ft.description, ' ') as descriptions
+              from fees f, fee_types ft
+              where f.claim_id = c.id
+                and f.fee_type_id = ft.id
+                and ft.type = 'Fee::MiscFeeType'
+              group by f.claim_id
+            ) misc_fees ON TRUE
+            WHERE c.deleted_at IS NULL
+              AND c.state != 'draft'
+              AND c.type IN #{claim_type_filter}
+              AND j.journey::text <> '[]'
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -107,7 +107,7 @@ module Stats
                                   where ct2.id = cs.case_type_id)
               ) as case_type_name,
               c2.scheme || ' ' || c2.sub_type as bill_type,
-              round(c.total + c.vat_amount, 2)::varchar as claim_total,
+              round(c.total + c.vat_amount, 4) as claim_total,
               c.last_submitted_at at time zone 'utc' at time zone 'Europe/London' as last_submitted_at,
               c.original_submission_date at time zone 'utc' at time zone 'Europe/London' as originally_submitted_at,
               main_defendant.name as main_defendant,

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -102,6 +102,7 @@ module Stats
               c2.scheme || ' ' || c2.sub_type as bill_type,
               round(c.total + c.vat_amount, 2)::varchar as claim_total,
               c.last_submitted_at at time zone 'utc' at time zone 'Europe/London' as last_submitted_at,
+              c.original_submission_date at time zone 'utc' at time zone 'Europe/London' as originally_submitted_at,
               main_defendant.name as main_defendant,
               earliest_representation_order.maat_reference as maat_reference,
               earliest_representation_order.representation_order_date as rep_order_issued_date,

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -39,7 +39,7 @@ module Stats
                   select t.claim_id,
                          t.from,
                          t.to,
-                         t.created_at,
+                         t.created_at at time zone 'utc' at time zone 'Europe/London' as created_at,
                          t.reason_code,
                          t.reason_text,
                          (authors.first_name || ' ' || authors.last_name) as author_name,

--- a/app/services/stats/management_information/daily_report_generator.rb
+++ b/app/services/stats/management_information/daily_report_generator.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module Stats
+  module ManagementInformation
+    class DailyReportGenerator
+      def self.call(options = {})
+        new(options).call
+      end
+
+      def initialize(options = {})
+        @scheme = options[:scheme]
+      end
+
+      def call
+        output = generate_report
+        Stats::Result.new(output, :csv)
+      end
+
+      private
+
+      def generate_report
+        log_info('Daily MI Report generation started...')
+        content = generate_csv
+        log_info('Daily MI Report generation finished')
+        content
+      rescue StandardError => e
+        log_error(e)
+        raise
+      end
+
+      def generate_csv
+        CSV.generate do |csv|
+          csv << headers
+          claim_journeys.each do |rec|
+            csv << row(rec)
+          end
+        end
+      end
+
+      def headers
+        Settings.claim_csv_headers.map { |header| header.to_s.humanize }
+      end
+
+      def claim_journeys
+        @claim_journeys ||= DailyReportQuery.call(scheme: @scheme)
+      end
+
+      def row(rec)
+        presenter = Presenter.new(rec)
+
+        Settings
+          .claim_csv_headers
+          .map { |header| presenter.send(header) }
+      end
+
+      def log_error(error)
+        LogStuff.error(class: self.class.name,
+                       action: caller_locations(1, 1)[0].label,
+                       error_message: "#{error.class} - #{error.message}",
+                       error_backtrace: error.backtrace.inspect.to_s) do
+                         'MI Report generation error'
+                       end
+      end
+
+      def log_info(message)
+        LogStuff.info(class: self.class.name, action: caller_locations(1, 1)[0].label) { message }
+      end
+    end
+  end
+end

--- a/app/services/stats/management_information/daily_report_query.rb
+++ b/app/services/stats/management_information/daily_report_query.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+Dir[File.join(__dir__, 'concerns', '*.rb')].each { |f| require_dependency f }
+Dir[File.join(__dir__, 'queries', '*.rb')].each { |f| require_dependency f }
+
+module Stats
+  module ManagementInformation
+    class DailyReportQuery
+      include JourneyQueryable
+      include ClaimTypeQueryable
+
+      attr_reader :scheme
+
+      def self.call(options = {})
+        new(options).call
+      end
+
+      def initialize(options = {})
+        @scheme = options[:scheme]&.to_s&.upcase
+        raise ArgumentError, 'scheme must be "agfs" or "lgfs"' if @scheme.present? && %w[AGFS LGFS].exclude?(@scheme)
+      end
+
+      def call
+        prepare
+        transform(journeys)
+      end
+
+      private
+
+      def journeys
+        ActiveRecord::Base.connection.execute(journeys_query)
+      end
+
+      def transform(result)
+        result.to_a.map(&:deep_symbolize_keys).map do |el|
+          el.each_with_object({}) do |(k, v), h|
+            h[k] = k.eql?(:journey) ? JSON.parse(v, symbolize_names: true) : v
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/stats/management_information/presenter.rb
+++ b/app/services/stats/management_information/presenter.rb
@@ -30,7 +30,7 @@ module Stats
       end
 
       def originally_submitted_at
-        record[:original_submission_date]&.strftime('%d/%m/%Y')
+        record[:originally_submitted_at]&.strftime('%d/%m/%Y')
       end
 
       # why `.last`, there should be only one allocation per journey?! see optimize below

--- a/app/services/stats/management_information/presenter.rb
+++ b/app/services/stats/management_information/presenter.rb
@@ -21,6 +21,10 @@ module Stats
         journey.first[:to] == 'submitted' ? 'new' : journey.first[:to]
       end
 
+      def claim_total
+        format('%.2f', record[:claim_total])
+      end
+
       def transitioned_at
         submissions.present? ? submissions.first[:created_at].strftime('%d/%m/%Y') : 'n/a'
       end

--- a/app/services/stats/management_information/presenter.rb
+++ b/app/services/stats/management_information/presenter.rb
@@ -95,8 +95,10 @@ module Stats
         @submission ||= journey.find { |transition| SUBMITTED_STATES.include?(transition[:to]) }
       end
 
+      # we have to find the last due to edge case of "stuck" claims that have been "unstuck".
+      # such claims may have been [allocated, submitted, allocated, ...] so we want the last.
       def allocation
-        @allocation ||= journey.find { |transition| transition[:to] == 'allocated' }
+        @allocation ||= journey.reverse.find { |transition| transition[:to] == 'allocated' }
       end
 
       def completion

--- a/app/services/stats/management_information/presenter.rb
+++ b/app/services/stats/management_information/presenter.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Stats
+  module ManagementInformation
+    class Presenter
+      # OPTIMIZE: share this array more centrally?!
+      # see also Claims::StateMachine::CASEWORKER_DASHBOARD_UNALLOCATED_STATES
+      SUBMITTED_STATES = %w[submitted redetermination awaiting_written_reasons].freeze
+
+      # OPTIMIZE: share this array with the SQL query itself?!
+      # see also Claims::StateMachine::CASEWORKER_DASHBOARD_COMPLETED_STATES
+      COMPLETED_STATES = %w[rejected refused authorised part_authorised].freeze
+
+      def initialize(record)
+        @record = record
+      end
+
+      attr_reader :record
+
+      def submission_type
+        journey.first[:to] == 'submitted' ? 'new' : journey.first[:to]
+      end
+
+      def transitioned_at
+        submissions.present? ? submissions.first[:created_at].strftime('%d/%m/%Y') : 'n/a'
+      end
+
+      def last_submitted_at
+        record[:last_submitted_at]&.strftime('%d/%m/%Y')
+      end
+
+      def originally_submitted_at
+        record[:original_submission_date]&.strftime('%d/%m/%Y')
+      end
+
+      # why `.last`, there should be only one allocation per journey?! see optimize below
+      def allocated_at
+        allocations.present? ? allocations.last[:created_at].strftime('%d/%m/%Y') : 'n/a'
+      end
+
+      # why `.first`, there should be only one completion per journey?! see optimize below
+      def completed_at
+        completions.present? ? completions.first[:created_at].strftime('%d/%m/%Y %H:%M') : 'n/a'
+      end
+
+      # This is the current claim journey end state, not that of the claim!
+      def current_or_end_state
+        state = journey.last[:to]
+        SUBMITTED_STATES.include?(state) ? 'submitted' : state
+      end
+
+      def state_reason_code
+        reason_codes = journey.last[:reason_code]
+        YAML.safe_load(reason_codes).join(', ') if reason_codes
+      end
+
+      def rejection_reason
+        journey.last[:reason_text]
+      end
+
+      def case_worker
+        if journey.last[:to].eql?('allocated')
+          journey.last[:subject_name]
+        elsif COMPLETED_STATES.include?(journey.last[:to])
+          journey.last[:author_name]
+        else
+          'n/a'
+        end
+      end
+
+      def disk_evidence_case
+        record[:disk_evidence] ? 'Yes' : 'No'
+      end
+
+      def rep_order_issued_date
+        record[:rep_order_issued_date]&.strftime('%d/%m/%Y')
+      end
+
+      def method_missing(method_name, *args, &block)
+        if record.key?(method_name)
+          record[method_name]
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, *args)
+        record.key?(method_name) || super
+      end
+
+      private
+
+      # OPTIMIZE: there should be only one submission per journey as each journey
+      # slice starts with a submission state (or possibly not if the submission was
+      # over 6 months ago). So could use `.find` to return first found and change name and
+      # callers to rely on it.
+      def submissions
+        @submissions ||= journey.select { |transition| SUBMITTED_STATES.include?(transition[:to]) }
+      end
+
+      # OPTIMIZE: there should be only one allocation per journey as deallocated
+      # allocations (and deallocations themselves) are removed. So could use `.find`
+      # to return first found and change name and callers to rely on it.
+      def allocations
+        @allocations ||= journey.select { |transition| transition[:to] == 'allocated' }
+      end
+
+      # OPTIMIZE: there should be only one completion per journey as a journey
+      # is defined as a slice ending in a completion (or remainder, when it is the last
+      # journey). So could use `.find` to return first found and change name and
+      # callers to rely on it.
+      def completions
+        @completions ||= journey.select { |transition| COMPLETED_STATES.include?(transition[:to]) }
+      end
+
+      def journey
+        @journey ||= record[:journey]
+      end
+    end
+  end
+end

--- a/app/services/stats/management_information/presenter.rb
+++ b/app/services/stats/management_information/presenter.rb
@@ -26,7 +26,7 @@ module Stats
       end
 
       def transitioned_at
-        submissions.present? ? submissions.first[:created_at].strftime('%d/%m/%Y') : 'n/a'
+        submission.present? ? submission[:created_at].strftime('%d/%m/%Y') : 'n/a'
       end
 
       def last_submitted_at
@@ -37,17 +37,14 @@ module Stats
         record[:originally_submitted_at]&.strftime('%d/%m/%Y')
       end
 
-      # why `.last`, there should be only one allocation per journey?! see optimize below
       def allocated_at
-        allocations.present? ? allocations.last[:created_at].strftime('%d/%m/%Y') : 'n/a'
+        allocation.present? ? allocation[:created_at].strftime('%d/%m/%Y') : 'n/a'
       end
 
-      # why `.first`, there should be only one completion per journey?! see optimize below
       def completed_at
-        completions.present? ? completions.first[:created_at].strftime('%d/%m/%Y %H:%M') : 'n/a'
+        completion.present? ? completion[:created_at].strftime('%d/%m/%Y %H:%M') : 'n/a'
       end
 
-      # This is the current claim journey end state, not that of the claim!
       def current_or_end_state
         state = journey.last[:to]
         SUBMITTED_STATES.include?(state) ? 'submitted' : state
@@ -94,27 +91,16 @@ module Stats
 
       private
 
-      # OPTIMIZE: there should be only one submission per journey as each journey
-      # slice starts with a submission state (or possibly not if the submission was
-      # over 6 months ago). So could use `.find` to return first found and change name and
-      # callers to rely on it.
-      def submissions
-        @submissions ||= journey.select { |transition| SUBMITTED_STATES.include?(transition[:to]) }
+      def submission
+        @submission ||= journey.find { |transition| SUBMITTED_STATES.include?(transition[:to]) }
       end
 
-      # OPTIMIZE: there should be only one allocation per journey as deallocated
-      # allocations (and deallocations themselves) are removed. So could use `.find`
-      # to return first found and change name and callers to rely on it.
-      def allocations
-        @allocations ||= journey.select { |transition| transition[:to] == 'allocated' }
+      def allocation
+        @allocation ||= journey.find { |transition| transition[:to] == 'allocated' }
       end
 
-      # OPTIMIZE: there should be only one completion per journey as a journey
-      # is defined as a slice ending in a completion (or remainder, when it is the last
-      # journey). So could use `.find` to return first found and change name and
-      # callers to rely on it.
-      def completions
-        @completions ||= journey.select { |transition| COMPLETED_STATES.include?(transition[:to]) }
+      def completion
+        @completion ||= journey.find { |transition| COMPLETED_STATES.include?(transition[:to]) }
       end
 
       def journey

--- a/app/services/stats/management_information_generator.rb
+++ b/app/services/stats/management_information_generator.rb
@@ -10,7 +10,7 @@ module Stats
 
     def initialize(options = {})
       @format = options.fetch(:format, DEFAULT_FORMAT)
-      @claim_scope = options.fetch(:claim_scope, :all)
+      @scheme = options.fetch(:scheme, :all)
     end
 
     def call
@@ -27,7 +27,7 @@ module Stats
     end
 
     def claims
-      Claim::BaseClaim.active.non_draft.send(@claim_scope)
+      Claim::BaseClaim.active.non_draft.send(@scheme)
     end
 
     # TODO: separate data retrieval from exporting the data itself

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -2,6 +2,25 @@ module Stats
   class StatsReportGenerator
     class InvalidReportType < StandardError; end
 
+    # rubocop:disable Metrics/MethodLength
+    def self.for(report_type)
+      Hash.new({ class: ReportGenerator, args: [report_type] }).merge(
+        management_information:
+          { class: ManagementInformationGenerator, args: [] },
+        agfs_management_information:
+          { class: ManagementInformationGenerator, args: [{ scheme: :agfs }] },
+        lgfs_management_information:
+          { class: ManagementInformationGenerator, args: [{ scheme: :lgfs }] },
+        management_information_v2:
+          { class: Stats::ManagementInformation::DailyReportGenerator, args: [] },
+        agfs_management_information_v2:
+          { class: Stats::ManagementInformation::DailyReportGenerator, args: [{ scheme: :agfs }] },
+        lgfs_management_information_v2:
+          { class: Stats::ManagementInformation::DailyReportGenerator, args: [{ scheme: :lgfs }] }
+      )[report_type.to_sym]
+    end
+    # rubocop:enable Metrics/MethodLength
+
     def self.call(report_type, options = {})
       new(report_type, options).call
     end
@@ -33,20 +52,8 @@ module Stats
     end
 
     def generate_new_report
-      return management_information_generator if report_type.include?('management_information')
-
-      ReportGenerator.call(report_type, **options)
-    end
-
-    def management_information_generator
-      case report_type.to_sym
-      when :agfs_management_information
-        options[:claim_scope] = :agfs
-      when :lgfs_management_information
-        options[:claim_scope] = :lgfs
-      end
-
-      ManagementInformationGenerator.call(options)
+      generator = self.class.for(report_type)
+      generator[:class].call(*generator[:args])
     end
 
     def notify_error(report_record, error)

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -4,19 +4,19 @@ module Stats
 
     # rubocop:disable Metrics/MethodLength
     def self.for(report_type)
-      Hash.new({ class: ReportGenerator, args: [report_type] }).merge(
+      Hash.new({ class: ReportGenerator, default_args: [report_type] }).merge(
         management_information:
-          { class: ManagementInformationGenerator, args: [] },
+          { class: ManagementInformationGenerator, default_args: [] },
         agfs_management_information:
-          { class: ManagementInformationGenerator, args: [{ scheme: :agfs }] },
+          { class: ManagementInformationGenerator, default_args: [{ scheme: :agfs }] },
         lgfs_management_information:
-          { class: ManagementInformationGenerator, args: [{ scheme: :lgfs }] },
+          { class: ManagementInformationGenerator, default_args: [{ scheme: :lgfs }] },
         management_information_v2:
-          { class: Stats::ManagementInformation::DailyReportGenerator, args: [] },
+          { class: Stats::ManagementInformation::DailyReportGenerator, default_args: [] },
         agfs_management_information_v2:
-          { class: Stats::ManagementInformation::DailyReportGenerator, args: [{ scheme: :agfs }] },
+          { class: Stats::ManagementInformation::DailyReportGenerator, default_args: [{ scheme: :agfs }] },
         lgfs_management_information_v2:
-          { class: Stats::ManagementInformation::DailyReportGenerator, args: [{ scheme: :lgfs }] }
+          { class: Stats::ManagementInformation::DailyReportGenerator, default_args: [{ scheme: :lgfs }] }
       )[report_type.to_sym]
     end
     # rubocop:enable Metrics/MethodLength
@@ -53,7 +53,7 @@ module Stats
 
     def generate_new_report
       generator = self.class.for(report_type)
-      generator[:class].call(*generator[:args])
+      generator[:class].call(*generator[:default_args])
     end
 
     def notify_error(report_record, error)

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -9,7 +9,7 @@
       = t('.report_instructions')
 
     - @available_report_types.each do |report_type, report|
-      - report_name = t(".report_types.#{report_type}")
+      - report_name = t(".report_types.#{report_type}_html")
       .form-section
         %h2.govuk-heading-l{ id: "heading-#{report_type}" }
           = report_name

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -3,42 +3,45 @@
 
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
-- @available_report_types.each do |report_type, report|
-  - report_name = t(".report_types.#{report_type}")
-  .form-section
-    %h2.govuk-heading-l{ id: "heading-#{report_type}" }
-      = report_name
-    %p{ role: 'group', 'aria-labelledby': "heading-#{report_type}" }
-      - if report&.started_at
-        = t('.report_generated_at', time: report.started_at.strftime(Settings.report_date_format))
-      - else
-        = t('.unavailable_report')
-    %p
-      - if report&.started_at.present?
-        = govuk_link_button(t('.download'), case_workers_admin_management_information_download_url(report_type: report_type, format: :csv))
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = govuk_inset_text do
+      = t('.report_instructions')
 
-      = govuk_link_button(t('.regenerate'), case_workers_admin_management_information_generate_url(report_type: report_type))
+    - @available_report_types.each do |report_type, report|
+      - report_name = t(".report_types.#{report_type}")
+      .form-section
+        %h2.govuk-heading-l{ id: "heading-#{report_type}" }
+          = report_name
+        %p{ role: 'group', 'aria-labelledby': "heading-#{report_type}" }
+          - if report&.started_at
+            = t('.report_generated_at', time: report.started_at.strftime(Settings.report_date_format))
+          - else
+            = t('.unavailable_report')
+        %p
+          - if report&.started_at.present?
+            = govuk_link_button(t('.download'), case_workers_admin_management_information_download_url(report_type: report_type, format: :csv))
 
-#provisional-assessment-date.form-section.fx-dates-chooser
-  %h2.govuk-heading-l
-    = t('.provisional_assessments_by_date')
+          = govuk_link_button_secondary(t('.update_report'), case_workers_admin_management_information_generate_url(report_type: report_type))
 
-  = form_with builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
-    = f.hidden_field :user_api_key, id: :user_api_key, value: @current_user.api_key
+    #provisional-assessment-date.form-section.fx-dates-chooser
+      %h2.govuk-heading-l
+        = t('.provisional_assessments_by_date')
 
-    %p= t('.report_information')
+      = form_with builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+        = f.hidden_field :user_api_key, id: :user_api_key, value: @current_user.api_key
 
-    .fx-start-date
-      = f.govuk_date_field :dob1,
-        legend: { text: t('.start_date') },
-        hint: { text: t('.example_date') }
+        %p= t('.report_information')
 
-    .fx-end-date
-      = f.govuk_date_field :dob2,
-        legend: { text: t('.end_date') },
-        hint: { text: t('.example_date') }
+        .fx-start-date
+          = f.govuk_date_field :dob1,
+            legend: { text: t('.start_date') },
+            hint: { text: t('.example_date') }
 
-  = govuk_link_button(t('.download'), '', disabled: 'true', id: 'provisional_assessments_date_download')
+        .fx-end-date
+          = f.govuk_date_field :dob2,
+            legend: { text: t('.end_date') },
+            hint: { text: t('.example_date') }
 
-= govuk_inset_text do
-  = t('.report_instructions')
+      = govuk_link_button(t('.download'), '', disabled: 'true', id: 'provisional_assessments_date_download')
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2505,14 +2505,18 @@ en:
             Click ‘Download’ to download the report now, or click ‘Update report’ to create a new version of the report with the latest data.
           report_generated_at: "The latest report was generated at %{time}"
           report_types:
-            agfs_management_information: AGFS management information
-            agfs_management_information_v2: AGFS management information V2
-            lgfs_management_information: LGFS management information
-            lgfs_management_information_v2: LGFS management information V2
-            management_information: Management information
-            management_information_v2: Management information V2
-            provisional_assessment: Provisional assessment
-            rejections_refusals: 'Rejections/Refusals'
+            agfs_management_information_html: AGFS management information
+            agfs_management_information_v2_html: |
+              AGFS management information <strong class="govuk-tag govuk-tag--blue">beta</strong>
+            lgfs_management_information_html: LGFS management information
+            lgfs_management_information_v2_html: |
+              LGFS management information <strong class="govuk-tag govuk-tag--blue">beta</strong>
+            management_information_html: Management information
+            management_information_v2_html: |
+              Management information <strong class="govuk-tag govuk-tag--blue">beta</strong>
+            provisional_assessment_html: Provisional assessment
+            rejections_refusals_html: 'Rejections/Refusals'
+            submitted_claims_html: Submitted claims
           start_date: Start date
           unavailable_report: "There is currently no report available"
           update_report: Update report

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2478,37 +2478,45 @@ en:
       management_information:
         validate_report_type:
           invalid_report_type: &invalid_report_type The requested report type is not supported
+        create:
+          invalid_report_type: *invalid_report_type
+          invalid_report_date: The supplied date is invalid
         download:
           invalid_report_type: *invalid_report_type
           missing_report: The requested report is missing
         generate:
           invalid_report_type: *invalid_report_type
         index:
-          page_title: View management information
-          page_heading: Reports
           all_claims_report: 'All claims report'
-          report_generated_at: "The latest report was generated at %{time}"
+          date_hint: For example 31 3 2017
           day: Day
-          month: Month
-          year: Year
-          example_date: "For example, 31 3 1980"
-          report_types:
-            agfs_management_information: AGFS management information
-            lgfs_management_information: LGFS management information
-            management_information: Management information
-            provisional_assessment: Provisional assessment
-            rejections_refusals: 'Rejections/Refusals'
-          unavailable_report: "There is currently no report available"
+          day_in_week: Day in week
           download: Download
           end_date: End date
+          example_date: "For example, 31 3 2020"
+          example_day_in_week: "For example, 05 08 2021 will generate report for Saturday 03/08/2021 to Friday 09/08/2021"
+          month: Month
+          page_heading: Reports
+          page_title: View management information
           provisional_assessments_by_date: Provisional assessment by date
           regenerate: Regenerate
           report_information: |
             These reports are not saved and are generated on demand
           report_instructions: |
             Click 'Download' to download the report now, or click 'Regenerate' to generate a more up to date report and refresh this page in a few minutes to download the new report.
+          report_generated_at: "The latest report was generated at %{time}"
+          report_types:
+            agfs_management_information: AGFS management information
+            agfs_management_information_v2: AGFS management information V2
+            lgfs_management_information: LGFS management information
+            lgfs_management_information_v2: LGFS management information V2
+            management_information: Management information
+            management_information_v2: Management information V2
+            provisional_assessment: Provisional assessment
+            rejections_refusals: 'Rejections/Refusals'
           start_date: Start date
-          date_hint: For example 31 3 2017
+          unavailable_report: "There is currently no report available"
+          year: Year
         job_scheduled: 'A background job has been scheduled to regenerate the report. Please refresh this page in a few minutes.'
     claims:
       archived:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2499,11 +2499,10 @@ en:
           page_heading: Reports
           page_title: View management information
           provisional_assessments_by_date: Provisional assessment by date
-          regenerate: Regenerate
           report_information: |
             These reports are not saved and are generated on demand
           report_instructions: |
-            Click 'Download' to download the report now, or click 'Regenerate' to generate a more up to date report and refresh this page in a few minutes to download the new report.
+            Click ‘Download’ to download the report now, or click ‘Update report’ to create a new version of the report with the latest data.
           report_generated_at: "The latest report was generated at %{time}"
           report_types:
             agfs_management_information: AGFS management information
@@ -2516,8 +2515,9 @@ en:
             rejections_refusals: 'Rejections/Refusals'
           start_date: Start date
           unavailable_report: "There is currently no report available"
+          update_report: Update report
           year: Year
-        job_scheduled: 'A background job has been scheduled to regenerate the report. Please refresh this page in a few minutes.'
+        job_scheduled: Refresh this page in a few minutes to download the new report.
     claims:
       archived:
         page_heading: Your archive

--- a/scheduled_tasks/agfs_management_information_v2_generation_task.rb
+++ b/scheduled_tasks/agfs_management_information_v2_generation_task.rb
@@ -1,0 +1,14 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class AgfsManagementInformationV2GenerationTask < Scheduler::SchedulerTask
+  every '1d', first_at: Chronic.parse('next 1:50 am')
+
+  def run
+    LogStuff.info { 'AGFS Management Information Generation V2 started' }
+    Stats::StatsReportGenerator.call('agfs_management_information_v2')
+    LogStuff.info { 'AGFS Management Information Generation V2 finished' }
+  rescue StandardError => e
+    LogStuff.error { 'AGFS Management Information Generation V2 error: ' + e.message }
+  end
+end

--- a/scheduled_tasks/lgfs_management_information_v2_generation_task.rb
+++ b/scheduled_tasks/lgfs_management_information_v2_generation_task.rb
@@ -1,0 +1,14 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class LgfsManagementInformationV2GenerationTask < Scheduler::SchedulerTask
+  every '1d', first_at: Chronic.parse('next 2:20 am')
+
+  def run
+    LogStuff.info { 'LGFS Management Information Generation V2 started' }
+    Stats::StatsReportGenerator.call('lgfs_management_information_v2')
+    LogStuff.info { 'LGFS Management Information Generation V2 finished' }
+  rescue StandardError => e
+    LogStuff.error { 'LGFS Management Information Generation V2 error: ' + e.message }
+  end
+end

--- a/scheduled_tasks/management_information_v2_generation_task.rb
+++ b/scheduled_tasks/management_information_v2_generation_task.rb
@@ -1,0 +1,14 @@
+require 'chronic'
+
+# https://github.com/ssoroka/scheduler_daemon for help
+class ManagementInformationV2GenerationTask < Scheduler::SchedulerTask
+  every '1d', first_at: Chronic.parse('next 2:50 am')
+
+  def run
+    LogStuff.info { 'AGFS Management Information Generation V2 started' }
+    Stats::StatsReportGenerator.call('management_information_v2')
+    LogStuff.info { 'AGFS Management Information Generation V2 finished' }
+  rescue StandardError => e
+    LogStuff.error { 'AGFS Management Information Generation V2 error: ' + e.message }
+  end
+end

--- a/spec/controllers/case_workers/admin/management_information_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/management_information_controller_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe CaseWorkers::Admin::ManagementInformationController, type: :contr
         %w[management_information
            agfs_management_information
            lgfs_management_information
+           management_information_v2
+           agfs_management_information_v2
+           lgfs_management_information_v2
            provisional_assessment
            rejections_refusals
            submitted_claims]

--- a/spec/controllers/case_workers/admin/management_information_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/management_information_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CaseWorkers::Admin::ManagementInformationController, type: :contr
         it 'redirects the user to the management information page with a successful alert message' do
           expect(response).to have_http_status(:redirect)
           expect(response).to redirect_to(case_workers_admin_management_information_url)
-          expect(flash[:alert]).to eq('A background job has been scheduled to regenerate the report. Please refresh this page in a few minutes.')
+          expect(flash[:notification]).to eq('Refresh this page in a few minutes to download the new report.')
         end
 
         it 'starts a ManagemenInformationGeneration job' do

--- a/spec/factories/case_stages.rb
+++ b/spec/factories/case_stages.rb
@@ -6,6 +6,15 @@ FactoryBot.define do
     sequence(:position) { |n| n }
     roles { %w[agfs lgfs] }
 
+    trait :agfs_pre_ptph do
+      description { 'Pre PTPH' }
+      unique_code { 'PREPTPH' }
+      position { 10 }
+      case_type_id { create(:case_type, :discontinuance).id }
+      roles { %w(agfs) }
+    end
+
+    # do not use obsolete
     trait :agfs_pre_ptph_evidence do
       description { 'Pre PTPH (evidence served)' }
       unique_code { 'PREPTPHES' }
@@ -14,6 +23,7 @@ FactoryBot.define do
       roles { %w(agfs) }
     end
 
+    # obsolete - do not use
     trait :agfs_pre_ptph_no_evidence do
       description { 'Pre PTPH (no evidence served)' }
       unique_code { 'PREPTPH' }
@@ -78,6 +88,7 @@ FactoryBot.define do
       roles { %w(agfs) }
     end
 
+    # obsolete - do not use
     trait :pre_ptph_with_evidence do
       description { 'Pre PTPH (evidence served)' }
       unique_code { 'NOPTPHWPPE' }
@@ -86,6 +97,7 @@ FactoryBot.define do
       roles { %w(lgfs) }
     end
 
+    # obsolete - do not use
     trait :pre_ptph_no_evidence do
       description { 'Pre PTPH (no evidence served)' }
       unique_code { 'NOPTPHNOPPE' }

--- a/spec/factories/case_stages.rb
+++ b/spec/factories/case_stages.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       roles { %w(agfs) }
     end
 
-    # do not use obsolete
+    # obsolete - do not use
     trait :agfs_pre_ptph_evidence do
       description { 'Pre PTPH (evidence served)' }
       unique_code { 'PREPTPHES' }

--- a/spec/factories/case_stages.rb
+++ b/spec/factories/case_stages.rb
@@ -14,24 +14,6 @@ FactoryBot.define do
       roles { %w(agfs) }
     end
 
-    # obsolete - do not use
-    trait :agfs_pre_ptph_evidence do
-      description { 'Pre PTPH (evidence served)' }
-      unique_code { 'PREPTPHES' }
-      position { 5 }
-      case_type_id { create(:case_type, :guilty_plea).id }
-      roles { %w(agfs) }
-    end
-
-    # obsolete - do not use
-    trait :agfs_pre_ptph_no_evidence do
-      description { 'Pre PTPH (no evidence served)' }
-      unique_code { 'PREPTPH' }
-      position { 10 }
-      case_type_id { create(:case_type, :discontinuance).id }
-      roles { %w(agfs) }
-    end
-
     trait :cracked_trial do
       description { 'After PTPH before trial' }
       unique_code { 'AFTPTPH' }
@@ -88,7 +70,7 @@ FactoryBot.define do
       roles { %w(agfs) }
     end
 
-    # obsolete - do not use
+    # TODO: this is case_stage with unique_code of "OBSOLETE1" on DB
     trait :pre_ptph_with_evidence do
       description { 'Pre PTPH (evidence served)' }
       unique_code { 'NOPTPHWPPE' }
@@ -97,7 +79,7 @@ FactoryBot.define do
       roles { %w(lgfs) }
     end
 
-    # obsolete - do not use
+    # TODO: this is case_stage with unique_code of "OBSOLETE2" on DB
     trait :pre_ptph_no_evidence do
       description { 'Pre PTPH (no evidence served)' }
       unique_code { 'NOPTPHNOPPE' }

--- a/spec/factories/claim/interim_claims.rb
+++ b/spec/factories/claim/interim_claims.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :interim_claim, class: 'Claim::InterimClaim' do
+  factory :interim_claim, aliases: [:litigator_interim_claim], class: 'Claim::InterimClaim' do
     litigator_base_setup
     case_concluded_at { nil }
 

--- a/spec/factories/claim/shared/common_claim_traits.rb
+++ b/spec/factories/claim/shared/common_claim_traits.rb
@@ -28,28 +28,28 @@ FactoryBot.define do
       allocate_claim(claim)
       claim.reload
       assign_fees_and_expenses_for(claim)
-      claim.authorise_part
+      claim.authorise_part({ author_id: claim.case_workers.first.user.id })
     end
   end
 
   trait :refused do
     after(:create) do |claim|
       allocate_claim(claim)
-      claim.refuse!
+      claim.refuse!({ author_id: claim.case_workers.first.user.id })
     end
   end
 
   trait :rejected do
     after(:create) do |claim|
       allocate_claim(claim)
-      claim.reject!
+      claim.reject!({ author_id: claim.case_workers.first.user.id })
     end
   end
 
   trait :awaiting_written_reasons do
     after(:create) do |claim|
       authorise_claim(claim)
-      claim.await_written_reasons!
+      claim.await_written_reasons!({ author_id: claim.external_user.user.id })
     end
   end
 
@@ -61,7 +61,7 @@ FactoryBot.define do
         assign_fees_and_expenses_for(claim)
         claim.authorise!
       end
-      claim.redetermine!
+      claim.redetermine!({ author_id: claim.external_user.user.id })
     end
   end
 
@@ -69,6 +69,13 @@ FactoryBot.define do
     after(:create) do |claim|
       authorise_claim(claim)
       claim.archive_pending_delete!
+    end
+  end
+
+  trait :archived_pending_review do
+    after(:create) do |claim|
+      authorise_claim(claim)
+      claim.archive_pending_review!
     end
   end
 end

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe Claim::BaseClaim do
     end
   end
 
+  describe '.claim_types' do
+    specify { expect(described_class.claim_types.map(&:to_s)).to match_array(agfs_claim_object_types | lgfs_claim_object_types) }
+  end
+
   describe '.agfs_claim_types' do
     specify { expect(described_class.agfs_claim_types.map(&:to_s)).to match_array(agfs_claim_object_types) }
   end

--- a/spec/presenters/management_information_presenter_spec.rb
+++ b/spec/presenters/management_information_presenter_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe ManagementInformationPresenter do
 
       it 'total (inc VAT)' do
         presenter.present! do |claim_journeys|
-          expect(claim_journeys.first).to include(claim.total_including_vat.to_s)
-          expect(claim_journeys.second).to include(claim.total_including_vat.to_s)
+          expect(claim_journeys.first).to include(format('%.2f', claim.total_including_vat))
+          expect(claim_journeys.second).to include(format('%.2f', claim.total_including_vat))
         end
       end
 
@@ -313,7 +313,7 @@ RSpec.describe ManagementInformationPresenter do
         let(:claim) { create :authorised_claim }
 
         it 'returns nil' do
-          presenter.present! { expect(presenter.af1_lf1_processed_by).to eq '' }
+          presenter.present! { expect(presenter.af1_lf1_processed_by).to be_nil }
         end
       end
 

--- a/spec/services/cleaners/litigator_hardship_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/litigator_hardship_claim_cleaner_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Cleaners::LitigatorHardshipClaimCleaner do
         case_stage: build(:case_stage, :pre_ptph_with_evidence)
       )
     end
+
     let(:hardship_fee) do
       create(
         :hardship_fee,

--- a/spec/services/stats/management_information/daily_report_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_generator_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+RSpec.describe Stats::ManagementInformation::DailyReportGenerator do
+  subject(:generator) { described_class.new(options) }
+
+  let(:options) { {} }
+  let(:expected_headers) do
+    [
+      'Id',
+      'Scheme',
+      'Case number',
+      'Supplier number',
+      'Organisation',
+      'Case type name',
+      'Bill type',
+      'Claim total',
+      'Submission type',
+      'Transitioned at',
+      'Last submitted at',
+      'Originally submitted at',
+      'Allocated at',
+      'Completed at',
+      'Current or end state',
+      'State reason code',
+      'Rejection reason',
+      'Case worker',
+      'Disk evidence case',
+      'Main defendant',
+      'Maat reference',
+      'Rep order issued date',
+      'AF1/LF1 processed by',
+      'Misc fees'
+    ]
+  end
+
+  describe '#call' do
+    subject(:result) { generator.call }
+
+    it 'returns a Stats::Result object' do
+      is_expected.to be_instance_of(Stats::Result)
+    end
+
+    it 'returns Stats::Result object with content' do
+      expect(result.content).to be_truthy
+    end
+
+    it 'csv has expected headers' do
+      csv = CSV.parse(result.content, headers: true)
+      expect(csv.headers).to match_array(expected_headers)
+    end
+
+    context 'with some data' do
+      let!(:agfs_claim) { create(:advocate_final_claim, :submitted) }
+
+      let!(:lgfs_claim) do
+        create(:litigator_final_claim, :allocated, disk_evidence: true).tap do |claim|
+          claim.tap do |c|
+            assign_fees_and_expenses_for(c)
+            c.authorise_part!({ author_id: create(:case_worker,
+                                                  user: create(:user,
+                                                               first_name: 'Case',
+                                                               last_name: 'Worker-one')).user.id })
+          end
+
+          claim.redetermine!
+          claim.allocate!
+          claim.refuse!({ author_id: create(:case_worker,
+                                            user: create(:user,
+                                                         first_name: 'Case',
+                                                         last_name: 'Worker-two')).user.id,
+                          reason_code: ['reason'],
+                          reason_text: 'reason text from caseworker' })
+        end
+      end
+
+      let(:rows) { CSV.parse(result.content, headers: true) }
+
+      it {
+        expect(rows['Id'])
+          .to match_array([agfs_claim.id.to_s, lgfs_claim.id.to_s, lgfs_claim.id.to_s])
+      }
+
+      it {
+        expect(rows['Scheme'])
+          .to match_array(%w[AGFS LGFS LGFS])
+      }
+
+      it {
+        expect(rows['Case number'])
+          .to match_array([agfs_claim.case_number, lgfs_claim.case_number, lgfs_claim.case_number])
+      }
+
+      it {
+        expect(rows['Supplier number'])
+          .to match_array([agfs_claim.supplier_number, lgfs_claim.supplier_number, lgfs_claim.supplier_number])
+      }
+
+      it {
+        expect(rows['Organisation'])
+          .to match_array([agfs_claim.creator.provider.name,
+                           lgfs_claim.creator.provider.name,
+                           lgfs_claim.creator.provider.name])
+      }
+
+      it {
+        expect(rows['Case type name'])
+          .to match_array([agfs_claim.case_type.name, lgfs_claim.case_type.name, lgfs_claim.case_type.name])
+      }
+
+      it {
+        expect(rows['Bill type'])
+          .to match_array(['AGFS Final', 'LGFS Final', 'LGFS Final'])
+      }
+
+      it {
+        expect(rows['Claim total'])
+          .to match_array([(agfs_claim.total + agfs_claim.vat_amount).to_s,
+                           (lgfs_claim.total + lgfs_claim.vat_amount).to_s,
+                           (lgfs_claim.total + lgfs_claim.vat_amount).to_s])
+      }
+
+      it { expect(rows['Submission type']).to match_array(%w[new new redetermination]) }
+      it { expect(rows['Transitioned at']).to all(match(%r{\d{2}/\d{2}/\d{4}})) }
+      it { expect(rows['Last submitted at']).to all(match(%r{\d{2}/\d{2}/\d{4}})) }
+      it { expect(rows['Originally submitted at']).to all(match(%r{\d{2}/\d{2}/\d{4}})) }
+      it { expect(rows['Allocated at']).to all(match(%r{(\d{2}/\d{2}/\d{4}|n/a)})) }
+      it { expect(rows['Completed at']).to all(match(%r{(\d{2}/\d{2}/\d{4} \d{2}:\d{2}|n/a)})) }
+      it { expect(rows['Current or end state']).to match_array(%w[submitted part_authorised refused]) }
+      it { expect(rows['State reason code']).to match_array([nil, nil, 'reason']) }
+      it { expect(rows['Rejection reason']).to match_array([nil, nil, 'reason text from caseworker']) }
+
+      it {
+        expect(rows['Case worker'])
+          .to match_array(['n/a',
+                           'Case Worker-one',
+                           'Case Worker-two'])
+      }
+
+      it { expect(rows['Disk evidence case']).to match_array(%w[No Yes Yes]) }
+
+      it {
+        expect(rows['Main defendant'])
+          .to match_array([agfs_claim.defendants.first.name,
+                           lgfs_claim.defendants.first.name,
+                           lgfs_claim.defendants.first.name])
+      }
+
+      it {
+        expect(rows['Maat reference'])
+          .to match_array([agfs_claim.earliest_representation_order.maat_reference,
+                           lgfs_claim.earliest_representation_order.maat_reference,
+                           lgfs_claim.earliest_representation_order.maat_reference])
+      }
+
+      it {
+        expect(rows['Rep order issued date'])
+          .to match_array([agfs_claim.earliest_representation_order_date.strftime('%d/%m/%Y'),
+                           lgfs_claim.earliest_representation_order_date.strftime('%d/%m/%Y'),
+                           lgfs_claim.earliest_representation_order_date.strftime('%d/%m/%Y')])
+      }
+
+      it { expect(rows['AF1/LF1 processed by']).to eql([nil, nil, 'Case Worker-one']) }
+
+      it {
+        expect(rows['Misc fees'])
+          .to match_array([agfs_claim.misc_fees.map { |f| f.fee_type.description }.join(' '),
+                           lgfs_claim.misc_fees.map { |f| f.fee_type.description }.join(' '),
+                           lgfs_claim.misc_fees.map { |f| f.fee_type.description }.join(' ')])
+      }
+    end
+
+    context 'when filtering by scheme' do
+      before do
+        create(:advocate_final_claim, :submitted)
+        create(:litigator_final_claim, :submitted)
+      end
+
+      let(:rows) { CSV.parse(result.content, headers: true) }
+
+      context 'with no scheme' do
+        let(:options) { {} }
+
+        it { expect(rows['Scheme']).to match_array(%w[AGFS LGFS]) }
+      end
+
+      context 'with AGFS scheme' do
+        let(:options) { { scheme: :agfs } }
+
+        it { expect(rows['Scheme']).to match_array(%w[AGFS]) }
+      end
+
+      context 'with LGFS scheme' do
+        let(:options) { { scheme: :lgfs } }
+
+        it { expect(rows['Scheme']).to match_array(%w[LGFS]) }
+      end
+    end
+
+    context 'with logging' do
+      before { allow(LogStuff).to receive(:info) }
+
+      it 'logs start and end' do
+        generator.call
+        expect(LogStuff).to have_received(:info).twice
+      end
+    end
+
+    context 'when unexpected errors raised' do
+      before do
+        allow(CSV).to receive(:generate).and_raise(StandardError, 'oops')
+        allow(LogStuff).to receive(:error)
+      end
+
+      it 'uses LogStuff to log error' do
+        generator.call
+      rescue StandardError
+        nil
+      ensure
+        expect(LogStuff).to have_received(:error).once
+      end
+
+      it 're-raises the error' do
+        expect { generator.call }.to raise_error(StandardError, 'oops')
+      end
+    end
+  end
+end

--- a/spec/services/stats/management_information/daily_report_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_generator_spec.rb
@@ -114,9 +114,9 @@ RSpec.describe Stats::ManagementInformation::DailyReportGenerator do
 
       it {
         expect(rows['Claim total'])
-          .to match_array([(agfs_claim.total + agfs_claim.vat_amount).to_s,
-                           (lgfs_claim.total + lgfs_claim.vat_amount).to_s,
-                           (lgfs_claim.total + lgfs_claim.vat_amount).to_s])
+          .to match_array([format('%.2f', agfs_claim.total + agfs_claim.vat_amount),
+                           format('%.2f', lgfs_claim.total + lgfs_claim.vat_amount),
+                           format('%.2f', lgfs_claim.total + lgfs_claim.vat_amount)])
       }
 
       it { expect(rows['Submission type']).to match_array(%w[new new redetermination]) }

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -142,25 +142,25 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       context 'with advocate final claim' do
         before { create(:advocate_final_claim, :submitted) }
 
-        it { is_expected.to match_array(['AGFS Final']) }
+        it { is_expected.to contain_exactly('AGFS Final') }
       end
 
       context 'with advocate supplementary claim' do
         before { create(:advocate_supplementary_claim, :submitted) }
 
-        it { is_expected.to match_array(['AGFS Supplementary']) }
+        it { is_expected.to contain_exactly('AGFS Supplementary') }
       end
 
       context 'with litigator final claim' do
         before { create(:litigator_final_claim, :submitted) }
 
-        it { is_expected.to match_array(['LGFS Final']) }
+        it { is_expected.to contain_exactly('LGFS Final') }
       end
 
       context 'with litigator transfer claim' do
         before { create(:litigator_transfer_claim, :submitted) }
 
-        it { is_expected.to match_array(['LGFS Transfer']) }
+        it { is_expected.to contain_exactly('LGFS Transfer') }
       end
     end
 

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -167,9 +167,17 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
     describe ':claim_total' do
       subject { response.pluck(:claim_total) }
 
-      let!(:claim) { create(:litigator_final_claim, :submitted) }
+      before do
+        create(:litigator_final_claim, :submitted).tap do |c|
+          c.update!(total: 9999.98555)
+        end
+      end
 
-      it { is_expected.to match_array([format('%.2f', claim.total_including_vat)]) }
+      it { is_expected.to all(be_a(BigDecimal)) }
+
+      it 'rounds to 4 decimal places' do
+        is_expected.to contain_exactly(9999.9856.to_d)
+      end
     end
 
     describe ':last_submitted_at' do

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       let!(:claim) { create(:litigator_final_claim, :submitted) }
 
-      it { is_expected.to match_array([claim.total_including_vat.to_s]) }
+      it { is_expected.to match_array([format('%.2f', claim.total_including_vat)]) }
     end
 
     describe ':main_defendant' do

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -204,6 +204,38 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       end
     end
 
+    describe ':originally_submitted_at' do
+      subject(:originally_submitted_ats) { response.pluck(:originally_submitted_at) }
+
+      context 'when outside of british summer time' do
+        let(:timestamp) { DateTime.parse('2021-03-27 23:59:59') }
+
+        before do
+          create(:litigator_final_claim, :submitted).tap do |claim|
+            claim.update!(original_submission_date: timestamp)
+          end
+        end
+
+        it 'retrieves correct date for Europe/London timezone' do
+          expect(originally_submitted_ats.first.to_date).to eql(Date.parse('2021-03-27'))
+        end
+      end
+
+      context 'when inside british summer time' do
+        let(:timestamp) { DateTime.parse('2021-03-29 23:59:59') }
+
+        before do
+          create(:litigator_final_claim, :submitted).tap do |claim|
+            claim.update!(original_submission_date: timestamp)
+          end
+        end
+
+        it 'retrieves correct date for Europe/London timezone' do
+          expect(originally_submitted_ats.first.to_date).to eql(Date.parse('2021-03-30'))
+        end
+      end
+    end
+
     describe ':main_defendant' do
       subject { response.pluck(:main_defendant) }
 

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -1,0 +1,417 @@
+# frozen_string_literal: true
+
+RSpec.describe Stats::ManagementInformation::DailyReportQuery do
+  describe '.call' do
+    subject(:response) { described_class.call }
+
+    let(:scheme_class) { Stats::ManagementInformation::Scheme }
+
+    it {
+      create(:advocate_final_claim, :submitted)
+      expect(response).to be_a(Array)
+    }
+
+    it {
+      create(:advocate_final_claim, :submitted)
+      expect(response).to all(be_a(Hash))
+    }
+
+    it {
+      create(:advocate_final_claim, :submitted)
+      keys = response.flat_map(&:keys)
+      expect(keys).to all(be_a(Symbol))
+    }
+
+    context 'with no scope' do
+      subject(:response) { described_class.call }
+
+      it 'returns active claims only' do
+        create(:advocate_final_claim, :authorised).soft_delete
+        create(:litigator_final_claim, :submitted)
+        deleted_ats = response.pluck(:deleted_at)
+
+        expect(deleted_ats).to all(be_nil)
+      end
+
+      it 'returns non-draft claims only' do
+        create(:advocate_final_claim, :draft)
+        create(:litigator_final_claim, :submitted)
+        states = response.pluck(:state)
+
+        expect(states).to match_array(%w[submitted])
+      end
+
+      it 'returns all claim types' do
+        create(:advocate_final_claim, :submitted)
+        create(:litigator_final_claim, :submitted)
+        types = response.pluck(:type)
+
+        expect(types).to match_array(%w[Claim::AdvocateClaim Claim::LitigatorClaim])
+      end
+    end
+
+    context 'with invalid scheme scope' do
+      subject(:call) { described_class.call({ scheme: scheme }) }
+
+      let(:scheme) { :foobar }
+
+      it { expect { call }.to raise_error ArgumentError, 'scheme must be "agfs" or "lgfs"' }
+    end
+
+    context 'with AGFS scheme scope' do
+      subject(:response) { described_class.call({ scheme: scheme }) }
+
+      let(:scheme) { :agfs }
+
+      it 'returns AGFS claims only' do
+        create(:advocate_final_claim, :submitted)
+        create(:litigator_final_claim, :submitted)
+        types = response.pluck(:type)
+
+        expect(types).to match_array(%w[Claim::AdvocateClaim])
+      end
+    end
+
+    context 'with LGFS claim scope' do
+      subject(:response) { described_class.call({ scheme: scheme }) }
+
+      let(:scheme) { :lgfs }
+
+      it 'returns LGFS claims only' do
+        create(:advocate_final_claim, :submitted)
+        create(:litigator_final_claim, :submitted)
+        types = response.pluck(:type)
+
+        expect(types).to match_array(%w[Claim::LitigatorClaim])
+      end
+    end
+
+    describe ':scheme' do
+      subject { response.pluck(:scheme) }
+
+      context 'with AGFS claim' do
+        before { create(:advocate_final_claim, :submitted) }
+
+        it { is_expected.to match_array(%w[AGFS]) }
+      end
+
+      context 'with LGFS claim' do
+        before { create(:litigator_final_claim, :submitted) }
+
+        it { is_expected.to match_array(%w[LGFS]) }
+      end
+    end
+
+    describe ':organisation' do
+      subject { response.pluck(:organisation) }
+
+      let!(:claim) { create(:advocate_final_claim, :submitted) }
+
+      it { is_expected.to match_array([claim.provider.name]) }
+    end
+
+    describe ':case_type_name' do
+      subject { response.pluck(:case_type_name) }
+
+      let!(:claim) { create(:advocate_final_claim, :submitted) }
+
+      it { is_expected.to match_array([claim.case_type.name]) }
+    end
+
+    describe ':bill_type' do
+      subject { response.pluck(:bill_type) }
+
+      context 'with advocate final claim' do
+        before { create(:advocate_final_claim, :submitted) }
+
+        it { is_expected.to match_array(['AGFS Final']) }
+      end
+
+      context 'with advocate supplementary claim' do
+        before { create(:advocate_supplementary_claim, :submitted) }
+
+        it { is_expected.to match_array(['AGFS Supplementary']) }
+      end
+
+      context 'with litigator final claim' do
+        before { create(:litigator_final_claim, :submitted) }
+
+        it { is_expected.to match_array(['LGFS Final']) }
+      end
+
+      context 'with litigator transfer claim' do
+        before { create(:litigator_transfer_claim, :submitted) }
+
+        it { is_expected.to match_array(['LGFS Transfer']) }
+      end
+    end
+
+    describe ':claim_total' do
+      subject { response.pluck(:claim_total) }
+
+      let!(:claim) { create(:litigator_final_claim, :submitted) }
+
+      it { is_expected.to match_array([claim.total_including_vat.to_s]) }
+    end
+
+    describe ':main_defendant' do
+      subject { response.pluck(:main_defendant) }
+
+      before do
+        create(:advocate_final_claim, :allocated, create_defendant_and_rep_order: false).tap do |claim|
+          create(:defendant, claim: claim, first_name: 'Main', last_name: 'Defendant')
+          create(:defendant, claim: claim, first_name: 'Jammy', last_name: 'Dodger')
+          claim.deallocate!
+          claim.allocate!
+
+          claim.tap do |c|
+            assign_fees_and_expenses_for(c)
+            c.authorise_part!
+          end
+
+          claim.redetermine!
+          claim.allocate!
+          claim.refuse!
+        end
+      end
+
+      it { is_expected.to match_array(['Main Defendant', 'Main Defendant']) }
+    end
+
+    describe ':maat_reference' do
+      subject { response.pluck(:maat_reference) }
+
+      before do
+        create(:advocate_final_claim, :allocated, create_defendant_and_rep_order: false).tap do |claim|
+          create(:defendant, claim: claim, first_name: 'Main', last_name: 'Defendant').tap do |defendant|
+            defendant.representation_orders = [create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 30.days.ago,
+                                                      maat_reference: '4444442'),
+                                               create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 29.days.ago,
+                                                      maat_reference: '4444444')]
+          end
+          create(:defendant, claim: claim, first_name: 'Jammy', last_name: 'Dodger').tap do |defendant|
+            defendant.representation_orders = [create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 31.days.ago,
+                                                      maat_reference: '4444441'),
+                                               create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 29.days.ago,
+                                                      maat_reference: '4444443')]
+          end
+        end
+      end
+
+      it { is_expected.to match_array(['4444441']) }
+    end
+
+    describe ':rep_order_issued_date' do
+      subject { response.pluck(:rep_order_issued_date) }
+
+      before do
+        create(:advocate_final_claim, :allocated, create_defendant_and_rep_order: false).tap do |claim|
+          create(:defendant, claim: claim, first_name: 'Main', last_name: 'Defendant').tap do |defendant|
+            defendant.representation_orders = [create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 30.days.ago),
+                                               create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 29.days.ago)]
+          end
+          create(:defendant, claim: claim, first_name: 'Jammy', last_name: 'Dodger').tap do |defendant|
+            defendant.representation_orders = [create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 31.days.ago),
+                                               create(:representation_order,
+                                                      defendant: defendant,
+                                                      representation_order_date: 29.days.ago)]
+          end
+        end
+      end
+
+      it { is_expected.to match_array([31.days.ago.strftime('%F')]) }
+    end
+
+    # authors full name for the "previous decision" that was redetermined or nil if previous decision was not redetermined
+    describe ':af1_lf1_processed_by' do
+      subject { response.pluck(:af1_lf1_processed_by) }
+
+      let(:case_worker1) { create(:case_worker, user: create(:user, first_name: 'Case', last_name: 'Worker-one')) }
+      let(:case_worker2) { create(:case_worker, user: create(:user, first_name: 'Case', last_name: 'Worker-two')) }
+      let(:case_worker3) { create(:case_worker, user: create(:user, first_name: 'Case', last_name: 'Worker-three')) }
+
+      before do
+        create(:advocate_final_claim, :allocated).tap do |claim|
+          claim.tap do |c|
+            assign_fees_and_expenses_for(c)
+            c.authorise_part!({ author_id: case_worker1.user.id })
+          end
+
+          claim.redetermine!
+          claim.allocate!
+          claim.refuse!({ author_id: case_worker2.user.id })
+          claim.redetermine!
+          claim.allocate!
+          claim.refuse!({ author_id: case_worker3.user.id })
+          claim.redetermine!
+          claim.allocate!
+        end
+      end
+
+      it {
+        is_expected.to eql([nil, 'Case Worker-one', 'Case Worker-two', 'Case Worker-three'])
+      }
+    end
+
+    describe ':misc_fees' do
+      subject { response.pluck(:misc_fees) }
+
+      before do
+        create(:advocate_final_claim, :allocated).tap do |claim|
+          claim.fees.clear
+          claim.fees << create(:misc_fee, :miaph_fee, claim: claim)
+          claim.fees << create(:misc_fee, :miahu_fee, claim: claim)
+        end
+      end
+
+      it {
+        is_expected.to match_array(['Abuse of process hearings (half day) Abuse of process hearings (half day uplift)'])
+      }
+    end
+
+    context 'with claim state transitions' do
+      subject(:response) { described_class.call }
+
+      let(:transition_tos) { response.pluck(:journey).map { |el| el.pluck(:to) } }
+
+      it 'excludes state transitions to draft' do
+        create(:advocate_final_claim, :allocated)
+        expect(transition_tos).to match_array([%w[submitted allocated]])
+      end
+
+      it 'excludes state transitions to archived_pending_delete' do
+        create(:litigator_final_claim, :archived_pending_delete)
+        expect(transition_tos).to match_array([%w[submitted allocated authorised]])
+      end
+
+      it 'excludes state transitions to archived_pending_review' do
+        create(:litigator_hardship_claim, :archived_pending_review)
+        expect(transition_tos).to match_array([%w[submitted allocated authorised]])
+      end
+
+      context 'when claim has transitions on or under 6 months old' do
+        before do
+          travel_to(6.months.ago + 1.day) { claim }
+          claim.allocate!
+        end
+
+        let(:claim) { create(:litigator_final_claim, :submitted) }
+
+        it 'include all state transitions' do
+          expect(transition_tos).to match_array([%w[submitted allocated]])
+        end
+      end
+
+      # TODO: The six month exclusion was only applied to handle failing reports and/or
+      # keep the spreadsheet small for filtering purposes. It could be removed
+      # if these problems are no longer issues.
+      context 'when claim has transitions over 6 months old' do
+        before do
+          travel_to(6.months.ago) { claim }
+          claim.allocate!
+        end
+
+        let(:claim) { create(:litigator_final_claim, :submitted) }
+
+        it 'excludes state transitions over 6 months old' do
+          expect(transition_tos).to match_array([%w[allocated]])
+        end
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it 'excludes deallocations and deallocated allocations' do
+        create(:advocate_final_claim, :allocated).tap do |claim|
+          claim.deallocate!
+          claim.allocate!
+          claim.deallocate!
+        end
+
+        expect(transition_tos).to eq([%w[submitted]])
+      end
+
+      it 'excludes deallocations and all but last allocation' do
+        create(:advocate_final_claim, :allocated).tap do |claim|
+          claim.deallocate!
+          claim.allocate!
+          claim.deallocate!
+          claim.allocate!
+        end
+
+        expect(transition_tos).to eq([%w[submitted allocated]])
+      end
+
+      context 'with a redetermination' do
+        it 'slices transitions into "completed" chunks' do
+          create(:advocate_final_claim, :allocated).tap do |claim|
+            claim.tap do |c|
+              assign_fees_and_expenses_for(c)
+              c.authorise_part!
+            end
+
+            claim.redetermine!
+            claim.allocate!
+            claim.refuse!
+          end
+
+          expect(transition_tos).to eq([%w[submitted allocated part_authorised], %w[redetermination allocated refused]])
+        end
+
+        it 'slices transitions into "completed" chunks plus remainder' do
+          create(:advocate_final_claim, :allocated).tap do |claim|
+            claim.tap do |c|
+              assign_fees_and_expenses_for(c)
+              c.authorise_part!
+            end
+
+            claim.redetermine!
+            claim.allocate!
+            claim.refuse!
+            claim.redetermine!
+            claim.allocate!
+          end
+
+          expect(transition_tos).to eq([%w[submitted allocated part_authorised],
+                                        %w[redetermination allocated refused],
+                                        %w[redetermination allocated]])
+        end
+
+        it 'excludes deallocations and deallocated allocations per slice' do
+          create(:advocate_final_claim, :allocated).tap do |claim|
+            claim.deallocate!
+            claim.allocate!
+            claim.deallocate!
+            claim.allocate!
+
+            claim.tap do |c|
+              assign_fees_and_expenses_for(c)
+              c.authorise_part!
+            end
+
+            claim.redetermine!
+            claim.allocate!
+            claim.deallocate!
+            claim.allocate!
+            claim.refuse!
+          end
+
+          expect(transition_tos).to eq([%w[submitted allocated part_authorised], %w[redetermination allocated refused]])
+        end
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+  end
+end

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -113,9 +113,23 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
     describe ':case_type_name' do
       subject { response.pluck(:case_type_name) }
 
-      let!(:claim) { create(:advocate_final_claim, :submitted) }
+      context 'with a claim without a case type' do
+        let!(:claim) { create(:litigator_transfer_claim, :submitted) }
 
-      it { is_expected.to match_array([claim.case_type.name]) }
+        it { is_expected.to all(be_nil) }
+      end
+
+      context 'with a claim with a case type' do
+        let!(:claim) { create(:advocate_final_claim, :submitted) }
+
+        it { is_expected.to match_array([claim.case_type.name]) }
+      end
+
+      context 'with a claim with a case stage' do
+        let!(:claim) { create(:advocate_hardship_claim, :submitted, case_stage: build(:case_stage, :agfs_pre_ptph)) }
+
+        it { is_expected.to match_array('Discontinuance') }
+      end
     end
 
     describe ':bill_type' do

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -386,16 +386,16 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       end
 
       # TODO: remove debug helper
-      let(:time_info) do
-        { ruby_current_datetime: DateTime.current.iso8601,
-          ruby_now_datetime: DateTime.now.iso8601,
-          postgres_now: ActiveRecord::Base.connection.execute('select now()').to_a,
-          postgres_now_6_months_ago: ActiveRecord::Base.connection.execute("select (now() - '6 months'::interval)").to_a,
-          postgres_now_6_months_ago_cast: ActiveRecord::Base.connection.execute("select (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London'").to_a,
-          postgres_now_6_months_ago_trunc_cast: ActiveRecord::Base.connection.execute("select DATE_TRUNC('day', (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')").to_a }
-      end
+      # let(:time_info) do
+      #   { ruby_current_datetime: DateTime.current.iso8601,
+      #     ruby_now_datetime: DateTime.now.iso8601,
+      #     postgres_now: ActiveRecord::Base.connection.execute('select now()').to_a,
+      #     postgres_now_6_months_ago: ActiveRecord::Base.connection.execute("select (now() - '6 months'::interval)").to_a,
+      #     postgres_now_6_months_ago_cast: ActiveRecord::Base.connection.execute("select (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London'").to_a,
+      #     postgres_now_6_months_ago_trunc_cast: ActiveRecord::Base.connection.execute("select DATE_TRUNC('day', (now() - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')").to_a }
+      # end
 
-      fcontext 'when applying 6 month rule' do
+      context 'when applying 6 month rule' do
         let(:claim) { create(:litigator_final_claim, :submitted) }
 
         # NOTE: The six month exclusion was only applied to handle failing reports and/or
@@ -412,33 +412,33 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
         # (beginning november to end of march roughly) and the query is not using
         # 'Europe/London' timezone "casting".
         #
-        # IMPORTANT: query uses postgres `current_date` which cannot be stubbed
+        # IMPORTANT: query uses postgres `now()` which cannot be stubbed
         #
 
         # TODO: this emulates MI version 1 current behaviour, however:
 
         # 1. the 6 month rule should probably include transitions that are exactly 6 months old.
-        # 2. it is time sensitive and performance sensitive as there is no way to stub postgres
-        #    db now() method. It is likely to be flaky therefore.
-        # 3. to improve this we should truncate the date comparisons on old and new MI reports to nearest date
-        #    (i.e. not datetime). This will provide clear behaviour as well as be more testable
+        # 2. it is time sensitive (and performance sensitive) as there is no way to stub postgres
+        #    db now() method. It may be flaky therefore.
+        # 3. to improve this, and the report logic generally, we should truncate the date comparisons on
+        # old and new MI reports to nearest date (i.e. not datetime). This will provide clear behaviour
+        # as well as be more testable.
 
-        it 'includes all transitions under 6 months old', skip: 'see comments above' do
+        it 'includes all transitions under 6 months old' do
           travel_to(6.months.ago + 1.second) { claim }
           claim.allocate!
           expect(transition_tos).to match_array([%w[submitted allocated]])
         end
 
-        it 'excludes state transitions exactly 6 months old', skip: 'see comments above' do
+        it 'excludes state transitions exactly 6 months old' do
           travel_to(6.months.ago) { claim }
           claim.allocate!
           expect(transition_tos).to match_array([%w[allocated]])
         end
 
-        it 'excludes state transitions over 6 months old', skip: 'see comments above' do
-          travel_to(6.months.ago - 1.second) { claim; ap time_info }
+        it 'excludes state transitions over 6 months old' do
+          travel_to(6.months.ago - 1.second) { claim }
           claim.allocate!
-          ap response.pluck(:journey).map { |el| el.pluck(:to, :created_at) }
           expect(transition_tos).to match_array([%w[allocated]])
         end
       end

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -172,6 +172,38 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       it { is_expected.to match_array([format('%.2f', claim.total_including_vat)]) }
     end
 
+    describe ':last_submitted_at' do
+      subject(:last_submitted_ats) { response.pluck(:last_submitted_at) }
+
+      context 'when outside of british summer time' do
+        let(:timestamp) { DateTime.parse('2021-03-27 23:59:59') }
+
+        before do
+          create(:litigator_final_claim, :submitted).tap do |claim|
+            claim.update!(last_submitted_at: timestamp)
+          end
+        end
+
+        it 'retrieves correct date for Europe/London timezone' do
+          expect(last_submitted_ats.first.to_date).to eql(Date.parse('2021-03-27'))
+        end
+      end
+
+      context 'when inside british summer time' do
+        let(:timestamp) { DateTime.parse('2021-03-29 23:59:59') }
+
+        before do
+          create(:litigator_final_claim, :submitted).tap do |claim|
+            claim.update!(last_submitted_at: timestamp)
+          end
+        end
+
+        it 'retrieves correct date for Europe/London timezone' do
+          expect(last_submitted_ats.first.to_date).to eql(Date.parse('2021-03-30'))
+        end
+      end
+    end
+
     describe ':main_defendant' do
       subject { response.pluck(:main_defendant) }
 

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       context 'with a claim without a case type' do
         before { create(:litigator_transfer_claim, :submitted) }
 
-        it { is_expected.to all(be_nil) }
+        it { is_expected.to contain_exactly(nil) }
       end
 
       context 'with a claim with a case type' do

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -114,21 +114,25 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       subject { response.pluck(:case_type_name) }
 
       context 'with a claim without a case type' do
-        let!(:claim) { create(:litigator_transfer_claim, :submitted) }
+        before { create(:litigator_transfer_claim, :submitted) }
 
         it { is_expected.to all(be_nil) }
       end
 
       context 'with a claim with a case type' do
-        let!(:claim) { create(:advocate_final_claim, :submitted) }
+        before { create(:advocate_final_claim, :submitted, case_type: build(:case_type, :cracked_trial)) }
 
-        it { is_expected.to match_array([claim.case_type.name]) }
+        it 'returns case_type#name' do
+          is_expected.to contain_exactly('Cracked Trial')
+        end
       end
 
       context 'with a claim with a case stage' do
-        let!(:claim) { create(:advocate_hardship_claim, :submitted, case_stage: build(:case_stage, :agfs_pre_ptph)) }
+        before { create(:advocate_hardship_claim, :submitted, case_stage: build(:case_stage, :agfs_pre_ptph)) }
 
-        it { is_expected.to match_array('Discontinuance') }
+        it 'returns case_type#name belonging to case_stage' do
+          is_expected.to contain_exactly('Discontinuance')
+        end
       end
     end
 

--- a/spec/services/stats/management_information/presenter_spec.rb
+++ b/spec/services/stats/management_information/presenter_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Stats::ManagementInformation::Presenter do
     context 'with no original_submission_date on record' do
       before do
         allow(record).to receive(:[])
-          .with(:original_submission_date).and_return(nil)
+          .with(:originally_submitted_at).and_return(nil)
       end
 
       it { is_expected.to be_nil }

--- a/spec/services/stats/management_information/presenter_spec.rb
+++ b/spec/services/stats/management_information/presenter_spec.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+RSpec.describe Stats::ManagementInformation::Presenter do
+  subject(:presenter) { described_class.new(record) }
+
+  # OPTIMIZE: to use factory build instead of create and hash the claim object instead
+  # of querying the database. This would spead the tests up at the cost of being a less
+  # realistic test.
+  #
+  let(:query) { Stats::ManagementInformation::DailyReportQuery.call }
+
+  describe '#submission_type' do
+    subject { presenter.submission_type }
+
+    before { create(:litigator_final_claim, :authorised).tap(&:redetermine!) }
+
+    context 'when first journey transition is submitted' do
+      let(:record) { query.first }
+
+      it { is_expected.to eq('new') }
+    end
+
+    context 'when first journey transition is redetermination' do
+      let(:record) { query.last }
+
+      it { is_expected.to eq('redetermination') }
+    end
+  end
+
+  describe '#transitioned_at' do
+    subject { presenter.transitioned_at }
+
+    let(:record) { query.first }
+
+    context 'when journey contains no submissions' do
+      before do
+        travel_to(6.months.ago) do
+          claim
+        end
+        claim.allocate!
+      end
+
+      let(:claim) { create(:litigator_final_claim, :submitted) }
+
+      it { is_expected.to eq('n/a') }
+    end
+
+    context 'when journey contains one or more submissions' do
+      before { create(:litigator_final_claim, :allocated) }
+
+      it { is_expected.to match(%r{\d{2}/\d{2}/\d{4}}) }
+    end
+  end
+
+  describe '#last_submitted_at' do
+    subject { presenter.last_submitted_at }
+
+    before { create(:litigator_final_claim, :submitted) }
+
+    let(:record) { query.first }
+
+    it { is_expected.to match(%r{\d{2}/\d{2}/\d{4}}) }
+
+    context 'with no last_submitted_at on record' do
+      before do
+        allow(record).to receive(:[])
+          .with(:last_submitted_at).and_return(nil)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#originally_submitted_at' do
+    subject { presenter.originally_submitted_at }
+
+    before { create(:litigator_final_claim, :submitted) }
+
+    let(:record) { query.first }
+
+    it { is_expected.to match(%r{\d{2}/\d{2}/\d{4}}) }
+
+    context 'with no original_submission_date on record' do
+      before do
+        allow(record).to receive(:[])
+          .with(:original_submission_date).and_return(nil)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#allocated_at' do
+    subject { presenter.allocated_at }
+
+    context 'with allocated claim journey' do
+      before { create(:advocate_final_claim, :allocated) }
+
+      let(:record) { query.first }
+
+      let(:allocated_at) do
+        record[:journey].find { |j| j[:to].eql?('allocated') }[:created_at]
+      end
+
+      it { is_expected.to eql(allocated_at.strftime('%d/%m/%Y')) }
+    end
+
+    context 'with unallocated claim journey' do
+      before { create(:advocate_final_claim, :submitted) }
+
+      let(:record) { query.first }
+
+      it { is_expected.to eql('n/a') }
+    end
+  end
+
+  describe '#completed_at' do
+    subject { presenter.completed_at }
+
+    context 'with completed claim journey' do
+      before { create(:advocate_final_claim, :authorised) }
+
+      let(:record) { query.first }
+
+      let(:completed_at) do
+        record[:journey].find { |j| j[:to].eql?('authorised') }[:created_at]
+      end
+
+      it { is_expected.to eql(completed_at.strftime('%d/%m/%Y %H:%M')) }
+    end
+
+    context 'with incomplete claim journey' do
+      before { create(:advocate_final_claim, :allocated) }
+
+      let(:record) { query.first }
+
+      it { is_expected.to eql('n/a') }
+    end
+  end
+
+  describe '#current_or_end_state' do
+    subject { presenter.current_or_end_state }
+
+    context 'with claim journey ending in submission state' do
+      before { create(:advocate_final_claim, :submitted) }
+
+      let(:record) { query.first }
+
+      it { is_expected.to eql('submitted') }
+    end
+
+    context 'with claim journey ending in non-submission state' do
+      before { create(:advocate_final_claim, :refused) }
+
+      let(:record) { query.first }
+
+      it { is_expected.to eql('refused') }
+    end
+  end
+
+  describe '#state_reason_code' do
+    subject { presenter.state_reason_code }
+
+    before do
+      create(:advocate_final_claim, :allocated).tap do |c|
+        c.reject!(options)
+      end
+    end
+
+    context 'with claim journey ending in transition with no reason' do
+      let(:options) { {} }
+      let(:record) { query.first }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with claim journey ending in transition with reason' do
+      let(:options) { { reason_code: ['reason'] } }
+      let(:record) { query.first }
+
+      it { is_expected.to eql('reason') }
+    end
+
+    context 'with claim journey ending in transition with array of reasons' do
+      let(:options) { { reason_code: %w[reason1 reason2] } }
+      let(:record) { query.first }
+
+      it { is_expected.to eql('reason1, reason2') }
+    end
+  end
+
+  describe '#rejection_reason' do
+    subject { presenter.rejection_reason }
+
+    before do
+      create(:advocate_final_claim, :allocated).tap do |c|
+        c.reject!(options)
+      end
+    end
+
+    context 'with claim journey ending in transition with no reason' do
+      let(:options) { {} }
+      let(:record) { query.first }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with claim journey ending in transition with reason' do
+      let(:options) { { reason_code: ['reason'], reason_text: 'reason text from caseworker' } }
+      let(:record) { query.first }
+
+      it { is_expected.to eql('reason text from caseworker') }
+    end
+  end
+
+  describe '#case_worker' do
+    subject { presenter.case_worker }
+
+    context 'with claim journey ending in allocated state' do
+      let!(:claim) { create(:advocate_final_claim, :allocated) }
+      let(:record) { query.first }
+
+      it { is_expected.to be == claim.claim_state_transitions.find_by(to: 'allocated').subject.name }
+    end
+
+    context 'with claim journey ending in "completed" state' do
+      let!(:claim) { create(:advocate_final_claim, :rejected) }
+      let(:record) { query.first }
+
+      it { is_expected.to be == claim.claim_state_transitions.find_by(to: 'rejected').author.name }
+    end
+
+    context 'with claim journey not ending in "completed" or allocated state' do
+      before { create(:advocate_final_claim, :redetermination) }
+
+      let(:record) { query.second }
+
+      it { is_expected.to be == 'n/a' }
+    end
+  end
+
+  describe '#disk_evidence_case' do
+    subject { presenter.disk_evidence_case }
+
+    let(:record) { query.first }
+
+    context 'with claim with disk evidence' do
+      before { create(:advocate_final_claim, :allocated, disk_evidence: true) }
+
+      let(:record) { query.first }
+
+      it { is_expected.to eql('Yes') }
+    end
+
+    context 'with claim without disk evidence' do
+      before { create(:advocate_final_claim, :rejected, disk_evidence: false) }
+
+      it { is_expected.to eql('No') }
+    end
+  end
+
+  describe '#rep_order_issued_date' do
+    subject { presenter.rep_order_issued_date }
+
+    before { create(:advocate_final_claim, :allocated) }
+
+    let(:record) { query.first }
+
+    it { is_expected.to eql(record[:rep_order_issued_date].strftime('%d/%m/%Y')) }
+  end
+
+  describe '#method_missing' do
+    before { create(:advocate_final_claim, :allocated) }
+
+    let(:record) { query.first }
+
+    let(:expected_missing_methods) do
+      %i[id scheme case_number supplier_number
+         organisation case_type_name bill_type
+         claim_total main_defendant maat_reference
+         af1_lf1_processed_by misc_fees]
+    end
+
+    it {
+      expect(presenter).to respond_to(*expected_missing_methods)
+    }
+  end
+end

--- a/spec/services/stats/management_information/presenter_spec.rb
+++ b/spec/services/stats/management_information/presenter_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe Stats::ManagementInformation::Presenter do
 
     let(:record) { query.first }
 
-    context 'when journey contains no submissions' do
+    context 'when journey contains no submissions (within 6 month cut off)' do
       before do
-        travel_to(6.months.ago - 1.second) { claim }
+        travel_to(6.months.ago.beginning_of_day - 1.second) { claim }
         claim.allocate!
       end
 

--- a/spec/services/stats/management_information/presenter_spec.rb
+++ b/spec/services/stats/management_information/presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Stats::ManagementInformation::Presenter do
   subject(:presenter) { described_class.new(record) }
 
   # OPTIMIZE: to use factory build instead of create and hash the claim object instead
-  # of querying the database. This would spead the tests up at the cost of being a less
+  # of querying the database. This would speed the tests up at the cost of being a less
   # realistic test.
   #
   let(:query) { Stats::ManagementInformation::DailyReportQuery.call }

--- a/spec/services/stats/management_information/presenter_spec.rb
+++ b/spec/services/stats/management_information/presenter_spec.rb
@@ -34,9 +34,7 @@ RSpec.describe Stats::ManagementInformation::Presenter do
 
     context 'when journey contains no submissions' do
       before do
-        travel_to(6.months.ago) do
-          claim
-        end
+        travel_to(6.months.ago - 1.second) { claim }
         claim.allocate!
       end
 

--- a/spec/services/stats/management_information/presenter_spec.rb
+++ b/spec/services/stats/management_information/presenter_spec.rb
@@ -155,10 +155,26 @@ RSpec.describe Stats::ManagementInformation::Presenter do
   describe '#current_or_end_state' do
     subject { presenter.current_or_end_state }
 
-    context 'with claim journey ending in submission state' do
+    context 'with claim journey ending in submitted state' do
       before { create(:advocate_final_claim, :submitted) }
 
-      let(:record) { query.first }
+      let(:record) { query.last }
+
+      it { is_expected.to eql('submitted') }
+    end
+
+    context 'with claim journey ending in redetermination state' do
+      before { create(:advocate_final_claim, :refused).tap(&:redetermine!) }
+
+      let(:record) { query.last }
+
+      it { is_expected.to eql('submitted') }
+    end
+
+    context 'with claim journey ending in awaiting_written_reasons state' do
+      before { create(:advocate_final_claim, :refused).tap(&:await_written_reasons!) }
+
+      let(:record) { query.last }
 
       it { is_expected.to eql('submitted') }
     end
@@ -166,7 +182,7 @@ RSpec.describe Stats::ManagementInformation::Presenter do
     context 'with claim journey ending in non-submission state' do
       before { create(:advocate_final_claim, :refused) }
 
-      let(:record) { query.first }
+      let(:record) { query.last }
 
       it { is_expected.to eql('refused') }
     end

--- a/spec/services/stats/management_information/presenter_spec.rb
+++ b/spec/services/stats/management_information/presenter_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe Stats::ManagementInformation::Presenter do
     end
   end
 
+  describe '#claim_total' do
+    subject { presenter.claim_total }
+
+    before do
+      create(:litigator_final_claim, :submitted).tap do |c|
+        c.update!(total: 9999.98555)
+      end
+    end
+
+    let(:record) { query.first }
+
+    it 'returns decimal rounded to 4 and kernel formatted to 2 decimal places' do
+      is_expected.to eql('9999.99')
+    end
+  end
+
   describe '#transitioned_at' do
     subject { presenter.transitioned_at }
 
@@ -275,7 +291,7 @@ RSpec.describe Stats::ManagementInformation::Presenter do
     let(:expected_missing_methods) do
       %i[id scheme case_number supplier_number
          organisation case_type_name bill_type
-         claim_total main_defendant maat_reference
+         main_defendant maat_reference
          af1_lf1_processed_by misc_fees]
     end
 

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
     end
 
     context 'with AGFS scope' do
-      subject(:call) { described_class.new({ claim_scope: :agfs }).call }
+      subject(:call) { described_class.new({ scheme: :agfs }).call }
 
       it 'returns rows of AGFS active non-draft claims' do
         expect(csv['Scheme']).to match_array(%w[AGFS] * 4)
@@ -71,7 +71,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
     end
 
     context 'with LGFS scope' do
-      subject(:call) { described_class.new({ claim_scope: :lgfs }).call }
+      subject(:call) { described_class.new({ scheme: :lgfs }).call }
 
       it 'returns rows of LGFS active non-draft claims' do
         expect(csv['Scheme']).to match_array(%w[LGFS] * 2)

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
       # excluded from MI report
       create(:advocate_final_claim, :draft)
       create(:advocate_final_claim, :authorised).soft_delete
-      travel_to(6.months.ago) { create(:advocate_final_claim, :allocated) }
+      travel_to(6.months.ago.beginning_of_day - 1.second) { create(:advocate_final_claim, :allocated) }
 
       # included in MI report
       create(:litigator_final_claim, :submitted)
@@ -47,7 +47,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
       create(:advocate_final_claim, :submitted)
       create(:advocate_final_claim, :allocated)
       create(:advocate_final_claim, :part_authorised)
-      travel_to(6.months.ago + 1.day) { create(:advocate_final_claim, :authorised) }
+      travel_to(6.months.ago.beginning_of_day) { create(:advocate_final_claim, :authorised) }
     end
 
     it 'has expected headers' do

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
 
         it 'calls management information generator with no claim scope' do
           call
-          expect(Stats::ManagementInformationGenerator).to have_received(:call).with(hash_excluding(:claim_scope))
+          expect(Stats::ManagementInformationGenerator).to have_received(:call).with(no_args)
         end
 
         it 'marks report as completed' do
@@ -82,7 +82,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
 
         it 'calls management information generator with agfs scope' do
           call
-          expect(Stats::ManagementInformationGenerator).to have_received(:call).with({ claim_scope: :agfs })
+          expect(Stats::ManagementInformationGenerator).to have_received(:call).with({ scheme: :agfs })
         end
       end
 
@@ -93,7 +93,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
 
         it 'calls management information generator with lgfs scope' do
           call
-          expect(Stats::ManagementInformationGenerator).to have_received(:call).with({ claim_scope: :lgfs })
+          expect(Stats::ManagementInformationGenerator).to have_received(:call).with({ scheme: :lgfs })
         end
       end
     end

--- a/spec/support/factory_helpers.rb
+++ b/spec/support/factory_helpers.rb
@@ -34,8 +34,7 @@ module FactoryHelpers
   def authorise_claim(claim)
     allocate_claim(claim)
     assign_fees_and_expenses_for(claim)
-    claim.authorise!
-    claim.last_decision_transition.update_author_id(claim.case_workers.first.user.id)
+    claim.authorise!({ author_id: claim.case_workers.first.user.id })
   end
 
   def advance_to_pending_delete(claim)


### PR DESCRIPTION
#### What
Create version 2 of the MI report using aggregatable SQL query

#### Tickets

[CFP-247](https://dsdmoj.atlassian.net/browse/CFP-247) MI spike
[CFP-299](https://dsdmoj.atlassian.net/browse/CFP-299) MI refactor
relates to [CFP-300](https://dsdmoj.atlassian.net/browse/CFP-299) MI weekly statistics

#### Why
1. to enable aggregations of the MI report
2. to improve performance of the MI report

#### TODO:

- [x] checks diffs of old and new versions for discrepancies - 0 diffs

#### Questions for caseworkers during catchup:

- [x]  can we use truncate the date for 6 month cut off. current MI report (v1) uses `Time.zone.now` to filter transitions which is sensitive to both the time the report started and time the claim is processed (it is a long time to process the claims). We should have it focused on any transitions for the day. This would be with a cut-off period of midnight 6 months earlier, where those at midnight are included, those at 11:59:59pm of previous day are not, to the second, taking daylight saving/BST into account. Caseworker (JW) and PM (JA) agrees.

- [x]  can we round the claim total to 2 decimal places. PM (JA) agrees

~~- [x]  can we get rid of the "af1/lf1 processed_by" field as this information is already available in the report as the caseworker who processed the previous redetermination (i.e. one row up). There could be issues in using the previous record due to the 6 month cut off though. i.e. previous record may be excluded due to date.~~


