### PR TITLE
Extract sequencer to separate class

### DIFF
--- a/app/presenters/error_message/presenter.rb
+++ b/app/presenters/error_message/presenter.rb
@@ -43,7 +43,7 @@ module ErrorMessage
         message.long,
         message.short,
         message.api,
-        generate_sequence(attribute)
+        sequencer.generate(attribute)
       )
     end
 
@@ -51,29 +51,8 @@ module ErrorMessage
       @translator ||= ErrorMessage::Translator.new(@translations)
     end
 
-    def translations_subset_and_parent_sequence(key)
-      key = ErrorMessage::Key.new(key)
-
-      if key.numbered_submodel?
-        parent_sequence = @translations.dig(key.model, '_seq')
-        translations_subset = @translations.dig(key.model, key.attribute)
-      else
-        translations_subset = @translations[key]
-      end
-      parent_sequence ||= 0
-
-      [translations_subset, parent_sequence]
-    end
-
-    # NOTE: sequence = (attribute's _seq value + parent's _seq value) or parents _seq or 99999
-    #
-    def generate_sequence(key)
-      translations_subset, parent_sequence = translations_subset_and_parent_sequence(key)
-      begin
-        translations_subset['_seq'].present? ? translations_subset['_seq'] + parent_sequence : parent_sequence || 99_999
-      rescue StandardError
-        99_999
-      end
+    def sequencer
+      @sequencer ||= ErrorMessage::Sequencer.new(translations: @translations)
     end
 
     def default_file

--- a/app/presenters/error_message/sequencer.rb
+++ b/app/presenters/error_message/sequencer.rb
@@ -1,0 +1,32 @@
+module ErrorMessage
+  class Sequencer
+    def initialize(translations:)
+      @translations = translations
+    end
+
+    def generate(key)
+      # NOTE: sequence = (attribute's _seq value + parent's _seq value) or parents _seq or 99999
+      #
+      translations_subset, parent_sequence = translations_subset_and_parent_sequence(key)
+      begin
+        translations_subset['_seq'].present? ? translations_subset['_seq'] + parent_sequence : parent_sequence || 99_999
+      rescue StandardError
+        99_999
+      end
+    end
+
+    def translations_subset_and_parent_sequence(key)
+      key = ErrorMessage::Key.new(key)
+
+      if key.numbered_submodel?
+        parent_sequence = @translations.dig(key.model, '_seq')
+        translations_subset = @translations.dig(key.model, key.attribute)
+      else
+        translations_subset = @translations[key]
+      end
+      parent_sequence ||= 0
+
+      [translations_subset, parent_sequence]
+    end
+  end
+end

--- a/spec/presenters/error_message/presenter_spec.rb
+++ b/spec/presenters/error_message/presenter_spec.rb
@@ -14,20 +14,6 @@ RSpec.describe ErrorMessage::Presenter do
   it { expect(presenter.method(:key?)).to eq(presenter.method(:errors_for?)) }
   it { expect(presenter.method(:field_errors_for)).to eq(presenter.method(:short_messages_for)) }
 
-  describe '#generate_sequence' do
-    context 'when attribute present' do
-      it 'returns the value from the error messages file' do
-        expect(presenter.send(:generate_sequence, 'name')).to eq 60
-      end
-    end
-
-    context 'when attribute not present' do
-      it 'returns 99999' do
-        expect(presenter.send(:generate_sequence, 'nokey')).to eq 99_999
-      end
-    end
-  end
-
   describe '#summary_errors' do
     subject(:summary_errors) { presenter.summary_errors }
 

--- a/spec/presenters/error_message/sequencer_spec.rb
+++ b/spec/presenters/error_message/sequencer_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe ErrorMessage::Sequencer do
+  subject(:sequencer) { described_class.new(translations: translations) }
+
+  let(:translations) do
+    {
+      name: {
+        _seq: 60,
+        cannot_be_blank: {
+          long: 'The claimant name must not be blank, please enter a name',
+          short: 'Enter a name',
+          api: 'The claimant name must not be blank'
+        },
+        too_long: {
+          long: 'The name cannot be longer than 50 characters',
+          short: 'Too long',
+          api: 'The name cannot be longer than 50 characters'
+        }
+      },
+      defendant: {
+        _seq: 40,
+        first_name: {
+          _seq: 10,
+          blank: {
+            long: 'Enter a first name for the defendant',
+            short: 'Enter a first name',
+            api: 'The first name for the defendant must not be blank'
+          }
+        }
+      }
+    }.with_indifferent_access
+  end
+
+  describe '#generate' do
+    subject { sequencer.generate(key) }
+
+    context 'when the attribute is present' do
+      let(:key) { 'name' }
+
+      it { is_expected.to eq(60) }
+    end
+
+    context 'with a nested attribute' do
+      let(:key) { 'defendant_1_first_name' }
+
+      it { is_expected.to eq(50) }
+    end
+
+    context 'when the attribute is not present' do
+      let(:key) { 'nokey' }
+
+      it { is_expected.to eq(99_999) }
+    end
+  end
+end


### PR DESCRIPTION
#### What

Separate out concerns in the error message presenter.

#### Ticket

N/A

#### Why

The error message presenter is complex and it is difficult to understand what is going on with various concerns in one place.

#### How

Extract the 'sequencer' to a separate class.

The sequencer calculates a sequence number for an error message so that all errors can be displayed in the correct order.