### PR TITLE
Enable capture_exception_frame_locals in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,5 +7,7 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
 
     # Send 5% of transactions for performance monitoring
     config.traces_sample_rate = 0.05
+
+    config.capture_exception_frame_locals = true
   end
 end


### PR DESCRIPTION
#### What

Enable the `capture_exception_frame_locals` option in Sentry.

#### Ticket

N/A

#### Why

Sentry 4.8.0 adds a feature to capture variables when exceptions are raised so, for example

```ruby
a = 1
b = 0
a / b #=> This would cause ZeroDivisionError
```

would capture the values of `a` and `b` so that they can be viewed in the Sentry dashboard.

See https://github.com/getsentry/sentry-ruby/pull/1580 for more details.

#### Why not

It is possible that personalised data may leak into Sentry if it is stored in variables that are involved in a raised exception.

#### How

`config.capture_exception_frame_locals = true` in `config/initializers/sentry.rb`.