### PR TITLE
CFP-485 Add rake task to identify and disable inactive users

### DIFF
--- a/lib/tasks/inactive_users.rake
+++ b/lib/tasks/inactive_users.rake
@@ -1,0 +1,78 @@
+namespace :inactive_users do
+  desc 'List inactive users'
+  task list: :environment do
+    CSV.open(Rails.root.join('tmp/inactive_users.csv'), 'wb') do |csv|
+      csv << %w[
+        id
+        email
+        last_sign_in_at
+        current_sign_in_at
+        created_at
+        updated_at
+        persona_type
+      ]
+      inactive_users = User.where('disabled_at IS NULL AND (last_sign_in_at < :limit OR (last_sign_in_at IS NULL AND created_at < :limit))', limit: 6.months.ago.to_date)
+      inactive_users.each do |inactive_user|
+        csv << [
+          inactive_user.id,
+          inactive_user.email,
+          inactive_user.last_sign_in_at,
+          inactive_user.current_sign_in_at,
+          inactive_user.created_at,
+          inactive_user.updated_at,
+          inactive_user.persona_type
+        ]
+      end
+      puts "Listed #{inactive_users.count} inactive users in tmp/inactive_users.csv"
+    end
+  end
+
+  desc 'Disable inactive users'
+  task disable: :environment do
+    inactive_users = User.where('disabled_at IS NULL AND (last_sign_in_at < :limit OR (last_sign_in_at IS NULL AND created_at < :limit))', limit: 6.months.ago.to_date)
+    puts "There are #{inactive_users.count} inactive users to be disabled"
+
+    disabled_pre = User.where('disabled_at IS NOT NULL').count
+    error_count = 0
+
+    inactive_users.each do |inactive_user|
+      inactive_user.update!(disabled_at: DateTime.now)
+    rescue ActiveRecord::RecordInvalid
+      error_count += 1
+    end
+
+    disabled_post = User.where('disabled_at IS NOT NULL').count
+    puts "#{disabled_post - disabled_pre} inactive users have been disabled - run `rake inactive_users:list_disabled` for details"
+    puts "Errors occurred when disabling #{error_count} users - run `rake inactive_users:list` for details" if error_count > 0
+  end
+
+  desc 'List disabled users'
+  task list_disabled: :environment do
+    CSV.open(Rails.root.join('tmp/disabled_users.csv'), 'wb') do |csv|
+      csv << %w[
+        id
+        email
+        last_sign_in_at
+        current_sign_in_at
+        created_at
+        updated_at
+        persona_type
+        disabled_at
+      ]
+      disabled_users = User.where('disabled_at IS NOT NULL')
+      disabled_users.each do |disabled_user|
+        csv << [
+          disabled_user.id,
+          disabled_user.email,
+          disabled_user.last_sign_in_at,
+          disabled_user.current_sign_in_at,
+          disabled_user.created_at,
+          disabled_user.updated_at,
+          disabled_user.persona_type,
+          disabled_user.disabled_at
+        ]
+      end
+      puts "Listed #{disabled_users.count} disabled users in tmp/disabled_users.csv"
+    end
+  end
+end

--- a/lib/tasks/inactive_users.rake
+++ b/lib/tasks/inactive_users.rake
@@ -1,38 +1,28 @@
+require_relative 'rake_helpers/user_management.rb'
+
 namespace :inactive_users do
   desc 'List inactive users'
   task list: :environment do
-    CSV.open(Rails.root.join('tmp/inactive_users.csv'), 'wb') do |csv|
-      csv << %w[
-        id
-        email
-        last_sign_in_at
-        current_sign_in_at
-        created_at
-        updated_at
-        persona_type
-      ]
-      inactive_users = User.where('disabled_at IS NULL AND (last_sign_in_at < :limit OR (last_sign_in_at IS NULL AND created_at < :limit))', limit: 6.months.ago.to_date)
-      inactive_users.each do |inactive_user|
-        csv << [
-          inactive_user.id,
-          inactive_user.email,
-          inactive_user.last_sign_in_at,
-          inactive_user.current_sign_in_at,
-          inactive_user.created_at,
-          inactive_user.updated_at,
-          inactive_user.persona_type
-        ]
-      end
-      puts "Listed #{inactive_users.count} inactive users in tmp/inactive_users.csv"
-    end
+    inactive_users = UserManagement.inactive_users
+    inactive_users_file = "tmp/inactive_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
+    UserManagement.create_csv_for(inactive_users, inactive_users_file)
+    puts "Listed #{inactive_users.count} inactive users in #{inactive_users_file}"
+  end
+
+  desc 'List disabled users'
+  task list_disabled: :environment do
+    disabled_users = UserManagement.disabled_users
+    disabled_users_file = "tmp/disabled_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
+    UserManagement.create_csv_for(disabled_users, disabled_users_file)
+    puts "Listed #{disabled_users.count} disabled users in #{disabled_users_file}"
   end
 
   desc 'Disable inactive users'
   task disable: :environment do
