### PR TITLE
More fixes from the Rubocop todo list

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2280,18 +2280,6 @@ Rails/Pluck:
   Exclude:
     - 'spec/api/v2/case_workers/claim_spec.rb'
 
-# Offense count: 44
-# Cop supports --auto-correct.
-Rails/PluralizationGrammar:
-  Exclude:
-    - 'spec/factories/claim/advocate_claims.rb'
-    - 'spec/factories/claim/base_claims.rb'
-    - 'spec/models/claims/financial_summary_spec.rb'
-    - 'spec/models/stats/collector/claim_redeterminations_collector_spec.rb'
-    - 'spec/models/subscribers/slack_spec.rb'
-    - 'spec/support/validation_helpers.rb'
-    - 'spec/validators/claim/advocate_interim_claim_web_validations_spec.rb'
-
 # Offense count: 10
 # Cop supports --auto-correct.
 Rails/Presence:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -125,25 +125,6 @@ Lint/UnusedMethodArgument:
   Exclude:
     - 'spec/support/view_spec_helpers.rb'
 
-# Offense count: 23
-Lint/UselessAssignment:
-  Exclude:
-    - 'spec/api/v1/external_users/fee_spec.rb'
-    - 'spec/controllers/external_users/admin/external_users_controller_spec.rb'
-    - 'spec/controllers/messages_controller_spec.rb'
-    - 'spec/factories/claim/litigator_claims.rb'
-    - 'spec/form_builders/adp_text_field_spec.rb'
-    - 'spec/models/assessment_spec.rb'
-    - 'spec/models/claim/advocate_claim_spec.rb'
-    - 'spec/models/claim/litigator_claim_spec.rb'
-    - 'spec/models/claim/transfer_brain_spec.rb'
-    - 'spec/support/api/claims/advocate_interim_claim_test.rb'
-    - 'spec/support/api/claims/advocate_supplementary_claim_test.rb'
-    - 'spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb'
-    - 'spec/support/shared_examples_for_api.rb'
-    - 'spec/support/validation_helpers.rb'
-    - 'spec/validators/claim/advocate_claim_validator_spec.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: AllowComments.

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -405,7 +405,6 @@ RSpec.describe API::V1::ExternalUsers::Fee do
           valid_params.delete(:fee_type_id)
           post_to_create_endpoint
           expect(last_response.status).to eq 400
-          json = JSON.parse(last_response.body)
           expect(last_response.body).to eq json_error_response
         end
       end

--- a/spec/controllers/external_users/admin/external_users_controller_spec.rb
+++ b/spec/controllers/external_users/admin/external_users_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController, type: :controller 
 
       it 'assigns @eternal_users' do
         external_user = create(:external_user, provider: admin.provider)
-        other_provider_external_user = create(:external_user)
+        create(:external_user)
         get :index
         expect(assigns(:external_users)).to match_array([admin, external_user])
       end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe MessagesController, type: :controller do
 
   context 'email notifications' do
     let(:claim) { create :claim }
-    let(:message_params) { message_params = { claim_id: claim.id, sender_id: sender.user.id, body: 'lorem ipsum' } }
+    let(:message_params) { { claim_id: claim.id, sender_id: sender.user.id, body: 'lorem ipsum' } }
 
     context 'external_user_sending_messages' do
       let(:sender) { claim.creator }

--- a/spec/factories/claim/advocate_claims.rb
+++ b/spec/factories/claim/advocate_claims.rb
@@ -97,8 +97,8 @@ FactoryBot.define do
     # DEPRECATED see shared traits
     factory :redetermination_claim do
       after(:create) do |claim|
-        Timecop.freeze(Time.now - 3.day) { claim.submit! }
-        Timecop.freeze(Time.now - 2.day) { claim.allocate! }
+        Timecop.freeze(Time.now - 3.days) { claim.submit! }
+        Timecop.freeze(Time.now - 2.days) { claim.allocate! }
         Timecop.freeze(Time.now - 1.day) { assign_fees_and_expenses_for(claim); claim.authorise! }
         claim.redetermine!
       end

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -96,7 +96,7 @@ def populate_required_fields(claim)
     if claim.case_type.requires_cracked_dates?
       claim.trial_fixed_notice_at ||= 3.months.ago
       claim.trial_cracked_at ||= 2.months.ago
