### PR TITLE
Enable annotations in views in development env

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
+  config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION
#### What

Enable `annotate_rendered_view_with_filenames` in the development environment.

#### Ticket

N/A

#### Why

The `annotate_rendered_view_with_filenames` option was added to Action View in version 6.1. When this is enabled annotations are added to the HTML that is generated to indicate which views and partials have been rendered. The latest version of the `haml` gem is compatible with this option and so we can use it. The "inspect" view in the browser now shows something like this:

![Screenshot 2021-11-03 at 15 04 11](https://user-images.githubusercontent.com/4415912/140086385-f50001d5-85ac-4ea2-94c5-287baa823cd1.png)

#### How

Set

```ruby
config.action_view.annotate_rendered_view_with_filenames = true
```

in `config/environments/development.rb` only.