### PR TITLE
Update #data_item_for to return DataItem instance

### DIFF
--- a/app/models/claim/transfer_brain.rb
+++ b/app/models/claim/transfer_brain.rb
@@ -73,10 +73,6 @@ module Claim
       CASE_CONCLUSIONS[detail.case_conclusion_id]
     end
 
-    def self.details_combo_valid?(detail)
-      TransferBrain::DataItemCollection.instance.detail_valid?(detail) unless detail.errors?
-    end
-
     def self.data_attributes
       TransferBrain::DataItemCollection.instance.to_json.chomp
     end

--- a/app/models/claim/transfer_brain/data_item.rb
+++ b/app/models/claim/transfer_brain/data_item.rb
@@ -27,7 +27,7 @@ module Claim
       end
 
       def litigator_type=(value)
-        @litigator_type = value.downcase
+        @litigator_type = value&.downcase
       end
 
       def elected_case=(value)

--- a/app/models/claim/transfer_brain/data_item.rb
+++ b/app/models/claim/transfer_brain/data_item.rb
@@ -43,10 +43,20 @@ module Claim
         @case_conclusion_id = value.blank? ? '*' : TransferBrain.case_conclusion_id(value)
         @conclusion = value
       end
+      alias case_conclusion= conclusion=
 
       def valid=(value)
         @validity = ActiveModel::Type::Boolean.new.cast(value)
         @valid = value
+      end
+
+      def ==(other)
+        return false unless litigator_type == other.litigator_type
+        return false unless elected_case == other.elected_case
+        return false unless transfer_stage_id == other.transfer_stage_id
+        return false unless elected_case || conclusion == other.conclusion
+
+        true
       end
     end
   end

--- a/app/models/claim/transfer_brain/data_item_collection.rb
+++ b/app/models/claim/transfer_brain/data_item_collection.rb
@@ -34,18 +34,21 @@ module Claim
       end
 
       def valid_transfer_stage_ids(litigator_type, elected_case)
-        transfer_stages = collection_hash.fetch(litigator_type).fetch(elected_case)
-        ids = []
-        transfer_stages.each do |transfer_stage_id, result_hash|
-          result_hash.each_value do |result|
-            ids << transfer_stage_id if result[:validity] == true
-          end
+        valid_data_items = data_items.select do |item|
+          item.litigator_type == litigator_type &&
+            item.elected_case == elected_case &&
+            item.validity
         end
+        ids = valid_data_items.map(&:transfer_stage_id)
         ids.uniq.sort
       end
 
       def valid_case_conclusion_ids(litigator_type, elected_case, transfer_stage_id)
-        result = collection_hash.fetch(litigator_type).fetch(elected_case).fetch(transfer_stage_id).keys
+        result = data_items.select do |item|
+          item.litigator_type == litigator_type &&
+            item.elected_case == elected_case &&
+            item.transfer_stage_id == transfer_stage_id
+        end.map(&:case_conclusion_id)
         result = TransferBrain.case_conclusion_ids if result == ['*']
         result.sort
       end

--- a/app/models/claim/transfer_brain/data_item_collection.rb
+++ b/app/models/claim/transfer_brain/data_item_collection.rb
@@ -30,7 +30,7 @@ module Claim
         return false if detail.unpopulated?
         data_item = data_item_for(detail)
         return false if data_item.nil?
-        data_item[:validity]
+        data_item.validity
       end
 
       def valid_transfer_stage_ids(litigator_type, elected_case)
@@ -51,28 +51,11 @@ module Claim
       end
 
       def data_item_for(detail)
-        specific_mapping_for(detail) || wildcard_mapping_for(detail)
+        seek = DataItem.new(detail.slice(:litigator_type, :elected_case, :transfer_stage_id, :case_conclusion))
+        data_items.find { |item| item == seek }
       end
 
       private
-
-      def specific_mapping_for(detail)
-        collection_hash.dig(
-          detail.litigator_type,
-          detail.elected_case,
-          detail.transfer_stage_id,
-          detail.case_conclusion_id
-        )
-      end
-
-      def wildcard_mapping_for(detail)
-        collection_hash.dig(
-          detail.litigator_type,
-          detail.elected_case,
-          detail.transfer_stage_id,
-          '*'
-        )
-      end
 
       def csv
         @csv ||= begin

