### PR TITLE
fix for branch building env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,6 +608,8 @@ workflows:
       - build-app-container:
           requires:
             - hold-branch-build
+          context:
+            - cccd-live-base
       - hold-dev:
           type: approval
           requires:


### PR DESCRIPTION
#### What
Fix branch build step in circle

#### Why
Broken due to tidy of of project env vars.
Now need to use circleci contexts to set them
