### PR TITLE
[CFP-295] Use kwargs instead of options hash

### DIFF
--- a/app/jobs/stats_report_generation_job.rb
+++ b/app/jobs/stats_report_generation_job.rb
@@ -6,7 +6,7 @@ class StatsReportGenerationJob < ApplicationJob
       "Stats report job starting for report type: #{kwargs[:report_type]}"
     end
 
-    Stats::StatsReportGenerator.call(kwargs)
+    Stats::StatsReportGenerator.call(**kwargs)
 
     LogStuff.info(class: self.class.name, action: 'perform', report_type: kwargs[:report_type]) do
       "Stats report job finished for report type: #{kwargs[:report_type]}"

--- a/app/services/stats/management_information/daily_report_count_query.rb
+++ b/app/services/stats/management_information/daily_report_count_query.rb
@@ -13,8 +13,8 @@ Dir.glob(File.join(__dir__, 'queries', '**', '*.rb')).each { |f| require_depende
 module Stats
   module ManagementInformation
     class DailyReportCountQuery
-      def self.call(**kwargs)
-        new(kwargs).call
+      def self.call(...)
+        new(...).call
       end
 
       def initialize(**kwargs)

--- a/app/services/stats/management_information/daily_report_query.rb
+++ b/app/services/stats/management_information/daily_report_query.rb
@@ -9,12 +9,12 @@ module Stats
       include JourneyQueryable
       include ClaimTypeFilterable
 
-      def self.call(options = {})
-        new(options).call
+      def self.call(...)
+        new(...).call
       end
 
-      def initialize(options = {})
-        self.scheme = options[:scheme]
+      def initialize(**kwargs)
+        self.scheme = kwargs[:scheme]
         raise ArgumentError, 'scheme must be "agfs" or "lgfs"' if @scheme.present? && %w[AGFS LGFS].exclude?(@scheme)
       end
 

--- a/app/services/stats/management_information/queries/base_count_query.rb
+++ b/app/services/stats/management_information/queries/base_count_query.rb
@@ -6,8 +6,8 @@ module Stats
       include JourneyQueryable
       include ClaimTypeFilterable
 
-      def self.call(**kwargs)
-        new(kwargs).call
+      def self.call(...)
+        new(...).call
       end
 
       def initialize(date_range:, date_column_filter:)

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -33,8 +33,8 @@ module Stats
     end
     # rubocop:enable Metrics/MethodLength
 
-    def self.call(**kwargs)
-      new(kwargs).call
+    def self.call(...)
+      new(...).call
     end
 
     def initialize(**kwargs)

--- a/spec/services/stats/management_information/daily_report_count_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_count_generator_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
   describe '.call' do
-    subject(:call) { described_class.call(kwargs) }
+    subject(:call) { described_class.call(**kwargs) }
 
     let(:kwargs) { { query_set: 'foo', start_at: 'bar' } }
     let(:instance) { instance_double(described_class) }
@@ -25,7 +25,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
   end
 
   describe '#call' do
-    subject(:call) { described_class.new(kwargs).call }
+    subject(:call) { described_class.new(**kwargs).call }
 
     context 'without query_set' do
       let(:kwargs) { { start_at: Date.current } }
@@ -41,7 +41,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
     end
 
     context 'with query_set and start_at' do
-      subject(:result) { described_class.new(kwargs).call }
+      subject(:result) { described_class.new(**kwargs).call }
 
       let(:kwargs) { { query_set: query_set, start_at: start_date } }
       let(:query_set) { Stats::ManagementInformation::LgfsQuerySet.new }
@@ -67,7 +67,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
     end
 
     context 'with valid scheme, start_at and duration' do
-      subject(:result) { described_class.new(kwargs).call }
+      subject(:result) { described_class.new(**kwargs).call }
 
       let(:query_set) { Stats::ManagementInformation::LgfsQuerySet.new }
       let(:start_date) { 1.week.ago.to_date }
@@ -114,7 +114,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
     #   .to_a
     #
     context 'when AGFS final claims data exists' do
-      subject(:result) { described_class.new(kwargs).call }
+      subject(:result) { described_class.new(**kwargs).call }
 
       before do
         travel_to(start_date.beginning_of_day) do

--- a/spec/services/stats/management_information/daily_report_count_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_count_query_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Stats::ManagementInformation::DailyReportCountQuery do
   describe '.call' do
-    subject(:call) { described_class.call(kwargs) }
+    subject(:call) { described_class.call(**kwargs) }
 
     let(:kwargs) { { date_range: 1.month.ago.to_date..Time.zone.today, scheme: 'lgfs' } }
 
@@ -26,7 +26,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountQuery do
   end
 
   describe '#call' do
-    subject(:call) { described_class.new(kwargs).call }
+    subject(:call) { described_class.new(**kwargs).call }
 
     let(:month_range) { 1.month.ago.to_date..Time.zone.today }
 
@@ -43,7 +43,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountQuery do
     end
 
     context 'with query_set and date range' do
-      subject(:result) { described_class.new(kwargs).call }
+      subject(:result) { described_class.new(**kwargs).call }
 
       let(:kwargs) { { query_set: Stats::ManagementInformation::AgfsQuerySet.new, date_range: month_range } }
 

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
     end
 
     context 'with invalid scheme scope' do
-      subject(:call) { described_class.call({ scheme: scheme }) }
+      subject(:call) { described_class.call(scheme: scheme) }
 
       let(:scheme) { :foobar }
 
@@ -63,7 +63,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
     end
 
     context 'with AGFS scheme scope' do
-      subject(:response) { described_class.call({ scheme: scheme }) }
+      subject(:response) { described_class.call(scheme: scheme) }
 
       let(:scheme) { :agfs }
 
@@ -77,7 +77,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
     end
 
     context 'with LGFS claim scope' do
-      subject(:response) { described_class.call({ scheme: scheme }) }
+      subject(:response) { described_class.call(scheme: scheme) }
 
       let(:scheme) { :lgfs }
 

--- a/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
+++ b/spec/services/stats/management_information/shared_examples_for_base_count_query.rb
@@ -17,7 +17,7 @@ RSpec.shared_examples 'a base count query' do |scheme|
   it_behaves_like 'a claim journeys query'
 
   describe '.call' do
-    subject(:call) { described_class.call(kwargs) }
+    subject(:call) { described_class.call(**kwargs) }
 
     let(:kwargs) { { date_range: 'foo', date_column_filter: 'bar' } }
 
@@ -43,7 +43,7 @@ RSpec.shared_examples 'a base count query' do |scheme|
   describe '#call' do
     subject(:call) { instance.call }
 
-    let(:instance) { described_class.new(kwargs) }
+    let(:instance) { described_class.new(**kwargs) }
     let(:kwargs) { { date_range: date_range, date_column_filter: :originally_submitted_at } }
     let(:date_range) { Time.zone.today..Time.zone.today }
 
@@ -130,7 +130,7 @@ end
 
 RSpec.shared_examples 'an originally_submitted_at filterable query' do
   describe '#call' do
-    subject(:result) { described_class.new(kwargs).call }
+    subject(:result) { described_class.new(**kwargs).call }
 
     let(:kwargs) { { date_range: date_range, date_column_filter: :originally_submitted_at } }
 
@@ -152,7 +152,7 @@ end
 
 RSpec.shared_examples 'a completed_at filterable query' do
   describe '#call' do
-    subject(:result) { described_class.new(kwargs).call }
+    subject(:result) { described_class.new(**kwargs).call }
 
     let(:kwargs) { { date_range: date_range, date_column_filter: :completed_at } }
 


### PR DESCRIPTION
#### What

Some minor changes to ease the move to Ruby 3. See #4654 

#### Ticket

[Update Ruby to 3.0 (or 3.1)](https://dsdmoj.atlassian.net/browse/CFP-295)

#### Why

Prior to Ruby 3.0 it was possible to use the final positional argument to a function as a hash of keyword arguments. This has been removed in Ruby 3.0.

#### How

To avoid issue changes are being made gradually. This PR updates files related to the generation of MI stats reports.
