### PR TITLE
[CFP-300] MI statistics - function prep optimization

### DIFF
--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -9,84 +9,8 @@ module Stats
 
       included do
         def prepare
-          ActiveRecord::Base.connection.execute(drop_journeys_func)
-          ActiveRecord::Base.connection.execute(create_journeys_func)
-        end
-
-        def drop_journeys_func
-          <<~SQL
-            DROP FUNCTION IF EXISTS journeys(integer);
-          SQL
-        end
-
-        def create_journeys_func
-          <<~SQL
-            CREATE OR REPLACE FUNCTION journeys(in_claim_id int)
-            RETURNS TABLE(journey jsonb)
-            COST 100
-            STABLE
-            AS
-            $BODY$
-            DECLARE
-              rec record;
-              transition jsonb;
-              slice jsonb := '[]'::jsonb;
-              filtered_states constant varchar[] := array['draft', 'archived_pending_delete' , 'archived_pending_review'];
-              completed_states constant varchar[] := array['rejected', 'refused', 'authorised', 'part_authorised'];
-            BEGIN
-              for rec in (
-                with transitions as (
-                  select t.claim_id,
-                         t.from,
-                         t.to,
-                         t.created_at at time zone 'utc' at time zone 'Europe/London' as created_at,
-                         t.reason_code,
-                         t.reason_text,
-                         (authors.first_name || ' ' || authors.last_name) as author_name,
-                         (subjects.first_name || ' ' || subjects.last_name) as subject_name
-                  from claim_state_transitions t
-                  left outer join users as authors
-                    on t.author_id = authors.id
-                  left outer join users as subjects
-                    on t.subject_id = subjects.id
-                  where t.claim_id = in_claim_id
-                  and t.to not in (select * from unnest(filtered_states))
-                  and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')
-                )
-                select t.claim_id,
-                       jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions
-                from transitions t
-                group by t.claim_id
-              ) loop
-                slice := '[]'::jsonb;
-
-                for transition in (select jsonb_array_elements(rec.transitions))
-                loop
-                  -- remove "deallocated" allocations as not wanted for report
-                  if transition ->> 'to' = 'deallocated' then
-                    slice := slice - -1;
-                  else
-                    slice := slice || transition;
-                  end if;
-
-                  -- pipe out completed slice as row
-                  if transition ->> 'to' in (select * from unnest(completed_states)) then
-                    journey := slice;
-                    return next;
-                    slice := '[]'::jsonb;
-                  end if;
-                end loop;
-
-                -- pipe out last slice for claim unless it already has been above (because it has a completed status)
-                if transition ->> 'to' not in (select * from unnest(completed_states)) then
-                  journey := slice;
-                  return next;
-                end if;
-              end loop;
-            END
-            $BODY$
-            LANGUAGE plpgsql;
-          SQL
+          return if journeys_func_exists? && !replace_journeys_func?
+          recreate_journeys_func
         end
 
         def journeys_query
@@ -178,6 +102,99 @@ module Stats
               AND c.state != 'draft'
               AND c.type IN #{claim_type_filter}
               AND j.journey::text <> '[]'
+          SQL
+        end
+
+        private
+
+        def journeys_func_exists?
+          sql = 'select exists(select * from pg_proc where proname = \'journeys\');'
+          res = ActiveRecord::Base.connection.execute(sql)
+          res.first['exists']
+        end
+
+        def replace_journeys_func?
+          Settings.replace_journeys_func?
+        end
+
+        def recreate_journeys_func
+          ActiveRecord::Base.connection.execute(drop_journeys_func)
+          ActiveRecord::Base.connection.execute(create_journeys_func)
+        end
+
+        def drop_journeys_func
+          <<~SQL
+            DROP FUNCTION IF EXISTS journeys(integer);
+          SQL
+        end
+
+        def create_journeys_func
+          <<~SQL
+            CREATE OR REPLACE FUNCTION journeys(in_claim_id int)
+            RETURNS TABLE(journey jsonb)
+            COST 100
+            STABLE
+            AS
+            $BODY$
+            DECLARE
+              rec record;
+              transition jsonb;
+              slice jsonb := '[]'::jsonb;
+              filtered_states constant varchar[] := array['draft', 'archived_pending_delete' , 'archived_pending_review'];
+              completed_states constant varchar[] := array['rejected', 'refused', 'authorised', 'part_authorised'];
+            BEGIN
+              for rec in (
+                with transitions as (
+                  select t.claim_id,
+                         t.from,
+                         t.to,
+                         t.created_at at time zone 'utc' at time zone 'Europe/London' as created_at,
+                         t.reason_code,
+                         t.reason_text,
+                         (authors.first_name || ' ' || authors.last_name) as author_name,
+                         (subjects.first_name || ' ' || subjects.last_name) as subject_name
+                  from claim_state_transitions t
+                  left outer join users as authors
+                    on t.author_id = authors.id
+                  left outer join users as subjects
+                    on t.subject_id = subjects.id
+                  where t.claim_id = in_claim_id
+                  and t.to not in (select * from unnest(filtered_states))
+                  and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')
+                )
+                select t.claim_id,
+                       jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions
+                from transitions t
+                group by t.claim_id
+              ) loop
+                slice := '[]'::jsonb;
+
+                for transition in (select jsonb_array_elements(rec.transitions))
+                loop
+                  -- remove "deallocated" allocations as not wanted for report
+                  if transition ->> 'to' = 'deallocated' then
+                    slice := slice - -1;
+                  else
+                    slice := slice || transition;
+                  end if;
+
+                  -- pipe out completed slice as row
+                  if transition ->> 'to' in (select * from unnest(completed_states)) then
+                    journey := slice;
+                    return next;
+                    slice := '[]'::jsonb;
+                  end if;
+                end loop;
+
+                -- pipe out last slice for claim unless it already has been above (because it has a completed status)
+                if transition ->> 'to' not in (select * from unnest(completed_states)) then
+                  journey := slice;
+                  return next;
+                end if;
+              end loop;
+            END
+            $BODY$
+            LANGUAGE plpgsql;
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/base_count_query.rb
+++ b/app/services/stats/management_information/queries/base_count_query.rb
@@ -25,11 +25,6 @@ module Stats
 
       private
 
