### PR TITLE
Some more Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3186,14 +3186,6 @@ Style/SymbolProc:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Exclude:
-    - 'spec/api/v1/external_users/claims/interim_claim_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 # Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, AllowedMethods.
 # AllowedMethods: to_ary, to_a, to_c, to_enum, to_h, to_hash, to_i, to_int, to_io, to_open, to_path, to_proc, to_r, to_regexp, to_str, to_s, to_sym
 Style/TrivialAccessors:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3035,14 +3035,6 @@ Style/RedundantAssignment:
   Exclude:
     - 'app/controllers/case_conclusions_controller.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/RedundantBegin:
-  Exclude:
-    - 'spec/factories/claim/base_claims.rb'
-    - 'spec/support/matchers/raise_error_matchers.rb'
-    - 'spec/support/view_spec_helpers.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/RedundantCapitalW:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2783,29 +2783,6 @@ Style/HashEachMethods:
   Exclude:
     - 'spec/services/cclf/fee/shared_examples_for_cclf_fee_adapters.rb'
 
-# Offense count: 47
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedShorthandSyntax, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-# SupportedShorthandSyntax: always, never, either
-Style/HashSyntax:
-  Exclude:
-    - 'spec/api/v1/external_users/claims/advocates/interim_claim_spec.rb'
-    - 'spec/api/v1/external_users/claims/advocates/supplementary_claim_spec.rb'
-    - 'spec/api/v2/case_workers/allocate_spec.rb'
-    - 'spec/lib/extensions/hash_extension_spec.rb'
-    - 'spec/models/claim/transfer_brain_data_item_collection_spec.rb'
-    - 'spec/models/claim/transfer_brain_data_item_spec.rb'
-    - 'spec/presenters/claim/base_claim_presenter_spec.rb'
-    - 'spec/presenters/fixed_fee_presenter_spec.rb'
-    - 'spec/rails_helper.rb'
-    - 'spec/services/claims/case_worker_claims_spec.rb'
-    - 'spec/services/message_queue/aws_client_spec.rb'
-    - 'spec/services/zendesk_sender_spec.rb'
-    - 'spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb'
-    - 'spec/validators/claim/litigator_claim_validator_spec.rb'
-    - 'spec/vcr_helper.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/HashTransformValues:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3091,12 +3091,6 @@ Style/RedundantReturn:
 
 # Offense count: 2
 # Cop supports --auto-correct.
-Style/RedundantSelf:
-  Exclude:
-    - 'spec/support/claim_api_endpoints.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
 Style/RedundantSort:
   Exclude:
     - 'app/models/defendant.rb'

--- a/spec/api/v1/external_users/claims/advocates/interim_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/interim_claim_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::InterimClaim do
   let!(:court) { create(:court) }
   let!(:valid_params) do
     {
-      :api_key => provider.api_key,
-      :creator_email => vendor.user.email,
-      :user_email => advocate.user.email,
-      :case_number => 'A20161234',
-      :advocate_category => 'Leading junior',
-      :offence_id => offence.id,
-      :court_id => court.id
+      api_key: provider.api_key,
+      creator_email: vendor.user.email,
+      user_email: advocate.user.email,
+      case_number: 'A20161234',
+      advocate_category: 'Leading junior',
+      offence_id: offence.id,
+      court_id: court.id
     }
   end
 

--- a/spec/api/v1/external_users/claims/advocates/supplementary_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/supplementary_claim_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::SupplementaryClaim do
   let!(:court) { create(:court) }
   let!(:valid_params) do
     {
-      :api_key => provider.api_key,
-      :creator_email => vendor.user.email,
-      :user_email => advocate.user.email,
-      :case_number => 'T20191234',
-      :advocate_category => 'Leading junior',
-      :court_id => court.id
+      api_key: provider.api_key,
+      creator_email: vendor.user.email,
+      user_email: advocate.user.email,
+      case_number: 'T20191234',
+      advocate_category: 'Leading junior',
+      court_id: court.id
     }
   end
 

--- a/spec/api/v1/external_users/claims/interim_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/interim_claim_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe API::V1::ExternalUsers::Claims::InterimClaim do
       case_type_id: create(:case_type, :trial).id,
       case_number: 'A20161234',
       offence_id: offence.id,
-      court_id: court.id,
+      court_id: court.id
     }
   end
 

