### PR TITLE
[CFP-502] Enable ModSecurity WAF on dev

### DIFF
--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
   name: cccd-app-ingress
   namespace: cccd-dev
 spec:


### PR DESCRIPTION
#### What

Enable ModSecurity WAF on dev

Enables the ModSecurity WAF (web application firewall) on the dev environment following MOJ Cloud Platform [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall). This configures the WAF to actively block malicious traffic using default MOJ configuration.

#### Ticket

[CFP-502](https://dsdmoj.atlassian.net/browse/CFP-502)

#### Why
To protect our applications from malicious requests.