### PR TITLE
Refactor of error message presenter

### DIFF
--- a/app/presenters/error_message/detail_collection.rb
+++ b/app/presenters/error_message/detail_collection.rb
@@ -9,11 +9,10 @@ module ErrorMessage
     end
 
     def []=(fieldname, error_detail)
-      if @detail_collection.key?(fieldname)
-        @detail_collection[fieldname] << error_detail
-      else
-        @detail_collection[fieldname] = [error_detail]
-      end
+      @detail_collection[fieldname] ||= []
+      return if @detail_collection[fieldname][0]&.long_message.eql?(error_detail.long_message)
+
+      @detail_collection[fieldname] << error_detail
     end
 
     def errors_for?(fieldname)

--- a/app/presenters/error_message/detail_collection.rb
+++ b/app/presenters/error_message/detail_collection.rb
@@ -10,7 +10,7 @@ module ErrorMessage
 
     def []=(fieldname, error_detail)
       @detail_collection[fieldname] ||= []
-      return if @detail_collection[fieldname][0]&.long_message.eql?(error_detail.long_message)
+      return if @detail_collection[fieldname].map(&:long_message).include?(error_detail.long_message)
 
       @detail_collection[fieldname] << error_detail
     end

--- a/app/presenters/error_message/detail_factory.rb
+++ b/app/presenters/error_message/detail_factory.rb
@@ -1,0 +1,17 @@
+module ErrorMessage
+  class DetailFactory
+    def initialize(sequencer:)
+      @sequencer = sequencer
+    end
+
+    def build(attribute, message)
+      Detail.new(
+        attribute,
+        message.long,
+        message.short,
+        message.api,
+        @sequencer.generate(attribute)
+      )
+    end
+  end
+end

--- a/app/presenters/error_message/presenter.rb
+++ b/app/presenters/error_message/presenter.rb
@@ -32,13 +32,7 @@ module ErrorMessage
     end
 
     def add_error_detail(attribute, message)
-      @error_detail_collection[attribute] = Detail.new(
-        attribute,
-        message.long,
-        message.short,
-        message.api,
-        sequencer.generate(attribute)
-      )
+      @error_detail_collection[attribute] = detail_factory.build(attribute, message)
     end
 
     def translator
@@ -47,6 +41,10 @@ module ErrorMessage
 
     def sequencer
       @sequencer ||= ErrorMessage::Sequencer.new(translations: @translations)
+    end
+
+    def detail_factory
+      @detail_factory ||= ErrorMessage::DetailFactory.new(sequencer: sequencer)
     end
 
     def default_file

--- a/app/presenters/error_message/presenter.rb
+++ b/app/presenters/error_message/presenter.rb
@@ -27,14 +27,8 @@ module ErrorMessage
         attribute = error.attribute
         message = translator.message(error.attribute, error.message)
 
-        next if error_detail_item?(attribute, message)
         add_error_detail(attribute, message)
       end
-    end
-
-    def error_detail_item?(attribute, message)
-      @error_detail_collection[attribute] &&
-        @error_detail_collection[attribute][0].long_message.eql?(message.long)
     end
 
     def add_error_detail(attribute, message)

--- a/app/presenters/error_message/presenter.rb
+++ b/app/presenters/error_message/presenter.rb
@@ -25,7 +25,7 @@ module ErrorMessage
     def generate_messages
       @errors.each do |error|
         attribute = error.attribute
-        message = translator.message(error.attribute, error.message)
+        message = translator.message(error)
 
         add_error_detail(attribute, message)
       end

--- a/app/presenters/error_message/translator.rb
+++ b/app/presenters/error_message/translator.rb
@@ -23,9 +23,9 @@ module ErrorMessage
       @api_message = nil
     end
 
-    def message(key, error)
-      key = ErrorMessage::Key.new(key)
-      error = format_error(error)
+    def message(error)
+      key = ErrorMessage::Key.new(error.attribute)
+      error = format_error(error.message)
       set = translations_for(key)
       message_set = message_set(set, key, error)
       ErrorMessage::Message.new(*message_set, key)

--- a/spec/presenters/error_message/detail_collection_spec.rb
+++ b/spec/presenters/error_message/detail_collection_spec.rb
@@ -29,21 +29,21 @@ RSpec.describe ErrorMessage::DetailCollection do
 
   describe '#[]=' do
     context 'when assigning a single value to a key' do
-      before { instance[:key1] = 'value for key 1' }
+      before { instance[:key1] = ed1 }
 
       it 'makes an array containing the single element' do
-        expect(instance[:key1]).to eq(['value for key 1'])
+        expect(instance[:key1]).to eq([ed1])
       end
     end
 
     context 'when assigning multiple values to a key' do
       before do
