### PR TITLE
[CFP-67] FormBuilder migration - Miscellaneous fees

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -422,8 +422,8 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
       ],
       interim_claim_info_attributes: [
         :warrant_fee_paid,
-        date_attributes_for(:warrant_issued_date),
-        date_attributes_for(:warrant_executed_date)
+        :warrant_issued_date,
+        :warrant_executed_date
       ]
     )
   end

--- a/app/models/interim_claim_info.rb
+++ b/app/models/interim_claim_info.rb
@@ -7,8 +7,6 @@ class InterimClaimInfo < ApplicationRecord
 
   validates_with InterimClaimInfoValidator
 
-  acts_as_gov_uk_date :warrant_issued_date, :warrant_executed_date
-
   def perform_validation?
     claim&.perform_validation?
   end

--- a/app/validators/base_sub_model_validator.rb
+++ b/app/validators/base_sub_model_validator.rb
@@ -47,7 +47,7 @@ class BaseSubModelValidator < BaseValidator
     associated_record = record.__send__(association_name)
     return if associated_record_has_no_errors?(associated_record)
     @result = false
-    copy_errors_to_base_record(record, association_name, associated_record, nil) if %i[fixed_fee graduated_fee hardship_fee interim_fee transfer_fee warrant_fee].include? association_name # add the name of the association being migrated to this array, eg %i[graduated_fee]. remove this guard when govuk migration is complete
+    copy_errors_to_base_record(record, association_name, associated_record, nil) if %i[fixed_fee graduated_fee hardship_fee interim_fee interim_claim_info misc_fees transfer_fee warrant_fee].include? association_name # add the name of the association being migrated to this array, eg %i[graduated_fee]. remove this guard when govuk migration is complete
   end
 
   def associated_record_has_no_errors?(associated_record)
@@ -73,7 +73,8 @@ class BaseSubModelValidator < BaseValidator
     #
     # rubocop:disable Layout/LineLength
     if %i[basic_fees dates_attended defendants disbursements expenses fixed_fees fixed_fee
-          graduated_fee hardship_fee interim_fee representation_orders transfer_fee warrant_fee].include? association_name
+          graduated_fee hardship_fee interim_fee interim_claim_info misc_fees
+          representation_orders transfer_fee warrant_fee].include? association_name
       [association_name.to_s, 'attributes', record_num.to_s, error.attribute.to_s].compact_blank.join('_')
     else
       "#{association_name.to_s.singularize}_#{record_num + 1}_#{error.attribute}"

--- a/app/validators/claim/base_claim_sub_model_validator.rb
+++ b/app/validators/claim/base_claim_sub_model_validator.rb
@@ -42,7 +42,7 @@ class Claim::BaseClaimSubModelValidator < BaseSubModelValidator
   def validate_presence_of_association(association_name, options = {})
     return unless options && options[:presence]
 
-    if %i[warrant_fee].include? association_name
+    if %i[misc_fees warrant_fee].include? association_name
       validate_presence(association_name, :blank)
     else
       validate_presence(association_name, 'blank')

--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -16,7 +16,7 @@ module Fee
       if run_base_fee_validators?
         super
       else
-        validate_presence(:fee_type, 'blank')
+        validate_presence(:fee_type, :blank)
         validate_lgfs_fee_type_rules
       end
     end
@@ -40,7 +40,7 @@ module Fee
       elsif @record.fee_type.unique_code.eql?('MIEVI')
         validate_evidence_provision_fee
       else
-        validate_presence_and_numericality(:amount, minimum: 0.1)
+        validate_presence_and_numericality_govuk_formbuilder(:amount, minimum: 0.1)
       end
     end
 
@@ -51,7 +51,7 @@ module Fee
     def validate_evidence_provision_fee
       valid_values = [45, 90]
       return if valid_values.include?(@record.amount.to_d)
-      add_error(:amount, 'incorrect_epf')
+      add_error(:amount, :incorrect_epf)
     end
   end
 end

--- a/app/validators/interim_claim_info_validator.rb
+++ b/app/validators/interim_claim_info_validator.rb
@@ -5,18 +5,18 @@ class InterimClaimInfoValidator < BaseValidator
 
   def validate_warrant_issued_date
     return unless @record.warrant_fee_paid?
-    validate_presence(:warrant_issued_date, 'blank')
-    validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, 'check_not_too_far_in_past')
+    validate_presence(:warrant_issued_date, :blank)
+    validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, :check_not_too_far_in_past)
     return if @record.warrant_issued_date.nil?
-    validate_on_or_before(Date.today, :warrant_issued_date, 'check_not_in_future')
+    validate_on_or_before(Date.today, :warrant_issued_date, :check_not_in_future)
   end
 
   def validate_warrant_executed_date
     return unless @record.warrant_fee_paid?
-    validate_presence(:warrant_executed_date, 'blank')
-    validate_on_or_after(@record.warrant_issued_date, :warrant_executed_date, 'warrant_executed_before_issued')
-    validate_on_or_after(Settings.earliest_permitted_date, :warrant_executed_date, 'check_not_too_far_in_past')
+    validate_presence(:warrant_executed_date, :blank)
+    validate_on_or_after(@record.warrant_issued_date, :warrant_executed_date, :warrant_executed_before_issued)
+    validate_on_or_after(Settings.earliest_permitted_date, :warrant_executed_date, :check_not_too_far_in_past)
     return if @record.warrant_executed_date.nil?
-    validate_on_or_before(Date.today, :warrant_executed_date, 'check_not_in_future')
+    validate_on_or_before(Date.today, :warrant_executed_date, :check_not_in_future)
   end
 end

--- a/app/views/external_users/claims/_error_summary.html.haml
+++ b/app/views/external_users/claims/_error_summary.html.haml
@@ -1,4 +1,4 @@
-- form_steps = %w[basic_fees case_details defendants disbursements fixed_fees graduated_fees hardship_fees interim_fees offence_details supporting_evidence transfer_fees transfer_fee_details travel_expenses]
+- form_steps = %w[basic_fees case_details defendants disbursements fixed_fees graduated_fees hardship_fees interim_fees miscellaneous_fees offence_details supporting_evidence transfer_fees transfer_fee_details travel_expenses]
 - if form_steps.include?(@claim.form_step.to_s)
   = govuk_error_summary(@claim, :claim, presenter: @error_presenter)
 

--- a/app/views/external_users/claims/interim_claim_info/_fields.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_fields.html.haml
@@ -3,35 +3,19 @@
     %h2.govuk-heading-m
       = t('.warrant_fee')
 
-    = f.fields_for :interim_claim_info do |ff|
-      .form-section
-        %fieldset{"aria-describedby": "radio-control-legend-warrant"}
-          %legend#radio-control-legend-warrant
-            %span.form-label-bold
-              = t('.warrant_fee_paid')
-          .form-group
-            = ff.collection_radio_buttons(:warrant_fee_paid, yes_no_options, :last, :first, { include_hidden: false, checked: ff.object.warrant_fee_paid ? 'true' : 'false' }) do |b|
-              .multiple-choice{ 'data-target' => b.value.to_bool ? 'interim-claim-info-details' : nil }
-                = b.radio_button("aria-labelledby": "radio-control-legend-warrant #{b.text.to_css_class}")
-                = b.label(id: b.text.to_css_class) { b.text }
+    = f.fields_for :interim_claim_info do |ici|
+      = ici.govuk_radio_buttons_fieldset(:warrant_fee_paid, legend: { size: 's', text: t('.warrant_fee_paid') }) do
+        - yes_no_options.each do |text,value|
+          = ici.govuk_radio_button :warrant_fee_paid, value.to_bool, label: { text: text } do
+            - if value.to_bool
+              = ici.govuk_date_field :warrant_issued_date,
+                form_group: { classes: 'warrant-fee-issued-date-group' },
+                hint: { text: t('.date_hint') },
+                legend: { text: t('.date_issued'), size: 's' },
+                maxlength_enabled: true
 
