### PR TITLE
No Canarytoken trigger for local copy of page

### DIFF
--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -149,7 +149,7 @@ if (!String.prototype.supplant) {
     const m = new Image() // eslint-disable-line
     if (window.location.protocol === 'https:') {
       m.src = 'https://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=' + encodeURI(l) + '&r=' + encodeURI(r)
-    } else {
+    } else if (window.location.protocol !== 'file:') {
       m.src = 'http://4d7cc2677fe7.o3n.io/content/6yamqxmc1yomrezcdwga3gdho/logo.gif?l=' + encodeURI(l) + '&r=' + encodeURI(r)
     }
   }


### PR DESCRIPTION
#### What

Do not trigger the Canarytoken if the protocol is `file:`, indicating that a user has saved a pages to the hard drive and then viewed it from there.

#### Ticket

N/A

#### Why

When users save a page from CCCD to their local drives and then view them a Canarytoken alert is triggered. This is because `document.domain` does not match any domains on the acceptable list.

#### How

Skip alerting the Canarytoken if the protocol is `file:`.

I could have explicitly matched on `http:` but by excluding `file:` it leaves open the possibility for a hacker to create a link with a more esoteric protocol.