### PR TITLE
Update packages in docker image

### DIFF
--- a/.github/actions/delete-ecr-images/Dockerfile
+++ b/.github/actions/delete-ecr-images/Dockerfile
@@ -8,7 +8,7 @@ LABEL "com.github.actions.color"="red"
 
 # install dependencies
 
-RUN apk update \
+RUN apk --update-cache upgrade \
     && apk add --no-cache git python3 py3-pip
 
 RUN pip3 install --upgrade pip \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,7 @@ RAILS_ENV=production \
 bundle exec rails assets:precompile 2> /dev/null
 
 # tidy up installation
-RUN apk update && apk del build-dependencies
+RUN apk --update-cache upgrade && apk del build-dependencies
 
 # non-root/appuser should own only what they need to
 RUN chown -R appuser:appgroup log tmp db


### PR DESCRIPTION
#### What

Ensure all packages in docker images are updated to their latest versions.

#### Ticket

[CVE-2022-37434](https://security.snyk.io/vuln/SNYK-ALPINE315-ZLIB-2976173)

#### Why

Executing `apk --update-cache upgrade` when the docker image is built ensures that the most recent versions of all packages are used. `apk update`, as was previously done, will update the index of packages in the repository but will not install any updated versions.

The security alert CVE-2022-37434 indicates that an updated package exists in the repository for the Alpine image but we are not yet using it.

#### How

Replace `apk update` with `apk --update-cache-upgrade` in docker files.