-        instance[:key1] = 'value 1'
-        instance[:key1] = 'value 2'
+        instance[:key1] = ed1
+        instance[:key1] = ed3
       end
 
       it 'makes an array of all the elements assigned' do
-        expect(instance[:key1]).to match_array(['value 1', 'value 2'])
+        expect(instance[:key1]).to match_array([ed1, ed3])
       end
     end
   end

--- a/spec/presenters/error_message/detail_collection_spec.rb
+++ b/spec/presenters/error_message/detail_collection_spec.rb
@@ -28,23 +28,24 @@ RSpec.describe ErrorMessage::DetailCollection do
   end
 
   describe '#[]=' do
-    context 'when assigning a single value to a key' do
-      before { instance[:key1] = ed1 }
+    subject(:setter) { instance[:key1] = new_detail }
 
-      it 'makes an array containing the single element' do
-        expect(instance[:key1]).to eq([ed1])
-      end
+    let(:new_detail) { ed1 }
+
+    context 'when assigning a single value to a key' do
+      it { expect { setter }.to change { instance[:key1] }.from(nil).to([ed1]) }
     end
 
     context 'when assigning multiple values to a key' do
-      before do
-        instance[:key1] = ed1
-        instance[:key1] = ed3
-      end
+      before { instance[:key1] = ed3 }
 
-      it 'makes an array of all the elements assigned' do
-        expect(instance[:key1]).to match_array([ed1, ed3])
-      end
+      it { expect { setter }.to change { instance[:key1] }.from([ed3]).to([ed3, ed1]) }
+    end
+
+    context 'with a duplicate message' do
+      before { instance[:key1] = ed1 }
+
+      it { expect { setter }.not_to change { instance[:key1] } }
     end
   end
 

--- a/spec/presenters/error_message/detail_collection_spec.rb
+++ b/spec/presenters/error_message/detail_collection_spec.rb
@@ -43,7 +43,10 @@ RSpec.describe ErrorMessage::DetailCollection do
     end
 
     context 'with a duplicate message' do
-      before { instance[:key1] = ed1 }
+      before do
+        instance[:key1] = ed3
+        instance[:key1] = ed1
+      end
 
       it { expect { setter }.not_to change { instance[:key1] } }
     end
@@ -55,7 +58,7 @@ RSpec.describe ErrorMessage::DetailCollection do
     context 'when fieldname key exists in collection' do
       let(:fieldname) { :foo }
 
-      before { instance[:foo] = 'bar' }
+      before { instance[:foo] = ed1 }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/presenters/error_message/detail_factory_spec.rb
+++ b/spec/presenters/error_message/detail_factory_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe ErrorMessage::DetailFactory do
+  subject(:factory) { described_class.new(sequencer: sequencer) }
+
+  let(:sequencer) { instance_double(ErrorMessage::Sequencer) }
+
+  before { allow(sequencer).to receive(:generate).with('attribute').and_return(123) }
+
+  describe '#build' do
+    subject(:detail) { factory.build(key, message) }
+
+    let(:key) { 'attribute' }
+    let(:message) do
+      instance_double(
+        ErrorMessage::Message,
+        long: 'Long message',
+        short: 'Short message',
+        api: 'API message'
+      )
+    end
+
+    it { is_expected.to be_an_instance_of(ErrorMessage::Detail) }
+    it { expect(detail.sequence).to eq(123) }
+  end
+end

--- a/spec/presenters/error_message/translator_spec.rb
+++ b/spec/presenters/error_message/translator_spec.rb
@@ -80,12 +80,11 @@ RSpec.describe ErrorMessage::Translator do
   include_context 'with custom error messages'
 
   describe '#message' do
-    subject(:message) { translator.message(key, error) }
+    subject(:message) { translator.message(error) }
 
     context 'with unnested translations' do
       context 'when key and error exists' do
-        let(:key) { :name }
-        let(:error) { 'cannot_be_blank' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: :name, message: 'cannot_be_blank') }
 
         it_behaves_like 'message found',
                         long: 'The claimant name must not be blank, please enter a name',
@@ -94,8 +93,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key does not exist' do
-        let(:key) { :stepmother }
-        let(:error) { 'too_long' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: :stepmother, message: 'too_long') }
 
         it_behaves_like 'message found',
                         long: 'Stepmother too long',
@@ -104,8 +102,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key exists but error does not exist' do
-        let(:key) { :name }
-        let(:error) { 'rubbish' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: :name, message: 'rubbish') }
 
         it_behaves_like 'message found',
                         long: 'Name rubbish',
@@ -116,8 +113,7 @@ RSpec.describe ErrorMessage::Translator do
 
     context 'with custom single nested errors' do
       context 'when key and error exist' do
