### PR TITLE
Factory pattern for stats report generators

### DIFF
--- a/app/services/stats/report_generator.rb
+++ b/app/services/stats/report_generator.rb
@@ -5,24 +5,14 @@ module Stats
     end
 
     def call
-      data = report_klass.call
-      output = Stats::CsvExporter.call(data, headers: report_klass::COLUMNS)
+      data = @report_klass.call
+      output = Stats::CsvExporter.call(data, headers: @report_klass::COLUMNS)
       Stats::Result.new(output, @format)
     end
 
-    def initialize(report, format: 'csv')
-      @report = report
+    def initialize(report_klass:, format: 'csv')
       @format = format
-    end
-
-    private
-
-    def report_klass
-      @report_klass ||= {
-        provisional_assessment: Reports::ProvisionalAssessments,
-        rejections_refusals: Reports::RejectionsRefusals,
-        submitted_claims: Reports::SubmittedClaims
-      }[@report.to_sym]
+      @report_klass = report_klass
     end
   end
 end

--- a/app/services/stats/stats_report_factory/agfs_management_information.rb
+++ b/app/services/stats/stats_report_factory/agfs_management_information.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class AgfsManagementInformation < Base
+      def generator
+        ManagementInformationGenerator.new(**@options.merge(scheme: :agfs))
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/agfs_management_information_v2.rb
+++ b/app/services/stats/stats_report_factory/agfs_management_information_v2.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class AgfsManagementInformationV2 < Base
+      def generator
+        Stats::ManagementInformation::DailyReportGenerator.new(**@options.merge(scheme: :agfs))
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/base.rb
+++ b/app/services/stats/stats_report_factory/base.rb
@@ -1,0 +1,13 @@
+module Stats
+  module StatsReportFactory
+    class Base
+      def self.generator(options)
+        new(options).generator
+      end
+
+      def initialize(options)
+        @options = options
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/base.rb
+++ b/app/services/stats/stats_report_factory/base.rb
@@ -5,7 +5,7 @@ module Stats
         new(options).generator
       end
 
-      def initialize(options)
+      def initialize(options = {})
         @options = options
       end
     end

--- a/app/services/stats/stats_report_factory/lgfs_management_information.rb
+++ b/app/services/stats/stats_report_factory/lgfs_management_information.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class LgfsManagementInformation < Base
+      def generator
+        ManagementInformationGenerator.new(**@options.merge(scheme: :lgfs))
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/lgfs_management_information_v2.rb
+++ b/app/services/stats/stats_report_factory/lgfs_management_information_v2.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class LgfsManagementInformationV2 < Base
+      def generator
+        Stats::ManagementInformation::DailyReportGenerator.new(**@options.merge(scheme: :lgfs))
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/management_information.rb
+++ b/app/services/stats/stats_report_factory/management_information.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class ManagementInformation < Base
+      def generator
+        ManagementInformationGenerator.new(**@options)
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/management_information_v2.rb
+++ b/app/services/stats/stats_report_factory/management_information_v2.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class ManagementInformationV2 < Base
+      def generator
+        Stats::ManagementInformation::DailyReportGenerator.new(**@options)
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/provisional_assessment.rb
+++ b/app/services/stats/stats_report_factory/provisional_assessment.rb
@@ -2,7 +2,7 @@ module Stats
   module StatsReportFactory
     class ProvisionalAssessment < Base
       def generator
-        ReportGenerator.new('provisional_assessment', @options)
+        ReportGenerator.new(**@options.merge(report_klass: Reports::ProvisionalAssessments))
       end
     end
   end

--- a/app/services/stats/stats_report_factory/provisional_assessment.rb
+++ b/app/services/stats/stats_report_factory/provisional_assessment.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class ProvisionalAssessment < Base
+      def generator
+        ReportGenerator.new('provisional_assessment', @options)
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/rejections_refusals.rb
+++ b/app/services/stats/stats_report_factory/rejections_refusals.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class RejectionsRefusals < Base
+      def generator
+        ReportGenerator.new('rejections_refusals', @options)
+      end
+    end
+  end
+end

--- a/app/services/stats/stats_report_factory/rejections_refusals.rb
+++ b/app/services/stats/stats_report_factory/rejections_refusals.rb
@@ -2,7 +2,7 @@ module Stats
   module StatsReportFactory
     class RejectionsRefusals < Base
       def generator
-        ReportGenerator.new('rejections_refusals', @options)
+        ReportGenerator.new(**@options.merge(report_klass: Reports::RejectionsRefusals))
       end
     end
   end

--- a/app/services/stats/stats_report_factory/submitted_claims.rb
+++ b/app/services/stats/stats_report_factory/submitted_claims.rb
@@ -2,7 +2,7 @@ module Stats
   module StatsReportFactory
     class SubmittedClaims < Base
       def generator
-        ReportGenerator.new('submitted_claims', @options)
+        ReportGenerator.new(**@options.merge(report_klass: Reports::SubmittedClaims))
       end
     end
   end

--- a/app/services/stats/stats_report_factory/submitted_claims.rb
+++ b/app/services/stats/stats_report_factory/submitted_claims.rb
@@ -1,0 +1,9 @@
+module Stats
+  module StatsReportFactory
+    class SubmittedClaims < Base
+      def generator
+        ReportGenerator.new('submitted_claims', @options)
+      end
+    end
+  end
+end

