### PR TITLE
[CFP-295] Fix `Remote` module for Ruby 3

### DIFF
--- a/app/services/case_worker_service.rb
+++ b/app/services/case_worker_service.rb
@@ -7,6 +7,6 @@ class CaseWorkerService
   end
 
   def active
-    Remote::CaseWorker.all(current_user, criteria)
+    Remote::CaseWorker.all(current_user, **criteria)
   end
 end

--- a/app/services/claims/case_worker_claims.rb
+++ b/app/services/claims/case_worker_claims.rb
@@ -26,19 +26,19 @@ module Claims
     private
 
     def current_claims
-      Remote::Claim.user_allocations(current_user, criteria)
+      Remote::Claim.user_allocations(current_user, **criteria)
     end
 
     def archived_claims
-      Remote::Claim.archived(current_user, criteria)
+      Remote::Claim.archived(current_user, **criteria)
     end
 
     def allocated_claims
-      Remote::Claim.allocated(current_user, criteria)
+      Remote::Claim.allocated(current_user, **criteria)
     end
 
     def unallocated_claims
-      Remote::Claim.unallocated(current_user, criteria)
+      Remote::Claim.unallocated(current_user, **criteria)
     end
   end
 end

--- a/app/services/remote/base.rb
+++ b/app/services/remote/base.rb
@@ -18,8 +18,8 @@ module Remote
         raise 'not implemented'
       end
 
-      def all(query = {})
-        result = client.get(resource_path, query)
+      def all(**query)
+        result = client.get(resource_path, **query)
         parse_result(result)
       end
 

--- a/app/services/remote/case_worker.rb
+++ b/app/services/remote/case_worker.rb
@@ -6,7 +6,7 @@ module Remote
       end
 
       def all(user, **query)
-        super(**query.merge(api_key: user.api_key))
+        super(api_key: user.api_key, **query)
       end
     end
   end

--- a/app/services/remote/case_worker.rb
+++ b/app/services/remote/case_worker.rb
@@ -5,8 +5,8 @@ module Remote
         'case_workers'
       end
 
-      def all(user, query = {})
-        super(query.merge(api_key: user.api_key))
+      def all(user, **query)
+        super(**query.merge(api_key: user.api_key))
       end
     end
   end

--- a/app/services/remote/claim.rb
+++ b/app/services/remote/claim.rb
@@ -28,26 +28,26 @@ module Remote
         'case_workers/claims'
       end
 
-      def user_allocations(user, query = {})
+      def user_allocations(user, **query)
         all_by_status('current', user: user, query: query)
       end
 
-      def allocated(user, query = {})
+      def allocated(user, **query)
         all_by_status('allocated', user: user, query: query)
       end
 
-      def unallocated(user, query = {})
+      def unallocated(user, **query)
         all_by_status('unallocated', user: user, query: query)
       end
 
-      def archived(user, query = {})
+      def archived(user, **query)
         all_by_status('archived', user: user, query: query)
       end
 
       private
 
       def all_by_status(status, user:, query:)
-        all(query.merge(api_key: user.api_key, status: status))
+        all(**query.merge(api_key: user.api_key, status: status))
       end
     end
 

--- a/app/services/remote/claim.rb
+++ b/app/services/remote/claim.rb
@@ -47,7 +47,7 @@ module Remote
       private
 
       def all_by_status(status, user:, query:)
-        all(**query.merge(api_key: user.api_key, status: status))
+        all(api_key: user.api_key, status: status, **query)
       end
     end
 

--- a/app/services/remote/http_client.rb
+++ b/app/services/remote/http_client.rb
@@ -21,18 +21,18 @@ module Remote
       end
     end
 
-    def get(path, query = {})
-      execute_request(:get, path, query)
+    def get(path, **query)
+      execute_request(:get, path, **query)
     end
 
     private
 
-    def build_endpoint(path, query)
-      [self.class.base_url, path].join('/') + '?' + { api_key: api_key }.merge(query).to_query
+    def build_endpoint(path, **query)
+      [self.class.base_url, path].join('/') + '?' + { api_key: api_key }.merge(**query).to_query
     end
 
-    def execute_request(method, path, query)
-      endpoint = build_endpoint(path, query)
+    def execute_request(method, path, **query)
+      endpoint = build_endpoint(path, **query)
       response = Caching::ApiRequest.cache(endpoint) do
         RestClient::Request.execute(method: method, url: endpoint, timeout: timeout, open_timeout: open_timeout)
       end