-        let(:key) { :defendant_2_first_name }
-        let(:error) { 'blank' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: :defendant_2_first_name, message: 'blank') }
 
         it_behaves_like 'message found',
                         long: 'Enter a first name for the second defendant',
@@ -126,8 +122,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for submodel does not exist in base model' do
-        let(:key) { :person_2_first_name }
-        let(:error) { 'blank' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: :person_2_first_name, message: 'blank') }
 
         it_behaves_like 'message found',
                         long: 'Person 2 first name blank',
@@ -136,8 +131,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for submodel exists but key for field in submodel does not' do
-        let(:key) { :defendant_2_age }
-        let(:error) { 'blank' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: :defendant_2_age, message: 'blank') }
 
         it_behaves_like 'message found',
                         long: 'Defendant 2 age blank',
@@ -146,8 +140,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for submodel and field on submodel exists but error does not' do
-        let(:key) { :defendant_2_first_name }
-        let(:error) { 'foo' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: :defendant_2_first_name, message: 'foo') }
 
         it_behaves_like 'message found',
                         long: 'Defendant 2 first name foo',
@@ -158,8 +151,7 @@ RSpec.describe ErrorMessage::Translator do
 
     context 'with custom sinlge nested error with .format' do
       context 'when nested key and error exists' do
-        let(:key) { 'fixed_fee.quantity' }
-        let(:error) { 'invalid' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: 'fixed_fee.quantity', message: 'invalid') }
 
         it_behaves_like 'message found',
                         long: 'Enter a valid quantity for the first fixed fee',
@@ -170,8 +162,13 @@ RSpec.describe ErrorMessage::Translator do
 
     context 'with custom double level nested errors' do
       context 'when nested keys and errors exist' do
-        let(:key) { :defendant_5_representation_order_2_maat_reference }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(
+            ActiveModel::Error,
+            attribute: :defendant_5_representation_order_2_maat_reference,
+            message: 'blank'
+          )
+        end
 
         it_behaves_like 'message found',
                         long: 'Enter a valid MAAT reference for the second representation order of the fifth defendant',
@@ -180,8 +177,9 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for sub-sub-model does not exist' do
-        let(:key) { :defendant_5_court_order_2_maat_reference }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(ActiveModel::Error, attribute: :defendant_5_court_order_2_maat_reference, message: 'blank')
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 5 court order 2 maat reference blank',
@@ -190,8 +188,9 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for field on sub sub model does not exist' do
-        let(:key) { :defendant_5_representation_order_2_court }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(ActiveModel::Error, attribute: :defendant_5_representation_order_2_court, message: 'blank')
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 5 representation order 2 court blank',
@@ -200,8 +199,13 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for error on sub sub model does not exist' do
-        let(:key) { :defendant_5_representation_order_2_maat_reference }
-        let(:error) { 'no_such_error' }
+        let(:error) do
+          instance_double(
+            ActiveModel::Error,
+            attribute: :defendant_5_representation_order_2_maat_reference,
+            message: 'no_such_error'
+          )
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 5 representation order 2 maat reference no such error',
@@ -212,8 +216,9 @@ RSpec.describe ErrorMessage::Translator do
 
     context 'with rails single level nested errors' do
       context 'when key and error exist' do
-        let(:key) { 'defendants_attributes_0_first_name' }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(ActiveModel::Error, attribute: 'defendants_attributes_0_first_name', message: 'blank')
+        end
 
         it_behaves_like 'message found',
                         long: 'Enter a first name for the first defendant',
@@ -222,8 +227,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for submodel does not exist in base model' do
-        let(:key) { 'foos_attributes_0_age' }
-        let(:error) { 'blank' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: 'foos_attributes_0_age', message: 'blank') }
 
         it_behaves_like 'message found',
                         long: 'Foo 1 age blank',
@@ -232,8 +236,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for submodel exists but key for attribute on submodel does not' do
-        let(:key) { 'defendants_attributes_0_age' }
-        let(:error) { 'blank' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: 'defendants_attributes_0_age', message: 'blank') }
 
         it_behaves_like 'message found',
                         long: 'Defendant 1 age blank',
@@ -242,8 +245,9 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for submodel and attribute on submodel exists but error does not' do
-        let(:key) { 'defendants_attributes_0_first_name' }
-        let(:error) { 'bar' }
+        let(:error) do
+          instance_double(ActiveModel::Error, attribute: 'defendants_attributes_0_first_name', message: 'bar')
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 1 first name bar',
@@ -254,8 +258,13 @@ RSpec.describe ErrorMessage::Translator do
 
     context 'with rails double level nested errors' do
       context 'when nested keys and errors exist' do
