### PR TITLE
Fix MI report version 2 overnight job run

### DIFF
--- a/scheduled_tasks/agfs_management_information_v2_generation_task.rb
+++ b/scheduled_tasks/agfs_management_information_v2_generation_task.rb
@@ -6,7 +6,7 @@ class AgfsManagementInformationV2GenerationTask < Scheduler::SchedulerTask
 
   def run
     LogStuff.info { 'AGFS Management Information Generation V2 started' }
-    Stats::StatsReportGenerator.call('agfs_management_information_v2')
+    Stats::StatsReportGenerator.call(report_type: 'agfs_management_information_v2')
     LogStuff.info { 'AGFS Management Information Generation V2 finished' }
   rescue StandardError => e
     LogStuff.error { 'AGFS Management Information Generation V2 error: ' + e.message }

--- a/scheduled_tasks/lgfs_management_information_v2_generation_task.rb
+++ b/scheduled_tasks/lgfs_management_information_v2_generation_task.rb
@@ -6,7 +6,7 @@ class LgfsManagementInformationV2GenerationTask < Scheduler::SchedulerTask
 
   def run
     LogStuff.info { 'LGFS Management Information Generation V2 started' }
-    Stats::StatsReportGenerator.call('lgfs_management_information_v2')
+    Stats::StatsReportGenerator.call(report_type: 'lgfs_management_information_v2')
     LogStuff.info { 'LGFS Management Information Generation V2 finished' }
   rescue StandardError => e
     LogStuff.error { 'LGFS Management Information Generation V2 error: ' + e.message }

--- a/scheduled_tasks/management_information_v2_generation_task.rb
+++ b/scheduled_tasks/management_information_v2_generation_task.rb
@@ -6,7 +6,7 @@ class ManagementInformationV2GenerationTask < Scheduler::SchedulerTask
 
   def run
     LogStuff.info { 'Management Information Generation V2 started' }
-    Stats::StatsReportGenerator.call('management_information_v2')
+    Stats::StatsReportGenerator.call(report_type: 'management_information_v2')
     LogStuff.info { 'Management Information Generation V2 finished' }
   rescue StandardError => e
     LogStuff.error { 'Management Information Generation V2 error: ' + e.message }


### PR DESCRIPTION

#### What
Fix MI report version 2 overnight job run

#### Why
Following a change in the args expected for calling of the
stats generators the overnight jobs were failing for the
mi daily report v2 reports with this error.

```
{"@source":"cccd.production.production","@tags":[],"@fields":{},"@severity":"info","message":"AGFS Management Information Generation V2 started","@timestamp":"2021-12-10T01:50:00.209757+00:00"}
{"@source":"cccd.production.production","@tags":[],"@fields":{},"@severity":"error","message":"AGFS Management Information Generation V2 error: wrong number of arguments (given 1, expected 0)","@timestamp":"2021-12-10T01:50:00.210594+00:00"}
```