### PR TITLE
Replace deprecated postgres circleci db image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
           LIVE1_DB_TASK: none
-      - image: circleci/postgres:13.1
+      - image: cimg/postgres:13.3
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"
@@ -104,7 +104,7 @@ executors:
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
-      - image: circleci/postgres:13.1
+      - image: cimg/postgres:13.3
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: "circleci"


### PR DESCRIPTION
#### What
Replace all deprecated circleci container images with modern convenience images

#### Ticket

n/a

#### Why
Warnings raised on circleci UI plus we need to bump to postgres 13.3 which is current 
production version in use.

see https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
for details.
