### PR TITLE
Add external-dns annotations to dev ingress

### DIFF
--- a/kubernetes_deploy/dev/ingress.yaml
+++ b/kubernetes_deploy/dev/ingress.yaml
@@ -1,6 +1,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
   name: cccd-app-ingress
   namespace: cccd-dev
 spec:


### PR DESCRIPTION
#### What

Adding external-dns annotations to the dev environment as [requested by Cloud Platforms.](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live-ingress-annotation.html#add-external-dns-annotations-to-your-ingress-resource-in-live-1)