### PR TITLE
[SPIKE] [CFP-370] FormBuilder migration - Defendants details

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -321,14 +321,14 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
         :claim_id,
         :first_name,
         :last_name,
-        date_attributes_for(:date_of_birth),
+        :date_of_birth,
         :order_for_judicial_apportionment,
         :_destroy,
         representation_orders_attributes: [
           :id,
           :document,
           :maat_reference,
-          date_attributes_for(:representation_order_date),
+          :representation_order_date,
           :_destroy
         ]
       ],

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -23,10 +23,6 @@ class Defendant < ApplicationRecord
   validates_with DefendantValidator
   validates_with DefendantSubModelValidator
 
-  acts_as_gov_uk_date :date_of_birth,
-                      validate_if: :validate_date?,
-                      error_clash_behaviour: :override_with_gov_uk_date_field_error
-
   accepts_nested_attributes_for :representation_orders, reject_if: :all_blank, allow_destroy: true
 
   def name

--- a/app/models/representation_order.rb
+++ b/app/models/representation_order.rb
@@ -23,10 +23,6 @@ class RepresentationOrder < ApplicationRecord
     self.maat_reference = nil if case_type&.requires_maat_reference?.eql?(false)
   end
 
-  acts_as_gov_uk_date :representation_order_date,
-                      validate_if: :perform_validation?,
-                      error_clash_behaviour: :override_with_gov_uk_date_field_error
-
   default_scope { order('id ASC') }
 
   belongs_to :defendant

--- a/app/validators/defendant_validator.rb
+++ b/app/validators/defendant_validator.rb
@@ -19,9 +19,9 @@ class DefendantValidator < BaseValidator
   end
 
   def validate_date_of_birth
-    validate_presence(:date_of_birth, 'blank')
-    validate_on_or_before(10.years.ago, :date_of_birth, 'check')
-    validate_on_or_after(120.years.ago, :date_of_birth, 'check')
+    validate_presence(:date_of_birth, :blank)
+    validate_on_or_before(10.years.ago, :date_of_birth, :check)
+    validate_on_or_after(120.years.ago, :date_of_birth, :check)
   end
 
   def validate_representation_orders
@@ -32,12 +32,12 @@ class DefendantValidator < BaseValidator
   end
 
   def validate_first_name
-    validate_presence(:first_name, 'blank')
-    validate_max_length(:first_name, 40, 'max_length')
+    validate_presence(:first_name, :blank)
+    validate_max_length(:first_name, 40, :max_length)
   end
 
   def validate_last_name
-    validate_presence(:last_name, 'blank')
-    validate_max_length(:last_name, 40, 'max_length')
+    validate_presence(:last_name, :blank)
+    validate_max_length(:last_name, 40, :max_length)
   end
 end

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -14,8 +14,8 @@ class RepresentationOrderValidator < BaseValidator
   # must not be earlier than the first rep order date
   # must not be earlier than the earliest permitted date
   def validate_representation_order_date
-    validate_presence(:representation_order_date, 'blank')
-    validate_on_or_before(Date.today, :representation_order_date, 'in_future')
+    validate_presence(:representation_order_date, :blank)
+    validate_on_or_before(Date.today, :representation_order_date, :in_future)
     validate_on_or_after(earliest_permitted[:date], :representation_order_date, earliest_permitted[:error])
 
     validate_against_agfs_fee_reform_release_date
@@ -28,36 +28,36 @@ class RepresentationOrderValidator < BaseValidator
 
   def validate_against_agfs_fee_reform_release_date
     return unless claim.from_api? && post_agfs_reform?
-    validate_on_or_after(Settings.agfs_fee_reform_release_date, :representation_order_date, 'agfs_reform_offence')
+    validate_on_or_after(Settings.agfs_fee_reform_release_date, :representation_order_date, :agfs_reform_offence)
   end
 
   def validate_against_trial_dates
     return unless claim&.requires_trial_dates?
     return if claim&.requires_retrial_dates?
-    validate_on_or_before(claim.first_day_of_trial, :representation_order_date, 'not_on_or_before_first_day_of_trial')
+    validate_on_or_before(claim.first_day_of_trial, :representation_order_date, :not_on_or_before_first_day_of_trial)
   end
 
   def validate_against_retrial_dates
     return unless claim&.requires_retrial_dates?
-    validate_on_or_before(claim.retrial_started_at, :representation_order_date, 'not_on_or_before_first_day_of_retrial')
+    validate_on_or_before(claim.retrial_started_at, :representation_order_date, :not_on_or_before_first_day_of_retrial)
   end
 
   def validate_against_cracked_trial_dates
     return unless claim&.requires_cracked_dates?
     validate_on_or_before(claim.trial_cracked_at,
-                          :representation_order_date, 'not_on_or_before_trial_cracked_date')
+                          :representation_order_date, :not_on_or_before_trial_cracked_date)
   end
 
   def validate_against_case_concluded_date
     return unless claim&.requires_case_concluded_date?
-    validate_on_or_before(claim.case_concluded_at, :representation_order_date, 'not_on_or_before_case_concluded_date')
+    validate_on_or_before(claim.case_concluded_at, :representation_order_date, :not_on_or_before_case_concluded_date)
   end
 
   def validate_against_first_rep_order_date
     return if @record.is_first_reporder_for_same_defendant?
     first_reporder_date = @record.first_reporder_for_same_defendant&.representation_order_date
     return if first_reporder_date.nil?
-    validate_on_or_after(first_reporder_date, :representation_order_date, 'check')
+    validate_on_or_after(first_reporder_date, :representation_order_date, :check)
   end
 
   # mandatory where case type isn't breach of crown court order
@@ -65,9 +65,9 @@ class RepresentationOrderValidator < BaseValidator
   def validate_maat_reference
     case_type = claim.try(:case_type)
     return unless case_type&.requires_maat_reference?
-    validate_presence(:maat_reference, 'invalid')
-    validate_pattern(:maat_reference, Settings.maat_regexp, 'invalid')
-    validate_matt_reference_uniqueness(:maat_reference, 'unique')
+    validate_presence(:maat_reference, :invalid)
+    validate_pattern(:maat_reference, Settings.maat_regexp, :invalid)
+    validate_matt_reference_uniqueness(:maat_reference, :unique)
   end
 
   # helper methods
@@ -88,9 +88,9 @@ class RepresentationOrderValidator < BaseValidator
 
   def earliest_permitted
     if claim&.lgfs? && claim&.interim?
-      { date: Settings.interim_earliest_permitted_repo_date, error: 'not_before_interim_earliest_permitted_date' }
+      { date: Settings.interim_earliest_permitted_repo_date, error: :not_before_interim_earliest_permitted_date }
     else
