### PR TITLE
[CFP-238] Migrate caseworkers table to Design System 3/3

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -42,14 +42,14 @@
   %h2.govuk-heading-m
     = t('.allocation_queue')
 
-  = govuk_table(class: 'app-jq-datatable') do
+  = govuk_table(class: 'report app-jq-datatable', style: 'width:100%') do
     = govuk_table_caption(class: 'govuk-visually-hidden') do
       = t('.table_summary')
 
     = govuk_table_thead_collection ['',
-    t('.case_number'),
-    t('.court'),
-    t('.defendents'),
-    t('.type'),
-    t('.submitted'),
-    t('.total')]
+      t('.case_number'),
+      t('.court'),
+      t('.defendents'),
+      t('.type'),
+      t('.submitted'),
+      t('.total')]

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -29,80 +29,79 @@
           = f.govuk_submit t('.re_allocate'), name: 'tab', value: 'allocated'
 
       - if @claims.any?
-        .table-container
-          = govuk_table(class: 'report js-checkbox-table js-reallocation-report') do
-            = govuk_table_caption(id: 'allocation-claim-ids-field-error') do
-              .govuk-grid-row
-                .govuk-grid-column-one-half
-                  = t('.re_allocation')
-                .govuk-grid-column-one-half.claim-count{ class: 'govuk-!-text-align-right' }
-                  = t('.number_of_claims', claim_count: @claims.total_count)
+        = govuk_table(class: 'report js-checkbox-table') do
+          = govuk_table_caption(id: 'allocation-claim-ids-field-error') do
+            .govuk-grid-row
+              .govuk-grid-column-one-half
+                = t('.re_allocation')
+              .govuk-grid-column-one-half.claim-count{ class: 'govuk-!-text-align-right' }
+                = t('.number_of_claims', claim_count: @claims.total_count)
 
-            = govuk_table_thead do
-              = govuk_table_row do
-                = govuk_table_th(class: 'select') do
-                  = govuk_link_to t('.select_all'), '#', class: 'select-all', data: { 'all-checked': 'false' }, 'aria-label': t('.select_all_label')
-                = govuk_table_th(class: 'case-number') do
-                  = t('.case_number')
-                = govuk_table_th(class: 'court') do
-                  = t('.court')
+          = govuk_table_thead do
+            = govuk_table_row do
+              = govuk_table_th do
+                = govuk_link_to t('.select_all'), '#', class: 'select-all', data: { 'all-checked': 'false' }, 'aria-label': t('.select_all_label')
+              = govuk_table_th do
+                = t('.case_number')
+              = govuk_table_th do
+                = t('.court')
+              = govuk_table_th do
+                = t('.defendants')
+              = govuk_table_th do
+                = t('.type')
+              = govuk_table_th_numeric do
+                = t('.submitted_date')
+              = govuk_table_th_numeric do
+                = t('.claim_total')
+              - if params[:tab] == 'allocated'
                 = govuk_table_th do
-                  = t('.defendants')
-                = govuk_table_th(class: 'type') do
-                  = t('.type')
-                = govuk_table_th_numeric(class: 'submit-date') do
-                  = t('.submitted_date')
-                = govuk_table_th_numeric(class: 'claim-total') do
-                  = t('.claim_total')
-                - if params[:tab] == 'allocated'
-                  = govuk_table_th do
-                    = t('.allocated_to')
+                  = t('.allocated_to')
 
-            = govuk_table_tbody do
-              = collection_check_boxes :allocation, :claim_ids, @claims, :id, :case_number do |b|
-                - present(b.object) do |claim|
-                  = govuk_table_row(id: dom_id(claim), class: claim.injection_error ? 'error injection-error' : nil) do
-                    = govuk_table_td('data-label': t('.select')) do
-                      .govuk-form-group.error-message-container
-                        .govuk-checkboxes.govuk-checkboxes--small{ 'data-module': 'govuk-checkboxes' }
-                          .govuk-checkboxes__item
-                            = b.check_box(class: 'govuk-checkboxes__input')
-                            = b.label(class: 'govuk-label govuk-checkboxes__label'){ t('.choose_label_html', case_number: claim.case_number) }
+          = govuk_table_tbody do
+            = collection_check_boxes :allocation, :claim_ids, @claims, :id, :case_number do |b|
+              - present(b.object) do |claim|
+                = govuk_table_row(id: dom_id(claim), class: claim.injection_error ? 'error injection-error' : nil) do
+                  = govuk_table_td('data-label': t('.select')) do
+                    .govuk-form-group.error-message-container
+                      .govuk-checkboxes.govuk-checkboxes--small{ 'data-module': 'govuk-checkboxes' }
+                        .govuk-checkboxes__item
+                          = b.check_box(class: 'govuk-checkboxes__input')
+                          = b.label(class: 'govuk-label govuk-checkboxes__label'){ t('.choose_label_html', case_number: claim.case_number) }
 
-                        - claim.injection_error do |message|
-                          .error-message
-                            = message
+                      - claim.injection_error do |message|
+                        .error-message
+                          = message
 
-                    = govuk_table_td('data-label': t('.case_number')) do
-                      %span.js-test-case-number
-                        = govuk_link_to claim.case_number, case_workers_claim_path(claim), 'aria-label': t('.case_number_label', case_number: claim.case_number)
-                        %span.unique-id-small
-                          = claim.unique_id
-                        - if claim.disk_evidence == true
-                          %span.disk-evidence
-                            = t('.disk_evidence')
+                  = govuk_table_td('data-label': t('.case_number')) do
+                    %span.js-test-case-number
+                      = govuk_link_to claim.case_number, case_workers_claim_path(claim), 'aria-label': t('.case_number_label', case_number: claim.case_number)
+                      %span.unique-id-small
+                        = claim.unique_id
+                      - if claim.disk_evidence == true
+                        %span.disk-evidence
+                          = t('.disk_evidence')
 
-                    = govuk_table_td('data-label': t('.court')) do
-                      = claim.court.name
+                  = govuk_table_td('data-label': t('.court')) do
+                    = claim.court.name
 
-                    = govuk_table_td('data-label': t('.defendants')) do
-                      = claim.defendant_names
+                  = govuk_table_td('data-label': t('.defendants')) do
+                    = claim.defendant_names
 
-                    = govuk_table_td('data-label': t('.type')) do
-                      = claim.case_type_name
-                      %br/
-                      %span.claim-state
-                        = claim.claim_state
+                  = govuk_table_td('data-label': t('.type')) do
+                    = claim.case_type_name
+                    %br/
+                    %span.claim-state
+                      = claim.claim_state
 
-                    = govuk_table_td_numeric('data-label': t('.submitted_date')) do
-                      = claim.submitted_at_short
+                  = govuk_table_td_numeric('data-label': t('.submitted_date')) do
+                    = claim.submitted_at_short
 
-                    = govuk_table_td_numeric('data-label': t('.claim_total')) do
-                      = claim.total_inc_vat
+                  = govuk_table_td_numeric('data-label': t('.claim_total')) do
+                    = claim.total_inc_vat
 
-                    - if params[:tab] == 'allocated'
-                      = govuk_table_td('data-label': t('.allocated_to')) do
-                        = claim.case_workers.map(&:name).join(', ')
+                  - if params[:tab] == 'allocated'
+                    = govuk_table_td('data-label': t('.allocated_to')) do
+                      = claim.case_workers.map(&:name).join(', ')
 
       - else
         %p.govuk-body{ class: 'govuk-!-font-weight-bold' }

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -30,39 +30,39 @@
 
       - if @claims.any?
         .table-container
-          %table.report.js-checkbox-table.js-reallocation-report
-            %caption#allocation-claim-ids-field-error
+          = govuk_table(class: 'report js-checkbox-table js-reallocation-report') do
+            = govuk_table_caption(id: 'allocation-claim-ids-field-error') do
               .govuk-grid-row
                 .govuk-grid-column-one-half
                   = t('.re_allocation')
-                .govuk-grid-column-one-half.claim-count
-                  = t('.number_of_claims')
-                  = @claims.total_count
+                .govuk-grid-column-one-half.claim-count{ class: 'govuk-!-text-align-right' }
+                  = t('.number_of_claims', claim_count: @claims.total_count)
 
-            %thead
-              %th.select{ scope: 'col' }
-                = govuk_link_to t('.select_all'), '#', class: 'select-all', data: { 'all-checked': 'false' }, 'aria-label': t('.select_all_label')
-              %th.case-number{ scope: 'col' }
-                = t('.case_number')
-              %th.court{ scope: 'col' }
-                = t('.court')
-              %th{ scope: 'col' }
-                = t('.defendants')
-              %th.type{ scope: 'col' }
-                = t('.type')
-              %th.numeric.submit-date{ scope: 'col' }
-                = t('.submitted_date')
-              %th.numeric.claim-total{ scope: 'col' }
-                = t('.claim_total')
-              - if params[:tab] == 'allocated'
-                %th{ scope: 'col' }
-                  = t('.allocated_to')
+            = govuk_table_thead do
+              = govuk_table_row do
+                = govuk_table_th(class: 'select') do
+                  = govuk_link_to t('.select_all'), '#', class: 'select-all', data: { 'all-checked': 'false' }, 'aria-label': t('.select_all_label')
+                = govuk_table_th(class: 'case-number') do
+                  = t('.case_number')
+                = govuk_table_th(class: 'court') do
+                  = t('.court')
+                = govuk_table_th do
+                  = t('.defendants')
+                = govuk_table_th(class: 'type') do
+                  = t('.type')
+                = govuk_table_th_numeric(class: 'submit-date') do
+                  = t('.submitted_date')
+                = govuk_table_th_numeric(class: 'claim-total') do
+                  = t('.claim_total')
+                - if params[:tab] == 'allocated'
+                  = govuk_table_th do
+                    = t('.allocated_to')
 
-            %tbody
+            = govuk_table_tbody do
               = collection_check_boxes :allocation, :claim_ids, @claims, :id, :case_number do |b|
                 - present(b.object) do |claim|
-                  %tr{ id: dom_id(claim), class: claim.injection_error ? 'error injection-error' : nil }
-                    %td{ 'data-label': t('.select') }
+                  = govuk_table_row(id: dom_id(claim), class: claim.injection_error ? 'error injection-error' : nil) do
+                    = govuk_table_td('data-label': t('.select')) do
                       .govuk-form-group.error-message-container
                         .govuk-checkboxes.govuk-checkboxes--small{ 'data-module': 'govuk-checkboxes' }
                           .govuk-checkboxes__item
@@ -73,7 +73,7 @@
                           .error-message
                             = message
 
-                    %td{ 'data-label': t('.case_number') }
+                    = govuk_table_td('data-label': t('.case_number')) do
                       %span.js-test-case-number
                         = govuk_link_to claim.case_number, case_workers_claim_path(claim), 'aria-label': t('.case_number_label', case_number: claim.case_number)
                         %span.unique-id-small
@@ -82,26 +82,26 @@
                           %span.disk-evidence
                             = t('.disk_evidence')
 
-                    %td{ 'data-label': t('.court') }
+                    = govuk_table_td('data-label': t('.court')) do
                       = claim.court.name
 
-                    %td{ 'data-label': t('.defendants') }
+                    = govuk_table_td('data-label': t('.defendants')) do
                       = claim.defendant_names
 
-                    %td{ 'data-label': t('.type') }
+                    = govuk_table_td('data-label': t('.type')) do
                       = claim.case_type_name
                       %br/
                       %span.claim-state
                         = claim.claim_state
 
-                    %td.numeric{ 'data-label': t('.submitted_date') }
+                    = govuk_table_td_numeric('data-label': t('.submitted_date')) do
                       = claim.submitted_at_short
 
-                    %td.numeric{ 'data-label': t('.claim_total') }
+                    = govuk_table_td_numeric('data-label': t('.claim_total')) do
                       = claim.total_inc_vat
 
                     - if params[:tab] == 'allocated'
