### PR TITLE
Fix caseworker summary

### DIFF
--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -18,7 +18,7 @@
             %div
               = validation_error_message(@error_presenter, :determinations)
 
-      = govuk_table(class: 'report js-cw-claim-assessment', id: 'determinations') do
+      = govuk_table( id: 'determinations', class: 'js-cw-claim-assessment', data: { apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }) do
         = govuk_table_caption(class: 'govuk-visually-hidden') do
           %h3.govuk-heading-m
             = t('.assessment_summary')

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -45,6 +45,6 @@
             = govuk_table_td_numeric('data-label': t('.actions')) do
               .app-link-group
                 - if document.converted_preview_document.present?
-                  = govuk_link_to t('common.view_html', context: "#{document.document_file_name}")
+                  = govuk_link_to t('common.view_html', context: "#{document.document_file_name}"), document_path(document)
 
                 = govuk_link_to t('common.download_html', context: "#{document.document_file_name}"), download_document_path(document)


### PR DESCRIPTION
#### What
- Attachments are not showing when pressing view
- Total not visible on summary assessment 

#### Ticket
[Attachments are not showing when pressing view](https://dsdmoj.atlassian.net/browse/CFP-312)

[Total not visible on summary assessment ](https://dsdmoj.atlassian.net/browse/CFP-313)
