### PR TITLE
[SPIKE] [CFP-408] FormBuilder migration - Miscellaneous fees

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -422,8 +422,8 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
       ],
       interim_claim_info_attributes: [
         :warrant_fee_paid,
-        date_attributes_for(:warrant_issued_date),
-        date_attributes_for(:warrant_executed_date)
+        :warrant_issued_date,
+        :warrant_executed_date
       ]
     )
   end

--- a/app/models/interim_claim_info.rb
+++ b/app/models/interim_claim_info.rb
@@ -7,8 +7,6 @@ class InterimClaimInfo < ApplicationRecord
 
   validates_with InterimClaimInfoValidator
 
-  acts_as_gov_uk_date :warrant_issued_date, :warrant_executed_date
-
   def perform_validation?
     claim&.perform_validation?
   end

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -189,6 +189,12 @@ class BaseValidator < ActiveModel::Validator
     validate_amount_less_than_item_max(field)
   end
 
+  def validate_presence_and_numericality_govuk_formbuilder(field, minimum: 0, allow_blank: false)
+    validate_presence(field, :blank) unless allow_blank
+    validate_float_numericality(field, :numericality, minimum, nil)
+    validate_amount_less_than_item_max(field)
+  end
+
   def validate_vat_less_than_max(vat_attribute, net_attribute)
     vat_amount = @record.send(vat_attribute) || 0
     net_amount = @record.send(net_attribute) || 0

--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -16,7 +16,7 @@ module Fee
       if run_base_fee_validators?
         super
       else
-        validate_presence(:fee_type, 'blank')
+        validate_presence(:fee_type, :blank)
         validate_lgfs_fee_type_rules
       end
     end
@@ -40,7 +40,7 @@ module Fee
       elsif @record.fee_type.unique_code.eql?('MIEVI')
         validate_evidence_provision_fee
       else
-        validate_presence_and_numericality(:amount, minimum: 0.1)
+        validate_presence_and_numericality_govuk_formbuilder(:amount, minimum: 0.1)
       end
     end
 
@@ -51,7 +51,7 @@ module Fee
     def validate_evidence_provision_fee
       valid_values = [45, 90]
       return if valid_values.include?(@record.amount.to_d)
-      add_error(:amount, 'incorrect_epf')
+      add_error(:amount, :incorrect_epf)
     end
   end
 end

--- a/app/views/external_users/claims/_error_summary.html.haml
+++ b/app/views/external_users/claims/_error_summary.html.haml
@@ -1,4 +1,4 @@
-- form_steps = %w[case_details transfer_fee_details offence_details supporting_evidence]
+- form_steps = %w[case_details transfer_fee_details miscellaneous_fees offence_details supporting_evidence]
 - if form_steps.include?(@claim.form_step.to_s)
   = govuk_error_summary(@claim, :claim, presenter: @error_presenter)
 

--- a/app/views/external_users/claims/interim_claim_info/_fields.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_fields.html.haml
@@ -3,35 +3,19 @@
     %h2.govuk-heading-m
       = t('.warrant_fee')
 
-    = f.fields_for :interim_claim_info do |ff|
-      .form-section
-        %fieldset{"aria-describedby": "radio-control-legend-warrant"}
-          %legend#radio-control-legend-warrant
-            %span.form-label-bold
-              = t('.warrant_fee_paid')
-          .form-group
-            = ff.collection_radio_buttons(:warrant_fee_paid, yes_no_options, :last, :first, { include_hidden: false, checked: ff.object.warrant_fee_paid ? 'true' : 'false' }) do |b|
-              .multiple-choice{ 'data-target' => b.value.to_bool ? 'interim-claim-info-details' : nil }
-                = b.radio_button("aria-labelledby": "radio-control-legend-warrant #{b.text.to_css_class}")
-                = b.label(id: b.text.to_css_class) { b.text }
+    = f.fields_for :interim_claim_info do |ici|
+      = ici.govuk_radio_buttons_fieldset(:warrant_fee_paid, legend: { size: 's', text: t('.warrant_fee_paid') }) do
+        - yes_no_options.each do |text,value|
+          = ici.govuk_radio_button :warrant_fee_paid, value.to_bool, label: { text: text } do
+            - if value.to_bool
+              = ici.govuk_date_field :warrant_issued_date,
+                form_group: { classes: 'warrant-fee-issued-date-group' },
+                hint: { text: t('.date_hint') },
+                legend: { text: t('.date_issued'), size: 's' },
+                maxlength_enabled: true
 