-                      %td{ 'data-label': t('.allocated_to') }
+                      = govuk_table_td('data-label': t('.allocated_to')) do
                         = claim.case_workers.map(&:name).join(', ')
 
       - else

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -1,93 +1,104 @@
-.table-container
-  %table.report
-    %caption
-      .govuk-grid-row
-        .govuk-grid-column-one-half
-          = params[:action] == 'archived' ? t('case_workers.table_headings.archived_claims') : t('case_workers.table_headings.your_claims')
-        .govuk-grid-column-one-half.claim-count
-          = t('.number_of_claims')
-          = claims.total_count
+.govuk-grid-row{class: 'govuk-!-margin-top-9'}
+  .govuk-grid-column-full
+    %p.govuk-body{class: 'claim-count govuk-!-text-align-right'}
+      = t('.number_of_claims', claim_count: claims.total_count)
 
-    %thead
-      %tr
-        %th{ scope: 'col' }
-          = sortable 'type', t('.type'), 'aria-label': t('.type_sort_label'), id: 'type'
+  .govuk-grid-column-full
+    = govuk_table(class: 'report') do
+      = govuk_table_caption(class: 'govuk-visually-hidden') do
+        = params[:action] == 'archived' ? t('case_workers.table_headings.archived_claims') : t('case_workers.table_headings.your_claims')
 
-        %th{ scope: 'col' }
-          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number'
+      = govuk_table_thead do
+        = govuk_table_row do
+          = govuk_table_th do
+            = sortable 'type', t('.type'), 'aria-label': t('.type_sort_label'), id: 'type'
 
-        %th{ scope: 'col' }
-          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate'
+          = govuk_table_th do
+            = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number'
 
-        %th{ scope: 'col' }
-          = t('.defendants')
+          = govuk_table_th do
+            = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate'
 
-        %th.numeric{ scope: 'col' }
-          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat'
+          = govuk_table_th do
+            = t('.defendants')
 
-        - if params[:action] == 'archived'
-          %th{ scope: 'col' }
-            = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state'
+          = govuk_table_th_numeric do
+            = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat'
 
-        %th{ scope: 'col' }
-          = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), id: 'case_type'
-
-        %th.numeric{ scope: 'col' }
-          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at'
-
-        %th.message-placeholder{ scope: 'col' }
-          = t('.messages')
-    %tbody
-      %tr.mobile-sort
-        %th{ scope: 'col' }
-          Sort by:
-          = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number_ms'
-          = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate_ms'
-          = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat_ms'
           - if params[:action] == 'archived'
-            = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state_ms'
-          = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), id: 'case_type_ms'
-          = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at_ms'
-      - present_collection(claims).each do |claim|
-        %tr{ class: claim.injection_error ? 'error injection-error' : nil }
-          %td
-            .error-message-container
-              = claim.pretty_type
-              - claim.injection_error do |message|
-                .error-message
-                  = message
-          %td
-            = govuk_link_to claim.case_number,
-                      case_workers_claim_path(claim),
-                      class: 'js-test-case-number-link',
-                      'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
+            = govuk_table_th do
+              = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state'
 
-            - if claim.disk_evidence == true
-              %span.disk-evidence
-                = t('.disk_evidence')
+          = govuk_table_th do
+            = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), id: 'case_type'
 
-          %td
-            = claim.external_user.name
-          %td
-            = claim.defendant_names
-          %td.numeric.js-test-total
-            = claim.total_inc_vat
-          - if params[:action] == 'archived'
-            %td
-              = govuk_tag claim.state.humanize, class: "app-tag--#{claim.state.dasherize}"
-          %td
-            = claim.case_type_name
-            %br/
-            %span.claim-state
-              = claim.claim_state
-          %td.numeric
-            = claim.submitted_at(include_time: false)
-          %td.messages
-            - if claim.has_messages?
-              - if claim.remote?
-                = govuk_link_to claim.unread_messages_count.to_int > 0 ? t('.view_with_messages', message_count: claim.unread_messages_count) : t('.view'), "#{case_workers_claim_path(claim, messages: true)}#messages", 'aria-label': t('.view_messages_label', case_number: claim.case_number)
+          = govuk_table_th_numeric do
+            = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at'
+
+          = govuk_table_th(class: 'message-placeholder') do
+            = t('.messages')
+
+      = govuk_table_tbody do
+        = govuk_table_row(class: 'mobile-sort') do
+          = govuk_table_th do
+            Sort by:
+            = sortable 'case_number', t('.case_number'), 'aria-label': t('.case_number_sort_label'), id: 'case_number_ms'
+            = sortable 'advocate', t('.advocate_litigator'), 'aria-label': t('.advocate_sort_label'), id: 'advocate_ms'
+            = sortable 'total_inc_vat', t('.total'), 'aria-label': t('.total_inc_vat_sort_label'), id: 'total_inc_vat_ms'
+            - if params[:action] == 'archived'
+              = sortable 'state', t('.status'), 'aria-label': t('.state_sort_label'), id: 'state_ms'
+            = sortable 'case_type', t('.case_type'), 'aria-label': t('.case_type_sort_label'), id: 'case_type_ms'
+            = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at_ms'
+
+        - present_collection(claims).each do |claim|
+          = govuk_table_row(class: claim.injection_error ? 'error injection-error' : nil) do
+            = govuk_table_td('data-label': t('.type')) do
+              .error-message-container
+                = claim.pretty_type
+                - claim.injection_error do |message|
+                  .error-message
+                    = message
+
+            = govuk_table_td('data-label': t('.case_number')) do
+              = govuk_link_to claim.case_number,
+                        case_workers_claim_path(claim),
+                        class: 'js-test-case-number-link',
+                        'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
+
+              - if claim.disk_evidence == true
+                %span.disk-evidence
+                  = t('.disk_evidence')
+
+            = govuk_table_td('data-label': t('.advocate_litigator')) do
+              = claim.external_user.name
+
+            = govuk_table_td('data-label': t('.defendants')) do
+              = claim.defendant_names
+
+            = govuk_table_td_numeric(class: 'js-test-total', 'data-label': t('.total')) do
+              = claim.total_inc_vat
+
+            - if params[:action] == 'archived'
+              = govuk_table_td('data-label': t('.status')) do
+                = govuk_tag claim.state.humanize, class: "app-tag--#{claim.state.dasherize}"
+
+            = govuk_table_td('data-label': t('.case_type')) do
+              = claim.case_type_name
+              %br/
+              %span.claim-state
+                = claim.claim_state
+
+            = govuk_table_td_numeric('data-label': t('.submission_date')) do
+              = claim.submitted_at(include_time: false)
+
+            = govuk_table_td(class: 'messages', 'data-label': t('.messages')) do
+              - if claim.has_messages?
+                - if claim.remote?
+                  = govuk_link_to claim.unread_messages_count.to_int > 0 ? t('.view_with_messages', message_count: claim.unread_messages_count) : t('.view'), "#{case_workers_claim_path(claim, messages: true)}#messages", 'aria-label': t('.view_messages_label', case_number: claim.case_number)
+
+                - else
+                  = govuk_link_to claim.unread_messages_for(current_user).any? ? t('.view_with_messages', message_count: claim.unread_messages_for(current_user).count) : t('.view'), "#{case_workers_claim_path(claim, messages: true)}#messages", 'aria-label': t('.view_messages_label', case_number: claim.case_number)
+
               - else
-                = govuk_link_to claim.unread_messages_for(current_user).any? ? t('.view_with_messages', message_count: claim.unread_messages_for(current_user).count) : t('.view'), "#{case_workers_claim_path(claim, messages: true)}#messages", 'aria-label': t('.view_messages_label', case_number: claim.case_number)
-            - else
-              %span.none
-                = t('.none')
+                %span.none
+                  = t('.none')

--- a/app/views/case_workers/claims/_determination_agfs_vat_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_agfs_vat_fields.html.haml
@@ -1,16 +1,21 @@
-%tr.determination-form-fields
-  %td
+= govuk_table_row do
+  = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
     = t('.vat_rate', vat_rate: VatRate.pretty_rate(Date.parse(claim.vat_date)))
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.vat_amount
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     %span.js-vat-determination
       = number_to_currency(f.object.vat_amount)
-%tr.determination-form-fields
-  %td
+
+= govuk_table_row do
+  = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
     = t('.total_inc_vat_rate', vat_rate: VatRate.pretty_rate(Date.parse(claim.vat_date)))
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.total_inc_vat
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     %span.js-total-determination
       = number_to_currency(f.object.total_including_vat)

--- a/app/views/case_workers/claims/_determination_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_fields.html.haml
@@ -1,41 +1,49 @@
 - unless claim.lgfs? && claim.interim? && claim.disbursement_only?
-  %tr.determination-form-fields
-    %td
+  = govuk_table_row do
+    = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
       = f.label :fees, t('.fees')
-    %td
+
+    = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
       = claim.fees_total
-    %td
+
+    = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
       .pound-wrapper
         = f.text_field :fees, value: number_with_precision(f.object.fees, precision: 2), class: 'form-control js-fees', size: 10, maxlength: 10
       = validation_error_message(f.object, :fees)
 
-%tr.determination-form-fields
-  %td
+= govuk_table_row do
+  = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
     = f.label :expenses, t('.expenses')
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.expenses_total
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     .pound-wrapper
       = f.text_field :expenses, value: number_with_precision(f.object.expenses, precision: 2), class: 'form-control js-expenses', size: 10, maxlength: 10
     = validation_error_message(f.object, :expenses)
 
 - if claim.can_have_disbursements?
-  %tr.determination-form-fields
-    %td
+  = govuk_table_row do
+    = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
       = f.label :disbursements, t('.disbursements')
-    %td
+
+    = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
       = claim.disbursements_total
-    %td
+
+    = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
       .pound-wrapper
         = f.text_field :disbursements, value: number_with_precision(f.object.disbursements, precision: 2), class: 'form-control js-disbursements', size: 10, maxlength: 10
       = validation_error_message(f.object, :disbursements)
 
-%tr.determination-form-fields
-  %td
+= govuk_table_row do
+  = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
     = t('.total_excluding_vat')
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.total
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     %span.js-total-exc-vat-determination
       = number_to_currency(f.object.total || 0)
 

--- a/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
@@ -1,17 +1,22 @@
-%tr.determination-form-fields
-  %td
+= govuk_table_row do
+  = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
     = f.label :vat_amount, t('.vat')
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.vat_amount
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     .pound-wrapper
       = f.text_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control js-lgfs-vat-determination', size: 10, maxlength: 8
     = validation_error_message(f.object, :vat_amount)
-%tr.determination-form-fields
-  %td
+
+= govuk_table_row do
+  = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
     = t('.total_inc_vat')
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.total_inc_vat
-  %td
+
+  = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     %span.js-total-determination
       = number_to_currency(f.object.total_including_vat)

--- a/app/views/external_users/claims/offence_details/_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_summary.html.haml
@@ -10,12 +10,14 @@
       = govuk_summary_list do
         - if claim.agfs_reform?
           = render partial: 'external_users/claims/offence_details/fee_reform_summary', locals: { claim: claim }
+
         - else
           = render partial: 'external_users/claims/offence_details/default_summary', locals: { claim: claim }
 
     - else
       - if local_assigns.has_key?(:editable) && !local_assigns[:editable]
         = render partial: 'external_users/claims/summary/section_status', locals: { claim: claim, section: section, step: :offence_details }
+
       - else
-        %p
+        %p.govuk-body
           = t('shared.summary.no_values.offence_details')

--- a/app/views/shared/_certification.html.haml
+++ b/app/views/shared/_certification.html.haml
@@ -1,20 +1,10 @@
 %h3.govuk-heading-m
   = t('.certification_box_title')
 
-%table.table-summary
-  %caption.govuk-visually-hidden
-    = t('.certification_caption')
+= govuk_summary_list do
+  = govuk_summary_list_row(t('.instructed_heading')) do
+    = claim.external_user.name
 
-  %tbody
-    %tr
-      %th{ scope: 'row' }
-        = t('.instructed_heading')
-      %td
-        = claim.external_user.name
-
-    - if @claim.agfs?
-      %tr
-        %th{ scope: 'row' }
-          = t('.certification_reason')
-        %td
-          = claim.certification.certification_type.name rescue ''
+  - if @claim.agfs?
+    = govuk_summary_list_row(t('.certification_reason')) do
+      = claim.certification.certification_type.name rescue ''

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -2,129 +2,92 @@
   = render partial: 'shared/certification', locals: { claim: claim }
 
 %h3.govuk-heading-m
