### PR TITLE
Quickfix: remove case conclusion value

### DIFF
--- a/app/webpack/javascripts/modules/external_users/claims/TransferDetailFieldsDisplay.js
+++ b/app/webpack/javascripts/modules/external_users/claims/TransferDetailFieldsDisplay.js
@@ -51,8 +51,8 @@ moj.Modules.TransferDetailFieldsDisplay = {
     if (toggle) {
       $(this.caseConclusionSelect).removeClass('hidden')
     } else {
-      $(this.caseConclusionSelect + 'select').prop('selectedIndex', 0) // reset actual select list value
-      $('#claim_case_conclusion_id_input').val('') // reset awesomplete displayed value
+      $(this.caseConclusionSelect + ' select').prop('selectedIndex', 0) // reset actual select list value
+      $(this.caseConclusionSelect + ' .autocomplete__input').val('') // reset autocomplete displayed value
       $(this.caseConclusionSelect).addClass('hidden')
     }
   },


### PR DESCRIPTION
#### What

Fix Transfer details Javascript to remove value from hidden input

#### Ticket

n/a

#### Why

When signed in as an LGFS user and completing a Transfer fee claim, while editing the transfer details form step and toggling the visual state of the input `How did the case conclude?`, the validation is off.

If you edit the transfer details of an LGFS transfer claim and change from ‘new’ litigator type to ‘original’ you get a ‘Do not enter a case conclusion’ error when you try to save and continue.

