### PR TITLE
[CFP-70] FormBuilder migration - Transfer fee

### DIFF
--- a/app/presenters/error_message/presenter.rb
+++ b/app/presenters/error_message/presenter.rb
@@ -36,7 +36,7 @@ module ErrorMessage
     end
 
     def govuk_has_one_associations
-      @govuk_has_one_associations ||= %w[fixed_fee. graduated_fee.] # add associations to the array as they are migrated - eg %w[graduated_fee. fixed_fee.]
+      @govuk_has_one_associations ||= %w[fixed_fee. graduated_fee. transfer_fee.] # add associations to the array as they are migrated - eg %w[graduated_fee. fixed_fee.]
     end
 
     def error_detail_item?(attribute, message)

--- a/app/validators/base_sub_model_validator.rb
+++ b/app/validators/base_sub_model_validator.rb
@@ -47,7 +47,7 @@ class BaseSubModelValidator < BaseValidator
     associated_record = record.__send__(association_name)
     return if associated_record_has_no_errors?(associated_record)
     @result = false
-    copy_errors_to_base_record(record, association_name, associated_record, nil) if %i[fixed_fee graduated_fee hardship_fee].include? association_name # add the name of the association being migrated to this array, eg %i[graduated_fee]. remove this guard when govuk migration is complete
+    copy_errors_to_base_record(record, association_name, associated_record, nil) if %i[fixed_fee graduated_fee hardship_fee transfer_fee].include? association_name # add the name of the association being migrated to this array, eg %i[graduated_fee]. remove this guard when govuk migration is complete
   end
 
   def associated_record_has_no_errors?(associated_record)
@@ -71,12 +71,10 @@ class BaseSubModelValidator < BaseValidator
     #
     # NOTE: Once form migrations are complete, this conditional can be removed
     #
-    if %i[dates_attended defendants
-          expenses
-          fixed_fees fixed_fee
-          graduated_fee
-          hardship_fee
-          representation_orders].include? association_name
+    if %i[dates_attended defendants expenses fixed_fees fixed_fee
+          graduated_fee hardship_fee
+          representation_orders
+          transfer_fee].include? association_name
       [association_name.to_s, 'attributes', record_num.to_s, error.attribute.to_s].compact_blank.join('_')
     else
       "#{association_name.to_s.singularize}_#{record_num + 1}_#{error.attribute}"

--- a/app/validators/fee/transfer_fee_validator.rb
+++ b/app/validators/fee/transfer_fee_validator.rb
@@ -6,14 +6,14 @@ class Fee::TransferFeeValidator < Fee::BaseFeeValidator
   end
 
   def validate_amount
-    validate_presence_and_numericality(:amount, minimum: 0.1)
+    validate_presence_and_numericality_govuk_formbuilder(:amount, minimum: 0.1)
   end
 
   def validate_quantity
     if @record.claim&.transfer_detail&.ppe_required?
-      validate_presence_and_numericality(:quantity, minimum: 1)
+      validate_presence_and_numericality_govuk_formbuilder(:quantity, minimum: 1)
     else
-      validate_presence_and_numericality(:quantity, minimum: 0)
+      validate_presence_and_numericality_govuk_formbuilder(:quantity, minimum: 0)
     end
   end
 end

--- a/app/views/external_users/claims/_error_summary.html.haml
+++ b/app/views/external_users/claims/_error_summary.html.haml
@@ -1,4 +1,4 @@
-- form_steps = %w[case_details defendants fixed_fees graduated_fees hardship_fees offence_details supporting_evidence transfer_fee_details travel_expenses]
+- form_steps = %w[case_details defendants fixed_fees graduated_fees hardship_fees offence_details supporting_evidence transfer_fees transfer_fee_details travel_expenses]
 - if form_steps.include?(@claim.form_step.to_s)
   = govuk_error_summary(@claim, :claim, presenter: @error_presenter)
 

