### PR TITLE
[CFP-300] MI statistics group by optimisation

### DIFF
--- a/app/services/stats/management_information/daily_report_count_query.rb
+++ b/app/services/stats/management_information/daily_report_count_query.rb
@@ -20,10 +20,11 @@ module Stats
       def initialize(**kwargs)
         @query_set = kwargs[:query_set]
         @date_range = kwargs[:date_range]
+        raise ArgumentError, 'query set must be provided' if @query_set.blank?
+        raise ArgumentError, 'date range must be provided' if @date_range.blank?
+
         @start_at = @date_range.first.iso8601
         @end_at = @date_range.last.iso8601
-
-        raise ArgumentError, 'query set must be provided' if @query_set.blank?
       end
 
       def call

--- a/app/services/stats/management_information/daily_report_count_query.rb
+++ b/app/services/stats/management_information/daily_report_count_query.rb
@@ -30,6 +30,14 @@ module Stats
 
       private
 
+      def submission_queries
+        filter_by(:originally_submitted_at)
+      end
+
+      def completion_queries
+        filter_by(:completed_at)
+      end
+
       def filter_by(date_column_filter)
         @query_set.each_with_object([]) do |(name, query), results|
           result = { name: name.to_s.humanize, filter: date_column_filter.to_s.humanize }
@@ -42,14 +50,6 @@ module Stats
           result.merge!(counts_by_day)
           results.append(result)
         end
-      end
-
-      def submission_queries
-        filter_by(:originally_submitted_at)
-      end
-
-      def completion_queries
-        filter_by(:completed_at)
       end
     end
   end

--- a/app/services/stats/management_information/daily_report_count_query.rb
+++ b/app/services/stats/management_information/daily_report_count_query.rb
@@ -22,9 +22,6 @@ module Stats
         @date_range = kwargs[:date_range]
         raise ArgumentError, 'query set must be provided' if @query_set.blank?
         raise ArgumentError, 'date range must be provided' if @date_range.blank?
-
-        @start_at = @date_range.first.iso8601
-        @end_at = @date_range.last.iso8601
       end
 
       def call
@@ -37,7 +34,7 @@ module Stats
         @query_set.each_with_object([]) do |(name, query), results|
           result = { name: name.to_s.humanize, filter: date_column_filter.to_s.humanize }
 
