### PR TITLE
Mark timezone sensitive test as 'pending'

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -258,6 +258,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with a completed journey' do
         before do
+          pending 'Bug with timezones in BST'
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -275,6 +276,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with an uncompleted journey' do
         before do
+          pending 'Bug with timezones in BST'
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do


### PR DESCRIPTION
The 'handling timezones' test fails due to a bug when calculating the 'completed_at' times.
This affects the tests when the timezone is BST.