### PR TITLE
Refactor ZendeskSender specs

### DIFF
--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -1,54 +1,48 @@
 RSpec.describe ZendeskSender do
-  subject(:sender) { ZendeskSender.new(ticket_payload) }
+  shared_examples 'Zendesk send' do
+    let(:ticket_payload) do
+      instance_double(
+        Feedback,
+        subject: 'Bug report',
+        description: 'event - outcome - email address',
+        referrer: '/claims',
+        user_agent: 'chrome'
+      )
+    end
 
-  let(:ticket_payload) { double('ticket_payload', subject: 'Bug report', description: 'event - outcome - email address', referrer: '/claims', user_agent: 'chrome') }
+    let(:zendesk_payload) do
+      {
+        subject: 'Bug report',
+        description: 'event - outcome - email address',
+        custom_fields: [
+          { id: '26047167', value: '/claims' },
+          { id: '23757677', value: 'advocate_defence_payments' },
+          { id: '23791776', value: 'chrome' },
+          { id: '32342378', value: 'test_environment' }
+        ]
+      }
+    end
 
-  before do
-    allow(Rails).to receive(:host).and_return(double(env: 'test'))
-    stub_request(:post, %r{\Ahttps://.*ministryofjustice.zendesk.com/api/v2/tickets\z})
+    before do
+      stub_const('ENV', ENV.to_hash.merge('ENV' => 'test_environment'))
+      allow(ZendeskAPI::Ticket).to receive(:create!)
+    end
+
+    it 'calls ZendeskAPI::Ticket.create!' do
+      zen_send
+      expect(ZendeskAPI::Ticket).to have_received(:create!).with(ZENDESK_CLIENT, **zendesk_payload)
+    end
   end
 
   describe '.send!' do
-    it 'calls #send!' do
-      expect(described_class).to receive(:new).with(ticket_payload).and_return(sender)
-      expect(sender).to receive(:send!)
-      described_class.send!(ticket_payload)
+    include_examples 'Zendesk send' do
+      subject(:zen_send) { described_class.send!(ticket_payload) }
     end
   end
 
   describe '#send!' do
-    let(:stubbed_request) do
-      stub_request(:post, 'https://ministryofjustice.zendesk.com/api/v2/tickets')
-        .with(
-          body: {
-            ticket: {
-              subject: 'Bug report',
-              description: 'event - outcome - email address',
-              custom_fields: [
-                { id: '26047167', value: '/claims' },
-                { id: '23757677', value: 'advocate_defence_payments' },
-                { id: '23791776', value: 'chrome' },
-                { id: '32342378', value: 'test' }
-              ]
-            }
-          }.to_json,
-          headers: {
-            'Accept' => 'application/json',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'User-Agent' => /ZendeskAPI Ruby 1\.\d+\.\d+/
-          }
-        )
-    end
-
-    it 'calls ZendeskAPI::Ticket.create!' do
-      expect(ZendeskAPI::Ticket).to receive(:create!)
-      sender.send!
-    end
-
-    it 'makes the expected request, with common and custom fields' do
-      sender.send!
-      expect(stubbed_request).to have_been_requested
+    include_examples 'Zendesk send' do
+      subject(:zen_send) { described_class.new(ticket_payload).send! }
     end
   end
 end


### PR DESCRIPTION
#### What

Refactor `ZendeskSender` specs.

#### Ticket

N/A

#### Why

Dependabot PR #4885 is failing because of one of the spec tests. The test in question is testing the request that the Zendesk API makes so it is not really necessary.

#### How

Refactor the tests to check that `ZendeskAPI::Ticket.create!` is called with the correct arguments when called either as `ZendeskSender.send!(...)` or `ZendeskSender.new(...).send!`
