### PR TITLE
[CFP-300] Ensure count queries have a scheme associated

### DIFF
--- a/app/services/stats/management_information/concerns/claim_type_filterable.rb
+++ b/app/services/stats/management_information/concerns/claim_type_filterable.rb
@@ -2,11 +2,31 @@
 
 module Stats
   module ManagementInformation
-    module ClaimTypeQueryable
+    module ClaimTypeFilterable
       extend ActiveSupport::Concern
 
+      class_methods do
+        def acts_as_scheme(scheme)
+          define_method(:scheme) do
+            scheme&.to_s&.upcase
+          end
+        end
+      end
+
       included do
-        delegate :claim_types, :agfs_claim_types, :lgfs_claim_types, to: :'::Claim::BaseClaim'
+        def scheme
+          @scheme&.to_s&.upcase
+        end
+
+        def scheme=(scheme)
+          @scheme = scheme&.to_s&.upcase
+        end
+
+        delegate :claim_types, :agfs_claim_types, :lgfs_claim_types, to: :base_claim_klass
+
+        def base_claim_klass
+          ::Claim::BaseClaim
+        end
 
         def claim_type_filter
           return in_statement_for(agfs_claim_types) if scheme.eql?('AGFS')

--- a/app/services/stats/management_information/daily_report_query.rb
+++ b/app/services/stats/management_information/daily_report_query.rb
@@ -7,16 +7,14 @@ module Stats
   module ManagementInformation
     class DailyReportQuery
       include JourneyQueryable
-      include ClaimTypeQueryable
-
-      attr_reader :scheme
+      include ClaimTypeFilterable
 
       def self.call(options = {})
         new(options).call
       end
 
       def initialize(options = {})
-        @scheme = options[:scheme]&.to_s&.upcase
+        self.scheme = options[:scheme]
         raise ArgumentError, 'scheme must be "agfs" or "lgfs"' if @scheme.present? && %w[AGFS LGFS].exclude?(@scheme)
       end
 

--- a/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
@@ -13,6 +13,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class Af1DiskQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
@@ -15,6 +15,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class Af1HighValueQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
@@ -13,6 +13,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class Af2DiskQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
@@ -14,6 +14,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class Af2HighValueQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
@@ -14,6 +14,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class Af2RedeterminationQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
@@ -15,6 +15,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class IntakeFinalFeeQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         # NOTE: on time zone edge cases:

--- a/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
@@ -16,6 +16,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class IntakeFixedFeeQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
@@ -12,6 +12,8 @@ module Stats
   module ManagementInformation
     module Agfs
       class WrittenReasonsQuery < BaseCountQuery
+        acts_as_scheme :agfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/base_count_query.rb
+++ b/app/services/stats/management_information/queries/base_count_query.rb
@@ -4,9 +4,7 @@ module Stats
   module ManagementInformation
     class BaseCountQuery
       include JourneyQueryable
-      include ClaimTypeQueryable
-
-      attr_reader :scheme
+      include ClaimTypeFilterable
 
       def self.call(**kwargs)
         new(kwargs).call

--- a/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
@@ -16,6 +16,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class IntakeFinalFeeQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
@@ -15,6 +15,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class IntakeFixedFeeQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
@@ -15,6 +15,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class IntakeInterimFeeQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         def query

--- a/app/services/stats/management_information/queries/lgfs/lf1_disk_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf1_disk_query.rb
@@ -13,6 +13,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class Lf1DiskQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         # OPTIMIZE: this is the sames as Af1DiskQuery

--- a/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
@@ -14,6 +14,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class Lf1HighValueQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         # OPTIMIZE: this is the sames as Af1HighValueQuery

--- a/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
@@ -13,6 +13,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class Lf2DiskQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         # OPTIMIZE: this is the sames as Af2DiskQuery

--- a/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
@@ -14,6 +14,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class Lf2HighValueQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         # OPTIMIZE: this is the sames as Af2HighValueQuery

--- a/app/services/stats/management_information/queries/lgfs/lf2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_redetermination_query.rb
@@ -14,6 +14,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class Lf2RedeterminationQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         # OPTIMIZE: this is the sames as Af2RedeterminationQuery

--- a/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
@@ -12,6 +12,8 @@ module Stats
   module ManagementInformation
     module Lgfs
       class WrittenReasonsQuery < BaseCountQuery
+        acts_as_scheme :lgfs
+
         private
 
         # OPTIMIZE: this is the sames as Agfs::WrittenReasonsQuery

--- a/spec/services/stats/management_information/agfs/af1_disk_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af1_disk_query_spec.rb
@@ -4,7 +4,7 @@ require_relative '../shared_examples_for_journey_queryable'
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::Af1DiskQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/agfs/af1_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af1_high_value_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::Af1HighValueQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/agfs/af2_disk_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af2_disk_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::Af2DiskQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today

--- a/spec/services/stats/management_information/agfs/af2_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af2_high_value_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::Af2HighValueQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today

