### PR TITLE
[CFP-69] FormBuilder migration- Supporting evidence

### DIFF
--- a/app/views/external_users/claims/_error_summary.html.haml
+++ b/app/views/external_users/claims/_error_summary.html.haml
@@ -1,4 +1,5 @@
-- if %w[case_details transfer_fee_details offence_details].include?(@claim.form_step.to_s)
+- form_steps = %w[case_details transfer_fee_details offence_details supporting_evidence]
+- if form_steps.include?(@claim.form_step.to_s)
   = govuk_error_summary(@claim, :claim, presenter: @error_presenter)
 
 - else

--- a/app/views/external_users/claims/additional_information/_fields.html.haml
+++ b/app/views/external_users/claims/additional_information/_fields.html.haml
@@ -1,10 +1,5 @@
-%h2#additional-information.govuk-heading-l{ class: 'govuk-!-margin-top-6' }
+%h3.govuk-heading-m{ class: 'govuk-!-margin-top-6' }
   = t('.additional_information')
 
-.form-group
-  = f.label :additional_information,
-            t('.additional_information_prompt_text'),
-            class: 'form-label'
-
-  = f.text_area :additional_information, rows: 5,
-                class: 'form-control form-control-full'
+= f.govuk_text_area :additional_information,
+  label: { text: t('.additional_information_prompt_text') }

--- a/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
@@ -1,15 +1,4 @@
-.form-group{ class: error_class?(@error_presenter, :disk_evidence) }
-  %fieldset{ 'aria-describedby': 'radio-control-legend-evidence' }
-    %legend#radio-control-legend-evidence
-      %span.govuk-heading-m
-        = t('disk_evidence.question')
-
-    = f.collection_radio_buttons(:disk_evidence, [['Yes','true'],['No','false']], :last, :first ) do |b|
-      .multiple-choice{ data: { target: b.text == 'Yes' ? 'evidence-info' : nil } }
-        = b.radio_button('aria-labelledby': "radio-control-legend-evidence #{b.text.to_css_class}")
-        = b.label(id: b.text.to_css_class) { b.text }
-      - if (b.text == 'Yes')
-        #evidence-info.panel.panel-border-narrow.js-hidden
-          = render partial: 'shared/disk_evidence_info', locals: { f: f }
-
-  = validation_error_message(@error_presenter, :disk_evidence)
+= f.govuk_radio_buttons_fieldset :disk_evidence, legend: { size: 'm', text: t('disk_evidence.question') } do
+  = f.govuk_radio_button :disk_evidence, 'true', label: { text: t('global_yes') }, link_errors: true do
+    = render partial: 'shared/disk_evidence_info'
+  = f.govuk_radio_button :disk_evidence, 'false', label: { text: t('global_no') }

--- a/app/views/external_users/claims/supporting_documents/_new.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_new.html.haml
@@ -8,13 +8,13 @@
   - @claim.documents.each do |document|
     = f.hidden_field :document_ids, multiple: true, value: document.id, id: "claim_document_ids_#{document.id}"
 
-.form-group
-  %fieldset
-    %legend
-      = t('.legend')
-    .dropzone
-      = f.label :documents, 'Upload file', class: 'form-group'
-      = f.file_field :documents, name: 'documents', multiple: true, class: 'form-control'
+%h3.govuk-heading-m
+  = t('.upload_supporting_evidence')
+
+= f.govuk_file_field :documents,
+  form_group: { classes: 'dropzone' },
+  label: { text: t('.upload_file') },
+  multiple: true
 
 = govuk_table(id: 'dropzone-files', class: 'files hidden') do
   = govuk_table_caption do

--- a/app/views/external_users/claims/supporting_evidence_checklist/_evidence_checklist.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_evidence_checklist.html.haml
@@ -1,4 +1,0 @@
-= f.collection_check_boxes :evidence_checklist_ids, collection, :id, :name do |b|
-  .multiple-choice
-    = b.check_box
-    = b.label { b.text }

--- a/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
@@ -1,8 +1,12 @@
-= f.govuk_check_boxes_fieldset :evidence_checklist_ids, form_group: { 'data-mute-indictment': @claim.allows_fixed_fees? ? 'true' : 'false' } , legend: { text: t('.supporting_evidence_checklist'), size: 's' } do
+= f.govuk_check_boxes_fieldset :evidence_checklist_ids,
+  form_group: { classes: 'cc-evidence-checklist', 'data-mute-indictment': @claim.allows_fixed_fees? ? 'true' : 'false' },
+  hint: { text: t('.supporting_evidence_checklist_hint') },
+  legend: { text: t('.supporting_evidence_checklist'), size: 's' } do
+
   - f.object.eligible_document_types.each do |eligible_document_type|
     = f.govuk_check_box :evidence_checklist_ids,
       eligible_document_type.id,
       label: { text: eligible_document_type.name } do
 
       - if eligible_document_type.name.eql?('Expenses invoices')
-        = render partial: 'external_users/claims/supporting_evidence_checklist/expenses_invoices_requirement', locals: { f: f }
+        = t('.expenses_invoices_requirement_html')