-      { date: Settings.earliest_permitted_date, error: 'not_before_earliest_permitted_date' }
+      { date: Settings.earliest_permitted_date, error: :not_before_earliest_permitted_date }
     end
   end
 end

--- a/app/views/external_users/claims/_error_summary.html.haml
+++ b/app/views/external_users/claims/_error_summary.html.haml
@@ -1,4 +1,4 @@
-- form_steps = %w[case_details transfer_fee_details offence_details supporting_evidence]
+- form_steps = %w[case_details defendants transfer_fee_details offence_details supporting_evidence]
 - if form_steps.include?(@claim.form_step.to_s)
   = govuk_error_summary(@claim, :claim, presenter: @error_presenter)
 

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -12,18 +12,18 @@
     - @representation_order_count = 0
 
     = f.govuk_text_field :first_name,
-      form_group: { classes: ['first-name'] },
+      form_group: { classes: ['cc-first-name'] },
       label: { text: t('.first_name_html') },
       width: 'one-half'
       
     = f.govuk_text_field :last_name,
-      form_group: { classes: ['last-name'] },
+      form_group: { classes: ['cc-last-name'] },
       label: { text: t('.last_name_html') },
       width: 'one-half'
 
     = f.govuk_date_field :date_of_birth,
       date_of_birth: true,
-      form_group: { classes: ['dob'], id: "defendant_#{@defendant_count+1}_date_of_birth_group" },
+      form_group: { classes: ['cc-dob'], id: "defendant_#{@defendant_count+1}_date_of_birth_group" },
       hint: { text: t('.date_hint') },
       legend: { text: t('.date_of_birth_html'), size: 's' },
       maxlength_enabled: true

--- a/app/views/external_users/claims/defendants/_defendant_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_defendant_fields.html.haml
@@ -9,25 +9,34 @@
     = link_to_remove_association f, class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
       = t('common.remove_html', context: t('.defendant'))
 
-    .form-group.first-name
-      - @representation_order_count = 0
-      = f.adp_text_field :first_name, label: t('.first_name_html'), errors: @error_presenter
+    - @representation_order_count = 0
 
-    .form-group.last-name
-      = f.adp_text_field :last_name, label: t('.last_name_html'), errors: @error_presenter
+    = f.govuk_text_field :first_name,
+      form_group: { classes: ['first-name'] },
+      label: { text: t('.first_name_html') },
+      width: 'one-half'
+      
+    = f.govuk_text_field :last_name,
+      form_group: { classes: ['last-name'] },
+      label: { text: t('.last_name_html') },
+      width: 'one-half'
 