--- a/app/views/external_users/claims/transfer_fee/_fields.html.haml
+++ b/app/views/external_users/claims/transfer_fee/_fields.html.haml
@@ -1,42 +1,47 @@
 #transfer-fee
   = f.fields_for :transfer_fee do |tf|
-    .form-section.fx-fee-group.transfer-fee-group.js-block.fx-do-init{data:{"type": "transferFees", autovat: @claim.apply_vat? ? "true" : "false"}}
+    .fx-fee-group.transfer-fee-group.js-block.fx-do-init{ data: { 'type': 'transferFees', autovat: @claim.apply_vat? ? 'true' : 'false' } }
 
-      .js-fee-calculator-effector
-        = tf.hidden_field :fee_type_id, value: @claim.transfer_fee.fee_type.id, class: 'js-fee-type'
+      = tf.govuk_text_field :fee_type_id,
+        class: 'js-fee-type',
+        form_group: { classes: 'js-fee-calculator-effector' },
+        label: { hidden: true },
+        type: 'hidden',
+        value: @claim.transfer_fee.fee_type.id
 
       - unless @claim.transfer_detail.elected_case?
 
         - if @claim.transfer_detail.days_claimable?
-          .js-fee-calculator-effector
-            = f.adp_text_field :actual_trial_length,
-              label: t('.actual_trial_length'),
-              input_classes:'form-control form-control-1-4 js-fee-calculator-days',
-              input_type: 'number',
-              errors: @error_presenter
+          = f.govuk_number_field :actual_trial_length,
+            class: 'js-fee-calculator-days',
+            form_group: { classes: 'js-fee-calculator-effector' },
+            label: { text: t('.actual_trial_length') },
+            min: 0,
+            width: 'one-quarter'
 
-        .js-fee-calculator-effector
-          = tf.adp_text_field :quantity,
-            label: t('.quantity'),
-            input_type: 'number',
-            input_classes:'quantity fee-quantity js-fee-calculator-ppe form-control-1-4',
-            value: number_with_precision(tf.object.quantity, precision: 0),
-            errors: @error_presenter,
-            error_key:'transfer_fee.quantity'
+        = tf.govuk_number_field :quantity,
+          class: 'quantity fee-quantity js-fee-calculator-ppe',
+          form_group: { classes: 'js-fee-calculator-effector' },
+          label: { text: t('.quantity') },
+          min: 0,
+          value: number_with_precision(tf.object.quantity, precision: 0),
+          width: 'one-quarter'
 
-      .js-graduated-price-effectee
-        .calculated-grad-fee
-        = tf.adp_text_field :amount,
-            label: t('.amount'),
-            input_classes:'total fee-amount form-input-denote__input form-control-1-4 ',
-            input_type: 'currency',
-            value: number_with_precision(tf.object.amount, precision: 2),
-            error_key: 'transfer_fee.amount',
-            errors: @error_presenter
+      = tf.govuk_number_field :amount,
+        class: 'total fee-amount',
+        form_group: { classes: 'calculated-grad-fee js-graduated-price-effectee' },
+        label: { text: t('.amount') },
+        min: 0,
+        prefix_text: '£',
+        value: number_with_precision(tf.object.amount, precision: 2),
+        width: 'one-quarter'
 
-      .js-fee-calculator-success
-        = tf.hidden_field :price_calculated, value: tf.object.price_calculated?
+      = tf.govuk_text_field :price_calculated,
+        form_group: { classes: 'js-fee-calculator-success' },
+        label: { hidden: true },
+        type: 'hidden',
+        value: tf.object.price_calculated?
 
-      .fee-calc-help-wrapper.form-group.hidden
+      .fee-calc-help-wrapper.hidden
         = govuk_detail t('.help_how_we_calculate_amount_title') do
           = t('.help_how_we_calculate_amount_body')

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -1384,17 +1384,16 @@ transfer_fee:
     long: Add a transfer fee
     short: *enter_amount
     api: Add a transfer fee