-      claim.trial_fixed_at ||= 1.months.ago
+      claim.trial_fixed_at ||= 1.month.ago
       claim.trial_cracked_at_third ||= 'final_third'
     end
 

--- a/spec/factories/claim/litigator_claims.rb
+++ b/spec/factories/claim/litigator_claims.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
 
     trait :trial do
       after(:build) do |claim|
-        fee_type = create(:graduated_fee_type, :grtrl)
+        create(:graduated_fee_type, :grtrl)
         case_type = create(:case_type, :graduated_fee, :trial)
         claim.case_type = case_type
       end

--- a/spec/form_builders/adp_text_field_spec.rb
+++ b/spec/form_builders/adp_text_field_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe AdpTextField do
   context 'top level text fields' do
     let(:helper) do
       TestHelper.new(
-        lookup_context = ActionView::LookupContext.new([]),
-        assigns = {},
-        controller = ActionController::Base.new()
+        ActionView::LookupContext.new([]), # lookup_context
+        {}, # assigns
+        ActionController::Base.new() # controller
       )
     end
     let(:resource) { create :claim, case_number: nil }

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Assessment do
 
   context 'automatic calculation of total' do
     it 'calculates the total on save' do
-      ass = create :assessment, expenses: 102.33, fees: 44.86
+      create :assessment, expenses: 102.33, fees: 44.86
       ass = claim.assessment
       expect(ass.total).to eq(ass.fees + ass.expenses + ass.disbursements)
     end

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -932,8 +932,8 @@ RSpec.describe Claim::AdvocateClaim, type: :model do
     it 'only returns claims with fixed fee case types' do
       claim_1 = create :claim, case_type_id: ct_fixed_1.id
       claim_2 = create :claim, case_type_id: ct_fixed_2.id
-      claim_3 = create :claim, case_type_id: ct_basic_1.id
-      claim_4 = create :claim, case_type_id: ct_basic_2.id
+      create :claim, case_type_id: ct_basic_1.id
+      create :claim, case_type_id: ct_basic_2.id
       expect(Claim::AdvocateClaim.fixed_fee.count).to eq 2
       expect(Claim::AdvocateClaim.fixed_fee).to include claim_1
       expect(Claim::AdvocateClaim.fixed_fee).to include claim_2

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Claim::LitigatorClaim, type: :model do
       claim = build :litigator_claim
       CaseType.delete_all
       agfs_lgfs_case_type = create :case_type, name: 'AGFS and LGFS case type', roles: ['agfs', 'lgfs']
-      agfs_case_type      = create :case_type, name: 'AGFS case type', roles: ['agfs']
-      lgfs_case_type      = create :case_type, name: 'LGFS case type', roles: ['lgfs']
+      create :case_type, name: 'AGFS case type', roles: ['agfs']
+      lgfs_case_type = create :case_type, name: 'LGFS case type', roles: ['lgfs']
 
       expect(claim.eligible_case_types).to eq([agfs_lgfs_case_type, lgfs_case_type])
     end

--- a/spec/models/claim/transfer_brain_spec.rb
+++ b/spec/models/claim/transfer_brain_spec.rb
@@ -226,15 +226,15 @@ RSpec.describe Claim::TransferBrain do
   describe '.case_conclusion_required?' do
     [10, 20, 30, 50, 60].each do |ts|
       it "is visible for new, unelected cases that were transfered at stage #{ts}" do
-        td = td = transfer_detail('new', false, ts)
+        td = transfer_detail('new', false, ts)
         expect(described_class.case_conclusion_required?(td)).to eq true
       end
     end
 
     it 'returns false for nil values' do