-  = "Claim and case type"
-%table.table-summary
-  %caption.govuk-visually-hidden
-    = "This section contains details of the case"
-  %tbody
-    - unless claim.providers_ref.blank?
-      %tr
-        %th{ scope: 'row' }
-          = 'Provider reference number'
-        %td
-          = claim.providers_ref
+  = t('.claim_type')
 
-    - unless claim.draft?
-      %tr
-        %th{ scope: 'row' }
-          = "Claim submitted on"
-        %td
-          = claim.submitted_at
+= govuk_summary_list do
+  - unless claim.providers_ref.blank?
+    = govuk_summary_list_row('Provider reference number') do
+      = claim.providers_ref
 
-    - if claim.case_workers.any? && current_user_is_caseworker? && current_user.persona.admin?
-      %tr
-        %th{ scope: 'row' }
-          = t ('.assignee')
-        %td
-          = claim.case_worker_names
+  - unless claim.draft?
+    = govuk_summary_list_row('Claim submitted on') do
+      = claim.submitted_at
 
-    - if @claim.lgfs?
-      %tr
-        %th{ scope: 'row' }
-          = t('common.external_user.claim_creator')
-        %td
-          = claim.creator.name
+  - if claim.case_workers.any? && current_user_is_caseworker? && current_user.persona.admin?
+    = govuk_summary_list_row(t('.assignee')) do
+      = claim.case_worker_names
 
-    - if @claim.agfs?
-      %tr
-        %th{ scope: 'row' }
-          = t("common.external_user.#{@claim.external_user_type}")
-        %td
-          = claim.external_user.name
-      %tr
-        %th{ scope: 'row' }
-          = t("common.external_user.category.#{@claim.external_user_type}")
-        %td
-          = claim.advocate_category
+  - if @claim.lgfs?
+    = govuk_summary_list_row(t('common.external_user.claim_creator')) do
+      = claim.creator.name
 
-    %tr
-      %th{ scope: 'row' }
-        = t("common.external_user.account_number.#{@claim.external_user_type}")
-      %td
-        = claim.supplier_number
+  - if @claim.agfs?
+    = govuk_summary_list_row(t("common.external_user.#{@claim.external_user_type}")) do
+      = claim.external_user.name
+    = govuk_summary_list_row(t("common.external_user.category.#{@claim.external_user_type}")) do
+      = claim.advocate_category
 
-    %tr
-      %th{ scope: 'row' }
-        = t('common.crown_court')
-      %td
-        = claim.court.name if claim.court
+  = govuk_summary_list_row(t("common.external_user.account_number.#{@claim.external_user_type}")) do
+    = claim.supplier_number
 
-    %tr
-      %th{ scope: 'row' }
-        =t('.case_num')
-      %td
-        = claim.case_number
-        %span.unique-id-small
-          = claim.unique_id
+  - if claim.court
+    = govuk_summary_list_row(t('common.crown_court')) do
+      = claim.court.name
 
-    - if claim.transfer_court.present?
-      %tr
-        %th{ scope: 'row' }
-          = t('common.transfer_court')
-        %td
-          = claim.transfer_court.name
+  = govuk_summary_list_row(t('.case_num')) do
+    = claim.case_number
+    %span.unique-id-small
+      = claim.unique_id
 
-      %tr
-        %th{ scope: 'row' }
-          = t('common.transfer_case_number')
-        %td
-          = claim.transfer_case_number
+  - if claim.transfer_court.present?
+    = govuk_summary_list_row(t('common.transfer_court')) do
+      = claim.transfer_court.name
+    = govuk_summary_list_row(t('common.transfer_case_number')) do
+      = claim.transfer_case_number
 
-    - if claim.case_stage
-      %tr
-        %th{ scope: 'row' }
-          = t('.case_stage')
-        %td
-          = claim.case_stage&.description
+  - if claim.case_stage
+    = govuk_summary_list_row(t('.case_stage')) do
+      = claim.case_stage&.description
 
-    - if claim.display_case_type?
-      %tr
-        %th{ scope: 'row' }
-          = t('.case_type')
-        %td
-          = claim.case_type&.name
+  - if claim.display_case_type?
+    = govuk_summary_list_row(t('.case_type')) do
+      = claim.case_type&.name
 
-    - if claim.discontinuance?
-      %tr
-        %th{ scope: 'row' }
-          = t('common.prosecution_evidence')
-        %td
-          = t(claim.prosecution_evidence?.class)
+  - if claim.discontinuance?
+    = govuk_summary_list_row(t('common.prosecution_evidence')) do
+      = t(claim.prosecution_evidence?.class)
 
-    - if claim.agfs? && claim.case_type.present? && claim.requires_cracked_dates?
-      = render partial: 'shared/claim_cracked_trial_details', locals: { claim: claim }
+  - if claim.agfs? && claim.case_type.present? && claim.requires_cracked_dates?
+    = render partial: 'shared/claim_cracked_trial_details', locals: { claim: claim }
 
-    - if claim.case_type && claim.case_concluded_at
-      = render partial: 'shared/claim_case_concluded_at_details', locals: { claim: claim }
+  - if claim.case_type && claim.case_concluded_at
+    = render partial: 'shared/claim_case_concluded_at_details', locals: { claim: claim }
 
-    - if claim.lgfs? && claim.interim? && !claim.interim_fee.nil?
-      = render partial: 'shared/claim_interim_details', locals: { claim: claim }
+  - if claim.lgfs? && claim.interim? && !claim.interim_fee.nil?
+    = render partial: 'shared/claim_interim_details', locals: { claim: claim }
 
-    - if claim.transfer?
-      = render partial: 'shared/claim_transfer_details', locals: { claim: claim }
+  - if claim.transfer?
+    = render partial: 'shared/claim_transfer_details', locals: { claim: claim }
 
-    - if claim&.requires_trial_dates?
-      = render partial: 'shared/claim_trial_details', locals: { claim: claim }
+  - if claim&.requires_trial_dates?
+    = render partial: 'shared/claim_trial_details', locals: { claim: claim }
 
-    - if claim&.requires_retrial_dates?
-      = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
+  - if claim&.requires_retrial_dates?
+    = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
 
 - if claim.defendants.any?
-  %h3.govuk-heading-m
-    = "Defendants"
-  = render partial: 'shared/claim_defendants', locals: {defendants: claim.defendants }
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h3.govuk-heading-m
+        = t('.defendants')
+
+    = render partial: 'shared/claim_defendants', locals: {defendants: claim.defendants }
+
 - else
-  = "No defendant details have been supplied for this claim."
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body
+        = t('.no_defendant')
 
 - unless claim.fixed_fee_case?
   = render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -16,17 +16,17 @@
   = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }
 
-  %h2.govuk-heading-m
+  %h2.govuk-heading-l
     = t('.h2_basic_info')
   .js-accordion__panel
     = render partial: 'shared/claim', locals: { claim: claim, hide_totals: true }
 
-  %h2.govuk-heading-m
+  %h2.govuk-heading-l
     = t('.h2_evidence')
   .js-accordion__panel
     = render partial: 'shared/evidence_list'
 
-  %h2.govuk-heading-m
+  %h2.govuk-heading-l
     = t('.h2_summary')
   .js-accordion__panel.fees-summary
     - if claim.agfs?
@@ -35,7 +35,7 @@
       = render partial: 'shared/summary_lgfs', locals: { claim: claim }
 
   - if claim.additional_information.present?
-    %h2.govuk-heading-m
+    %h2.govuk-heading-l
       = t('.additional_information')
     %p
       = claim.additional_information

--- a/app/views/shared/_claim_case_concluded_at_details.html.haml
+++ b/app/views/shared/_claim_case_concluded_at_details.html.haml
@@ -1,6 +1,4 @@
 - cracked_trial_detail_translations = 'external_users.claims.case_details.cracked_trial_fields'
-%tr
-  %th{ scope: 'row' }
-    = t("external_users.claims.case_details.case_concluded_date.case_concluded_at")
-  %td
-    = claim.case_concluded_at
+
+= govuk_summary_list_row(t('external_users.claims.case_details.case_concluded_date.case_concluded_at')) do
+  = claim.case_concluded_at

--- a/app/views/shared/_claim_cracked_trial_details.html.haml
+++ b/app/views/shared/_claim_cracked_trial_details.html.haml
@@ -1,27 +1,19 @@
 - cracked_trial_detail_translations = 'external_users.claims.case_details.cracked_trial_fields'
-%tr
-  %th{ scope: 'row' }
-    = t("#{cracked_trial_detail_translations}.trial_fixed_notice_at")
-  %td
-    = claim.trial_fixed_notice_at.strftime(Settings.date_format) rescue ''
 
-%tr
-  %th{ scope: 'row' }
-    = t("#{cracked_trial_detail_translations}.trial_fixed_at")
-  %td
-    = claim.trial_fixed_at.strftime(Settings.date_format) rescue ''
+- trial_cracked_at_third_key = ''
+- if claim.hardship?
+  - trial_cracked_at_third_key = t("#{cracked_trial_detail_translations}.trial_cracked_at_third.hardship")
+- else
+  - trial_cracked_at_third_key = t("#{cracked_trial_detail_translations}.trial_cracked_at_third.default")
 
-%tr
-  %th{ scope: 'row' }
-    = t("#{cracked_trial_detail_translations}.trial_cracked_at")
-  %td
-    =  claim.trial_cracked_at.strftime(Settings.date_format) rescue ''
+= govuk_summary_list_row(t("#{cracked_trial_detail_translations}.trial_fixed_notice_at")) do
+  = claim.trial_fixed_notice_at.strftime(Settings.date_format) rescue ''
 
-%tr
-  %th{ scope: 'row' }
-    - if claim.hardship?
-      = t("#{cracked_trial_detail_translations}.trial_cracked_at_third.hardship")
-    - else
-      = t("#{cracked_trial_detail_translations}.trial_cracked_at_third.default")
-  %td
-    = claim.trial_cracked_at_third.humanize rescue ''
+= govuk_summary_list_row(t("#{cracked_trial_detail_translations}.trial_fixed_at")) do
+  = claim.trial_fixed_at.strftime(Settings.date_format) rescue ''
+
+= govuk_summary_list_row(t("#{cracked_trial_detail_translations}.trial_cracked_at")) do
+  = claim.trial_cracked_at.strftime(Settings.date_format) rescue ''
+
+= govuk_summary_list_row(trial_cracked_at_third_key) do
+  = claim.trial_cracked_at_third.humanize rescue ''

--- a/app/views/shared/_claim_defendant_details.html.haml
+++ b/app/views/shared/_claim_defendant_details.html.haml
@@ -1,7 +1,6 @@
-.defendant-card
+.app-card--defendant
   %h4.govuk-heading-s
-    = t('common.defendant')
-    = index
+    = t('.defendant', context: index)
 
   = govuk_summary_list do
     = govuk_summary_list_row( t('external_users.claims.defendants.defendant_fields.full_name') ) { defendant.name }
@@ -14,23 +13,20 @@
 
 
   - if defendant.representation_orders.any?
-    %table.govuk-table
-      %caption.govuk-table__caption
+    = govuk_table(class: 'report') do
+      = govuk_table_caption do
         = t('shared.claim.reporders')
 
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header{ scope: 'col' }
-            = t('.date')
-          %th.govuk-table__header{ scope: 'col' }
-            = t('external_users.claims.defendants.representation_order_fields.maat_reference_number')
+      = govuk_table_thead_collection [t('.date'),
+      t('external_users.claims.defendants.representation_order_fields.maat_reference_number')]
 
-      %tbody.govuk-table__body
+      = govuk_table_tbody do
         - defendant.representation_orders.each do | representation_order |
-          %tr.govuk-table__row
-            %td.govuk-table__cell
+          = govuk_table_row do
+            = govuk_table_td('data-label': t('.date')) do
               = representation_order.representation_order_date.strftime(Settings.date_format) rescue ''
-            %td.govuk-table__cell
+
+            = govuk_table_td('data-label': t('external_users.claims.defendants.representation_order_fields.maat_reference_number')) do
               = representation_order.maat_reference
 
   - else