--- a/spec/services/case_worker_service_spec.rb
+++ b/spec/services/case_worker_service_spec.rb
@@ -1,11 +1,16 @@
 require 'rails_helper'
 
-describe CaseWorkerService do
+RSpec.describe CaseWorkerService do
+  subject(:service) { described_class.new(current_user: :my_user, criteria: { key: :my_criteria }) }
+
   describe '#active' do
+    subject(:active) { service.active }
+
+    before { allow(Remote::CaseWorker).to receive(:all) }
+
     it 'calls Remote::Caseworker with user and criteria' do
-      service = CaseWorkerService.new(current_user: :my_user, criteria: { key: :my_criteria })
-      expect(Remote::CaseWorker).to receive(:all).with(:my_user, { key: :my_criteria })
       service.active
+      expect(Remote::CaseWorker).to have_received(:all).with(:my_user, { key: :my_criteria })
     end
   end
 end

--- a/spec/services/claims/case_worker_claims_spec.rb
+++ b/spec/services/claims/case_worker_claims_spec.rb
@@ -22,28 +22,28 @@ module Claims
 
       context 'action current' do
         it 'calls user_allocations on Remote::Claim' do
-          expect(Remote::Claim).to receive(:user_allocations).with(user, criteria)
+          expect(Remote::Claim).to receive(:user_allocations).with(user, **criteria)
           CaseWorkerClaims.new(current_user: user, action: 'current', criteria: criteria).claims
         end
       end
 
       context 'archived' do
         it 'calls archived on Remote::Claim' do
-          expect(Remote::Claim).to receive(:archived).with(user, criteria)
+          expect(Remote::Claim).to receive(:archived).with(user, **criteria)
           CaseWorkerClaims.new(current_user: user, action: 'archived', criteria: criteria).claims
         end
       end
 
       context 'allocated' do
         it 'calls allocated on Remote::Claim' do
-          expect(Remote::Claim).to receive(:allocated).with(user, criteria)
+          expect(Remote::Claim).to receive(:allocated).with(user, **criteria)
           CaseWorkerClaims.new(current_user: user, action: 'allocated', criteria: criteria).claims
         end
       end
 
       context 'unallocated' do
         it 'calls unallocated on Remote::Claim' do
-          expect(Remote::Claim).to receive(:unallocated).with(user, criteria)
+          expect(Remote::Claim).to receive(:unallocated).with(user, **criteria)
           CaseWorkerClaims.new(current_user: user, action: 'unallocated', criteria: criteria).claims
         end
       end

--- a/spec/services/claims/case_worker_claims_spec.rb
+++ b/spec/services/claims/case_worker_claims_spec.rb
@@ -17,42 +17,58 @@ module Claims
       }
     end
 
-    context 'Using remote' do
-      # before(:each) { allow(Settings).to receive(:case_workers_remote_allocations?).and_return(true) }
+    describe '#claims' do
+      subject(:claims) { described_class.new(current_user: user, action: action, criteria: criteria).claims }
 
-      context 'action current' do
+      let(:method) { action.to_sym }
+
+      before do
+        allow(Remote::Claim).to receive(method)
+      end
+
+      context 'with current action' do
+        let(:action) { 'current' }
+        let(:method) { :user_allocations }
+
         it 'calls user_allocations on Remote::Claim' do
-          expect(Remote::Claim).to receive(:user_allocations).with(user, **criteria)
-          CaseWorkerClaims.new(current_user: user, action: 'current', criteria: criteria).claims
+          claims
+          expect(Remote::Claim).to have_received(method).with(user, **criteria)
         end
       end
 
-      context 'archived' do
+      context 'with archived action' do
+        let(:action) { 'archived' }
+
         it 'calls archived on Remote::Claim' do
-          expect(Remote::Claim).to receive(:archived).with(user, **criteria)
-          CaseWorkerClaims.new(current_user: user, action: 'archived', criteria: criteria).claims
+          claims
+          expect(Remote::Claim).to have_received(method).with(user, **criteria)
         end
       end
 
-      context 'allocated' do
+      context 'with allocated action' do
+        let(:action) { 'allocated' }
+
         it 'calls allocated on Remote::Claim' do
-          expect(Remote::Claim).to receive(:allocated).with(user, **criteria)
-          CaseWorkerClaims.new(current_user: user, action: 'allocated', criteria: criteria).claims
+          claims
+          expect(Remote::Claim).to have_received(method).with(user, **criteria)
         end
       end
 