-      expect(described_class.case_conclusion_required?(td = transfer_detail(nil, true, 10))).to eq false
-      expect(described_class.case_conclusion_required?(td = transfer_detail('new', nil, 10))).to eq false
-      expect(described_class.case_conclusion_required?(td = transfer_detail('new', true, nil))).to eq false
+      expect(described_class.case_conclusion_required?(transfer_detail(nil, true, 10))).to eq false
+      expect(described_class.case_conclusion_required?(transfer_detail('new', nil, 10))).to eq false
+      expect(described_class.case_conclusion_required?(transfer_detail('new', true, nil))).to eq false
     end
   end
 

--- a/spec/models/claims/financial_summary_spec.rb
+++ b/spec/models/claims/financial_summary_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Claims::FinancialSummary, type: :model do
     let!(:allocated_claim)  { create(:allocated_claim) }
 
     let!(:old_part_authorised_claim) do
-      travel_to(Time.now - 2.week)
+      travel_to(Time.now - 2.weeks)
       create(:part_authorised_claim).tap do |claim|
         travel_to(Time.now + 1.week)
         claim.determinations.first.update(fees: claim.fees_total / 2, expenses: claim.expenses_total)
@@ -18,9 +18,9 @@ RSpec.describe Claims::FinancialSummary, type: :model do
     end
 
     let!(:part_authorised_claim) do
-      travel_to(Time.now - 2.week)
+      travel_to(Time.now - 2.weeks)
       create(:part_authorised_claim).tap do |claim|
-        travel_to(Time.now + 2.week)
+        travel_to(Time.now + 2.weeks)
         claim.determinations.first.update(fees: claim.fees_total / 2, expenses: claim.expenses_total)
         travel_back
       end

--- a/spec/models/stats/collector/claim_redeterminations_collector_spec.rb
+++ b/spec/models/stats/collector/claim_redeterminations_collector_spec.rb
@@ -7,8 +7,8 @@ module Stats
 
       before do
         create_claim(:redetermination,  report_day)
-        create_claim(:redetermination,  report_day - 1.days)
-        create_claim(:redetermination,  report_day - 1.days)
+        create_claim(:redetermination,  report_day - 1.day)
+        create_claim(:redetermination,  report_day - 1.day)
         create_claim(:draft,            report_day - 2.days) # will be ignored (not a redetermination)
         create_claim(:redetermination,  report_day - 5.days)
         create_claim(:redetermination,  report_day - 8.days) # will be ignored (out of 7-days range)

--- a/spec/models/subscribers/slack_spec.rb
+++ b/spec/models/subscribers/slack_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Subscribers::Slack, type: :subscriber do
 
     let(:event_name) { 'call_failed.stats_report' }
     let(:start) { 2.minutes.ago }
-    let(:ending) { 1.minutes.ago }
+    let(:ending) { 1.minute.ago }
     let(:transaction_id) { SecureRandom.uuid }
     let(:error) { StandardError.new('Test error') }
     let(:payload) { { id: 999, name: 'provisional_assessment', error: error } }

--- a/spec/support/api/claims/advocate_interim_claim_test.rb
+++ b/spec/support/api/claims/advocate_interim_claim_test.rb
@@ -26,7 +26,7 @@ class AdvocateInterimClaimTest < BaseClaimTest
     client.post_to_endpoint('representation_orders', representation_order_data(defendant_id))
 
     # CREATE warrant fee
-    response = client.post_to_endpoint('fees', warrant_fee_data)
+    client.post_to_endpoint('fees', warrant_fee_data)
 
     # CREATE miscellaneous fee
     response = client.post_to_endpoint('fees', misc_fee_data)

--- a/spec/support/api/claims/advocate_supplementary_claim_test.rb
+++ b/spec/support/api/claims/advocate_supplementary_claim_test.rb
@@ -35,11 +35,11 @@ class AdvocateSupplementaryClaimTest < BaseClaimTest
   end
 
   def claim_data
-    case_type_id = json_value_at_index(client.get_dropdown_endpoint(CASE_TYPE_ENDPOINT, api_key, role: 'agfs'), 'id', 11) # Trial
+    client.get_dropdown_endpoint(CASE_TYPE_ENDPOINT, api_key, role: 'agfs') # Trial
     advocate_category = json_value_at_index(client.get_dropdown_endpoint(ADVOCATE_CATEGORY_ENDPOINT, api_key))