-    .form-group.dob
-      %a{ id: "defendant_#{@defendant_count+1}_date_of_birth_html" }
-      = f.gov_uk_date_field(:date_of_birth, legend_text: t('.date_of_birth_html'), legend_class: 'govuk-legend', id: "defendant_#{@defendant_count+1}_date_of_birth_group", error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_date_of_birth"))
+    = f.govuk_date_field :date_of_birth,
+      date_of_birth: true,
+      form_group: { classes: ['dob'], id: "defendant_#{@defendant_count+1}_date_of_birth_group" },
+      hint: { text: t('.date_hint') },
+      legend: { text: t('.date_of_birth_html'), size: 's' },
+      maxlength_enabled: true
 
     - unless @claim.lgfs? && @claim.interim?
-      .form-group
-        .multiple-choice
-          = f.check_box :order_for_judicial_apportionment
-          = f.label :order_for_judicial_apportionment, t('.order_for_judicial_apportionment_html'), class: 'judicial-apportionment-notice'
-          = validation_error_message(@error_presenter, :order_for_judicial_apportionment)
+      = f.govuk_check_box :order_for_judicial_apportionment,
+        1,
+        0,
+        label: { text: t('.order_for_judicial_apportionment_html') },
+        link_errors: true,
+        multiple: false
 
-      .form-group
+      .govuk-form-group
         = govuk_detail 'Help with judicial apportionment' do
           = t('.order_for_judicial_apportionment_help')
 

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -1,4 +1,4 @@
-.nested-fields.ro-details
+.nested-fields.cc-ro-details
   - @representation_order_count += 1
   %a{ id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count}_representation_order_date" }
   %fieldset
@@ -11,13 +11,13 @@
       = t('common.remove_html', context: t('.representation_order'))
 
     = f.govuk_date_field :representation_order_date,
-      form_group: { classes: ['ro-date'], id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date" },
+      form_group: { classes: ['cc-ro-date'], id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date" },
       hint: { text: t('.date_hint') },
       legend: { text: t('.date_html'), size: 's' },
       maxlength_enabled: true
 
     = f.govuk_text_field :maat_reference,
-      form_group: { classes: ['maat'] },
+      form_group: { classes: ['cc-maat'] },
       hint: { text: t('.maat_reference_number_eg') },
       label: { text: t('.maat_reference_number_html') },
       width: 'one-half'

--- a/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_representation_order_fields.html.haml
@@ -10,15 +10,14 @@
     = link_to_remove_association f, class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
       = t('common.remove_html', context: t('.representation_order'))
 
-    .form-group.ro-date
-      = f.gov_uk_date_field(:representation_order_date,
-                            legend_text: t('.date_html'),
-                            legend_class: 'govuk-legend',
-                            id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date",
-                            error_messages: gov_uk_date_field_error_messages(@error_presenter, "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date"))
+    = f.govuk_date_field :representation_order_date,
+      form_group: { classes: ['ro-date'], id: "defendant_#{@defendant_count+1}_representation_order_#{@representation_order_count+1}_representation_order_date" },
+      hint: { text: t('.date_hint') },
+      legend: { text: t('.date_html'), size: 's' },
+      maxlength_enabled: true
 
-    .form-group.maat
-      = f.adp_text_field :maat_reference,
-                          label: t('.maat_reference_number_html'),
-                          hint_text: t('.maat_reference_number_eg'),
-                          errors: @error_presenter
+    = f.govuk_text_field :maat_reference,
+      form_group: { classes: ['maat'] },
+      hint: { text: t('.maat_reference_number_eg') },
+      label: { text: t('.maat_reference_number_html') },
+      width: 'one-half'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
   TrueClass: *global_yes
   FalseClass: *global_no
 
+  date_hint: &date_hint For example, 31 3 1980
+
   pages:
     api_landing:
       page_heading: Claim for crown court defence API
@@ -1103,6 +1105,7 @@ en:
           full_name: Full name
           date_of_birth: Date of birth
           date_of_birth_html: Date of birth <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
+          date_hint: *date_hint
           judical_apportionment: Judicial apportionment
           order_for_judicial_apportionment:  Order for judicial apportionment
           order_for_judicial_apportionment_html: Order for judicial apportionment <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
@@ -1117,6 +1120,7 @@ en:
           page_heading: Defendant details
         representation_order_fields:
           date: Representation order date
+          date_hint: *date_hint
           date_html: Representation order date <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           representation_order: Representation order details
           maat_reference_number: MAAT reference

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -633,39 +633,39 @@ defendant:
 
   first_name:
     _seq: 10
-    blank:
+    enter_a_first_name:
       long: "Enter a first name for the #{defendant}"
-      short: Enter a first name
+      short: _
       api: "Enter a first name for the defendant"
-    max_length:
+    first_name_is_too_long:
       long: "First name for the #{defendant} is too long"
-      short: *max_length
+      short: _
       api: "First name for the defendant is too long"
 
   last_name:
     _seq: 20
-    blank:
+    enter_a_last_name:
       long: "Enter a last name for the #{defendant}"
-      short: Enter a last name
+      short: _
       api: "Enter a last name for the defendant"
-    max_length:
+    last_name_is_too_long:
       long: "Last name for the #{defendant} is too long"
-      short: *max_length
+      short: _
       api: "Last name for the defendant is too long"
 
   date_of_birth:
     _seq: 30
-    blank:
+    enter_a_date_of_birth:
       long: "Enter a date of birth for the #{defendant}"
-      short: Enter a date of birth
+      short: _
       api: "Enter a date of birth for the defendant"
-    check:
+    check_the_date_of_birth:
       long: "Check the date of birth for of the #{defendant}"
-      short: Check the date of birth
+      short: _
       api: "Check the date of birth for the defendant"
     invalid_date:
       long: "Enter a valid date of birth for the #{defendant}"
-      short: *enter_valid_date
+      short: _
       api: "Enter a valid date of birth for the defendant"
 
   #################################################################################
@@ -685,60 +685,60 @@ representation_order:
 
   representation_order_date:
     _seq: 20
-    blank:
+    enter_a_representation_order_date:
       long: 'Enter a representation order date for the #{representation_order} of the #{defendant}'
-      short: *enter_date
+      short: _
       api: 'Enter a representation order date for the representation order of the defendant'
-    check:
+    representation_orders_should_be_entered_in_chronological_order:
       long: 'Representation orders should be entered in chronological order. Please check representation order dates of the #{defendant}'
-      short: *check_date
+      short: _
       api: 'Representation orders should be entered in chronological order. Please check representation order dates of the defendant'
-    invalid_date:
+    enter_a_valid_date_for_the_representation_order_date:
       long: 'Enter a valid date for the representation order date of the #{representation_order} of the #{defendant}'
-      short: *enter_valid_date
+      short: _
       api: 'Enter a valid date for the representation order date of the representation order of the defendant'
-    in_future:
+    representation_order_date_can_not_be_too_far_in_the_future:
       long: 'Check the representation order date for the #{representation_order} of the #{defendant}'
-      short: *in_future
+      short: _
       api: 'Check the representation order date for the representation order of the defendant'
-    not_before_earliest_permitted_date:
+    representation_order_date_is_too_far_in_the_past:
       long: 'Representation order date of the #{defendant} is too far in the past. Please check this date'
-      short: *check_date
+      short: _
       api: 'Representation order date of the defendant is too far in the past. Please check this date'
-    not_before_interim_earliest_permitted_date:
+    representation_order_date_cannot_be_prior_to_02/10/14:
       long: 'Representation order date of the #{defendant} cannot be prior to 02/10/14. Please check this date'
-      short: *check_date
+      short: _
       api: 'Representation order date of the defendant cannot be prior to 02/10/14. Please check this date'
-    not_on_or_before_case_concluded_date:
+    check_combination_of_representation_order_date_and_case_concluded_date:
       long: 'Check the combination of the representation order date and the case concluded date'
-      short: 'Check combination of representation order date and case concluded date'
+      short: _
       api: 'Check combination of rep order date and case concluded date'
-    not_on_or_before_first_day_of_retrial:
+    check_combination_of_representation_order_date_and_trial_dates:
       long: 'Check the combination of the representation order date and the dates of trial'
-      short: 'Check combination of representation order date and trial dates'
+      short: _
       api: 'Check combination of rep order date and trial dates'
-    not_on_or_before_first_day_of_trial:
+    check_combination_of_representation_order_date_and_trial_dates:
       long: 'Check the combination of the representation order date and the dates of trial'
-      short: 'Check combination of representation order date and trial dates'
+      short: _
       api: 'Check combination of rep order date and trial dates'
-    not_on_or_before_trial_cracked_date:
+    check_combination_of_representation_order_date_and_case_cracked_date:
       long: 'Check the combination of the representation order date and the case cracked date'
-      short: 'Check combination of representation order date and case cracked date'
+      short: _
       api: 'Check combination of rep order date and case cracked date'
-    agfs_reform_offence:
+    check_combination_of_representation_order_date_and_offence:
       long: Check the combination of the representation order date and offence
-      short: *check_date
+      short: _
       api: Check the combination of the representation order date and offence
 
   maat_reference:
     _seq: 30
-    invalid:
+    enter_a_valid_maat_reference:
       long: "Enter a valid MAAT reference for the #{representation_order} of the #{defendant}"
-      short: Enter a valid MAAT reference
+      short: _
       api: "Enter a valid MAAT reference for the representation order of the defendant"
-    unique:
+    enter_a_unique_maat_reference:
       long: "Each defendant must have a unique MAAT reference"
-      short: "Enter a unique MAAT reference"
+      short: _
       api: "Each defendant must have a unique MAAT reference"
 
 #################################################################################

--- a/config/locales/en/models/claim/defendants.yml
+++ b/config/locales/en/models/claim/defendants.yml
@@ -1,0 +1,37 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        defendant:
+          attributes:
+            first_name:
+              blank: Enter a first name
+              max_length: First name is too long
+
+            last_name:
+              blank: Enter a last name
+              max_length: Last name is too long
+
+            date_of_birth:
+              blank: Enter a date of birth
+              check: Check the date of birth
+
+        representation_order:
+          attributes:
+            representation_order_date:
+              blank: Enter a representation order date
+              check: Representation orders should be entered in chronological order
+              invalid_date: Enter a valid date for the representation order date
+              in_future: Representation order date can not be too far in the future
+              not_before_earliest_permitted_date: Representation order date is too far in the past
+              not_before_interim_earliest_permitted_date: Representation order date cannot be prior to 02/10/14
+              not_on_or_before_case_concluded_date: Check combination of representation order date and case concluded date
+              not_on_or_before_first_day_of_retrial: Check combination of representation order date and trial dates
+              not_on_or_before_first_day_of_trial: Check combination of representation order date and trial dates
+              not_on_or_before_trial_cracked_date: Check combination of representation order date and case cracked date
+              agfs_reform_offence: Check the combination of the representation order date and offence
+           
+            maat_reference:
+              invalid: Enter a valid MAAT reference
+              unique: Enter a unique MAAT reference

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -43,14 +43,14 @@ class ClaimFormPage < BasePage
   section :cracked_trial_details, CrackedTrialSection, "#cracked-trial-dates"
 
   sections :defendants, ".defendant-details" do
-    element :first_name, "div.first-name input"
-    element :last_name, "div.last-name input"
+    element :first_name, "div.cc-first-name input"
+    element :last_name, "div.cc-last-name input"
 
-    section :dob, CommonDateSection, 'div.dob'
+    section :dob, GovukDateSection, 'div.cc-dob'
 
-    sections :representation_orders, ".ro-details" do
-      section :date, CommonDateSection, 'div.ro-date'
-      element :maat_reference, "div.maat input"
+    sections :representation_orders, ".cc-ro-details" do
+      section :date, GovukDateSection, 'div.cc-ro-date'
+      element :maat_reference, "div.cc-maat input"
     end
 
     element :add_another_representation_order, "div.links > a"

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
 
         before { travel_to(Date.new(2018, 5, 1)) { post_to_create_endpoint } }
 
-        specify { expect_error_response('Check the combination of the representation order date and offence') }
+        specify { expect_error_response('Representation order 1 representation order date check the combination of the representation order date and offence') }
       end
 
       describe 'and the rep_order_date post-dates the start of the scheme' do

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -159,14 +159,14 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController, type: :controller do
                 {
                   first_name: 'John',
                   last_name: 'Smith',
-                  date_of_birth_dd: '4',
-                  date_of_birth_mm: '10',
-                  date_of_birth_yyyy: '1980',
+                  'date_of_birth(3i)': '4',
+                  'date_of_birth(2i)': '10',
+                  'date_of_birth(1i)': '1980',
                   representation_orders_attributes: [
                     {
-                      representation_order_date_dd: representation_order_date.day.to_s,
-                      representation_order_date_mm: representation_order_date.month.to_s,
-                      representation_order_date_yyyy: representation_order_date.year.to_s,
+                      'representation_order_date(3i)': representation_order_date.day.to_s,
+                      'representation_order_date(2i)': representation_order_date.month.to_s,
+                      'representation_order_date(1i)': representation_order_date.year.to_s,
                       maat_reference: '4561237'
                     }
                   ]

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -133,14 +133,14 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController, type: :contro
                 {
                   first_name: 'John',
                   last_name: 'Smith',
-                  date_of_birth_dd: '4',
-                  date_of_birth_mm: '10',
-                  date_of_birth_yyyy: '1980',
+                  'date_of_birth(3i)': '4',
+                  'date_of_birth(2i)': '10',
+                  'date_of_birth(1i)': '1980',
                   representation_orders_attributes: [
                     {
-                      representation_order_date_dd: Time.now.day.to_s,
-                      representation_order_date_mm: Time.now.month.to_s,
-                      representation_order_date_yyyy: Time.now.year.to_s,
+                      'representation_order_date(3i)': Time.now.day.to_s,
+                      'representation_order_date(2i)': Time.now.month.to_s,
+                      'representation_order_date(1i)': Time.now.year.to_s,
                       maat_reference: '4561237'
                     }
                   ]

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1285,15 +1285,15 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
             '0' => {
               'first_name' => 'Foo',
               'last_name' => 'Bar',
-              'date_of_birth_dd' => '04',
-              'date_of_birth_mm' => '10',
-              'date_of_birth_yyyy' => '1980',
+              'date_of_birth(3i)' => '04',
+              'date_of_birth(2i)' => '10',
+              'date_of_birth(1i)' => '1980',
               'order_for_judicial_apportionment' => '0',
               'representation_orders_attributes' => {
                 '0' => {
-                  'representation_order_date_dd' => '30',
-                  'representation_order_date_mm' => '08',
-                  'representation_order_date_yyyy' => '2015',
+                  'representation_order_date(3i)' => '30',
+                  'representation_order_date(2i)' => '08',
+                  'representation_order_date(1i)' => '2015',
                   'maat_reference' => '1234567890',
                   '_destroy' => 'false'
                 }

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Defendant, type: :model do
       before { subject.claim = create(:submitted_claim) }
 
       it { should validate_presence_of(:claim).with_message('blank') }
-      it { should validate_presence_of(:first_name).with_message('blank') }
-      it { should validate_presence_of(:last_name).with_message('blank')  }
+      it { should validate_presence_of(:first_name).with_message('Enter a first name') }
+      it { should validate_presence_of(:last_name).with_message('Enter a last name') }
     end
 
     context 'draft claim from api' do
@@ -40,8 +40,8 @@ RSpec.describe Defendant, type: :model do
       }
 
       it { should validate_presence_of(:claim).with_message('blank') }
-      it { should validate_presence_of(:first_name).with_message('blank') }
-      it { should validate_presence_of(:last_name).with_message('blank') }
+      it { should validate_presence_of(:first_name).with_message('Enter a first name') }
+      it { should validate_presence_of(:last_name).with_message('Enter a last name') }
     end
   end
 

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -18,25 +18,25 @@ RSpec.describe RepresentationOrder do
       it 'errors if blank' do
         representation_order.maat_reference = nil
         expect(representation_order).not_to be_valid
-        expect(representation_order.errors[:maat_reference]).to eq(['invalid'])
+        expect(representation_order.errors[:maat_reference]).to eq(['Enter a valid MAAT reference'])
       end
 
       it 'errors if less than 7 numeric characters' do
         representation_order.maat_reference = '456213'
         expect(representation_order).not_to be_valid
-        expect(representation_order.errors[:maat_reference]).to eq(['invalid'])
+        expect(representation_order.errors[:maat_reference]).to eq(['Enter a valid MAAT reference'])
       end
 
       it 'errors if greater than 7 numeric characters' do
         representation_order.maat_reference = '4562131111111'
         expect(representation_order).not_to be_valid
-        expect(representation_order.errors[:maat_reference]).to eq(['invalid'])
+        expect(representation_order.errors[:maat_reference]).to eq(['Enter a valid MAAT reference'])
       end
 
       it 'errors if non-numeric characters present' do
         representation_order.maat_reference = '1111a1111'
         expect(representation_order).not_to be_valid
-        expect(representation_order.errors[:maat_reference]).to eq(['invalid'])
+        expect(representation_order.errors[:maat_reference]).to eq(['Enter a valid MAAT reference'])
       end
 
       it 'does not error if 7 numeric digits' do

--- a/spec/models/timed_transitions/transitioner_spec.rb
+++ b/spec/models/timed_transitions/transitioner_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe TimedTransitions::Transitioner do
 
               it 'submodel is invalid' do
                 record.valid?
-                expect(record.errors.messages[:maat_reference]).to eq ['invalid']
+                expect(record.errors.messages[:maat_reference]).to eq ['Enter a valid MAAT reference']
               end
 
               it 'still transitions to archived_pending_delete' do

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -178,9 +178,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
     let(:one_one_representation_order_attrs) { valid_one_one_representation_order_attrs }
     let(:valid_one_other_representation_order_attrs) {
       {
-        'representation_order_date(3i)': (release_date + 2.day).day.to_s,
-        'representation_order_date(2i)': (release_date + 2.day).month.to_s,
-        'representation_order_date(1i)': (release_date + 2.day).year.to_s
+        'representation_order_date(3i)': (release_date + 2.days).day.to_s,
+        'representation_order_date(2i)': (release_date + 2.days).month.to_s,
+        'representation_order_date(1i)': (release_date + 2.days).year.to_s
       }
     }
     let(:one_other_representation_order_attrs) { valid_one_other_representation_order_attrs }
@@ -431,9 +431,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 2.day).year.to_s
+                'representation_order_date(3i)': (release_date + 2.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.days).year.to_s
               }
             }
           },
@@ -446,9 +446,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 3.day).year.to_s
+                'representation_order_date(3i)': (release_date + 3.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.days).year.to_s
               }
             }
           }