-    inactive_users = User.where('disabled_at IS NULL AND (last_sign_in_at < :limit OR (last_sign_in_at IS NULL AND created_at < :limit))', limit: 6.months.ago.to_date)
+    inactive_users = UserManagement.inactive_users
     puts "There are #{inactive_users.count} inactive users to be disabled"
 
-    disabled_pre = User.where('disabled_at IS NOT NULL').count
+    disabled_pre = UserManagement.disabled_users.count
     error_count = 0
 
     inactive_users.each do |inactive_user|
@@ -41,38 +31,8 @@ namespace :inactive_users do
       error_count += 1
     end
 
-    disabled_post = User.where('disabled_at IS NOT NULL').count
+    disabled_post = UserManagement.disabled_users.count
     puts "#{disabled_post - disabled_pre} inactive users have been disabled - run `rake inactive_users:list_disabled` for details"
     puts "Errors occurred when disabling #{error_count} users - run `rake inactive_users:list` for details" if error_count > 0
-  end
-
-  desc 'List disabled users'
-  task list_disabled: :environment do
-    CSV.open(Rails.root.join('tmp/disabled_users.csv'), 'wb') do |csv|
-      csv << %w[
-        id
-        email
-        last_sign_in_at
-        current_sign_in_at
-        created_at
-        updated_at
-        persona_type
-        disabled_at
-      ]
-      disabled_users = User.where('disabled_at IS NOT NULL')
-      disabled_users.each do |disabled_user|
-        csv << [
-          disabled_user.id,
-          disabled_user.email,
-          disabled_user.last_sign_in_at,
-          disabled_user.current_sign_in_at,
-          disabled_user.created_at,
-          disabled_user.updated_at,
-          disabled_user.persona_type,
-          disabled_user.disabled_at
-        ]
-      end
-      puts "Listed #{disabled_users.count} disabled users in tmp/disabled_users.csv"
-    end
   end
 end

--- a/lib/tasks/inactive_users.rake
+++ b/lib/tasks/inactive_users.rake
@@ -1,38 +1,57 @@
 require_relative 'rake_helpers/user_management.rb'
 
 namespace :inactive_users do
-  desc 'List inactive users'
-  task list: :environment do
-    inactive_users = UserManagement.inactive_users
-    inactive_users_file = "tmp/inactive_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
+  desc 'List inactive provider users'
+  task list_providers: :environment do
+    inactive_users = UserManagement.inactive_provider_users
+    inactive_users_file = "tmp/inactive_provider_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
     UserManagement.create_csv_for(inactive_users, inactive_users_file)
-    puts "Listed #{inactive_users.count} inactive users in #{inactive_users_file}"
+    puts "Listed #{inactive_users.count} inactive provider users in #{inactive_users_file}"
   end
 
-  desc 'List disabled users'
-  task list_disabled: :environment do
-    disabled_users = UserManagement.disabled_users
-    disabled_users_file = "tmp/disabled_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
+  desc 'List inactive caseworker users'
+  task list_caseworkers: :environment do
+    inactive_users = UserManagement.inactive_caseworker_users
+    inactive_users_file = "tmp/inactive_caseworker_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
+    UserManagement.create_csv_for(inactive_users, inactive_users_file)
+    puts "Listed #{inactive_users.count} inactive caseworker users in #{inactive_users_file}"
+  end
+
+  desc 'List disabled provider users'
+  task list_disabled_providers: :environment do
+    disabled_users = UserManagement.disabled_provider_users
+    disabled_users_file = "tmp/disabled_provider_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
     UserManagement.create_csv_for(disabled_users, disabled_users_file)
