### PR TITLE
Add AccountSetter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Service for the remunerating of advocates and litigators by the Legal Aid Agency
 * [Maintenance mode](docs/maintenance_mode.md)
 * [Cheat sheet](docs/cheat_sheet.md)
 * [Note on VAT](docs/vat_note.md)
+* [Account setter utility](docs/account_setter.md)
 
 ## Contributing
 

--- a/docs/account_setter.md
+++ b/docs/account_setter.md
@@ -1,0 +1,28 @@
+## Account setter
+
+### Description:
+
+Utility class for bulk operations on **external** user accounts.
+
+Specifically this was written for soft deleting, undoing a soft deletion and password resetting
+of an external user account. NB: "soft deletion" is a mechanism to deactivate an
+account by marking it as deleted without actually deleting it.
+
+### Requirements:
+
+The utility class is not autoloaded so it needs to be required befure use:
+
+```ruby
+require 'utils/account_setter'
+```
+
+### Usage:
+
+```ruby
+emails = ['user1@exaxmple.com', 'user2@exaxmple.com']
+accounts = AccountSetter.new(emails)
+accounts.report
+accounts.soft_delete
+accounts.un_soft_delete
+accounts.change_password
+```

--- a/lib/utils/account_setter.rb
+++ b/lib/utils/account_setter.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Utility class for bulk operations on external user account(s).
+#
+# Needs to be loaded and run in a rails console
+# running an instance of the [CCCD application](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence)
+#
+# example:
+#  accounts = AccountSetter.new(EMAILS)
+#  accounts.report
+#  accounts.soft_delete
+#  accounts.un_soft_delete
+#  accounts.change_password
+#
+
+class AccountSetter
+  attr_reader :emails
+
+  def initialize(emails)
+    @emails = emails
+  end
+
+  # Find active or inactve accounts with matching email and
+  # report basic information.
+  #
+  def report
+    emails.each do |email|
+      users = User.where(email: email)
+
+      users.each do |user|
+        puts "User #{user.email} with id #{user.id} have #{user.persona.provider.claims.count} claims for their provider, \"#{user.persona.provider.name}\""
+      end
+      puts("No users found for email #{email}".red) if users.empty?
+
+      users = User.where('email LIKE ?', "#{email}.deleted.%")
+
+      users.each do |user|
+        puts "User #{user.email} with id #{user.id} have #{user.persona.provider.claims.count} claims for their provider, \"#{user.persona.provider.name}\""
+      end
+      puts("No deleted users found for email \"#{email}.deleted.%\"".red) if users.empty?
+    end
+  end
+
+  # Deactivate an active account!
+  #
+  # WARNING: this will
+  #   - log out any currently logged in user with that email address
+  #   - mark the account as inactive
+  #   - prevent future login of the account
+  #
+  def soft_delete
+    emails.each do |email|
+      user = User.find_by(email: email)
+
+      if user
+        user.persona.soft_delete
+        puts "Softly deleted #{user.email}!".green
+      else
+        puts "User with email #{email} not found!".red
+      end
+    end
+  end
+
+  # Reactivate deactivated account
+  #
+  # This will allow the user to login
+  # with existing password.
+  #
+  def un_soft_delete
+    emails.each do |email|
+      user = User.find_by('email LIKE ?', "#{email}.deleted.%")
+
+      if user
+        user.persona.update(deleted_at: nil)
+        user.update!(deleted_at: nil)
+        user.update!(email: email)
+        puts "Undid soft delete for #{user.email}!".green
+      else
+        puts "User email \"#{email}.delete.%\" not found!".red
+      end
+    end
+  end
+
+  # Resets password of users
+  #
+  # This will:
+  #  - log the user out
+  #  - force them to request a password reset via the app
+  #
+  # TODO: could send a password reset autumatically
+  #
+  def change_password
+    emails.each do |email|
+      user = User.find_by(email: email)
+
+      if user
+        pwd = SecureRandom.base64(15)
+        user.update!(password: pwd, password_confirmation: pwd)
+        puts "Updated password for #{user.email} with id #{user.id}! They will need to reest it to login!".green
+      else
+        puts "User with email #{email} not found!".red
+      end
+    end
+  end
+end

--- a/lib/utils/account_setter.rb
+++ b/lib/utils/account_setter.rb
@@ -23,6 +23,9 @@ class AccountSetter
   # Find active or inactve accounts with matching email and
   # report basic information.
   #
+  # rubocop:disable Rails/Output
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def report
     emails.each do |email|
       users = User.where(email: email)
@@ -40,6 +43,9 @@ class AccountSetter
       puts("No deleted users found for email \"#{email}.deleted.%\"".red) if users.empty?
     end
   end
+  # rubocop:enable Rails/Output
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   # Deactivate an active account!
   #
@@ -48,6 +54,7 @@ class AccountSetter
   #   - mark the account as inactive
   #   - prevent future login of the account
   #
+  # rubocop:disable Rails/Output
   def soft_delete
     emails.each do |email|
       user = User.find_by(email: email)
@@ -60,12 +67,15 @@ class AccountSetter
       end
     end
   end
+  # rubocop:enable Rails/Output
 
   # Reactivate deactivated account
   #
   # This will allow the user to login
   # with existing password.
   #
+  # rubocop:disable Rails/Output
+  # rubocop:disable Metrics/MethodLength
   def un_soft_delete
     emails.each do |email|
       user = User.find_by('email LIKE ?', "#{email}.deleted.%")
@@ -80,6 +90,8 @@ class AccountSetter
       end
     end
   end