-              - if b.value.to_bool
-                #interim-claim-info-details.panel.panel-border-narrow.js-hidden
-                  .form-group
-                    %fieldset
-                      %legend.govuk-visually-hidden
-                        = t('.warrant_fee')
-                      .warrant-fee-issued-date-group
-                        = ff.gov_uk_date_field :warrant_issued_date,
-                                                legend_text: t('.date_issued'),
-                                                legend_class: 'form-label-bold',
-                                                id: 'interim_claim_info.warrant_issued_date',
-                                                error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_issued_date')
-
-                  .form-group
-                    .warrant-fee-executed-date-group
-                      = ff.gov_uk_date_field :warrant_executed_date,
-                                              legend_text: t('.date_executed'),
-                                              legend_class: 'govuk-legend',
-                                              id: 'interim_claim_info.warrant_executed_date',
-                                              error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_executed_date')
+              = ici.govuk_date_field :warrant_executed_date,
+                form_group: { classes: 'warrant-fee-executed-date-group' },
+                hint: { text: t('.date_hint') },
+                legend: { text: t('.date_executed'), size: 's' },
+                maxlength_enabled: true

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -3,51 +3,38 @@
 
 .form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{ data: { 'type': 'miscFees', autovat: @claim.apply_vat? ? 'true' : 'false', 'block-type': 'FeeBlockCalculator' } }
 
-  %fieldset
-    %legend
-      %span.govuk-heading-m
-        = t('.misc_fee')
-        %span.fx-numberedList-number
+  = f.govuk_fieldset legend: {} do
+    %span.govuk-heading-m
+      = t('.misc_fee_html')
 
     = link_to_remove_association f, wrapper_class: 'misc-fee-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
       = t('common.remove_html', context: t('.misc_fee'))
 
-    .form-group
-      .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") ? 'form-group-error dropdown_field_with_errors' : '' }
-        = f.label :fee_type_id_input,
-          t('.fee_type_html', context: t('.misc_fee')),
-          { class: 'form-label-bold' }
-
-        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
-
-        = f.select :fee_type_id,
-          options_for_select(claim.eligible_misc_fee_type_options_for_select, f.object&.fee_type&.id),
-          { include_blank: ''.html_safe },
-          { class: 'form-control form-control-full js-misc-fee-type js-fee-type js-fee-calculator-fee-type typeahead fx-misc-fee-calculation',
-          id: "misc_fee_#{@misc_fee_count}_fee_type",
-          'aria-label': t('.fee_type') }
+    = f.govuk_select(:fee_type_id,
+      label: { text: t('.fee_type_html', context: t('.misc_fee')), size: 's' },
+      class: 'js-misc-fee-type js-fee-type js-fee-calculator-fee-type fx-misc-fee-calculation',
+      options: { include_blank: '' },
+      form_group: { classes: 'fee-type fx-autocomplete-wrapper cc-fee-type'} ) do
+      = options_for_select(claim.eligible_misc_fee_type_options_for_select, f.object&.fee_type&.id)
 
     .form-group.fx-unused-materials-warning.js-hidden
       = render 'warnings/unused_material_over_3_hours'
 
-    = f.adp_text_field :quantity,
-                            label: t('.quantity_html', context: t('.misc_fee')),
-                            hint_text: t('.quantity_hint'),
-                            hide_hint: true,
-                            input_classes: 'quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity',
-                            input_type: 'number',
-                            value: fee.quantity,
-                            errors: @error_presenter
+    = f.govuk_number_field :quantity,
+      label: { text: t('.quantity_html', context: t('.misc_fee')) },
+      hint: { text: t('.quantity_hint') , hidden: true},
+      class: 'quantity fee-quantity js-fee-quantity js-fee-calculator-quantity',
+      value: fee.quantity,
+      width: 5
 
