### PR TITLE
[Security] Selectively bump minimist to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "glob-parent": "^6.0.2",
     "hosted-git-info": "^3.0.8",
     "is-svg": "^4.3.1",
+    "minimist": "^1.2.6",
     "node-forge": "^1.2.1",
     "normalize-url": "^4.5.1",
     "nth-check": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5717,10 +5717,10 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#### What
Resolve yarn packages security vulnerability: minimist

#### Ticket
N/A

#### Why
See Github's Advisory database related to issue

minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h

#### How
Selectively bump yarn packages `minimist`
