### PR TITLE
[CFP-541] Improve feedback tasks mechanism

### DIFF
--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -17,12 +17,12 @@
           = t('.callout')
           = render partial: 'feedback/claim_edit_alert' if referrer_is_claim?(@feedback.referrer)
 
-      %p.govuk-body{class: 'govuk-!-margin-bottom-6'}
-        = t('.report_fault_html', bug_report_link: new_feedback_path(type: 'bug_report'))
-
-      = f.govuk_collection_radio_buttons :task,
-        @feedback_form.tasks.answers, :key, :label,
-        legend: { text: t('.task_legend') }
+      = f.govuk_radio_buttons_fieldset :task, legend: { text: t('.task_legend'), size: 'm' } do
+        - @feedback_form.tasks.answers.map do |task|
+          = f.govuk_radio_button :task, task.key, label: { text: task.label } do
+            - if task.label.eql?('No') || task.label.eql?('Partially')
+              %p.govuk-body{class: 'govuk-!-margin-bottom-6'}
+                = t('.report_fault_html', bug_report_link: new_feedback_path(type: 'bug_report'))
 
       = f.govuk_collection_radio_buttons :rating,
         @feedback_form.ratings.answers, :key, :label,

--- a/config/locales/en/views/feedback.yml
+++ b/config/locales/en/views/feedback.yml
@@ -17,6 +17,6 @@ en:
       rating: How satisfied have you been in your experience of Claim for crown court defence today?
       reason: What were you aiming to achieve on Claim for crown court defence today?
       reason_other: Enter your comment
-      report_fault_html: If you are reporting an issue or a bug, <a class='govuk-link' href="%{bug_report_link}">report a fault</a>
+      report_fault_html: If you have found an issue or a bug, <a class='govuk-link' href="%{bug_report_link}" rel='noreferrer noopener' target='_blank'>report a fault (opens in a new tab)</a>
       task_legend: Were you able to complete the tasks you aimed to on Claim for crown court defence today?
       send: Send


### PR DESCRIPTION
#### What

Include conditional text to prompt users to report a fault when they answer ‘no’ or ‘partially’ to the question, “Were you able to complete the tasks you aimed to on Claim for crown court defence today?”

#### Ticket

[Improve feedback mechanism](https://dsdmoj.atlassian.net/browse/CFP-541)

#### Why

This aims to encourage users to submit a bug report to Zendesk and provide more details of their issue

