### PR TITLE
Ensure attributes have ErrorMessage::Key type

### DIFF
--- a/app/presenters/error_message/key.rb
+++ b/app/presenters/error_message/key.rb
@@ -60,7 +60,7 @@ module ErrorMessage
         model.slice!('_attributes')
         model = model.singularize
         all_model_indices[model] = Regexp.last_match(3)
-        attribute = Regexp.last_match(4)
+        attribute = Key.new(Regexp.last_match(4))
       end
 
       { model: model, attribute: attribute, all_model_indices: all_model_indices }


### PR DESCRIPTION
#### What

Use `Key.new` for remainder of regex match.

#### Ticket

[Update Ruby to 3.0 (or 3.1)](https://dsdmoj.atlassian.net/browse/CFP-295)

#### Why

In Ruby 2.7 `Regexp.last_match(n)` returns a `ErrorMessage::Key` when the original string is an `ErrorMessage::Key`. In Ruby 3.0 the matches are returned as Strings. The last 'remainder' from the regex match in `parse` needs to be an instance of `ErrorMessage::Key` so in Ruby 3 it needs to be created explicitly (and it also works in Ruby 2.7).

#### How

```ruby
attribute = Key.new(Regexp.last_match(4))
```

This will ensure that the value is an instance of `ErrorMessage::Key`. This works correctly whether `Regexp.last_match(4)` is already a `ErrorMessage::Key` or is a string.