### PR TITLE
CFP-532 Provider admin: Display disabled user status

### DIFF
--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -38,7 +38,7 @@
           = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
 
         = govuk_table_td('data-label': t('.actions')) do
-          - if advocate.active?
+          - if advocate.active? && advocate.enabled?
             .app-link-group
               = govuk_link_to t('.edit_html', context: advocate.name), edit_external_users_admin_external_user_path(advocate)
               = govuk_link_to t('.delete_html', context: advocate.name), external_users_admin_external_user_path(advocate), method: :delete, data: { confirm: t('.confirmation') }

--- a/features/enable_disable_users.feature
+++ b/features/enable_disable_users.feature
@@ -72,3 +72,12 @@ Scenario: Super admin can enable user
     Then I should be on the provider manager user show page
     And I should see 'Live, Enabled'
     And I should see link 'Disable account'
+
+Scenario: Provider admin can identify disabled users
+    Given I am a signed in advocate admin
+    And an "advocate" user account exists
+    And the advocate is disabled
+    And both users belong to the same firm
+    When I click the link 'Manage users'
+    Then I am on the manage users page
+    And I should see 'Inactive'

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -161,3 +161,8 @@ end
 When(/^I should be on the Allocation page$/) do
   expect(find('#page-h1')).to have_content('Allocation')
 end
+
+Given(/^both users belong to the same firm$/) do
+  provider = User.first.provider
+  User.last.persona.update!(provider: provider)
+end


### PR DESCRIPTION
#### What

Display the correct status of disabled provider users to provider admins

#### Ticket

[CFP-532](https://dsdmoj.atlassian.net/browse/CFP-532)

#### Why

When a provider admin views the list of users on the Manage users page,
there is currently nothing to indicate that a user has been disabled;
they appear with the Edit and Delete links as with an enabled user. This
may be confusing for admins.

#### How

* Update `app/views/external_users/admin/external_users/index.html.haml` to display a disabled user as `Inactive`.
* Add a feature test to confirm this works as expected.