--- a/app/views/shared/_claim_defendants.html.haml
+++ b/app/views/shared/_claim_defendants.html.haml
@@ -1,4 +1,3 @@
-.govuk-grid-row
-  - defendants.each_with_index do | defendant, index |
-    .govuk-grid-column-one-half
-      = render partial: 'shared/claim_defendant_details', locals: { defendant: defendant, index: index += 1 }
+- defendants.each_with_index do | defendant, index |
+  .govuk-grid-column-one-half
+    = render partial: 'shared/claim_defendant_details', locals: { defendant: defendant, index: index += 1 }

--- a/app/views/shared/_claim_interim_details.html.haml
+++ b/app/views/shared/_claim_interim_details.html.haml
@@ -1,75 +1,42 @@
 - fee = present(claim.interim_fee)
-%tr
-  %th{ scope: 'row' }
-    = t('shared.summary.fee_type')
-  %td
-    = fee.fee_type.description
+
+= govuk_summary_list_row(t('shared.summary.fee_type')) do
+  = fee.fee_type.description
 
 - if fee.is_interim_warrant?
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.warrant_fee.date_issued')
-    %td
-      = fee.warrant_issued_date
+  = govuk_summary_list_row(t('shared.summary.warrant_fee.date_issued')) do
+    = fee.warrant_issued_date
 
 - if fee.warrant_executed_date.present?
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.warrant_fee.date_executed')
-    %td
-      = fee.warrant_executed_date
+  = govuk_summary_list_row(t('shared.summary.warrant_fee.date_executed')) do
+    = fee.warrant_executed_date
 
 - else
   - unless fee.is_disbursement?
-    %tr
-      %th{ scope: 'row' }
-        = t('shared.summary.ppe_total')
-      %td
-        = fee.quantity
+    = govuk_summary_list_row(t('shared.summary.ppe_total')) do
+      = fee.quantity
+
     - if fee.is_effective_pcmh?
-      %tr
-        %th{ scope: 'row' }
-          = t('shared.summary.effective_pcmh_date')
-        %td
-          = fee.effective_pcmh_date
+      = govuk_summary_list_row(t('shared.summary.effective_pcmh_date')) do
+        = fee.effective_pcmh_date
 
 - if fee.is_trial_start?
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.trial_start')
-    %td
-      = fee.first_day_of_trial
+  = govuk_summary_list_row(t('shared.summary.trial_start')) do
+    = fee.first_day_of_trial
 
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.estimated_trial_length')
-    %td
-      = fee.estimated_trial_length
-
+  = govuk_summary_list_row(t('shared.summary.estimated_trial_length')) do
+    = fee.estimated_trial_length
 
 - if fee.is_retrial_start?
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.retrial_start')
-    %td
-      = fee.retrial_started_at
+  = govuk_summary_list_row(t('shared.summary.retrial_start')) do
+    = fee.retrial_started_at
 
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.estimated_retrial_length')
-    %td
-      = fee.retrial_estimated_length
-
+  = govuk_summary_list_row(t('shared.summary.estimated_retrial_length')) do
+    = fee.retrial_estimated_length
 
 - if fee.is_retrial_new_solicitor?
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.legal_aid_transfer_date')
-    %td
-      = fee.legal_aid_transfer_date
+  = govuk_summary_list_row(t('shared.summary.legal_aid_transfer_date')) do
+    = fee.legal_aid_transfer_date
 
-  %tr
-    %th{ scope: 'row' }
-      = t('shared.summary.trial_concluded_at')
-    %td
-      = fee.trial_concluded_at
+  = govuk_summary_list_row(t('shared.summary.trial_concluded_at')) do
+    = fee.trial_concluded_at

--- a/app/views/shared/_claim_retrial_details.html.haml
+++ b/app/views/shared/_claim_retrial_details.html.haml
@@ -1,30 +1,16 @@
 - retrial_i18n_scope = %i[external_users claims case_details retrial_detail_fields]
-%tr
-  %th{ scope: 'row' }
-    = t('retrial_started_at', scope: retrial_i18n_scope)
-  %td
-    = claim&.retrial_started_at&.strftime(Settings.date_format)
 
-%tr
-  %th{ scope: 'row' }
-    = t('retrial_estimated_length', scope: retrial_i18n_scope)
-  %td
-    = claim&.retrial_estimated_length
+= govuk_summary_list_row(t('retrial_started_at', scope: retrial_i18n_scope)) do
+  = claim&.retrial_started_at&.strftime(Settings.date_format)
 
-%tr
-  %th{ scope: 'row' }
-    = t('retrial_actual_length', scope: retrial_i18n_scope)
-  %td
-    = claim&.retrial_actual_length
+= govuk_summary_list_row(t('retrial_estimated_length', scope: retrial_i18n_scope)) do
+  = claim&.retrial_estimated_length
 
-%tr
-  %th{ scope: 'row' }
-    = t('retrial_concluded_at', scope: retrial_i18n_scope)
-  %td
-    = claim&.retrial_concluded_at&.strftime(Settings.date_format)
+= govuk_summary_list_row(t('retrial_actual_length', scope: retrial_i18n_scope)) do
+  = claim&.retrial_actual_length
 
-%tr
-  %th{ scope: 'row' }
-    = t('retrial_reduction', scope: retrial_i18n_scope)
-  %td
-    = claim&.retrial_reduction? ? 'Yes' : 'No'
+= govuk_summary_list_row(t('retrial_concluded_at', scope: retrial_i18n_scope)) do
+  = claim&.retrial_concluded_at&.strftime(Settings.date_format)
+
+= govuk_summary_list_row(t('retrial_reduction', scope: retrial_i18n_scope)) do
+  = claim&.retrial_reduction? ? 'Yes' : 'No'

--- a/app/views/shared/_claim_transfer_details.html.haml
+++ b/app/views/shared/_claim_transfer_details.html.haml
@@ -1,11 +1,5 @@
-%tr
-  %th{ scope: 'row' }
-    = t('common.transfer_detail_summary')
-  %td
-    = claim.transfer_detail_summary
+= govuk_summary_list_row(t('common.transfer_detail_summary')) do
+  = claim.transfer_detail_summary
 
-%tr
-  %th{ scope: 'row' }
-    = t('common.transfer_date')
-  %td
-    = claim.transfer_date
+= govuk_summary_list_row(t('common.transfer_date')) do
+  = claim.transfer_date

--- a/app/views/shared/_claim_trial_details.html.haml
+++ b/app/views/shared/_claim_trial_details.html.haml
@@ -1,24 +1,13 @@
 - trial_detail_translations = 'external_users.claims.case_details.trial_detail_fields'
-%tr
-  %th{ scope: 'row' }
-    = t("#{trial_detail_translations}.first_day_of_trial")
-  %td
-    = claim.first_day_of_trial.strftime(Settings.date_format) rescue ''
 
-%tr
-  %th{ scope: 'row' }
-    = t("#{trial_detail_translations}.estimated_trial_length")
-  %td
-    = claim.estimated_trial_length rescue ''
+= govuk_summary_list_row(t("#{trial_detail_translations}.first_day_of_trial")) do
+  = claim.first_day_of_trial.strftime(Settings.date_format) rescue ''
 
-%tr
-  %th{ scope: 'row' }
-    = t("#{trial_detail_translations}.actual_trial_length")
-  %td
-    = claim.actual_trial_length rescue ''
+= govuk_summary_list_row(t("#{trial_detail_translations}.estimated_trial_length")) do
+  = claim.estimated_trial_length rescue ''
 
-%tr
-  %th{ scope: 'row' }
-    = t("#{trial_detail_translations}.trial_concluded_at")
-  %td
-    = claim.trial_concluded_at.strftime(Settings.date_format) rescue ''
+= govuk_summary_list_row(t("#{trial_detail_translations}.actual_trial_length")) do
+  = claim.actual_trial_length rescue ''
+
+= govuk_summary_list_row(t("#{trial_detail_translations}.trial_concluded_at")) do
+  = claim.trial_concluded_at.strftime(Settings.date_format) rescue ''

--- a/app/views/shared/_determination.html.haml
+++ b/app/views/shared/_determination.html.haml
@@ -6,12 +6,22 @@
       .message-container
         .message-body
           = determination.event
-          %table
-            %caption.govuk-visually-hidden
+
+          = govuk_table(class: 'report') do
+            = govuk_table_caption(class: 'govuk-visually-hidden') do
               = t('.caption')
-            - determination.itemise do |item, amount|
-              %tr
-                %th{ scope: 'row' }
-                  #{item}:
-                %td
-                  #{number_to_currency(amount)}
+
+            = govuk_table_thead do
+              = govuk_table_row do
+                = govuk_table_th do
+                  = t('.item')
+                = govuk_table_th_numeric do
+                  = t('.amount')
+
+            = govuk_table_tbody do
+              - determination.itemise do |item, amount|
+                = govuk_table_row do
+                  = govuk_table_th(scope: 'row', 'data-label': t('.item')) do
+                    #{item}
+                  = govuk_table_td_numeric('data-label': t('.amount')) do
+                    #{number_to_currency(amount)}

--- a/app/views/shared/_determination_amounts.html.haml
+++ b/app/views/shared/_determination_amounts.html.haml
@@ -1,50 +1,62 @@
 - present(determination) do |determination|
   - unless claim.lgfs? && claim.interim? && claim.disbursement_only?
-    %tr.determination-display
-      %td
-        Fees
-      %td.numeric
+    = govuk_table_row do
+      = govuk_table_th(scope: 'row', 'data-label': t('common.description')) do
+        = t('.fees')
+
+      = govuk_table_td_numeric('data-label': t('.claimed_by', type: claim.external_user_description)) do
         = claim.fees_total
-      %td.numeric#determination-fees
+
+      = govuk_table_td_numeric('data-label': t('.laa_heading')) do
         = determination.fees_total
 
-  %tr.determination-display
-    %td
-      Expenses
-    %td.numeric
-      = claim.expenses_total
-    %td.numeric#determination-expenses
-      = determination.expenses_total
+    = govuk_table_row do
+      = govuk_table_th(scope: 'row', 'data-label': t('common.description')) do
+        = t('.expenses')
+
+      = govuk_table_td_numeric('data-label': t('.claimed_by', type: claim.external_user_description)) do
+        = claim.expenses_total
+
+      = govuk_table_td_numeric('data-label': t('.laa_heading')) do
+        = determination.expenses_total
 
   - if claim.can_have_disbursements?
-    %tr.determination-display
-      %td
-        Disbursements
-      %td.numeric
+    = govuk_table_row do
+      = govuk_table_th(scope: 'row', 'data-label': t('common.description')) do
+        = t('.disbursements')
+
+      = govuk_table_td_numeric('data-label': t('.claimed_by', type: claim.external_user_description)) do
         = claim.disbursements_total
-      %td.numeric#determination-disbursements
+
+      = govuk_table_td_numeric('data-label': t('.laa_heading')) do
         = determination.disbursements_total
 
-  %tr.determination-display
-    %td
-      Total(excluding VAT)
-    %td.numeric
+  = govuk_table_row do
+    = govuk_table_th(scope: 'row', 'data-label': t('common.description')) do
+      = t('.total_without_vat')
+
+    = govuk_table_td_numeric('data-label': t('.claimed_by', type: claim.external_user_description)) do
       = claim.total
-    %td.numeric#js-determination-total-exc-vat
+
+    = govuk_table_td_numeric('data-label': t('.laa_heading')) do
       = determination.total
 
-  %tr.determination-display
-    %td
-      = "VAT(#{VatRate.pretty_rate(Date.parse(claim.vat_date))})"
-    %td.numeric
+  = govuk_table_row do
+    = govuk_table_th(scope: 'row', 'data-label': t('common.description')) do
+      = t('.vat', context: "#{VatRate.pretty_rate(Date.parse(claim.vat_date))}")
+
+    = govuk_table_td_numeric('data-label': t('.claimed_by', type: claim.external_user_description)) do
       = claim.vat_amount
-    %td.numeric#js-determination-total-vat
+
+    = govuk_table_td_numeric('data-label': t('.laa_heading')) do
       = determination.vat_amount
 
-  %tr.determination-display
-    %td
-      = "Total(including #{VatRate.pretty_rate(Date.parse(claim.vat_date))} VAT)"
-    %td.numeric
+  = govuk_table_row do
+    = govuk_table_th(scope: 'row', 'data-label': t('common.description')) do
+      = t('.total_with_vat', context: "#{VatRate.pretty_rate(Date.parse(claim.vat_date))}")
+
+    = govuk_table_td_numeric('data-label': t('.claimed_by', type: claim.external_user_description)) do
       = claim.total_inc_vat