--- a/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
@@ -1,7 +1,8 @@
-%fieldset.evidence-checklist{ 'data-mute-indictment': @claim.allows_fixed_fees? ? 'true' : 'false' }
-  %legend.form-label-bold
-    = t('.supporting_evidence_checklist')
-    %span.form-hint
-      = t('.supporting_evidence_checklist_hint')
+= f.govuk_check_boxes_fieldset :evidence_checklist_ids, form_group: { 'data-mute-indictment': @claim.allows_fixed_fees? ? 'true' : 'false' } , legend: { text: t('.supporting_evidence_checklist'), size: 's' } do
+  - f.object.eligible_document_types.each do |eligible_document_type|
+    = f.govuk_check_box :evidence_checklist_ids,
+      eligible_document_type.id,
+      label: { text: eligible_document_type.name } do
 
-  = render partial: 'external_users/claims/supporting_evidence_checklist/evidence_checklist', locals: { f: f, collection: f.object.eligible_document_types }
+      - if eligible_document_type.name.eql?('Expenses invoices')
+        = render partial: 'external_users/claims/supporting_evidence_checklist/expenses_invoices_requirement', locals: { f: f }

--- a/app/webpack/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/webpack/javascripts/modules/external_users/claims/NewClaim.js
@@ -15,7 +15,7 @@ moj.Modules.NewClaim = {
     // Tests in /spec/javascripts/supporting-evidence_spec.js
     //
     $('button[name="commit_submit_claim"]').on('click', function (e) {
-      if ($('#claim-evidence-checklist-ids-4-field').exists() && !$('#claim-evidence-checklist-ids-4-field').prop('checked')&& !$('[data-mute-indictment]').data('mute-indictment')) {
+      if ($('#claim-evidence-checklist-ids-4-field').exists() && !$('#claim-evidence-checklist-ids-4-field').prop('checked') && !$('[data-mute-indictment]').data('mute-indictment')) {
         return confirm(
           'The evidence checklist suggests that no indictment has been attached.\n' +
           'This can lead to your claim being rejected.\n\n' +

--- a/app/webpack/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/webpack/javascripts/modules/external_users/claims/NewClaim.js
@@ -15,7 +15,7 @@ moj.Modules.NewClaim = {
     // Tests in /spec/javascripts/supporting-evidence_spec.js
     //
     $('button[name="commit_submit_claim"]').on('click', function (e) {
-      if ($('#claim_evidence_checklist_ids_4').exists() && !$('#claim_evidence_checklist_ids_4').prop('checked') && !$('[data-mute-indictment]').data('mute-indictment')) {
+      if ($('#claim-evidence-checklist-ids-4-field').exists() && !$('#claim-evidence-checklist-ids-4-field').prop('checked')&& !$('[data-mute-indictment]').data('mute-indictment')) {
         return confirm(
           'The evidence checklist suggests that no indictment has been attached.\n' +
           'This can lead to your claim being rejected.\n\n' +

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -160,12 +160,6 @@ form {
   display: none;
 }
 
-.evidence-checklist div {
-  margin-top: $gutter-two-thirds;
-  margin-right: $gutter-one-third;
-  float: left;
-}
-
 .defendants {
   .nested-fields .indent-fieldset {
     padding: 0;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1481,10 +1481,11 @@ en:
           status: 'Status'
           choose_file: 'Choose a file'
           file_name: "File name"
+          upload_file: 'Upload file'
           supporting_evidence_docs: 'Upload supporting evidence'
           supporting_evidence: Supporting evidence
           file_upload_message: Drag and drop files here
-          legend: Upload supporting evidence
+          upload_supporting_evidence: Upload supporting evidence
           or: or
           uploading_docs: 'Documents waiting to be saved'
       supporting_evidence:
@@ -1502,6 +1503,14 @@ en:
         fields:
           supporting_evidence_checklist: Supporting evidence checklist
           supporting_evidence_checklist_hint: Select all that apply
+          expenses_invoices_requirement_html:
+            <p class="govuk-body govuk-!-font-weight-bold">Please make sure invoices include:</p>
+            <ul class="govuk-list govuk-list--bullet">
+            <li>date</li>
+            <li>case number or case URN</li>
+            <li>defendant name</li>
+            <li>hourly rates and details of the work done</li>
+            </ul>
       warrant_fee:
         summary:
           caption: 'Warrant Fees: This section contains details of any warrant fees that have been claimed.'

--- a/features/claims/advocate/accessibility.feature
+++ b/features/claims/advocate/accessibility.feature
@@ -67,7 +67,7 @@ Feature: Advocate submits a claim
     And I should see 10 evidence check boxes
     And I check the evidence boxes for 'A copy of the indictment'
     And I add some additional information
-    Then the page should be accessible
+    Then the page should be accessible skipping 'aria-allowed-attr'
     Then I click Submit to LAA
 
     And I should be on the check your claim page

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -75,9 +75,9 @@ class ClaimFormPage < BasePage
   element :add_another_expense, "div#expense > a.add_fields"
   element :additional_information_expenses, ".fx-additional-info"
 
-  section :evidence_checklist, EvidenceChecklistSection, "fieldset.evidence-checklist"
+  section :evidence_checklist, EvidenceChecklistSection, ".cc-evidence-checklist fieldset"
 
-  element :additional_information, "textarea#claim_additional_information"
+  element :additional_information, "textarea#claim-additional-information-field"
   element :continue, "div.button-holder > input:nth-of-type(1)"
   element :submit_to_laa, "div.button-holder > button:nth-of-type(1)" # this maps to Save and continue too
   element :save_to_drafts, "div.button-holder > button:nth-of-type(2)"
@@ -121,7 +121,7 @@ class ClaimFormPage < BasePage
     available_docs[0...count].each do |path|
       # element needs to be visible in order to attach_file
       page.execute_script("$('.dropzone-enhanced [type=file]').css('position','unset')");
-      attach_file("claim_documents", path)
+      attach_file("claim-documents-field", path)
     end
   end
 

--- a/features/page_objects/sections/evidence_checklist_section.rb
+++ b/features/page_objects/sections/evidence_checklist_section.rb
@@ -1,5 +1,5 @@
 class EvidenceChecklistSection < SitePrism::Section
-  sections :items, ".multiple-choice" do
+  sections :items, ".cc-evidence-checklist .govuk-checkboxes__item" do
     element :input, "input"
     element :label, "label"
   end

--- a/spec/javascripts/supporting-evidence_spec.js
+++ b/spec/javascripts/supporting-evidence_spec.js
@@ -17,26 +17,26 @@ describe('supportingEvidence', function () {
   }
 
   $indictmentEvidence = function () {
-    return $('#claim_evidence_checklist_ids_4')
+    return $('#claim-evidence-checklist-ids-4-field')
   }
 
   const fixtureDom = $(`
   <div data-mute-indictment="false">
     <form method="post" action="" id="supporting-evidence-fixture-form">
         <fieldset class="checklist">
-            <h3>Supporting evidence checklist</h3>
+            <legend>Supporting evidence checklist</legend>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-one-half">
-                    <label class="block-label" for="claim_evidence_checklist_ids_5"><input type="checkbox" value="5" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_5">Order in respect of judicial apportionment</label>
-                    <label class="block-label" for="claim_evidence_checklist_ids_3"><input type="checkbox" value="3" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_3">Committal bundle front sheet(s)</label>
-                    <label class="block-label" for="claim_evidence_checklist_ids_4"><input type="checkbox" value="4" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_4">A copy of the indictment</label>
-                    <label class="block-label" for="claim_evidence_checklist_ids_1"><input type="checkbox" value="1" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_1">Representation order</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-5-field"><input type="checkbox" value="5" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-5-field">Order in respect of judicial apportionment</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-3-field"><input type="checkbox" value="3" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-3-field">Committal bundle front sheet(s)</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-4-field"><input type="checkbox" value="4" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-4-field">A copy of the indictment</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-1-field"><input type="checkbox" value="1" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-1-field">Representation order</label>
                 </div>
                 <div class="govuk-grid-column-one-half">
-                    <label class="block-label" for="claim_evidence_checklist_ids_8"><input type="checkbox" value="8" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_8">Details of previous fee advancements</label>
-                    <label class="block-label" for="claim_evidence_checklist_ids_7"><input type="checkbox" value="7" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_7">Hardship supporting evidence</label>
-                    <label class="block-label" for="claim_evidence_checklist_ids_6"><input type="checkbox" value="6" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_6">Expenses invoices</label>
-                    <label class="block-label" for="claim_evidence_checklist_ids_9"><input type="checkbox" value="9" name="claim[evidence_checklist_ids][]" id="claim_evidence_checklist_ids_9">Justification for out of time claim</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-8-field"><input type="checkbox" value="8" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-8-field">Details of previous fee advancements</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-7-field"><input type="checkbox" value="7" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-7-field">Hardship supporting evidence</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-6-field"><input type="checkbox" value="6" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-6-field">Expenses invoices</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-9-field"><input type="checkbox" value="9" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-9-field">Justification for out of time claim</label>
                 </div>
             </div>
         </fieldset>


### PR DESCRIPTION
#### What
Migrate the relevant form to use the [GOVUKDesignSystemFormBuilder](https://govuk-form-builder.netlify.app/) gem.

#### Ticket

[CFP-69](https://dsdmoj.atlassian.net/browse/CFP-69)

#### Why

- Continue the migration away from the deprecated design system to the current GOVUK Frontend
- Resolve related accessibility issues identified in the [2020 DAC Accessibility report](https://drive.google.com/file/d/16RrVZoZFb8VMSlwUj_kfvwhm-mAVCKXs/view?usp=sharing)
- Reduce/remove redundant form builders throughout the codebase

--------

#### TODO

 - [x] Migrate FormBuilder elements
 - [x] Fix failing tests