@@ -511,9 +511,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 2.day).year.to_s
+                'representation_order_date(3i)': (release_date + 2.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.days).year.to_s
               }
             }
           },
@@ -526,9 +526,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 3.day).year.to_s
+                'representation_order_date(3i)': (release_date + 3.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.days).year.to_s
               }
             }
           }
@@ -710,9 +710,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 2.day).year.to_s
+                'representation_order_date(3i)': (release_date + 2.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.days).year.to_s
               }
             }
           },
@@ -725,9 +725,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 3.day).year.to_s
+                'representation_order_date(3i)': (release_date + 3.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.days).year.to_s
               }
             }
           }
@@ -921,9 +921,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 2.day).year.to_s
+                'representation_order_date(3i)': (release_date + 2.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.days).year.to_s
               }
             }
           },
@@ -936,9 +936,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 3.day).year.to_s
+                'representation_order_date(3i)': (release_date + 3.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.days).year.to_s
               }
             }
           }
@@ -1065,9 +1065,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 2.day).year.to_s
+                'representation_order_date(3i)': (release_date + 2.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.days).year.to_s
               }
             }
           },
@@ -1080,9 +1080,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
-                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
-                'representation_order_date(1i)': (release_date + 3.day).year.to_s
+                'representation_order_date(3i)': (release_date + 3.days).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.days).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.days).year.to_s
               }
             }
           }

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -170,17 +170,17 @@ RSpec.describe 'Advocate interim claim WEB validations' do
     let(:release_date) { Date.parse(Settings.agfs_fee_reform_release_date.to_s) }
     let(:valid_one_one_representation_order_attrs) {
       {
-        representation_order_date_dd: release_date.day.to_s,
-        representation_order_date_mm: release_date.month.to_s,
-        representation_order_date_yyyy: release_date.year.to_s
+        'representation_order_date(3i)': release_date.day.to_s,
+        'representation_order_date(2i)': release_date.month.to_s,
+        'representation_order_date(1i)': release_date.year.to_s
       }
     }
     let(:one_one_representation_order_attrs) { valid_one_one_representation_order_attrs }
     let(:valid_one_other_representation_order_attrs) {
       {
-        representation_order_date_dd: (release_date + 2.days).day.to_s,
-        representation_order_date_mm: (release_date + 2.days).month.to_s,
-        representation_order_date_yyyy: (release_date + 2.days).year.to_s
+        'representation_order_date(3i)': (release_date + 2.day).day.to_s,
+        'representation_order_date(2i)': (release_date + 2.day).month.to_s,
+        'representation_order_date(1i)': (release_date + 2.day).year.to_s
       }
     }
     let(:one_other_representation_order_attrs) { valid_one_other_representation_order_attrs }
