### PR TITLE
Disable IRB autocompletion in rails console

### DIFF
--- a/.k8s/live/api-sandbox/deployment-worker.yaml
+++ b/.k8s/live/api-sandbox/deployment-worker.yaml
@@ -24,7 +24,12 @@ spec:
         - name: cccd-worker
           imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
-          command: ['bundle', 'exec', 'sidekiq']
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "IRB.conf[:USE_AUTOCOMPLETE] = false" >> ~/.irbrc
+              bundle exec sidekiq
           readinessProbe:
             exec:
               command: ['bin/worker_healthcheck']

--- a/.k8s/live/dev-lgfs/deployment-worker.yaml
+++ b/.k8s/live/dev-lgfs/deployment-worker.yaml
@@ -24,7 +24,12 @@ spec:
         - name: cccd-worker
           imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
-          command: ['bundle', 'exec', 'sidekiq']
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "IRB.conf[:USE_AUTOCOMPLETE] = false" >> ~/.irbrc
+              bundle exec sidekiq
           readinessProbe:
             exec:
               command: ['bin/worker_healthcheck']

--- a/.k8s/live/dev/deployment-worker.yaml
+++ b/.k8s/live/dev/deployment-worker.yaml
@@ -24,7 +24,12 @@ spec:
         - name: cccd-worker
           imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
-          command: ['bundle', 'exec', 'sidekiq']
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "IRB.conf[:USE_AUTOCOMPLETE] = false" >> ~/.irbrc
+              bundle exec sidekiq
           readinessProbe:
             exec:
               command: ['bin/worker_healthcheck']

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -24,7 +24,12 @@ spec:
         - name: cccd-worker
           imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
-          command: ['bundle', 'exec', 'sidekiq']
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "IRB.conf[:USE_AUTOCOMPLETE] = false" >> ~/.irbrc
+              bundle exec sidekiq
           readinessProbe:
             exec:
               command: ['bin/worker_healthcheck']

--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -24,7 +24,12 @@ spec:
         - name: cccd-worker
           imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
-          command: ['bundle', 'exec', 'sidekiq']
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "IRB.conf[:USE_AUTOCOMPLETE] = false" >> ~/.irbrc
+              bundle exec sidekiq
           readinessProbe:
             exec:
               command: ['bin/worker_healthcheck']

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -23,4 +23,5 @@ printf '\e[33mINFO: Starting scheduler_daemon daemon\e[0m\n'
 bundle exec scheduler_daemon start
 
 printf '\e[33mINFO: Launching unicorn\e[0m\n'
+echo 'IRB.conf[:USE_AUTOCOMPLETE] = false' >> ~/.irbrc # Disable IRB autocompletion in rails console
 bundle exec unicorn -p 3000 -c config/unicorn.rb


### PR DESCRIPTION
#### What

Disable the (very annoying) autocompletion in the rails console on hosted environments (dev/api-sandbox/staging/production).

#### Why

When using ruby 3.1.x, the rails console contains an autocomplete feature which is not user friendly. The commands it suggests are hard to read (white on turquoise) and lead to lag when typing.

<img width="385" alt="image" src="https://user-images.githubusercontent.com/28729201/172655665-1339b76c-da24-4ddd-aff5-4a36265889af.png">


#### How

* Amend the `docker-entrypoint.sh` script used by docker to start the rails server, so that the autocomplete functionality is disabled in IRB (and thus the rails console) before the server is started.
* Amend the `deployment-worker.yaml` files for all environments so that the autocomplete functionality is disabled in worker pods.
