### PR TITLE
[CFP-527]- Paginate provider index page

### DIFF
--- a/app/controllers/case_workers/admin/case_workers_controller.rb
+++ b/app/controllers/case_workers/admin/case_workers_controller.rb
@@ -1,5 +1,6 @@
 class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::ApplicationController
   include PasswordHelpers
+  include PaginationHelpers
 
   before_action :set_case_worker, only: %i[show edit update destroy change_password update_password]
 
@@ -7,7 +8,7 @@ class CaseWorkers::Admin::CaseWorkersController < CaseWorkers::Admin::Applicatio
     @case_workers = CaseWorker.includes(:location).joins(:user)
     query = "lower(users.first_name || ' ' || users.last_name) ILIKE :term"
     @case_workers = @case_workers.where(query, term: "%#{params[:search]}%") if params[:search].present?
-    @case_workers = @case_workers.order('users.last_name', 'users.first_name')
+    @case_workers = @case_workers.order('users.last_name', 'users.first_name').page(current_page).per(page_size)
   end
 
   def show; end

--- a/app/controllers/provider_management/providers_controller.rb
+++ b/app/controllers/provider_management/providers_controller.rb
@@ -4,6 +4,11 @@ class ProviderManagement::ProvidersController < ApplicationController
 
   def index
     @providers = Provider.order(name: :asc).page(current_page).per(page_size)
+
+    if params[:search]
+      query = "lower(name) ILIKE :term"
+      @providers = @providers.where(query, term: "%#{params[:search]}%")
+    end
   end
 
   def new

--- a/app/controllers/provider_management/providers_controller.rb
+++ b/app/controllers/provider_management/providers_controller.rb
@@ -1,8 +1,9 @@
 class ProviderManagement::ProvidersController < ApplicationController
   include ProviderAdminConcern
+  include PaginationHelpers
 
   def index
-    @providers = Provider.order(name: :asc)
+    @providers = Provider.order(name: :asc).page(current_page).per(page_size)
   end
 
   def new

--- a/app/controllers/provider_management/providers_controller.rb
+++ b/app/controllers/provider_management/providers_controller.rb
@@ -4,11 +4,9 @@ class ProviderManagement::ProvidersController < ApplicationController
 
   def index
     @providers = Provider.order(name: :asc).page(current_page).per(page_size)
-
-    if params[:search]
-      query = "lower(name) ILIKE :term"
-      @providers = @providers.where(query, term: "%#{params[:search]}%")
-    end
+    return unless params[:search]
+    query = 'lower(name) ILIKE :term'
+    @providers = @providers.where(query, term: "%#{params[:search]}%")
   end
 
   def new

--- a/app/views/case_workers/admin/case_workers/index.html.haml
+++ b/app/views/case_workers/admin/case_workers/index.html.haml
@@ -37,3 +37,5 @@
                   = govuk_link_to(t('.delete_caseworker_html', case_worker: case_worker.name), case_workers_admin_case_worker_path(case_worker), method: :delete, data: { confirm: t('.confirmation') })
               - else
                 = t('.inactive')
+
+= paginate @case_workers

--- a/app/views/provider_management/providers/index.html.haml
+++ b/app/views/provider_management/providers/index.html.haml
@@ -10,6 +10,8 @@
         = govuk_link_button(t('.add_a_provider'), new_provider_management_provider_path)
       = govuk_link_button_secondary(t('.find_provider_by_email'), provider_management_external_users_find_path)
 
+= render partial: 'shared/search_form', locals: { search_path: provider_management_providers_path(anchor: 'search-button'), hint_text: t('hint.search_for_provider_name'), button_text: t('search.provider_name') }
+
 = render partial: 'providers', locals: { providers: @providers }
 
 = paginate @providers

--- a/app/views/provider_management/providers/index.html.haml
+++ b/app/views/provider_management/providers/index.html.haml
@@ -11,3 +11,5 @@
       = govuk_link_button_secondary(t('.find_provider_by_email'), provider_management_external_users_find_path)
 
 = render partial: 'providers', locals: { providers: @providers }
+
+= paginate @providers

--- a/app/views/provider_management/providers/index.html.haml
+++ b/app/views/provider_management/providers/index.html.haml
@@ -10,7 +10,7 @@
         = govuk_link_button(t('.add_a_provider'), new_provider_management_provider_path)
       = govuk_link_button_secondary(t('.find_provider_by_email'), provider_management_external_users_find_path)
 
-= render partial: 'shared/search_form', locals: { search_path: provider_management_providers_path(anchor: 'search-button'), hint_text: t('hint.search_for_provider_name'), button_text: t('search.provider_name') }
+= render partial: 'shared/search_form', locals: { search_path: provider_management_providers_path(anchor: 'search-button'), hint_text: t('.provider_hint_text'), button_text: t('.find_provider_by_name') }
 
 = render partial: 'providers', locals: { providers: @providers }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,6 +538,8 @@ en:
         add_a_provider: Add a provider
         page_title: View providers in claim for Crown court defence
         find_provider_by_email: Find provider by email
+        find_provider_by_name: Find provider by name
+        provider_hint_text: Search for a provider by name
       providers:
         fee_schemes: Fee schemes
         provider_type: *provider_type


### PR DESCRIPTION
#### What

The provider index page is very slow to load. 

#### Ticket

[CFP-527-Spike- Paginate provider index page](https://dsdmoj.atlassian.net/browse/CFP-527)

#### Why

Due to the large number of providers.

#### How

By paginating the list the load time can be improved greatly.

--------

#### TODO (wip)

 - [x] paginate provider page
 - [X] paginate caseworkers page
