### PR TITLE
Refactor rspec shared examples

### DIFF
--- a/spec/api/v1/external_users/date_attended_spec.rb
+++ b/spec/api/v1/external_users/date_attended_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe API::V1::ExternalUsers::DateAttended do
     end
 
     context 'when date_attended params are invalid' do
-      include_examples 'invalid API key create endpoint', exclude: :other_provider
+      include_examples 'invalid API key', exclude: :other_provider, action: :create
 
       context 'missing expected params' do
         it 'returns a JSON error array with required model attributes' do
@@ -106,7 +106,7 @@ RSpec.describe API::V1::ExternalUsers::DateAttended do
       post endpoint(:dates_attended, :validate), valid_params, format: :json
     end
 
-    include_examples 'invalid API key validate endpoint', exclude: :other_provider
+    include_examples 'invalid API key', exclude: :other_provider, action: :validate
 
     it 'valid requests should return 200 and String true' do
       post_to_validate_endpoint

--- a/spec/api/v1/external_users/date_attended_spec.rb
+++ b/spec/api/v1/external_users/date_attended_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe API::V1::ExternalUsers::DateAttended do
   end
 
   describe "POST #{endpoint(:dates_attended)}" do
-    def post_to_create_endpoint
-      post endpoint(:dates_attended), valid_params, format: :json
-    end
+    let(:post_to_create_endpoint) { post endpoint(:dates_attended), valid_params, format: :json }
 
     include_examples 'should NOT be able to amend a non-draft claim'
 
@@ -102,9 +100,7 @@ RSpec.describe API::V1::ExternalUsers::DateAttended do
   end
 
   describe "POST #{endpoint(:dates_attended, :validate)}" do
-    def post_to_validate_endpoint
-      post endpoint(:dates_attended, :validate), valid_params, format: :json
-    end
+    let(:post_to_validate_endpoint) { post endpoint(:dates_attended, :validate), valid_params, format: :json }
 
     include_examples 'invalid API key', exclude: :other_provider, action: :validate
 

--- a/spec/api/v1/external_users/defendant_spec.rb
+++ b/spec/api/v1/external_users/defendant_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe API::V1::ExternalUsers::Defendant do
 
     context 'when defendant params are invalid' do
       context 'invalid API key' do
-        include_examples 'invalid API key create endpoint', exclude: :other_provider
+        include_examples 'invalid API key', exclude: :other_provider, action: :create
       end
 
       context 'missing expected params' do
@@ -99,7 +99,7 @@ RSpec.describe API::V1::ExternalUsers::Defendant do
       post endpoint(:defendants, :validate), valid_params, format: :json
     end
 
-    include_examples 'invalid API key validate endpoint', exclude: :other_provider
+    include_examples 'invalid API key', exclude: :other_provider, action: :validate
 
     it 'valid requests should return 200 and String true' do
       post_to_validate_endpoint

--- a/spec/api/v1/external_users/defendant_spec.rb
+++ b/spec/api/v1/external_users/defendant_spec.rb
@@ -34,9 +34,7 @@ RSpec.describe API::V1::ExternalUsers::Defendant do
   end
 
   describe "POST #{endpoint(:defendants)}" do
-    def post_to_create_endpoint
-      post endpoint(:defendants), valid_params, format: :json
-    end
+    let(:post_to_create_endpoint) { post endpoint(:defendants), valid_params, format: :json }
 
     include_examples 'should NOT be able to amend a non-draft claim'
 
@@ -95,9 +93,7 @@ RSpec.describe API::V1::ExternalUsers::Defendant do
   end
 
   describe "POST #{endpoint(:defendants, :validate)}" do
-    def post_to_validate_endpoint
-      post endpoint(:defendants, :validate), valid_params, format: :json
-    end
+    let(:post_to_validate_endpoint) { post endpoint(:defendants, :validate), valid_params, format: :json }
 
     include_examples 'invalid API key', exclude: :other_provider, action: :validate
 

--- a/spec/api/v1/external_users/disbursement_spec.rb
+++ b/spec/api/v1/external_users/disbursement_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe API::V1::ExternalUsers::Disbursement do
       context 'invalid API key' do
         let(:valid_params) { params }
 
-        include_examples 'invalid API key create endpoint', exclude: :other_provider
+        include_examples 'invalid API key', exclude: :other_provider, action: :create
       end
 
       context 'missing expected params' do
@@ -186,7 +186,7 @@ RSpec.describe API::V1::ExternalUsers::Disbursement do
     context 'invalid API key' do
       let(:valid_params) { params }
 
-      include_examples 'invalid API key validate endpoint', exclude: :other_provider
+      include_examples 'invalid API key', exclude: :other_provider, action: :validate
     end
 
     context 'missing expected params' do

--- a/spec/api/v1/external_users/disbursement_spec.rb
+++ b/spec/api/v1/external_users/disbursement_spec.rb
@@ -56,9 +56,7 @@ RSpec.describe API::V1::ExternalUsers::Disbursement do
   }
 
   describe "POST #{endpoint(:disbursements)}" do
-    def post_to_create_endpoint
-      post endpoint(:disbursements), params, format: :json
-    end
+    let(:post_to_create_endpoint) { post endpoint(:disbursements), params, format: :json }
 
     include_examples 'should NOT be able to amend a non-draft claim'
 
