### PR TITLE
Increase RestClient OpenTimeout from `5` to `10`

### DIFF
--- a/config/initializers/remote_client.rb
+++ b/config/initializers/remote_client.rb
@@ -1,7 +1,13 @@
+# open_timeout value temporarily increased
+# to reduce caseworkers timeout errors
+#
+# Ticket CFP-587 has been created to further investigate
+# the root cause and therefore reduce the open_timeout
+#
 Remote::HttpClient.configure do |client|
   client.base_url = Settings.remote_api_url
   client.api_key = Settings.remote_api_key
   client.logger = Rails.logger
-  client.open_timeout = 5
+  client.open_timeout = 10
   client.timeout = 15
 end


### PR DESCRIPTION
#### What

Increase RestClient OpenTimeout from `5` to `10`

#### Ticket

[n/a](#)

#### Why

Users are increasingly experiencing time outs connecting to server

