### PR TITLE
[CFP-502] Enable ModSecurity WAF on production

### DIFF
--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
   name: cccd-app-ingress
   namespace: cccd-production
 spec:

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -8,6 +8,8 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRuleRemoveById 941100
+      SecRuleRemoveById 941120
   name: cccd-app-ingress
   namespace: cccd-production
 spec:


### PR DESCRIPTION
What
Enable ModSecurity WAF on production

Enables the ModSecurity WAF (web application firewall) on the production environment following MOJ Cloud Platform [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall). This configures the WAF to actively block malicious traffic using default MOJ configuration.

Ticket
[CFP-502](https://dsdmoj.atlassian.net/browse/CFP-502)

Why
To protect our applications from malicious requests.