--- a/spec/api/v2/case_workers/allocate_spec.rb
+++ b/spec/api/v2/case_workers/allocate_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe API::V2::CaseWorkers::Allocate do
 
       it 'returns JSON containing an error description' do
         body = JSON.parse(last_response.body, symbolize_names: true)
-        expected = [{ :error => 'claim_ids is invalid' }]
+        expected = [{ error: 'claim_ids is invalid' }]
         expect(body).to eq(expected)
       end
     end

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -66,31 +66,29 @@ FactoryBot.define do
 end
 
 def publicise_errors(claim)
-  begin
-    yield
-  rescue => e
-    puts "***************** DEBUG validation errors #{__FILE__}::#{__LINE__} **********"
-    ap claim
-    puts claim.errors.full_messages
-    claim.defendants.each do |defendant|
-      ap defendant
-      puts defendant.errors.full_messages
-      defendant.representation_orders.each do |rep|
-        ap rep
-        puts '>>> rep order'
-        puts rep.errors.full_messages
-      end
+  yield
+rescue => e
+  puts "***************** DEBUG validation errors #{__FILE__}::#{__LINE__} **********"
+  ap claim
+  puts claim.errors.full_messages
+  claim.defendants.each do |defendant|
+    ap defendant
+    puts defendant.errors.full_messages
+    defendant.representation_orders.each do |rep|
+      ap rep
+      puts '>>> rep order'
+      puts rep.errors.full_messages
     end
-    claim.fees.each do |fee|
-      ap fee
-      puts fee.errors.full_messages
-    end
-    claim.expenses.each do |expense|
-      ap expense
-      puts expense.errors.full_messages
-    end
-    raise e
   end
+  claim.fees.each do |fee|
+    ap fee
+    puts fee.errors.full_messages
+  end
+  claim.expenses.each do |expense|
+    ap expense
+    puts expense.errors.full_messages
+  end
+  raise e
 end
 
 def populate_required_fields(claim)

--- a/spec/lib/extensions/hash_extension_spec.rb
+++ b/spec/lib/extensions/hash_extension_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hash do
     subject { h.all_values_for(:key_id) }
 
     it 'returns an array of all values for the specified key' do
-      is_expected.to match_array ['1', '2', '3', '4', '5', '6', { :key_id => '7' }, '7', [:key_id, :key_id]]
+      is_expected.to match_array ['1', '2', '3', '4', '5', '6', { key_id: '7' }, '7', [:key_id, :key_id]]
     end
   end
 

--- a/spec/models/claim/transfer_brain_data_item_collection_spec.rb
+++ b/spec/models/claim/transfer_brain_data_item_collection_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Claim::TransferBrainDataItemCollection do
       let(:detail) { with_specific_mapping }
 
       it 'returns a valid data item' do
-        is_expected.to include({ :validity => true })
+        is_expected.to include({ validity: true })
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Claim::TransferBrainDataItemCollection do
       let(:detail) { with_wildcard_mapping }
 
       it 'returns a valid data item' do
-        is_expected.to include({ :validity => true })
+        is_expected.to include({ validity: true })
       end
     end
 

--- a/spec/models/claim/transfer_brain_data_item_spec.rb
+++ b/spec/models/claim/transfer_brain_data_item_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe Claim::TransferBrainDataItem do
           false => {
             10 => {
               50 => {
-                :validity => true,
-                :transfer_fee_full_name => 'up to and including PCMH transfer (new) - guilty plea',
-                :allocation_type => 'Grad',
-                :bill_scenario => 'ST3TS1T2',
-                :ppe_required => 'FALSE',
-                :days_claimable => 'FALSE'
+                validity: true,
+                transfer_fee_full_name: 'up to and including PCMH transfer (new) - guilty plea',
+                allocation_type: 'Grad',
+                bill_scenario: 'ST3TS1T2',
+                ppe_required: 'FALSE',
+                days_claimable: 'FALSE'
               }
             }
           }

--- a/spec/presenters/claim/base_claim_presenter_spec.rb
+++ b/spec/presenters/claim/base_claim_presenter_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe Claim::BaseClaimPresenter do
     it 'lists valid transitions from part_authorised' do
       claim.state = 'part_authorised'
       presenter = Claim::BaseClaimPresenter.new(claim, view)
