### PR TITLE
Rename Slack bot for archive job alerts

### DIFF
--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,11 +1,11 @@
 class SlackNotifier
-  def initialize(channel, formatter:)
+  def initialize(channel, formatter:, slack_bot_name: Settings.slack.bot_name)
     @formatter = formatter
     @slack_url = Settings.slack.bot_url
     @ready_to_send = false
     @payload = {
       channel: channel,
-      username: Settings.slack.bot_name
+      username: slack_bot_name
     }
   end
 

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -124,7 +124,11 @@ namespace :claims do
       raise ArgumentError.new "Only valid parameter is 'dummy'"
     end
 
-    slack_notifier = SlackNotifier.new('laa-cccd-alerts', formatter: SlackNotifier::Formatter::Transitioner.new)
+    slack_notifier = SlackNotifier.new(
+      'laa-cccd-alerts',
+      formatter: SlackNotifier::Formatter::Transitioner.new,
+      slack_bot_name: 'Stale Claim Archiver'
+    )
 
     TimedTransitions::BatchTransitioner.new(limit: 10000, dummy: @dummy, notifier: slack_notifier).run
   end


### PR DESCRIPTION
#### What

Rename the Slack bot name used when reporting failures in the stale claim archiver task.

#### Ticket

N/A

#### Why

Alerts are being sent with the name 'Injectotron', which is the default Slack bot name that was set when the alerter was only used for Injection failures.

#### How

Add an optional argument to `SlackNotifier.new` for the bot name.