### PR TITLE
[CFP-324] Add dev-clar to the 'Cloned Website' Canarytoken

### DIFF
--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -138,6 +138,7 @@ if (!String.prototype.supplant) {
     'claim-crown-court-defence.service.gov.uk',
     'www.claim-crown-court-defence.service.gov.uk',
     'dev.claim-crown-court-defence.service.justice.gov.uk',
+    'dev-clar.claim-crown-court-defence.service.justice.gov.uk',
     'dev-lgfs.claim-crown-court-defence.service.justice.gov.uk',
     'api-sandbox.claim-crown-court-defence.service.justice.gov.uk',
     'staging.claim-crown-court-defence.service.justice.gov.uk'


### PR DESCRIPTION
#### What

Add the dev-clar environment to the list of acceptable domains for the cloned website Canarytoken.

#### Ticket

[Implement cloned website Canary](https://dsdmoj.atlassian.net/browse/CFP-324)

#### Why

dev-clar is an alternative DNS record for dev-lgfs

#### How

Add dev-clar to the `ctAcceptable` array.