-      expect(presenter.valid_transitions).to eq({ :redetermination => 'Redetermination', :awaiting_written_reasons => 'Awaiting written reasons' })
+      expect(presenter.valid_transitions)
+        .to eq({ redetermination: 'Redetermination', awaiting_written_reasons: 'Awaiting written reasons' })
     end
   end
 

--- a/spec/presenters/fixed_fee_presenter_spec.rb
+++ b/spec/presenters/fixed_fee_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Fee::FixedFeePresenter do
-  let(:fixed_fee) { instance_double(Fee::FixedFee, claim: double, quantity_is_decimal?: false, errors: { :quantity => [] }) }
+  let(:fixed_fee) { instance_double(Fee::FixedFee, claim: double, quantity_is_decimal?: false, errors: { quantity: [] }) }
   let(:presenter) { Fee::FixedFeePresenter.new(fixed_fee, view) }
 
   context '#rate' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -178,7 +178,7 @@ RSpec.configure do |config|
 
   config.before do |example|
     if example.metadata[:delete]
-      DatabaseCleaner.strategy = :truncation, { :except => ['vat_rates'] }
+      DatabaseCleaner.strategy = :truncation, { except: ['vat_rates'] }
     else
       DatabaseCleaner.strategy = :transaction
     end

--- a/spec/services/claims/case_worker_claims_spec.rb
+++ b/spec/services/claims/case_worker_claims_spec.rb
@@ -6,14 +6,14 @@ module Claims
 
     let(:criteria) do
       {
-        :sorting => 'last_submitted_at',
-        :direction => 'asc',
-        :scheme => 'agfs',
-        :filter => 'all',
-        :page => 0,
-        :limit => 25,
-        :search => nil,
-        :value_band_id => 0
+        sorting: 'last_submitted_at',
+        direction: 'asc',
+        scheme: 'agfs',
+        filter: 'all',
+        page: 0,
+        limit: 25,
+        search: nil,
+        value_band_id: 0
       }
     end
 

--- a/spec/services/message_queue/aws_client_spec.rb
+++ b/spec/services/message_queue/aws_client_spec.rb
@@ -26,7 +26,7 @@ module MessageQueue
     let(:stub_queue_response_failure) do
       Aws::SQS::Errors::NonExistentQueue.new(
         double('request'),
-        double('response', :status => 400, :body => '<foo/>', :empty? => false)
+        double('response', status: 400, body: '<foo/>', empty?: false)
       )
     end
     let(:body) do