-    puts "Listed #{disabled_users.count} disabled users in #{disabled_users_file}"
+    puts "Listed #{disabled_users.count} disabled provider users in #{disabled_users_file}"
   end
 
-  desc 'Disable inactive users'
-  task disable: :environment do
-    inactive_users = UserManagement.inactive_users
-    puts "There are #{inactive_users.count} inactive users to be disabled"
+  desc 'List disabled caseworker users'
+  task list_disabled_caseworkers: :environment do
+    disabled_users = UserManagement.disabled_caseworker_users
+    disabled_users_file = "tmp/disabled_caseworker_users_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv"
+    UserManagement.create_csv_for(disabled_users, disabled_users_file)
+    puts "Listed #{disabled_users.count} disabled caseworker users in #{disabled_users_file}"
+  end
 
-    disabled_pre = UserManagement.disabled_users.count
-    error_count = 0
+  desc 'Disable inactive provider users'
+  task disable_providers: :environment do
+    inactive_users = UserManagement.inactive_provider_users
+    puts "There are #{inactive_users.count} inactive provider users to be disabled"
+    disabled_pre = UserManagement.disabled_provider_users.count
+    error_count = UserManagement.disable(inactive_users)
+    disabled_post = UserManagement.disabled_provider_users.count
+    puts "#{disabled_post - disabled_pre} inactive provider users have been disabled - run `rake inactive_users:list_disabled_providers` for details"
+    puts "Errors occurred when disabling #{error_count} provider users - run `rake inactive_users:list_providers` for details" if error_count > 0
+  end
 
-    inactive_users.each do |inactive_user|
-      inactive_user.update!(disabled_at: DateTime.now)
-    rescue ActiveRecord::RecordInvalid
-      error_count += 1
-    end
-
-    disabled_post = UserManagement.disabled_users.count
-    puts "#{disabled_post - disabled_pre} inactive users have been disabled - run `rake inactive_users:list_disabled` for details"
-    puts "Errors occurred when disabling #{error_count} users - run `rake inactive_users:list` for details" if error_count > 0
+  desc 'Disable inactive caseworker users'
+  task disable_caseworkers: :environment do
+    inactive_users = UserManagement.inactive_caseworker_users
+    puts "There are #{inactive_users.count} inactive caseworker users to be disabled"
+    disabled_pre = UserManagement.disabled_caseworker_users.count
+    error_count = UserManagement.disable(inactive_users)
+    disabled_post = UserManagement.disabled_caseworker_users.count
+    puts "#{disabled_post - disabled_pre} inactive caseworker users have been disabled - run `rake inactive_users:list_disabled_caseworkers` for details"
+    puts "Errors occurred when disabling #{error_count} caseworker users - run `rake inactive_users:list_caseworkers` for details" if error_count > 0
   end
 end

--- a/lib/tasks/rake_helpers/user_management.rb
+++ b/lib/tasks/rake_helpers/user_management.rb
@@ -2,21 +2,21 @@ class UserManagement
   def self.inactive_provider_users
     User.where(last_sign_in_at: ..6.months.ago).or(
       User.where(last_sign_in_at: nil, created_at: ..6.months.ago)
-    ).where(disabled_at: nil, persona_type: 'ExternalUser')
+    ).enabled.where(persona_type: 'ExternalUser')
   end
 
   def self.disabled_provider_users
-    User.where.not(disabled_at: nil).where(persona_type: 'ExternalUser')
+    User.disabled.where(persona_type: 'ExternalUser')
   end
 
   def self.inactive_caseworker_users
     User.where(last_sign_in_at: ..6.months.ago).or(
       User.where(last_sign_in_at: nil, created_at: ..6.months.ago)
-    ).where(disabled_at: nil, persona_type: 'CaseWorker')
+    ).enabled.where(persona_type: 'CaseWorker')
   end
 
   def self.disabled_caseworker_users
-    User.where.not(disabled_at: nil).where(persona_type: 'CaseWorker')
+    User.disabled.where(persona_type: 'CaseWorker')
   end
 
   def self.create_csv_for(users, filename)
@@ -49,7 +49,7 @@ class UserManagement
   def self.disable(users)
     error_count = 0
     users.each do |user|
