### PR TITLE
Fix some Rubocop errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,14 +48,6 @@ Lint/ConstantDefinitionInBlock:
     - 'spec/services/claims/fetch_eligible_fixed_fee_types_spec.rb'
     - 'spec/services/simple_bill_adapter_spec.rb'
 
-# Offense count: 3
-# Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
-Lint/DuplicateBranch:
-  Exclude:
-    - 'app/helpers/external_users/claim_types_helper.rb'
-    - 'app/interfaces/api/helpers/api_helper.rb'
-    - 'spec/support/scheme_date_helpers.rb'
-
 # Offense count: 12
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:

--- a/app/helpers/external_users/claim_types_helper.rb
+++ b/app/helpers/external_users/claim_types_helper.rb
@@ -1,17 +1,5 @@
 module ExternalUsers
   module ClaimTypesHelper
-    def claim_type_prompt_heading_for(user)
-      if user.persona.has_roles?('admin')
-        t('external_users.claim_heading')
-      elsif user.persona.has_roles?('advocate')
-        t('external_users.agfs_claim_heading')
-      elsif user.persona.has_roles?('litigator')
-        t('external_users.lgfs_claim_heading')
-      else
-        t('external_users.claim_heading')
-      end
-    end
-
     def claim_type_page_header(user)
       if user.persona.roles.eql?(['advocate'])
         t('.page_title_advocate')

--- a/app/interfaces/api/helpers/api_helper.rb
+++ b/app/interfaces/api/helpers/api_helper.rb
@@ -47,9 +47,7 @@ module API
           model_instance = adapt(model_instance)
 
           test_editability(model_instance)
-          if model_instance.errors.present?
-            pop_error_response(model_instance, api_response)
-          elsif model_instance.valid?
+          if model_instance.valid? && model_instance.errors.blank?
             api_response.status = 200
             api_response.body = { valid: true }
           else

--- a/spec/support/scheme_date_helpers.rb
+++ b/spec/support/scheme_date_helpers.rb
@@ -7,11 +7,9 @@ module SchemeDateHelpers
       Settings.agfs_scheme_11_release_date.strftime
     when 'scheme 10' || 'post agfs reform'
       Settings.agfs_fee_reform_release_date.strftime
-    when 'scheme 9' || 'pre agfs reform'
-      '2016-01-01'
     when 'lgfs'
       '2016-04-01'
-    else
+    else # 'scheme 9' or 'pre agfs reform'
       '2016-01-01'
     end
   end


### PR DESCRIPTION
#### What

Fix some Rubocop failures.

#### Ticket

N/A

#### Why

Improving code quality

#### How

* `Lint/DuplicateBranch`: This cop failed in three places:
  - In one case, in `app/helpers/external_users/claim_types_helper.rb`, the only use of the method was removed in 847f26a97844257ef95dc77b3575adc70ed904b2 so it can be removed completely
  - In the other two cases one option in an `if` or `case` statement has been combined with the default option
