### PR TITLE
[CFP-525] Bump dockerfile gmp version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apk --no-cache add --virtual build-dependencies \
                     postgresql-dev \
                     git \
                     yarn \
+                    gmp=6.2.1-r1 \
 && apk --no-cache add \
                   file \
                   nodejs \


### PR DESCRIPTION
#### What
Bump docker images version of gmp library

#### Ticket

[CFP-525](https://dsdmoj.atlassian.net/browse/CFP-525)

#### Why
Fixes Integer Overflow or Wraparound vulnerability
introduced by our base image (ruby:2.7.4-alpine3.13)

More details on issue can be found [here](https://app.snyk.io/org/legal-aid-agency/project/a1511220-f1c3-4953-8ad1-601e354df9fe#issue-SNYK-ALPINE313-GMP-2419279)

#### How
Upgrade [gmp](https://pkgs.alpinelinux.org/package/edge/main/x86/gmp) via Alpine Package Manager


