### PR TITLE
Set surnames of test users

### DIFF
--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -6,12 +6,24 @@ RSpec.describe ExternalUsers::ClaimsController, type: :controller do
   before { sign_in advocate.user }
 
   describe 'list views' do
-    let!(:advocate_admin) { create(:external_user, :admin, provider: advocate.provider) }
-    let!(:other_advocate) { create(:external_user, :advocate, provider: advocate.provider) }
+    let!(:advocate_admin) do
+      create(:external_user, :admin, provider: advocate.provider, user: build(:user, last_name: 'Advocate-Admin'))
+    end
+    let!(:other_advocate) do
+      create(:external_user, :advocate, provider: advocate.provider, user: build(:user, last_name: 'Other-Advocate'))
+    end
 
-    let!(:litigator)      { create(:external_user, :litigator) }
-    let!(:litigator_admin) { create(:external_user, :litigator_and_admin, provider: litigator.provider) }
-    let!(:other_litigator) { create(:external_user, :litigator, provider: litigator.provider) }
+    let!(:litigator) { create(:external_user, :litigator, user: build(:user, last_name: 'Litigator')) }
+    let!(:litigator_admin) do
+      create(
+        :external_user, :litigator_and_admin,
+        provider: litigator.provider,
+        user: build(:user, last_name: 'Litigator-Admin')
+      )
+    end
+    let!(:other_litigator) do
+      create(:external_user, :litigator, provider: litigator.provider, user: build(:user, last_name: 'Other-Litigator'))
+    end
 
     describe '#GET index' do
       it 'returns success' do


### PR DESCRIPTION
#### What

Fix one of the flickering tests.

#### Ticket

N/A

#### Why

One of the tests (spec/controllers/external_users/claims_controller_spec.rb:475) flickers because it is searching for the advocates surname and expecting nothing to be returned but the surname is randomly chosen and 'Smith' is used as one of the other test user's name. See #4452 for the previous partial fix.

#### How

The solution is to fix the name of all the test users to ensure that a result is not found.