-
   quantity:
     _seq: 10
     enter_a_ppe_quantity_for_the_transfer_fee:
       long: Enter a PPE quantity for the transfer fee
       short: _
       api: Enter a PPE quantity for the transfer fee
-    enter_a_valid_ppe_quantity_for_the_transfer_fee:
-      long: Enter a valid PPE quantity for the transfer fee
+    the_ppe_quantity_for_the_transfer_fee_exceeds_the_limit:
+      long: The PPE quantity for the transfer fee exceeds the limit
       short: _
-      api: Enter a valid PPE quantity for the transfer fee
+      api: The PPE quantity for the transfer fee exceeds the limit
     enter_a_valid_ppe_quantity_for_the_transfer_fee:
       long: Enter a valid PPE quantity for the transfer fee
       short: _
@@ -1405,10 +1404,43 @@ transfer_fee:
       long: Enter an amount for the transfer
       short: _
       api: Enter an amount for the transfer
+    the_amount_for_the_transfer_fee_exceeds_the_limit:
+      long: The amount for the transfer fee exceeds the limit
+      short: _
+      api: The amount for the transfer fee exceeds the limit
     enter_a_valid_amount_for_the_transfer_fee:
       long: Enter a valid amount for the transfer fee
       short: _
       api: Enter a valid amount for the transfer fee
+
+transfer_fee_attributes_quantity:
+  _seq: 10
+  enter_a_ppe_quantity_for_the_transfer_fee:
+    long: Enter a PPE quantity for the transfer fee
+    short: _
+    api: Enter a PPE quantity for the transfer fee
+  the_ppe_quantity_for_the_transfer_fee_exceeds_the_limit:
+    long: The PPE quantity for the transfer fee exceeds the limit
+    short: _
+    api: The PPE quantity for the transfer fee exceeds the limit
+  enter_a_valid_ppe_quantity_for_the_transfer_fee:
+    long: Enter a valid PPE quantity for the transfer fee
+    short: _
+    api: Enter a valid PPE quantity for the transfer fee
+transfer_fee_attributes_amount:
+  _seq: 20
+  enter_an_amount_for_the_transfer:
+    long: Enter an amount for the transfer
+    short: _
+    api: Enter an amount for the transfer
+  the_amount_for_the_transfer_fee_exceeds_the_limit:
+    long: The amount for the transfer fee exceeds the limit
+    short: _
+    api: The amount for the transfer fee exceeds the limit
+  enter_a_valid_amount_for_the_transfer_fee:
+    long: Enter a valid amount for the transfer fee
+    short: _
+    api: Enter a valid amount for the transfer fee
 
 
 #################################################################################

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -1387,27 +1387,27 @@ transfer_fee:
 
   quantity:
     _seq: 10
-    blank:
+    enter_a_ppe_quantity_for_the_transfer_fee:
       long: Enter a PPE quantity for the transfer fee
-      short: *enter_quantity
+      short: _
       api: Enter a PPE quantity for the transfer fee
-    numericality:
+    enter_a_valid_ppe_quantity_for_the_transfer_fee:
       long: Enter a valid PPE quantity for the transfer fee
-      short: *enter_valid_quantity
+      short: _
       api: Enter a valid PPE quantity for the transfer fee
-    item_max_amount:
+    enter_a_valid_ppe_quantity_for_the_transfer_fee:
       long: Enter a valid PPE quantity for the transfer fee
-      short: *enter_valid_quantity
+      short: _
       api: Enter a valid PPE quantity for the transfer fee
   amount:
     _seq: 20
-    blank:
+    enter_an_amount_for_the_transfer:
       long: Enter an amount for the transfer
-      short: *enter_amount
+      short: _
       api: Enter an amount for the transfer
-    numericality:
+    enter_a_valid_amount_for_the_transfer_fee:
       long: Enter a valid amount for the transfer fee
-      short: *enter_valid_amount
+      short: _
       api: Enter a valid amount for the transfer fee
 
 

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -298,7 +298,7 @@ en:
               blank: Choose a type for the fee
             quantity:
               blank: Enter a PPE quantity for the transfer fee