-        let(:key) { :defendants_attributes_4_representation_orders_attributes_1_maat_reference }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(
+            ActiveModel::Error,
+            attribute: :defendants_attributes_4_representation_orders_attributes_1_maat_reference,
+            message: 'blank'
+          )
+        end
 
         it_behaves_like 'message found',
                         long: 'Enter a valid MAAT reference for the second representation order of the fifth defendant',
@@ -264,8 +273,13 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for sub-sub-model does not exist' do
-        let(:key) { :defendants_attributes_4_foobars_attributes_1_maat_reference }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(
+            ActiveModel::Error,
+            attribute: :defendants_attributes_4_foobars_attributes_1_maat_reference,
+            message: 'blank'
+          )
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 4 foobar 1 maat reference blank',
@@ -274,8 +288,13 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for attribute on sub-sub-model does not exist' do
-        let(:key) { :defendants_attributes_4_representation_orders_attributes_1_foobar }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(
+            ActiveModel::Error,
+            attribute: :defendants_attributes_4_representation_orders_attributes_1_foobar,
+            message: 'blank'
+          )
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 4 representation order 1 foobar blank',
@@ -284,8 +303,13 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key for error on sub-sub-model does not exist' do
-        let(:key) { :defendants_attributes_4_representation_orders_attributes_1_maat_reference }
-        let(:error) { 'foobar' }
+        let(:error) do
+          instance_double(
+            ActiveModel::Error,
+            attribute: :defendants_attributes_4_representation_orders_attributes_1_maat_reference,
+            message: 'foobar'
+          )
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 4 representation order 1 maat reference foobar',
@@ -296,8 +320,7 @@ RSpec.describe ErrorMessage::Translator do
 
     context 'with nested attribute single level errors with .format' do
       context 'when key and error exists' do
-        let(:key) { 'fixed_fee.quantity' }
-        let(:error) { 'invalid' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: 'fixed_fee.quantity', message: 'invalid') }
 
         it_behaves_like 'message found',
                         long: 'Enter a valid quantity for the first fixed fee',
@@ -306,8 +329,7 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key does not exist' do
-        let(:key) { 'foo.bar' }
-        let(:error) { 'invalid' }
+        let(:error) { instance_double(ActiveModel::Error, attribute: 'foo.bar', message: 'invalid') }
 
         it_behaves_like 'message found',
                         long: 'Foo 1 bar invalid',
@@ -318,8 +340,13 @@ RSpec.describe ErrorMessage::Translator do
 
     context 'with nested attribute double level errors with . format' do
       context 'when key and error exists' do
-        let(:key) { 'defendant.representation_order.maat_reference' }
-        let(:error) { 'blank' }
+        let(:error) do
+          instance_double(
+            ActiveModel::Error,
+            attribute: 'defendant.representation_order.maat_reference',
+            message: 'blank'
+          )
+        end
 
         it_behaves_like 'message found',
                         long: 'Enter a valid MAAT reference for the first representation order of the first defendant',
@@ -328,8 +355,9 @@ RSpec.describe ErrorMessage::Translator do
       end
 
       context 'when key does not exist' do
-        let(:key) { 'defendant.court_order.maat_reference' }
-        let(:error) { 'invalid' }
+        let(:error) do
+          instance_double(ActiveModel::Error, attribute: 'defendant.court_order.maat_reference', message: 'invalid')
+        end
 
         it_behaves_like 'message found',
                         long: 'Defendant 1 court order 1 maat reference invalid',
@@ -339,8 +367,13 @@ RSpec.describe ErrorMessage::Translator do
     end
 
     context 'with nested attribute double level errors with . plus numbered format' do
-      let(:key) { 'defendant.representation_order_1_maat_reference' }
-      let(:error) { 'blank' }
+      let(:error) do
+        instance_double(
+          ActiveModel::Error,
+          attribute: 'defendant.representation_order_1_maat_reference',
+          message: 'blank'
+        )
+      end
 
       it_behaves_like 'message found',
                       long: 'Enter a valid MAAT reference for the first representation order of the first defendant',


### PR DESCRIPTION
#### What

Separate out concerns in the error message presenter

#### Ticket

N/A

#### Why

The error message presenter is complex and it is difficult to understand what is going on with various concerns in one place.

#### How

* Move the responsibility for avoiding duplication of error details into `ErrorMessage::DetailCollection`
  - Also update to check for duplication with all existing errors, not just the first
* Use the abstract factory pattern for creating instances of `ErrorMessage::Detail`
  - Currently this does not add much but ultimately the factory could return a null object in certain circumstances to drop the error message (see 3f7fe2615aa0c5a6b99b863c42d65039b95bf0c1 in [cfp-77-graduated-fees-mw](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/tree/cfp-77-graduated-fees-mw))
