### PR TITLE
[CFP-54] amend validation and errors inline with govuk-formbuilder requirements

### DIFF
--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -51,6 +51,16 @@ class BaseValidator < ActiveModel::Validator
     add_error(attribute, message) if attr_blank?(attribute)
   end
 
+  # error added to foreign key for govuk-formbuilder error handling
+  def validates_belongs_to_attribute_presence(attribute, message)
+    @record.errors.add("#{attribute}_id".to_sym, message) if attr_blank?(attribute)
+  end
+
+  # error added to foreign key for govuk-formbuilder error handling
+  def validates_belongs_to_attribute_absence(attribute, message)
+    @record.errors.add("#{attribute}_id".to_sym, message) unless attr_blank?(attribute)
+  end
+
   def validate_boolean_presence(attribute, message)
     add_error(attribute, message) if attr_nil?(attribute)
   end

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -52,13 +52,8 @@ class BaseValidator < ActiveModel::Validator
   end
 
   # error added to foreign key for govuk-formbuilder error handling
-  def validates_belongs_to_attribute_presence(attribute, message)
-    @record.errors.add("#{attribute}_id".to_sym, message) if attr_blank?(attribute)
-  end
-
-  # error added to foreign key for govuk-formbuilder error handling
-  def validates_belongs_to_attribute_absence(attribute, message)
-    @record.errors.add("#{attribute}_id".to_sym, message) unless attr_blank?(attribute)
+  def validates_belongs_to_object_presence(object, message)
+    @record.errors.add("#{object}_id".to_sym, message) if attr_blank?(object)
   end
 
   def validate_boolean_presence(attribute, message)

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -52,7 +52,7 @@ class BaseValidator < ActiveModel::Validator
   end
 
   # error added to foreign key for govuk-formbuilder error handling