-          query_results = query.call(start_at: @start_at, end_at: @end_at,
+          query_results = query.call(date_range: @date_range,
                                      date_column_filter: date_column_filter).to_a
 
           counts_by_day = query_results.map { |rec| { rec['day'].to_date.iso8601 => rec['count'] } }.reduce(:merge)

--- a/app/services/stats/management_information/daily_report_count_query.rb
+++ b/app/services/stats/management_information/daily_report_count_query.rb
@@ -37,13 +37,10 @@ module Stats
         @query_set.each_with_object([]) do |(name, query), results|
           result = { name: name.to_s.humanize, filter: date_column_filter.to_s.humanize }
 
-          query_results = query.call(start_at: @start_at,
-                                     end_at: @end_at,
+          query_results = query.call(start_at: @start_at, end_at: @end_at,
                                      date_column_filter: date_column_filter).to_a
 
-          counts_by_day = query_results.map do |tuple|
-            { tuple['day'].to_date.iso8601 => tuple['count'] }
-          end.reduce(:merge)
+          counts_by_day = query_results.map { |rec| { rec['day'].to_date.iso8601 => rec['count'] } }.reduce(:merge)
 
           result.merge!(counts_by_day)
           results.append(result)

--- a/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
@@ -17,15 +17,21 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND j.disk_evidence
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'AGFS'
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND j.disk_evidence
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
@@ -22,13 +22,14 @@ module Stats
             WITH journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
+            SELECT count(*), date_trunc('day', j.#{@date_column_filter}) as day
             FROM journeys j
             WHERE j.scheme = 'AGFS'
             AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
+            AND date_trunc('day', j.#{@date_column_filter}) between '#{@start_at}' and '#{@end_at}'
             AND NOT j.disk_evidence
-            AND j.claim_total::float >= 20000.00
+            AND j.claim_total::float < 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
@@ -19,16 +19,21 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*), date_trunc('day', j.#{@date_column_filter}) as day
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND date_trunc('day', j.#{@date_column_filter}) between '#{@start_at}' and '#{@end_at}'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float < 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'AGFS'
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float >= 20000.00
             GROUP BY day
           SQL
         end

--- a/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
@@ -17,15 +17,21 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND j.journey -> 0 ->> 'to' = 'redetermination'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND j.disk_evidence
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'AGFS'
+              AND j.journey -> 0 ->> 'to' = 'redetermination'
+              AND j.disk_evidence
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
@@ -29,7 +29,7 @@ module Stats
             FROM days d
             LEFT OUTER JOIN journeys j
               ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              ON j.scheme = 'AGFS'
+              AND j.scheme = 'AGFS'
               AND j.journey -> 0 ->> 'to' = 'redetermination'
               AND NOT j.disk_evidence
               AND j.claim_total::float >= 20000.00

--- a/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
@@ -18,16 +18,22 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND j.journey -> 0 ->> 'to' = 'redetermination'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float >= 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              ON j.scheme = 'AGFS'
+              AND j.journey -> 0 ->> 'to' = 'redetermination'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float >= 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
@@ -29,6 +29,7 @@ module Stats
             FROM days d
             LEFT OUTER JOIN journeys j
               ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'AGFS'
               AND j.journey -> 0 ->> 'to' = 'redetermination'
               AND NOT j.disk_evidence
               AND j.claim_total::float < 20000.00

--- a/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
@@ -18,16 +18,21 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND j.journey -> 0 ->> 'to' = 'redetermination'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float < 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.journey -> 0 ->> 'to' = 'redetermination'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float < 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
@@ -28,20 +28,26 @@ module Stats
         #
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND (
-                trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
-                OR j.case_type_name is NULL
-                )
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float < 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'AGFS'
+              AND (
+                  trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
+                  OR j.case_type_name is NULL
+                  )
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float < 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
@@ -20,17 +20,23 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded')
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float < 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'AGFS'
+              AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded')
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float < 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
@@ -16,14 +16,20 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'AGFS'
-            AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'AGFS'
+              AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/base_count_query.rb
+++ b/app/services/stats/management_information/queries/base_count_query.rb
@@ -12,8 +12,9 @@ module Stats
         new(kwargs).call
       end
 
-      def initialize(day:, date_column_filter:)
-        @day = day.to_date.iso8601
+      def initialize(start_at: , end_at:, date_column_filter:)
+        @start_at = start_at.to_date.iso8601
+        @end_at = end_at.to_date.iso8601
         @date_column_filter = sql_quote(date_column_filter)
       end
 

--- a/app/services/stats/management_information/queries/base_count_query.rb
+++ b/app/services/stats/management_information/queries/base_count_query.rb
@@ -12,7 +12,7 @@ module Stats
         new(kwargs).call
       end
 
-      def initialize(start_at: , end_at:, date_column_filter:)
+      def initialize(start_at:, end_at:, date_column_filter:)
         @start_at = start_at.to_date.iso8601
         @end_at = end_at.to_date.iso8601
         @date_column_filter = sql_quote(date_column_filter)

--- a/app/services/stats/management_information/queries/base_count_query.rb
+++ b/app/services/stats/management_information/queries/base_count_query.rb
@@ -12,9 +12,9 @@ module Stats
         new(kwargs).call
       end
 
-      def initialize(start_at:, end_at:, date_column_filter:)
-        @start_at = start_at.to_date.iso8601
-        @end_at = end_at.to_date.iso8601
+      def initialize(date_range:, date_column_filter:)
+        @start_at = date_range.first.iso8601
+        @end_at = date_range.last.iso8601
         @date_column_filter = sql_quote(date_column_filter)
       end
 

--- a/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
@@ -20,21 +20,27 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'LGFS'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND trim(lower(j.bill_type)) = 'lgfs final'
-            AND (
-                trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
-                OR j.case_type_name is NULL
-                )
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float < 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'LGFS'
+              AND trim(lower(j.bill_type)) = 'lgfs final'
+              AND (
+                  trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
+                  OR j.case_type_name is NULL
+                  )
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float < 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
@@ -19,17 +19,23 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'LGFS'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded', 'hearing subsequent to sentence')
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float < 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'LGFS'
+              AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded', 'hearing subsequent to sentence')
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float < 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
@@ -19,17 +19,23 @@ module Stats
 
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'LGFS'
-            AND trim(lower(j.bill_type)) = 'lgfs interim'
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float < 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'LGFS'
+              AND trim(lower(j.bill_type)) = 'lgfs interim'
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float < 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
@@ -19,16 +19,22 @@ module Stats
         # OPTIMIZE: this is the sames as Af1HighValueQuery
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'LGFS'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND j.journey -> 0 ->> 'to' = 'submitted'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float >= 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'LGFS'
+              AND j.journey -> 0 ->> 'to' = 'submitted'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float >= 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
@@ -18,15 +18,21 @@ module Stats
         # OPTIMIZE: this is the sames as Af2DiskQuery
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'LGFS'
-            AND j.journey -> 0 ->> 'to' = 'redetermination'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND j.disk_evidence
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'LGFS'
+              AND j.journey -> 0 ->> 'to' = 'redetermination'
+              AND j.disk_evidence
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
@@ -19,16 +19,22 @@ module Stats
         # OPTIMIZE: this is the sames as Af2HighValueQuery
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'LGFS'
-            AND j.journey -> 0 ->> 'to' = 'redetermination'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
-            AND NOT j.disk_evidence
-            AND j.claim_total::float >= 20000.00
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'LGFS'
+              AND j.journey -> 0 ->> 'to' = 'redetermination'
+              AND NOT j.disk_evidence
+              AND j.claim_total::float >= 20000.00
+            GROUP BY day
           SQL
         end
       end

--- a/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
@@ -17,14 +17,20 @@ module Stats
         # OPTIMIZE: this is the sames as Agfs::WrittenReasonsQuery
         def query
           <<~SQL
-            WITH journeys AS (
+            WITH days AS (
+              SELECT day::date
+              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+            ),
+            journeys AS (
               #{journeys_query}
             )
-            SELECT count(*)
-            FROM journeys j
-            WHERE j.scheme = 'LGFS'
-            AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
-            AND date_trunc('day', j.#{@date_column_filter}) = '#{@day}'
+            SELECT count(j.*), date_trunc('day', d.day) as day
+            FROM days d
+            LEFT OUTER JOIN journeys j
+              ON date_trunc('day', j.#{@date_column_filter}) = d.day
+              AND j.scheme = 'LGFS'
+              AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
+            GROUP BY day
           SQL
         end
       end

--- a/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
+++ b/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
@@ -57,13 +57,21 @@ RSpec.shared_examples 'a base count query' do
     end
 
     context 'with start_at and end_at as Date objects' do
-      let(:kwargs) { { start_at: Date.parse('2021-01-01'), end_at: Date.parse('2021-01-01'), date_column_filter: :originally_submitted_at } }
+      let(:kwargs) do
+        { start_at: Date.parse('2021-01-01'),
+          end_at: Date.parse('2021-01-01'),
+          date_column_filter: :originally_submitted_at }
+      end
 
       it { expect { call }.not_to raise_error }
     end
 
     context 'with start_at or end_at as invalid date string' do
-      let(:kwargs) { { start_at: '2021-13-01', end_at: Date.parse('2021-01-01'), date_column_filter: :originally_submitted_at } }
+      let(:kwargs) do
+        { start_at: '2021-13-01',
+          end_at: Date.parse('2021-01-01'),
+          date_column_filter: :originally_submitted_at }
+      end
 
       it { expect { call }.to raise_error Date::Error, /invalid date/ }
     end

--- a/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
+++ b/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'a base count query' do
   describe '.call' do
     subject(:call) { described_class.call(kwargs) }
 
-    let(:kwargs) { { start_at: Time.zone.today, end_at: Time.zone.today, date_column_filter: :bar } }
+    let(:kwargs) { { date_range: Time.zone.today..Time.zone.today, date_column_filter: :bar } }
 
     let(:instance) { instance_double(described_class) }
     let(:result) { instance_double(PG::Result) }
@@ -16,7 +16,7 @@ RSpec.shared_examples 'a base count query' do
 
     it 'sends \'new\' with arguments' do
       call
-      expect(described_class).to have_received(:new).with(hash_including(:start_at, :end_at, :date_column_filter))
+      expect(described_class).to have_received(:new).with(hash_including(:date_range, :date_column_filter))
     end
 
     it 'sends \'call\' to instance of class' do
@@ -28,10 +28,10 @@ RSpec.shared_examples 'a base count query' do
   describe '#call' do
     subject(:call) { described_class.new(kwargs).call }
 
-    let(:day) { Time.zone.today }
+    let(:date_range) { Time.zone.today..Time.zone.today }
 
-    context 'with valid day and date_column_filter' do
-      let(:kwargs) { { start_at: day, end_at: day, date_column_filter: :originally_submitted_at } }
+    context 'with valid date_range and date_column_filter' do
+      let(:kwargs) { { date_range: date_range, date_column_filter: :originally_submitted_at } }
 
       it 'returned object behaves like array' do
         is_expected.to respond_to(:[])
@@ -50,48 +50,39 @@ RSpec.shared_examples 'a base count query' do
       end
     end
 
-    context 'with start_at and end_at as valid date strings' do
-      let(:kwargs) { { start_at: '2021-01-01', end_at: '2021-01-01', date_column_filter: :originally_submitted_at } }
-
-      it { expect { call }.not_to raise_error }
-    end
-
-    context 'with start_at and end_at as Date objects' do
+    context 'with date_range as Date objects' do
       let(:kwargs) do
-        { start_at: Date.parse('2021-01-01'),
-          end_at: Date.parse('2021-01-01'),
+        { date_range: Date.parse('2021-01-01')..Date.parse('2021-01-01'),
           date_column_filter: :originally_submitted_at }
       end
 
       it { expect { call }.not_to raise_error }
     end
 
-    context 'with start_at or end_at as invalid date string' do
+    context 'with date_range string' do
       let(:kwargs) do
-        { start_at: '2021-13-01',
-          end_at: Date.parse('2021-01-01'),
+        { date_range: '2021-13-01'..Date.parse('2021-01-01'),
           date_column_filter: :originally_submitted_at }
       end
 
-      it { expect { call }.to raise_error Date::Error, /invalid date/ }
+      it { expect { call }.to raise_error ArgumentError, /bad value for range/ }
     end
 
-    context 'without start_at or end_at key' do
+    context 'without date_range key' do
       let(:kwargs) { { date_column_filter: :originally_submitted_at } }
 
-      it { expect { call }.to raise_error ArgumentError, /missing keywords:.*start_at.*end_at/ }
+      it { expect { call }.to raise_error ArgumentError, /missing keyword.*date_range/ }
     end
 
     context 'without date_column_filter' do
-      let(:kwargs) { { start_at: '2021-01-01', end_at: '2021-01-01' } }
+      let(:kwargs) { { date_range: Time.zone.today..Time.zone.today } }
 
-      it { expect { call }.to raise_error ArgumentError, /missing keyword:.*date_column_filter/ }
+      it { expect { call }.to raise_error ArgumentError, /missing keyword.*date_column_filter/ }
     end
 
     context 'when trying to inject SQL' do
       let(:kwargs) do
-        { start_at: day,
-          end_at: day,
+        { date_range: Time.zone.today..Time.zone.today,
           date_column_filter: 'originally_submitted_at; (select PG_SLEEP(15))' }
       end
 
@@ -104,18 +95,18 @@ RSpec.shared_examples 'an originally_submitted_at filterable query' do
   describe '#call' do
     subject(:result) { described_class.new(kwargs).call }
 
-    let(:kwargs) { { start_at: day, end_at: day, date_column_filter: :originally_submitted_at } }
+    let(:kwargs) { { date_range: date_range, date_column_filter: :originally_submitted_at } }
 
     before { claim }
 
     context 'with submissions on day' do
-      let(:day) { Time.zone.today }
+      let(:date_range) { Time.zone.today..Time.zone.today }
 
       it { expect(result.first['count']).to eq(1) }
     end
 
     context 'without submissions on day' do
-      let(:day) { 1.day.ago }
+      let(:date_range) { 1.day.ago..1.day.ago }
 
       it { expect(result.first['count']).to eq(0) }
     end
@@ -126,18 +117,18 @@ RSpec.shared_examples 'a completed_at filterable query' do
   describe '#call' do
     subject(:result) { described_class.new(kwargs).call }
 
-    let(:kwargs) { { start_at: day, end_at: day, date_column_filter: :completed_at } }
+    let(:kwargs) { { date_range: date_range, date_column_filter: :completed_at } }
 
     before { claim }
 
     context 'with completions on day' do
-      let(:day) { Time.zone.today }
+      let(:date_range) { Time.zone.today..Time.zone.today }
 
       it { expect(result.first['count']).to eq(1) }
     end
 
     context 'without completions on day' do
-      let(:day) { 1.day.ago }
+      let(:date_range) { 1.day.ago..1.day.ago }
 
       it { expect(result.first['count']).to eq(0) }
     end


### PR DESCRIPTION
#### What
Optimise statistics calculation using a group by

#### Ticket

[CFP-300](https://dsdmoj.atlassian.net/browse/CFP-300)

#### Why
A production like load can take upwards of 10 minutes
to generate a months worth of daily counts for each
of the 17 categories (i.e. 30 X 17 = 510 queries)

On a test run this took 1+ minutes compared with 11+ minutes for the
`mi-weekly-statistic-report-v2` branch against a production like load.

#### How
Use one query per category and group by day, including 0
for days that have no counts. 17 queries instead of 510