--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -20,8 +20,19 @@ RSpec.describe ZendeskSender do
     let(:stubbed_request) do
       stub_request(:post, 'https://ministryofjustice.zendesk.com/api/v2/tickets')
         .with(
-          :body => '{"ticket":{"subject":"Bug report","description":"event - outcome - email address","custom_fields":[{"id":"26047167","value":"/claims"},{"id":"23757677","value":"advocate_defence_payments"},{"id":"23791776","value":"chrome"},{"id":"32342378","value":"test"}]}}',
-          :headers => {
+          body: {
+            ticket: {
+              subject: 'Bug report',
+              description: 'event - outcome - email address',
+              custom_fields: [
+                { id: '26047167', value: '/claims' },
+                { id: '23757677', value: 'advocate_defence_payments' },
+                { id: '23791776', value: 'chrome' },
+                { id: '32342378', value: 'test' }
+              ]
+            }
+          }.to_json,
+          headers: {
             'Accept' => 'application/json',
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Type' => 'application/json',

--- a/spec/support/claim_api_endpoints.rb
+++ b/spec/support/claim_api_endpoints.rb
@@ -30,7 +30,7 @@ class ClaimApiEndpoints
     private
 
     def namespace
-      self.type.to_sym == :advocate ? '' : "/#{self.type}"
+      type.to_sym == :advocate ? '' : "/#{type}"
     end
   end
 end

--- a/spec/support/matchers/raise_error_matchers.rb
+++ b/spec/support/matchers/raise_error_matchers.rb
@@ -2,13 +2,11 @@ require 'rspec/expectations'
 
 RSpec::Matchers.define :raise_only_amount_assessed_error do
   match do |actual|
-    begin
-      actual.call
-      false
-    rescue StateMachines::InvalidTransition => e
-      @error_message = e.message
-      e.message.match?(/\(Reason\(s\)\: Amount assessed Amount assessed cannot be zero for claims in state .*\)/)
-    end
+    actual.call
+    false
+  rescue StateMachines::InvalidTransition => e
+    @error_message = e.message
+    e.message.match?(/\(Reason\(s\)\: Amount assessed Amount assessed cannot be zero for claims in state .*\)/)
   end
 
   def supports_block_expectations?

--- a/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
+++ b/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
@@ -258,7 +258,7 @@ RSpec.shared_examples 'common defendant uplift fees aggregation validation' do
       it 'are ignored' do
         midwu_fee = claim.fees.joins(:fee_type).where(fee_types: { unique_code: 'MIDWU' }).first
         claim.update(
-          :misc_fees_attributes => {
+          misc_fees_attributes: {
             '0' => {
               'id' => midwu_fee.id,
               '_destroy' => '1'
@@ -284,7 +284,7 @@ RSpec.shared_examples 'common defendant uplift fees aggregation validation' do
 
       it 'are ignored' do
         claim.update(
-          :defendants_attributes => {
+          defendants_attributes: {
             '0' => {
               'id' => claim.defendants.first.id,
               '_destroy' => '1'

--- a/spec/support/view_spec_helpers.rb
+++ b/spec/support/view_spec_helpers.rb
@@ -20,16 +20,14 @@ module ViewSpecHelper
   end
 
   def within(selector)
-    begin
-      if scopes.empty?
-        scopes << Capybara.string(rendered).find(selector)
-      else
-        scopes << rendered.find(selector)
-      end
-      yield rendered
-    ensure
-      scopes.pop
+    if scopes.empty?
+      scopes << Capybara.string(rendered).find(selector)
+    else
+      scopes << rendered.find(selector)
     end
+    yield rendered
+  ensure
+    scopes.pop
   end
 
   def rendered

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
       it 'are ignored' do
         miupl_fee = claim.fees.joins(:fee_type).where(fee_types: { unique_code: 'MIUPL' }).first
         claim.update(
-          :misc_fees_attributes => {
+          misc_fees_attributes: {
             '0' => {
               'id' => miupl_fee.id,
               '_destroy' => '1'
@@ -150,7 +150,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
 
       it 'are ignored' do
         claim.update(
-          :defendants_attributes => {
+          defendants_attributes: {
             '0' => {
               'id' => claim.defendants.first.id,
               '_destroy' => '1'

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -72,7 +72,7 @@ end
 
 # Turn off vcr from the command line, for example:
 # `VCR_OFF=true cucumber|rspec`
-VCR.turn_off!(:ignore_cassettes => true) if ENV['VCR_OFF']
+VCR.turn_off!(ignore_cassettes: true) if ENV['VCR_OFF']
 
 # Create VCR cassettes for any specs with a :fee_calc_vcr tag
 # in the cassette library under a directory structure
@@ -81,7 +81,7 @@ RSpec.configure do |config|
   config.around(:each, [:fee_calc_vcr, :currency_vcr]) do |example|
     if VCR.turned_on?
       cassette = Pathname.new(example.metadata[:file_path]).cleanpath.sub_ext('').to_s
-      VCR.use_cassette(cassette, :record => :new_episodes, :match_requests_on => [:method, :path_query_matcher]) do
+      VCR.use_cassette(cassette, record: :new_episodes, match_requests_on: [:method, :path_query_matcher]) do
         example.run
       end
     else


### PR DESCRIPTION
#### What

Fix some more of the Rubocop offences listed in `.rubocop_todo.yml`.

#### Ticket

N/A

#### Why

The continuing mission towards a consistent code standard.

#### How

Auto-correct some of the easily fixable offences;

**Style/HashSyntax**

```ruby
# Bad
{ :foo => 'bar' }
# Good
{ foo: 'bar' }
```

**Style/TrailingCommaInHashLiteral**

```ruby
# Bad
{
  foo: 'bar',
}
# Good
{
  foo: 'bar'
}
```

**Style/RedundantSelf**

```ruby
class Thing
  attr_reader :foo 

  def bar
    # Bad
    puts self.foo
    # Good
    puts foo
  end
end
```

**Style/RedundantBegin**

```ruby
# Bad
def foo
  begin
    ...
  rescue
    ...
  end
end

# Good
def foo
  ...
rescue
  ...
end
```