-      context 'unallocated' do
+      context 'with unallocated action' do
+        let(:action) { 'unallocated' }
+
         it 'calls unallocated on Remote::Claim' do
-          expect(Remote::Claim).to receive(:unallocated).with(user, **criteria)
-          CaseWorkerClaims.new(current_user: user, action: 'unallocated', criteria: criteria).claims
+          claims
+          expect(Remote::Claim).to have_received(method).with(user, **criteria)
         end
       end
 
-      context 'unrecognised action' do
+      context 'with unrecognised action' do
+        let(:action) { 'no-such-action' }
+        let(:method) { :user_allocations }
+
         it 'raises' do
-          expect {
-            CaseWorkerClaims.new(current_user: user, action: 'no-such-action', criteria: criteria).claims
-          }.to raise_error ArgumentError, 'Unknown action: no-such-action'
+          expect { claims }.to raise_error ArgumentError, 'Unknown action: no-such-action'
         end
       end
     end

--- a/spec/services/remote/case_worker_spec.rb
+++ b/spec/services/remote/case_worker_spec.rb
@@ -14,10 +14,16 @@ module Remote
     let(:query) { { 'query_key' => 'query value' } }
     let(:case_worker_collection) { double 'CaseWorker Collection', map: 'mapped_collection' }
 
-    it 'calls HttpClient to make the query' do
+    before do
       client = double Remote::HttpClient
-      expect(Remote::HttpClient).to receive(:current).and_return(client)
-      expect(client).to receive(:get).with('case_workers', 'query_key' => 'query value', api_key: 'my_api_key').and_return(case_worker_collection)
+      allow(Remote::HttpClient).to receive(:current).and_return(client)
+      allow(client)
+        .to receive(:get)
+        .with('case_workers', 'query_key' => 'query value', api_key: 'my_api_key')
+        .and_return(case_worker_collection)
+    end
+
+    it 'calls HttpClient to make the query' do
       expect(::Remote::CaseWorker.all(user, **query)).to eq('mapped_collection')
     end
   end

--- a/spec/services/remote/case_worker_spec.rb
+++ b/spec/services/remote/case_worker_spec.rb
@@ -18,7 +18,7 @@ module Remote
       client = double Remote::HttpClient
       expect(Remote::HttpClient).to receive(:current).and_return(client)
       expect(client).to receive(:get).with('case_workers', 'query_key' => 'query value', api_key: 'my_api_key').and_return(case_worker_collection)
-      expect(::Remote::CaseWorker.all(user, query)).to eq('mapped_collection')
+      expect(::Remote::CaseWorker.all(user, **query)).to eq('mapped_collection')
     end
   end
 end

--- a/spec/services/remote/claim_spec.rb
+++ b/spec/services/remote/claim_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module Remote
   describe Claim do
-    let(:user) { double ::Remote::User }
+    let(:user) { instance_double ::Remote::User }
     let(:query) { { 'my_query_key' => 'my query value' } }
 
     describe '.resource_path' do
@@ -12,34 +12,42 @@ module Remote
     end
 
     describe '.user_allocations' do
+      before { allow(::Remote::Claim).to receive(:all_by_status).with('current', user: user, query: query) }
+
       it 'calls all by status' do
-        expect(::Remote::Claim).to receive(:all_by_status).with('current', user: user, query: query)
         ::Remote::Claim.user_allocations(user, **query)
+        expect(::Remote::Claim).to have_received(:all_by_status).with('current', user: user, query: query)
       end
     end
 
     describe '.allocated' do
+      before { allow(::Remote::Claim).to receive(:all_by_status).with('allocated', user: user, query: query) }
+
       it 'calls all by status' do
-        expect(::Remote::Claim).to receive(:all_by_status).with('allocated', user: user, query: query)
         ::Remote::Claim.allocated(user, **query)
+        expect(::Remote::Claim).to have_received(:all_by_status).with('allocated', user: user, query: query)
       end
     end
 
     describe '.unallocated' do
+      before { allow(::Remote::Claim).to receive(:all_by_status).with('unallocated', user: user, query: query) }
+
       it 'calls all by status' do
-        expect(::Remote::Claim).to receive(:all_by_status).with('unallocated', user: user, query: query)
         ::Remote::Claim.unallocated(user, **query)
+        expect(::Remote::Claim).to have_received(:all_by_status).with('unallocated', user: user, query: query)
       end
     end
 
     describe '.archived' do
+      before { allow(::Remote::Claim).to receive(:all_by_status).with('archived', user: user, query: query) }
+
       it 'calls all by status' do
