### PR TITLE
[CFP-348] prevent deploy to live-1 cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -480,13 +480,6 @@ jobs:
           cluster: live
           environment: api-sandbox
 
-  deploy-live-1-production:
-    executor: cloud-platform-executor
-    steps:
-      - deploy-to:
-          cluster: live-1
-          environment: production
-
   deploy-live-production:
     executor: cloud-platform-executor
     steps:
@@ -575,12 +568,6 @@ workflows:
           type: approval
           requires:
             - ui-smoke-test-dev
-      - deploy-live-1-production:
-          requires:
-            - hold-production
-          context:
-            - cccd-live-1-base
-            - cccd-live-1-production
       - deploy-live-production:
           requires:
             - hold-production

--- a/.k8s/live-1/production/deployment-worker.yaml
+++ b/.k8s/live-1/production/deployment-worker.yaml
@@ -4,7 +4,7 @@ metadata:
   name: claim-for-crown-court-defence-worker
   namespace: cccd-production
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/.k8s/live-1/production/deployment.yaml
+++ b/.k8s/live-1/production/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: claim-for-crown-court-defence
   namespace: cccd-production
 spec:
-  replicas: 4
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
#### What
Persist the reducing of pods to zero replicas

- Reduce app/worker pod live-1 replicas to 0
- Prevent deploy to live-1 cluster cccd-production

#### Ticket

[CFP-348](https://dsdmoj.atlassian.net/browse/CFP-348)

#### Why
prevent replicas and cronjobs being spun up on
the live-1 cluster
