### PR TITLE
Remove ttf-ubuntu-font-family from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,6 @@ RUN apk --no-cache add --virtual build-dependencies \
                   nodejs \
                   linux-headers \
                   runit \
-                  ttf-ubuntu-font-family \
                   libreoffice \
                   redis \
                   postgresql-client


### PR DESCRIPTION


Testing on an envionment will be done to test if the PDF conversion issue has
been resolved.

#### What

Remove the `ttf-ubuntu-font-family` package from the `Dockerfile`.

#### Ticket

N/A

#### Why

`ttf-ubuntu-font-family` was added in #2995 to fix PDF conversion of uploaded documents. This package has since been removed from Ubuntu and is not available in the latest alpine image.

#### How

Remove form `docker/Dockerfile`

--------

#### TODO

 - [ ] Test document conversion on an environment