-    .js-unit-price-effectee
-      .calculated-unit-fee
-      = f.adp_text_field :rate,
-          label: t('.rate_html', context: t('.misc_fee')),
-          input_classes: 'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
-          input_type: 'currency',
-          errors: @error_presenter,
-          input_readonly: f.object.price_calculated?,
-          value: number_with_precision(f.object.rate, precision: 2)
+    = f.govuk_number_field :rate,
+      class: 'rate fee-rate js-fee-calculator-rate',
+      form_group: { classes: 'js-unit-price-effectee calculated-unit-fee' },
+      label: { text: t('.rate_html', context: t('.misc_fee')) },
+      prefix_text: '£',
+      value: number_with_precision(f.object.rate, precision: 2),
+      width: 5,
+      readonly: f.object.price_calculated?
 
     .js-fee-calculator-success
       = f.hidden_field :price_calculated, value: f.object.price_calculated?
@@ -69,6 +56,6 @@
         = f.fields_for :dates_attended do |date_attended|
           = render 'date_attended_fields', f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "misc_fee_#{@misc_fee_count}"
 
-      = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: '', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
+      = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'govuk-link', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
 
   %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -1,42 +1,26 @@
 .form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{ data: { 'type': 'miscFees', autovat: @claim.apply_vat? ? 'true' : 'false' } }
 
-  %fieldset
-    %legend
-      %span.govuk-heading-m
-        = t('.misc_fee')
-        %span.fx-numberedList-number
+  = f.govuk_fieldset legend: {} do
+    %span.govuk-heading-m
+      = t('.misc_fee_html')
 
     = link_to_remove_association f, wrapper_class: 'misc-fee-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
       = t('common.remove_html', context: t('.misc_fee'))
 
