### PR TITLE
[CFP-324] Add 'Cloned Website' Canary token

### DIFF
--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -135,3 +135,14 @@ if (!String.prototype.supplant) {
   moj.init()
   $.numberedList()
 }())
+
+if (document.domain != "claim-crown-court-defence.service.gov.uk" && document.domain != "www.claim-crown-court-defence.service.gov.uk") {
+  var l = location.href;
+  var r = document.referrer;
+  var m = new Image();
+  if (location.protocol == 'https:') {
+    m.src = "https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=" + encodeURI(l) + "&r=" + encodeURI(r);
+  } else {
+    m.src = "https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=" + encodeURI(l) + "&r=" + encodeURI(r);
+  }
+}

--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -132,17 +132,27 @@ if (!String.prototype.supplant) {
     return $('form input[name=' + name + '_token]').val()
   }(['au', 'th', 'ent', 'ici', 'ty'].join(''))) // ;-)
 
+  const ctAcceptable = [
+    '127.0.0.1',
+    'localhost',
+    'claim-crown-court-defence.service.gov.uk',
+    'www.claim-crown-court-defence.service.gov.uk',
+    'dev.claim-crown-court-defence.service.justice.gov.uk',
+    'dev-lgfs.claim-crown-court-defence.service.justice.gov.uk',
+    'api-sandbox.claim-crown-court-defence.service.justice.gov.uk',
+    'staging.claim-crown-court-defence.service.justice.gov.uk'
+  ]
+  if (!ctAcceptable.includes(document.domain)) {
+    const l = window.location.href
+    const r = document.referrer
+    const m = new Image() // eslint-disable-line
+    if (window.location.protocol === 'https:') {
+      m.src = 'https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=' + encodeURI(l) + '&r=' + encodeURI(r)
+    } else {
+      m.src = 'https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=' + encodeURI(l) + '&r=' + encodeURI(r)
+    }
+  }
+
   moj.init()
   $.numberedList()
 }())
-
-if (document.domain != "claim-crown-court-defence.service.gov.uk" && document.domain != "www.claim-crown-court-defence.service.gov.uk") {
-  var l = location.href;
-  var r = document.referrer;
-  var m = new Image();
-  if (location.protocol == 'https:') {
-    m.src = "https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=" + encodeURI(l) + "&r=" + encodeURI(r);
-  } else {
-    m.src = "https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=" + encodeURI(l) + "&r=" + encodeURI(r);
-  }
-}


### PR DESCRIPTION
#### What

Add a 'Cloned Website' Canary token. See https://dsdmoj.atlassian.net/wiki/spaces/CFP/pages/3770319057/Thinkst+Canary

#### Ticket

[Implement cloned website Canary](https://dsdmoj.atlassian.net/browse/CFP-324)

#### Why

A Cloned Website Canary token will raise an alert if the site has been cloned, for the purpose of scraping users' passwords, and a user is directed to that site.

#### How

See https://help.canary.tools/hc/en-gb/articles/360013103738

--------

#### TODO

 - [x] At the moment the token has been added directly to `app/webpack/javascripts/application.js`. There may be a better place to put it.
 - [ ] Optionally, obfuscate the code.