--- a/app/models/claim/transfer_brain/data_item_delegatable.rb
+++ b/app/models/claim/transfer_brain/data_item_delegatable.rb
@@ -8,7 +8,7 @@ module Claim
           method_names.each do |method_name|
             define_method(method_name) do |detail|
               return unless detail_valid?(detail)
-              data_item_for(detail)[method_name.to_sym]
+              data_item_for(detail).send(method_name.to_sym)
             end
           end
         end

--- a/spec/models/claim/transfer_brain/data_item_collection_spec.rb
+++ b/spec/models/claim/transfer_brain/data_item_collection_spec.rb
@@ -187,6 +187,87 @@ RSpec.describe Claim::TransferBrain::DataItemCollection do
 
       it { is_expected.to be true }
     end
+
+    context 'with new litigator on an elected case' do
+      let(:detail) do
+        build(
+          :transfer_detail,
+          litigator_type: 'new',
+          elected_case: true,
+          case_conclusion_id: 10,
+          transfer_stage_id:
+        )
+      end
+
+      context 'when "Up to and including PCMH transfer"' do
+        let(:transfer_stage_id) { 10 }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when "During trial transfer"' do
+        let(:transfer_stage_id) { 20 }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when "During trial transfer"' do
+        let(:transfer_stage_id) { 30 }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when "Transfer after trial and before sentence hearing"' do
+        let(:transfer_stage_id) { 40 }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when "Transfer during retrial"' do
+        let(:transfer_stage_id) { 60 }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when "Transfer after retrial and before sentence hearing"' do
+        let(:transfer_stage_id) { 70 }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context 'with new litigator on a non elected case' do
+      let(:detail) do
+        build(
+          :transfer_detail,
+          litigator_type: 'new',
+          elected_case: false,
+          case_conclusion_id:,
+          transfer_stage_id:
+        )
+      end
+
+      context 'with cracked trial "Before trial transfer"' do
+        let(:case_conclusion_id) { 30 }
+        let(:transfer_stage_id) { 20 }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with retrial "During trial transfer"' do
+        let(:case_conclusion_id) { 20 }
+        let(:transfer_stage_id) { 30 }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with cracked before retrial "Transfer before reretrial"' do
+        let(:case_conclusion_id) { 40 }
+        let(:transfer_stage_id) { 50 }
+
+        it { is_expected.to be_truthy }
+      end
+    end
   end
 
   describe '#valid_transfer_stage_ids' do

--- a/spec/models/claim/transfer_brain/data_item_collection_spec.rb
+++ b/spec/models/claim/transfer_brain/data_item_collection_spec.rb
@@ -131,6 +131,44 @@ RSpec.describe Claim::TransferBrain::DataItemCollection do
         is_expected.to eq 'ST4TS0T3'
       end
     end
+
+    context 'with a scheme 9 claim' do
+      context 'with an "elected case - up to and including PCMH transfer (new)" case' do
+        let(:detail) { build(:transfer_detail, litigator_type: 'new', elected_case: true, transfer_stage_id: 10, case_conclusion_id: nil) }
+
+        it { is_expected.to eq 'ST4TS0T3' }
+      end
+
+      context 'with an "elected case - up to and including PCMH transfer (org)" case' do
+        let(:detail) { build(:transfer_detail, litigator_type: 'original', elected_case: true, transfer_stage_id: 10, case_conclusion_id: nil) }
+
+        it { is_expected.to eq 'ST4TS0T2' }
+      end
+
+      context 'with an "elected case - before trial transfer (new)" case' do
+        let(:detail) { build(:transfer_detail, litigator_type: 'new', elected_case: true, transfer_stage_id: 20, case_conclusion_id: nil) }
+
+        it { is_expected.to eq 'ST4TS0T5' }
+      end
+
+      context 'with an "elected case - before trial transfer (org)" case' do
+        let(:detail) { build(:transfer_detail, litigator_type: 'original', elected_case: true, transfer_stage_id: 20, case_conclusion_id: nil) }
+
+        it { is_expected.to eq 'ST4TS0T4' }
+      end
+
+      context 'with an "elected case - transfer before retrial (new)" case' do
+        let(:detail) { build(:transfer_detail, litigator_type: 'new', elected_case: true, transfer_stage_id: 50, case_conclusion_id: nil) }
+
+        it { is_expected.to eq 'ST4TS0T7' }
+      end
+
+      context 'with an "elected case - transfer before retrial (org)" case' do
+        let(:detail) { build(:transfer_detail, litigator_type: 'original', elected_case: true, transfer_stage_id: 50, case_conclusion_id: nil) }
+
+        it { is_expected.to eq 'ST4TS0T6' }
+      end
+    end
   end
 
   describe '#ppe_required' do

