### PR TITLE
Revert newer method to accommodate IE11

### DIFF
--- a/app/webpack/javascripts/modules/Modules.AutocompleteWrapper.js
+++ b/app/webpack/javascripts/modules/Modules.AutocompleteWrapper.js
@@ -6,12 +6,13 @@ moj.Modules.AutocompleteWrapper = {
   },
 
   Autocomplete: function (nodeList) {
-    nodeList.forEach((node) => {
-      return moj.Helpers.Autocomplete.new('#' + node.id, {
+    for (let i = 0; i < nodeList.length; i++) {
+      const node = nodeList[i]
+      moj.Helpers.Autocomplete.new('#' + node.id, {
         showAllValues: true,
         autoselect: false,
         displayMenu: 'overlay'
       })
-    })
+    }
   }
 }


### PR DESCRIPTION
#### What
Our new Autocomplete wrapper uses `nodeList.forEach` and this is supported by all the major browsers other than Internet Explorer. This causes an error in IE even the user is not on a page that uses this component. 


#### TODO (wip)

 - [ ] item 1
 - [X] item 2
