### PR TITLE
Order main defendant by created_at

### DIFF
--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -135,8 +135,9 @@ module Stats
             ) c2 ON TRUE
             LEFT JOIN LATERAL (
               select first_name || ' ' || last_name as name
-              from defendants
+              from defendants d
               where claim_id = c.id
+              order by d.created_at asc
               fetch first row only
             ) main_defendant ON TRUE
             LEFT JOIN LATERAL (

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -249,8 +249,12 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       before do
         create(:advocate_final_claim, :allocated, create_defendant_and_rep_order: false).tap do |claim|
-          create(:defendant, claim: claim, first_name: 'Main', last_name: 'Defendant')
           create(:defendant, claim: claim, first_name: 'Jammy', last_name: 'Dodger')
+
+          travel_to(2.seconds.ago) do
+            create(:defendant, claim: claim, first_name: 'Main', last_name: 'Defendant')
+          end
+
           claim.deallocate!
           claim.allocate!
 
@@ -265,7 +269,9 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
         end
       end
 
-      it { is_expected.to match_array(['Main Defendant', 'Main Defendant']) }
+      it 'returns the defendant that was created first for each journey' do
+        is_expected.to match_array(['Main Defendant', 'Main Defendant'])
+      end
     end
 
     describe ':maat_reference' do


### PR DESCRIPTION
#### What
Order main defendant by created_at

#### Ticket

[change to CFP-299](https://dsdmoj.atlassian.net/browse/CFP-299)

#### Why
Diffs with prod data versions for reports indicate
a non-deterministic return for main defendant. This
may not fix the diff completely but creates consistency for the
version 2 of the report.

Evidence from diffs shows it may resolve some of diffs
plus rails model `first` calls (`defendants.first`) supposedly
orders by `id` by default, which will match `defendant.order(:created_at)`).