-      user.update!(disabled_at: DateTime.now)
+      user.disable
     rescue ActiveRecord::RecordInvalid
       error_count += 1
     end

--- a/lib/tasks/rake_helpers/user_management.rb
+++ b/lib/tasks/rake_helpers/user_management.rb
@@ -1,11 +1,22 @@
 class UserManagement
-  def self.inactive_users
-    User.where(last_sign_in_at: ..6.months.ago).or(User.where(last_sign_in_at: nil,
-                                                              created_at: ..6.months.ago)).where(disabled_at: nil)
+  def self.inactive_provider_users
+    User.where(last_sign_in_at: ..6.months.ago).or(
+      User.where(last_sign_in_at: nil, created_at: ..6.months.ago)
+    ).where(disabled_at: nil, persona_type: 'ExternalUser')
   end
 
-  def self.disabled_users
-    User.where.not(disabled_at: nil)
+  def self.disabled_provider_users
+    User.where.not(disabled_at: nil).where(persona_type: 'ExternalUser')
+  end
+
+  def self.inactive_caseworker_users
+    User.where(last_sign_in_at: ..6.months.ago).or(
+      User.where(last_sign_in_at: nil, created_at: ..6.months.ago)
+    ).where(disabled_at: nil, persona_type: 'CaseWorker')
+  end
+
+  def self.disabled_caseworker_users
+    User.where.not(disabled_at: nil).where(persona_type: 'CaseWorker')
   end
 
   def self.create_csv_for(users, filename)
@@ -33,5 +44,15 @@ class UserManagement
         ]
       end
     end
+  end
+
+  def self.disable(users)
+    error_count = 0
+    users.each do |user|
+      user.update!(disabled_at: DateTime.now)
+    rescue ActiveRecord::RecordInvalid
+      error_count += 1
+    end
+    return error_count
   end
 end

--- a/lib/tasks/rake_helpers/user_management.rb
+++ b/lib/tasks/rake_helpers/user_management.rb
@@ -1,0 +1,37 @@
+class UserManagement
+  def self.inactive_users
+    User.where(last_sign_in_at: ..6.months.ago).or(User.where(last_sign_in_at: nil,
+                                                              created_at: ..6.months.ago)).where(disabled_at: nil)
+  end
+
+  def self.disabled_users
+    User.where.not(disabled_at: nil)
+  end
+
+  def self.create_csv_for(users, filename)
+    CSV.open(Rails.root.join(filename), 'wb') do |csv|
+      csv << %w[
+        id
+        email
+        last_sign_in_at
+        current_sign_in_at
+        created_at
+        updated_at
+        persona_type
+        disabled_at
+      ]
+      users.each do |user|
+        csv << [
+          user.id,
+          user.email,
+          user.last_sign_in_at,
+          user.current_sign_in_at,
+          user.created_at,
+          user.updated_at,
+          user.persona_type,
+          user.disabled_at
+        ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

Add a facility to identify and disable inactive users

#### Ticket

[CFP-485](https://dsdmoj.atlassian.net/browse/CFP-485)

#### Why

We need a re-runnable (and potentially automatable) process to allow us  to identify and subsequently disable user records that have been inactive for over six months.

#### How

This change adds a rake file `inactive_users` which contains six tasks:

1) `inactive_users:list_providers` which generates a csv file of all inactive provider users (ie users which were last logged into more than six months ago or were created more than six months ago and have never been logged into, and are not already disabled). A csv file is used as this may potentially result in large volumes of data which will be hard to manipulate from the command line.

2) `inactive_users:list_caseworkers` as above but for inactive caseworker users.

3) `inactive_users:list_disabled_providers` which generates a csv file of all provider user records where the `disabled_at` field has been populated. A csv file is used as this may potentially result in large volumes of data which will be hard to manipulate from  the command line.

4) `inactive_users:list_disabled_caseworkers` as above but for disabled caseworker users.

5) `inactive_users:disable_providers` which populates the `disabled_at` field on all provider user records identified by (1) with the current date and time.

6) `inactive_users:disable_caseworkers` as above but for inactive caseworker users.

It also adds a helper class to provide methods to support these actions.

In combination, these should allow us to identify which users need to be disabled, disable them, and subsequently identify 
which have successfully been disabled and which have failed.