--- a/spec/services/stats/management_information/agfs/af2_redetermination_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af2_redetermination_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::Af2RedeterminationQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today

--- a/spec/services/stats/management_information/agfs/intake_final_fee_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/intake_final_fee_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::IntakeFinalFeeQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/agfs/intake_fixed_fee_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/intake_fixed_fee_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::IntakeFixedFeeQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/agfs/written_reasons_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/written_reasons_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Agfs::WrittenReasonsQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [awaiting_written_reasons] today

--- a/spec/services/stats/management_information/claim_type_filterable_spec.rb
+++ b/spec/services/stats/management_information/claim_type_filterable_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
+  let(:agfs_in_statement) do
+    <<~STATEMENT.squish.squeeze(' ')
+      ('Claim::AdvocateClaim',
+      'Claim::AdvocateInterimClaim',
+      'Claim::AdvocateSupplementaryClaim',
+      'Claim::AdvocateHardshipClaim')
+    STATEMENT
+  end
+
+  let(:lgfs_in_statement) do
+    <<~STATEMENT.squish.squeeze(' ')
+      ('Claim::LitigatorClaim',
+      'Claim::InterimClaim',
+      'Claim::TransferClaim',
+      'Claim::LitigatorHardshipClaim')
+    STATEMENT
+  end
+
+  let(:all_in_statement) do
+    <<~STATEMENT.squish.squeeze(' ')
+      ('Claim::AdvocateClaim',
+      'Claim::AdvocateInterimClaim',
+      'Claim::AdvocateSupplementaryClaim',
+      'Claim::AdvocateHardshipClaim',
+      'Claim::LitigatorClaim',
+      'Claim::InterimClaim',
+      'Claim::TransferClaim',
+      'Claim::LitigatorHardshipClaim')
+    STATEMENT
+  end
+
+  describe 'MockClaimTypeFilter' do
+    before do
+      stub_const('MockClaimTypeFilter', mock_claim_type_filter)
+    end
+
+    let(:instance) { MockClaimTypeFilter.new }
+
+    let(:mock_claim_type_filter) do
+      Class.new do
+        include Stats::ManagementInformation::ClaimTypeFilterable
+      end
+    end
+
+    specify { expect(MockClaimTypeFilter).to respond_to(:acts_as_scheme) }
+
+    specify do
+      expect(instance).to respond_to(:scheme, :scheme=,
+                                     :claim_types, :agfs_claim_types, :lgfs_claim_types,
+                                     :claim_type_filter, :in_statement_for)
+    end
+
+    it { expect(instance).to delegate_method(:claim_types).to(:base_claim_klass) }
+    it { expect(instance).to delegate_method(:agfs_claim_types).to(:base_claim_klass) }
+    it { expect(instance).to delegate_method(:lgfs_claim_types).to(:base_claim_klass) }
+
+    describe '#scheme' do
+      subject { instance.scheme }
+
+      it { is_expected.to be_nil }
+    end
+
+    describe '#claim_type_filter' do
+      subject(:claim_type_filter) { instance.claim_type_filter }
+
+      it 'returns AGFS claims types in statement when scheme set to AGFS' do
+        instance.scheme = :agfs
+        expect(claim_type_filter).to eql(agfs_in_statement)
+      end
+
+      it 'returns LGFS claims types in statement when scheme set to LGFS' do
+        instance.scheme = :lgfs
+        expect(claim_type_filter).to eql(lgfs_in_statement)
+      end
+
+      it 'returns all claim types in statement when scheme not set' do
+        expect(claim_type_filter).to eql(all_in_statement)
+      end
+    end
+  end
+
+  describe 'MockClaimTypeFilterWithInitializer' do
+    before do
+      stub_const('MockClaimTypeFilterWithInitializer', mock_claim_type_filter_with_initilizer)
+    end
+
+    let(:mock_claim_type_filter_with_initilizer) do
+      Class.new do
+        include Stats::ManagementInformation::ClaimTypeFilterable
+
+        def initialize(**kwargs)
+          @scheme = kwargs[:scheme]
+        end
+      end
+    end
+
+    describe '#scheme' do
+      subject { MockClaimTypeFilterWithInitializer.new(scheme: :foobar).scheme }
+
+      it { is_expected.to eql('FOOBAR') }
+    end
+
+    describe '#claim_type_filter' do
+      subject(:claim_type_filter) { instance.claim_type_filter }
+
+      context 'with LGFS scheme arg' do
+        let(:instance) { MockClaimTypeFilterWithInitializer.new(scheme: :lgfs) }
+
+        it 'returns LGFS claims types in statement' do
+          expect(claim_type_filter).to eql(lgfs_in_statement)
+        end
+      end
+
+      context 'with AGFS scheme arg' do
+        let(:instance) { MockClaimTypeFilterWithInitializer.new(scheme: :agfs) }
+
+        it 'returns AGFS claims types in statement' do
+          expect(claim_type_filter).to eql(agfs_in_statement)
+        end
+      end
+
+      context 'with nil scheme' do
+        let(:instance) { MockClaimTypeFilterWithInitializer.new }
+
+        it 'returns all claims types in statement' do
+          expect(claim_type_filter).to eql(all_in_statement)
+        end
+      end
+    end
+  end
+
+  describe 'MockAgfsClaimTypeFilter' do
+    before do
+      stub_const('MockAgfsClaimTypeFilter', mock_agfs_claim_type_filter)
+    end
+
+    let(:mock_agfs_claim_type_filter) do
+      Class.new do
+        include Stats::ManagementInformation::ClaimTypeFilterable
+
+        acts_as_scheme :agfs
+      end
+    end
+
+    let(:instance) { MockAgfsClaimTypeFilter.new }
+
+    describe '#scheme' do
+      subject { instance.scheme }
+
+      it { is_expected.to eql('AGFS') }
+    end
+
+    describe '#claim_type_filter' do
+      subject(:claim_type_filter) { instance.claim_type_filter }
+
+      it 'returns AGFS claim types in statement even when scheme set to :lgfs' do
+        instance.scheme = :lgfs
+        expect(claim_type_filter).to eql(agfs_in_statement)
+      end
+
+      it 'returns AGFS claim types in statement even when scheme set to nil' do
+        expect(claim_type_filter).to eql(agfs_in_statement)
+      end
+    end
+  end
+
+  describe 'MockLgfsClaimTypeFilter' do
+    before do
+      stub_const('MockLgfsClaimTypeFilter', mock_lgfs_claim_type_filter)
+    end
+
+    let(:mock_lgfs_claim_type_filter) do
+      Class.new do
+        include Stats::ManagementInformation::ClaimTypeFilterable
+
+        acts_as_scheme :lgfs
+      end
+    end
+
+    let(:instance) { MockLgfsClaimTypeFilter.new }
+
+    describe '#scheme' do
+      subject { instance.scheme }
+
+      it { is_expected.to eql('LGFS') }
+    end
+
+    describe '#claim_type_filter' do
+      subject(:claim_type_filter) { instance.claim_type_filter }
+
+      it 'returns LGFS claim types in statement even when scheme set to :agfs' do
+        instance.scheme = :agfs
+        expect(claim_type_filter).to eql(lgfs_in_statement)
+      end
+
+      it 'returns LGFS claim types in statement even when scheme set to nil' do
+        expect(claim_type_filter).to eql(lgfs_in_statement)
+      end
+    end
+  end
+end

