### PR TITLE
[CFP-54] Controller workaround for govuk_uk_date_field multiparameter assignment errors

### DIFF
--- a/app/controllers/concerns/multiparameter_attribute_cleaner.rb
+++ b/app/controllers/concerns/multiparameter_attribute_cleaner.rb
@@ -27,10 +27,18 @@ module MultiparameterAttributeCleaner
       if v.respond_to?(:each_pair)
         find_and_clean_dates(v)
       elsif k.to_s.include?('(3i)')
-        parameters[k] = '' unless (1..31).cover?(v.to_i)
+        parameters[k] = '' unless valid_day_param?(v)
       elsif k.to_s.include?('(2i)')
-        parameters[k] = '' unless (1..12).cover?(v.to_i)
+        parameters[k] = '' unless valid_month_param?(v)
       end
     end
+  end
+
+  def valid_day_param?(val)
+    val.blank? || (1..31).cover?(val.to_i)
+  end
+
+  def valid_month_param?(val)
+    val.blank? || (1..12).cover?(val.to_i)
   end
 end

--- a/app/controllers/concerns/multiparameter_attribute_cleaner.rb
+++ b/app/controllers/concerns/multiparameter_attribute_cleaner.rb
@@ -1,0 +1,36 @@
+# Mixin for parsing govuk_date_fields parameters prior to handling by
+# rails.
+#
+# The govuk_date_fields helper uses the rails default multiparameters
+# for dates:
+# ```
+# my_date_attribute(3i), my_date_attribute(2i), my_date_attribute(1i).
+# ````
+# These are parsed by rails and raise an `ActiveRecord::MultiparameterAssignmentErrors`
+# if the parameters are invalid for a date (e.g. 32-01-2021).
+# This would then result in a 500 unless handled so we parse the date
+# from the params first and clean invalid date part values before rails
+# can raise this error.
+#
+module MultiparameterAttributeCleaner
+  extend ActiveSupport::Concern
+
+  def clean_multiparameter_dates
+    return unless params
+    find_and_clean_dates(params)
+  end
+
+  private
+
+  def find_and_clean_dates(parameters)
+    parameters.each_pair do |k, v|
+      if v.respond_to?(:each_pair)
+        find_and_clean_dates(v)
+      elsif k.to_s.include?('(3i)')
+        parameters[k] = '' unless (1..31).cover?(v.to_i)
+      elsif k.to_s.include?('(2i)')
+        parameters[k] = '' unless (1..12).cover?(v.to_i)
+      end
+    end
+  end
+end

--- a/app/controllers/external_users/certifications_controller.rb
+++ b/app/controllers/external_users/certifications_controller.rb
@@ -1,4 +1,7 @@
 class ExternalUsers::CertificationsController < ExternalUsers::ApplicationController
+  include MultiparameterAttributeCleaner
+
+  prepend_before_action :clean_multiparameter_dates, only: [:create, :update]
   before_action :set_claim, only: %i[new create update]
   before_action :redirect_already_certified, only: %i[new create]
   before_action :redirect_if_not_valid, only: %i[new create]

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -1,6 +1,7 @@
 class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   # This performs magic
   include PaginationHelpers
+  include MultiparameterAttributeCleaner
 
   class ResourceClassNotDefined < StandardError; end
 
@@ -10,6 +11,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
   respond_to :html
 
+  prepend_before_action :clean_multiparameter_dates, only: [:create, :update]
   before_action :set_user_and_provider
   before_action :set_claims_context, only: %i[index archived outstanding authorised]
   before_action :set_financial_summary, only: %i[index outstanding authorised]

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -34,7 +34,9 @@
         hint: { text: t('.certified_by_prompt_text') }
 
       = f.govuk_date_field :certification_date,
-        legend: { text: t('.date'), size: 's' }
+        maxlength_enabled: true,
+        legend: { text: t('.date'), size: 's' },
+        form_group: { id: 'certification_date' }
 
       = f.govuk_submit t('.submit')
       = govuk_link_button_secondary t('.return'), edit_polymorphic_path(@claim)