-    %td.numeric#js-determination-total-inc-vat
+
+    = govuk_table_td_numeric('data-label': t('.laa_heading')) do
       = determination.total_inc_vat

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -2,7 +2,7 @@
   = hidden_field_tag :messages, 'true'
   .fx-assesment-hook
     #claim-status
-      %h3#radio-control-heading.govuk-heading-m{ 'aria-describedby': 'radio-control-heading radio-control-legend' }
+      %h2#radio-control-heading.govuk-heading-l{ 'aria-describedby': 'radio-control-heading radio-control-legend' }
         = t('.assessment_summary')
 
 
@@ -18,18 +18,25 @@
             %div
               = validation_error_message(@error_presenter, :determinations)
 
-      %table#determinations.js-cw-claim-assessment{ data: { apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' } }
-        %thead
-          %tr
-            %th{ scope: 'col' }
+      = govuk_table(class: 'report js-cw-claim-assessment', id: 'determinations') do
+        = govuk_table_caption(class: 'govuk-visually-hidden') do
+          %h3.govuk-heading-m
+            = t('.assessment_summary')
+
+        = govuk_table_thead do
+          = govuk_table_row do
+            = govuk_table_th do
               = t('shared.description')
-            %th{ scope: 'col' }
-              = t('.claimed_by', type: claim.external_user_description)
-            %th{ scope: 'col' }
+
+            = govuk_table_th_numeric do
+              = t('shared.determinations_table.claimed_by', type: claim.external_user_description)
+
+            = govuk_table_th_numeric do
               = t('shared.determinations_table.laa_heading')
               - if claim.opened_for_redetermination?
-                .form-hint.xsmall include any amount already authorised
-        %tbody
+                .govuk-hint= t('.laa_heading_hint')
+
+        = govuk_table_tbody do
           // CASEWORKER
           - if current_user_is_caseworker? && @claim.enable_assessment_input?
             // ASSESSMENT INPUT

--- a/app/views/shared/_determinations_table.html.haml
+++ b/app/views/shared/_determinations_table.html.haml
@@ -4,21 +4,23 @@
 
   = render partial: 'shared/summary_totals', locals: { claim: claim }
 
-  %h2.govuk-heading-m
-    = t('shared.determinations_form.assessment_summary')
+  = govuk_table(class: 'report', id: 'determinations') do
+    = govuk_table_caption do
+      %h2.govuk-heading-l
+        = t('shared.determinations_form.assessment_summary')
 
-  %table#determinations
-    %caption.govuk-visually-hidden
-      = t('.caption')
-    %thead
-      %tr
-        %th{ scope: 'col' }
+    = govuk_table_thead do
+      = govuk_table_row do
+        = govuk_table_th do
           = t('common.description')
-        %th.numeric{ scope: 'col' }
+
+        = govuk_table_th_numeric do
           = t('.claimed_by', type: claim.external_user_description)
-        %th.numeric{ scope: 'col' }
+
+        = govuk_table_th_numeric do
           = t('.laa_heading')
-    %tbody
+
+    = govuk_table_tbody do
       - if claim.redeterminations.any?
         = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.redeterminations.last }
       - else

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -3,44 +3,48 @@
 .app-summary-section
   %h3.govuk-heading-m
     = t('.existing_evidence')
+
   - if current_user_persona_is?(CaseWorker) && @claim.documents.any?
-    = govuk_link_to t('shared.download_all'), download_zip_case_workers_claim_path(@claim), class: 'download-all-link'
+    = govuk_link_to t('shared.download_all_html', context: t('.existing_evidence')), download_zip_case_workers_claim_path(@claim), class: 'download-all-link'
 
   - if @claim.documents.none?
-    = t('.no_documents_uploaded')
+    %p.govuk-body
+      = t('.no_documents_uploaded')
 
   - else
-    %table#download-files-report
-      %caption.govuk-visually-hidden
+    = govuk_table(class: 'report') do
+      = govuk_table_caption(class: 'govuk-visually-hidden') do
         = t('.caption')
-      %thead
-        %tr
-          %th{ scope: 'col' }
+
+      = govuk_table_thead do
+        = govuk_table_row do
+          = govuk_table_th do
             = t('.name_of_file')
-          %th{ scope: 'col' }
+
+          = govuk_table_th_numeric do
             = t('.file_size')
-          %th.numeric{ scope: 'col' }
+
+          = govuk_table_th_numeric do
             = t('.date_added')
-          %th.numeric{ scope: 'col' }
+
+          = govuk_table_th_numeric do
             = t('.actions')
 
-      %tbody
+      = govuk_table_tbody do
         - @claim.documents.each do |document|
-          %tr
-            %td
+          = govuk_table_row do
+            = govuk_table_td('data-label': t('.name_of_file')) do
               = document.document_file_name
-            %td
+
+            = govuk_table_td_numeric('data-label': t('.file_size')) do
               = number_to_human_size(document.document_file_size)
-            %td.numeric
+
+            = govuk_table_td_numeric('data-label': t('.date_added')) do
               = document.created_at.strftime(Settings.date_format)
-            %td.numeric
-              - if document.converted_preview_document.present?
-                = govuk_link_to t('common.view'),
-                          document_path(document),
-                          class: 'view',
-                          'aria-label': "Evidence: View document #{document.document_file_name}, opens in new window"
-                = ' | '
-              = govuk_link_to t('common.download'),
-                        download_document_path(document),
-                        class: 'download',
-                        'aria-label': "Evidence: Download document #{document.document_file_name}"
+
+            = govuk_table_td_numeric('data-label': t('.actions')) do
+              .app-link-group
+                - if document.converted_preview_document.present?
+                  = govuk_link_to t('common.view_html', context: "#{document.document_file_name}")
+
+                = govuk_link_to t('common.download_html', context: "#{document.document_file_name}"), download_document_path(document)

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -4,31 +4,31 @@
     %h3.govuk-heading-m
       = t('common.fees')
     - if @claim.fees_total == 0
-      %p
+      %p.govuk-body
         = t('shared.summary.no_values.fees')
     - else
       / table does not require summary
-      %table.figures
-        %caption.govuk-visually-hidden
+      = govuk_table(class: 'report') do
+        = govuk_table_caption(class: 'govuk-visually-hidden') do
           = t('.fees.caption')
-        %thead
-          %tr
-            %th.col-fee-cat{ scope: 'col' }
+        = govuk_table_thead do
+          = govuk_table_row do
+            = govuk_table_th do
               = t('.fee_category')
-            %th{ scope: 'col' }
+            = govuk_table_th do
               = t('.fee_type')
             - unless claim.interim?
-              %th.numeric{ scope: 'col' }
+              = govuk_table_th_numeric do
                 = t('.quantity')
 
-            %th.numeric{ scope: 'col' }
+            = govuk_table_th_numeric do
               = t('.rate')
-            %th.numeric.col-gross{ scope: 'col' }
+            = govuk_table_th_numeric do
               = t('shared.net_amount')
-        %tbody
+        = govuk_table_tbody do
           - present_collection(claim.fees.select(&:present?).sort_by(&:position)).each do |fee|
-            %tr
-              %td
+            = govuk_table_row do
+              = govuk_table_td do
                 = fee.fee_type&.fee_category_name || 'n/a'
                 %br/
                 - if fee.fee_type.unique_code.eql?('BABAF')
@@ -59,7 +59,7 @@
                 - if fee.date?
                   = t('.date')
                   = fee.date
-              %td
+              = govuk_table_td do
                 = fee.fee_type&.description || 'n/a'
                 - if fee.sub_type.present?
                   %p
@@ -68,34 +68,34 @@
                   %br
                   = "#{t('.case_numbers')}: #{fee.case_numbers}"
               - unless claim.interim?
-                %td.numeric
+                = govuk_table_td_numeric do
                   = fee.quantity
-              %td.numeric
+              = govuk_table_td_numeric do
                 = fee.rate
-              %td.numeric
+              = govuk_table_td_numeric do
                 = fee.amount
 
-      %table.figures
-        %thead
-          %tr
-            %th{ scope: 'col' }
+      = govuk_table(class: 'report') do
+        = govuk_table_thead do
+          = govuk_table_row do
+            = govuk_table_th do
               = t('shared.description')
-            %th.col-net.numeric{ scope: 'col' }
+            = govuk_table_th_numeric do
               = t('shared.net_amount')
-            %th.col-vat.numeric{ scope: 'col' }
+            = govuk_table_th_numeric do
               = t('shared.vat')
-            %th.col-gross.numeric{ scope: 'col' }
+            = govuk_table_th_numeric do
               = t('shared.gross_amount')
 
-        %tbody
-          %tr.totals
-            %td
+        = govuk_table_tbody do
+          = govuk_table_row do
+            = govuk_table_td do
               = t('shared.summary.fees_total')
-            %td.numeric
+            = govuk_table_td_numeric do
               = claim.fees_total
-            %td.numeric
+            = govuk_table_td_numeric do
               = claim.fees_vat
-            %td.numeric
+            = govuk_table_td_numeric do
               = claim.fees_gross
 
     - if claim.final? && claim.interim_claim_info.present?
@@ -103,25 +103,25 @@
         - if info.warrant_fee_paid?
           %h3.govuk-heading-m
             = t('common.interim_claim_info')
-          %table.table-summary
-            %caption.hidden
+          = govuk_table(class: 'report') do
+            = govuk_table_caption(class: 'govuk-visually-hidden') do
               = t('.fees.caption')
-            %tbody
-              %tr
-                %th.col-date{ scope: 'col' }
+            = govuk_table_tbody do
+              = govuk_table_row do
+                = govuk_table_th(scope: 'row') do
                   = t('shared.claims.interim_claim_info.fields.date_issued')
-                %td
+                = govuk_table_td do
                   = info.warrant_issued_date
-              %tr
-                %th.col-date{ scope: 'col' }
+              = govuk_table_row do
+                = govuk_table_th(scope: 'row') do
                   = t('shared.claims.interim_claim_info.fields.date_executed')
-                %td
+                = govuk_table_td do
                   = info.warrant_executed_date
 
     - if claim.expenses.empty?
       %h3.govuk-heading-m
         = t('common.expenses')
-      %p
+      %p.govuk-body
         = t('shared.summary.no_values.expenses')
     - else
       = render partial: 'shared/summary/expenses', locals: { claim: claim }

--- a/app/views/shared/_summary_agfs.html.haml
+++ b/app/views/shared/_summary_agfs.html.haml
@@ -7,7 +7,6 @@
       %p.govuk-body
         = t('shared.summary.no_values.fees')
     - else
-      / table does not require summary
       = govuk_table(class: 'report') do
         = govuk_table_caption(class: 'govuk-visually-hidden') do
           = t('.fees.caption')
@@ -28,7 +27,7 @@
         = govuk_table_tbody do
           - present_collection(claim.fees.select(&:present?).sort_by(&:position)).each do |fee|
             = govuk_table_row do
-              = govuk_table_td do
+              = govuk_table_td('data-label': t('.fee_category')) do
                 = fee.fee_type&.fee_category_name || 'n/a'
                 %br/
                 - if fee.fee_type.unique_code.eql?('BABAF')
@@ -59,7 +58,7 @@
                 - if fee.date?
                   = t('.date')
                   = fee.date
-              = govuk_table_td do
+              = govuk_table_td('data-label': t('.fee_type')) do
                 = fee.fee_type&.description || 'n/a'
                 - if fee.sub_type.present?
                   %p
@@ -68,11 +67,11 @@
                   %br
                   = "#{t('.case_numbers')}: #{fee.case_numbers}"
               - unless claim.interim?
-                = govuk_table_td_numeric do
+                = govuk_table_td_numeric('data-label': t('.quantity')) do
                   = fee.quantity
-              = govuk_table_td_numeric do
+              = govuk_table_td_numeric('data-label': t('.rate')) do
                 = fee.rate
-              = govuk_table_td_numeric do
+              = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
                 = fee.amount
 
       = govuk_table(class: 'report') do
@@ -89,13 +88,13 @@
 
         = govuk_table_tbody do
           = govuk_table_row do
-            = govuk_table_td do
+            = govuk_table_td('data-label': t('shared.description')) do
               = t('shared.summary.fees_total')