@@ -188,9 +188,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       {
         first_name: 'John',
         last_name: 'Doe',
-        date_of_birth_dd: '03',
-        date_of_birth_mm: '11',
-        date_of_birth_yyyy: '1967',
+        'date_of_birth(3i)': '03',
+        'date_of_birth(2i)': '11',
+        'date_of_birth(1i)': '1967',
         order_for_judicial_apportionment: '0',
         representation_orders_attributes: {
           '0' => one_one_representation_order_attrs,
@@ -201,9 +201,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
     let(:one_defendant_attrs) { valid_one_defendant_attrs }
     let(:valid_other_one_representation_order_attrs) {
       {
-        representation_order_date_dd: (release_date + 1.day).day.to_s,
-        representation_order_date_mm: (release_date + 1.day).month.to_s,
-        representation_order_date_yyyy: (release_date + 1.day).year.to_s
+        'representation_order_date(3i)': (release_date + 1.day).day.to_s,
+        'representation_order_date(2i)': (release_date + 1.day).month.to_s,
+        'representation_order_date(1i)': (release_date + 1.day).year.to_s
       }
     }
     let(:other_one_representation_order_attrs) { valid_other_one_representation_order_attrs }
@@ -211,9 +211,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       {
         first_name: 'Jane',
         last_name: 'Doe',
-        date_of_birth_dd: '26',
-        date_of_birth_mm: '07',
-        date_of_birth_yyyy: '1959',
+        'date_of_birth(3i)': '26',
+        'date_of_birth(2i)': '07',
+        'date_of_birth(1i)': '1959',
         order_for_judicial_apportionment: '0',
         representation_orders_attributes: {
           '0' => other_one_representation_order_attrs
@@ -256,7 +256,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_1_first_name]).to match_array(['blank'])
+        expect(claim.errors[:defendant_1_first_name]).to match_array(['Enter a first name'])
       }
     end
 
@@ -265,7 +265,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_2_first_name]).to match_array(['max_length'])
+        expect(claim.errors[:defendant_2_first_name]).to match_array(['First name is too long'])
       }
     end
 
@@ -274,7 +274,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_1_last_name]).to match_array(['blank'])
+        expect(claim.errors[:defendant_1_last_name]).to match_array(['Enter a last name'])
       }
     end
 
@@ -283,18 +283,18 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_2_last_name]).to match_array(['max_length'])
+        expect(claim.errors[:defendant_2_last_name]).to match_array(['Last name is too long'])
       }
     end
 
     context 'when one of the defendants has no date of birth set' do
       let(:one_defendant_attrs) {
-        valid_one_defendant_attrs.except(:date_of_birth_dd, :date_of_birth_mm, :date_of_birth_yyyy)
+        valid_one_defendant_attrs.except(:'date_of_birth(3i)', :'date_of_birth(2i)', :'date_of_birth(1i)')
       }
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_1_date_of_birth]).to match_array(['blank'])
+        expect(claim.errors[:defendant_1_date_of_birth]).to match_array(['Enter a date of birth'])
       }
     end
 