--- a/app/views/external_users/claims/case_details/_case_concluded_date.html.haml
+++ b/app/views/external_users/claims/case_details/_case_concluded_date.html.haml
@@ -3,3 +3,4 @@
   hint: { text: t('.date_hint') },
   legend: { text: t('.case_concluded_at') },
   maxlength_enabled: true
+

--- a/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
@@ -115,20 +115,25 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
       | miscellaneous-fees-section | 2 | Net amount | 108.00 |
 
     And I should see 'Hotel accommodation'
-
     And I should see 'judicial_appointment_order.pdf'
     And I should see 'Order in respect of judicial apportionment'
     And I should see 'Bish bosh bash'
-
     And I should see a page title "View claim summary for advocate final fees claim"
+
     When I click "Continue"
     Then I should be on the certification page
+    And I should see a page title "Certify and submit the advocate final fees claim"
+    And certified by should be set to current user name
+    And certification date should be set to today
 
     When I check “I attended the main hearing”
-
-    And I should see a page title "Certify and submit the advocate final fees claim"
+    And I fill in '32' as the certification date day
     And I click Certify and submit claim
+    Then I should be on the certification page
+    And I should see "Enter certifying date"
 
+    When I fill in todays date as the certification date
+    And I click Certify and submit claim
     Then I should be on the claim confirmation page
     And I should see a page title "Thank you for submitting your claim"
 

--- a/features/claims/litigator/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/litigator_trial_claim_draft_submit.feature
@@ -134,8 +134,16 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     When I click "Continue"
     Then I should be on the certification page
     And I should see a page title "Certify and submit the litigator final fees claim"
+    And certified by should be set to current user name
+    And certification date should be set to today
 
-    When I click Certify and submit claim
+    When I fill in '32' as the certification date day
+    And I click Certify and submit claim
+    Then I should be on the certification page
+    And I should see "Enter certifying date"
+
+    When I fill in todays date as the certification date
+    And I click Certify and submit claim
     Then I should be on the claim confirmation page
 
     When I click View your claims

--- a/features/page_objects/certification_page.rb
+++ b/features/page_objects/certification_page.rb
@@ -1,6 +1,8 @@
 class CertificationPage < BasePage
-  set_url "/external_users/claims/{id}/certification/new"
+  set_url_matcher(/external_users\/claims\/\d+\/certification(\/new)?/)
 
   element :attended_main_hearing, "label.govuk-radios__label", text: "I attended the main hearing (1st day of trial)"
+  element :certified_by, "input[name='certification[certified_by]']"
+  section :certification_date, GovukDateSection, '#certification_date'
   element :certify_and_submit_claim, 'button.govuk-button', text: 'Certify and submit claim'
 end

--- a/features/page_objects/sections/govuk_date_section.rb
+++ b/features/page_objects/sections/govuk_date_section.rb
@@ -1,6 +1,6 @@
 class GovukDateSection < SitePrism::Section
   include DateHelper
-  element :day,   'div.govuk-date-input div.govuk-date-input__item:nth-child(1) input'
+  element :day, 'div.govuk-date-input div.govuk-date-input__item:nth-child(1) input'
   element :month, 'div.govuk-date-input div.govuk-date-input__item:nth-child(2) input'
-  element :year,  'div.govuk-date-input div.govuk-date-input__item:nth-child(3) input'
+  element :year, 'div.govuk-date-input div.govuk-date-input__item:nth-child(3) input'
 end

