### PR TITLE
Move docker scan success alerting channel

### DIFF
--- a/.github/workflows/docker_image_scan.yml
+++ b/.github/workflows/docker_image_scan.yml
@@ -28,9 +28,6 @@ jobs:
       uses: github/codeql-action/upload-sarif@v1
       with:
         sarif_file: snyk.sarif
-    - name: Output outcome
-      run: |
-        echo ${{ steps.image-scan.outcome }}
     - name: Slack notify failure
       if: ${{ steps.image-scan.outcome == 'failure' }}
       uses: rtCamp/action-slack-notify@v2
@@ -48,7 +45,7 @@ jobs:
       env:
         SLACK_USERNAME: Snyk docker image scan
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_CHANNEL: laa-cccd-alerts
+        SLACK_CHANNEL: laa-claim-for-payment-development
         SLACK_ICON_EMOJI: ':snyk:'
         SLACK_COLOR: success
         SLACK_MESSAGE: docker scan found no vulnerabilites!


### PR DESCRIPTION
#### What
Move docker scan alerting channel.

Also remove unecessary output of step
status. It was just used during testing.

#### Why
To keep the alerts channel for failures only
and thereby avoid noise. It would however still
be of use to easily confirm that the scan is
functioning as expected.
