### PR TITLE
[CFP-295] Ruby 3 prep; Even more use of kwargs

### DIFF
--- a/spec/services/stats/management_information/daily_report_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_generator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Stats::ManagementInformation::DailyReportGenerator do
-  subject(:generator) { described_class.new(options) }
+  subject(:generator) { described_class.new(**options) }
 
   let(:options) { {} }
   let(:expected_headers) do


### PR DESCRIPTION
#### What

Update use of keyword arguments as required in Ruby 3.

#### Ticket

[Update Ruby to 3.0 (or 3.1)](https://dsdmoj.atlassian.net/browse/CFP-295)

#### Why

Keyword arguments can no longer be passed to methods as a has as the final argument in Ruby 3. These changes prepare for this.

#### How

The subject in `spec/services/stats/management_information/daily_report_generator_spec.rb` need to be fixed as it causes all the tests to fail.