### PR TITLE
[CFP-295] Ruby 3 prep; More use of kwargs

### DIFF
--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -15,8 +15,8 @@ class SlackNotifier
     RestClient.post(@slack_url, @payload.to_json, content_type: :json)
   end
 
-  def build_payload(*args)
-    @payload[:attachments] = [@formatter.attachment(*args)]
+  def build_payload(**kwargs)
+    @payload[:attachments] = [@formatter.attachment(**kwargs)]
     @payload[:icon_emoji] = @formatter.message_icon
     @ready_to_send = true
   rescue StandardError

--- a/features/support/select_helper.rb
+++ b/features/support/select_helper.rb
@@ -4,7 +4,7 @@ module SelectHelper
   #
   def select(value, options)
     if options.delete(:autocomplete) == false
-      super value.to_s, {visible: false}.merge(options)
+      super value.to_s, visible: false, **options
     else
       fill_autocomplete(options[:from], with: value.to_s)
     end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -18,6 +18,12 @@ RSpec.shared_examples 'a successful report generator caller' do
     file_path = ActiveStorage::Blob.service.path_for(record.document.blob.key)
     expect(File.read(file_path)).to eq('some new content')
   end
+
+  context 'when the generator is called' do
+    before { allow(generator).to receive(:call).and_call_original }
+
+    it { expect { call }.not_to raise_error }
+  end
 end
 
 RSpec.describe Stats::StatsReportGenerator, type: :service do

--- a/spec/support/capybara_extensions.rb
+++ b/spec/support/capybara_extensions.rb
@@ -19,8 +19,8 @@ module Capybara
 
   class Session
     CapybaraExtensions.extension_methods.each do |method|
-      define_method method do |*args, &block|
-        current_scope.send method, *args, &block
+      define_method method do |*args, **kwargs, &block|
+        current_scope.send method, *args, **kwargs, &block
       end
     end
   end

--- a/spec/support/capybara_extensions/govuk_component/matchers.rb
+++ b/spec/support/capybara_extensions/govuk_component/matchers.rb
@@ -4,7 +4,7 @@
 module CapybaraExtensions
   module GOVUKComponent
     module Matchers
-      def has_govuk_link?(**options)
+      def has_govuk_link?(options)
         href = options.delete(:href)
         has_selector?('a.govuk-link', **options) &&
           has_link?(options[:text], href: href)
@@ -17,7 +17,7 @@ module CapybaraExtensions
         end.any?
       end
 
-      def has_govuk_section_title?(**options)
+      def has_govuk_section_title?(options)
         has_selector?('h2.govuk-heading-l', **options)
       end
 


### PR DESCRIPTION
#### What

Update use of keyword arguments as required in Ruby 3.

#### Ticket

[Update Ruby to 3.0 (or 3.1)](https://dsdmoj.atlassian.net/browse/CFP-295)

#### Why

Keyword arguments can no longer be passed to methods as a has as the final argument in Ruby 3. These changes prepare for this.

#### How

Hashes or arguments are passed as `method(**kwargs)` instead of just `method(kwargs)`.