### PR TITLE
[CFP-330] Anonymise claim_state_transitions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -117,6 +117,11 @@ In order to create an anonymised dump of an environments database you can:
 $ bundle exec rake db:dump:run_job['dev']
 ```
 
+```bash
+# run the db-dump job in the given environment using a built branch docker tag
+$ bundle exec rake db:dump:run_job['dev','my-branch-latest']
+```
+
 This task requires you have kubectl installed locally and access to git-crypted secrets.
 
 This will create a `private` dump file in the host environments s3 bucket and list all such dumps at the end. If the log tailing times out (it will on production currently) then you will need to list the dump files using:

--- a/docs/development.md
+++ b/docs/development.md
@@ -110,7 +110,14 @@ With your local rails server running you can browse to ```http://localhost:3000/
 
 ## Anonymised database dump and restore
 
-In order to create an anonymised dump of an environments database you can:
+In order to test running of an anonymised dump against your local database you can:
+
+```bash
+# run anonymised db dump locally for testing purposes
+$ bundle exec rails db:dump:anonymised
+```
+
+In order to create an anonymised dump of a hosted environments database you can:
 
 ```bash
 # run the db-dump job in the given environment

--- a/docs/development.md
+++ b/docs/development.md
@@ -169,10 +169,10 @@ Alternatively, if dump files already exist for the environment you can list them
 
 ```bash
 # delete all but the latest dump file
-$ rake db:dump:delete_s3_dumps['production']
+$ bundle exec rake db:dump:delete_s3_dumps['production']
 
 # delete all dump files
-$ rake db:dump:delete_s3_dumps['production','all']
+$ bundle exec rake db:dump:delete_s3_dumps['production','all']
 ```
 
 ### Restoring dump on remote host

--- a/lib/tasks/dump.rake
+++ b/lib/tasks/dump.rake
@@ -169,7 +169,7 @@ namespace :db do
           # typically less than 5% will have reasons and fewer with additional text
           ClaimStateTransition.where.not(reason_text: nil).find_each(batch_size: batch_size) do |claim_state_transition|
             claim_state_transition.reason_code = ['other_refuse'] if claim_state_transition.reason_code.present?
-            claim_state_transition.reason_text = Faker::Lorem.sentence(word_count: 10, supplemental: false) if claim_state_transition.reason_text.present?
+            claim_state_transition.reason_text = Faker::Lorem.sentence(word_count: 10) if claim_state_transition.reason_text.present?
             writer.call(claim_state_transition)
           end
 

--- a/lib/tasks/dump.rake
+++ b/lib/tasks/dump.rake
@@ -107,6 +107,9 @@ namespace :db do
 
       s3_bucket = S3Bucket.new(host)
       dump_files = s3_bucket.list('tmp').select { |item| item.key.match?('dump') }
+
+      abort("#{dump_files.size} dump file(s) found!".yellow) if dump_files.empty?
+
       dump_files.sort_by(&:last_modified).reverse[start..].map do |object|
         print "Deleting #{object.key}..."
         object.delete

--- a/lib/tasks/rake_helpers/dump_file_writer.rb
+++ b/lib/tasks/rake_helpers/dump_file_writer.rb
@@ -54,7 +54,7 @@ class DumpFileWriter
   end
 
   def prepare_sql
-    table.compile_insert(data).to_sql.gsub('"', '') + ';'
+    table.compile_insert(data).to_sql + ';'
   end
 
   def extract_attribute_names(column_names)


### PR DESCRIPTION
#### What
Anonymise claim_state_transitions reason_text

#### Ticket

[CFP-330](https://dsdmoj.atlassian.net/browse/CFP-330)
came out of [CFP-299](https://dsdmoj.atlassian.net/browse/CFP-299)

#### Why
approx 2.5% of claim_state_transitions
will have a reason_text attribute. And
it is possible this could contain
sensitive information so it should be
anonymised.

Note that this table contains a large number
of records so it will slow the dump process
down.

Also:
 - enable local db anonymised dump for testing purposes.
 - default file extension resolution to pdf for invalid content_type
 - overwrite reason code array because it causes a write error
 - * quote all columns and table names to avoid reserved word conflicts (this needs testing against a prod load)