### PR TITLE
Add synk monitor action to cccd docker image

### DIFF
--- a/.github/workflows/docker_image_scan.yml
+++ b/.github/workflows/docker_image_scan.yml
@@ -10,11 +10,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Build docker image
       run: |
         docker build \
           --tag cccd:scan \
           --file docker/Dockerfile .
+
     - name: Scan docker image using snyk
       id: image-scan
       continue-on-error: true
@@ -24,10 +26,22 @@ jobs:
       with:
         image: cccd:scan
         args: --file=docker/Dockerfile
+
+    - name: Monitor docker image using snyk
+      id: image-monitor
+      uses: snyk/actions/docker@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        command: monitor
+        image: cccd:scan
+        args: --file=docker/Dockerfile
+
     - name: Upload result to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v1
       with:
         sarif_file: snyk.sarif
+
     - name: Slack notify failure
       if: ${{ steps.image-scan.outcome == 'failure' }}
       uses: rtCamp/action-slack-notify@v2
@@ -36,9 +50,12 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_CHANNEL: laa-cccd-alerts
         SLACK_ICON_EMOJI: ':snyk:'
-        SLACK_COLOR: '#fc0303'
+        SLACK_COLOR: ${{ steps.image-scan.outcome }}
+        SLACK_TITLE: Scanned ${{ github.repository }}
         SLACK_MESSAGE: docker scan detected vulnerabilites! @laa-claim-for-payment-devs
         SLACK_LINK_NAMES: true
+        SLACK_FOOTER:
+
     - name: Slack notify success
       if: ${{ steps.image-scan.outcome == 'success' }}
       uses: rtCamp/action-slack-notify@v2
@@ -47,5 +64,7 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_CHANNEL: laa-claim-for-payment-development
         SLACK_ICON_EMOJI: ':snyk:'
-        SLACK_COLOR: success
+        SLACK_COLOR: ${{ steps.image-scan.outcome }}
+        SLACK_TITLE: Scanned ${{ github.repository }}
         SLACK_MESSAGE: docker scan found no vulnerabilites!
+        SLACK_FOOTER:


### PR DESCRIPTION
#### What
This updates the docker image for monitoring
based on the schedule.

Also tweaks the slack notifications to:

 - rely on status for color of the "attachment"
 - adds a message TITLE containing repo name to differentiate
   from other snyk alerts in the same channel.
 - removes the default footer from the slack action library

#### Why
Monitoring of the up-to-date image allows snyk to provide
upto date information and possible fix PRs.