-        expect(::Remote::Claim).to receive(:all_by_status).with('archived', user: user, query: query)
         ::Remote::Claim.archived(user, **query)
+        expect(::Remote::Claim).to have_received(:all_by_status).with('archived', user: user, query: query)
       end
     end
 
-    describe 'all_by_status' do
+    describe '.all_by_status' do
       let(:claim_collection) { double 'Claim Collection', map: 'mapped_collection' }
       let(:user) { double Remote::User, api_key: 'my_api_key' }
       let(:query_params) do
@@ -50,10 +58,13 @@ module Remote
         }
       end
 
-      it 'calls HttpClient to make the query' do
+      before do
         client = double Remote::HttpClient
-        expect(Remote::HttpClient).to receive(:current).and_return(client)
-        expect(client).to receive(:get).with('case_workers/claims', **query_params).and_return(claim_collection)
+        allow(Remote::HttpClient).to receive(:current).and_return(client)
+        allow(client).to receive(:get).with('case_workers/claims', **query_params).and_return(claim_collection)
+      end
+
+      it 'calls HttpClient to make the query' do
         expect(::Remote::Claim.__send__(:all_by_status, 'current', user: user, query: query)).to eq('mapped_collection')
       end
     end

--- a/spec/services/remote/claim_spec.rb
+++ b/spec/services/remote/claim_spec.rb
@@ -14,28 +14,28 @@ module Remote
     describe '.user_allocations' do
       it 'calls all by status' do
         expect(::Remote::Claim).to receive(:all_by_status).with('current', user: user, query: query)
-        ::Remote::Claim.user_allocations(user, query)
+        ::Remote::Claim.user_allocations(user, **query)
       end
     end
 
     describe '.allocated' do
       it 'calls all by status' do
         expect(::Remote::Claim).to receive(:all_by_status).with('allocated', user: user, query: query)
-        ::Remote::Claim.allocated(user, query)
+        ::Remote::Claim.allocated(user, **query)
       end
     end
 
     describe '.unallocated' do
       it 'calls all by status' do
         expect(::Remote::Claim).to receive(:all_by_status).with('unallocated', user: user, query: query)
-        ::Remote::Claim.unallocated(user, query)
+        ::Remote::Claim.unallocated(user, **query)
       end
     end
 
     describe '.archived' do
       it 'calls all by status' do
         expect(::Remote::Claim).to receive(:all_by_status).with('archived', user: user, query: query)
-        ::Remote::Claim.archived(user, query)
+        ::Remote::Claim.archived(user, **query)
       end
     end
 
@@ -53,7 +53,7 @@ module Remote
       it 'calls HttpClient to make the query' do
         client = double Remote::HttpClient
         expect(Remote::HttpClient).to receive(:current).and_return(client)
-        expect(client).to receive(:get).with('case_workers/claims', query_params).and_return(claim_collection)
+        expect(client).to receive(:get).with('case_workers/claims', **query_params).and_return(claim_collection)
         expect(::Remote::Claim.__send__(:all_by_status, 'current', user: user, query: query)).to eq('mapped_collection')
       end
     end

--- a/spec/services/remote/http_client_spec.rb
+++ b/spec/services/remote/http_client_spec.rb
@@ -1,41 +1,47 @@
 require 'rails_helper'
 
 module Remote
-  describe HttpClient do
+  describe Remote::HttpClient do
     describe '.current' do
-      context 'self.instance already exists' do
+      context 'when self.instance already exists' do
         it 'returns the instance' do
-          client = HttpClient.current
-          expect(client).to be_instance_of(HttpClient)
+          client = described_class.current
+          expect(client).to be_instance_of(described_class)
         end
       end
 
-      context 'self.instance does not already exist' do
+      context 'when self.instance does not already exist' do
         it 'calls new and returns the new instance' do
-          client = HttpClient.current
-          expect(HttpClient.current).to eq client
+          client = described_class.current
+          expect(described_class.current).to eq client
         end
       end
     end
 
     describe 'base_url' do
-      context 'base_url is specified in configure clause' do
+      context 'when base_url is specified in configure clause' do
+        before { described_class.configure { |client| client.base_url = 'my_base_url' } }
+
         it 'uses the base url suppllied in the configure clause' do
-          HttpClient.configure { |client| client.base_url = 'my_base_url' }
-          expect(HttpClient.base_url).to eq 'my_base_url'
+          expect(described_class.base_url).to eq 'my_base_url'
         end
       end
 
