### PR TITLE
[CFP-173] Cleaner for misc fees on transfer claims

### DIFF
--- a/app/services/cleaners/advocate_supplementary_claim_cleaner.rb
+++ b/app/services/cleaners/advocate_supplementary_claim_cleaner.rb
@@ -1,5 +1,7 @@
 module Cleaners
   class AdvocateSupplementaryClaimCleaner < BaseClaimCleaner
+    include IneligibleMiscFeesCleanable
+
     def call
       destroy_invalid_fees
     end
@@ -7,14 +9,7 @@ module Cleaners
     private
 
     def destroy_invalid_fees
-      misc_fees.delete(ineligible_misc_fees)
-    end
-
-    def ineligible_misc_fees
-      eligbile_fee_types = Claims::FetchEligibleMiscFeeTypes.new(self).call
-      misc_fees.reject do |fee|
-        eligbile_fee_types.map(&:unique_code).include?(fee.fee_type.unique_code)
-      end
+      clear_ineligible_misc_fees
     end
   end
 end

--- a/app/services/cleaners/ineligible_misc_fees_cleanable.rb
+++ b/app/services/cleaners/ineligible_misc_fees_cleanable.rb
@@ -1,0 +1,16 @@
+module Cleaners
+  module IneligibleMiscFeesCleanable
+    private
+
+    def clear_ineligible_misc_fees
+      misc_fees.delete(ineligible_misc_fees)
+    end
+
+    def ineligible_misc_fees
+      eligible_fee_types = Claims::FetchEligibleMiscFeeTypes.new(self).call
+      misc_fees.reject do |fee|
+        eligible_fee_types.map(&:unique_code).include?(fee.fee_type.unique_code)
+      end
+    end
+  end
+end

--- a/app/services/cleaners/transfer_claim_cleaner.rb
+++ b/app/services/cleaners/transfer_claim_cleaner.rb
@@ -1,12 +1,15 @@
 module Cleaners
   class TransferClaimCleaner < BaseClaimCleaner
+    include IneligibleMiscFeesCleanable
+
     def call
-      destroy_invalid_fees
+      clear_graduate_fees
+      clear_ineligible_misc_fees
     end
 
     private
 
-    def destroy_invalid_fees
+    def clear_graduate_fees
       fees.where(type: 'Fee::GraduatedFee').destroy_all
     end
   end

--- a/spec/services/cleaners/transfer_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/transfer_claim_cleaner_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe Cleaners::TransferClaimCleaner do
 
   let(:claim) { create(:transfer_claim) }
 
+  before do
+    seed_case_types
+    seed_fee_types
+    seed_fee_schemes
+  end
+
   describe '#call' do
     subject(:call_cleaner) { cleaner.call }
 
@@ -20,14 +26,59 @@ RSpec.describe Cleaners::TransferClaimCleaner do
       end
     end
 
-    context 'when a non-graduated fee is added to the claim' do
-      before { create(:misc_fee, claim: claim) }
+    context 'when a valid non-graduated fee is added to the claim' do
+      before { create(:misc_fee, :mispf_fee, claim: claim) }
 
       it { expect { call_cleaner }.not_to change(claim.fees, :count).from 2 }
 
       it do
         call_cleaner
         expect(claim.fees.map(&:class)).to match_array([Fee::TransferFee, Fee::MiscFee])
+      end
+    end
+
+    context 'with unused materials fees' do
+      subject { claim.misc_fees.map { |fee| fee.fee_type.unique_code } }
+
+      before do
+        allow(claim).to receive(:earliest_representation_order_date).and_return(Date.parse('1 January 2021'))
+
+        create(:misc_fee, :miumu_fee, claim: claim)
+        create(:misc_fee, :miumo_fee, claim: claim)
+
+        claim.transfer_detail.update(transfer_stage_id: 10, case_conclusion_id: case_conclusion)
+
+        call_cleaner
+      end
+
+      context 'with a guilty plea case conclusion' do
+        let(:case_conclusion) { 50 }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'with a cracked before retrial case conclusion' do
+        let(:case_conclusion) { 40 }
+
+        it { is_expected.to match_array(%w[MIUMU MIUMO]) }
+      end
+
+      context 'with a cracked case conclusion' do
+        let(:case_conclusion) { 30 }
+
+        it { is_expected.to match_array(%w[MIUMU MIUMO]) }
+      end
+
+      context 'with a retrial case conclusion' do
+        let(:case_conclusion) { 20 }
+
+        it { is_expected.to match_array(%w[MIUMU MIUMO]) }
+      end
+
+      context 'with a trial case conclusion' do
+        let(:case_conclusion) { 10 }
+
+        it { is_expected.to match_array(%w[MIUMU MIUMO]) }
       end
     end
   end


### PR DESCRIPTION
Transfer claims with a 'guilty plea' case conclusion cannot have unused
materials fees. Update the cleaner to remove these if necessary.

#### What

Remove unused materials fees from transfer claims with 'guilty plea' case conclusions.

#### Ticket

[Transfer guilty plea claims Unused material fee flag ](https://dsdmoj.atlassian.net/browse/CFP-173)

#### Why

Transfer claims with a 'guilty plea' case conclusion are not eligible for unused materials fees. If a transfer claim is created with a different case conclusion and fees added, and then changed to 'guilty plea' then the fees should be removed.

#### How

Remove ineligible miscellaneous fees in the transfer cleaner.