-    .form-group
-      .fee-type{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") }
-        %fieldset{ 'aria-describedby': "radio-control-legend-#{@misc_fee_count}" }
-          %legend{ id: "radio-control-legend-#{@misc_fee_count}" }
-            %span.form-label-bold
-              = t('.fee_type')
+    = f.govuk_radio_buttons_fieldset(:fee_type_id, form_group: {classes: 'fee-type'}, legend: { size: 's', text: t('.fee_type') }) do
+      - present_collection(@claim.eligible_misc_fee_types).each do |misc_fee_type|
+        = f.govuk_radio_button :fee_type_id,
+          misc_fee_type.id,
+          label: { text: misc_fee_type.description },
+          'data-unique-code': misc_fee_type.unique_code do
+          - if misc_fee_type.unique_code.eql?('MIUMO')
+            = render 'warnings/unused_material_over_3_hours'
 
-          %a{ id: "misc_fee_#{@misc_fee_count}_fee_type" }
-
-          - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
-          - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
-
-          = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
-            .multiple-choice
-              = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}",
-                data: { unique_code: b.object.fee_type.unique_code})
-              = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { t('.type_of_fee_html', context: b.text) }
-
-        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
-
-    .form-group.fx-unused-materials-warning.js-hidden
-      = render 'warnings/unused_material_over_3_hours'
-
-    = f.adp_text_field :amount,
-                      label: t('.net_amount_html', context: t('.misc_fee')),
-                      input_classes: 'total fee-rate form-input-denote__input form-control-1-4',
-                      input_type: 'currency',
-                      errors: @error_presenter,
-                      value: number_with_precision(f.object.amount, precision: 2)
+    = f.govuk_number_field :amount,
+      label: { text: t('.net_amount_html', context: t('.misc_fee')) },
+      class: 'total fee-rate',
+      prefix_text: '£',
+      value: number_with_precision(f.object.amount, precision: 2),
+      width: 5
 
   %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -62,12 +62,14 @@ if (!String.prototype.supplant) {
    */
   $('#fixed-fees, #misc-fees, #documents').on('cocoon:after-insert', function (e, insertedItem) {
     const $insertedItem = $(insertedItem)
-    const insertedSelect = $insertedItem.find('select.typeahead')
-    const typeaheadWrapper = $insertedItem.find('.js-typeahead')
+    const insertedGovUkSelect = $insertedItem.find('.fx-autocomplete-wrapper select').attr('id')
+    // const insertedSelect = $insertedItem.find('select.typeahead')
+    // const typeaheadWrapper = $insertedItem.find('.js-typeahead')
 
-    moj.Modules.Autocomplete.typeaheadKickoff(insertedSelect)
-    moj.Modules.Autocomplete.typeaheadBindEvents(typeaheadWrapper)
+    // moj.Modules.Autocomplete.typeaheadKickoff(insertedSelect)
+    // moj.Modules.Autocomplete.typeaheadBindEvents(typeaheadWrapper)
     moj.Modules.FeeFieldsDisplay.addFeeChangeEvent(insertedItem)
+    moj.Modules.AutocompleteWrapper.Autocomplete(insertedGovUkSelect)
 
     $insertedItem.find('.remove_fields:first').trigger('focus')
   })

--- a/app/webpack/javascripts/modules/Modules.AutocompleteWrapper.js
+++ b/app/webpack/javascripts/modules/Modules.AutocompleteWrapper.js
@@ -2,17 +2,20 @@ moj.Modules.AutocompleteWrapper = {
   init: function () {
     const list = document.querySelectorAll('.fx-autocomplete-wrapper select')
     if (!list.length) return
-    this.Autocomplete(list)
+    this.initAutocomplete(list)
   },
 
-  Autocomplete: function (nodeList) {
+  initAutocomplete: function (nodeList) {
     for (let i = 0; i < nodeList.length; i++) {
-      const node = nodeList[i]
-      moj.Helpers.Autocomplete.new('#' + node.id, {
-        showAllValues: true,
-        autoselect: false,
-        displayMenu: 'overlay'
-      })
+      this.Autocomplete(nodeList[i].id)
     }
+  },
+
+  Autocomplete: function (elementId) {
+    moj.Helpers.Autocomplete.new('#' + elementId, {
+      autoselect: false,
+      displayMenu: 'overlay',
+      showAllValues: true
+    })
   }
 }

--- a/app/webpack/javascripts/modules/external_users/claims/CocoonHelper.js
+++ b/app/webpack/javascripts/modules/external_users/claims/CocoonHelper.js
@@ -15,6 +15,7 @@ moj.Modules.CocoonHelper = {
 
   addCocoonHooks: function () {
     const $elem = $(this.el)
+    let counter = 0
 
     $elem.on('cocoon:after-insert', function (e) {
       const $el = $(e.target)
@@ -28,6 +29,14 @@ moj.Modules.CocoonHelper = {
       }
 
       $el.trigger('recalculate')
+    })
+
+    $elem.on('cocoon:before-insert', function (e, insertedItem) {
+      insertedItem.find('.govuk-form-group').each(function () {
+        const newId = $(this).find(':input').attr('id').concat('-', counter++)
+        $(this).find(':input').attr('id', newId)
+        $(this).find('label').attr('for', newId)
+      })
     })
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1392,6 +1392,7 @@ en:
             add_misc_fee: Add another fee
           misc_fee_fields:
             misc_fee: *miscellaneous_fee
+            misc_fee_html: 'Miscellaneous fees <span class="fx-numberedList-number"></span>'
             rate: Rate
             rate_html: Rate <span class="govuk-visually-hidden">in pounds for %{context} <span class="fx-numberedList-number"></span></span>
             net_amount: *net_amount

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1432,6 +1432,7 @@ en:
               and attach to the claim.
           misc_fee_fields:
             misc_fee: *miscellaneous_fee
+            misc_fee_html: 'Miscellaneous fees <span class="fx-numberedList-number"></span>'
             fee_type: *fee_type
             case_numbers: *case_numbers
             type_of_fee_html: '%{context} <span class="govuk-visually-hidden">for miscellaneous fee <span class="fx-numberedList-number"></span></span>'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1479,6 +1479,7 @@ en:
           warrant_fee_paid: 'Have you previously been paid for an interim warrant fee?'
           date_issued: Warrant issued date
           date_executed: Warrant executed date
+          date_hint: For example, 31 3 1980
         summary:
           caption: 'Warrant fees: This section contains info related to interim claimed warrant fees.'
           summary: 'Note: To best navigate this table, select the right hand column and then step down through the rows.'

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -993,9 +993,9 @@ misc_fee:
 
   fee_type:
     _seq: 10
-    blank:
-      long: 'Choose a type for the #{misc_fee}'
-      short: Choose a fee type
+    choose_a_type_for_the_miscellaneous_fee:
+      long: Choose a type for the miscellaneous fee
+      short: _
       api: Choose a type for the miscellaneous fee
     case_type_inclusion:
       long: 'Choose an applicable type for the #{misc_fee}'
@@ -1057,14 +1057,14 @@ misc_fee:
 
   amount:
     _seq: 50
-    numericality:
-      long: 'Enter a valid amount for the #{misc_fee}'
-      short: *enter_valid_amount
+    enter_a_valid_amount_for_the_miscellaneous_fee:
+      long: Enter a valid amount for the miscellaneous fee
+      short: _
       api: Enter a valid amount for the miscellaneous fee
-    incorrect_epf:
-      long: 'Evidence provision fee can only be £45 or £90'
-      short: 'Enter £45 or £90'
-      api: 'Evidence provision fee can only be £45 or £90'
+    evidence_provision_fee_can_only_be_£45_or_£90:
+      long: Evidence provision fee can only be £45 or £90
+      short: _
+      api: Evidence provision fee can only be £45 or £90
 
 #################################################################################
 #                                                                               #

--- a/config/locales/en/models/misc_fee.yml
+++ b/config/locales/en/models/misc_fee.yml
@@ -1,0 +1,11 @@
+en:
+  activerecord:
+    errors:
+      models:
+        fee/misc_fee:
+          attributes:
+            fee_type:
+              blank: Choose a type for the miscellaneous fee
+            amount:
+              numericality: Enter a valid amount for the miscellaneous fee
+              incorrect_epf: Evidence provision fee can only be £45 or £90

--- a/features/claims/advocate/accessibility.feature
+++ b/features/claims/advocate/accessibility.feature
@@ -48,7 +48,7 @@ Feature: Advocate submits a claim
     And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
     Then the last 'miscellaneous' fee rate should be populated with '108.00'
-    Then the page should be accessible
+    Then the page should be accessible skipping 'aria-allowed-attr'
     And I eject the VCR cassette
     Then I click "Continue" in the claim form
 

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -115,6 +115,12 @@ class ClaimFormPage < BasePage
     end
   end
 
+  def add_govuk_misc_fee_if_required
+    if miscellaneous_fees.last.govuk_element_populated?
+      add_another_miscellaneous_fee.click
+    end
+  end
+
   def attach_evidence(count: 1, document: '*')
     count ||= 1
     available_docs = Dir.glob "#{Rails.root}/spec/fixtures/files/#{document.gsub('.pdf','')}.pdf"

--- a/features/page_objects/sections/lgfs_misc_fee_section.rb
+++ b/features/page_objects/sections/lgfs_misc_fee_section.rb
@@ -1,7 +1,7 @@
 require_relative 'radio_section'
 
 class FeeTypeSection < SitePrism::Section
-  sections :radios, RadioSection, '.multiple-choice'
+  sections :radios, RadioSection, '.govuk-radios__item'
 
   def radio_labels
     radios.map { |radio| radio.label.text.gsub(/\n(.*)/, '') }

--- a/features/page_objects/sections/typed_fee_section.rb
+++ b/features/page_objects/sections/typed_fee_section.rb
@@ -1,6 +1,9 @@
 class TypedFeeSection < SitePrism::Section
+
   sections :select_options, "select.js-fee-type > option" do end
   element :select_input, "input.tt-input", visible: true
+  section :govuk_fee_type_autocomplete, CommonAutocomplete, ".cc-fee-type"
+  element :govuk_fee_type_autocomplete_input, ".cc-fee-type input", visible: true
   element :quantity, "input.quantity"
   element :quantity_hint, ".quantity_wrapper span.form-hint"
   element :calc_help_text, ".fee-calc-help-wrapper"
@@ -24,5 +27,9 @@ class TypedFeeSection < SitePrism::Section
 
   def populated?
     select_input.value.present?
+  end
+
+  def govuk_element_populated?
+    govuk_fee_type_autocomplete_input.value.present?
   end
 end

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -119,10 +119,10 @@ end
 When(/^I add a calculated miscellaneous fee '(.*?)'(?: with quantity of '(.*?)')?(?: with dates attended\s*(.*))?$/) do |name, quantity, date|
   quantity = quantity.present? ? quantity : '1'
   patiently do
-    @claim_form_page.add_misc_fee_if_required
+    @claim_form_page.add_govuk_misc_fee_if_required
   end
-  @claim_form_page.miscellaneous_fees.last.select_fee_type name
-  @claim_form_page.miscellaneous_fees.last.select_input.send_keys(:tab)
+  @claim_form_page.miscellaneous_fees.last.govuk_fee_type_autocomplete.choose_autocomplete_option(name)
+  @claim_form_page.miscellaneous_fees.last.govuk_fee_type_autocomplete_input.send_keys(:tab)
   wait_for_ajax
   @claim_form_page.miscellaneous_fees.last.quantity.set quantity
   @claim_form_page.miscellaneous_fees.last.quantity.send_keys(:tab)

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -45,6 +45,26 @@ RSpec.shared_examples 'common LGFS amount validations' do
   end
 end
 
+RSpec.shared_examples 'common LGFS amount validations with migrated govuk formbuilder' do
+  describe '#validate_amount' do
+    it 'adds error if amount is blank' do
+      should_error_if_equal_to_value(fee, :amount, '', 'Enter a valid amount for the miscellaneous fee')
+    end
+
+    it 'adds error if amount is equal to zero' do
+      should_error_if_equal_to_value(fee, :amount, 0.00, 'Enter a valid amount for the miscellaneous fee')
+    end
+
+    it 'adds error if amount is less than zero' do
+      should_error_if_equal_to_value(fee, :amount, -10.00, 'Enter a valid amount for the miscellaneous fee')
+    end
+
+    it 'adds error if amount is greater than the max limit' do
+      should_error_if_equal_to_value(fee, :amount, 200_001, 'item_max_amount')
+    end
+  end
+end
+
 RSpec.shared_examples 'common AGFS number of cases uplift validations' do
   context 'case numbers list valid' do
     it 'when case_numbers is blank and quantity is zero' do

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
         end
       end
 
-      it { should_error_if_not_present(fee, :fee_type, 'blank') }
+      it { should_error_if_not_present(fee, :fee_type, 'Choose a type for the miscellaneous fee') }
 
       context 'when validating Unused material (up to 3 hours)' do
         before { create(:misc_fee_type, :miumu) }
@@ -141,7 +141,7 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       end
     end
 
-    include_examples 'common LGFS amount validations'
+    include_examples 'common LGFS amount validations with migrated govuk formbuilder'
 
     context 'override validation of fields from the superclass validator' do
       let(:superclass) { described_class.superclass }
@@ -174,11 +174,11 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       end
 
       it 'will error if passed a decimal amount' do
-        should_error_if_equal_to_value(fee, :amount, '45.10', 'incorrect_epf')
+        should_error_if_equal_to_value(fee, :amount, '45.10', 'Evidence provision fee can only be £45 or £90')
       end
 
       it 'will error is passed a zero amount' do
-        should_error_if_equal_to_value(fee, :amount, '0', 'incorrect_epf')
+        should_error_if_equal_to_value(fee, :amount, '0', 'Evidence provision fee can only be £45 or £90')
       end
     end
 


### PR DESCRIPTION
What
Migrate external_users form step: misc_fees form

Ticket
[FormBuilder migration - Miscellaneous fees](https://dsdmoj.atlassian.net/browse/CFP-408)

Why
- Update the service to use GOV.UK styles, components and patterns
- To improve and resolve the service's accessibility issues
- To reduce code complexity
- To improve maintainability

--------

#### TODO

 - [x] Migrate LGFS View
 - [x] Migrate LGFS View - Warrant fees partial
 - [x] Migrate AGFS View
 - [ ] Migrate AGFS View - Supplementary view
 - [ ] Retire `FeeTypeCtrl.js`
