### PR TITLE
User list page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,12 @@
 #
 
 class UsersController < ApplicationController
+  include PaginationHelpers
+
+  def index
+    @users = User.order(created_at: :desc).page(current_page).per(page_size)
+  end
+
   def update_settings
     @settings = settings_params
     @result = current_user.save_settings!(@settings)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,7 @@ class Ability
       can [:update_settings], User, id: user.id
       can %i[show index], Provider
       can %i[show index find search change_availability update_availability], ExternalUser
+      can %i[index], User
       return
     end
 

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -18,7 +18,8 @@
                 = govuk_link_to t('.sidekiq_console'), sidekiq_web_path, class: cp(sidekiq_web_path)
               %li
                 = govuk_link_to t('.manage_providers'), provider_management_providers_path, class: cp(provider_management_providers_path)
-
+              %li
+                = govuk_link_to t('.users'), users_path, class: cp(users_path)
 
             - elsif current_user.persona.is_a?(ExternalUser)
               %li

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,0 +1,32 @@
+= content_for :page_title, flush: true do
+  = t('.heading')
+
+= render partial: 'layouts/header', locals: { page_heading: t('.heading') }
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = govuk_table(class: 'govuk-!-margin-top-9') do
+      = govuk_table_caption(class: 'govuk-visually-hidden') do
+        = t('.heading')
+
+      = govuk_table_thead_collection [ t('.name'),
+         t('.email'),
+         t('.persona'),
+         t('.created')]
+
+      = govuk_table_tbody do
+        - @users.each do |user|
+          = govuk_table_row do
+            = govuk_table_td('data-label': t('.name')) do
+              = user.name
+
+            = govuk_table_td('data-label': t('.email')) do
+              = user.email
+
+            = govuk_table_td('data-label': t('.persona')) do
+              = user.persona.class
+
+            = govuk_table_td('data-label': t('.created')) do
+              = user.created_at
+
+= paginate @users

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1900,6 +1900,15 @@ en:
         supporting_evidence_form_step:
           page_title: Upload supporting evidence for litigator hardship fees claim
 
+# en.users
+  users:
+    index:
+      created: Created at
+      email: Email
+      name: Name
+      persona: User type
+      heading: All users
+
   shared:
     not_available: 'not available'
     claim_header:

--- a/config/locales/en/views/layouts.yml
+++ b/config/locales/en/views/layouts.yml
@@ -47,6 +47,7 @@ en:
       sidekiq_console: Sidekiq console
       all_claims: Your claims
       sub_navigation: Sub navigation
+      users: Users
 
     skip_content: Skip to main content
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { sessions: 'sessions', passwords: 'passwords', unlocks: 'unlocks', registrations: 'external_users/registrations' }
 
+  resources :users, only: :index
+
   authenticated :user, -> (u) { u.persona.is_a?(ExternalUser) } do
     root to: 'external_users/claims#index', as: :external_users_home
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Ability do
     it { should_not be_able_to(:update, UserMessageStatus.new) }
     it { should_not be_able_to(:create, Document.new) }
     it { should_not be_able_to(:update_settings, User.new) }
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
+    end
   end
 
   context 'when a signed in user' do
@@ -35,6 +39,10 @@ RSpec.describe Ability do
 
     it { should be_able_to(:update_settings, user) }
     it { should_not be_able_to(:update_settings, another_user) }
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
+    end
   end
 
   context 'external_user advocate' do
@@ -120,6 +128,10 @@ RSpec.describe Ability do
       [:show, :edit, :update, :regenerate_api_key].each do |action|
         it { should_not be_able_to(action, other_provider) }
       end
+    end
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
     end
   end
 
@@ -229,6 +241,10 @@ RSpec.describe Ability do
         it { should_not be_able_to(action, ExternalUser.new(provider: other_provider)) }
       end
     end
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
+    end
   end
 
   context 'external_user litigator' do
@@ -304,6 +320,10 @@ RSpec.describe Ability do
           it { should_not be_able_to(action, model.new(external_user: other_external_user)) }
         end
       end
+    end
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
     end
   end
 
@@ -383,6 +403,10 @@ RSpec.describe Ability do
         it { should be_able_to(action, ExternalUser.new(provider: provider)) }
       end
     end
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
+    end
   end
 
   context 'case worker' do
@@ -445,6 +469,10 @@ RSpec.describe Ability do
     context 'can dismiss injection attempt errors' do
       it { should be_able_to(:dismiss, InjectionAttempt.new) }
     end
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
+    end
   end
 
   context 'with a case worker admin' do
@@ -481,6 +509,10 @@ RSpec.describe Ability do
 
     context 'can dismiss injection attempt errors' do
       it { should be_able_to(:dismiss, InjectionAttempt.new) }
+    end
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
     end
   end
 
@@ -535,6 +567,10 @@ RSpec.describe Ability do
       it { is_expected.not_to be_able_to(:change_availability, target) }
       it { is_expected.not_to be_able_to(:update_availability, target) }
     end
+
+    context 'with user management' do
+      it { is_expected.not_to be_able_to(:index, User) }
+    end
   end
 
   context 'with a super admin' do
@@ -582,6 +618,10 @@ RSpec.describe Ability do
       it { is_expected.not_to be_able_to(:change_password, target) }
       it { is_expected.not_to be_able_to(:update_password, target) }
       it { is_expected.not_to be_able_to(:destroy, target) }
+    end
+
+    context 'with user management' do
+      it { is_expected.to be_able_to(:index, User) }
     end
   end
 end

--- a/spec/requests/devise/users_spec.rb
+++ b/spec/requests/devise/users_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe 'User management', type: :request do
+  describe 'index view' do
+    subject do
+      get users_path
+      response
+    end
+
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    context 'when logged in as superadmin' do
+      let(:user) { create(:super_admin).user }
+
+      it { is_expected.to be_successful }
+    end
+
+    context 'when logged in a case worker' do
+      let(:user) { create(:case_worker).user }
+
+      it { is_expected.to redirect_to case_workers_root_path }
+    end
+
+    context 'when logged in an external user' do
+      let(:user) { create(:external_user).user }
+
+      it { is_expected.to redirect_to external_users_root_path }
+    end
+
+    context 'when user is not signed in' do
+      before { sign_out user }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+  end
+end


### PR DESCRIPTION
#### What

Add a page to view recently created users.

#### Ticket

N/A

#### Why

For security reasons we want to be able to monitor new users for possible unauthorized creation.

#### How

Create an index page in the `User` controller that is only visible to a superadmin user. The users are paginated and ordered by the 'created at' date in descending order.