@@ -302,15 +302,15 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       let(:recent_date_of_birth) { 5.years.ago.to_date }
       let(:other_defendant_attrs) {
         valid_other_defendant_attrs.merge(
-          date_of_birth_dd: recent_date_of_birth.day.to_s,
-          date_of_birth_mm: recent_date_of_birth.month.to_s,
-          date_of_birth_yyyy: recent_date_of_birth.year.to_s
+          'date_of_birth(3i)': recent_date_of_birth.day.to_s,
+          'date_of_birth(2i)': recent_date_of_birth.month.to_s,
+          'date_of_birth(1i)': recent_date_of_birth.year.to_s
         )
       }
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_2_date_of_birth]).to match_array(['check'])
+        expect(claim.errors[:defendant_2_date_of_birth]).to match_array(['Check the date of birth'])
       }
     end
 
@@ -318,15 +318,15 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       let(:recent_date_of_birth) { 140.years.ago.to_date }
       let(:other_defendant_attrs) {
         valid_other_defendant_attrs.merge(
-          date_of_birth_dd: recent_date_of_birth.day.to_s,
-          date_of_birth_mm: recent_date_of_birth.month.to_s,
-          date_of_birth_yyyy: recent_date_of_birth.year.to_s
+          'date_of_birth(3i)': recent_date_of_birth.day.to_s,
+          'date_of_birth(2i)': recent_date_of_birth.month.to_s,
+          'date_of_birth(1i)': recent_date_of_birth.year.to_s
         )
       }
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_2_date_of_birth]).to match_array(['check'])
+        expect(claim.errors[:defendant_2_date_of_birth]).to match_array(['Check the date of birth'])
       }
     end
 
@@ -337,18 +337,18 @@ RSpec.describe 'Advocate interim claim WEB validations' do
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_1_representation_order_1_representation_order_date]).to match_array(['blank'])
+        expect(claim.errors[:defendant_1_representation_order_1_representation_order_date]).to match_array(['Enter a representation order date'])
       }
     end
 
     context 'when one of the defendants has a representation order with no date set' do
       let(:other_one_representation_order_attrs) {
-        valid_other_one_representation_order_attrs.except(:representation_order_date_dd, :representation_order_date_mm, :representation_order_date_yyyy)
+        valid_other_one_representation_order_attrs.except(:'representation_order_date(3i)', :'representation_order_date(2i)', :'representation_order_date(1i)')
       }
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_2_representation_order_1_representation_order_date]).to match_array(['blank'])
+        expect(claim.errors[:defendant_2_representation_order_1_representation_order_date]).to match_array(['Enter a representation order date'])
       }
     end
 
@@ -356,15 +356,15 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       let(:future_date) { 2.days.from_now.to_date }
       let(:one_other_representation_order_attrs) {
         valid_one_other_representation_order_attrs.merge(
-          representation_order_date_dd: future_date.day.to_s,
-          representation_order_date_mm: future_date.month.to_s,
-          representation_order_date_yyyy: future_date.year.to_s
+          'representation_order_date(3i)': future_date.day.to_s,
+          'representation_order_date(2i)': future_date.month.to_s,
+          'representation_order_date(1i)': future_date.year.to_s
         )
       }
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_1_representation_order_2_representation_order_date]).to match_array(['in_future'])
+        expect(claim.errors[:defendant_1_representation_order_2_representation_order_date]).to match_array(['Representation order date can not be too far in the future'])
       }
     end
 
@@ -372,15 +372,15 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       let(:earliest_permitted_date) { Date.parse(Settings.earliest_permitted_date.to_s) }
       let(:one_other_representation_order_attrs) do
         valid_one_other_representation_order_attrs.merge(
-          representation_order_date_dd: (earliest_permitted_date - 1.day).day.to_s,
-          representation_order_date_mm: (earliest_permitted_date - 1.day).month.to_s,
-          representation_order_date_yyyy: (earliest_permitted_date - 1.day).year.to_s
+          'representation_order_date(3i)': (earliest_permitted_date - 1.day).day.to_s,
+          'representation_order_date(2i)': (earliest_permitted_date - 1.day).month.to_s,
+          'representation_order_date(1i)': (earliest_permitted_date - 1.day).year.to_s
         )
       end
 
       specify {
         is_expected.to be_invalid
-        expect(claim.errors[:defendant_1_representation_order_2_representation_order_date]).to match_array(['check', 'not_before_earliest_permitted_date'])
+        expect(claim.errors[:defendant_1_representation_order_2_representation_order_date]).to match_array(['Representation order date is too far in the past', 'Representation orders should be entered in chronological order'])
       }
     end
 
@@ -388,9 +388,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
       let(:release_date) { Date.parse(Settings.agfs_fee_reform_release_date.to_s) }
       let(:one_other_representation_order_attrs) do
         valid_one_other_representation_order_attrs.merge(
-          representation_order_date_dd: (release_date - 1.day).day.to_s,
-          representation_order_date_mm: (release_date - 1.day).month.to_s,
-          representation_order_date_yyyy: (release_date - 1.day).year.to_s
+          'representation_order_date(3i)': (release_date - 1.day).day.to_s,
+          'representation_order_date(2i)': (release_date - 1.day).month.to_s,
+          'representation_order_date(1i)': (release_date - 1.day).year.to_s
         )
       end
 
@@ -420,35 +420,35 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           '0' => {
             first_name: 'John',
             last_name: 'Doe',
-            date_of_birth_dd: '03',
-            date_of_birth_mm: '11',
-            date_of_birth_yyyy: '1967',
+            'date_of_birth(3i)': '03',
+            'date_of_birth(2i)': '11',
+            'date_of_birth(1i)': '1967',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: earliest_representation_order_date.day.to_s,
-                representation_order_date_mm: earliest_representation_order_date.month.to_s,
-                representation_order_date_yyyy: earliest_representation_order_date.year.to_s
+                'representation_order_date(3i)': earliest_representation_order_date.day.to_s,
+                'representation_order_date(2i)': earliest_representation_order_date.month.to_s,
+                'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.days).day.to_s,
-                representation_order_date_mm: (release_date + 2.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.days).year.to_s
+                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.day).year.to_s
               }
             }
           },
           '1' => {
             first_name: 'Jane',
             last_name: 'Doe',
-            date_of_birth_dd: '26',
-            date_of_birth_mm: '07',
-            date_of_birth_yyyy: '1959',
+            'date_of_birth(3i)': '26',
+            'date_of_birth(2i)': '07',
+            'date_of_birth(1i)': '1959',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.days).day.to_s,
-                representation_order_date_mm: (release_date + 3.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.days).year.to_s
+                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.day).year.to_s
               }
             }
           }
