### PR TITLE
Add circle context for docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,6 +520,8 @@ workflows:
       - build-app-container:
           requires:
             - upload-coverage
+          context:
+            - cccd-live-base
       - smoke-test:
           requires:
             - build-app-container


### PR DESCRIPTION
#### What
Add circleci context reference for docker build and push step

#### Why
Contains env vars for docker login and ECR
access that were remove from project settings
as part of cleanup.