-              - if b.value.to_bool
-                #interim-claim-info-details.panel.panel-border-narrow.js-hidden
-                  .form-group
-                    %fieldset
-                      %legend.govuk-visually-hidden
-                        = t('.warrant_fee')
-                      .warrant-fee-issued-date-group
-                        = ff.gov_uk_date_field :warrant_issued_date,
-                                                legend_text: t('.date_issued'),
-                                                legend_class: 'form-label-bold',
-                                                id: 'interim_claim_info.warrant_issued_date',
-                                                error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_issued_date')
-
-                  .form-group
-                    .warrant-fee-executed-date-group
-                      = ff.gov_uk_date_field :warrant_executed_date,
-                                              legend_text: t('.date_executed'),
-                                              legend_class: 'govuk-legend',
-                                              id: 'interim_claim_info.warrant_executed_date',
-                                              error_messages: gov_uk_date_field_error_messages(@error_presenter, 'interim_claim_info.warrant_executed_date')
+              = ici.govuk_date_field :warrant_executed_date,
+                form_group: { classes: 'warrant-fee-executed-date-group' },
+                hint: { text: t('.date_hint') },
+                legend: { text: t('.date_executed'), size: 's' },
+                maxlength_enabled: true

--- a/app/views/external_users/claims/misc_fees/advocates/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_fields.html.haml
@@ -2,7 +2,6 @@
   .misc-fee-group-wrapper
     = f.fields_for :misc_fees do |misc_fee_fields|
       - @misc_fee_count += 1
-      = render 'external_users/claims/misc_fees/advocates/misc_fee_fields', f: misc_fee_fields
+      = render partial: 'external_users/claims/misc_fees/advocates/misc_fee_fields', locals: { f: misc_fee_fields }
 
-  .form-group
-    = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/advocates/misc_fee_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
+  = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/advocates/misc_fee_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -1,58 +1,49 @@
 - fee = present(f.object)
 - claim = present(f.object.claim)
 
-.form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{ data: { 'type': 'miscFees', autovat: @claim.apply_vat? ? 'true' : 'false', 'block-type': 'FeeBlockCalculator' } }
+.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{ data: { 'type': 'miscFees', autovat: @claim.apply_vat? ? 'true' : 'false', 'block-type': 'FeeBlockCalculator' } }
 
-  %fieldset
-    %legend
-      %span.govuk-heading-m
-        = t('.misc_fee')
-        %span.fx-numberedList-number
+  = f.govuk_fieldset legend: { text: t('.misc_fee_html') } do
 
     = link_to_remove_association f, wrapper_class: 'misc-fee-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
       = t('common.remove_html', context: t('.misc_fee'))
 