-      context 'base_url _NOT_ specified in configure bloack' do
+      context 'when base_url _NOT_ specified in configure block' do
+        before do
+          described_class.configure { |c| c.base_url = nil }
+          allow(Settings).to receive(:remote_api_url).and_return('default_base_url')
+        end
+
         it 'uses the base url from Settings' do
-          HttpClient.configure { |c| c.base_url = nil }
-          expect(Settings).to receive(:remote_api_url).and_return('default_base_url')
-          expect(HttpClient.base_url).to eq 'default_base_url'
+          expect(described_class.base_url).to eq 'default_base_url'
         end
       end
     end
 
     describe '.get' do
+      subject(:result) { described_class.current.get(path, **query) }
+
       let(:api_url)  { 'my_api_url' }
       let(:api_key)  { 'my_key' }
       let(:path)     { 'my_path' }
@@ -43,23 +49,31 @@ module Remote
       let(:endpoint) { 'my_api_url/my_path?api_key=my_key&key=value' }
 
       before do
-        HttpClient.configure do |client|
+        described_class.configure do |client|
           client.base_url = api_url
           client.api_key = api_key
           client.logger = Rails.logger
           client.open_timeout = 2
           client.timeout = 4
         end
+        response = instance_double('HTTPResponse', body: 'body', headers: {})
+        allow(Caching::ApiRequest).to receive(:cache).with(endpoint).and_call_original
+        allow(JSON).to receive(:parse).with('body', symbolize_names: true).and_return({ key: 'value' })
+        allow(RestClient::Request)
+          .to receive(:execute)
+          .with(method: :get, url: endpoint, timeout: 4, open_timeout: 2)
+          .and_return(response)
       end
 
       it 'calls execute on RestClient::Request' do
-        response = double('HTTPResponse', body: 'body', headers: {})
-        expect(Caching::ApiRequest).to receive(:cache).with(endpoint).and_call_original
-        expect(JSON).to receive(:parse).with('body', symbolize_names: true).and_return({ key: 'value' })
-        expect(RestClient::Request).to receive(:execute).with(method: :get, url: endpoint, timeout: 4, open_timeout: 2).and_return(response)
+        result
 
-        result = HttpClient.current.get(path, **query)
+        expect(RestClient::Request)
+          .to have_received(:execute)
+          .with(method: :get, url: endpoint, timeout: 4, open_timeout: 2)
+      end
 
+      it 'returns the expected response' do
         expect(result).to eq({ key: 'value' })
       end
     end

--- a/spec/services/remote/http_client_spec.rb
+++ b/spec/services/remote/http_client_spec.rb
@@ -58,7 +58,7 @@ module Remote
         expect(JSON).to receive(:parse).with('body', symbolize_names: true).and_return({ key: 'value' })
         expect(RestClient::Request).to receive(:execute).with(method: :get, url: endpoint, timeout: 4, open_timeout: 2).and_return(response)
 
-        result = HttpClient.current.get(path, query)
+        result = HttpClient.current.get(path, **query)
 
         expect(result).to eq({ key: 'value' })
       end


### PR DESCRIPTION
#### What

Update `app/services/remote/*` to use keyword arguments correctly for Ruby 3.

#### Ticket

[Update Ruby to 3.0 (or 3.1)](https://dsdmoj.atlassian.net/browse/CFP-295)

#### Why

Ruby 3 changes the behaviour of keyword arguments so that they can no longer be passed as a hash in the final positional argument. The `Remote` module was written to explicitly take hash as an argument for keyword arguments and so this is now inconsistent with correct usage.

#### How

Method definitions are updated to have the argument `**query` instead of `query = {}` so that keyword arguments are read in correctly as a hash into `query`. Calls to these methods are updated accordingly.

Originally, the `Remote::CaseWorker#all` and `Remote::Claim#all_by_status` methods would ignore an `api_key` argument if it is passed in in favour of the default value. This has been changed (4c849534bd5971671a9cbd5e857eaae0e8056ec8) so that the passed in value can override the default. This isn't currently used anywhere but it is more logical.

E.g.

```ruby
Remote::CaseWorker.all(user, api_key: 'non-standard-api-key', **query)

# see app/services/remote/case_worker.rb:9
# Old behaviour
super(api_key: user.api_key, **query)

# New behaviour
super(api_key: 'non-standard-api-key', **query)
```

(Possibly, the `api_key` should be passed in anyway as `user` is not used for anything else)