+  # rubocop:enable Rails/Output
+  # rubocop:enable Metrics/MethodLength
 
   # Resets password of users
   #
@@ -89,6 +101,7 @@ class AccountSetter
   #
   # TODO: could send a password reset autumatically
   #
+  # rubocop:disable Rails/Output
   def change_password
     emails.each do |email|
       user = User.find_by(email: email)
@@ -102,4 +115,5 @@ class AccountSetter
       end
     end
   end
+  # rubocop:enable Rails/Output
 end

--- a/spec/lib/utils/account_setter_spec.rb
+++ b/spec/lib/utils/account_setter_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe AccountSetter do
+  subject(:instance) { described_class.new(emails) }
+
+  let(:emails) { [email] }
+  let(:email) { 'test@example.com' }
+  let(:user) { create(:user, id: 99, email: 'test@example.com', password: 'testing123') }
+
+  before { allow($stdout).to receive(:puts) }
+
+  describe '#report' do
+    subject(:report) { instance.report }
+
+    let(:external_user) { create(:external_user, user: user, provider: create(:provider, name: 'Test provider')) }
+
+    before { create_list(:claim, 5, external_user: external_user) }
+
+    it 'reports on the user' do
+      expect { report }.to output(
+        /User test@example\.com with id 99 have 5 claims for their provider, "Test provider"/
+      ).to_stdout
+    end
+
+    it { expect { report }.to output(/No deleted users found for email "test@example\.com\.deleted\..*"/).to_stdout }
+
+    context 'with an unknown user' do
+      let(:emails) { ['unknown@example.com'] }
+
+      it { expect { report }.to output(/No users found for email unknown@example\.com/).to_stdout }
+    end
+
+    context 'with a deleted user' do
+      before { user.persona.soft_delete }
+
+      it 'reports on the deleted user' do
+        expect { report }.to output(
+          /User test@example\.com\.deleted\..* with id 99 have 5 claims for their provider, "Test provider"/
+        ).to_stdout
+      end
+
+      it { expect { report }.to output(/No users found for email test@example\.com/).to_stdout }
+    end
+  end
+
+  describe '#soft_delete' do
+    subject(:soft_delete) { instance.soft_delete }
+
+    before { create(:external_user, user: user) }
+
+    it 'appends deleted to the email of the user' do
+      expect { soft_delete }
+        .to change { user.reload.email }
+        .from('test@example.com')
+        .to(/test@example\.com\.deleted\.\d*/)
+    end
+
+    it 'marks the user as deleted' do
+      expect { soft_delete }
+        .to change { user.reload.deleted_at }
+        .from(nil)
+        .to(an_instance_of(ActiveSupport::TimeWithZone))
+    end
+
+    it 'marks the persona of the user as deleted' do
+      expect { soft_delete }
+        .to change { user.reload.persona.deleted_at }
+        .from(nil)
+        .to(an_instance_of(ActiveSupport::TimeWithZone))
+    end
+
+    context 'with an unknown user' do
+      let(:emails) { ['unknown@example.com'] }
+
+      it { expect { soft_delete }.to output(/User with email unknown@example\.com not found/).to_stdout }
+    end
+  end
+
+  describe '#un_soft_delete' do
+    subject(:un_soft_delete) { instance.un_soft_delete }
+
+    before do
+      external_user = create(:external_user, user: user)
+      external_user.soft_delete
+    end
+
+    it 'removes deleted from the email of the user' do
+      expect { un_soft_delete }
+        .to change { user.reload.email }
+        .from(/test@example\.com\.deleted\.\d*/)
+        .to('test@example.com')
+    end
+
+    it 'removes the deleted at timestamp of the user' do
+      expect { un_soft_delete }
+        .to change { user.reload.deleted_at }
+        .from(an_instance_of(ActiveSupport::TimeWithZone))
+        .to(nil)
+    end
+
+    it 'removes the deleted at timestamp of the persona of the user' do
+      expect { un_soft_delete }
+        .to change { user.reload.persona.deleted_at }
+        .from(an_instance_of(ActiveSupport::TimeWithZone))
+        .to(nil)
+    end
+
+    context 'with an unknown user' do
+      let(:emails) { ['unknown@example.com'] }
+
+      it { expect { un_soft_delete }.to output(/User email "unknown@example\.com\.delete\.%" not found/).to_stdout }
+    end
+  end
+
+  describe '#change_password' do
+    subject(:change_password) { instance.change_password }
+
+    it 'changes the password of the user' do
+      expect { change_password }.to change { user.reload.valid_password?('testing123') }.from(true).to(false)
+    end
+
+    context 'with an unknown user' do
+      let(:emails) { ['unknown@example.com'] }
+
+      it { expect { change_password }.to output(/User with email unknown@example\.com not found/).to_stdout }
+    end
+  end
+end


### PR DESCRIPTION
Copied the AccountSetter class from laa-cccd-scripts

This has been copied into `lib/utils/` which, as a subdirectory of `lib/`,
means that it will not be autoloaded. To use;

```ruby
require 'utils/account_setter`

accounts = AccountSetter.new(['user1@example.com', 'user2.example.com'])
accounts.report
```

#### What

Copy the `AccountSetter` class from [laa-cccd-scripts](/ministryofjustice/laa-cccd-scripts)

#### Ticket

N/A

#### Why

laa-cccd-scripts contains some utilities for managing user accounts but to use them in an environment it is necessary to copy on to the kubernetes pod. It is copied into this repository for convenience.

#### How

Copy `account_setter.rb` into `lib/utils`. Being in a subdirectory it does not get autoloaded so to use it has to be required:

```ruby
require 'utils/account_setter'
```