-            = govuk_table_td_numeric do
+            = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
               = claim.fees_total
-            = govuk_table_td_numeric do
+            = govuk_table_td_numeric('data-label': t('shared.vat')) do
               = claim.fees_vat
-            = govuk_table_td_numeric do
+            = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
               = claim.fees_gross
 
     - if claim.final? && claim.interim_claim_info.present?

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -157,16 +157,16 @@
 
             = govuk_table_tfoot do
               = govuk_table_row do
-                = govuk_table_th(scope: 'row') do
+                = govuk_table_th(scope: 'row', 'data-label': t('shared.disbursement_type')) do
                   = t('shared.disbursements_gross')
 
-                = govuk_table_td_numeric do
+                = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
                   = claim.disbursements_with_vat_net
 
-                = govuk_table_td_numeric do
+                = govuk_table_td_numeric('data-label': t('shared.vat')) do
                   = claim.disbursements_vat
 
-                = govuk_table_td_numeric do
+                = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
                   = claim.disbursements_with_vat_gross
 
         - if claim.disbursements.without_vat.any?
@@ -202,11 +202,11 @@
 
             = govuk_table_tfoot do
               = govuk_table_row do
-                = govuk_table_th(scope: 'row') do
+                = govuk_table_th(scope: 'row', 'data-label': t('shared.disbursement_type')) do
                   = t('shared.disbursements_no_vat')
 
-                = govuk_table_td_numeric do
+                = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
                   = claim.disbursements_without_vat_net
 
-                = govuk_table_td_numeric do
+                = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
                   = claim.disbursements_without_vat_gross

--- a/app/views/shared/_summary_lgfs.html.haml
+++ b/app/views/shared/_summary_lgfs.html.haml
@@ -2,34 +2,42 @@
   %section#summary
     %h3.govuk-heading-m
       = t('common.fees')
+
     - if @claim.fees_total == 0
-      %p
+      %p.govuk-body
         = t('shared.summary.no_values.fees')
+
     - else
-      / table does noe require summary
-      %table.figures
-        %caption.govuk-visually-hidden
+      = govuk_table(class: 'report') do
+        = govuk_table_caption(class: 'govuk-visually-hidden') do
           = t('.fees.caption')
-        %thead
-          %tr
-            %th{ scope: 'col' }
+
+        = govuk_table_thead do
+          = govuk_table_row do
+            = govuk_table_th do
               = t('.fee_category')
-            %th{ scope: 'col' }
+
+            = govuk_table_th do
               = t('.fee_type')
+
             - if claim.display_days?
-              %th.numeric{ scope: 'col' }
+              = govuk_table_th_numeric do
                 = claim.transfer? ? t('.days_claimed') : t('.actual_trial_length')
-            %th.numeric{ scope: 'col' }
+
+            = govuk_table_th_numeric do
               = claim.fixed_fee_case? ? t('.quantity') : 'PPE'
+
             - if claim.fixed_fee_case?
-              %th.numeric{ scope: 'col' }
+              = govuk_table_th_numeric do
                 = t('.rate')
-            %th.numeric{ scope: 'col' }
+
+            = govuk_table_th_numeric do
               = t('.amount')
-        %tbody
+
+        = govuk_table_tbody do
           - present_collection(claim.fees.select(&:present?).sort_by(&:position)).each do |fee|
-            %tr
-              %td
+            = govuk_table_row do
+              = govuk_table_td('data-label': t('.fee_category')) do
                 = fee.fee_type&.fee_category_name || fee.not_applicable
                 - if fee.dates_attended.any?
                   %br
@@ -39,23 +47,28 @@
                   %br
                   = t('.date')
                   = fee.date
-              %td
+
+              = govuk_table_td('data-label': t('.fee_type')) do
                 = fee.fee_type&.description || fee.not_applicable
                 - if fee.sub_type.present?
-                  %p
-                    = "#{t('.fee_subtype')}: #{fee.sub_type.description}"
+                  %br
+                  = "#{t('.fee_subtype')}: #{fee.sub_type.description}"
                 - if fee.case_uplift?
                   %br
                   = "(#{t('.case_numbers')}: #{fee.case_numbers})"
+
               - if claim.display_days?
-                %td.numeric{ scope: 'col' }
+                = govuk_table_td_numeric('data-label': claim.transfer? ? t('.days_claimed') : t('.actual_trial_length')) do
                   = fee.days_claimed
-              %td.numeric
+
+              = govuk_table_td_numeric('data-label': claim.fixed_fee_case? ? t('.quantity') : 'PPE') do
                 = fee.quantity
+
               - if claim.fixed_fee_case?
-                %td.numeric
+                = govuk_table_td_numeric('data-label': t('.rate')) do
                   = fee.rate
-              %td.numeric
+
+              = govuk_table_td_numeric('data-label': t('.amount')) do
                 = fee.amount
 
       .totals
@@ -67,25 +80,31 @@
         - if info.warrant_fee_paid?
           %h3.govuk-heading-m
             = t('common.interim_claim_info')
-          %table.table-summary
-            %caption.hidden
+
+          = govuk_table(class: 'report') do
+            = govuk_table_caption(class: 'govuk-visually-hidden') do
               = t('.fees.caption')
-            %tbody
-              %tr
-                %th.col-date{ scope: 'col' }
+
+            = govuk_table_tbody do
+              = govuk_table_row do
+                = govuk_table_th do
                   = t('shared.claims.interim_claim_info.fields.date_issued')
-                %td
+
+                = govuk_table_td do
                   = info.warrant_issued_date
-              %tr
-                %th.col-date{ scope: 'col' }
+
+              = govuk_table_row do
+                = govuk_table_th do
                   = t('shared.claims.interim_claim_info.fields.date_executed')
-                %td
+
+                = govuk_table_td do
                   = info.warrant_executed_date
 
     - if claim.expenses.empty?
       %h3.govuk-heading-m
         = t('common.expenses')
-      %p
+
+      %p.govuk-body
         = t('shared.summary.no_values.expenses')
     - else
       = render partial: 'shared/summary/expenses', locals: { claim: claim }
@@ -94,76 +113,100 @@
       - if claim.disbursements.empty?
         %h3.govuk-heading-m
           = t('common.disbursements')
-        %p
+
+        %p.govuk-body
           = t('shared.summary.no_values.disbursements')
+
       - else
-        / table does noe require summary
         - if claim.disbursements.with_vat.any?
           %h3.govuk-heading-m
             = t('shared.disbursements_gross')
-          %table.figures
-            %caption.govuk-visually-hidden
+
+          = govuk_table(class: 'report') do
+            = govuk_table_caption(class: 'govuk-visually-hidden') do
               = t('.disbursements.caption')
-            %thead
-              %tr
-                %th{ scope: 'col' }
+
+            = govuk_table_thead do
+              = govuk_table_row do
+                = govuk_table_th do
                   = t('shared.disbursement_type')
-                %th.col-net.numeric{ scope: 'col' }
+
+                = govuk_table_th_numeric do
                   = t('shared.net_amount')
-                %th.col-vat.numeric{ scope: 'col' }
+
+                = govuk_table_th_numeric do
                   = t('shared.vat')
-                %th.col-gross.numeric{ scope: 'col' }
+
+                = govuk_table_th_numeric do
                   = t('shared.gross_amount')
-            %tbody
+
+            = govuk_table_tbody do
               - present_collection(claim.disbursements.with_vat).each do |disbursement|
-                %tr
-                  %td
+                = govuk_table_row do
+                  = govuk_table_td('data-label': t('shared.disbursement_type')) do
                     = disbursement.name
-                  %td.numeric
+
+                  = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
                     = disbursement.net_amount
-                  %td.numeric
+
+                  = govuk_table_td_numeric('data-label': t('shared.vat')) do
                     = disbursement.vat_amount
-                  %td.numeric
+
+                  = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
                     = disbursement.total
-            %tfoot
-              %tr.totals
-                %td
+
+            = govuk_table_tfoot do
+              = govuk_table_row do
+                = govuk_table_th(scope: 'row') do
                   = t('shared.disbursements_gross')
-                %td.numeric
+
+                = govuk_table_td_numeric do
                   = claim.disbursements_with_vat_net
-                %td.numeric
+
+                = govuk_table_td_numeric do
                   = claim.disbursements_vat
-                %td.numeric
+
+                = govuk_table_td_numeric do
                   = claim.disbursements_with_vat_gross
 
         - if claim.disbursements.without_vat.any?
           %h3.govuk-heading-m
             = t('shared.disbursements_no_vat')
-          %table.figures
-            %caption.govuk-visually-hidden
+
+          = govuk_table(class: 'report') do
+            = govuk_table_caption(class: 'govuk-visually-hidden') do
               = t('.disbursements.caption')
-            %thead
-              %tr
-                %th{ scope: 'col' }
+
+            = govuk_table_thead do
+              = govuk_table_row do
+                = govuk_table_th do
                   = t('shared.disbursement_type')
-                %th.col-net.numeric{ scope: 'col' }
+
+                = govuk_table_th_numeric do
                   = t('shared.net_amount')
-                %th.col-gross.numeric{ scope: 'col' }
+
+                = govuk_table_th_numeric do
                   = t('shared.gross_amount')
-            %tbody
+
+            = govuk_table_tbody do
               - present_collection(claim.disbursements.without_vat).each do |disbursement|
-                %tr
-                  %td
+                = govuk_table_row do
+                  = govuk_table_td('data-label': t('shared.disbursement_type')) do
                     = disbursement.name
-                  %td.numeric
+
+                  = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
                     = disbursement.net_amount
-                  %td.numeric
+
+                  = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
                     = disbursement.total
-            %tfoot
-              %tr.totals
-                %td
+
+            = govuk_table_tfoot do
+              = govuk_table_row do
+                = govuk_table_th(scope: 'row') do
                   = t('shared.disbursements_no_vat')
-                %td.numeric
+
+                = govuk_table_td_numeric do
                   = claim.disbursements_without_vat_net
-                %td.numeric
+
+                = govuk_table_td_numeric do
                   = claim.disbursements_without_vat_gross

--- a/app/views/shared/_summary_totals.html.haml
+++ b/app/views/shared/_summary_totals.html.haml
@@ -1,79 +1,81 @@
-%h2.govuk-heading-m
-  = t('shared.summary_totals')
+= govuk_table(class: 'report') do
+  = govuk_table_caption do
+    %h2.govuk-heading-l
+      = t('shared.summary_totals')
 
-%table.figures
-  %thead
-    %tr
-      %th{ scope: 'col' }
+  = govuk_table_thead do
+    = govuk_table_row do
+      = govuk_table_th do
         = t('shared.description')
-      %th.col-net.numeric{ scope: 'col' }
+      = govuk_table_th_numeric do
         = t('shared.net_amount')
-      %th.col-vat.numeric{ scope: 'col' }
+      = govuk_table_th_numeric do
         = t('shared.vat')
-      %th.col-gross.numeric{ scope: 'col' }
+      = govuk_table_th_numeric do
         = t('shared.gross_amount')
 
-  %tbody
-    %tr
-      %td
+  = govuk_table_tbody do
+    = govuk_table_row do
+      = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
         = t('shared.fees')
-      %td.numeric
+      = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
         = claim.fees_total
-      %td.numeric
+      = govuk_table_td_numeric('data-label': t('shared.vat')) do
         = claim.fees_vat
-      %td.numeric
+      = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
         = claim.fees_gross
 
     - if claim.expenses.with_vat.any?
-      %tr
-        %td
+      = govuk_table_row do
+        = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
           = "Expenses with VAT"
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
           = claim.expenses_with_vat_net
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.vat')) do
           = claim.expenses_vat
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
           = claim.expenses_with_vat_gross
 
     - if claim.expenses.without_vat.any?
-      %tr
-        %td
+      = govuk_table_row do
+        = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
           = t('shared.expenses_net')
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
           = claim.expenses_without_vat_net
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.vat')) do
           = ''
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
           = claim.expenses_without_vat_gross
 
     - if claim.disbursements.with_vat.any?
-      %tr
-        %td
+      = govuk_table_row do
+        = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
           = t('shared.disbursements_gross')
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
           = claim.disbursements_with_vat_net
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.vat')) do
           = claim.disbursements_vat
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
           = claim.disbursements_with_vat_gross
 
     - if claim.disbursements.without_vat.any?
