### PR TITLE
[CFP-658] Remove duplicate shared examples for fee validators

### DIFF
--- a/spec/support/shared_examples_for_fee_validators.rb
+++ b/spec/support/shared_examples_for_fee_validators.rb
@@ -5,33 +5,6 @@
 
 RSpec.shared_examples 'common LGFS fee date validations' do
   describe '#validate_date' do
-    it { should_error_if_not_present(fee, :date, 'blank') }
-
-    it 'adds error if too far in the past' do
-      fee.date = 11.years.ago
-      expect(fee).to_not be_valid
-      expect(fee.errors[:date]).to include 'check_not_too_far_in_past'
-    end
-
-    it 'adds error if in the future' do
-      fee.date = 3.days.from_now
-      expect(fee).not_to be_valid
-      expect(fee.errors[:date]).to include 'check_not_in_future'
-    end
-
-    it 'adds error if before the first repo order date' do
-      allow(claim).to receive(:earliest_representation_order_date).and_return(Date.today)
-      allow(fee).to receive(:claim).and_return(claim)
-
-      fee.date = Date.today - 3.days
-      expect(fee).not_to be_valid
-      expect(fee.errors[:date]).to include 'too_long_before_earliest_reporder'
-    end
-  end
-end
-
-RSpec.shared_examples 'common LGFS fee date govuk validations' do
-  describe '#validate_date' do
     it { should_error_if_not_present(fee, :date, 'Enter the (.*?)(fixed|graduated) fee date') }
 
     it 'adds error if too far in the past' do
@@ -58,26 +31,6 @@ RSpec.shared_examples 'common LGFS fee date govuk validations' do
 end
 
 RSpec.shared_examples 'common LGFS amount validations' do
-  describe '#validate_amount' do
-    it 'adds error if amount is blank' do
-      should_error_if_equal_to_value(fee, :amount, '', 'numericality')
-    end
-
-    it 'adds error if amount is equal to zero' do
-      should_error_if_equal_to_value(fee, :amount, 0.00, 'numericality')
-    end
-
-    it 'adds error if amount is less than zero' do
-      should_error_if_equal_to_value(fee, :amount, -10.00, 'numericality')
-    end
-
-    it 'adds error if amount is greater than the max limit' do
-      should_error_if_equal_to_value(fee, :amount, 200_001, 'item_max_amount')
-    end
-  end
-end
-
-RSpec.shared_examples 'common LGFS amount govuk validations' do
   describe '#validate_amount' do
     let(:amount_error_message) do
       'Enter a valid amount for the (.*?)(graduated|hardship|interim|miscellaneous|transfer|warrant) fee'

--- a/spec/validators/fee/fixed_fee_validator_spec.rb
+++ b/spec/validators/fee/fixed_fee_validator_spec.rb
@@ -110,6 +110,6 @@ RSpec.describe Fee::FixedFeeValidator, type: :validator do
       end
     end
 
-    include_examples 'common LGFS fee date govuk validations'
+    include_examples 'common LGFS fee date validations'
   end
 end

--- a/spec/validators/fee/graduated_fee_validator_spec.rb
+++ b/spec/validators/fee/graduated_fee_validator_spec.rb
@@ -100,6 +100,6 @@ RSpec.describe Fee::GraduatedFeeValidator, type: :validator do
     end
   end
 
-  include_examples 'common LGFS amount govuk validations'
-  include_examples 'common LGFS fee date govuk validations'
+  include_examples 'common LGFS amount validations'
+  include_examples 'common LGFS fee date validations'
 end

--- a/spec/validators/fee/hardship_fee_validator_spec.rb
+++ b/spec/validators/fee/hardship_fee_validator_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe Fee::HardshipFeeValidator, type: :validator do
       end
     end
 
-    include_examples 'common LGFS amount govuk validations'
+    include_examples 'common LGFS amount validations'
   end
 end

--- a/spec/validators/fee/interim_fee_validator_spec.rb
+++ b/spec/validators/fee/interim_fee_validator_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Fee::InterimFeeValidator, type: :validator do
   end
 
   describe '#validate_amount' do
-    include_examples 'common LGFS amount govuk validations'
+    include_examples 'common LGFS amount validations'
 
     context 'disbursement fee' do
       it 'is invalid if present' do

--- a/spec/validators/fee/misc_fee_validator_spec.rb
+++ b/spec/validators/fee/misc_fee_validator_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Fee::MiscFeeValidator, type: :validator do
       end
     end
 
-    include_examples 'common LGFS amount govuk validations'
+    include_examples 'common LGFS amount validations'
 
     context 'override validation of fields from the superclass validator' do
       let(:superclass) { described_class.superclass }

--- a/spec/validators/fee/transfer_fee_validator_spec.rb
+++ b/spec/validators/fee/transfer_fee_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Fee::TransferFeeValidator, type: :validator do
     end
   end
 
-  include_examples 'common LGFS amount govuk validations'
+  include_examples 'common LGFS amount validations'
 
   describe 'absence of unnecessary attributes' do
     it 'validates absence of warrant issued date' do

--- a/spec/validators/fee/warrant_fee_validator_spec.rb
+++ b/spec/validators/fee/warrant_fee_validator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Fee::WarrantFeeValidator, type: :validator do
     allow(fee).to receive(:perform_validation?).and_return(true)
   end
 
-  include_examples 'common LGFS amount govuk validations'
+  include_examples 'common LGFS amount validations'
   include_examples 'common warrant fee validations'
 
   describe '#validate_warrant_issued_date' do


### PR DESCRIPTION
#### What

Remove duplicate shared examples for fee validators

#### Ticket

[Remove duplicate shared examples for fee validators](https://dsdmoj.atlassian.net/browse/CFP-658)

#### Why

Duplicate shared examples for fee validators were created to facilitate the FormBuilder migration epic.
This allow us to change the error message format of specs related to migrated fee forms, without breaking the spec of un-migrated fee forms.
Now that we have complete the epic, said duplicates are no longer required.