### PR TITLE
[CFP-300] Improve MI report page link accessibility

### DIFF
--- a/app/views/case_workers/admin/management_information/_stats_report.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report.html.haml
@@ -1,5 +1,4 @@
 - i18n_scope = 'case_workers.admin.management_information.index'
-- action_context = t("report_types.#{report_object}_html", scope: i18n_scope)
 
 - if report_rec&.started_at
   %p
@@ -12,8 +11,8 @@
     = t('unavailable_report', scope: i18n_scope)
 
 - if report_rec&.started_at.present?
-  = govuk_link_button(t('download', scope: i18n_scope, context: action_context),
+  = govuk_link_button(t('download_html', scope: i18n_scope, report_name: report_name_html),
                     case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
 
-= govuk_link_button_secondary(t('update_report', scope: i18n_scope, context: action_context),
+= govuk_link_button_secondary(t('update_report_html', scope: i18n_scope, report_name: report_name_html),
                             case_workers_admin_management_information_generate_url(report_type: report_object.name))

--- a/app/views/case_workers/admin/management_information/_stats_report.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report.html.haml
@@ -1,4 +1,5 @@
 - i18n_scope = 'case_workers.admin.management_information.index'
+- action_context = t("report_types.#{report_object}_html", scope: i18n_scope)
 
 - if report_rec&.started_at
   %p
@@ -11,8 +12,8 @@
     = t('unavailable_report', scope: i18n_scope)
 
 - if report_rec&.started_at.present?
-  = govuk_link_button(t('download', scope: i18n_scope),
+  = govuk_link_button(t('download', scope: i18n_scope, context: action_context),
                     case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
 
-= govuk_link_button_secondary(t('update_report', scope: i18n_scope),
+= govuk_link_button_secondary(t('update_report', scope: i18n_scope, context: action_context),
                             case_workers_admin_management_information_generate_url(report_type: report_object.name))

--- a/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
@@ -1,5 +1,4 @@
 - i18n_scope = 'case_workers.admin.management_information.index'
-- action_context = t("report_types.#{report_object}_html", scope: i18n_scope)
 
 - if report_rec&.started_at
   %p
@@ -8,7 +7,7 @@
         datetime: report_rec.started_at.iso8601,
         time: report_rec.started_at.strftime(Settings.report_date_format))
 
-  = govuk_link_button(t('download', scope: i18n_scope, context: action_context),
+  = govuk_link_button(t('download_html', scope: i18n_scope, report_name: report_name_html),
                       case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
 - else
   %p
@@ -20,4 +19,4 @@
                        legend: { text: t('start_date', scope: i18n_scope) },
                        hint: { text: t('daily_report_count_hint', scope: i18n_scope) }
 
-  = f.govuk_submit(t('update_report_html', scope: i18n_scope, context: action_context), class: 'govuk-button--secondary')
+  = f.govuk_submit(t('update_report_html', scope: i18n_scope, report_name: report_name_html), class: 'govuk-button--secondary')

--- a/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
@@ -1,4 +1,5 @@
 - i18n_scope = 'case_workers.admin.management_information.index'
+- action_context = t("report_types.#{report_object}_html", scope: i18n_scope)
 
 - if report_rec&.started_at
   %p
@@ -7,7 +8,7 @@
         datetime: report_rec.started_at.iso8601,
         time: report_rec.started_at.strftime(Settings.report_date_format))
 
-  = govuk_link_button(t('download', scope: i18n_scope),
+  = govuk_link_button(t('download', scope: i18n_scope, context: action_context),
                       case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
 - else
   %p
@@ -19,4 +20,4 @@
                        legend: { text: t('start_date', scope: i18n_scope) },
                        hint: { text: t('daily_report_count_hint', scope: i18n_scope) }
 
-  = f.govuk_submit(t('update_report', scope: i18n_scope), class: 'govuk-button--secondary')
+  = f.govuk_submit(t('update_report_html', scope: i18n_scope, context: action_context), class: 'govuk-button--secondary')

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -10,14 +10,15 @@
     - @available_reports.each do |report_object, report_rec|
       .form-section
         %h2.govuk-heading-l{ id: "heading-#{report_object}" }
-          = t(".report_types.#{report_object}_html")
+          - report_name_html = t(".report_types.#{report_object}_html")
+          = report_name_html
 
         %p{ role: 'group', 'aria-labelledby': "heading-#{report_object}" }
         - if report_object.date_required?
-          = render partial: 'stats_report_with_date_form', locals: { report_object: report_object, report_rec: report_rec}
+          = render partial: 'stats_report_with_date_form', locals: { report_object: report_object, report_rec: report_rec, report_name_html: report_name_html }
 
         - else
-          = render partial: 'stats_report', locals: { report_object: report_object, report_rec: report_rec}
+          = render partial: 'stats_report', locals: { report_object: report_object, report_rec: report_rec, report_name_html: report_name_html }
 
     #provisional-assessment-date.form-section.fx-dates-chooser
       %h2.govuk-heading-l
@@ -38,4 +39,4 @@
             legend: { text: t('.end_date') },
             hint: { text: t('.example_date') }
 
-      = govuk_link_button(t('.download_html', context: t('.provisional_assessments_by_date')), '', disabled: 'true', id: 'provisional_assessments_date_download')
+      = govuk_link_button(t('.download_html', report_name: t('.provisional_assessments_by_date')), '', disabled: 'true', id: 'provisional_assessments_date_download')

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -38,4 +38,4 @@
             legend: { text: t('.end_date') },
             hint: { text: t('.example_date') }
 
-      = govuk_link_button(t('.download'), '', disabled: 'true', id: 'provisional_assessments_date_download')
+      = govuk_link_button(t('.download_html', context: t('.provisional_assessments_by_date')), '', disabled: 'true', id: 'provisional_assessments_date_download')

--- a/config/locales/en/views/management_information.yml
+++ b/config/locales/en/views/management_information.yml
@@ -23,7 +23,7 @@ en:
             Enter a start date to create a new report covering a month from that date. For example,
             18 10 2021 will create a report for 18 October 2021 to 17 November 2021.
           download_html: |
-            Download <span class="govuk-visually-hidden">%{context} report</span>
+            Download <span class="govuk-visually-hidden">%{report_name} report</span>
           end_date: End date
           example_date: "For example, 31 3 2020"
           example_day_in_week: "For example, 05 08 2021 will generate report for Saturday 03/08/2021 to Friday 09/08/2021"
@@ -57,6 +57,6 @@ en:
           start_date: Start date
           unavailable_report: "There is currently no report available"
           update_report_html: |
-            Update <span class="govuk-visually-hidden">%{context}</span> report
+            Update <span class="govuk-visually-hidden">%{report_name}</span> report
           year: Year
         job_scheduled: Refresh this page in a few minutes to download the new report.

--- a/config/locales/en/views/management_information.yml
+++ b/config/locales/en/views/management_information.yml
@@ -22,7 +22,8 @@ en:
           daily_report_count_hint: |
             Enter a start date to create a new report covering a month from that date. For example,
             18 10 2021 will create a report for 18 October 2021 to 17 November 2021.
-          download: Download
+          download_html: |
+            Download <span class="govuk-visually-hidden">%{context} report</span>
           end_date: End date
           example_date: "For example, 31 3 2020"
           example_day_in_week: "For example, 05 08 2021 will generate report for Saturday 03/08/2021 to Friday 09/08/2021"
@@ -55,6 +56,7 @@ en:
             submitted_claims_html: Submitted claims
           start_date: Start date
           unavailable_report: "There is currently no report available"
-          update_report: Update report
+          update_report_html: |
+            Update <span class="govuk-visually-hidden">%{context}</span> report
           year: Year
         job_scheduled: Refresh this page in a few minutes to download the new report.


### PR DESCRIPTION
#### What
Improve MI report page link accessibility

#### Ticket

[CFP-300](https://dsdmoj.atlassian.net/browse/CFP-300)

#### Why
multiple download and update report links are indistinguishable by
screen readers without explicit text to differentiate them. This differentiates 
using a span with content based on report name.