--- a/features/step_definitions/certification_steps.rb
+++ b/features/step_definitions/certification_steps.rb
@@ -1,0 +1,37 @@
+Then('I should be on the certification page') do
+  expect(@certification_page).to be_displayed
+end
+
+Then('certified by should be set to current user name') do
+  expect(@certification_page.certified_by.value).to eql(@current_user.name)
+end
+
+Then('certification date should be set to today') do
+  dd, mm, yyyy = Time.current.strftime('%-d-%-m-%Y').split('-')
+  expect(@certification_page.certification_date.day.value).to eql(dd)
+  expect(@certification_page.certification_date.month.value).to eql(mm)
+  expect(@certification_page.certification_date.year.value).to eql(yyyy)
+end
+
+When('I check “I attended the main hearing”') do
+  @certification_page.attended_main_hearing.click
+end
+
+When('I fill in {string} as the certification date day') do |day|
+  @certification_page.certification_date.day.set(day)
+end
+
+When('I fill in todays date as the certification date') do
+  dd, mm, yyyy = Time.current.strftime('%-d-%-m-%Y').split('-')
+  @certification_page.certification_date.day.set(dd)
+  @certification_page.certification_date.month.set(mm)
+  @certification_page.certification_date.year.set(yyyy)
+end
+
+When('I click Certify and submit claim') do
+  allow(Aws::SNS::Client).to receive(:new).and_return Aws::SNS::Client.new(region: 'eu-west-1', stub_responses: true)
+  @certification_page.wait_until_certify_and_submit_claim_visible
+  patiently do
+    @certification_page.certify_and_submit_claim.click
+  end
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -83,22 +83,6 @@ When(/I edit this claim/) do
   @external_user_claim_show_page.edit_this_claim.click
 end
 
-Then(/^I should be on the certification page$/) do
-  expect(@certification_page).to be_displayed
-end
-
-When(/^I check “I attended the main hearing”$/) do
-  @certification_page.attended_main_hearing.click
-end
-
-When(/^I click Certify and submit claim$/) do
-  allow(Aws::SNS::Client).to receive(:new).and_return Aws::SNS::Client.new(region: 'eu-west-1', stub_responses: true)
-  @certification_page.wait_until_certify_and_submit_claim_visible
-  patiently do
-    @certification_page.certify_and_submit_claim.click
-  end
-end
-
 Then(/^I should be on the claim confirmation page$/) do
   patiently do
     expect(@confirmation_page).to be_displayed

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -28,14 +28,14 @@ Given(/an? "(.*?)" user account exists$/) do |role|
 end
 
 Given(/^I am a signed in advocate$/) do
-  @advocate = create(:external_user, :advocate)
+  @advocate = @current_user = create(:external_user, :advocate)
   visit new_user_session_path
   switch_to_chrome_window
   sign_in(@advocate.user, 'password')
 end
 
 Given('I am a signed in advocate with final claim {string}') do |case_number|
