### PR TITLE
Bump docker container resource size for other tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ jobs:
 
   other-tests:
     executor: test-executor
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - build-base


### PR DESCRIPTION
#### What
Bump circleci container resource class for brakeman

#### Ticket
 n/a

#### Why
Brakeman is regularly failing with:
```
Received "killed" signal
```
while parsing files. Could be related to
number of files and memory limits of the
small resource class used for these tests.
