### PR TITLE
[CFP-546] Remove codeclimate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,6 @@ group :test do
   gem 'axe-core-cucumber', '~> 4.4'
   gem 'capybara-selenium'
   gem 'capybara', '~> 3.37'
-  gem 'codeclimate-test-reporter', require: false
   gem 'cucumber-rails', '~> 2.5.1', require: false
   gem 'database_cleaner'
   gem 'i18n-tasks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,8 +167,6 @@ GEM
     childprocess (4.1.0)
     chronic (0.10.2)
     cocoon (1.2.15)
-    codeclimate-test-reporter (1.0.7)
-      simplecov
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -781,7 +779,6 @@ DEPENDENCIES
   capybara (~> 3.37)
   capybara-selenium
   cocoon (~> 1.2.15)
-  codeclimate-test-reporter
   colorize
   config (~> 4.0)
   cucumber-rails (~> 2.5.1)


### PR DESCRIPTION
#### What

Remove the `codeclimate` gem.

#### Ticket

[Replace `codeclimate-test-reporter` gem](https://dsdmoj.atlassian.net/browse/CFP-546)

#### Why

The `codeclimate-test-reporter` gem is deprecated in favour of the [new test reporter.](https://docs.codeclimate.com/docs/configuring-test-coverage)

#### How

Simply remove `codeclimate-test-reporter` from `Gemfile`. It appears that we had already been using the new test reporter (see [here](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/985fc04bc607f4cdff1c484450afaea9bb5eebfe/.circleci/config.yml#L21-L26)) but were still installing the gem as well.