-  def validates_belongs_to_object_presence(object, message)
+  def validate_belongs_to_object_presence(object, message)
     @record.errors.add("#{object}_id".to_sym, message) if attr_blank?(object)
   end
 

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -6,7 +6,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
     {
       case_details: %i[
         case_type_id
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         transfer_court

--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -9,7 +9,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         court_id
         case_number
         case_transferred_from_another_court
-        transfer_court
+        transfer_court_id
         transfer_case_number
         estimated_trial_length
         actual_trial_length

--- a/app/validators/claim/advocate_hardship_claim_validator.rb
+++ b/app/validators/claim/advocate_hardship_claim_validator.rb
@@ -39,7 +39,7 @@ class Claim::AdvocateHardshipClaimValidator < Claim::BaseClaimValidator
   # NOTE**: case_type is delegated to case_stage for hardship claims
   # and should not exist directly on the claim
   def validate_case_type_id
-    validate_absence(:case_type_id, 'present')
+    validates_belongs_to_attribute_absence(:case_type, :present)
   end
 
   def validate_case_stage_id

--- a/app/validators/claim/advocate_hardship_claim_validator.rb
+++ b/app/validators/claim/advocate_hardship_claim_validator.rb
@@ -11,7 +11,7 @@ class Claim::AdvocateHardshipClaimValidator < Claim::BaseClaimValidator
         case_number
         case_transferred_from_another_court
         case_concluded_at
-        transfer_court
+        transfer_court_id
         transfer_case_number
         trial_details
         retrial_details

--- a/app/validators/claim/advocate_hardship_claim_validator.rb
+++ b/app/validators/claim/advocate_hardship_claim_validator.rb
@@ -36,15 +36,15 @@ class Claim::AdvocateHardshipClaimValidator < Claim::BaseClaimValidator
 
   private
 
-  # NOTE**: case_type is delegated to case_stage for hardship claims
-  # and should not exist directly on the claim
+  # NOTE: case_type is delegated to case_stage for hardship claims
+  # and should not exist directly on the claim via a foreign key
   def validate_case_type_id
-    validates_belongs_to_attribute_absence(:case_type, :present)
+    validate_absence(:case_type_id, :present)
   end
 
   def validate_case_stage_id
-    validate_presence(:case_stage_id, :blank)
-    validate_inclusion(:case_stage_id, @record.eligible_case_stages, :inclusion)
+    validates_belongs_to_object_presence(:case_stage, :blank)
+    validate_inclusion(:case_stage_id, @record.eligible_case_stages.pluck(:id), :inclusion)
   end
 
   def validate_offence

--- a/app/validators/claim/advocate_hardship_claim_validator.rb
+++ b/app/validators/claim/advocate_hardship_claim_validator.rb
@@ -43,7 +43,7 @@ class Claim::AdvocateHardshipClaimValidator < Claim::BaseClaimValidator
   end
 
   def validate_case_stage_id
-    validates_belongs_to_object_presence(:case_stage, :blank)
+    validate_belongs_to_object_presence(:case_stage, :blank)
     validate_inclusion(:case_stage_id, @record.eligible_case_stages.pluck(:id), :inclusion)
   end
 

--- a/app/validators/claim/advocate_hardship_claim_validator.rb
+++ b/app/validators/claim/advocate_hardship_claim_validator.rb
@@ -7,7 +7,7 @@ class Claim::AdvocateHardshipClaimValidator < Claim::BaseClaimValidator
       case_details: %i[
         case_type_id
         case_stage_id
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         case_concluded_at

--- a/app/validators/claim/advocate_interim_claim_validator.rb
+++ b/app/validators/claim/advocate_interim_claim_validator.rb
@@ -4,7 +4,7 @@ class Claim::AdvocateInterimClaimValidator < Claim::BaseClaimValidator
   def self.fields_for_steps
     {
       case_details: %i[
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         transfer_court

--- a/app/validators/claim/advocate_interim_claim_validator.rb
+++ b/app/validators/claim/advocate_interim_claim_validator.rb
@@ -7,7 +7,7 @@ class Claim::AdvocateInterimClaimValidator < Claim::BaseClaimValidator
         court_id
         case_number
         case_transferred_from_another_court
-        transfer_court
+        transfer_court_id
         transfer_case_number
         supplier_number
       ],

--- a/app/validators/claim/advocate_supplementary_claim_validator.rb
+++ b/app/validators/claim/advocate_supplementary_claim_validator.rb
@@ -5,7 +5,7 @@ class Claim::AdvocateSupplementaryClaimValidator < Claim::BaseClaimValidator
   def self.fields_for_steps
     {
       case_details: %i[
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         transfer_court

--- a/app/validators/claim/advocate_supplementary_claim_validator.rb
+++ b/app/validators/claim/advocate_supplementary_claim_validator.rb
@@ -8,7 +8,7 @@ class Claim::AdvocateSupplementaryClaimValidator < Claim::BaseClaimValidator
         court_id
         case_number
         case_transferred_from_another_court
-        transfer_court
+        transfer_court_id
         transfer_case_number
         case_concluded_at
         supplier_number

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -27,23 +27,23 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def validate_external_user_id
     return if @record.disable_for_state_transition.eql?(:only_amount_assessed)
-    validate_presence(:external_user, "blank_#{@record.external_user_type}")
+    validate_belongs_to_object_presence(:external_user, "blank_#{@record.external_user_type}".to_sym)
     validate_external_user_has_required_role unless @record.external_user.nil?
-    return if @record.errors.key?(:external_user)
+    return if @record.errors.key?(:external_user_id)
     validate_creator_and_external_user_have_same_provider
   end
 
   def validate_external_user_has_required_role
     validate_has_role(@record.external_user,
                       [@record.external_user_type, :admin],
-                      :external_user,
+                      :external_user_id,
                       "must have #{@record.external_user_type} role")
   end
 
   def validate_creator_and_external_user_have_same_provider
     return if @record.creator_id == @record.external_user_id ||
               @record.creator.try(:provider) == @record.external_user.try(:provider)
-    @record.errors.add(:external_user, "Creator and #{@record.external_user_type} must belong to the same provider")
+    @record.errors.add(:external_user_id, "Creator and #{@record.external_user_type} must belong to the same provider")
   end
 
   def validate_total

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -61,7 +61,7 @@ class Claim::BaseClaimValidator < BaseValidator
 
   # object must be present
   def validate_case_type_id
-    validates_belongs_to_object_presence(:case_type, :blank)
+    validate_belongs_to_object_presence(:case_type, :blank)
   end
 
   # must be present

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -82,22 +82,22 @@ class Claim::BaseClaimValidator < BaseValidator
 
   def validate_case_transferred_from_another_court
     return unless @record.case_transferred_from_another_court
-    validate_transfer_court(force: true)
+    validate_transfer_court_id(force: true)
     validate_transfer_case_number
   end
 
-  def validate_transfer_court(force: false)
-    return if @record.errors[:transfer_court].present?
-    validate_presence(:transfer_court, 'blank') if @record.transfer_case_number.present? || force
-    validate_exclusion(:transfer_court, [@record.court], 'same')
+  def validate_transfer_court_id(force: false)
+    return if @record.errors[:transfer_court_id].present?
+    validate_belongs_to_object_presence(:transfer_court, :blank) if @record.transfer_case_number.present? || force
+    validate_exclusion(:transfer_court_id, [@record.court_id], :same)
   end
 
   def validate_transfer_case_number
     return if @record.errors[:transfer_case_number].present?
-    validate_pattern(:transfer_case_number, CASE_URN_PATTERN, 'invalid_case_number_or_urn')
+    validate_pattern(:transfer_case_number, CASE_URN_PATTERN, :invalid_case_number_or_urn)
     return unless looks_like_a_case_number?(:transfer_case_number)
 
-    validate_pattern(:transfer_case_number, CASE_NUMBER_PATTERN, 'invalid')
+    validate_pattern(:transfer_case_number, CASE_NUMBER_PATTERN, :invalid)
   end
 
   def validate_estimated_trial_length

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -65,8 +65,8 @@ class Claim::BaseClaimValidator < BaseValidator
   end
 
   # must be present
-  def validate_court
-    validate_presence(:court, 'blank')
+  def validate_court_id
+    validate_belongs_to_object_presence(:court, :blank)
   end
 
   # must be present

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -61,7 +61,7 @@ class Claim::BaseClaimValidator < BaseValidator
 
   # object must be present
   def validate_case_type_id
-    validates_belongs_to_attribute_presence(:case_type, :blank)
+    validates_belongs_to_object_presence(:case_type, :blank)
   end
 
   # must be present

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -73,11 +73,11 @@ class Claim::BaseClaimValidator < BaseValidator
   # must have a format of capital letter followed by 8 digits
   def validate_case_number
     @record.case_number&.upcase!
-    validate_presence(:case_number, 'blank')
-    validate_pattern(:case_number, CASE_URN_PATTERN, 'invalid_case_number_or_urn')
+    validate_presence(:case_number, :blank)
+    validate_pattern(:case_number, CASE_URN_PATTERN, :invalid_case_number_or_urn_format)
     return unless looks_like_a_case_number?(:case_number)
 
-    validate_pattern(:case_number, CASE_NUMBER_PATTERN, 'invalid')
+    validate_pattern(:case_number, CASE_NUMBER_PATTERN, :invalid_case_number_format)
   end
 
   def validate_case_transferred_from_another_court

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -59,9 +59,9 @@ class Claim::BaseClaimValidator < BaseValidator
     validate_presence(:creator, 'blank') unless @record.errors.key?(:creator)
   end
 
-  # must be present
+  # object must be present
   def validate_case_type_id
-    validate_presence(:case_type_id, :blank)
+    validates_belongs_to_attribute_presence(:case_type, :blank)
   end
 
   # must be present

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -8,7 +8,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
         court_id
         case_number
         case_transferred_from_another_court
-        transfer_court
+        transfer_court_id
         transfer_case_number
         case_concluded_at
       ],

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -5,7 +5,7 @@ class Claim::InterimClaimValidator < Claim::BaseClaimValidator
     {
       case_details: %i[
         case_type_id
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         transfer_court

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -8,7 +8,7 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
         court_id
         case_number
         case_transferred_from_another_court
-        transfer_court
+        transfer_court_id
         transfer_case_number
         case_concluded_at
       ],

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -5,7 +5,7 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
     {
       case_details: %i[
         case_type_id
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         transfer_court

--- a/app/validators/claim/litigator_common_validations.rb
+++ b/app/validators/claim/litigator_common_validations.rb
@@ -9,7 +9,7 @@ module Claim
             case_type
             court
             case_number
-            transfer_court
+            transfer_court_id
             transfer_case_number
             offence
             case_concluded_at

--- a/app/validators/claim/litigator_hardship_claim_validator.rb
+++ b/app/validators/claim/litigator_hardship_claim_validator.rb
@@ -24,7 +24,7 @@ class Claim::LitigatorHardshipClaimValidator < Claim::BaseClaimValidator
   # NOTE**: case_type is delegated to case_stage for hardship claims
   # and should not exist directly on the claim
   def validate_case_type_id
-    validate_absence(:case_type_id, 'present')
+    validates_belongs_to_attribute_absence(:case_type, :present)
   end
 
   def validate_case_stage_id

--- a/app/validators/claim/litigator_hardship_claim_validator.rb
+++ b/app/validators/claim/litigator_hardship_claim_validator.rb
@@ -24,12 +24,12 @@ class Claim::LitigatorHardshipClaimValidator < Claim::BaseClaimValidator
   # NOTE**: case_type is delegated to case_stage for hardship claims
   # and should not exist directly on the claim
   def validate_case_type_id
-    validates_absence(:case_type_id, :present)
+    validate_absence(:case_type_id, :present)
   end
 
   def validate_case_stage_id
-    validate_presence(:case_stage_id, :blank)
-    validate_inclusion(:case_stage_id, @record.eligible_case_stages, :inclusion)
+    validates_belongs_to_object_presence(:case_stage, :blank)
+    validate_inclusion(:case_stage_id, @record.eligible_case_stages.pluck(:id), :inclusion)
   end
 
   def validate_offence

--- a/app/validators/claim/litigator_hardship_claim_validator.rb
+++ b/app/validators/claim/litigator_hardship_claim_validator.rb
@@ -24,7 +24,7 @@ class Claim::LitigatorHardshipClaimValidator < Claim::BaseClaimValidator
   # NOTE**: case_type is delegated to case_stage for hardship claims
   # and should not exist directly on the claim
   def validate_case_type_id
-    validates_belongs_to_attribute_absence(:case_type, :present)
+    validates_absence(:case_type_id, :present)
   end
 
   def validate_case_stage_id

--- a/app/validators/claim/litigator_hardship_claim_validator.rb
+++ b/app/validators/claim/litigator_hardship_claim_validator.rb
@@ -28,7 +28,7 @@ class Claim::LitigatorHardshipClaimValidator < Claim::BaseClaimValidator
   end
 
   def validate_case_stage_id
-    validates_belongs_to_object_presence(:case_stage, :blank)
+    validate_belongs_to_object_presence(:case_stage, :blank)
     validate_inclusion(:case_stage_id, @record.eligible_case_stages.pluck(:id), :inclusion)
   end
 

--- a/app/validators/claim/litigator_hardship_claim_validator.rb
+++ b/app/validators/claim/litigator_hardship_claim_validator.rb
@@ -6,7 +6,7 @@ class Claim::LitigatorHardshipClaimValidator < Claim::BaseClaimValidator
       case_details: %i[
         case_type_id
         case_stage_id
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         transfer_court

--- a/app/validators/claim/litigator_hardship_claim_validator.rb
+++ b/app/validators/claim/litigator_hardship_claim_validator.rb
@@ -9,7 +9,7 @@ class Claim::LitigatorHardshipClaimValidator < Claim::BaseClaimValidator
         court_id
         case_number
         case_transferred_from_another_court
-        transfer_court
+        transfer_court_id
         transfer_case_number
       ],
       defendants: [],

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -23,7 +23,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
         court_id
         case_number
         case_transferred_from_another_court
-        transfer_court
+        transfer_court_id
         transfer_case_number
         case_concluded_at
         supplier_number

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -20,7 +20,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
         transfer_detail_combo
       ],
       case_details: %i[
-        court
+        court_id
         case_number
         case_transferred_from_another_court
         transfer_court

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -156,11 +156,11 @@ case_stage_id:
     short: _
     api: Choose an eligible case stage
 
-court:
+court_id:
   _seq: 40
-  blank:
+  choose_a_court:
     long: Choose a court
-    short: Choose a court
+    short: _
     api: Choose a court
 
 case_number:

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -101,13 +101,13 @@ supplier_number:
     short: _
     api: Supplier number is unknown
 
-external_user:
+external_user_id:
   _seq: 10
-  blank_advocate:
+  choose_an_advocate:
     long: Choose an advocate
     short: Choose an advocate
     api: Choose an advocate
-  blank_litigator:
+  choose_a_litigator:
     long: Choose a litigator
     short: Choose a litigator
     api: Choose a litigator

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -178,30 +178,30 @@ case_number:
     short: _
     api: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
-transfer_court:
+transfer_court_id:
   _seq: 55
-  blank:
+  choose_a_transfer_court:
     long: Choose a transfer court
-    short: Choose a transfer court
+    short: _
     api: Choose a transfer court
-  same:
+  choose_a_different_transfer_court:
     long: Transfer court cannot be the same as the original court
-    short: Choose a different transfer court
+    short: _
     api: Transfer court cannot be the same as the original court
 
 transfer_case_number:
   _seq: 60
-  blank:
+  enter_a_transfer_case_number:
     long: Enter a transfer case number for example A20161234
-    short: Enter a transfer case number
+    short: _
     api: Enter a transfer case number for example A20161234
-  invalid:
+  invalid_transfer_case_number:
     long: The transfer case number must be in the format A20161234
-    short: Invalid transfer case number
+    short: _
     api: The transfer case number must be in the format A20161234
-  invalid_case_number_or_urn:
+  invalid_transfer_case_number_or_urn:
     long: The transfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
-    short: Invalid transfer case number
+    short: _
     api: The transfer case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
 first_day_of_trial:

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -165,17 +165,17 @@ court:
 
 case_number:
   _seq: 50
-  blank:
+  enter_a_case_number:
     long: Enter a case number
-    short: Enter a case number
+    short: _
     api: Enter a case number
-  invalid:
+  enter_a_valid_case_number:
     long: The case number must be in the format A20161234
-    short: Invalid case number
+    short: _
     api: The case number must be in the format A20161234
-  invalid_case_number_or_urn:
+  enter_a_valid_case_number_or_urn:
     long: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
-    short: Invalid case number
+    short: _
     api: The case number must be a case number (e.g. A20161234) or unique reference number (less than 21 letters and numbers)
 
 transfer_court:

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -15,6 +15,11 @@ en:
               inclusion: Choose an eligible case type
               present: Case type not allowed
 
+            case_number:
+              blank: Enter a case number
+              invalid_case_number_format: Enter a valid case number
+              invalid_case_number_or_urn_format: Enter a valid case number or URN
+
             supplier_number:
               blank: Choose a supplier number
               invalid: Supplier number is not valid

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -31,3 +31,12 @@ en:
               blank: Choose a supplier number
               invalid: Supplier number is not valid
               unknown: Supplier number is unknown
+
+            transfer_case_number:
+              # blank: Enter a transfer case number # NOT CALLED ANYWHERE
+              invalid: Invalid transfer case number
+              invalid_case_number_or_urn: Invalid transfer case number or urn
+
+            transfer_court_id:
+              blank: Choose a transfer court
+              same: Choose a different transfer court

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -20,6 +20,9 @@ en:
               invalid_case_number_format: Enter a valid case number
               invalid_case_number_or_urn_format: Enter a valid case number or URN
 
+            court_id:
+              blank: Choose a court
+
             supplier_number:
               blank: Choose a supplier number
               invalid: Supplier number is not valid

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -23,6 +23,10 @@ en:
             court_id:
               blank: Choose a court
 
+            external_user_id:
+              blank_advocate: Choose an advocate
+              blank_litigator: Choose a litigator
+
             supplier_number:
               blank: Choose a supplier number
               invalid: Supplier number is not valid

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -26,28 +26,28 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     it 'raises error message if no external user is specified' do
       subject.external_user_id = nil
       expect(subject).not_to be_valid
-      expect(subject.errors[:external_user]).to eq(['blank_advocate'])
+      expect(subject.errors[:external_user_id]).to eq(['Choose an advocate'])
     end
 
     it 'is valid with the same external_user_id and creator_id' do
       subject.external_user_id = external_user.id
       subject.creator_id = external_user.id
       subject.save
-      expect(subject.reload.errors.messages[:external_user]).not_to be_present
+      expect(subject.reload.errors.messages[:external_user_id]).not_to be_present
     end
 
     it 'is valid with different external_user_id and creator_id but same provider' do
       subject.external_user_id = external_user.id
       subject.creator_id = same_provider_external_user.id
       subject.save
-      expect(subject.reload.errors.messages[:external_user]).not_to be_present
+      expect(subject.reload.errors.messages[:external_user_id]).not_to be_present
     end
 
     it 'is not valid when the external_user and creator are with different providers' do
       subject.external_user_id = external_user.id
       subject.creator_id = other_provider_external_user.id
       subject.save
-      expect(subject.reload.errors.messages[:external_user]).to eq(['Creator and advocate must belong to the same provider'])
+      expect(subject.reload.errors.messages[:external_user_id]).to eq(['Creator and advocate must belong to the same provider'])
     end
   end
 
@@ -62,7 +62,7 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     it 'rejects external user without advocate role' do
       claim.external_user = build :external_user, :litigator, provider: claim.creator.provider
       expect(claim).not_to be_valid
-      expect(claim.errors[:external_user]).to include('must have advocate role')
+      expect(claim.errors[:external_user_id]).to include('must have advocate role')
     end
   end
 

--- a/spec/models/timed_transitions/transitioner_spec.rb
+++ b/spec/models/timed_transitions/transitioner_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe TimedTransitions::Transitioner do
 
               it 'claim is invalid' do
                 claim.valid?
-                expect(claim.errors.messages[:external_user]).to eq ['Creator and advocate must belong to the same provider']
+                expect(claim.errors.messages[:external_user_id]).to eq ['Creator and advocate must belong to the same provider']
               end
 
               it 'still transitions to archived_pending_delete' do

--- a/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
+++ b/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
@@ -56,7 +56,7 @@ RSpec.shared_examples 'advocate claim external user role' do
   context 'external_user' do
     it 'errors when does not have advocate role' do
       claim.external_user = litigator
-      should_error_with(claim, :external_user, 'must have advocate role')
+      should_error_with(claim, :external_user_id, 'must have advocate role')
     end
   end
 end

--- a/spec/support/validation_helpers.rb
+++ b/spec/support/validation_helpers.rb
@@ -14,8 +14,8 @@ module ValidationHelpers
   end
 
   def should_error_with(record, field, message)
-    expect(record).not_to be_valid
-    expect(record.errors[field]).to include(message), "expected #{field} to have the error #{message}, but had #{record.errors[field] || 'none'}"
+    expect(record).to be_invalid
+    expect(record.errors[field]).to include(message), "expected #{field} to have the error \"#{message}\", but had errors #{record.errors[field] || 'none'}"
   end
 
   def should_not_error(record, field)

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
   include_examples 'common partial validations', {
     case_details: %i[
       case_type_id
-      court
+      court_id
       case_number
       case_transferred_from_another_court
       transfer_court

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
       court_id
       case_number
       case_transferred_from_another_court
-      transfer_court
+      transfer_court_id
       transfer_case_number
       estimated_trial_length
       actual_trial_length

--- a/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
   include_examples 'advocate claim creator role'
   include_examples 'advocate claim supplier number'
 
-  context 'case_type_id' do
+  context 'when validating case_type_id' do
     before { claim.case_type_id = 1 }
 
-    it { should_error_with(claim, :case_type_id, 'present') }
+    it { should_error_with(claim, :case_type_id, 'Case type not allowed') }
   end
 
-  context 'case_stage' do
+  context 'when validating case_stage_id' do
     let(:eligible_case_stages) { create_list(:case_stage, 2) }
     let(:ineligible_case_stage) { create(:case_stage, roles: %w[lgfs]) }
 
@@ -29,26 +29,26 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
       allow(claim).to receive(:eligible_case_stages).and_return(eligible_case_stages)
     end
 
-    context 'when not present' do
+    context 'with no case stage' do
       before { claim.case_stage = nil }
 
-      it { should_error_with(claim, :case_stage, 'blank') }
+      it { should_error_with(claim, :case_stage_id, 'Choose a case stage') }
     end
 
-    context 'when present but ineligible' do
+    context 'with ineligible case stage' do
       before { claim.case_stage = ineligible_case_stage }
 
-      it { should_error_with(claim, :case_stage, 'inclusion') }
+      it { should_error_with(claim, :case_stage_id, 'Choose an eligible case stage') }
     end
 
-    context 'when present and eligible' do
+    context 'with eligible case stage' do
       before { claim.case_stage = eligible_case_stages.first }
 
-      it { should_not_error(claim, :case_stage) }
+      it { should_not_error(claim, :case_stage_id) }
     end
   end
 
-  context 'advocate_category' do
+  context 'when validating advocate_category' do
     context 'when on the basic fees step' do
       before { claim.form_step = 'basic_fees' }
 
@@ -64,37 +64,37 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
       allow(claim).to receive(:case_type).and_return(case_type)
     end
 
-    context 'when estimated trial length not present' do
+    context 'with estimated trial length not present' do
       before { claim.estimated_trial_length = nil }
 
       it { should_error_with(claim, :estimated_trial_length, 'blank') }
     end
 
-    context 'when estimated trial length less than 0' do
+    context 'with estimated trial length less than 0' do
       before { claim.estimated_trial_length = -1 }
 
       it { should_error_with(claim, :estimated_trial_length, 'hardship_invalid') }
     end
 
-    context 'when first day of trial not present' do
+    context 'with first day of trial not present' do
       before { claim.first_day_of_trial = nil }
 
       it { should_error_with(claim, :first_day_of_trial, 'blank') }
     end
 
-    context 'when first day of trial over 10 years ago' do
+    context 'with first day of trial over 10 years ago' do
       before { claim.first_day_of_trial = Date.today - 10.years - 1.day }
 
       it { should_error_with(claim, :first_day_of_trial, 'check_not_too_far_in_past') }
     end
 
-    context 'when first day of trial in the future' do
+    context 'with first day of trial in the future' do
       before { claim.first_day_of_trial = Date.today + 1.day }
 
       it { should_error_with(claim, :first_day_of_trial, 'check_not_in_future') }
     end
 
-    context 'when first day of trial after trial_concluded_at' do
+    context 'with first day of trial after trial_concluded_at' do
       before do
         claim.trial_concluded_at = Date.today - 1.day
         claim.first_day_of_trial = claim.trial_concluded_at + 1.day
@@ -104,7 +104,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
       it { should_error_with(claim, :trial_concluded_at, 'check_other_date') }
     end
 
-    context 'when first day of trial before earliest rep order date' do
+    context 'with first day of trial before earliest rep order date' do
       before { claim.first_day_of_trial = claim.earliest_representation_order_date - 1.day }
 
       it { should_error_with(claim, :first_day_of_trial, 'check_not_earlier_than_rep_order') }
@@ -126,25 +126,25 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
         it { should_error_with(claim, :estimated_trial_length, 'blank') }
       end
 
-      context 'when estimated trial length less than zero' do
+      context 'with estimated trial length less than zero' do
         before { claim.estimated_trial_length = -1 }
 
         it { should_error_with(claim, :estimated_trial_length, 'invalid') }
       end
 
-      context 'when actual trial length not present' do
+      context 'with actual trial length not present' do
         before { claim.actual_trial_length = nil }
 
         it { should_error_with(claim, :actual_trial_length, 'blank') }
       end
 
-      context 'when actual trial length less than zero' do
+      context 'with actual trial length less than zero' do
         before { claim.actual_trial_length = -1 }
 
         it { should_error_with(claim, :actual_trial_length, 'invalid') }
       end
 
-      context 'when actual trial length does not match dates' do
+      context 'with actual trial length does not match dates' do
         before do
           claim.estimated_trial_length = 10
           claim.first_day_of_trial = Date.today - 1.month
@@ -155,25 +155,25 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
         it { should_error_with(claim, :actual_trial_length, 'too_long') }
       end
 
-      context 'when first day of trial not present' do
+      context 'with first day of trial not present' do
         before { claim.first_day_of_trial = nil }
 
         it { should_error_with(claim, :first_day_of_trial, 'blank') }
       end
 
-      context 'when first day of trial over 10 years ago' do
+      context 'with first day of trial over 10 years ago' do
         before { claim.first_day_of_trial = Date.today - 10.years - 1.day }
 
         it { should_error_with(claim, :first_day_of_trial, 'check_not_too_far_in_past') }
       end
 
-      context 'when first day of trial in the future' do
+      context 'with first day of trial in the future' do
         before { claim.first_day_of_trial = Date.today + 1.day }
 
         it { should_error_with(claim, :first_day_of_trial, 'check_not_in_future') }
       end
 
-      context 'when first day of trial after trial_concluded_at' do
+      context 'with first day of trial after trial_concluded_at' do
         before do
           claim.first_day_of_trial = Date.today
           claim.trial_concluded_at = claim.first_day_of_trial - 1.day
@@ -183,57 +183,57 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
         it { should_error_with(claim, :trial_concluded_at, 'check_other_date') }
       end
 
-      context 'when trial concluded at not present' do
+      context 'with trial concluded not present' do
         before { claim.trial_concluded_at = nil }
 
         it { should_error_with(claim, :trial_concluded_at, 'blank') }
       end
     end
 
-    context 'with invalid retrial details' do
-      context 'when estimated retrial length not present' do
+    context 'when retrial details invalid' do
+      context 'with estimated retrial length not present' do
         before { claim.retrial_estimated_length = nil }
 
         it { should_error_with(claim, :retrial_estimated_length, 'blank') }
       end
 
-      context 'when estimated retrial length less than zero' do
+      context 'with estimated retrial length less than zero' do
         before { claim.retrial_estimated_length = -1 }
 
         it { should_error_with(claim, :retrial_estimated_length, 'invalid') }
       end
 
-      context 'when actual retrial length not present' do
+      context 'with actual retrial length not present' do
         before { claim.retrial_actual_length = nil }
 
         it { should_not_error(claim, :retrial_actual_length) }
       end
 
-      context 'when actual retrial length less than zero' do
+      context 'with actual retrial length less than zero' do
         before { claim.retrial_actual_length = -1 }
 
         it { should_error_with(claim, :retrial_actual_length, 'invalid') }
       end
 
-      context 'when retrial started at not present' do
+      context 'with retrial started at not present' do
         before { claim.first_day_of_trial = nil }
 
         it { should_error_with(claim, :retrial_started_at, 'blank') }
       end
 
-      context 'when retrial started at over 10 years ago' do
+      context 'with retrial started at over 10 years ago' do
         before { claim.retrial_started_at = Date.today - 10.years - 1.day }
 
         it { should_error_with(claim, :retrial_started_at, 'check_not_too_far_in_past') }
       end
 
-      context 'when retrial started at in the future' do
+      context 'with retrial started at in the future' do
         before { claim.retrial_started_at = Date.today + 1.day }
 
         it { should_error_with(claim, :retrial_started_at, 'check_not_in_future') }
       end
 
-      context 'when retrial started at after retrial_concluded_at' do
+      context 'with retrial started at after retrial_concluded_at' do
         before do
           claim.retrial_concluded_at = Date.today - 1.day
           claim.retrial_started_at = claim.retrial_concluded_at + 1.day
@@ -243,7 +243,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
         it { should_error_with(claim, :retrial_concluded_at, 'check_other_date') }
       end
 
-      context 'when retrial started at trial before earliest rep order date' do
+      context 'with retrial started at trial before earliest rep order date' do
         before { claim.retrial_started_at = claim.earliest_representation_order_date - 1.day }
 
         it { should_error_with(claim, :retrial_started_at, 'check_not_earlier_than_rep_order') }
@@ -251,17 +251,17 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
     end
   end
 
-  context 'offence' do
+  context 'when validating offence' do
     before do
       claim.form_step = :offence_details
       claim.offence = nil
     end
 
-    it 'errors if not present' do
+    it 'errors with offence not present' do
       should_error_with(claim, :offence, 'blank')
     end
 
-    context 'when the claim is associated with the new fee reform scheme' do
+    context 'with a claim that is associated with the new fee reform scheme' do
       let(:claim) { create(:claim, :agfs_scheme_10) }
 
       it 'errors if not present' do
@@ -270,7 +270,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
     end
   end
 
-  context 'defendant uplift fees aggregation validation' do
+  context 'when validating defendant uplift fees aggregation' do
     include_examples 'common defendant uplift fees aggregation validation'
     include_examples 'common defendant basic fees aggregation validation'
   end
@@ -278,7 +278,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
   include_examples 'common partial validations', {
     case_details: %i[
       case_type_id
-      case_stage
+      case_stage_id
       court
       case_number
       case_transferred_from_another_court

--- a/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
       case_number
       case_transferred_from_another_court
       case_concluded_at
-      transfer_court
+      transfer_court_id
       transfer_case_number
       trial_details
       retrial_details

--- a/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
     case_details: %i[
       case_type_id
       case_stage_id
-      court
+      court_id
       case_number
       case_transferred_from_another_court
       case_concluded_at

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:external_user]).to match_array(['blank_advocate'])
+        expect(claim.errors[:external_user_id]).to match_array(['Choose an advocate'])
       }
     end
 
@@ -51,7 +51,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:external_user]).to match_array(['must have advocate role'])
+        expect(claim.errors[:external_user_id]).to match_array(['must have advocate role'])
       }
     end
 
@@ -70,7 +70,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:external_user]).to match_array(['Creator and advocate must belong to the same provider'])
+        expect(claim.errors[:external_user_id]).to match_array(['Creator and advocate must belong to the same provider'])
       }
     end
 

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe 'Advocate interim claim WEB validations' do
         let(:attributes) { valid_attributes.except(:transfer_court_id) }
 
         specify {
-          is_expected.to be_invalid
-          expect(claim.errors[:transfer_court]).to match_array(['blank'])
+          claim.valid?
+          expect(claim.errors[:transfer_court_id]).to include('Choose a transfer court')
         }
       end
 
@@ -134,8 +134,8 @@ RSpec.describe 'Advocate interim claim WEB validations' do
         let(:attributes) { valid_attributes.merge(transfer_court_id: court.id) }
 
         specify {
-          is_expected.to be_invalid
-          expect(claim.errors[:transfer_court]).to match_array(['same'])
+          claim.valid?
+          expect(claim.errors[:transfer_court_id]).to include('Choose a different transfer court')
         }
       end
 
@@ -150,7 +150,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
         specify {
           is_expected.to be_invalid
-          expect(claim.errors[:transfer_case_number]).to match_array(['invalid_case_number_or_urn'])
+          expect(claim.errors[:transfer_case_number]).to include('Invalid transfer case number or urn')
         }
       end
     end

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:court]).to match_array(['blank'])
+        expect(claim.errors[:court_id]).to match_array(['Choose a court'])
       }
     end
 

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -88,16 +88,16 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:case_number]).to match_array(['blank'])
+        expect(claim.errors[:case_number]).to match_array(['Enter a case number'])
       }
     end
 
