### PR TITLE
Add error message to MI report Slack failure notifications

### DIFF
--- a/app/models/subscribers/slack.rb
+++ b/app/models/subscribers/slack.rb
@@ -3,7 +3,7 @@ module Subscribers
     def process
       report_id = event.payload[:id]
       report_name = event.payload[:name]
-      slack_notifier = SlackNotifier.new('cccd_development', formatter: SlackNotifier::Formatter::Generic.new)
+      slack_notifier = SlackNotifier.new('laa-cccd-alerts', formatter: SlackNotifier::Formatter::Generic.new)
       slack_notifier.build_payload(
         icon: ':robot_face:',
         title: "#{report_name} failed on #{ENV['ENV']}",

--- a/app/models/subscribers/slack.rb
+++ b/app/models/subscribers/slack.rb
@@ -1,13 +1,11 @@
 module Subscribers
   class Slack < Base
     def process
-      report_id = event.payload[:id]
-      report_name = event.payload[:name]
       slack_notifier = SlackNotifier.new('laa-cccd-alerts', formatter: SlackNotifier::Formatter::Generic.new)
       slack_notifier.build_payload(
         icon: ':robot_face:',
-        title: "#{report_name} failed on #{ENV['ENV']}",
-        message: "Stats::StatsReport.id: #{report_id}",
+        title: "#{event.payload[:name]} failed on #{ENV['ENV']}",
+        message: "Error: #{event.payload[:error].message}\nStats::StatsReport.id: #{event.payload[:id]}",
         status: :fail
       )
       slack_notifier.send_message

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
     let(:start) { 2.minutes.ago }
     let(:ending) { 1.minutes.ago }
     let(:transaction_id) { SecureRandom.uuid }
-    let(:payload) { { id: 999, name: 'provisional_assessment', error: 'Some error' } }
+    let(:error) { StandardError.new('Test error') }
+    let(:payload) { { id: 999, name: 'provisional_assessment', error: error } }
     let(:notifier) { instance_double(SlackNotifier) }
     let(:send_result) { double(:send_result) }
 
@@ -32,7 +33,7 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
       notifier_args = {
         icon: ':robot_face:',
         title: 'provisional_assessment failed on test',
-        message: 'Stats::StatsReport.id: 999',
+        message: "Error: Test error\nStats::StatsReport.id: 999",
         status: :fail
       }
 

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
     it 'creates a new SlackNotifier' do
       expect(SlackNotifier)
         .to have_received(:new)
-        .with('cccd_development', formatter: an_instance_of(SlackNotifier::Formatter::Generic))
+        .with('laa-cccd-alerts', formatter: an_instance_of(SlackNotifier::Formatter::Generic))
     end
 
     it 'builds the payload with the notifier arguments' do

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -12,11 +12,18 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
 
     subject(:process) { described_class.new(event_name, start, ending, transaction_id, payload) }
 
+    before do
+      allow(SlackNotifier).to receive(:new).and_return(notifier)
+      allow(notifier).to receive(:build_payload)
+      allow(notifier).to receive(:send_message).and_return(send_result)
+    end
+
     it 'sends a message to slack channel with the error content' do
+      process
+
       expect(SlackNotifier)
-        .to receive(:new)
+        .to have_received(:new)
         .with('cccd_development', formatter: an_instance_of(SlackNotifier::Formatter::Generic))
-        .and_return(notifier)
 
       notifier_args = {
         icon: ':robot_face:',
@@ -25,9 +32,8 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
         status: :fail
       }
 
-      expect(notifier).to receive(:build_payload).with(**notifier_args)
-      expect(notifier).to receive(:send_message).and_return(send_result)
-      process
+      expect(notifier).to have_received(:build_payload).with(**notifier_args)
+      expect(notifier).to have_received(:send_message)
       expect(process).to be_kind_of(Subscribers::Base)
     end
   end

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Subscribers::Slack, type: :subscriber do
   describe '#process' do
+    subject(:process) { described_class.new(event_name, start, ending, transaction_id, payload) }
+
     let(:event_name) { 'call_failed.stats_report' }
     let(:start) { 2.minutes.ago }
     let(:ending) { 1.minutes.ago }
@@ -10,21 +12,23 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
     let(:notifier) { instance_double(SlackNotifier) }
     let(:send_result) { double(:send_result) }
 
-    subject(:process) { described_class.new(event_name, start, ending, transaction_id, payload) }
-
     before do
       allow(SlackNotifier).to receive(:new).and_return(notifier)
       allow(notifier).to receive(:build_payload)
       allow(notifier).to receive(:send_message).and_return(send_result)
+
+      process
     end
 
-    it 'sends a message to slack channel with the error content' do
-      process
+    it { is_expected.to be_kind_of(Subscribers::Base) }
 
+    it 'creates a new SlackNotifier' do
       expect(SlackNotifier)
         .to have_received(:new)
         .with('cccd_development', formatter: an_instance_of(SlackNotifier::Formatter::Generic))
+    end
 
+    it 'builds the payload with the notifier arguments' do
       notifier_args = {
         icon: ':robot_face:',
         title: 'provisional_assessment failed on test',
@@ -33,8 +37,10 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
       }
 
       expect(notifier).to have_received(:build_payload).with(**notifier_args)
+    end
+
+    it 'sends the message with the notifier' do
       expect(notifier).to have_received(:send_message)
-      expect(process).to be_kind_of(Subscribers::Base)
     end
   end
 end


### PR DESCRIPTION
#### What

Add the error message to the Slack notification when an MI report fails. Also, send the notification to #laa-cccd-alerts instead of #cccd_development

#### Ticket

N/A

#### Why

The alert currently looks like this;

![Screenshot 2021-11-16 at 10 13 05](https://user-images.githubusercontent.com/4415912/141966272-e5485588-b1c9-4e78-9e85-1339c6bd02ec.png)

To actually find the error, though, it is necessary to log on to the pod and look through the logs.

#### How

The error is already being passed to the Slack notifier class, `Subscribers::Slack`, but it is not being used. This has been changed to add the message to the payload.

The alert now looks like this;

![Screenshot 2021-11-16 at 11 40 37](https://user-images.githubusercontent.com/4415912/141979094-8ecbbe3f-d078-4520-901e-c8c1ceccfa59.png)

FYI, this was generated by

```ruby
begin
  2/0
rescue => e
  ActiveSupport::Notifications.instrument('call_failed.stats_report', id: 999, name: 'just-a-test', error: e)
end
```