### PR TITLE
[CFP-348] Persist 100% traffic to live cluster cccd-production

### DIFF
--- a/.k8s/live-1/production/ingress.yaml
+++ b/.k8s/live-1/production/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-production-blue
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
   name: cccd-app-ingress
   namespace: cccd-production
 spec:

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-production-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
   name: cccd-app-ingress
   namespace: cccd-production
 spec:


### PR DESCRIPTION
#### What
Persist 100% traffic to live cluster cccd-production

#### Why
100% traffic already directed to live cluster. This is to keep it 
that way.

#### Ticket

[CFP-348](https://dsdmoj.atlassian.net/browse/CFP-348)
