### PR TITLE
[CFP-54] Model workaround for govuk_uk_date_field multiparameter assignment errors

### DIFF
--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -1,4 +1,5 @@
 class ExternalUsers::CertificationsController < ExternalUsers::ApplicationController
+  # prepend_before_action :validate_and_amend_multi_parameter_dates
   before_action :set_claim, only: %i[new create update]
   before_action :redirect_already_certified, only: %i[new create]
   before_action :redirect_if_not_valid, only: %i[new create]
@@ -53,6 +54,15 @@ class ExternalUsers::CertificationsController < ExternalUsers::ApplicationContro
     @certification.certified_by = current_user.name
     @certification.certification_date = Date.today
   end
+
+  # def validate_and_amend_multi_parameter_dates
+  #   return unless params[:certification]
+
+  #   model_params = params[:certification]
+  #   model_params['certification_date(3i)'] = '' if model_params['certification_date(3i)'].to_i > 31
+  #   model_params['certification_date(2i)'] = '' if model_params['certification_date(2i)'].to_i > 12
+  #   model_params['certification_date(1i)'] = '' if model_params['certification_date(1i)'].to_i < 1900
+  # end
 
   def certification_params
     params.require(:certification).permit(

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -12,7 +12,10 @@
 #
 
 class Certification < ApplicationRecord
+  include MultiparameterAttributeCleanable
+
   auto_strip_attributes :certified_by, squish: true, nullify: true
+  clean_multiparameter_date_attributes :certification_date
 
   belongs_to :claim, class_name: 'Claim::BaseClaim'
   belongs_to :certification_type

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -7,10 +7,19 @@ module Claim
 
   class BaseClaim < ApplicationRecord
     include SoftlyDeletable
+    include MultiparameterAttributeCleanable
 
     self.table_name = 'claims'
 
     auto_strip_attributes :case_number, :cms_number, :supplier_number, squish: true, nullify: true
+    clean_multiparameter_date_attributes :first_day_of_trial,
+                                         :trial_concluded_at,
+                                         :retrial_started_at,
+                                         :retrial_concluded_at,
+                                         :trial_fixed_notice_at,
+                                         :trial_fixed_at,
+                                         :trial_cracked_at,
+                                         :case_concluded_at
 
     serialize :evidence_checklist_ids, Array
 

--- a/app/models/concerns/multiparameter_attribute_cleanable.rb
+++ b/app/models/concerns/multiparameter_attribute_cleanable.rb
@@ -1,0 +1,41 @@
+module MultiparameterAttributeCleanable
+  extend ActiveSupport::Concern
+
+  included do
+    def clean_multiparameter_dates(new_attributes, attribute_names)
+      return unless new_attributes
+
+      attribute_names.map(&:to_s).each do |attribute_name|
+        parse_and_clean_date_attributes(new_attributes, attribute_name)
+      end
+    end
+
+    # TODO: ??? could extend to add errors to the model object
+    # possible example: https://github.com/errriclee/validates_multiparameter_assignments/blob/master/lib/validates_multiparameter_assignments.rb
+    #
+    def parse_and_clean_date_attributes(new_attributes, attribute_name)
+      date_parts = date_parts(new_attributes, attribute_name)
+      return if date_parts.all?(&:blank?)
+
+      Time.zone.local(*date_parts.map(&:to_i))
+    rescue ArgumentError
+      new_attributes["#{attribute_name}(2i)"] = '' unless (1..12).cover?(new_attributes["#{attribute_name}(2i)"].to_i)
+      new_attributes["#{attribute_name}(3i)"] = '' unless (1..31).cover?(new_attributes["#{attribute_name}(3i)"].to_i)
+    end
+
+    def date_parts(attributes, attribute_name)
+      [attributes["#{attribute_name}(1i)"],
+       attributes["#{attribute_name}(2i)"],
+       attributes["#{attribute_name}(3i)"]]
+    end
+  end
+
+  class_methods do
+    def clean_multiparameter_date_attributes(*date_attribute_names)
+      define_method(:assign_attributes) do |new_attributes|
+        clean_multiparameter_dates(new_attributes, date_attribute_names)
+        super(new_attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Handle `ActiveRecord::MultiparameterAssignmentErrors` for date
fields when supplying args such as 32/01/2021 or A/01/2021 or
1/13/2021.

This overrides `assign_attributes` for any model that implements
`clean_multiparameter_date_attributes :my_date_attribute` to
clean any date parts.

Applies this to `certification_date` which already errors in production
plus all case_details form related date fields, I believe.


#### Ticket

[CFP-54](https://dsdmoj.atlassian.net/browse/CFP-54)

#### Why
Currently entering invalid args such as 32/01/2021 or A/01/2021 or
1/13/2021 results in 500 errors.