@@ -500,35 +500,35 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           '0' => {
             first_name: 'John',
             last_name: 'Doe',
-            date_of_birth_dd: '03',
-            date_of_birth_mm: '11',
-            date_of_birth_yyyy: '1967',
+            'date_of_birth(3i)': '03',
+            'date_of_birth(2i)': '11',
+            'date_of_birth(1i)': '1967',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: earliest_representation_order_date.day.to_s,
-                representation_order_date_mm: earliest_representation_order_date.month.to_s,
-                representation_order_date_yyyy: earliest_representation_order_date.year.to_s
+                'representation_order_date(3i)': earliest_representation_order_date.day.to_s,
+                'representation_order_date(2i)': earliest_representation_order_date.month.to_s,
+                'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.days).day.to_s,
-                representation_order_date_mm: (release_date + 2.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.days).year.to_s
+                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.day).year.to_s
               }
             }
           },
           '1' => {
             first_name: 'Jane',
             last_name: 'Doe',
-            date_of_birth_dd: '26',
-            date_of_birth_mm: '07',
-            date_of_birth_yyyy: '1959',
+            'date_of_birth(3i)': '26',
+            'date_of_birth(2i)': '07',
+            'date_of_birth(1i)': '1959',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.days).day.to_s,
-                representation_order_date_mm: (release_date + 3.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.days).year.to_s
+                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.day).year.to_s
               }
             }
           }
@@ -699,35 +699,35 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           '0' => {
             first_name: 'John',
             last_name: 'Doe',
-            date_of_birth_dd: '03',
-            date_of_birth_mm: '11',
-            date_of_birth_yyyy: '1967',
+            'date_of_birth(3i)': '03',
+            'date_of_birth(2i)': '11',
+            'date_of_birth(1i)': '1967',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: earliest_representation_order_date.day.to_s,
-                representation_order_date_mm: earliest_representation_order_date.month.to_s,
-                representation_order_date_yyyy: earliest_representation_order_date.year.to_s
+                'representation_order_date(3i)': earliest_representation_order_date.day.to_s,
+                'representation_order_date(2i)': earliest_representation_order_date.month.to_s,
+                'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.days).day.to_s,
-                representation_order_date_mm: (release_date + 2.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.days).year.to_s
+                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.day).year.to_s
               }
             }
           },
           '1' => {
             first_name: 'Jane',
             last_name: 'Doe',
-            date_of_birth_dd: '26',
-            date_of_birth_mm: '07',
-            date_of_birth_yyyy: '1959',
+            'date_of_birth(3i)': '26',
+            'date_of_birth(2i)': '07',
+            'date_of_birth(1i)': '1959',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.days).day.to_s,
-                representation_order_date_mm: (release_date + 3.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.days).year.to_s
+                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.day).year.to_s
               }
             }
           }
@@ -910,35 +910,35 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           '0' => {
             first_name: 'John',
             last_name: 'Doe',
-            date_of_birth_dd: '03',
-            date_of_birth_mm: '11',
-            date_of_birth_yyyy: '1967',
+            'date_of_birth(3i)': '03',
+            'date_of_birth(2i)': '11',
+            'date_of_birth(1i)': '1967',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: earliest_representation_order_date.day.to_s,
-                representation_order_date_mm: earliest_representation_order_date.month.to_s,
-                representation_order_date_yyyy: earliest_representation_order_date.year.to_s
+                'representation_order_date(3i)': earliest_representation_order_date.day.to_s,
+                'representation_order_date(2i)': earliest_representation_order_date.month.to_s,
+                'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.days).day.to_s,
-                representation_order_date_mm: (release_date + 2.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.days).year.to_s
+                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.day).year.to_s
               }
             }
           },
           '1' => {
             first_name: 'Jane',
             last_name: 'Doe',
-            date_of_birth_dd: '26',
-            date_of_birth_mm: '07',
-            date_of_birth_yyyy: '1959',
+            'date_of_birth(3i)': '26',
+            'date_of_birth(2i)': '07',
+            'date_of_birth(1i)': '1959',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.days).day.to_s,
-                representation_order_date_mm: (release_date + 3.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.days).year.to_s
+                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.day).year.to_s
               }
             }
           }
@@ -1054,35 +1054,35 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           '0' => {
             first_name: 'John',
             last_name: 'Doe',
-            date_of_birth_dd: '03',
-            date_of_birth_mm: '11',
-            date_of_birth_yyyy: '1967',
+            'date_of_birth(3i)': '03',
+            'date_of_birth(2i)': '11',
+            'date_of_birth(1i)': '1967',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: earliest_representation_order_date.day.to_s,
-                representation_order_date_mm: earliest_representation_order_date.month.to_s,
-                representation_order_date_yyyy: earliest_representation_order_date.year.to_s
+                'representation_order_date(3i)': earliest_representation_order_date.day.to_s,
+                'representation_order_date(2i)': earliest_representation_order_date.month.to_s,
+                'representation_order_date(1i)': earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.days).day.to_s,
-                representation_order_date_mm: (release_date + 2.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.days).year.to_s
+                'representation_order_date(3i)': (release_date + 2.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 2.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 2.day).year.to_s
               }
             }
           },
           '1' => {
             first_name: 'Jane',
             last_name: 'Doe',
-            date_of_birth_dd: '26',
-            date_of_birth_mm: '07',
-            date_of_birth_yyyy: '1959',
+            'date_of_birth(3i)': '26',
+            'date_of_birth(2i)': '07',
+            'date_of_birth(1i)': '1959',
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.days).day.to_s,
-                representation_order_date_mm: (release_date + 3.days).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.days).year.to_s
+                'representation_order_date(3i)': (release_date + 3.day).day.to_s,
+                'representation_order_date(2i)': (release_date + 3.day).month.to_s,
+                'representation_order_date(1i)': (release_date + 3.day).year.to_s
               }
             }
           }

--- a/spec/validators/claim/base_claim_sub_model_validator_spec.rb
+++ b/spec/validators/claim/base_claim_sub_model_validator_spec.rb
@@ -67,22 +67,23 @@ RSpec.describe Claim::BaseClaimSubModelValidator, type: :validator do
         claim.force_validation = true
         claim.reload.valid?
 
