### PR TITLE
Add our github team as default dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
   reviewers:
   - "naseberry"
   - "imtiazAhmd"
+  - "ministryofjustice/laa-claim-for-payment"
 - package-ecosystem: bundler
   directory: "/"
   schedule:
@@ -25,3 +26,4 @@ updates:
   reviewers:
   - "jsugarman"
   - "jrmhaig"
+  - "ministryofjustice/laa-claim-for-payment"


### PR DESCRIPTION
#### What
Created a new github team for CFP and add as default reviewer

#### Why
Makes it clear who can review and provides
a separate team to provide access rights too
if needed.