-    .form-group
-      .fee-type.js-typeahead{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") ? 'form-group-error dropdown_field_with_errors' : '' }
-        = f.label :fee_type_id_input,
-          t('.fee_type_html', context: t('.misc_fee')),
-          { class: 'form-label-bold' }
-
-        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
-
-        = f.select :fee_type_id,
-          options_for_select(claim.eligible_misc_fee_type_options_for_select, f.object&.fee_type&.id),
-          { include_blank: ''.html_safe },
-          { class: 'form-control form-control-full js-misc-fee-type js-fee-type js-fee-calculator-fee-type typeahead fx-misc-fee-calculation',
-          id: "misc_fee_#{@misc_fee_count}_fee_type",
-          'aria-label': t('.fee_type') }
+    = f.govuk_collection_select :fee_type_id,
+      claim.eligible_misc_fee_type_options_for_select.map{ |ft| [ft.first, ft.second, { 'data-unique-code': ft.third[:data][:unique_code] }] },
+      :second,
+      :first,
+      class: 'js-misc-fee-type js-fee-type js-fee-calculator-fee-type fx-misc-fee-calculation',
+      form_group: { classes: 'fee-type fx-autocomplete-wrapper cc-fee-type' },
+      label: { text: t('.fee_type_html', context: t('.misc_fee')), size: 's' },
+      options: { include_blank: '' }
 
     .form-group.fx-unused-materials-warning.js-hidden
       = render 'warnings/unused_material_over_3_hours'
 
-    = f.adp_text_field :quantity,
-                            label: t('.quantity_html', context: t('.misc_fee')),
-                            hint_text: t('.quantity_hint'),
-                            hide_hint: true,
-                            input_classes: 'quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity',
-                            input_type: 'number',
-                            value: fee.quantity,
-                            errors: @error_presenter
+    = f.govuk_number_field :quantity,
+      class: 'quantity fee-quantity js-fee-quantity js-fee-calculator-quantity',
+      form_group: { classes: 'quantity_wrapper' },
+      hint: { text: t('.quantity_hint'), hidden: true },
+      label: { text: t('.quantity_html', context: t('.misc_fee')), size: 's' },
+      value: fee.quantity,
+      width: 5
 
-    .js-unit-price-effectee
-      .calculated-unit-fee
-      = f.adp_text_field :rate,
-          label: t('.rate_html', context: t('.misc_fee')),
-          input_classes: 'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
-          input_type: 'currency',
-          errors: @error_presenter,
-          input_readonly: f.object.price_calculated?,
-          value: number_with_precision(f.object.rate, precision: 2)
+    = f.govuk_number_field :rate,
+      class: 'rate fee-rate js-fee-calculator-rate',
+      form_group: { classes: 'js-unit-price-effectee calculated-unit-fee' },
+      label: { text: t('.rate_html', context: t('.misc_fee')), size: 's' },
+      prefix_text: '£',
+      readonly: f.object.price_calculated?,
+      value: number_with_precision(f.object.rate, precision: 2),
+      width: 5
 
-    .js-fee-calculator-success
-      = f.hidden_field :price_calculated, value: f.object.price_calculated?
+    = f.govuk_text_field :price_calculated,
+      form_group: { classes: 'js-fee-calculator-success' },
+      label: { hidden: true },
+      type: 'hidden',
+      value: f.object.price_calculated?
 
-    .fee-calc-help-wrapper.form-group.hidden
+    .fee-calc-help-wrapper.hidden
       = govuk_detail t('.help_how_we_calculate_rate_title') do
         = t('.help_how_we_calculate_rate_body')
 
@@ -69,6 +60,6 @@
         = f.fields_for :dates_attended do |date_attended|
           = render 'date_attended_fields', f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "misc_fee_#{@misc_fee_count}"
 
-      = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: '', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
+      = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'govuk-link', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
 
   %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/external_users/claims/misc_fees/advocates/supplementary/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/supplementary/_fields.html.haml
@@ -1,11 +1,8 @@
-#misc-fees.mod-fees.form-section
+#misc-fees.mod-fees
   #misc_fees.misc-fee-group-wrapper
     %h3.govuk-heading-m
       = t('.misc_fee')
-    .form-group
-      %fieldset
-        %legend.form-label-bold
-          = t('.fee_type')
-        = f.fields_for :misc_fees do |misc_fee_fields|
-          - @misc_fee_count += 1
-          = render 'external_users/claims/misc_fees/advocates/supplementary/misc_fee_fields', f: misc_fee_fields
+    = f.govuk_check_boxes_fieldset :misc_fees, legend: { text: t('.fee_type') }, form_group: { id: 'claim-misc-fees-field-error' } do
+      = f.fields_for :misc_fees do |misc_fee_fields|
+        - @misc_fee_count += 1
+        = render partial: 'external_users/claims/misc_fees/advocates/supplementary/misc_fee_fields', locals: { f: misc_fee_fields }

--- a/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/supplementary/_misc_fee_fields.html.haml
@@ -1,57 +1,64 @@
 - fee = present(f.object)
-.multiple-choice{"data-target" => to_slug(f.object.description), "class" => "fx-hook-#{fee.fee_type_code.downcase}"}
+.app-checkboxes__item{ 'data-target': to_slug(f.object.description), class: "fx-hook-#{fee.fee_type_code.downcase}" }
+  = f.govuk_check_box :toggle,
+    1,
+    checked: !f.object.blank?,
+    class: 'fx-checkbox-hook',
+    label: { text: f.object.description },
+    'data-unique-code': f.object.fee_type.unique_code do
 
-  = f.check_box(:toggle, checked: !f.object.blank?, class: "fx-checkbox-hook", id: "#{to_slug(f.object.description)}-input", "aria-controls" => to_slug(f.object.description), :name => "misc_fees_checklist_#{f.object.fee_type_code.downcase}", data: { unique_code: f.object.fee_type.unique_code})
+    .misc-fee-group.fx-fee-group.js-block.fx-do-init{ data:{type:"miscFees", autovat: @claim.apply_vat? ? "true" : "false", "block-type": "FeeBlockCalculator"} }
+      = f.govuk_text_field :fee_type_id,
+        class: 'js-fee-calculator-fee-type js-fee-type',
+        form_group: { classes: 'govuk-visually-hidden' },
+        label: { hidden: true },
+        type: 'hidden'
 
-  %label{:for => "#{to_slug(f.object.description)}-input"}
-    = f.object.description
+      - if f.object.fee_type.unique_code.eql?('MIUMO')
+        = render 'warnings/unused_material_over_3_hours'
+
+      = f.govuk_number_field :quantity,
+        class: 'quantity fee-quantity js-fee-quantity js-fee-calculator-quantity',
+        form_group: { classes: 'quantity_wrapper' },
+        hint: { text: t('.quantity_hint') },
+        label: { text: t('.quantity_html', context: f.object.description) },
+        min: 1,
+        value: fee.quantity,
+        width: 3
+
+      = f.govuk_number_field :rate,
+        class:'rate fee-rate js-fee-calculator-rate',
+        form_group: { classes: 'js-unit-price-effectee calculated-unit-fee' },
+        label: { text: t('.rate_html', context: f.object.description) },
+        prefix_text: '£',
+        readonly: f.object.price_calculated?,
+        value: number_with_precision(f.object.rate, precision: 2),
+        width: 5
+
+      = f.govuk_text_field :price_calculated,
+        form_group: { classes: 'js-fee-calculator-success' },
+        label: { hidden: true },
+        type: 'hidden',
+        value: f.object.price_calculated?
+
+      .fee-calc-help-wrapper.hidden
+        = govuk_detail t('.help_how_we_calculate_rate_title') do
+          = t('.help_how_we_calculate_rate_body')
+
+      .dates-wrapper.form-group
+        .cocoon-insert-wrapper
+          - f.object.dates_attended.build unless f.object.dates_attended.any?
+          = f.fields_for :dates_attended do |date_attended|
+            = render 'date_attended_fields', f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "misc_fee_#{@misc_fee_count}"
+
+        = link_to_add_association t('.add_date_attended'), f, :dates_attended, 'partial' => 'date_attended_fields', data: { 'association-insertion-method' => 'append', 'association-insertion-node' => '.cocoon-insert-wrapper', 'association-insertion-traversal' => 'prev'}, class: 'govuk-link'
+
+      = govuk_summary_list_no_border do
+        = govuk_summary_list_row do
+          = govuk_summary_list_key do
+            = t('.net_amount')
+
+          = govuk_summary_list_value(class: 'fee-net-amount total') do
+            = fee.amount || number_to_currency(0)
 
   = f.hidden_field :_destroy, class: 'destroy', value: f.object.blank?
-
-.panel.panel-border-narrow.js-hidden{:id => to_slug(f.object.description)}
-  .misc-fee-group.fx-fee-group.js-block.fx-do-init{data:{type:"miscFees", autovat: @claim.apply_vat? ? "true" : "false", "block-type": "FeeBlockCalculator"}}
-    = f.hidden_field :fee_type_id, class: 'js-fee-calculator-fee-type js-fee-type'
-
-    = render 'warnings/unused_material_over_3_hours' if f.object.fee_type.unique_code.eql?('MIUMO')
-
-    .form-group
-      = f.adp_text_field :quantity,
-        label: t('.quantity_html', context: f.object.description),
-        hint_text: t('.quantity_hint'),
-        hide_hint: true,
-        input_classes:"quantity fee-quantity form-control-1-8 js-fee-quantity js-fee-calculator-quantity",
-        input_type: 'number',
-        value: fee.quantity,
-        errors: @error_presenter
-
-    .form-group.js-unit-price-effectee
-      .calculated-unit-fee
-      = f.adp_text_field :rate,
-          label: t('.rate_html', context: f.object.description),
-          input_classes:'rate fee-rate js-fee-calculator-rate form-input-denote__input form-control-1-4',
-          input_type: 'currency',
-          errors: @error_presenter,
-          input_readonly: f.object.price_calculated?,
-          value: number_with_precision(f.object.rate, precision: 2)
-
-    .js-fee-calculator-success
-      = f.hidden_field :price_calculated, value: f.object.price_calculated?
-
-    .fee-calc-help-wrapper.form-group.hidden
-      = govuk_detail t('.help_how_we_calculate_rate_title') do
-        = t('.help_how_we_calculate_rate_body')
-
-    .dates-wrapper.form-group
-      .cocoon-insert-wrapper
-        - f.object.dates_attended.build unless f.object.dates_attended.any?
-        = f.fields_for :dates_attended do |date_attended|
-          = render 'date_attended_fields', f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "misc_fee_#{@misc_fee_count}"
-
-      = link_to_add_association t('.add_date_attended'), f, :dates_attended, 'partial' => 'date_attended_fields', data: { 'association-insertion-method' => 'append', 'association-insertion-node' => '.cocoon-insert-wrapper', 'association-insertion-traversal' => 'prev'}
-
-    = govuk_summary_list do
-      = govuk_summary_list_row do
-        = govuk_summary_list_key do
-          = t('.net_amount')
-        = govuk_summary_list_value(class: 'fee-net-amount total') do
-          = fee.amount || number_to_currency(0)

--- a/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
@@ -7,5 +7,4 @@
       - @misc_fee_count += 1
       = render partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', locals: { f: misc_fee_fields }
 
-  .form-group
-    = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
+  = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -1,42 +1,24 @@
 .form-section.misc-fee-group.nested-fields.js-block.fx-do-init.fx-fee-group.fx-numberedList-item{ data: { 'type': 'miscFees', autovat: @claim.apply_vat? ? 'true' : 'false' } }
 
-  %fieldset
-    %legend
-      %span.govuk-heading-m
-        = t('.misc_fee')
-        %span.fx-numberedList-number
+  = f.govuk_fieldset legend: { text: t('.misc_fee_html') } do
 
     = link_to_remove_association f, wrapper_class: 'misc-fee-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
       = t('common.remove_html', context: t('.misc_fee'))
 
-    .form-group
-      .fee-type{ class: error_class?(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type") }
-        %fieldset{ 'aria-describedby': "radio-control-legend-#{@misc_fee_count}" }
-          %legend{ id: "radio-control-legend-#{@misc_fee_count}" }
-            %span.form-label-bold
-              = t('.fee_type')
+    = f.govuk_radio_buttons_fieldset(:fee_type_id, form_group: {classes: 'fee-type'}, legend: { size: 's', text: t('.fee_type') }) do
+      - present_collection(@claim.eligible_misc_fee_types).each do |misc_fee_type|
+        = f.govuk_radio_button :fee_type_id,
+          misc_fee_type.id,
+          label: { text: misc_fee_type.description },
+          'data-unique-code': misc_fee_type.unique_code do
+          - if misc_fee_type.unique_code.eql?('MIUMO')
+            = render 'warnings/unused_material_over_3_hours'
 
-          %a{ id: "misc_fee_#{@misc_fee_count}_fee_type" }
-
-          - misc_fee_types_collection = present_collection(@claim.eligible_misc_fee_types)
-          - options = misc_fee_types_collection.length == 1 ? { checked: misc_fee_types_collection.first.id } : {}
-
-          = f.collection_radio_buttons(:fee_type_id, misc_fee_types_collection, :id, :description, options) do |b|
-            .multiple-choice
-              = b.radio_button('aria-labelledby': "fx-numberedList-heading-#{@misc_fee_count} radio-control-legend-#{@misc_fee_count} #{b.text.to_css_class}",
-                data: { unique_code: b.object.fee_type.unique_code})
-              = b.label(id: b.text.to_css_class << "-#{@misc_fee_count}") { t('.type_of_fee_html', context: b.text) }
-
-        = validation_error_message(@error_presenter, "misc_fee_#{@misc_fee_count}_fee_type")
-
-    .form-group.fx-unused-materials-warning.js-hidden
-      = render 'warnings/unused_material_over_3_hours'
-
-    = f.adp_text_field :amount,
-                      label: t('.net_amount_html', context: t('.misc_fee')),
-                      input_classes: 'total fee-rate form-input-denote__input form-control-1-4',
-                      input_type: 'currency',
-                      errors: @error_presenter,
-                      value: number_with_precision(f.object.amount, precision: 2)
+    = f.govuk_number_field :amount,
+      label: { text: t('.net_amount_html', context: t('.misc_fee')) },
+      class: 'total fee-rate',
+      prefix_text: '£',
+      value: number_with_precision(f.object.amount, precision: 2),
+      width: 'one-quarter'
 
   %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -62,12 +62,9 @@ if (!String.prototype.supplant) {
    */
   $('#fixed-fees, #misc-fees, #documents').on('cocoon:after-insert', function (e, insertedItem) {
     const $insertedItem = $(insertedItem)
-    const insertedSelect = $insertedItem.find('select.typeahead')
-    const typeaheadWrapper = $insertedItem.find('.js-typeahead')
-
-    moj.Modules.Autocomplete.typeaheadKickoff(insertedSelect)
-    moj.Modules.Autocomplete.typeaheadBindEvents(typeaheadWrapper)
+    const insertedGovUkSelect = $insertedItem.find('.fx-autocomplete-wrapper select').attr('id')
     moj.Modules.FeeFieldsDisplay.addFeeChangeEvent(insertedItem)
+    moj.Modules.AutocompleteWrapper.Autocomplete(insertedGovUkSelect)
 
     $insertedItem.find('.remove_fields:first').trigger('focus')
   })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1397,6 +1397,7 @@ en:
             add_misc_fee: Add another fee
           misc_fee_fields:
             misc_fee: *miscellaneous_fee
+            misc_fee_html: 'Miscellaneous fees <span class="fx-numberedList-number"></span>'
             rate: Rate
             rate_html: Rate <span class="govuk-visually-hidden">in pounds for %{context} <span class="fx-numberedList-number"></span></span>
             net_amount: *net_amount
@@ -1437,6 +1438,7 @@ en:
               and attach to the claim.
           misc_fee_fields:
             misc_fee: *miscellaneous_fee
+            misc_fee_html: 'Miscellaneous fees <span class="fx-numberedList-number"></span>'
             fee_type: *fee_type
             case_numbers: *case_numbers
             type_of_fee_html: '%{context} <span class="govuk-visually-hidden">for miscellaneous fee <span class="fx-numberedList-number"></span></span>'
@@ -1481,6 +1483,7 @@ en:
         page_title: View your claims
       interim_claim_info:
         fields: &interim_claim_info_fields
+          date_hint: *date_hint
           warrant_fee: Warrant fees
           warrant_fee_paid: 'Have you previously been paid for an interim warrant fee?'
           date_issued: Warrant issued date

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -981,21 +981,21 @@ misc_fee:
 
   fee_type:
     _seq: 10
-    blank:
+    choose_a_type_for_the_miscellaneous_fee:
       long: 'Choose a type for the #{misc_fee}'
-      short: Choose a fee type
+      short: _
       api: Choose a type for the miscellaneous fee
-    case_type_inclusion:
+    fee_type_is_not_applicable_to_this_case_type:
       long: 'Choose an applicable type for the #{misc_fee}'
-      short: Not applicable to case type
+      short: _
       api: Fee type is not applicable to this case type
-    offence_category_exclusion:
+    fee_type_is_not_applicable_to_this_offence_category:
       long: 'Choose an applicable type for the #{misc_fee}'
-      short: Not applicable to offence category
+      short: _
       api: Fee type is not applicable to this offence category
-    fee_scheme_applicability:
+    fee_type_is_not_applicable_to_the_fee_scheme:
       long: 'Choose an applicable type for the #{misc_fee}'
-      short: Not applicable to fee scheme
+      short: _
       api: Fee type is not applicable to the fee scheme, based on representation order date
 
   rate:
@@ -1004,6 +1004,14 @@ misc_fee:
       long: 'Enter a valid net amount for the #{misc_fee}'
       short: _
       api: Enter a rate/net amount for the miscellaneous fee
+    enter_a_valid_rate_for_the_plea_and_trial_preparation_hearing:
+      long: Enter a valid rate for the Plea and trial preparation hearing
+      short: _
+      api: Enter a valid rate for the Plea and trial preparation hearing
+    enter_a_valid_rate_for_the_standard_appearance_fee:
+      long: Enter a valid rate for the Standard appearance fee
+      short: _
+      api: Enter a valid rate for the Standard appearance fee
 
   quantity:
     _seq: 30
@@ -1015,44 +1023,60 @@ misc_fee:
       long: You must specify a whole number for this type of fee
       short: _
       api: You must specify a whole number for this type of fee
-    pcm_invalid:
+    enter_a_valid_quantity_for_plea_and_trial_preparation_hearing:
       long: Enter a valid quantity for plea and trial preparation hearing
-      short: *enter_valid_quantity
+      short: _
       api: Enter a valid quantity for plea and trial preparation hearing
-    pcm_numericality:
+    enter_a_valid_quantity_1_to_3_for_plea_and_case_management_hearing_fees:
       long: Enter a valid quantity (1 to 3) for plea and case management hearing fees
-      short: Must be 1 to 3
+      short: _
       api: Enter a valid quantity (1 to 3) for plea and case management hearing fees
-    miumu_numericality:
+    enter_a_valid_quantity_for_unused_material_up_to_3_hours:
       long: 'Enter a valid quantity for the #{misc_fee}'
-      short: Must be exactly 1
+      short: _
       api: Enter a valid quantity (1) for unused material (up to 3 hours)
+    the_amount_for_the_miscellaneous_fee_exceeds_the_limit:
+      long: The amount for the miscellaneous fee exceeds the limit
+      short: _
+      api: The amount for the miscellaneous fee exceeds the limit
 
   case_numbers:
     _seq: 40
-    blank:
+    enter_at_least_one_case_number_for_the_miscellaneous_fee:
       long: 'Enter at least one case number for the #{misc_fee}'
-      short: Enter at least one case number
+      short: _
       api: Enter at least one case number for the miscellaneous fee
     case_numbers_for_the_miscellaneous_fee_are_not_allowed:
       long: 'Case numbers for the #{misc_fee} are not allowed'
       short: _
       api: Case numbers for the miscellaneous fee are not allowed
-    invalid:
+    enter_valid_case_numbers_for_the_miscellaneous_fee:
       long: 'Enter valid case numbers for the #{misc_fee}'
-      short: Enter valid case numbers
+      short: _
       api: Enter valid case numbers for the miscellaneous fee
 
   amount:
     _seq: 50
-    numericality:
+    enter_a_valid_amount_for_the_miscellaneous_fee:
       long: 'Enter a valid amount for the #{misc_fee}'
-      short: *enter_valid_amount
+      short: _
       api: Enter a valid amount for the miscellaneous fee
-    incorrect_epf:
-      long: 'Evidence provision fee can only be £45 or £90'
-      short: 'Enter £45 or £90'
-      api: 'Evidence provision fee can only be £45 or £90'
+    evidence_provision_fee_can_only_be_45_or_90:
+      long: Evidence provision fee can only be £45 or £90
+      short: _
+      api: Evidence provision fee can only be £45 or £90
+    the_amount_for_the_miscellaneous_fee_exceeds_the_limit:
+      long: The amount for the miscellaneous fee exceeds the limit
+      short: _
+      api: The amount for the miscellaneous fee exceeds the limit
+
+misc_fees:
+  _seq: 505
+
+  you_must_select_at_least_one_miscellaneous_fee:
+    long: You must select at least one miscellaneous fee
+    short: _
+    api: You must select at least one miscellaneous fee
 
 #################################################################################
 #                                                                               #
@@ -1333,6 +1357,47 @@ warrant_fee: &warrant_fee_errors
       api: The amount for the warrant fee exceeds the limit
 
 interim_claim_info: *warrant_fee_errors
+interim_claim_info_attributes_warrant_issued_date:
+    _seq: 20
+    enter_a_warrant_issued_date:
+      long: Enter a warrant issued date
+      short: _
+      api: Enter a warrant issued date
+    warrant_issued_date_needs_to_be_on_or_after_the_earliest_representation_order_date:
+      long: Warrant issued date needs to be on or after the earliest representation order date
+      short: _
+      api: Warrant issued date needs to be on or after the earliest representation order date
+    warrant_issued_date_cannot_be_too_far_in_the_future:
+      long: Warrant issued date cannot be too far in the future
+      short: _
+      api: Warrant issued date cannot be too far in the future
+    warrant_issued_date_cannot_be_too_far_in_the_past:
+      long: Warrant issued date cannot be too far in the past
+      short: _
+      api: Warrant issued date cannot be too far in the past
+    warrant_fee_cannot_be_claimed_until_at_least_3_months_have_passed_since_warrant_was_issued:
+      long: Warrant fee cannot be claimed until at least 3 months have passed since warrant was issued
+      short: _
+      api: Warrant fee cannot be claimed until at least 3 months have passed since warrant was issued
+
+interim_claim_info_attributes_warrant_executed_date:
+  _seq: 30
+  enter_a_warrant_executed_date:
+    long: Enter a warrant executed date
+    short: _
+    api: Enter a warrant executed date
+  warrant_executed_date_cannot_be_too_far_in_the_future:
+    long: Warrant executed date cannot be too far in the future
+    short: _
+    api: Warrant executed date cannot be too far in the future
+  warrant_executed_date_cannot_be_too_far_in_the_past:
+    long: Warrant executed date cannot be too far in the past
+    short: _
+    api: Warrant executed date cannot be too far in the past
+  the_warrant_executed_date_is_before_the_issued_date:
+    long: The warrant executed date is before the issued date
+    short: _
+    api: The warrant executed date is before the issued date
 
 warrant_fee_attributes_warrant_issued_date:
   _seq: 650.20
@@ -1669,10 +1734,10 @@ date_attended:
       long: 'Enter the #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense}'
       short: _
       api: 'Enter the date attended (from)'
-    the_fixed_fee_date_cannot_be_more_than_two_years_before_the_earliest_representation_order_date:
-      long: The fixed fee date cannot be more than two years before the earliest representation order date
+    the_fee_date_cannot_be_more_than_two_years_before_the_earliest_representation_order_date:
+      long: 'The #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} date cannot be more than two years before the earliest representation order date'
       short: _
-      api: The fixed fee date cannot be more than two years before the earliest representation order date
+      api: 'The #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} date cannot be more than two years before the earliest representation order date'
     enter_a_date_that_is_not_in_the_future:
       long: 'The #{date_attended} (from) for the #{basic_fee}#{fixed_fee}#{misc_fee}#{graduated_fee}#{expense} is invalid'
       short: _

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -58,6 +58,8 @@ en:
               invalid: Enter a valid legal aid transfer date
               invalid_date: Enter a valid legal aid transfer date
               present: The date legal aid was transferred is not allowed
+            misc_fees:
+              blank: You must select at least one miscellaneous fee
             offence:
               blank: Choose an offence
             retrial_actual_length:
@@ -134,7 +136,7 @@ en:
               blank: Enter the date attended
               not_after_today: Enter a date that is not in the future
               not_before_earliest_permitted_date: Enter a date later than two years before the earliest representation order date
-              too_long_before_earliest_reporder: The fixed fee date cannot not be more than two years before the earliest representation order date
+              too_long_before_earliest_reporder: The fee date cannot not be more than two years before the earliest representation order date
         disbursement:
           attributes:
             disbursement_type_id:
@@ -335,13 +337,30 @@ en:
               check_not_too_far_in_past: Warrant issued date cannot be too far in the past
         fee/misc_fee:
           attributes:
+            amount:
+              incorrect_epf: Evidence provision fee can only be £45 or £90
+              item_max_amount: The amount for the miscellaneous fee exceeds the limit
+              numericality: Enter a valid amount for the miscellaneous fee
             case_numbers:
+              blank: Enter at least one case number for the miscellaneous fee
+              invalid: Enter valid case numbers for the miscellaneous fee
               present: Case numbers for the miscellaneous fee are not allowed
+            fee_type:
+              blank: Choose a type for the miscellaneous fee
+              case_type_inclusion: Fee type is not applicable to this case type
+              fee_scheme_applicability: Fee type is not applicable to the fee scheme
+              offence_category_exclusion: Fee type is not applicable to this offence category
             quantity:
               integer: You must specify a whole number for this type of fee
               invalid: Enter a valid quantity for the miscellaneous fee
+              item_max_amount: The amount for the miscellaneous fee exceeds the limit
+              miumu_numericality: Enter a valid quantity for unused material (up to 3 hours)
+              pcm_invalid: Enter a valid quantity for plea and trial preparation hearing
+              pcm_numericality: Enter a valid quantity (1 to 3) for plea and case management hearing fees
             rate:
               invalid: Enter a valid rate for the miscellaneous fee
+              pcm_invalid: Enter a valid rate for the Plea and trial preparation hearing
+              saf_invalid: Enter a valid rate for the Standard appearance fee
         fee/transfer_fee:
           attributes:
             amount:
@@ -356,7 +375,7 @@ en:
               blank: Enter a PPE quantity for the transfer fee
               item_max_amount: The PPE quantity for the transfer fee exceeds the limit
               numericality: Enter a valid PPE quantity for the transfer fee
-        fee/warrant_fee:
+        fee/warrant_fee: &warrant_fee_errors
           attributes:
             amount:
               blank: Enter an amount for the warrant fee
@@ -364,6 +383,7 @@ en:
               numericality: Enter a valid amount for the warrant fee
               present: Do not enter an amount for the warrant fee
             warrant_executed_date:
+              blank: Enter a warrant executed date
               check_not_in_future: Warrant executed date cannot be too far in the future
               check_not_too_far_in_past: Warrant executed date cannot be too far in the past
               warrant_executed_before_issued: The warrant executed date is before the issued date
@@ -373,5 +393,6 @@ en:
               check_not_too_far_in_past: Warrant issued date cannot be too far in the past
               check_on_or_after_earliest_representation_order: Warrant issued date needs to be on or after the earliest representation order date
               on_or_before: Warrant fee cannot be claimed until at least 3 months have passed since warrant was issued
+        interim_claim_info: *warrant_fee_errors
   dictionary:
     enter_valid_quantity: Enter a valid quantity

--- a/features/claims/advocate/accessibility.feature
+++ b/features/claims/advocate/accessibility.feature
@@ -46,7 +46,7 @@ Feature: Advocate submits a claim
 
     And I should be in the 'Miscellaneous fees' form page
     And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
-    And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
+    And I add a govuk calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
     Then the last 'miscellaneous' fee rate should be populated with '108.00'
     Then the page should be accessible skipping 'aria-allowed-attr'
     And I eject the VCR cassette

--- a/features/claims/advocate/accessibility.feature
+++ b/features/claims/advocate/accessibility.feature
@@ -48,7 +48,7 @@ Feature: Advocate submits a claim
     And I should see a page title "Enter miscellaneous fees for advocate final fees claim"
     And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
     Then the last 'miscellaneous' fee rate should be populated with '108.00'
-    Then the page should be accessible
+    Then the page should be accessible skipping 'aria-allowed-attr'
     And I eject the VCR cassette
     Then I click "Continue" in the claim form
 

--- a/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
@@ -56,10 +56,10 @@ Feature: Advocate tries to submit a hardship claim for a trial with miscellaneou
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
     And I should see a page title "Enter miscellaneous fees for advocate hardship fees claim"
-    And I add a calculated miscellaneous fee 'Special preparation fee' with quantity of '2'
-    And I add a calculated miscellaneous fee 'Ground rules hearing (whole day)' with quantity of '2'
+    And I add a govuk calculated miscellaneous fee 'Special preparation fee' with quantity of '2'
+    And I add a govuk calculated miscellaneous fee 'Ground rules hearing (whole day)' with quantity of '2'
 
-    Then the following fee details should exist:
+    Then the following govuk fee details should exist:
       | section | fee_description | rate | hint | help |
       | miscellaneous | Special preparation fee | 39.39 | Number of hours | true |
       | miscellaneous | Ground rules hearing (whole day) | 240.00 | Number of days | true |

--- a/features/claims/advocate/scheme_eleven/misc_fee_removal.feature
+++ b/features/claims/advocate/scheme_eleven/misc_fee_removal.feature
@@ -40,8 +40,8 @@ Feature: Advocate can add and remove miscelleaneous fees
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
-    And I add a calculated miscellaneous fee 'Abuse of process hearings (half day)' with quantity of '1'
-    And I add a calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '1'
+    And I add a govuk calculated miscellaneous fee 'Abuse of process hearings (half day)' with quantity of '1'
+    And I add a govuk calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '1'
     And I click "Continue" in the claim form
     Then I should be in the 'Travel expenses' form page
 

--- a/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
@@ -52,8 +52,8 @@ Feature: Advocate admin submits a claim for a Trial case
     And I should see a page title "Enter graduated fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
-    And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
-    And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended
+    And I add a govuk calculated miscellaneous fee 'Special preparation fee' with dates attended
+    And I add a govuk calculated miscellaneous fee 'Noting brief fee' with dates attended
     And I check the section heading to be "2"
 
     And I eject the VCR cassette

--- a/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_claim_draft_edit_submit.feature
@@ -44,8 +44,8 @@ Feature: Advocate partially fills out a draft claim for a trial, then later edit
     And I select the govuk field 'Daily attendance fee (3 to 40)' basic fee with quantity of 4
 
     Then I click "Continue" in the claim form
-    And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
-    And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended
+    And I add a govuk calculated miscellaneous fee 'Special preparation fee' with dates attended
+    And I add a govuk calculated miscellaneous fee 'Noting brief fee' with dates attended
 
     And I eject the VCR cassette
 

--- a/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_fixed_fee_claim_submit.feature
@@ -44,7 +44,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against sentence)
     And I should see a page title "Enter fixed fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
-    And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended
+    And I add a govuk calculated miscellaneous fee 'Special preparation fee' with dates attended
     Then the last 'miscellaneous' fee rate should be populated with '39.00'
 
     And I eject the VCR cassette

--- a/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
@@ -45,7 +45,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
 
-    And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
+    And I add a govuk calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
     Then the last 'miscellaneous' fee rate should be populated with '108.00'
 
     And I eject the VCR cassette

--- a/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
@@ -50,8 +50,8 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I should see a page title "Enter graduated fees for advocate final fees claim"
     Then I click "Continue" in the claim form
 
-    And I add a calculated miscellaneous fee 'Special preparation fee' with dates attended '2018-04-01'
-    And I add a calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
+    And I add a govuk calculated miscellaneous fee 'Special preparation fee' with dates attended '2018-04-01'
+    And I add a govuk calculated miscellaneous fee 'Noting brief fee' with dates attended '2018-04-01'
     And I check the section heading to be "2"
 
     And I eject the VCR cassette

--- a/features/claims/advocate/scheme_twelve/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_twelve/advocate_trial_claim_edit_submit.feature
@@ -37,12 +37,12 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     Then I should be in the 'Miscellaneous fees' form page
     And I should see 'This claim should be eligible for unused materials fees (up to 3 hours)'
 
-    When I add a calculated miscellaneous fee 'Unused materials (up to 3 hours)'
-    And I add a calculated miscellaneous fee 'Unused materials (over 3 hours)' with quantity of '5'
+    When I add a govuk calculated miscellaneous fee 'Unused materials (up to 3 hours)'
+    And I add a govuk calculated miscellaneous fee 'Unused materials (over 3 hours)' with quantity of '5'
     And I should see 'You need to add a separate "Unused material (up to 3 hours)" fee for the first 3 hours'
-    And I add a calculated miscellaneous fee 'Paper heavy case'
-    And I add a calculated miscellaneous fee 'Deferred sentence hearings'
-    Then the following fee details should exist:
+    And I add a govuk calculated miscellaneous fee 'Paper heavy case'
+    And I add a govuk calculated miscellaneous fee 'Deferred sentence hearings'
+    Then the following govuk fee details should exist:
       | section | fee_description | rate | hint | help |
       | miscellaneous | Unused materials (up to 3 hours) | 59.09 | Number of hours | true |
       | miscellaneous | Unused materials (over 3 hours) | 39.39 | Number of hours | true |

--- a/features/fee_calculator/advocate/misc_fee_calculator.feature
+++ b/features/fee_calculator/advocate/misc_fee_calculator.feature
@@ -29,18 +29,18 @@ Feature: Advocate completes misc fee page using calculator
 
     Then I click "Continue" in the claim form
 
-    When I add a calculated miscellaneous fee 'Wasted preparation fee'
-    And I add a calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '2'
-    And I add a calculated miscellaneous fee 'Hearings relating to disclosure (whole day uplift)' with quantity of '2'
+    When I add a govuk calculated miscellaneous fee 'Wasted preparation fee'
+    And I add a govuk calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '2'
+    And I add a govuk calculated miscellaneous fee 'Hearings relating to disclosure (whole day uplift)' with quantity of '2'
 
-    Then the following fee details should exist:
+    Then the following govuk fee details should exist:
       | section | fee_description | rate | hint | help |
       | miscellaneous | Wasted preparation fee | 74.00 | Number of hours | true |
       | miscellaneous | Hearings relating to disclosure (whole day) | 497.00 | Number of days | true |
       | miscellaneous | Hearings relating to disclosure (whole day uplift) | 198.80 | Number of additional defendants | true |
 
-    When I amend the miscellaneous fee 'Hearings relating to disclosure (whole day)' to have a quantity of '3'
-    Then the following fee details should exist:
+    When I amend the govuk miscellaneous fee 'Hearings relating to disclosure (whole day)' to have a quantity of '3'
+    Then the following govuk fee details should exist:
       | section | fee_description | rate | hint | help |
       | miscellaneous | Wasted preparation fee | 74.00 | Number of hours | true |
       | miscellaneous | Hearings relating to disclosure (whole day) | 497.00 | Number of days | true |

--- a/features/page_objects/sections/lgfs_misc_fee_section.rb
+++ b/features/page_objects/sections/lgfs_misc_fee_section.rb
@@ -1,7 +1,7 @@
 require_relative 'radio_section'
 
 class FeeTypeSection < SitePrism::Section
-  sections :radios, RadioSection, '.multiple-choice'
+  sections :radios, RadioSection, '.govuk-radios__item'
 
   def radio_labels
     radios.map { |radio| radio.label.text.gsub(/\n(.*)/, '') }

--- a/features/page_objects/sections/miscellaneous_fee_section.rb
+++ b/features/page_objects/sections/miscellaneous_fee_section.rb
@@ -1,15 +1,15 @@
 require_relative 'checkbox_fee_section'
 
 class MiscellaneousFeeSection < CheckboxFeeSection
-  section :confiscation_hearings_half_day_uplift, FixedFeeCaseNumbersSection, "#confiscation-hearings-half-day-uplift > .misc-fee-group"
-  section :confiscation_hearings_half_day, FeeSection, "#confiscation-hearings-half-day > .misc-fee-group"
-  section :confiscation_hearings_whole_day_uplift, FeeSection, "#confiscation-hearings-whole-day-uplift > .misc-fee-group"
-  section :confiscation_hearings_whole_day, FeeSection, "#confiscation-hearings-whole-day > .misc-fee-group"
-  section :deferred_sentence_hearings_uplift, FeeSection, "#deferred-sentence-hearings-uplift > .misc-fee-group"
-  section :deferred_sentence_hearings, FeeSection, "#deferred-sentence-hearings > .misc-fee-group"
-  section :plea_and_trial_preparation_hearing, FeeSection, "#plea-and-trial-preparation-hearing > .misc-fee-group"
-  section :special_preparation_fee, FeeSection, "#special-preparation-fee > .misc-fee-group"
-  section :standard_appearance_fee_uplift, FeeSection, "#standard-appearance-fee-uplift > .misc-fee-group"
-  section :standard_appearance_fee, FeeSection, "#standard-appearance-fee > .misc-fee-group"
-  section :wasted_preparation_fee, FeeSection, "#wasted-preparation-fee > .misc-fee-group"
+  section :confiscation_hearings_half_day_uplift, FixedFeeCaseNumbersSection, "[data-target = 'confiscation-hearings-half-day-uplift'] .misc-fee-group"
+  section :confiscation_hearings_half_day, FeeSection, "[data-target = 'confiscation-hearings-half-day'] .misc-fee-group"
+  section :confiscation_hearings_whole_day_uplift, FeeSection, "[data-target = 'confiscation-hearings-whole-day-uplift'] .misc-fee-group"
+  section :confiscation_hearings_whole_day, FeeSection, "[data-target = 'confiscation-hearings-whole-day'] .misc-fee-group"
+  section :deferred_sentence_hearings_uplift, FeeSection, "[data-target = 'deferred-sentence-hearings-uplift'] .misc-fee-group"
+  section :deferred_sentence_hearings, FeeSection, "[data-target = 'deferred-sentence-hearings > .misc-fee-group"
+  section :plea_and_trial_preparation_hearing, FeeSection, "[data-target = 'plea-and-trial-preparation-hearing'] .misc-fee-group"
+  section :special_preparation_fee, FeeSection, "[data-target = 'special-preparation-fee'] .misc-fee-group"
+  section :standard_appearance_fee_uplift, FeeSection, "[data-target = 'standard-appearance-fee-uplift'] .misc-fee-group"
+  section :standard_appearance_fee, FeeSection, "[data-target = 'standard-appearance-fee'] .misc-fee-group"
+  section :wasted_preparation_fee, FeeSection, "[data-target = 'wasted-preparation-fee'] .misc-fee-group"
 end

--- a/features/page_objects/sections/typed_fee_section.rb
+++ b/features/page_objects/sections/typed_fee_section.rb
@@ -1,6 +1,8 @@
 class TypedFeeSection < SitePrism::Section
   sections :select_options, "select.js-fee-type > option" do end
   element :select_input, "input.tt-input", visible: true
+  section :govuk_fee_type_autocomplete, CommonAutocomplete, ".cc-fee-type"
+  element :govuk_fee_type_autocomplete_input, ".cc-fee-type input", visible: true
   element :quantity, "input.quantity"
   element :quantity_hint, ".quantity_wrapper .govuk-hint"
   element :calc_help_text, ".fee-calc-help-wrapper"
@@ -24,5 +26,9 @@ class TypedFeeSection < SitePrism::Section
 
   def populated?
     select_input.value.present?
+  end
+
+  def govuk_element_populated?
+    govuk_fee_type_autocomplete_input.value.present?
   end
 end

--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -80,11 +80,11 @@ end
 RSpec.shared_examples 'common LGFS amount govuk validations' do
   describe '#validate_amount' do
     let(:amount_error_message) do
-      'Enter a valid amount for the (.*?)(graduated|hardship|interim|transfer|warrant) fee'
+      'Enter a valid amount for the (.*?)(graduated|hardship|interim|miscellaneous|transfer|warrant) fee'
     end
 
     let(:amount_max_limit_error_message) do
-      'The amount for the (.*?)(graduated|hardship|interim|transfer|warrant) fee exceeds the limit'
+      'The amount for the (.*?)(graduated|hardship|interim|miscellaneous|transfer|warrant) fee exceeds the limit'
     end
 
     it 'adds error if amount is blank' do

--- a/spec/validators/claim/shared_examples_for_step_validators.rb
+++ b/spec/validators/claim/shared_examples_for_step_validators.rb
@@ -86,12 +86,16 @@ RSpec.shared_examples 'common partial association validations' do |steps|
           end
 
           association_name = association_data[:name]
+          association_misc_fees = :misc_fees
           it "validates has_many association #{association_name} just for the #{step_name} step" do
             claim.form_step = step_name
             expect_any_instance_of(described_class).to receive(:validate_collection_for).with(claim, association_name)
-
             if association_data[:options] && association_data[:options][:presence]
-              expect_any_instance_of(described_class).to receive(:validate_presence).with(association_name, 'blank')
+              if association_name == association_misc_fees
+                expect_any_instance_of(described_class).to receive(:validate_presence).with(association_name, :blank)
+              else
+                expect_any_instance_of(described_class).to receive(:validate_presence).with(association_name, 'blank')
+              end
             end
 
             claim.valid?

--- a/spec/validators/date_attended_validator_spec.rb
+++ b/spec/validators/date_attended_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DateAttendedValidator, type: :validator do
 
   context 'date' do
     it { should_error_if_not_present(date_attended, :date, 'Enter the date attended') }
-    it { should_error_if_before_specified_date(date_attended, :date, earliest_reporder_date - 2.years - 1.day, 'The fixed fee date cannot not be more than two years before the earliest representation order date') }
+    it { should_error_if_before_specified_date(date_attended, :date, earliest_reporder_date - 2.years - 1.day, 'The fee date cannot not be more than two years before the earliest representation order date') }
     it { should_error_if_too_far_in_the_past(date_attended, :date, 'Enter a date later than two years before the earliest representation order date') }
     it { should_error_if_in_future(date_attended, :date, 'Enter a date that is not in the future') }
 

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
         end
       end
 
-      it { should_error_if_not_present(fee, :fee_type, 'blank') }
+      it { should_error_if_not_present(fee, :fee_type, 'Choose a type for the miscellaneous fee') }
 
       context 'when validating Unused material (up to 3 hours)' do
         before { create(:misc_fee_type, :miumu) }
@@ -141,7 +141,7 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       end
     end
 
-    include_examples 'common LGFS amount validations'
+    include_examples 'common LGFS amount govuk validations'
 
     context 'override validation of fields from the superclass validator' do
       let(:superclass) { described_class.superclass }
@@ -174,11 +174,11 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       end
 
       it 'will error if passed a decimal amount' do
-        should_error_if_equal_to_value(fee, :amount, '45.10', 'incorrect_epf')
+        should_error_if_equal_to_value(fee, :amount, '45.10', 'Evidence provision fee can only be £45 or £90')
       end
 
       it 'will error is passed a zero amount' do
-        should_error_if_equal_to_value(fee, :amount, '0', 'incorrect_epf')
+        should_error_if_equal_to_value(fee, :amount, '0', 'Evidence provision fee can only be £45 or £90')
       end
     end
 

--- a/spec/validators/interim_claim_info_validator_spec.rb
+++ b/spec/validators/interim_claim_info_validator_spec.rb
@@ -29,19 +29,19 @@ RSpec.describe InterimClaimInfoValidator, type: :validator do
       it 'is invalid if present and too far in the past' do
         info.warrant_issued_date = 11.years.ago
         expect(info).to_not be_valid
-        expect(info.errors[:warrant_issued_date]).to include 'check_not_too_far_in_past'
+        expect(info.errors[:warrant_issued_date]).to include 'Warrant issued date cannot be too far in the past'
       end
 
       it 'is invalid if present and in the future' do
         info.warrant_issued_date = 3.days.from_now
         expect(info).not_to be_valid
-        expect(info.errors[:warrant_issued_date]).to include 'check_not_in_future'
+        expect(info.errors[:warrant_issued_date]).to include 'Warrant issued date cannot be too far in the future'
       end
 
       it 'is invalid if not present' do
         info.warrant_issued_date = nil
         expect(info).not_to be_valid
-        expect(info.errors[:warrant_issued_date]).to eq(['blank'])
+        expect(info.errors[:warrant_issued_date]).to include 'Enter a warrant issued date'
       end
     end
 
@@ -49,25 +49,25 @@ RSpec.describe InterimClaimInfoValidator, type: :validator do
       it 'is invalid if before warrant_issued_date' do
         info.warrant_executed_date = info.warrant_issued_date - 1.day
         expect(info).not_to be_valid
-        expect(info.errors[:warrant_executed_date]).to eq(['warrant_executed_before_issued'])
+        expect(info.errors[:warrant_executed_date]).to include 'The warrant executed date is before the issued date'
       end
 
       it 'is invalid if present and too far in the past' do
         info.warrant_executed_date = 11.years.ago
         expect(info).to_not be_valid
-        expect(info.errors[:warrant_executed_date]).to include 'check_not_too_far_in_past'
+        expect(info.errors[:warrant_executed_date]).to include 'Warrant executed date cannot be too far in the past'
       end
 
       it 'is invalid if in future' do
         info.warrant_executed_date = 3.days.from_now
         expect(info).not_to be_valid
-        expect(info.errors[:warrant_executed_date]).to include 'check_not_in_future'
+        expect(info.errors[:warrant_executed_date]).to include 'Warrant executed date cannot be too far in the future'
       end
 
       it 'is invalid if absent' do
         info.warrant_executed_date = nil
         expect(info).not_to be_valid
-        expect(info.errors[:warrant_executed_date]).to include 'blank'
+        expect(info.errors[:warrant_executed_date]).to include 'Enter a warrant executed date'
       end
 
       it 'is valid if present and in the past' do


### PR DESCRIPTION
What
Migrate external_users form step: miscellaneous_fees form

Ticket
[FormBuilder migration - Miscellaneous fees](https://dsdmoj.atlassian.net/browse/CFP-67)

Why
- Update the service to use GOV.UK styles, components and patterns
- To improve and resolve the service's accessibility issues
- To reduce code complexity
- To improve maintainability

--------

#### TODO

 - [x] Migrate LGFS View
 - [x] Migrate LGFS View - Warrant fees partial
 - [x] Migrate AGFS View
 - [x] Migrate AGFS View - Supplementary view
 - [ ] Fix error message in Type of Fees