-  @advocate = create(:external_user, :advocate)
+  @advocate = @current_user = create(:external_user, :advocate)
   create(:advocate_claim, creator: @advocate, external_user: @advocate, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
@@ -43,7 +43,7 @@ Given('I am a signed in advocate with final claim {string}') do |case_number|
 end
 
 Given('I am a signed in advocate with fixed fee claim {string}') do |case_number|
-  @advocate = create(:external_user, :advocate)
+  @advocate = @current_user = create(:external_user, :advocate)
   create(:advocate_claim, :with_fixed_fee_case, creator: @advocate, external_user: @advocate, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
@@ -51,21 +51,21 @@ Given('I am a signed in advocate with fixed fee claim {string}') do |case_number
 end
 
 Given(/^I am a signed in advocate admin$/) do
-  @advocate = create(:external_user, :advocate_and_admin)
+  @advocate = @current_user = create(:external_user, :advocate_and_admin)
   visit new_user_session_path
   switch_to_chrome_window
   sign_in(@advocate.user, 'password')
 end
 
 Given(/^I am a signed in litigator$/) do
-  @litigator = create(:external_user, :litigator)
+  @litigator = @current_user = create(:external_user, :litigator)
   visit new_user_session_path
   switch_to_chrome_window
   sign_in(@litigator.user, 'password')
 end
 
 Given('I am a signed in litigator with final claim {string}') do |case_number|
-  @litigator = create(:external_user, :litigator)
+  @litigator = @current_user = create(:external_user, :litigator)
   create(:litigator_claim, creator: @litigator, external_user: @litigator, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
@@ -73,21 +73,21 @@ Given('I am a signed in litigator with final claim {string}') do |case_number|
 end
 
 Given(/^I am a signed in litigator admin$/) do
-  @litigator = create(:external_user, :litigator_and_admin)
+  @litigator = @current_user = create(:external_user, :litigator_and_admin)
   visit new_user_session_path
   switch_to_chrome_window
   sign_in(@litigator.user, 'password')
 end
 
 Given(/^I am a signed in admin for an AGFS and LGFS firm$/) do
-  @admin = create(:external_user, :agfs_lgfs_admin)
+  @admin = @current_user = create(:external_user, :agfs_lgfs_admin)
   visit new_user_session_path
   switch_to_chrome_window
   sign_in(@admin.user, 'password')
 end
 
 Given(/^I am a signed in case worker$/) do
-  @case_worker = create(:case_worker)
+  @case_worker = @current_user = create(:case_worker)
   visit new_user_session_path
   switch_to_chrome_window
   sign_in(@case_worker.user, 'password')

--- a/spec/controllers/concerns/multiparameter_attribute_cleaner_spec.rb
+++ b/spec/controllers/concerns/multiparameter_attribute_cleaner_spec.rb
@@ -1,0 +1,201 @@
+RSpec.describe MultiparameterAttributeCleaner, type: :controller do
+  let(:person_params) do
+    {
+      person: {
+        name: 'Joe Bloggs',
+        'date_of_birth(1i)' => '1987',
+        'date_of_birth(2i)' => mm,
+        'date_of_birth(3i)' => dd
+      }
+    }
+  end
+
+  let(:mm) { '12' }
+  let(:dd) { '31' }
+
+  described_class.tap do |described_mod|
+    controller(ActionController::Base) do
+      include described_mod
+    end
+  end
+
+  it 'mixes in expected methods' do
+    expect(controller).to respond_to(:clean_multiparameter_dates)
+  end
+
+  context 'without before_action to call clean_multiparameter_dates' do
+    described_class.tap do |described_mod|
+      controller(ActionController::Base) do
+        include described_mod
+
+        def create
+          render json: person_params.to_json
+        end
+
+        def person_params
+          params.require(:person).permit(:date_of_birth)
+        end
+      end
+    end
+
+    context 'with valid date parts' do
+      it 'does not change parameters' do
+        post :create, params: person_params
+        expect(JSON.parse(response.body))
+          .to include({ 'date_of_birth(3i)' => '31', 'date_of_birth(2i)' => '12' })
+      end
+    end
+
+    context 'with invalid date parts' do
+      let(:mm) { '13' }
+      let(:dd) { '32' }
+
+      it 'does not change parameters' do
+        post :create, params: person_params
+        expect(JSON.parse(response.body))
+          .to include({ 'date_of_birth(3i)' => '32', 'date_of_birth(2i)' => '13' })
+      end
+    end
+  end
+
+  context 'with before_action to call clean_multiparameter_dates' do
+    described_class.tap do |described_mod|
+      controller(ActionController::Base) do
+        include described_mod
+
+        before_action :clean_multiparameter_dates, only: :create
+
+        def create
+          render json: person_params.to_json
+        end
+
+        def person_params
+          params.require(:person).permit(
+            :name,
+            :date_of_birth,
+            address_attributes: [:address1,
+                                 :moved_in,
+                                 { previous_address: [:prevaddress1,
+                                                      :moved_out] }]
+          )
+        end
+      end
+    end
+
+    it 'controller calls the cleaner once' do
+      allow(controller).to receive(:clean_multiparameter_dates)
+      post :create, params: person_params
+      expect(controller).to have_received(:clean_multiparameter_dates).once
+    end
+
+    context 'with valid date parts' do
+      let(:mm) { '12' }
+      let(:dd) { '31' }
+
+      it 'does not change params' do
+        post :create, params: person_params
+        expect(JSON.parse(response.body))
+          .to include({ 'date_of_birth(3i)' => '31', 'date_of_birth(2i)' => '12' })
+      end
+    end
+
+    context 'with invalid date parts' do
+      let(:mm) { '13' }
+      let(:dd) { '32' }
+
+      it 'clears invalid day and month values' do
+        post :create, params: person_params
+        expect(JSON.parse(response.body))
+          .to include({ 'date_of_birth(3i)' => '', 'date_of_birth(2i)' => '' })
+      end
+    end
+
+    context 'with valid nested attribute date parts' do
+      let(:person_params) do
+        { person: { 'name' => 'Joe Bloggs',
+                    'date_of_birth(1i)' => '1987',
+                    'date_of_birth(2i)' => '01',
+                    'date_of_birth(3i)' => '01',
+                    'address_attributes' => { '0' => { 'address1' => 'wherever',
+                                                       'moved_in(1i)' => '1987',
+                                                       'moved_in(2i)' => '01',
+                                                       'moved_in(3i)' => '01' } } } }
+      end
+
+      let(:expected_response) do
+        { 'name' => 'Joe Bloggs',
+          'date_of_birth(1i)' => '1987',
+          'date_of_birth(2i)' => '01',
+          'date_of_birth(3i)' => '01',
+          'address_attributes' => { '0' => { 'address1' => 'wherever',
+                                             'moved_in(1i)' => '1987',
+                                             'moved_in(2i)' => '01',
+                                             'moved_in(3i)' => '01' } } }
+      end
+
+      it 'does not change params' do
+        post :create, params: person_params
+        expect(JSON.parse(response.body)).to eql(expected_response)
+      end
+    end
+
+    context 'with invalid nested attribute date parts' do
+      let(:person_params) do
+        {
+          person: {
+            'name' => 'Joe Bloggs',
+            'date_of_birth(1i)' => '1987',
+            'date_of_birth(2i)' => '01',
+            'date_of_birth(3i)' => '01',
+            'address_attributes' => {
+              '0' => {
+                'address1' => 'wherever',
+                'moved_in(1i)' => '1987',
+                'moved_in(2i)' => 'JAN',
+                'moved_in(3i)' => '32',
+                'previous_address' => {
+                  '0' => {
+                    'prevaddress1' => 'whichever',
+                    'moved_out(1i)' => '1977',
+                    'moved_out(2i)' => '13',
+                    'moved_out(3i)' => 'fifteenth'
+                  }
+                }
+              }
+            }
+          }
+        }
+      end
+
+      let(:expected_response) do
+        {
+          'name' => 'Joe Bloggs',
+          'date_of_birth(1i)' => '1987',
+          'date_of_birth(2i)' => '01',
+          'date_of_birth(3i)' => '01',
+          'address_attributes' => {
+            '0' => {
+              'address1' => 'wherever',
+              'moved_in(1i)' => '1987',
+              'moved_in(2i)' => '',
+              'moved_in(3i)' => '',
+              'previous_address' => {
+                '0' => {
+                  'prevaddress1' => 'whichever',
+                  'moved_out(1i)' => '1977',
+                  'moved_out(2i)' => '',
+                  'moved_out(3i)' => ''
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it 'clears deeply nested invalid day and month values' do
+        post :create, params: person_params
+        expect(JSON.parse(response.body)).to eql(expected_response)
+      end
+    end
+  end
+end

--- a/spec/requests/external_users/advocates/advocate_final_claim_spec.rb
+++ b/spec/requests/external_users/advocates/advocate_final_claim_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Advocate final claims', type: :request do
+  let(:advocate) { create(:external_user, :advocate) }
+  let!(:case_type) { create(:case_type, :trial) }
+  let!(:court) { create(:court) }
+
+  describe 'GET #new' do
+    context 'when user is not signed in' do
+      before do
+        get new_advocates_claim_path
+      end
+
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'when user is signed in' do
+      before do
+        sign_in advocate.user
+        get new_advocates_claim_path
+      end
+
+      it 'returns http success' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns @claim' do
+        expect(assigns(:claim)).to be_new_record
+      end
+
+      it 'assigns @claim to be an advocate final claim' do
+        expect(assigns(:claim)).to be_instance_of Claim::AdvocateClaim
+      end
+
+      it 'assigns @case_types' do
+        expect(assigns(:case_types)).to all(be_a(CaseType))
+      end
+
+      it 'renders the template' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    before do
+      sign_in advocate.user
+      post advocates_claims_path, params: case_details_params
+    end
+
+    context 'when on case_details form step' do
+      let(:case_details_params) do
+        {
+          'claim' => {
+            'form_id' => SecureRandom.uuid, # not actually needed for test
+            'form_step' => 'case_details', # not actually needed as is the default
+            'providers_ref' => 'T20215555/1',
+            'case_type_id' => case_type.id,
+            'court_id' => court.id,
+            'case_number' => 'A20181234',
+            'first_day_of_trial(3i)' => '1',
+            'first_day_of_trial(2i)' => '1',
+            'first_day_of_trial(1i)' => '2021',
+            'trial_concluded_at(3i)' => '1',
+            'trial_concluded_at(2i)' => '10',
+            'trial_concluded_at(1i)' => '2021',
+            'estimated_trial_length' => '5',
+            'actual_trial_length' => '6'
+          },
+          'commit_continue' => ''
+        }
+      end
+
+      context 'with valid params' do
+        let(:claim) { Claim::BaseClaim.find_by(providers_ref: 'T20215555/1') }
+
+        it 'redirects' do
+          expect(response).to be_redirect
+        end
+
+        it 'redirects to defendants form step' do
+          expect(response).to redirect_to edit_advocates_claim_path(claim, step: 'defendants')
+        end
+      end
+
+      context 'with invalid date params' do
+        let(:case_details_params) do
+          {
+            'claim' => {
+              'form_id' => SecureRandom.uuid, # not actually needed for test
+              'form_step' => 'case_details', # not actually needed as is the default
+              'providers_ref' => 'T20215555/1',
+              'case_type_id' => case_type.id,
+              'court_id' => court.id,
+              'case_number' => 'A20181234',
+              'first_day_of_trial(3i)' => '32',
+              'first_day_of_trial(2i)' => 'JAN',
+              'first_day_of_trial(1i)' => '2021',
+              'trial_concluded_at(3i)' => '1',
+              'trial_concluded_at(2i)' => '10',
+              'trial_concluded_at(1i)' => '2021',
+              'estimated_trial_length' => '5',
+              'actual_trial_length' => '6'
+            },
+            'commit_continue' => ''
+          }
+        end
+
+        it 'renders new' do
+          expect(response).to render_template(:new)
+        end
+
+        it 'displays date error' do
+          expect(response.body).to include('Enter a date for the first day of trial')
+        end
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:claim) { create(:advocate_final_claim, external_user: advocate) }
+
+    context 'when user is signed in' do
+      before do
+        get edit_advocates_claim_path(claim)
+      end
+
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'when user is an advocate' do
+      before do
+        sign_in advocate.user
+        get edit_advocates_claim_path(claim)
+      end
+
+      it 'returns http success' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns @claim to be an advocate final claim' do
+        expect(assigns(:claim)).to be_instance_of Claim::AdvocateClaim
+      end
+
+      it 'assigns @case_types' do
+        expect(assigns(:case_types)).to all(be_a(CaseType))
+      end
+
+      it 'renders the template' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/requests/external_users/certification_spec.rb
+++ b/spec/requests/external_users/certification_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Certification', type: :request do
+  let(:advocate) { create(:external_user, :advocate) }
+  let(:claim) { create(:advocate_final_claim) }
+  let(:today_parts) { %i[dd mm yyyy].zip(Time.current.strftime('%-d-%-m-%Y').split('-')).to_h }
+
+  describe 'POST #create' do
+    let(:certification_params) do
+      {
+        'claim_id' => claim.id,
+        'commit' => 'Certify and Submit Claim',
+        'certification' => {
+          'certification_type_id' => '1',
+          'certified_by' => 'Joe Bloggs',
+          'main_hearing' => 'true',
+          'certification_date(3i)' => today_parts[:dd],
+          'certification_date(2i)' => today_parts[:mm],
+          'certification_date(1i)' => today_parts[:yyyy]
+        }
+      }
+    end
+
+    context 'when user is not signed in' do
+      before do
+        post external_users_claim_certification_path(claim.id), params: certification_params
+      end
+
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'when user is signed in' do
+      before do
+        sign_in advocate.user
+        post external_users_claim_certification_path(claim.id), params: certification_params
+      end
+
+      context 'with valid parameters' do
+        it { expect(response).to be_redirect }
+        it { expect(response).to redirect_to confirmation_external_users_claim_path(claim.id) }
+      end
+
+      context 'with invalid date part parameters' do
+        let(:certification_params) do
+          {
+            'claim_id' => claim.id,
+            'commit' => 'Certify and Submit Claim',
+            'certification' => {
+              'certification_type_id' => '1',
+              'certified_by' => 'Joe Bloggs',
+              'main_hearing' => 'true',
+              'certification_date(3i)' => '32',
+              'certification_date(2i)' => 'JAN',
+              'certification_date(1i)' => '2021'
+            }
+          }
+        end
+
+        it { expect(response).to render_template(:new) }
+
+        it 'displays date errors' do
+          expect(response.body).to include('Enter certifying date')
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -40,9 +40,9 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     end
   end
 
-  context 'when validating transfer_court_id' do
-    context 'with case_transferred_from_another_court not explictly set, but case number set' do
-      before { claim.transfer_case_number = 'A20161234' }
+
+  context 'when validating transfer_court' do
+    before { claim.transfer_case_number = 'A20161234' }
 
       it 'errors if blank' do
         claim.transfer_court = nil
@@ -55,7 +55,7 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
       end
     end
 
-    context 'with case transferred from another court set' do
+    context 'with case transferred from another court' do
       before do
         claim.case_transferred_from_another_court = true
       end
@@ -111,10 +111,14 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
       end
 
       context 'with transfer court not set' do
-        before { claim.transfer_court = nil }
+        before do
+          claim.transfer_court = nil
+        end
 
         context 'with transfer case number blank' do
-          before { claim.transfer_case_number = '' }
+          before do
+            claim.transfer_case_number = ''
+          end
 
           it 'does not contain errors on transfer case number' do
             should_not_error(claim, :transfer_case_number)
@@ -122,7 +126,9 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
         end
 
         context 'with transfer case number in invalid format' do
-          before { claim.transfer_case_number = 'ABC_' }
+          before do
+            claim.transfer_case_number = 'ABC_'
+          end
 
           it 'contains an invalid error on transfer case number' do
             should_error_with(claim, :transfer_case_number, 'Invalid transfer case number or urn')

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -40,19 +40,17 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
     end
   end
 
-
   context 'when validating transfer_court' do
     before { claim.transfer_case_number = 'A20161234' }
 
-      it 'errors if blank' do
-        claim.transfer_court = nil
-        should_error_with(claim, :transfer_court_id, 'Choose a transfer court')
-      end
+    it 'errors if blank' do
+      claim.transfer_court = nil
+      should_error_with(claim, :transfer_court_id, 'Choose a transfer court')
+    end
 
-      it 'errors when the same as the original court' do
-        claim.transfer_court = claim.court
-        should_error_with(claim, :transfer_court_id, 'Choose a different transfer court')
-      end
+    it 'errors when the same as the original court' do
+      claim.transfer_court = claim.court
+      should_error_with(claim, :transfer_court_id, 'Choose a different transfer court')
     end
 
     context 'with case transferred from another court' do


### PR DESCRIPTION
#### What
Handle `ActiveRecord::MultiparameterAssignmentErrors` for date
fields when supplying args such as 32/01/2021 or A/01/2021 or
1/13/2021.

Applies this to `certification` controller, which already errors in
production, plus the external_users/claims_controller form so that
we can progress case_details form step migration.

This should not have side affects since it only "cleans" params
that have an 'attribute_name(2i)|attribute_name(3i)' parameter
in the params of the request.

It handles deeply nested multiparameter dates using a recursive loop
over the entire params.

To apply to another controller we just need to add a `before_action`
such as below. The prepend was necessary for the claims controller
as other `before_actions` were beating it to punch and thereby encountering
the error.
```
  prepend_before_action :clean_multiparameter_dates, only: [:create, :update]
```

NOTE: Rails implicit parsing as Time or Time.zone.local bumps forward
certain dates automatically. This is default behaviour for rails but is
not necessarily desirable.
e.g.

31-09-2021 --> 01-10-2021
29-01-2021 --> 01-03-2021

We could prevent this behaviour here as well?!

#### Ticket

[CFP-54](https://dsdmoj.atlassian.net/browse/CFP-54)

#### Why
Currently entering invalid args such as 32/01/2021 or A/01/2021 or
1/13/2021 results in 500 errors.
