### PR TITLE
Add staging ingress annotations

### DIFF
--- a/kubernetes_deploy/staging/ingress.yaml
+++ b/kubernetes_deploy/staging/ingress.yaml
@@ -1,6 +1,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
   name: cccd-app-ingress
   namespace: cccd-staging
 spec:


### PR DESCRIPTION
#### What
Add two new annotations to staging ingress `set-identifier` and `aws-weight`

#### Ticket
[Update ingress annotations ](https://dsdmoj.atlassian.net/browse/CFP-291)

#### Why
Required by cloud platforms

This will become important during the migration phase, later in the Autumn, allowing load balancing across the two clusters, to gradually moving traffic to the copy of the app running on the new cluster.
