### PR TITLE
CFP-502 Enable ModSecurity WAF on api-sandbox

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -8,6 +8,8 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRuleRemoveById 941100
+      SecRuleRemoveById 941120
   name: cccd-app-ingress
   namespace: cccd-api-sandbox
 spec:

--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -4,6 +4,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-api-sandbox-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
   name: cccd-app-ingress
   namespace: cccd-api-sandbox
 spec:


### PR DESCRIPTION
#### What

Enable ModSecurity WAF on the `api-sandbox` environment.

#### Ticket

[CFP-502](https://dsdmoj.atlassian.net/browse/CFP-502)

#### Why

To protect our applications from malicious requests.

#### How

Enables the ModSecurity WAF (web application firewall) following MOJ Cloud Platform [guidance](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall). This configures the WAF to actively block malicious traffic using default MOJ configuration.