-              item_max_amount: Enter a valid PPE quantity for the transfer fee
+              item_max_amount: The PPE quantity for the transfer fee exceeds the limit
               numericality: Enter a valid PPE quantity for the transfer fee
   dictionary:
     enter_valid_quantity: Enter a valid quantity

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -286,5 +286,19 @@ en:
               invalid: Enter a valid quantity for the miscellaneous fee
             rate:
               invalid: Enter a valid rate for the miscellaneous fee
+        fee/transfer_fee:
+          attributes:
+            amount:
+              blank: Enter an amount for the transfer
+              item_max_amount: The amount for the transfer fee exceeds the limit
+              numericality: Enter a valid amount for the transfer fee
+            claim:
+              blank: Enter claim
+            fee_type:
+              blank: Choose a type for the fee
+            quantity:
+              blank: Enter a PPE quantity for the transfer fee
+              item_max_amount: Enter a valid PPE quantity for the transfer fee
+              numericality: Enter a valid PPE quantity for the transfer fee
   dictionary:
     enter_valid_quantity: Enter a valid quantity

--- a/features/page_objects/sections/lgfs_transfer_fee_section.rb
+++ b/features/page_objects/sections/lgfs_transfer_fee_section.rb
@@ -1,5 +1,5 @@
 class LgfsTransferFeeSection < SitePrism::Section
-  element :days_total, "input#actual_trial_length"
-  element :ppe_total, "input.quantity"
+  element :days_total, "input.js-fee-calculator-days"
+  element :ppe_total, "input.js-fee-calculator-ppe"
   element :amount, "input.fee-amount"
 end

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -80,7 +80,7 @@ end
 RSpec.shared_examples 'common LGFS amount govuk validations' do
   describe '#validate_amount' do
     let(:amount_error_message) do
-      'Enter a valid amount for the (.*?)(graduated|hardship) fee'
+      'Enter a valid amount for the (.*?)(graduated|hardship|transfer) fee'
     end
 
     it 'adds error if amount is blank' do
@@ -97,7 +97,7 @@ RSpec.shared_examples 'common LGFS amount govuk validations' do
 
     it 'adds error if amount is greater than the max limit' do
       should_error_if_equal_to_value(fee, :amount, 200_001,
-                                     'The amount for the (.*?)(graduated|hardship) fee exceeds the limit')
+                                     'The amount for the (.*?)(graduated|hardship|transfer) fee exceeds the limit')
     end
   end
 end

--- a/spec/validators/fee/transfer_fee_validator_spec.rb
+++ b/spec/validators/fee/transfer_fee_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Fee::TransferFeeValidator, type: :validator do
     end
   end
 
-  include_examples 'common LGFS amount validations'
+  include_examples 'common LGFS amount govuk validations'
 
   describe 'absence of unnecessary attributes' do
     it 'validates absence of warrant issued date' do
@@ -55,7 +55,7 @@ RSpec.describe Fee::TransferFeeValidator, type: :validator do
       let(:claim) { build(:transfer_claim, :requiring_ppe) }
 
       it { should_be_valid_if_equal_to_value(fee, :quantity, 1) }
-      it { should_error_if_equal_to_value(fee, :quantity, 0, 'numericality') }
+      it { should_error_if_equal_to_value(fee, :quantity, 0, 'Enter a valid PPE quantity for the transfer fee') }
     end
 
     context 'when transfer details does not require PPE to be supplied' do


### PR DESCRIPTION
What

Continue the migration away from the deprecated design system to the current GOVUK Frontend.

Ticket

[FormBuilder migration -  Transfer fee](https://dsdmoj.atlassian.net/browse/CFP-70)

Why

- Update the service to use GOV.UK styles, components and patterns
- To improve and resolve the service's accessibility issues
- To reduce code complexity
- To improve maintainability

--------

#### TODO (wip)

 - [x] Fix test
 - [x] Update spec
 - [x] Update aob
