### PR TITLE
Block crawlergo requests based on HTTP headers

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;
+      if ($http_spider_name ~* "crawlergo") {
+        return 403;
+      }
   name: cccd-app-ingress
   namespace: cccd-api-sandbox
 spec:

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;
+      if ($http_spider_name ~* "crawlergo") {
+        return 403;
+      }
   name: cccd-app-ingress
   namespace: cccd-dev-lgfs
 spec:

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;
+      if ($http_spider_name ~* "crawlergo") {
+        return 403;
+      }
   name: cccd-app-ingress
   namespace: cccd-dev
 spec:

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;
+      if ($http_spider_name ~* "crawlergo") {
+        return 403;
+      }
   name: cccd-app-ingress
   namespace: cccd-production
 spec:

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;
+      if ($http_spider_name ~* "crawlergo") {
+        return 403;
+      }
   name: cccd-app-ingress
   namespace: cccd-staging
 spec:


### PR DESCRIPTION
#### What

Block requests from the potentially malicious browser crawler `crawlergo`.

#### How

Requests from the tool include the HTTP header `spider-name` with a value of `crawlergo`. This change updates ingress files so that requests that include that header return a 403 unauthorised response. This won't help us block other crawlers, or if users are able to configure the tool so that it uses a different `spider-name`, but at least will give us some protection.
