### PR TITLE
Update all direct and indirect gem dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 5
   rebase-strategy: "disabled"
+  allow:
+    - dependency-type: "all"
   reviewers:
   - "jsugarman"
   - "jrmhaig"


### PR DESCRIPTION
#### What

Explicitly allow updates on all gem dependencies.

#### Ticket

N/A

#### Why

Dependabot is only updating explicitly defined dependencies and ignores dependencies of direct dependencies. There are currently 30 indirect dependencies in `Gemfile.lock` and not in `Gemfile` that can be updated.

#### How

See the [dependabot documentation on the `allow` option](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow)

This documentation seems to suggest that indirect dependencies should be updated by default but this does not appear to be the case.

*Update;* I have had confirmation from Github support that either the documentation or the actual behaviour is wrong. Their devs have been informed about this but I do not know if the fix will be a change of documentation or of the behaviour.

**NB;** This may also be an issue for the npm configuration but I don't know how to check that.