### PR TITLE
Remove Deterimation#to_s

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 7
-# Configuration parameters: AutoCorrect.
-Layout/LineContinuationLeadingSpace:
-  Exclude:
-    - 'app/models/determination.rb'
-
 # Offense count: 70
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums

--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -56,17 +56,6 @@ class Determination < ApplicationRecord
     !blank?
   end
 
-  def to_s
-    "  id:            #{id}\n" \
-      "  type           #{type}\n" \
-      "  claim_id:      #{claim_id}\n" \
-      "  expenses:      #{expenses}\n" \
-      "  fees:          #{fees}\n" \
-      "  disbursements: #{disbursements}\n" \
-      "  vat_amount:    #{vat_amount}\n" \
-      "  total:         #{total}\n\n"
-  end
-
   private
 
   def fees_valid

--- a/spec/models/redetermination_spec.rb
+++ b/spec/models/redetermination_spec.rb
@@ -88,19 +88,4 @@ RSpec.describe Redetermination do
       expect(rds.map(&:created_at).map(&:to_i)).to eq([date_1.to_i, date_2.to_i, date_3.to_i])
     end
   end
-
-  describe '#to_s' do
-    it 'outputs the totals' do
-      rd = create :redetermination, fees: 123.22, expenses: 301.55, disbursements: 44.33
-      expected = "  id:            #{rd.id}\n" +
-                 "  type           Redetermination\n" +
-                 "  claim_id:      #{rd.claim.id}\n" +
-                 "  expenses:      301.55\n" +
-                 "  fees:          123.22\n" +
-                 "  disbursements: 44.33\n" +
-                 "  vat_amount:    93.82\n" +
-                 "  total:         469.1\n\n"
-      expect(rd.to_s).to eq expected
-    end
-  end
 end


### PR DESCRIPTION
#### What

Remove the `Determination#to_s` method.

#### Ticket

Follow up to PR #4977 

#### Why

`Determination#to_s` appears to have been added for debugging in #1890 but never removed. Rubocop 1.31, updated in #4977, flags this. Instead of fixing the coding style it makes more sense to remove it if it is not being used.

#### To do

- [ ] Deploy on an environment and test with a few claims to confirm that this is only used for debugging.

#### How

Delete the method and update `.rubocop_todo.yml`.