--- a/spec/models/claim/transfer_brain/data_item_collection_spec.rb
+++ b/spec/models/claim/transfer_brain/data_item_collection_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Claim::TransferBrain::DataItemCollection do
       end
     end
 
-    context '@collection_hash' do
-      subject(:collection_hash) { collection.instance_variable_get(:@collection_hash) }
+    context 'collection_hash' do
+      subject(:collection_hash) { collection.send(:collection_hash) }
 
       it 'assigns a hash' do
         is_expected.to be_a Hash

--- a/spec/models/claim/transfer_brain/data_item_collection_spec.rb
+++ b/spec/models/claim/transfer_brain/data_item_collection_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe Claim::TransferBrain::DataItemCollection do
   end
 
   describe '#data_item_for' do
-    subject { collection.data_item_for(detail) }
+    subject(:data_item) { collection.data_item_for(detail) }
 
     context 'when given valid details with a mappable case conclusion id' do
       let(:detail) { with_specific_mapping }
 
       it 'returns a valid data item' do
-        is_expected.to include({ validity: true })
+        expect(data_item.validity).to be_truthy
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Claim::TransferBrain::DataItemCollection do
       let(:detail) { with_wildcard_mapping }
 
       it 'returns a valid data item' do
-        is_expected.to include({ validity: true })
+        expect(data_item.validity).to be_truthy
       end
     end
   end

--- a/spec/models/claim/transfer_brain/data_item_spec.rb
+++ b/spec/models/claim/transfer_brain/data_item_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe Claim::TransferBrain::DataItem do
 
       it { is_expected.to eq 'new' }
     end
+
+    context 'with litigator type missing' do
+      let(:data) { {} }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with litigator type explicitly set to nil' do
+      let(:data) { { litigator_type: nil } }
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '#elected_case' do

--- a/spec/models/claim/transfer_brain_spec.rb
+++ b/spec/models/claim/transfer_brain_spec.rb
@@ -157,27 +157,6 @@ RSpec.describe Claim::TransferBrain do
     end
   end
 
-  describe '.details_combo_valid?' do
-    it 'returns false for invalid combos' do
-      [30, 40, 60, 70].each do |transfer_stage_id|
-        detail = transfer_detail('new', true, transfer_stage_id)
-        expect(described_class.details_combo_valid?(detail)).to be false
-      end
-    end
-
-    it 'returns true for visible combos' do
-      [transfer_detail('new', false, 20, 30), transfer_detail('new', false, 30, 20), transfer_detail('new', false, 50, 40)].each do |detail|
-        expect(described_class.details_combo_valid?(detail)).to be true
-      end
-    end
-
-    it 'returns true for hidden combos' do
-      [transfer_detail('original', false, 70), transfer_detail('original', true, 50), transfer_detail('original', false, 10)].each do |detail|
-        expect(described_class.details_combo_valid?(detail)).to be true
-      end
-    end
-  end
-
   describe '.data_attributes' do
     subject { described_class.data_attributes }
 


### PR DESCRIPTION
#### What

Update #data_item_for to return DataItem instance

#### Ticket

[board ticket description](link)

#### Why

* Make the Transfer Brain cleaner and easier to understand
* Prepare for CLAIR work

#### How

* Add #== method for the DataItem
* Compare equality of DataItem instances to find correct item for a detail

Additionally, some tests for `Claim::TransferBrain::DataItemCollection#bill_scenario` have been added to return the correct bill scenarios for each of the six 'elected case not proceeded' scenarios. When CLAIR is implemented a different bill scenario needs to be returned for the corresponding graduated fee.