-    offence_id = json_value_at_index(client.get_dropdown_endpoint(OFFENCE_ENDPOINT, api_key), 'id')
+    client.get_dropdown_endpoint(OFFENCE_ENDPOINT, api_key)
     court_id = json_value_at_index(client.get_dropdown_endpoint(COURT_ENDPOINT, api_key), 'id')
-    trial_cracked_at_third = json_value_at_index(client.get_dropdown_endpoint(CRACKED_THIRD_ENDPOINT, api_key))
+    client.get_dropdown_endpoint(CRACKED_THIRD_ENDPOINT, api_key)
 
     {
       api_key: api_key,

--- a/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
+++ b/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
@@ -8,7 +8,6 @@ RSpec.shared_examples 'advocate category validations' do |options|
   default_valid_categories = ['QC', 'Led junior', 'Leading junior', 'Junior alone']
   fee_reform_valid_categories = ['QC', 'Leading junior', 'Junior']
   fee_reform_invalid_categories = default_valid_categories - fee_reform_valid_categories
-  all_valid_categories = (default_valid_categories + fee_reform_valid_categories).uniq
 
   it 'errors if not present' do
     claim.advocate_category = nil

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -278,7 +278,6 @@ RSpec.shared_examples 'a claim create endpoint' do |options|
         it 'response 400 and JSON error array of error message' do
           post_to_create_endpoint
           expect(last_response.status).to eq(400)
-          json = JSON.parse(last_response.body)
           expect_error_response('my unexpected error')
         end
 

--- a/spec/support/validation_helpers.rb
+++ b/spec/support/validation_helpers.rb
@@ -124,8 +124,8 @@ module ValidationHelpers
   end
 
   def should_errror_if_later_than_other_date(record, field, other_date, message, options = {})
-    record.send("#{field}=", 5.day.ago)
-    record.send("#{other_date}=", 7.day.ago)
+    record.send("#{field}=", 5.days.ago)
+    record.send("#{other_date}=", 7.days.ago)
     expect(record.send(:valid?)).to be false
     expect(record.errors[field]).to include(message)
     with_expected_error_translation(field, message, options) if options[:translated_message]

--- a/spec/support/validation_helpers.rb
+++ b/spec/support/validation_helpers.rb
@@ -144,7 +144,6 @@ module ValidationHelpers
   end
 
   def stub_earliest_rep_order(claim, date)
-    repo = double RepresentationOrder
     allow(claim).to receive(:earliest_representation_order_date).and_return(date)
   end
 

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
   context 'advocate_category' do
     default_valid_categories = ['QC', 'Led junior', 'Leading junior', 'Junior alone']
     fee_reform_valid_categories = ['QC', 'Leading junior', 'Junior']
-    fee_reform_invalid_categories = default_valid_categories - fee_reform_valid_categories
     all_valid_categories = (default_valid_categories + fee_reform_valid_categories).uniq
 
     # API behaviour is different because fixed fees

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -178,9 +178,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
     let(:one_one_representation_order_attrs) { valid_one_one_representation_order_attrs }
     let(:valid_one_other_representation_order_attrs) {
       {
-        representation_order_date_dd: (release_date + 2.day).day.to_s,
-        representation_order_date_mm: (release_date + 2.day).month.to_s,
-        representation_order_date_yyyy: (release_date + 2.day).year.to_s
+        representation_order_date_dd: (release_date + 2.days).day.to_s,
+        representation_order_date_mm: (release_date + 2.days).month.to_s,
+        representation_order_date_yyyy: (release_date + 2.days).year.to_s
       }
     }
     let(:one_other_representation_order_attrs) { valid_one_other_representation_order_attrs }
@@ -431,9 +431,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 representation_order_date_yyyy: earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.day).day.to_s,
-                representation_order_date_mm: (release_date + 2.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.day).year.to_s
+                representation_order_date_dd: (release_date + 2.days).day.to_s,
+                representation_order_date_mm: (release_date + 2.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 2.days).year.to_s
               }
             }
           },
