### PR TITLE
Migrate circleci ruby image to next gen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,6 @@ references:
       name: Run brakeman
       command: bundle exec brakeman
 
-  _jasmine: &jasmine
-    run:
-      name: Run jasmine
-      command: |
-        bundle exec rake webpacker:compile
-        bundle exec rake jasmine:ci
-
   _standardjs: &standardjs
     run:
       name: Run standardJS
@@ -141,6 +134,22 @@ executors:
 # COMMANDS
 # ------------------
 commands:
+  install-chrome:
+    steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+
+  run-jasmine:
+    description: >
+      Run jasmine tests
+    steps:
+      - install-chrome
+      - run:
+          name: Run jasmine
+          command: |
+            bundle exec rake webpacker:compile
+            bundle exec rake jasmine:ci
+
   run-rspec:
     description: >
       Run rspec tests and store results
@@ -171,6 +180,7 @@ commands:
     description: >
       Run cucumber tests and store results
     steps:
+      - install-chrome
       - run:
           name: Make cucumber test storage dir
           command: |
@@ -232,8 +242,6 @@ commands:
     steps:
       - install-gem-dependencies
       - install-js-dependencies
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
 
   deploy-to:
     description: >
@@ -395,7 +403,7 @@ jobs:
       - build-base
       - *rubocop
       - *brakeman
-      - *jasmine
+      - run-jasmine
       - *standardjs
       - *stylelint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.1
+  browser-tools: circleci/browser-tools@1.2.3
 
 references:
   _attach-tmp-workspace: &attach-tmp-workspace
@@ -123,7 +124,7 @@ executors:
   test-executor:
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.7.3-node-browsers
+      - image: cimg/ruby:2.7.3-browsers
         environment:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:circleci@127.0.0.1:5432/cccd_test
@@ -231,6 +232,8 @@ commands:
     steps:
       - install-gem-dependencies
       - install-js-dependencies
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
 
   deploy-to:
     description: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,26 +41,6 @@ references:
       name: Database setup
       command: bin/rails db:schema:load --trace
 
-  _rubocop: &rubocop
-    run:
-      name: Run rubocop
-      command: bundle exec rubocop
-
-  _brakeman: &brakeman
-    run:
-      name: Run brakeman
-      command: bundle exec brakeman
-
-  _standardjs: &standardjs
-    run:
-      name: Run standardJS
-      command: yarn run validate:js
-
-  _stylelint: &stylelint
-    run:
-      name: Run stylelint
-      command: yarn run validate:scss
-
   _script-build-app-container: &script-build-app-container
     run:
       name: Build and push cccd docker image
@@ -138,6 +118,38 @@ commands:
     steps:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
+
+  run-rubocop:
+    description: >
+      Run rubocop
+    steps:
+      - run:
+          name: Run rubocop
+          command: bundle exec rubocop
+
+  run-brakeman:
+    description: >
+      Run brakeman
+    steps:
+      - run:
+          name: Run brakeman
+          command: bundle exec brakeman
+
+  run-standardjs:
+    description: >
+      Run standardJS
+    steps:
+      - run:
+          name: Run standardJS
+          command: yarn run validate:js
+
+  run-stylelint:
+    description: >
+      Run stylelint
+    steps:
+      - run:
+          name: Run stylelint
+          command: yarn run validate:scss
 
   run-jasmine:
     description: >
@@ -401,11 +413,11 @@ jobs:
     steps:
       - checkout
       - build-base
-      - *rubocop
-      - *brakeman
+      - run-rubocop
+      - run-brakeman
       - run-jasmine
-      - *standardjs
-      - *stylelint
+      - run-standardjs
+      - run-stylelint
 
   upload-coverage:
     executor: test-executor


### PR DESCRIPTION
#### What
Migrate circleci ruby image to next gen

**note:** problems with uuid extensions for postgres means the cimg/postgres:13.3 will need doing as a separate piece of work

#### Ticket


#### Why
Following deprecation warning from circleci

see [warning](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAGAgJJpjkSiyEX0Y6ZMqtESKGzZQYbRUb1kyiJm37zycQXVhsbYdE4XWR3NbhgIYiafO410JA0WG9DBsz9nm_gUisZjUFhBCl_mLQaDE5GIpoo)

#### How
see [warning](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAGAgJJpjkSiyEX0Y6ZMqtESKGzZQYbRUb1kyiJm37zycQXVhsbYdE4XWR3NbhgIYiafO410JA0WG9DBsz9nm_gUisZjUFhBCl_mLQaDE5GIpoo)