### PR TITLE
Update CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
           LIVE1_DB_TASK: none
-      - image: circleci/postgres:13.1
+      - image: cimg/postgres:13.4
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"
@@ -123,14 +123,14 @@ executors:
   test-executor:
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.7.3-node-browsers
+      - image: cimg/ruby:2.7.4-browsers
         environment:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:circleci@127.0.0.1:5432/cccd_test
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
-      - image: circleci/postgres:13.1
+      - image: cimg/postgres:13.4
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"


### PR DESCRIPTION
See https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

The official CircleCI docker images are moving from the circleci namespace
to cimg. There are other changes necessary for upgrading.

* The '-node-browsers' variant has become '-browsers', and this includes node
* Ruby version bumped to 2.7.4 as there is no 2.7.3 image available in the
  cimg namespace
* Postgres version bumped to 13.4 as there is no 13.1 image available in the
  cimg namespace