### PR TITLE
[CFP-534] [CFP-535] Show disabled user as inactive in superadmin view

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -103,7 +103,7 @@ class Ability
   def can_administer_any_provider
     can %i[show index new create edit update], Provider
     can %i[index new create find search], ExternalUser
-    can %i[show edit update change_password update_password], ExternalUser, deleted_at: nil
+    can %i[show edit update change_password update_password], ExternalUser, deleted_at: nil, disabled_at: nil
   end
 
   def can_manage_litigator_claims(persona)

--- a/app/views/provider_management/external_users/index.html.haml
+++ b/app/views/provider_management/external_users/index.html.haml
@@ -30,4 +30,4 @@
               = govuk_mail_to advocate.email, advocate.email, 'aria-label': t('.title', provider: advocate.name)
 
             = govuk_table_td('data-label': t('.state')) do
-              = advocate.active? ? t('.live') : t('.inactive')
+              = (advocate.active? && advocate.enabled?) ? t('.live') : t('.inactive')

--- a/features/enable_disable_users.feature
+++ b/features/enable_disable_users.feature
@@ -37,7 +37,7 @@ Feature: Super admin can enable and disable users
     And I should see 'Live, Disabled'
     And I should see link 'Enable account'
 
-Scenario: Super admin can enable user
+  Scenario: Super admin can enable user
 
     Given a disabled external provider exists with first name 'John' and last name 'Doe'
     And I am a signed in super admin
@@ -73,11 +73,20 @@ Scenario: Super admin can enable user
     And I should see 'Live, Enabled'
     And I should see link 'Disable account'
 
-Scenario: Provider admin can identify disabled users
+  Scenario: Provider admin can identify disabled users
     Given I am a signed in advocate admin
     And an "advocate" user account exists
     And the advocate is disabled
     And both users belong to the same firm
     When I click the link 'Manage users'
     Then I am on the manage users page
+    And I should see 'Inactive'
+
+  Scenario: Superadmin can identify disabled users
+    Given I am a signed in super admin
+    And an "advocate" user account exists
+    And the advocate is disabled
+    When I click the link 'Providers'
+    And I click the link 'Manage users in provider'
+    Then I should be on the provider manager user index page
     And I should see 'Inactive'

--- a/spec/factories/external_users.rb
+++ b/spec/factories/external_users.rb
@@ -69,6 +69,12 @@ FactoryBot.define do
       deleted_at { 10.minutes.ago }
     end
 
+    trait :disabled do
+      after(:create) do |eu|
+        eu.user.update(disabled_at: 10.minutes.ago)
+      end
+    end
+
     trait :with_settings do
       after(:build) do |a|
         a.user = build(:user,

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -508,8 +508,22 @@ RSpec.describe Ability do
       it { is_expected.not_to be_able_to(:update_availability, target) }
     end
 
-    context 'with a disabled external user' do
+    context 'with a softly deleted external user' do
       let(:target) { create(:external_user, :softly_deleted) }
+
+      it { is_expected.not_to be_able_to(:show, target) }
+      it { is_expected.not_to be_able_to(:edit, target) }
+      it { is_expected.not_to be_able_to(:update, target) }
+      it { is_expected.not_to be_able_to(:change_password, target) }
+      it { is_expected.not_to be_able_to(:update_password, target) }
+      it { is_expected.not_to be_able_to(:destroy, target) }
+      it { is_expected.not_to be_able_to(:confirmation, target) }
+      it { is_expected.not_to be_able_to(:change_availability, target) }
+      it { is_expected.not_to be_able_to(:update_availability, target) }
+    end
+
+    context 'with a disabled external user' do
+      let(:target) { create(:external_user, :disabled) }
 
       it { is_expected.not_to be_able_to(:show, target) }
       it { is_expected.not_to be_able_to(:edit, target) }


### PR DESCRIPTION
#### What

Display the correct status of a disabled external user when viewed in the users list by the superadmin or caseworker with provider management access.

#### Ticket

* [Superadmin: Display when a user is disabled](https://dsdmoj.atlassian.net/browse/CFP-534)
* [Caseworker admin: Display when a user is disabled](https://dsdmoj.atlassian.net/browse/CFP-535)

#### Why

When the superadmin views a list of users for a provider there is no indication that a user is disabled.

#### How

Update `app/views/provider_management/external_users/index.html.haml` to show state inactive when a user is disabled.