-      def prepare
-        ActiveRecord::Base.connection.execute(drop_journeys_func)
-        ActiveRecord::Base.connection.execute(create_journeys_func)
-      end
-
       def sql_quote(column_name)
         ActiveRecord::Base.connection.quote_column_name(column_name)
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -118,6 +118,13 @@ timed_transition_soft_delete_weeks: 16
 remote_api_key: 'not-provided'
 remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') + '/api' %>
 
+# Postgres DB `journeys` function flag to allow for its "recreation".
+# This is used by MI reports.
+# If enabled, the existing function will be "lazily" dropped and created again during
+# the run of any report that requires it. It should be set to true only to apply changes to
+# the function on an environment, then switch off/false again in subsequent PR post deployment.
+replace_journeys_func?: false
+
 # contact email address
 laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
 advocates_email: advocates-fee@justice.gov.uk

--- a/spec/services/stats/management_information/agfs/af1_disk_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af1_disk_query_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../shared_examples_for_journey_queryable'
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::Af1DiskQuery do

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require_relative 'shared_examples_for_journey_queryable'
+
 RSpec.describe Stats::ManagementInformation::DailyReportQuery do
+  it_behaves_like 'a claim journeys query' do
+    let(:instance) { described_class.new }
+  end
+
   describe '.call' do
     subject(:response) { described_class.call }
-
-    let(:scheme_class) { Stats::ManagementInformation::Scheme }
 
     it {
       create(:advocate_final_claim, :submitted)

--- a/spec/services/stats/management_information/shared_examples_for_journey_queryable.rb
+++ b/spec/services/stats/management_information/shared_examples_for_journey_queryable.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a claim journeys query' do
+  describe '#prepare' do
+    subject(:prepare) { instance.prepare }
+
+    context 'when journeys function does not exist' do
+      before do
+        ActiveRecord::Base.connection.execute(instance.send(:drop_journeys_func))
+      end
+
+      specify 'function does not exist prior to call' do
+        expect(instance.send(:journeys_func_exists?)).to be false
+      end
+
+      it 'creates the journeys function' do
+        prepare
+        expect(instance.send(:journeys_func_exists?)).to be true
+      end
+    end
+
+    context 'when journeys function already exists' do
+      before do
+        allow(Settings).to receive(:replace_journeys_func?).and_return(replace_flag)
+        ActiveRecord::Base.connection.execute(instance.send(:create_journeys_func))
+        allow(instance).to receive(:recreate_journeys_func)
+      end
+
+      let(:replace_flag) { false }
+
+      specify 'function exists prior to call' do
+        expect(instance.send(:journeys_func_exists?)).to be true
+      end
+
+      context 'with replace flag false' do
+        let(:replace_flag) { false }
+
+        it 'does not recreate function' do
+          prepare
+          expect(instance).not_to have_received(:recreate_journeys_func)
+        end
+      end
+
+      context 'with replace flag true' do
+        let(:replace_flag) { true }
+
+        it 'recreates function' do
+          prepare
+          expect(instance).to have_received(:recreate_journeys_func).once
+        end
+      end
+    end
+  end
+
+  describe '#journeys_query' do
+    subject(:journeys_query) { instance.journeys_query }
+
+    it { is_expected.to be_instance_of(String) }
+  end
+end


### PR DESCRIPTION
**What**
Optimize MI query preparation

**Why**
Journeys postgres DB function is dropped and replaced
on every call. This is an unnecessary overhead most of the
time as only changes to the function signature or body
would require a drop and replace respectively.

This slows tests and there are race conditions running
on production(-like) load balanced servers where this can
result in errors such as below. I believe this is due to
trying to replace a function in use. It is unclear what the
DROP command could do in such instances.

```
Error: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "pg_proc_proname_args_nsp_index"
DETAIL:  Key (proname, proargtypes, pronamespace)=(journeys, 23, 16403) already
```

This change means it will only create the function if
1. There is no function of that name (irrespective of signature)
2. or if the app setting flag `Settings.replace_journeys_func?` is set to true.
   see below.

**The `Settings.replace_journeys_func?`**

Add a settings flag to forcibly cause recreation of the `journeys` function
every time a report that uses it is run.

We default replacing the function to false as it already exists
and will not require replacing unless changes are made to its
signature or body.

**Usage**
When changes are made to the 'journeys` function signature or body then this flag
must be enabled to recreate the function, the app deployed and a report run
against that environment. This will update the function on the environment which the
report is run.

1. A simple alternative is to run the following on each environment
```
Stats::ManagementInformation::DailyReportQuery.new.send(:recreate_journeys_func)
```

2. A version controlled alternative is to use a rails migration
 Example (untested):
 ```
 class ReplaceJourneysFunction < ActiveRecord::Migration[6.1]
  include Stats::ManagementInformation::JourneyQueryable
  def up
    send(:recreate_journeys_func)
  end

  def down
   raise ActiveRecord::IrreversibleMigration, 'function change cannot be undone!'
  end
end
```