--- a/spec/services/stats/management_information/lgfs/intake_final_fee_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/intake_final_fee_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::IntakeFinalFeeQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/lgfs/intake_fixed_fee_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/intake_fixed_fee_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::IntakeFixedFeeQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/lgfs/intake_interim_fee_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/intake_interim_fee_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::IntakeInterimFeeQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/lgfs/lf1_disk_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf1_disk_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::Lf1DiskQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) { create(:litigator_final_claim, :submitted, disk_evidence: true) }

--- a/spec/services/stats/management_information/lgfs/lf1_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf1_high_value_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::Lf1HighValueQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do

--- a/spec/services/stats/management_information/lgfs/lf2_disk_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf2_disk_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::Lf2DiskQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today

--- a/spec/services/stats/management_information/lgfs/lf2_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf2_high_value_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::Lf2HighValueQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today

--- a/spec/services/stats/management_information/lgfs/lf2_redetermination_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf2_redetermination_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::Lf2RedeterminationQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today

--- a/spec/services/stats/management_information/lgfs/written_reasons_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/written_reasons_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_base_count_query'
 
 RSpec.describe Stats::ManagementInformation::Lgfs::WrittenReasonsQuery do
-  it_behaves_like 'a base count query'
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [awaiting_written_reasons] today

--- a/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
+++ b/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
@@ -2,13 +2,19 @@
 
 require_relative 'shared_examples_for_journey_queryable'
 
-RSpec.shared_examples 'a base count query' do
-  it_behaves_like 'a claim journeys query' do
-    let(:instance) do
-      described_class.new(date_range: Time.zone.today..Time.zone.today,
-                          date_column_filter: :not_needed_for_test)
-    end
+RSpec.shared_examples 'a base count query' do |scheme|
+  let(:instance) do
+    described_class.new(date_range: Time.zone.today..Time.zone.today,
+                        date_column_filter: :not_needed_for_test)
   end
+
+  describe '#scheme' do
+    subject { instance.scheme }
+
+    it { is_expected.to eql(scheme) }
+  end
+
+  it_behaves_like 'a claim journeys query'
 
   describe '.call' do
     subject(:call) { described_class.call(kwargs) }


### PR DESCRIPTION
#### What
Ensure count queries have a scheme associated

#### Why
Without a `scheme` method with appropriate value the `journeys_query` will
query all journeys across AGFS and LGFS. This roughly doubles the number
of records requiring counting and can therefore significantly
increase query time.

#### How
I have amended the `claim_type_filterable` mixin to add a class
method `acts_as_scheme` which can be used over-ride the default
`scheme` method for any class including it. The overridden
`scheme` method will always return the value passed to
`acts_as_scheme` (but as up-cased string).
