### PR TITLE
Enable redis_logger in breadcrumbs_logger

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,7 @@
 if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
    Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
-    config.breadcrumbs_logger = [:active_support_logger]
+    config.breadcrumbs_logger = [:active_support_logger, :redis_logger]
 
     # Send 5% of transactions for performance monitoring
     config.traces_sample_rate = 0.05


### PR DESCRIPTION
#### What

Enable redis_logger in breadcrumbs_logger in Sentry

#### Ticket

N/A

#### Why

Sentry version 5.1.0, updated in #4684, adds an option to include Redis calls in the breadcrumb logger.

#### How

Add `:redis_logger` to `config.breadcrumbs_logger` in the configuration file.

#### Before

![Screenshot 2022-02-16 at 11 31 52](https://user-images.githubusercontent.com/4415912/154256447-862cabfe-52ad-4171-9a52-aad324d0c066.png)

#### After

![Screenshot 2022-02-16 at 11 31 38](https://user-images.githubusercontent.com/4415912/154256477-ae19729b-0f5a-4d33-a3f5-b7485d837159.png)

