### PR TITLE
[CFP-533] - Wording on login page for a disabled user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,13 +114,9 @@ class User < ApplicationRecord
   end
 
   def inactive_message
-    if active? && enabled?
-      super
-    elsif softly_deleted?
-      'This account has been deleted.'
-    elsif disabled?
-      'This account has been disabled.'
-    end
+    return 'Invalid Email or password.' unless active? && enabled?
+
+    super
   end
 
   def email_notification_of_message

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,9 +114,11 @@ class User < ApplicationRecord
   end
 
   def inactive_message
-    return 'Invalid Email or password.' unless active? && enabled?
-
-    super
+    if active? && enabled?
+      super
+    else
+      I18n.t('activerecord.attributes.user.disabled_and_deleted_message')
+    end
   end
 
   def email_notification_of_message

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,6 +186,7 @@ en:
         first_name: *first_name
         last_name: *last_name
         email_confirmation: *email_confirmation
+        disabled_and_deleted_message: 'Invalid Email or password.'
       claim:
         external_user: *advocate
         offence: 'Offence'

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -11,7 +11,7 @@ Feature: Caseworker can log in while active, but not once inactive
 
     Given the caseworker is marked as deleted
     When I attempt to sign in again as the deleted caseworker
-    Then I should see 'This account has been deleted'
+    Then I should see 'Invalid Email or password.'
     And the page should be accessible
 
     And I eject the VCR cassette
@@ -24,10 +24,10 @@ Feature: Caseworker can log in while active, but not once inactive
     Given the advocate is disabled
     When I click the link 'Your claims'
     Then I should be on the sign in page
-    And I should see 'This account has been disabled'
+    And I should see 'Invalid Email or password.'
 
     When I attempt to sign in again as the advocate
-    Then I should see 'This account has been disabled'
+    Then I should see 'Invalid Email or password.'
     And the page should be accessible
 
     Given the advocate is enabled

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -256,11 +256,11 @@ RSpec.describe User, type: :model do
       end
 
       it 'returns specialised message for softly deleted users' do
-        expect(inactive_user.inactive_message).to eq 'This account has been deleted.'
+        expect(inactive_user.inactive_message).to eq 'Invalid Email or password.'
       end
 
       it 'returns specialised message for disabled users' do
-        expect(disabled_user.inactive_message).to eq 'This account has been disabled.'
+        expect(disabled_user.inactive_message).to eq 'Invalid Email or password.'
       end
     end
 
@@ -312,19 +312,19 @@ RSpec.describe User, type: :model do
     context 'with active disabled user' do
       let(:user) { build(:user, deleted_at: nil, disabled_at: Time.zone.now) }
 
-      it { is_expected.to eq 'This account has been disabled.' }
+      it { is_expected.to eq 'Invalid Email or password.' }
     end
 
     context 'with inactive enabled user' do
       let(:user) { build(:user, deleted_at: Time.zone.now, disabled_at: nil) }
 
-      it { is_expected.to eq 'This account has been deleted.' }
+      it { is_expected.to eq 'Invalid Email or password.' }
     end
 
     context 'with an inactive disabled user' do
       let(:user) { build(:user, deleted_at: Time.zone.now, disabled_at: Time.zone.now) }
 
-      it { is_expected.to eq 'This account has been deleted.' }
+      it { is_expected.to eq 'Invalid Email or password.' }
     end
   end
 


### PR DESCRIPTION
#### What
Making the error message on login page generic 
#### Ticket

[Wording on login page for a disabled user needs to be a generic message instead of ‘this user is disabled’.](https://dsdmoj.atlassian.net/browse/CFP-533)

#### Why
Not providing information for security reasons 

#### How
Making message generic
