### PR TITLE
[CFP-347] Print formatting of claim tables

### DIFF
--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -49,7 +49,7 @@ tr {
 }
 
 .app-table--responsive {
-  @include govuk-media-query($until: desktop) {
+  @include govuk-media-query($until: desktop, $media-type: screen) {
     tr {
       display: block;
       margin-bottom: $gutter-one-third;


### PR DESCRIPTION
#### What

Mobile table styles should only apply to screen media types

#### Ticket

[Print formatting of claim tables](https://dsdmoj.atlassian.net/browse/CFP-347)

#### Why

Users were unhappy with the new table layout when printing.

#### Current print style

<img width="559" alt="table-print-mobile-vertical" src="https://user-images.githubusercontent.com/8057224/146514325-e1401d51-ed66-4288-9413-9a0af2edfbe2.png">

#### Updated print style

<img width="558" alt="table-print-desktop-horizontal" src="https://user-images.githubusercontent.com/8057224/146514362-22be3224-1bb2-4279-8290-ed5f910eb2aa.png">