--- a/spec/services/stats/report_generator_spec.rb
+++ b/spec/services/stats/report_generator_spec.rb
@@ -22,26 +22,21 @@ end
 
 RSpec.describe Stats::ReportGenerator, type: :service do
   describe '.call' do
-    subject(:result) { described_class.call(report, **options) }
-
-    let(:options) { {} }
+    subject(:result) { described_class.call(report_klass: reporter) }
 
     context 'with a provisional assessment report' do
-      let(:report) { 'provisional_assessment' }
       let(:reporter) { Reports::ProvisionalAssessments }
 
       it_behaves_like 'a stats report CSV exporter'
     end
 
     context 'with a rejections refusals report' do
-      let(:report) { 'rejections_refusals' }
       let(:reporter) { Reports::RejectionsRefusals }
 
       it_behaves_like 'a stats report CSV exporter'
     end
 
     context 'with a submitted claims report' do
-      let(:report) { 'submitted_claims' }
       let(:reporter) { Reports::SubmittedClaims }
 
       it_behaves_like 'a stats report CSV exporter'

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -31,14 +31,18 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
     context 'with a valid report type that is not already in progress' do
       let(:mocked_result) { Stats::Result.new('some new content', 'csv') }
 
+      before { allow(generator).to receive(:call).and_return(mocked_result) }
+
       context 'with generic report type' do
         let(:report_type) { 'submitted_claims' }
 
-        before { allow(Stats::ReportGenerator).to receive(:call).and_return(mocked_result) }
+        let(:generator) { instance_double(Stats::ReportGenerator) }
+
+        before { allow(Stats::ReportGenerator).to receive(:new).and_return(generator) }
 
         it 'calls report generator' do
           call
-          expect(Stats::ReportGenerator).to have_received(:call)
+          expect(Stats::ReportGenerator).to have_received(:new)
         end
 
         it 'marks report as completed' do
@@ -55,12 +59,13 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
 
       context 'with management information report' do
         let(:report_type) { 'management_information' }
+        let(:generator) { instance_double(Stats::ManagementInformationGenerator) }
 
-        before { allow(Stats::ManagementInformationGenerator).to receive(:call).and_return(mocked_result) }
+        before { allow(Stats::ManagementInformationGenerator).to receive(:new).and_return(generator) }
 
         it 'calls management information generator with no claim scope' do
           call
-          expect(Stats::ManagementInformationGenerator).to have_received(:call).with(no_args)
+          expect(Stats::ManagementInformationGenerator).to have_received(:new).with(no_args)
         end
 
         it 'marks report as completed' do
@@ -77,32 +82,36 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
 
       context 'with AGFS management information report' do
         let(:report_type) { 'agfs_management_information' }
+        let(:generator) { instance_double(Stats::ManagementInformationGenerator) }
 
-        before { allow(Stats::ManagementInformationGenerator).to receive(:call).and_return(mocked_result) }
+        before { allow(Stats::ManagementInformationGenerator).to receive(:new).and_return(generator) }
 
         it 'calls management information generator with agfs scope' do
           call
-          expect(Stats::ManagementInformationGenerator).to have_received(:call).with({ scheme: :agfs })
+          expect(Stats::ManagementInformationGenerator).to have_received(:new).with({ scheme: :agfs })
         end
       end
 
       context 'with LGFS management information report' do
         let(:report_type) { 'lgfs_management_information' }
+        let(:generator) { instance_double(Stats::ManagementInformationGenerator) }
 
-        before { allow(Stats::ManagementInformationGenerator).to receive(:call).and_return(mocked_result) }
+        before { allow(Stats::ManagementInformationGenerator).to receive(:new).and_return(generator) }
 
         it 'calls management information generator with lgfs scope' do
           call
-          expect(Stats::ManagementInformationGenerator).to have_received(:call).with({ scheme: :lgfs })
+          expect(Stats::ManagementInformationGenerator).to have_received(:new).with({ scheme: :lgfs })
         end
       end
     end
 
     context 'with an unexpected error' do
       let(:report_type) { 'management_information' }
+      let(:generator) { instance_double(Stats::ManagementInformationGenerator) }
 
       before do
-        allow(Stats::ManagementInformationGenerator).to receive(:call).and_raise(StandardError)
+        allow(Stats::ManagementInformationGenerator).to receive(:new).and_return(generator)
+        allow(generator).to receive(:call).and_raise(StandardError)
       end
 
       it 'marks report as errored' do


### PR DESCRIPTION
#### What

Apply factory pattern to create the stats report generator based on the name of the report.

#### Ticket

[CFP-299](https://dsdmoj.atlassian.net/browse/CFP-299) MI refactor

#### Why

`Stats::StatsReportGenerator` selects the correct report generator using a hash containing the generator classes together with specific arguments that are required for each. This hash is already quite long and needs to allow for two different styles of argument list. As more reports are added this will become longer and, possibly, more complex.

#### How

Extract the creation of report generators into factories, under the `Stats::StatsReportFactory` namespace, which can be selected based on the report name.

For clarity, `GENERATOR_FACTORIES` provides a mapping from the report name to the factory and the correct factory is found with;

```ruby
GENERATOR_FACTORIES[report_name.to_sym]
```

but, provided that the factories have consistent naming, this could be removed and replaced with

```ruby
Stats::StatsReportFactory.const_get(report_type.camelize)
```

and the mapping hash removed.