### PR TITLE
Update deprecated Sidekiq.default_worker_options call

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,7 @@
 #
 # https://github.com/mperham/sidekiq/wiki/Using-Redis
 
-Sidekiq.default_worker_options = { retry: 5 }
+Sidekiq.default_job_options = { retry: 5 }
 
 # Perform Sidekiq jobs immediately in development,
 # so you don't have to run a separate process.


### PR DESCRIPTION
#### What

Remove the use of the (soon-to-be) deprecated `Sidekiq.default_worker_options` method

#### Why

Since updating Sidekiq to v6.4.2 we are receiving the following warning:

```
DEPRECATION WARNING: default_worker_options= is deprecated and will be removed from Sidekiq 7.0 (use default_job_options= instead)
```

#### How

Replace the call to `Sidekiq.default_worker_options` in `config/initializers/sidekiq.rb` with `Sidekiq.default_job_options`. 