-      %tr
-        %td
+      = govuk_table_row do
+        = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
           = t('shared.disbursements_no_vat')
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
           = claim.disbursements_without_vat_net
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.vat')) do
           = "-"
-        %td.numeric
+        = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
           = claim.disbursements_without_vat_gross
-  %tfoot
-    %tr.totals
-      %td
+
+  = govuk_table_tfoot do
+    = govuk_table_row do
+      = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
         = t('shared.claim_total')
-      %td.numeric
+      = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
         = claim.total
-      %td.numeric
+      = govuk_table_td_numeric('data-label': t('shared.vat')) do
         = claim.vat_amount
-      %td.numeric
+      = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
         = claim.total_inc_vat

--- a/app/views/shared/summary/_expenses.html.haml
+++ b/app/views/shared/summary/_expenses.html.haml
@@ -6,9 +6,10 @@
 
 - if claim.travel_expense_additional_information.present?
   = govuk_inset_text do
-    %h3.govuk-heading-s
+    %h4.govuk-heading-s
       = t('.travel_expense_additional_information')
-    %p
+
+    %p.govuk-body
       = claim.travel_expense_additional_information
 
 - if claim.expenses.with_vat.any?

--- a/app/views/shared/summary/expenses/index.html.haml
+++ b/app/views/shared/summary/expenses/index.html.haml
@@ -1,41 +1,42 @@
-.table-container
-  %h3.govuk-heading-s
-    = t(".header_#{vat ? 'with_vat' : 'without_vat'}")
+%h3.govuk-heading-m
+  = t(".header_#{vat ? 'with_vat' : 'without_vat'}")
 
-  %table.figures{ class: (current_user.case_worker? ? 'expenses-data-table' : nil) }
-    %caption.govuk-visually-hidden
-      = t('.caption')
+= govuk_table(class: current_user.case_worker? ? 'expenses-data-table' : nil) do
+  = govuk_table_caption(class: 'govuk-visually-hidden') do
+    = t('.caption')
 
-    %thead
-      %tr
-        %th.col-type{ scope: 'col' }
-          = t('.expense_type')
-        %th.col-reason{ scope: 'col' }
-          = t('.reason')
-        %th.col-details{ scope: 'col' }
-          = t('.details')
-        %th.col-date{ scope: 'col' }
-          = t('.date')
-        %th.col-net.numeric{ scope: 'col' }
-          = t('.net_amount')
-        %th.col-vat.numeric{ scope: 'col' }
-          = vat ? t('.vat') : '-'
-        %th.col-vat.numeric{ scope: 'col' }
-          = t('.gross_amount')
+  = govuk_table_thead do
+    = govuk_table_row do
+      = govuk_table_th do
+        = t('.expense_type')
+      = govuk_table_th do
+        = t('.reason')
+      = govuk_table_th do
+        = t('.details')
+      = govuk_table_th do
+        = t('.date')
+      = govuk_table_th_numeric do
+        = t('.net_amount')
+      - if vat
+        = govuk_table_th_numeric do
+          = t('.vat')
+      = govuk_table_th_numeric do
+        = t('.gross_amount')
 
-    %tbody
-      - expenses = vat ? claim.expenses.with_vat : claim.expenses.without_vat
-      - present_collection(expenses).each do |expense|
-        = render template: 'shared/summary/expenses/show', locals: { claim: claim, expense: expense }
+  = govuk_table_tbody do
+    - expenses = vat ? claim.expenses.with_vat : claim.expenses.without_vat
+    - present_collection(expenses).each do |expense|
+      = render template: 'shared/summary/expenses/show', locals: { claim: claim, expense: expense }
 
-    %tfoot
-      %tr.totals
-        %td{ colspan: 4 }
-          = succeed ':' do
-            = t(".totals_#{vat ? 'with_vat' : 'without_vat'}")
-        %td.numeric
-          = vat ? claim.expenses_with_vat_net : claim.expenses_without_vat_net
-        %td.numeric
-          = vat ? claim.expenses_vat : ''
-        %td.numeric
-          = vat ? claim.expenses_with_vat_gross : claim.expenses_without_vat_gross
+  = govuk_table_tfoot do
+    = govuk_table_row do
+      = govuk_table_th(scope: 'row', colspan: 4) do
+        = succeed ':' do
+          = t(".totals_#{vat ? 'with_vat' : 'without_vat'}")
+      = govuk_table_td_numeric do
+        = vat ? claim.expenses_with_vat_net : claim.expenses_without_vat_net
+      - if vat
+        = govuk_table_td_numeric do
+          = claim.expenses_vat
+      = govuk_table_td_numeric do
+        = vat ? claim.expenses_with_vat_gross : claim.expenses_without_vat_gross

--- a/app/views/shared/summary/expenses/index.html.haml
+++ b/app/views/shared/summary/expenses/index.html.haml
@@ -1,7 +1,7 @@
 %h3.govuk-heading-m
   = t(".header_#{vat ? 'with_vat' : 'without_vat'}")
 
-= govuk_table(class: current_user.case_worker? ? 'expenses-data-table' : nil) do
+= govuk_table(class: current_user.case_worker? ? 'report expenses-data-table' : 'report', style: 'width:100%') do
   = govuk_table_caption(class: 'govuk-visually-hidden') do
     = t('.caption')
 
@@ -30,13 +30,13 @@
 
   = govuk_table_tfoot do
     = govuk_table_row do
-      = govuk_table_th(scope: 'row', colspan: 4) do
+      = govuk_table_th(scope: 'row', colspan: 4, 'data-label': t('.expense_type')) do
         = succeed ':' do
           = t(".totals_#{vat ? 'with_vat' : 'without_vat'}")
-      = govuk_table_td_numeric do
+      = govuk_table_td_numeric('data-label': t('.net_amount')) do
         = vat ? claim.expenses_with_vat_net : claim.expenses_without_vat_net
       - if vat
-        = govuk_table_td_numeric do
+        = govuk_table_td_numeric('data-label': t('.vat')) do
           = claim.expenses_vat
-      = govuk_table_td_numeric do
+      = govuk_table_td_numeric('data-label': t('.gross_amount')) do
         = vat ? claim.expenses_with_vat_gross : claim.expenses_without_vat_gross

--- a/app/views/shared/summary/expenses/show.html.haml
+++ b/app/views/shared/summary/expenses/show.html.haml
@@ -1,20 +1,20 @@
 = govuk_table_row do
-  = govuk_table_td do
+  = govuk_table_td('data-label': t('.expense_type')) do
     %span{class: 'govuk-!-font-weight-bold'}
       = expense.name
     - if current_user_is_caseworker? && @claim.lgfs?
       = govuk_tag expense.state, class: "app-tag--#{expense.state.downcase}"
-  = govuk_table_td do
+  = govuk_table_td('data-label': t('.reason')) do
     %span{class: 'govuk-!-font-weight-bold'}
       = expense.reason
-  = govuk_table_td do
+  = govuk_table_td('data-label': t('.details')) do
     = render partial: 'shared/summary/expenses/details', locals: { claim: claim, expense: expense }
-  = govuk_table_td do
+  = govuk_table_td('data-label': t('.date')) do
     = expense.pretty_date
-  = govuk_table_td_numeric do
+  = govuk_table_td_numeric('data-label': t('.net_amount')) do
     = expense.amount
   - if expense.vat_present?
-    = govuk_table_td_numeric do
+    = govuk_table_td_numeric('data-label': t('.vat')) do
       = expense.vat_amount
-  = govuk_table_td_numeric do
+  = govuk_table_td_numeric('data-label': t('.gross_amount')) do
     = expense.gross_amount

--- a/app/views/shared/summary/expenses/show.html.haml
+++ b/app/views/shared/summary/expenses/show.html.haml
@@ -1,19 +1,20 @@
-%tr.no-border
-  %td
-    %span.bold-normal
+= govuk_table_row do
+  = govuk_table_td do
+    %span{class: 'govuk-!-font-weight-bold'}
       = expense.name
     - if current_user_is_caseworker? && @claim.lgfs?
       = govuk_tag expense.state, class: "app-tag--#{expense.state.downcase}"
-  %td
-    %span.bold-normal
+  = govuk_table_td do
+    %span{class: 'govuk-!-font-weight-bold'}
       = expense.reason
-  %td
+  = govuk_table_td do
     = render partial: 'shared/summary/expenses/details', locals: { claim: claim, expense: expense }
-  %td
+  = govuk_table_td do
     = expense.pretty_date
-  %td.numeric
+  = govuk_table_td_numeric do
     = expense.amount