-        expect(claim.errors[:defendant_1_date_of_birth]).to eq(['blank'])
-        expect(claim.errors[:defendant_1_first_name]).to eq(['blank'])
+        expect(claim.errors[:defendant_1_date_of_birth]).to eq(['Enter a date of birth'])
+        expect(claim.errors[:defendant_1_first_name]).to eq(['Enter a first name'])
       end
     end
 
     context 'bubbling up errors two levels to the claim' do
       let(:expected_results) do
         {
-          defendant_1_representation_order_1_representation_order_date: 'not_before_earliest_permitted_date',
-          defendant_1_date_of_birth: 'blank'
+          defendant_1_representation_order_1_representation_order_date:
+            'Representation order date is too far in the past',
+          defendant_1_date_of_birth: 'Enter a date of birth'
         }
       end
 
       context 'when claim has case type requiring MAAT reference' do
         before do
-          expected_results[:defendant_1_representation_order_1_maat_reference] = 'invalid'
+          expected_results[:defendant_1_representation_order_1_maat_reference] = 'Enter a valid MAAT reference'
 
           claim.case_type.update_column(:requires_maat_reference, true)
 

--- a/spec/validators/defendant_validator_spec.rb
+++ b/spec/validators/defendant_validator_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe DefendantValidator, type: :validator do
   end
 
   describe '#first_name' do
-    it { should_error_if_not_present(defendant, :first_name, 'blank') }
-    it { should_error_if_exceeds_length(defendant, :first_name, 40, 'max_length') }
+    it { should_error_if_not_present(defendant, :first_name, 'Enter a first name') }
+    it { should_error_if_exceeds_length(defendant, :first_name, 40, 'First name is too long') }
   end
 
   describe '#last_name' do
-    it { should_error_if_not_present(defendant, :last_name, 'blank') }
-    it { should_error_if_exceeds_length(defendant, :last_name, 40, 'max_length') }
+    it { should_error_if_not_present(defendant, :last_name, 'Enter a last name') }
+    it { should_error_if_exceeds_length(defendant, :last_name, 40, 'Last name is too long') }
   end
 
   describe '#validate_date_of_birth' do
-    it { should_error_if_not_present(defendant, :date_of_birth, 'blank') }
-    it { should_error_if_before_specified_date(defendant, :date_of_birth, 120.years.ago, 'check') }
-    it { should_error_if_after_specified_date(defendant, :date_of_birth, 10.years.ago, 'check') }
+    it { should_error_if_not_present(defendant, :date_of_birth, 'Enter a date of birth') }
+    it { should_error_if_before_specified_date(defendant, :date_of_birth, 120.years.ago, 'Check the date of birth') }
+    it { should_error_if_after_specified_date(defendant, :date_of_birth, 10.years.ago, 'Check the date of birth') }
   end
 
   describe '#validate_representation_orders' do
@@ -46,8 +46,10 @@ RSpec.describe DefendantValidator, type: :validator do
 
       it 'validates for presence of a rep order' do
         expect(defendant).to_not be_valid
-        expect(defendant.errors[:representation_order_1_representation_order_date]).to eq ['blank']
-        expect(defendant.errors[:representation_order_1_maat_reference]).to eq ['invalid']
+        expect(
+          defendant.errors[:representation_order_1_representation_order_date]
+        ).to eq ['Enter a representation order date']
+        expect(defendant.errors[:representation_order_1_maat_reference]).to eq ['Enter a valid MAAT reference']
       end
     end
   end

--- a/spec/validators/representation_order_validator_spec.rb
+++ b/spec/validators/representation_order_validator_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
   end
 
   context 'representation_order_date' do
-    it { should_error_if_not_present(reporder, :representation_order_date, 'blank') }
-    it { should_error_if_in_future(reporder, :representation_order_date, 'in_future') }
-    it { should_error_if_too_far_in_the_past(reporder, :representation_order_date, 'not_before_earliest_permitted_date') }
+    it { should_error_if_not_present(reporder, :representation_order_date, 'Enter a representation order date') }
+    it { should_error_if_in_future(reporder, :representation_order_date, 'Representation order date can not be too far in the future') }
+    it { should_error_if_too_far_in_the_past(reporder, :representation_order_date, 'Representation orders should be entered in chronological order') }
 
     context 'for advocate final claims' do
       let(:case_type) { build(:case_type, :fixed_fee) }
@@ -43,7 +43,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
 
           it 'is invalid' do
             expect(reporder).not_to be_valid
-            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_first_day_of_trial')
+            expect(reporder.errors[:representation_order_date]).to include('Check combination of representation order date and trial dates')
           end
         end
       end
@@ -73,7 +73,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
 
           it 'is invalid' do
             expect(reporder).not_to be_valid
-            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_first_day_of_retrial')
+            expect(reporder.errors[:representation_order_date]).to include('Check combination of representation order date and trial dates')
           end
         end
       end
@@ -103,7 +103,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
 
           it 'is invalid' do
             expect(reporder).not_to be_valid
-            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_cracked_date')
+            expect(reporder.errors[:representation_order_date]).to include('Check combination of representation order date and case cracked date')
           end
         end
       end
@@ -133,7 +133,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
 
           it 'is invalid' do
             expect(reporder).not_to be_valid
-            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_trial_cracked_date')
+            expect(reporder.errors[:representation_order_date]).to include('Check combination of representation order date and case cracked date')
           end
         end
       end
@@ -171,7 +171,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
 
           it 'is invalid' do
             expect(reporder).not_to be_valid
-            expect(reporder.errors[:representation_order_date]).to include('not_on_or_before_case_concluded_date')
+            expect(reporder.errors[:representation_order_date]).to include('Check combination of representation order date and case concluded date')
           end
         end
       end
@@ -184,7 +184,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
     context 'representation_order_date' do
       let(:earliest_permitted_date) { Date.new(2014, 10, 2) }
 
-      it { should_error_if_before_specified_date(reporder, :representation_order_date, earliest_permitted_date, 'not_before_interim_earliest_permitted_date') }
+      it { should_error_if_before_specified_date(reporder, :representation_order_date, earliest_permitted_date, 'Representation orders should be entered in chronological order') }
     end
   end
 
@@ -211,7 +211,7 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
       ro2.representation_order_date = ro1.representation_order_date - 1.day
       claim.force_validation = true
       expect(ro2).not_to be_valid
-      expect(ro2.errors[:representation_order_date]).to include('check')
+      expect(ro2.errors[:representation_order_date]).to include('Representation orders should be entered in chronological order')
     end
   end
 end


### PR DESCRIPTION
#### What

Changing the defendants details from the old adp form builder to the new GOVUKDesignSystemFormBuilder

#### Ticket

[FormBuilder migration - Defendants details](https://dsdmoj.atlassian.net/browse/CFP-370)

#### Why

Continue the migration away from the deprecated design system to the current GOVUK Frontend,

Resolve related accessibility issues identified in the 2020 DAC Accessibility report

Reduce/remove redundant adp form builders throughout the codebase and using GOVUKDesignSystemFormBuilder

#### TODO

- [ ] Fix form error style
- [ ] Rewrite custom error presenter to resolve nested attributes error summary linking
