### PR TITLE
[CFP-295] Use kwargs instead of options hash

### DIFF
--- a/app/services/stats/management_information/daily_report_count_generator.rb
+++ b/app/services/stats/management_information/daily_report_count_generator.rb
@@ -7,8 +7,8 @@ module Stats
     class DailyReportCountGenerator
       include StuffLogger
 
-      def self.call(**kwargs)
-        new(kwargs).call
+      def self.call(...)
+        new(...).call
       end
 
       def initialize(**kwargs)

--- a/app/services/stats/management_information/daily_report_generator.rb
+++ b/app/services/stats/management_information/daily_report_generator.rb
@@ -7,12 +7,12 @@ module Stats
     class DailyReportGenerator
       include StuffLogger
 
-      def self.call(options = {})
-        new(options).call
+      def self.call(...)
+        new(...).call
       end
 
-      def initialize(options = {})
-        @scheme = options[:scheme]
+      def initialize(**kwargs)
+        @scheme = kwargs[:scheme]
       end
 
       def call

--- a/app/services/stats/management_information_generator.rb
+++ b/app/services/stats/management_information_generator.rb
@@ -4,8 +4,8 @@ module Stats
   class ManagementInformationGenerator
     include StuffLogger
 
-    def self.call(**kwargs)
-      new(kwargs).call
+    def self.call(...)
+      new(...).call
     end
 
     def initialize(**kwargs)

--- a/app/services/stats/simple_report_generator.rb
+++ b/app/services/stats/simple_report_generator.rb
@@ -1,7 +1,7 @@
 module Stats
   class SimpleReportGenerator
-    def self.call(**kwargs)
-      new(kwargs).call
+    def self.call(...)
+      new(...).call
     end
 
     def call

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -65,7 +65,7 @@ module Stats
     end
 
     def generate_new_report
-      generator[:class].call(options.merge(generator[:default_args]))
+      generator[:class].call(**options.merge(generator[:default_args]))
     end
 
     def notify_error(report_record, error)

--- a/spec/services/stats/management_information_generator_spec.rb
+++ b/spec/services/stats/management_information_generator_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
     end
 
     context 'with AGFS scope' do
-      subject(:call) { described_class.new({ scheme: :agfs }).call }
+      subject(:call) { described_class.new(scheme: :agfs).call }
 
       it 'returns rows of AGFS active non-draft claims' do
         expect(csv['Scheme']).to match_array(%w[AGFS] * 4)
@@ -71,7 +71,7 @@ RSpec.describe Stats::ManagementInformationGenerator do
     end
 
     context 'with LGFS scope' do
-      subject(:call) { described_class.new({ scheme: :lgfs }).call }
+      subject(:call) { described_class.new(scheme: :lgfs).call }
 
       it 'returns rows of LGFS active non-draft claims' do
         expect(csv['Scheme']).to match_array(%w[LGFS] * 2)


### PR DESCRIPTION
#### What

Some minor changes to ease the move to Ruby 3.

#### Ticket

[Update Ruby to 3.0 (or 3.1)](https://dsdmoj.atlassian.net/browse/CFP-295)

#### Why

Prior to Ruby 3.0 it was possible to use the final positional argument to a function as a hash of keyword arguments. This has been removed in Ruby 3.0.

#### How

Update `app/services/stats/management_information/daily_report_count_generator.rb`, `app/services/stats/management_information/daily_report_generator.rb` and `app/services/stats/management_information_generator.rb` to handle arguments consistently and then change `app/services/stats/stats_report_generator.rb` so that the arguments are passed correctly as keyword arguments and not a hash.

Additionally, use the `...` syntax (added in Ruby 2.7) to pass through arguments in the `self.call` methods. See [this article](https://ryanbigg.com/2021/07/ruby-27s-new-triple-dot-syntax) for details.