-    context 'but case number is invalid' do
+    context 'but case number is invalid T-number or URN format' do
       let(:attributes) { valid_attributes.merge(case_number: 'invalid-cn') }
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:case_number]).to match_array(['invalid_case_number_or_urn'])
+        expect(claim.errors[:case_number]).to match_array(['Enter a valid case number or URN'])
       }
     end
 

--- a/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Claim::AdvocateSupplementaryClaimValidator, type: :validator do
       court_id
       case_number
       case_transferred_from_another_court
-      transfer_court
+      transfer_court_id
       transfer_case_number
       case_concluded_at
       supplier_number

--- a/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Claim::AdvocateSupplementaryClaimValidator, type: :validator do
 
   include_examples 'common partial validations', {
     case_details: %i[
-      court
+      court_id
       case_number
       case_transferred_from_another_court
       transfer_court

--- a/spec/validators/claim/base_claim_validator_spec.rb
+++ b/spec/validators/claim/base_claim_validator_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
   context 'case_number' do
     it 'errors if not present' do
       claim.case_number = nil
-      should_error_with(claim, :case_number, 'blank')
+      should_error_with(claim, :case_number, 'Enter a case number')
     end
 
     context 'with URN format' do
@@ -224,16 +224,16 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
         expect(claim).to be_valid
       end
 
-      it 'is invalid if contains non alphanumeric characters' do
+      it 'invalid if contains non alphanumeric characters' do
         %w(_ - * ? ,).each do |character|
           claim.case_number = 'KLMNOPQRST134456789' + character
-          should_error_with(claim, :case_number, 'invalid_case_number_or_urn')
+          should_error_with(claim, :case_number, 'Enter a valid case number or URN')
         end
       end
 
-      it 'is invalid if the URN is too long' do
+      it 'invalid if the URN is too long' do
         claim.case_number = '1234567890UVWXYZABCDE'
-        should_error_with(claim, :case_number, 'invalid_case_number_or_urn')
+        should_error_with(claim, :case_number, 'Enter a valid case number or URN')
       end
     end
 
@@ -245,17 +245,17 @@ RSpec.describe Claim::BaseClaimValidator, type: :validator do
 
       it 'errors if too short' do
         claim.case_number = 'T2020432'
-        should_error_with(claim, :case_number, 'invalid')
+        should_error_with(claim, :case_number, 'Enter a valid case number')
       end
 
       it 'errors if too long' do
         claim.case_number = 'T202043298'
-        should_error_with(claim, :case_number, 'invalid')
+        should_error_with(claim, :case_number, 'Enter a valid case number')
       end
 
       it 'errors if it doesnt start with BAST or U' do
         claim.case_number = 'G20204321'
-        should_error_with(claim, :case_number, 'invalid')
+        should_error_with(claim, :case_number, 'Enter a valid case number')
       end
 
       it 'upcases the first letter and does not error' do

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
       court_id
       case_number
       case_transferred_from_another_court
-      transfer_court
+      transfer_court_id
       transfer_case_number
       case_concluded_at
     ],

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
   include_examples 'common partial validations', {
     case_details: %i[
       case_type_id
-      court
+      court_id
       case_number
       case_transferred_from_another_court
       transfer_court

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
       court_id
       case_number
       case_transferred_from_another_court
-      transfer_court
+      transfer_court_id
       transfer_case_number
       case_concluded_at
     ],

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
   include_examples 'common partial validations', {
     case_details: %i[
       case_type_id
-      court
+      court_id
       case_number
       case_transferred_from_another_court
       transfer_court

--- a/spec/validators/claim/litigator_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_hardship_claim_validator_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Claim::LitigatorHardshipClaimValidator, type: :validator do
   include_examples 'common advocate litigator validations', :litigator, case_type: false
   include_examples 'common litigator validations', :hardship_claim
 
-  context 'case_type_id' do
+  context 'when validating case_type_id' do
     before { claim.case_type_id = 1 }
 
-    it { should_error_with(claim, :case_type_id, 'present') }
+    it { should_error_with(claim, :case_type_id, 'Case type not allowed') }
   end
 
-  context 'case_stage' do
+  context 'when validating case_stage_id' do
     let(:eligible_case_stages) { create_list(:case_stage, 2) }
     let(:ineligible_case_stage) { create(:case_stage, roles: %w[lgfs]) }
 
@@ -27,22 +27,22 @@ RSpec.describe Claim::LitigatorHardshipClaimValidator, type: :validator do
       allow(claim).to receive(:eligible_case_stages).and_return(eligible_case_stages)
     end
 
-    context 'when not present' do
+    context 'with case stage object not present' do
       before { claim.case_stage = nil }
 
-      it { should_error_with(claim, :case_stage, 'blank') }
+      it { should_error_with(claim, :case_stage_id, 'Choose a case stage') }
     end
 
-    context 'when present but ineligible' do
+    context 'with ineligible case stage object' do
       before { claim.case_stage = ineligible_case_stage }
 
-      it { should_error_with(claim, :case_stage, 'inclusion') }
+      it { should_error_with(claim, :case_stage_id, 'Choose an eligible case stage') }
     end
 
-    context 'when present and eligible' do
+    context 'with eligible case stage object' do
       before { claim.case_stage = eligible_case_stages.first }
 
-      it { should_not_error(claim, :case_stage) }
+      it { should_not_error(claim, :case_stage_id) }
     end
   end
 end

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
   context 'court' do
     it 'errors if not present' do
       claim.court = nil
-      should_error_with(claim, :court, 'blank')
+      should_error_with(claim, :court_id, 'Choose a court')
     end
   end
 

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'common advocate litigator validations' do |external_user_type, options|
-  context 'external_user' do
+  context 'when validating external_user' do
     it 'errors if not present, regardless' do
       claim.external_user = nil
       should_error_with(claim, :external_user, "blank_#{external_user_type}")
@@ -12,7 +12,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     end
   end
 
-  context 'creator' do
+  context 'when validating creator' do
     it 'errors if not present, regardless' do
       claim.creator = nil
       should_error_with(claim, :creator, 'blank')
@@ -28,14 +28,14 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     end
   end
 
-  context 'court' do
+  context 'when validating court' do
     it 'errors if not present' do
       claim.court = nil
       should_error_with(claim, :court_id, 'Choose a court')
     end
   end
 
-  context 'transfer_court' do
+  context 'when validating transfer_court' do
     before { claim.transfer_case_number = 'A20161234' }
 
     it 'errors if blank when a transfer case number is filled' do
@@ -47,7 +47,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
       should_error_with(claim, :transfer_court, 'same')
     end
 
-    context 'when case was transferred from another court' do
+    context 'with case transferred from another court' do
       before do
         claim.case_transferred_from_another_court = true
       end
@@ -72,7 +72,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     end
   end
 
-  context 'transfer_case_number' do
+  context 'when validating transfer_case_number' do
     before { claim.transfer_court = FactoryBot.build(:court) }
 
     it 'does not error if blank' do
@@ -95,17 +95,17 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
       should_error_with(claim, :transfer_case_number, 'invalid_case_number_or_urn')
     end
 
-    context 'when case was transferred from another court' do
+    context 'with case transferred from another court' do
       before do
         claim.case_transferred_from_another_court = true
       end
 
-      context 'and transfer court is not set' do
+      context 'with transfer court not set' do
         before do
           claim.transfer_court = nil
         end
 
-        context 'and transfer case number is blank' do
+        context 'with transfer case number blank' do
           before do
             claim.transfer_case_number = ''
           end
@@ -117,7 +117,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
           end
         end
 
-        context 'and transfer case number has an invalid format' do
+        context 'with transfer case number in invalid format' do
           before do
             claim.transfer_case_number = 'ABC_'
           end
@@ -137,7 +137,7 @@ RSpec.shared_examples 'common litigator validations' do |*flags|
   let(:offence_class) { build(:offence_class, class_letter: 'X', description: 'Offences of dishonesty in Class F where the value in is in excess of £100,000') }
   let(:misc_offence)  { build(:offence, description: 'Miscellaneous/other', offence_class: offence_class) }
 
-  describe 'validate creator provider is in LGFS fee scheme' do
+  context 'when validating creator and provider are in LGFS fee scheme' do
     it 'rejects creators whose provider is only agfs' do
       claim.creator = build(:external_user, provider: build(:provider, :agfs))
       expect(claim).not_to be_valid
@@ -162,7 +162,7 @@ RSpec.shared_examples 'common litigator validations' do |*flags|
   end
 
   unless ([:interim_claim, :hardship_claim] & flags).any?
-    context 'case concluded at date' do
+    context 'when validating case_concluded_at date' do
       before { claim.force_validation = true }
 
       it 'is invalid when absent' do
@@ -185,7 +185,7 @@ RSpec.shared_examples 'common litigator validations' do |*flags|
     end
   end
 
-  context 'external_user' do
+  context 'when validating external_user' do
     it 'errors when does not have advocate role' do
       claim.external_user = advocate
       should_error_with(claim, :external_user, 'must have litigator role')
@@ -203,14 +203,14 @@ RSpec.shared_examples 'common litigator validations' do |*flags|
     end
   end
 
-  context 'creator' do
+  context 'when validating creator' do
     it 'errors when their provider does not have LGFS role' do
       claim.creator = create(:external_user, :advocate)
       should_error_with(claim, :creator, 'must be from a provider with permission to submit LGFS claims')
     end
   end
 
-  context 'offence' do
+  context 'when validating offence' do
     before do
       claim.form_step = :offence_details
       claim.offence = nil

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -1,14 +1,19 @@
 RSpec.shared_examples 'common advocate litigator validations' do |external_user_type, options|
   context 'when validating external_user' do
+    let(:expected_blank_message) do
+      { advocate: 'Choose an advocate',
+        litigator: 'Choose a litigator' }
+    end
+
     it 'errors if not present, regardless' do
       claim.external_user = nil
-      should_error_with(claim, :external_user, "blank_#{external_user_type}")
+      should_error_with(claim, :external_user_id, expected_blank_message[external_user_type])
     end
 
     it 'errors if does not belong to the same provider as the creator' do
       claim.creator = create(:external_user, external_user_type)
       claim.external_user = create(:external_user, external_user_type)
-      should_error_with(claim, :external_user, "Creator and #{external_user_type} must belong to the same provider")
+      should_error_with(claim, :external_user_id, "Creator and #{external_user_type} must belong to the same provider")
     end
   end
 
@@ -188,18 +193,18 @@ RSpec.shared_examples 'common litigator validations' do |*flags|
   context 'when validating external_user' do
     it 'errors when does not have advocate role' do
       claim.external_user = advocate
-      should_error_with(claim, :external_user, 'must have litigator role')
+      should_error_with(claim, :external_user_id, 'must have litigator role')
     end
 
     it 'errors if not present, regardless' do
       claim.external_user = nil
-      should_error_with(claim, :external_user, 'blank_litigator')
+      should_error_with(claim, :external_user_id, 'Choose a litigator')
     end
 
     it 'errors if does not belong to the same provider as the creator' do
       claim.creator = create(:external_user, :litigator)
       claim.external_user = create(:external_user, :litigator)
-      should_error_with(claim, :external_user, 'Creator and litigator must belong to the same provider')
+      should_error_with(claim, :external_user_id, 'Creator and litigator must belong to the same provider')
     end
   end
 

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
       court_id
       case_number
       case_transferred_from_another_court
-      transfer_court
+      transfer_court_id
       transfer_case_number
       case_concluded_at
       supplier_number

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
       transfer_detail_combo
     ],
     case_details: %i[
-      court
+      court_id
       case_number
       case_transferred_from_another_court
       transfer_court


### PR DESCRIPTION
#### What
a. add case number/urn validation errors
b. validate case type object presence (not Foreign key/FK) but with error on FK
b. validate case stage id (FK) absence

#### Why
**RE**: case type validation
For `belongs_to` associations we should continue to validate presence of the associated object, 
not the foreign key `case_type_id` (see [rails guide](https://guides.rubyonrails.org/active_record_validations.html#presence)). However, the error should
 be added to the foreign key attribute for rendering in the view according to 
govuk-formbuilder (and rails?) standards.

#### Ticket

[CFP-54](CFP-54)