@@ -172,9 +170,7 @@ RSpec.describe API::V1::ExternalUsers::Disbursement do
   end
 
   describe "POST #{endpoint(:disbursements, :validate)}" do
-    def post_to_validate_endpoint
-      post endpoint(:disbursements, :validate), params, format: :json
-    end
+    let(:post_to_validate_endpoint) { post endpoint(:disbursements, :validate), params, format: :json }
 
     it 'valid requests should return 200 and String true' do
       post_to_validate_endpoint

--- a/spec/api/v1/external_users/expense_spec.rb
+++ b/spec/api/v1/external_users/expense_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe API::V1::ExternalUsers::Expense do
         context 'invalid API key' do
           let(:valid_params) { params }
 
-          include_examples 'invalid API key create endpoint', exclude: :other_provider
+          include_examples 'invalid API key', exclude: :other_provider, action: :create
         end
 
         context 'missing expected params' do
@@ -190,7 +190,7 @@ RSpec.describe API::V1::ExternalUsers::Expense do
       context 'invalid API key' do
         let(:valid_params) { params }
 
-        include_examples 'invalid API key validate endpoint', exclude: :other_provider
+        include_examples 'invalid API key', exclude: :other_provider, action: :validate
       end
 
       context 'missing expected params' do

--- a/spec/api/v1/external_users/expense_spec.rb
+++ b/spec/api/v1/external_users/expense_spec.rb
@@ -54,9 +54,7 @@ RSpec.describe API::V1::ExternalUsers::Expense do
     }
 
     describe "POST #{endpoint(:expenses)}" do
-      def post_to_create_endpoint
-        post endpoint(:expenses), params, format: :json
-      end
+      let(:post_to_create_endpoint) { post endpoint(:expenses), params, format: :json }
 
       include_examples 'should NOT be able to amend a non-draft claim'
 
@@ -176,9 +174,7 @@ RSpec.describe API::V1::ExternalUsers::Expense do
     end
 
     describe "POST #{endpoint(:expenses, :validate)}" do
-      def post_to_validate_endpoint
-        post endpoint(:expenses, :validate), params, format: :json
-      end
+      let(:post_to_validate_endpoint) { post endpoint(:expenses, :validate), params, format: :json }
 
       it 'valid requests should return 200 and String true' do
         post_to_validate_endpoint

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe API::V1::ExternalUsers::Fee do
     end
 
     context 'when fee params are invalid' do
-      include_examples 'invalid API key create endpoint', exclude: :other_provider
+      include_examples 'invalid API key', exclude: :other_provider, action: :create
 
       context 'missing expected params' do
         it 'returns a JSON error array with required model attributes' do
@@ -464,7 +464,7 @@ RSpec.describe API::V1::ExternalUsers::Fee do
       post endpoint(:fees, :validate), valid_params, format: :json
     end
 
-    include_examples 'invalid API key validate endpoint', exclude: :other_provider
+    include_examples 'invalid API key', exclude: :other_provider, action: :validate
 
     context 'non-basic fees' do
       include_examples 'fee validate endpoint'

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe API::V1::ExternalUsers::Fee do
   end
 
   describe "POST #{endpoint(:fees)}" do
-    def post_to_create_endpoint
-      post endpoint(:fees), valid_params, format: :json
-    end
+    let(:post_to_create_endpoint) { post endpoint(:fees), valid_params, format: :json }
 
     include_examples 'should NOT be able to amend a non-draft claim'
 
@@ -460,9 +458,7 @@ RSpec.describe API::V1::ExternalUsers::Fee do
   end
 
   describe "POST #{endpoint(:fees, :validate)}" do
-    def post_to_validate_endpoint
-      post endpoint(:fees, :validate), valid_params, format: :json
-    end
+    let(:post_to_validate_endpoint) { post endpoint(:fees, :validate), valid_params, format: :json }
 
     include_examples 'invalid API key', exclude: :other_provider, action: :validate
 

--- a/spec/api/v1/external_users/representation_order_spec.rb
+++ b/spec/api/v1/external_users/representation_order_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
     end
 
     context 'when params are invalid' do
-      include_examples 'invalid API key create endpoint', exclude: :other_provider
+      include_examples 'invalid API key', exclude: :other_provider, action: :create
 
       context 'missing defendant id' do
         it 'returns 400 and a JSON error array' do
@@ -134,7 +134,7 @@ RSpec.describe API::V1::ExternalUsers::RepresentationOrder do
       post endpoint(:representation_orders, :validate), valid_params, format: :json
     end
 
-    include_examples 'invalid API key validate endpoint', exclude: :other_provider
+    include_examples 'invalid API key', exclude: :other_provider, action: :validate
 
     it 'valid requests should return 200 and String true' do
       post_to_validate_endpoint


### PR DESCRIPTION
#### What

Refactor rspec shared examples to reduce duplication

#### Ticket

Fixes issue https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/issues/2661.

#### Why

The `invalid API key validate endpoint` and `invalid API key create endpoint` rspec shared examples are essentially duplicates and can be consolidated to improve code quality.

#### How

* combine the two examples into a single shared example `invalid API key` which uses an `action` parameter to determine which endpoint is called. 
* update tests use the shared examples to pass in the appropriate `action` parameter