### PR TITLE
Silence Assets warning

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -67,6 +67,18 @@ module.exports = function (api) {
         {
           async: false
         }
+      ],
+      [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true
+        }
+      ],
+      [
+        '@babel/plugin-proposal-private-property-in-object',
+        {
+          loose: true
+        }
       ]
     ].filter(Boolean)
   }

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,8 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
+environment.config.merge({
+  stats: 'errors-only'
+})
+
 module.exports = environment.toWebpackConfig()

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -2,4 +2,8 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
 
+environment.config.merge({
+  stats: 'errors-only'
+})
+
 module.exports = environment.toWebpackConfig()

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node-forge": "^0.10.0",
     "normalize-url": "^4.5.1",
     "nth-check": "^2.0.1",
+    "sass": "~1.32.12",
     "set-value": "^4.0.1",
     "ssri": "^8.0.1",
     "webpack": "^4.44.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7677,10 +7677,10 @@ sass-loader@10.1.1:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@^1.38.0:
-  version "1.38.1"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.38.1.tgz#54dfb17fb168846b5850324b82fc62dc68f51bad"
-  integrity sha512-Lj8nPaSYOuRhgqdyShV50fY5jKnvaRmikUNalMPmbH+tKMGgEKVkltI/lP30PEfO2T1t6R9yc2QIBLgOc3uaFw==
+sass@^1.38.0, sass@~1.32.12:
+  version "1.32.13"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
+  integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
#### What

Ammend build tool to silence the majority warning surrounding our assests.

#### How

Amend babel config to silence babel warnings `Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for...`

Selectively bump sass dependency to silence Dart Sass warning `DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0`

Amend webpack stats config to only display errors on `prod` and `test` environments