-  %td.numeric
-    = expense.vat_present? ? expense.vat_amount : ''
-  %td.numeric
+  - if expense.vat_present?
+    = govuk_table_td_numeric do
+      = expense.vat_amount
+  = govuk_table_td_numeric do
     = expense.gross_amount

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -51,6 +51,15 @@ moj.Modules.AllocationDataTable = {
     // row callback to add injection errors
     createdRow: function (row, data, index) {
       $(row).addClass('govuk-table__row')
+      //  Add data row for responsive table label
+      $(row).find('td').eq(0).attr('data-label', 'Select claim')
+      $(row).find('td').eq(1).attr('data-label', 'Case number')
+      $(row).find('td').eq(2).attr('data-label', 'Court')
+      $(row).find('td').eq(3).attr('data-label', 'Defendants')
+      $(row).find('td').eq(4).attr('data-label', 'Type')
+      $(row).find('td').eq(5).attr('data-label', 'Submitted')
+      $(row).find('td').eq(6).attr('data-label', 'Total')
+
       $('td', row).addClass('govuk-table__cell')
 
       if (data.filter.injection_errored) {
@@ -141,7 +150,7 @@ moj.Modules.AllocationDataTable = {
       targets: 1,
       data: null,
       render: function (data, type, full) {
-        return data.filter.disk_evidence ? '<a aria-label="View Claim, Case number: ' + data.case_number + '" href="/case_workers/claims/' + data.id + '">' + data.case_number + '</a><br/><span class="disk-evidence">Disk evidence</span>' : '<a aria-label="View Claim, Case number: ' + data.case_number + '" href="/case_workers/claims/' + data.id + '">' + data.case_number + '</a>'
+        return data.filter.disk_evidence ? '<span class="js-test-case-number"><a aria-label="View Claim, Case number: ' + data.case_number + '" href="/case_workers/claims/' + data.id + '">' + data.case_number + '</a><br/><span class="disk-evidence">Disk evidence</span></span>' : '<span class="js-test-case-number"><a aria-label="View Claim, Case number: ' + data.case_number + '" href="/case_workers/claims/' + data.id + '">' + data.case_number + '</a></span>'
       }
 
     }, {

--- a/app/webpack/stylesheets/_messages.scss
+++ b/app/webpack/stylesheets/_messages.scss
@@ -75,15 +75,6 @@
           padding-right: 0;
           border: 0;
         }
-
-        table {
-          width: $half;
-          margin-left: auto;
-
-          td {
-            border-top: 1px solid $border-colour;
-          }
-        }
       }
 
       .message-right {

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -251,13 +251,6 @@ form {
   margin-right: 10px;
 }
 
-.defendant-card {
-  margin-top: $gutter-half;
-  margin-bottom: $gutter-half;
-  padding: $gutter-half $gutter-one-third $gutter-half $gutter-half;
-  border: 1px solid $border-colour;
-}
-
 // Styling for Claims Messaging
 .messages {
   .none {

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -435,7 +435,6 @@ form {
   }
 }
 
-#download-files-report,
 .previously-uploaded {
   td,
   th {

--- a/app/webpack/stylesheets/_tables.scss
+++ b/app/webpack/stylesheets/_tables.scss
@@ -210,23 +210,22 @@ table {
       margin-bottom: $gutter-one-third;
       border-bottom: 3px solid $grey-3;
 
+      .govuk-table__header:last-child,
+      .govuk-table__cell:last-child,
+      th,
       td {
         display: block;
+        padding: $gutter-half;
         border-bottom: 1px solid $grey-3;
         text-align: right;
+
+        br {
+          display: none;
+        }
       }
 
       td:last-child {
         border-bottom: 0;
-      }
-
-      th,
-      td {
-        br {
-          display: none;
-        }
-
-        padding: $gutter-half;
       }
 
       &.mobile-sort {
@@ -266,6 +265,7 @@ table {
       background-color: none;
     }
 
+    th:before,
     td:before {
       content: attr(data-label);
       float: left;

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -76,6 +76,7 @@ $govuk-font-url-function: frontend-font-url;
 
 @import 'cocoon';
 
+@import 'components/card';
 @import 'components/code';
 @import 'components/tag';
 @import 'components/notification_banner';

--- a/app/webpack/stylesheets/components/_card.scss
+++ b/app/webpack/stylesheets/components/_card.scss
@@ -1,0 +1,6 @@
+.app-card--defendant {
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+  padding: $gutter-half $gutter-one-third $gutter-half $gutter-half;
+  border: 1px solid $border-colour;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1894,7 +1894,9 @@ en:
       evidence_hint: "If you don't provide enough evidence, your claim may be rejected."
       no_evidence: 'No documentary evidence specified as having been provided.'
     determination:
+      amount: Amount
       caption: 'Total of assessed amounts by category'
+      item: Item
       summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows'
     determinations_form:
       update: Update
@@ -2073,6 +2075,14 @@ en:
           message:
             one: The distance claimed by the provider is greater than the calculated distance for one expense. Please see the table below for details.
             other: The distance claimed by the provider is greater than the calculated distance for %{count} expenses. Please see the table below for details.
+        show:
+          date: Date of expense
+          details: Details
+          expense_type: Type of expense
+          gross_amount: Gross amount
+          net_amount: *net_amount
+          reason: Reason for travel
+          vat: *vat_amount
       fee: Fee
       fee_index: Fee %{index}
       fees:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1878,9 +1878,12 @@ en:
       banner_title: Important
       banner_heading: This service will be unavailable on %{date_string} from 5pm until midnight.
       banner_paragraph: This is to enable routine maintenance work to be carried out. Please save and close any work before this time.
+    claim_defendants:
+      defendants: Defendants
     claim_defendant_details:
       caption: 'Defendant: Additional information'
       date: Order date
+      defendant: Defendant %{context}
       no_reporder: No representation orders have been supplied for this defendant.
     evidence_checklist:
       caption: 'Supporting evidence checklist'
@@ -1936,8 +1939,11 @@ en:
       case_type: *case_type
       case_stage: *case_stage
       case_worker: Case worker
+      claim_type: Claim and case type
       defendant: Defendant names
+      defendants: Defendants
       j_a: Judicial apportionment
+      no_defendant: No defendant details have been supplied for this claim
       offence: Offence
       offence_class: Offence class
       q:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2504,6 +2504,7 @@ en:
         advocate_litigator: *advocate_litigator
         advocate_sort_label: 'Sort by: Provider name'
         case_number: Case number
+        case_number_html: <span class="govuk-visually-hidden">View Case number</span> %{context}
         case_number_sort_label: 'Sort by: Case number'
         case_type: Case type
         case_type_sort_label: 'Sort by: Case type'
@@ -2512,7 +2513,7 @@ en:
         last_submitted_at_sort_label: 'Sort by: Last submitted at date'
         messages: Messages
         none: None
-        number_of_claims: 'Number of claims: '
+        number_of_claims: 'Number of claims: %{claim_count}'
         state_sort_label: 'Sort by: Claim state'
         status: Status
         submission_date: Date submitted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2412,7 +2412,7 @@ en:
           allocated_to: Allocated to
           disk_evidence: Disk evidence
           no_claims_allocated: There is no claim available for allocation
-          number_of_claims: 'Number of claims:'
+          number_of_claims: 'Number of claims: %{claim_count}'
           choose_label_html: <span class="govuk-visually-hidden">Select case %{case_number}</span>
           form_hint_html: |
             To de-allocate claims, choose "Allocation pool".

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,11 +316,13 @@ en:
     search: Search
     upload: Import claims
     download: Download
+    download_html: Download <span class="govuk-visually-hidden">%{context}</span>
     remove: Remove
     remove_html: Remove <span class="govuk-visually-hidden">%{context} <span class="fx-numberedList-number"></span></span>
     edit: Edit
     delete: Delete
     view: View
+    view_html: View <span class="govuk-visually-hidden">%{context}</span>
     warrant_fees: Warrant fees
     interim_claim_info: Warrant fees
     interim_fees: "Interim fees"
@@ -2291,7 +2293,7 @@ en:
     disbursements_gross: 'Disbursements with VAT'
     disbursements_no_vat: 'Disbursements without VAT'
     disbursements_total: 'Disbursements total'
-    download_all: 'Download all'
+    download_all_html: Download all <span class="govuk-visually-hidden">%{context}</span>
     expenses_net: 'Expenses without VAT'
     fees: 'Fees'
     gross_amount: 'Gross amount'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1901,11 +1901,22 @@ en:
       reason_hint: These reasons will be displayed to providers
       update_the_claim_status: Update the claim status
       reason_text: Reason text
+      laa_heading: Total authorised by LAA
+      laa_heading_hint: include any amount already authorised
     determinations_table:
       caption: 'This section contains a categorised list of amounts claimed and the amount authorised by the LAA'
       summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows.'
       claimed_by: 'Claimed by %{type}'
       laa_heading: 'Total authorised by LAA'
+    determination_amounts:
+      claimed_by: Claimed by %{type}
+      disbursements: Disbursements
+      expenses: Expenses
+      fees: Fees
+      laa_heading: Total authorised by LAA
+      total_with_vat: Total (including %{context} VAT)
+      total_without_vat: Total (excluding VAT)
+      vat: VAT (%{context})
     help_summary_heading: Help with completing this form
     no_claims_found: 'No claims found'
     certification:

--- a/lib/govuk_component/table_helpers.rb
+++ b/lib/govuk_component/table_helpers.rb
@@ -28,6 +28,12 @@ module GovukComponent
       tag.tbody(capture(&block), tag_options)
     end
 
+    def govuk_table_tfoot(tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__foot', tag_options)
+
+      tag.tfoot(capture(&block), tag_options)
+    end
+
     def govuk_table_row(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__row', tag_options)
 

--- a/lib/govuk_component/table_helpers.rb
+++ b/lib/govuk_component/table_helpers.rb
@@ -34,15 +34,28 @@ module GovukComponent
       tag.tr(capture(&block), tag_options)
     end
 
-    def govuk_table_th(scope = 'col', tag_options = {}, &block)
+    def govuk_table_th(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__header', tag_options)
-      tag_options[:scope] = scope
+      tag_options[:scope] = tag_options[:scope].presence || 'col'
+
+      tag.th(capture(&block), tag_options)
+    end
+
+    def govuk_table_th_numeric(tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__header govuk-table__header--numeric', tag_options)
+      tag_options[:scope] = tag_options[:scope].presence || 'col'
 
       tag.th(capture(&block), tag_options)
     end
 
     def govuk_table_td(tag_options = {}, &block)
       tag_options = prepend_classes('govuk-table__cell', tag_options)
+
+      tag.td(capture(&block), tag_options)
+    end
+
+    def govuk_table_td_numeric(tag_options = {}, &block)
+      tag_options = prepend_classes('govuk-table__cell govuk-table__cell--numeric', tag_options)
 
       tag.td(capture(&block), tag_options)
     end

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -59,7 +59,7 @@ describe('Modules.AllocationDataTable.js', function () {
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row error injection-error"><td class="govuk-table__cell"><div class="error-message-container"><div class="error-message">I am an error</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row error injection-error"><td data-label="Select claim" class="govuk-table__cell"><div class="error-message-container"><div class="error-message">I am an error</div></div></td></tr>')
     })
 
     it('...should have a `createdRow` callback defined for CAV warnings', function () {
@@ -71,7 +71,7 @@ describe('Modules.AllocationDataTable.js', function () {
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">CAVs not injected</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">CAVs not injected</div></div></td></tr>')
     })
 
     it('...should have a `createdRow` callback defined for CLAR fee warnings', function () {
@@ -83,7 +83,7 @@ describe('Modules.AllocationDataTable.js', function () {
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">CLAR fees not injected</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">CLAR fees not injected</div></div></td></tr>')
     })
 
     it('...should have `processing`', function () {

--- a/spec/lib/govuk_component/table_helpers_spec.rb
+++ b/spec/lib/govuk_component/table_helpers_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
     end
 
     context 'with row scope' do
-      subject(:markup) { helper.govuk_table_th('row') { 'table head' } }
+      subject(:markup) { helper.govuk_table_th(scope: 'row') { 'table head' } }
 
       it 'adds a govuk table header cell' do
         is_expected.to have_tag(:th, with: { class: 'govuk-table__header', scope: 'row' }, text: 'table head')
@@ -62,10 +62,39 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
     end
 
     context 'with custom class' do
-      subject(:markup) { helper.govuk_table_th('row', class: 'my-custom-class') { 'table head' } }
+      subject(:markup) { helper.govuk_table_th(scope: 'row', class: 'my-custom-class') { 'table head' } }
 
       it 'adds a govuk table header cell' do
         is_expected.to have_tag(:th, with: { class: 'govuk-table__header my-custom-class', scope: 'row' },
+                                     text: 'table head')
+      end
+    end
+  end
+
+  describe '#govuk_table_th_numeric' do
+    context 'with col scope' do
+      subject(:markup) { helper.govuk_table_th_numeric { 'table head' } }
+
+      it 'adds a govuk table header cell' do
+        is_expected.to have_tag(:th, with: { class: 'govuk-table__header govuk-table__header--numeric', scope: 'col' },
+                                     text: 'table head')
+      end
+    end
+
+    context 'with row scope' do
+      subject(:markup) { helper.govuk_table_th_numeric(scope: 'row') { 'table head' } }
+
+      it 'adds a govuk table header cell' do
+        is_expected.to have_tag(:th, with: { class: 'govuk-table__header govuk-table__header--numeric', scope: 'row' },
+                                     text: 'table head')
+      end
+    end
+
+    context 'with custom class' do
+      subject(:markup) { helper.govuk_table_th_numeric(class: 'custom-class') { 'table head' } }
+
+      it 'adds a govuk table header cell' do
+        is_expected.to have_tag(:th, with: { class: 'govuk-table__header govuk-table__header--numeric custom-class' },
                                      text: 'table head')
       end
     end
@@ -76,6 +105,15 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
 
     it 'adds a govuk table cell' do
       is_expected.to have_tag(:td, with: { class: 'govuk-table__cell my-custom-class' }, text: 'table cell')
+    end
+  end
+
+  describe '#govuk_table_td_numeric' do
+    subject(:markup) { helper.govuk_table_td_numeric(class: 'my-custom-class') { 'table cell' } }
+
+    it 'adds a govuk table cell' do
+      is_expected.to have_tag(:td, with: { class: 'govuk-table__cell govuk-table__cell--numeric my-custom-class' },
+                                   text: 'table cell')
     end
   end
 

--- a/spec/lib/govuk_component/table_helpers_spec.rb
+++ b/spec/lib/govuk_component/table_helpers_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe GovukComponent::TableHelpers, type: :helper do
     end
   end
 
+  describe '#govuk_table_tfoot' do
+    subject(:markup) { helper.govuk_table_tfoot(class: 'my-custom-class') { nil } }
+
+    it 'adds a govuk table tfoot' do
+      is_expected.to have_tag(:tfoot, with: { class: 'govuk-table__foot my-custom-class' })
+    end
+  end
+
   describe '#govuk_table_row' do
     subject(:markup) { helper.govuk_table_row(class: 'my-custom-class') { nil } }
 


### PR DESCRIPTION
#### What
Migrate caseworkers table markup to the GOVUK Design System Table markup.

#### Ticket
[Migrate caseworkers table markup to the GOVUK Design System Table](https://dsdmoj.atlassian.net/browse/CFP-238)

#### Why
Part of a larger change to:

- continue migration to GOVUK Frontend
- resolve accessibility issues identified in the 2020 DAC report
- reduce then remove deprecated code

#### Routes
* [x] /case_workers
* [x] /case_workers/claims
* [x] /case_workers/claims/archived
* [x] /case_workers/claims/:id
* [x] /case_workers/admin/allocations?tab=allocated

`/case_workers/claims/:id` is a summary page, therefore external users summary pages need to be sanity checked