### PR TITLE
Fix provider_delegator nil error on case_details page

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -499,7 +499,7 @@ module Claim
           "calculating VAT for #{id}"
         end
       end
-      provider_delegator.vat_registered?
+      provider_delegator&.vat_registered?
     end
 
     def trial_length

--- a/spec/models/claim/base_claim_spec.rb
+++ b/spec/models/claim/base_claim_spec.rb
@@ -772,10 +772,9 @@ RSpec.describe MockBaseClaim do
     subject(:registered) { claim.vat_registered? }
 
     let(:claim) { described_class.new }
-    let(:mock_provider_delegator) { provider_delegator }
 
     before do
-      allow(claim).to receive(:provider_delegator).and_return(mock_provider_delegator)
+      allow(claim).to receive(:provider_delegator).and_return(provider_delegator)
       allow(LogStuff).to receive(:error)
     end
 
@@ -788,17 +787,19 @@ RSpec.describe MockBaseClaim do
       end
     end
 
-    context 'when the provider is nil' do
-      # this should never happen but the logger is implemented to trace errors in live
+    # Can happen for a chambers provider with more than one external_user
+    # and creator does not select an external_user on case_details page
+    # for a "final" claim case_type (e.g. Trial)
+    context 'when the provider_delegator is nil' do
       let(:provider_delegator) { nil }
 
       it 'logs error' do
-        expect { registered }.to raise_error NoMethodError # spy on, call and swallow error
+        registered
         expect(LogStuff).to have_received(:error).once
       end
 
-      it 'raises error' do
-        expect { registered }.to raise_error NoMethodError
+      it 'does not raise error' do
+        expect { registered }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
#### What
Fix provider_delegator nil error on case details page

#### Why
Long standing bug that causes a 500 error on production environments 
in certain scenarios:

To replicate:
  1. login as a provider that is a chamber with more than one user
  2. start a advocate final claim (others too)
  3. on case details page select a case type for a final/graduated fee
     ,such as a "Trial"
  4. hit "Save and continue" --> 500 error (NoMethod error)

This is because:
  1. Having more than one user in a provider means the case details page requires you to select an external user ("Choose an advocate").
  2. By selecting a case type that is "final/graduated" fee the base_claim model will instantiate basic fees. The saving process (before_validation) will attempt to set the `apply_vat` flag on the claim which will, in turn, atttempt to determine whether the external user associated with the claim is vat_registered or not.
  3. Since the user has not selected an external user yet this causes a `nil` `provider_delegator` to receive the message `vat_registered?`, raising the NoMethod error thereby cuasing a 500.

IMPORTANT: need to check impact on VAT setting. Specifically
if the user does not provider an external user AND does provide
a final/gradfee case type and submit THEN does it set the `apply_vat`
flag on the claim permanently (or is it updated when they then correct
the submission by select an external user)

#### How
Add safe navigator on provider_delegator. This means vat_registered will default to `nil/false` if the
claim creator does not select an external user for the claim. Need to check that once they select the user it updates this to use the external_users `vat_registered?` status
