### PR TITLE
[CFP-343] Fix for previously upload table

### DIFF
--- a/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
+++ b/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
@@ -51,7 +51,9 @@ moj.Modules.Dropzone = {
   },
 
   toggleFileStatus: function () {
-    $('.files tbody tr').length >= 1 ? $('.files').removeClass('hidden') : $('.files').addClass('hidden')
+    setTimeout(function () {
+      $('#dropzone-files tbody .govuk-table__row').length >= 1 ? $('#dropzone-files').removeClass('hidden') : $('#dropzone-files').addClass('hidden')
+    }, 250)
   },
 
   onFileChange: function (e) {
@@ -126,8 +128,8 @@ moj.Modules.Dropzone = {
   uploadFiles: function (files) {
     for (let i = 0; i < files.length; i++) {
       if (files[i].size >= 20971520) {
-        const tableBody = $('.files tbody')
-        tableBody.append(this.notificationHTML(files[i].name, 'error', 'File is too big.'))
+        const tableBody = $('#dropzone-files tbody')
+        tableBody.prepend(this.notificationHTML(files[i].name, 'error', 'File is too big.'))
       } else {
         this.uploadFile(files[i])
       }
@@ -139,9 +141,9 @@ moj.Modules.Dropzone = {
     const formData = new FormData()
     formData.append('document[document]', file)
 
-    const tableBody = $('.files tbody')
+    const tableBody = $('#dropzone-files tbody')
     const tableRow = $('<tr class="govuk-table__row"><td data-label="File name" class="govuk-table__cell"><span class="file-name">' + file.name + '</span></td><td data-label="Upload Progress" class="govuk-table__cell"><progress value="0" max="100">0%</progress></td><td></td></tr>')
-    tableBody.append(tableRow)
+    tableBody.prepend(tableRow)
 
     const formId = $('#claim_form_id').val()
     formData.append('document[form_id]', formId)


### PR DESCRIPTION
#### What
Upload a supporting evidence document to a claim that already has a document attached breaks the table layout
#### Ticket
[CFP-343](https://dsdmoj.atlassian.net/browse/CFP-343)

#### Steps to reproduce

- Log in as an external user
- Open any draft claim
- While on the claim summary page, click change *Supporting evidence*
- If no files have have been previously uploaded, upload a supported file
- Click Save and continue
- While on the claim summary page, click change *Supporting evidence*
- Upload a supported file
- Visually inspect the file tables in the UI for error (see attached example)

#### How
Both Previously uploaded table and Document waiting to be saved table are using the same className that was using as a selector for targeting an action to update the tables. 

selector now changed to unique id to mitigate this issue.

