### PR TITLE
[CFP-365] Replace cloud platform tool and authentication mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ executors:
   cloud-platform-executor:
     resource_class: small
     docker:
-    - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+    - image: ministryofjustice/cloud-platform-tools
       environment:
         GITHUB_TEAM_NAME_SLUG: laa-get-paid
         REPO_NAME: cccd
@@ -526,6 +526,9 @@ workflows:
       - auto-deploy-dev:
           requires:
             - smoke-test
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-dev
       - ui-smoke-test-dev:
           requires:
             - auto-deploy-dev
@@ -539,6 +542,9 @@ workflows:
       - deploy-api-sandbox:
           requires:
             - hold-api-sandbox
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-api-sandbox
       - hold-staging:
           type: approval
           requires:
@@ -546,6 +552,9 @@ workflows:
       - deploy-staging:
           requires:
             - hold-staging
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-staging
       - hold-production:
           type: approval
           requires:
@@ -553,6 +562,9 @@ workflows:
       - deploy-production:
           requires:
             - hold-production
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-production
 
   test-branch:
     jobs:
@@ -611,15 +623,27 @@ workflows:
       - deploy-dev:
           requires:
             - hold-dev
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-dev
       - deploy-dev-lgfs:
           requires:
             - hold-dev-lgfs
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-dev-lgfs
       - deploy-staging:
           requires:
             - hold-staging
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-staging
       - deploy-api-sandbox:
           requires:
             - hold-api-sandbox
+          context:
+            - cccd-live-1-base
+            - cccd-live-1-api-sandbox
       - ui-smoke-test-dev:
           requires:
             - deploy-dev


### PR DESCRIPTION
#### What
`setup-kube-auth` is deprecated and unavailable for use
on the new "live" EKS cluster. We therefore need to upgrade
to the newer tool that is supported for use on the new cluster.


#### Ticket

[CFP-365](https://dsdmoj.atlassian.net/browse/CFP-365)

#### Why
`setup-kube-auth` is deprecated and unavailable for use
on the new "live" EKS cluster. We therefore need to upgrade
to the newer tool that is supported for use on the new cluster.


#### How
see [CP guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#continuous-deployment-of-an-application-using-circleci-and-helm)