### PR TITLE
Fix cloned website Canarytoken

### DIFF
--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -150,7 +150,7 @@ if (!String.prototype.supplant) {
     if (window.location.protocol === 'https:') {
       m.src = 'https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=' + encodeURI(l) + '&r=' + encodeURI(r)
     } else {
-      m.src = 'https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=' + encodeURI(l) + '&r=' + encodeURI(r)
+      m.src = 'http://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=' + encodeURI(l) + '&r=' + encodeURI(r)
     }
   }
 


### PR DESCRIPTION
#### What

Load non-ssl Canarytoken if the cloned site is non-ssl.

#### Ticket

N/A

#### Why

The Canarytoken should be loaded as non-ssl if the cloned site is non-ssl. This is how the original code should have been downloaded from https://canary.tools