@@ -446,9 +446,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.day).day.to_s,
-                representation_order_date_mm: (release_date + 3.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.day).year.to_s
+                representation_order_date_dd: (release_date + 3.days).day.to_s,
+                representation_order_date_mm: (release_date + 3.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 3.days).year.to_s
               }
             }
           }
@@ -511,9 +511,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 representation_order_date_yyyy: earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.day).day.to_s,
-                representation_order_date_mm: (release_date + 2.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.day).year.to_s
+                representation_order_date_dd: (release_date + 2.days).day.to_s,
+                representation_order_date_mm: (release_date + 2.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 2.days).year.to_s
               }
             }
           },
@@ -526,9 +526,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.day).day.to_s,
-                representation_order_date_mm: (release_date + 3.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.day).year.to_s
+                representation_order_date_dd: (release_date + 3.days).day.to_s,
+                representation_order_date_mm: (release_date + 3.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 3.days).year.to_s
               }
             }
           }
@@ -710,9 +710,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 representation_order_date_yyyy: earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.day).day.to_s,
-                representation_order_date_mm: (release_date + 2.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.day).year.to_s
+                representation_order_date_dd: (release_date + 2.days).day.to_s,
+                representation_order_date_mm: (release_date + 2.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 2.days).year.to_s
               }
             }
           },
@@ -725,9 +725,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.day).day.to_s,
-                representation_order_date_mm: (release_date + 3.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.day).year.to_s
+                representation_order_date_dd: (release_date + 3.days).day.to_s,
+                representation_order_date_mm: (release_date + 3.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 3.days).year.to_s
               }
             }
           }
@@ -921,9 +921,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 representation_order_date_yyyy: earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.day).day.to_s,
-                representation_order_date_mm: (release_date + 2.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.day).year.to_s
+                representation_order_date_dd: (release_date + 2.days).day.to_s,
+                representation_order_date_mm: (release_date + 2.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 2.days).year.to_s
               }
             }
           },
@@ -936,9 +936,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.day).day.to_s,
-                representation_order_date_mm: (release_date + 3.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.day).year.to_s
+                representation_order_date_dd: (release_date + 3.days).day.to_s,
+                representation_order_date_mm: (release_date + 3.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 3.days).year.to_s
               }
             }
           }
@@ -1065,9 +1065,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
                 representation_order_date_yyyy: earliest_representation_order_date.year.to_s
               },
               '1' => {
-                representation_order_date_dd: (release_date + 2.day).day.to_s,
-                representation_order_date_mm: (release_date + 2.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 2.day).year.to_s
+                representation_order_date_dd: (release_date + 2.days).day.to_s,
+                representation_order_date_mm: (release_date + 2.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 2.days).year.to_s
               }
             }
           },
@@ -1080,9 +1080,9 @@ RSpec.describe 'Advocate interim claim WEB validations' do
             order_for_judicial_apportionment: '0',
             representation_orders_attributes: {
               '0' => {
-                representation_order_date_dd: (release_date + 3.day).day.to_s,
-                representation_order_date_mm: (release_date + 3.day).month.to_s,
-                representation_order_date_yyyy: (release_date + 3.day).year.to_s
+                representation_order_date_dd: (release_date + 3.days).day.to_s,
+                representation_order_date_mm: (release_date + 3.days).month.to_s,
+                representation_order_date_yyyy: (release_date + 3.days).year.to_s
               }
             }
           }


### PR DESCRIPTION
#### What

Fix some deviations from our coding standard.

#### Ticket

N/A

#### Why

To maintain consistent coding styles throughout the code base.

#### How

Fix for two types of offences from the Rubocop todo list:

* `Rails/PluralizationGrammar`; E.g., Using `3.days.ago` instead of `3.day.ago`.
* `Lint/UselessAssignment`; Remove assignment of variables that are not used. In some cases the whole line can be removed but in other cases the variable is being set to a function call that is still required.