### PR TITLE
[Spike] Allow use of future dates when creating claims

### DIFF
--- a/.k8s/live/api-sandbox/app-config.yaml
+++ b/.k8s/live/api-sandbox/app-config.yaml
@@ -18,3 +18,4 @@ data:
   SETTINGS__AWS__POLL_MESSAGE_WAIT_TIME: '10'
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
+  ALLOW_FUTURE_DATES: 'false'

--- a/.k8s/live/dev-lgfs/app-config.yaml
+++ b/.k8s/live/dev-lgfs/app-config.yaml
@@ -18,3 +18,4 @@ data:
   SETTINGS__AWS__POLL_MESSAGE_WAIT_TIME: '10'
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
+  ALLOW_FUTURE_DATES: 'true'

--- a/.k8s/live/dev/app-config.yaml
+++ b/.k8s/live/dev/app-config.yaml
@@ -18,3 +18,4 @@ data:
   SETTINGS__AWS__POLL_MESSAGE_WAIT_TIME: '10'
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
+  ALLOW_FUTURE_DATES: 'false'

--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -20,3 +20,4 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   SURVEY_MONKEY_COLLECTOR_ID: '330140894'
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
+  ALLOW_FUTURE_DATES: 'false'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -20,3 +20,4 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   # SURVEY_MONKEY_COLLECTOR_ID: '330142588'
   LAA_FEE_CALCULATOR_HOST: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
+  ALLOW_FUTURE_DATES: 'false'

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -157,6 +157,10 @@ class BaseValidator < ActiveModel::Validator
     compare_date_with_attribute(date, attribute, message, :>=)
   end
 
+  def validate_not_in_future(attribute)
+    validate_on_or_before(Time.zone.today, attribute, :check_not_in_future)
+  end
+
   def validate_has_role(object, role_or_roles, error_message_key, error_message)
     return if object.nil?
 

--- a/app/validators/base_validator.rb
+++ b/app/validators/base_validator.rb
@@ -158,7 +158,7 @@ class BaseValidator < ActiveModel::Validator
   end
 
   def validate_not_in_future(attribute)
-    validate_on_or_before(Time.zone.today, attribute, :check_not_in_future)
+    validate_on_or_before(Time.zone.today, attribute, :check_not_in_future) unless allow_future_dates
   end
 
   def validate_has_role(object, role_or_roles, error_message_key, error_message)
@@ -237,5 +237,11 @@ class BaseValidator < ActiveModel::Validator
   def looks_like_a_case_number?(attribute)
     return if attr_blank?(attribute)
     @record.__send__(attribute).match?(CASE_NUMBER_OR_URN_PATTERN)
+  end
+
+  def allow_future_dates
+    return false if ENV.fetch('ENV', nil).eql?('production')
+
+    ActiveRecord::Type::Boolean.new.cast(ENV.fetch('ALLOW_FUTURE_DATES', nil))
   end
 end

--- a/app/validators/certification_validator.rb
+++ b/app/validators/certification_validator.rb
@@ -19,6 +19,6 @@ class CertificationValidator < BaseValidator
   def validate_certification_date
     validate_presence(:certification_date, :blank)
     validate_on_or_after(@record.claim&.created_at, :certification_date, :after_claim_creation)
-    validate_on_or_before(Date.today, :certification_date, :not_in_the_future)
+    validate_not_in_future(:certification_date)
   end
 end

--- a/app/validators/claim/advocate_hardship_claim_validator.rb
+++ b/app/validators/claim/advocate_hardship_claim_validator.rb
@@ -83,7 +83,7 @@ class Claim::AdvocateHardshipClaimValidator < Claim::BaseClaimValidator
     validate_numericality(:retrial_actual_length, :invalid, 0, nil)
     validate_presence(:retrial_started_at, :blank)
     validate_too_far_in_past(:retrial_started_at)
-    validate_on_or_before(Date.today, :retrial_started_at, :check_not_in_future)
+    validate_not_in_future(:retrial_started_at)
     validate_on_or_after(@record.trial_concluded_at, :retrial_started_at, :check_not_earlier_than_trial_concluded)
     validate_on_or_after(@record.retrial_started_at, :retrial_concluded_at, :check_other_date)
     validate_on_or_before(@record.retrial_concluded_at, :retrial_started_at, :check_other_date)

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -181,7 +181,7 @@ class Claim::BaseClaimValidator < BaseValidator
   def validate_trial_fixed_notice_at
     return unless @record.case_type && @record.requires_cracked_dates?
     validate_presence(:trial_fixed_notice_at, :blank)
-    validate_on_or_before(Date.today, :trial_fixed_notice_at, :check_not_in_future)
+    validate_not_in_future(:trial_fixed_notice_at)
     validate_presence(:trial_fixed_notice_at, :blank)
     validate_too_far_in_past(:trial_fixed_notice_at)
     validate_before(@record.trial_fixed_at&.ago(1.day), :trial_fixed_notice_at, :check_before_trial_fixed_at)
@@ -212,7 +212,7 @@ class Claim::BaseClaimValidator < BaseValidator
   def validate_trial_cracked_at
     return if ignore_validation_for_cracked_trials?
     validate_presence(:trial_cracked_at, :blank)
-    validate_on_or_before(Date.today, :trial_cracked_at, :check_not_in_future)
+    validate_not_in_future(:trial_cracked_at)
     validate_too_far_in_past(:trial_cracked_at)
     validate_on_or_after(@record.trial_fixed_notice_at, :trial_cracked_at, :check_after_trial_fixed_notice_at)
   end
@@ -358,10 +358,6 @@ class Claim::BaseClaimValidator < BaseValidator
 
     validate_on_or_after(earliest_rep_order, start_attribute, :check_not_earlier_than_rep_order)
     validate_too_far_in_past(start_attribute)
-  end
-
-  def validate_not_in_future(attribute)
-    validate_on_or_before(Date.today, attribute, :check_not_in_future)
   end
 
   def validate_too_far_in_past(start_attribute)

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -129,7 +129,7 @@ module Claim
     #
     def validate_presence_and_not_in_future(attribute)
       validate_presence(attribute, :blank)
-      validate_on_or_before(Time.zone.today, attribute, :check_not_in_future)
+      validate_not_in_future(attribute)
     end
 
     def validate_presence_and_length(attribute)

--- a/app/validators/claim/litigator_common_validations.rb
+++ b/app/validators/claim/litigator_common_validations.rb
@@ -35,10 +35,8 @@ module Claim
     def validate_case_concluded_at
       validate_presence(:case_concluded_at, :blank)
       validate_on_or_after(Settings.earliest_permitted_date, :case_concluded_at, :check_not_too_far_in_past)
-      validate_on_or_before(Date.today, :case_concluded_at, :check_not_in_future)
+      validate_not_in_future(:case_concluded_at)
     end
-
-    # validate_supplier_number called from ValidateLitigatorSupplierNumber
 
     # local helpers
     # ---------------------------

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -65,7 +65,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
 
   def validate_transfer_date
     validate_presence(:transfer_date, :blank)
-    validate_on_or_before(Date.today, :transfer_date, :check_not_in_future)
+    validate_not_in_future(:transfer_date)
     validate_on_or_after(Settings.earliest_permitted_date, :transfer_date, :check_not_too_far_in_past)
   end
 

--- a/app/validators/date_attended_validator.rb
+++ b/app/validators/date_attended_validator.rb
@@ -18,6 +18,6 @@ class DateAttendedValidator < BaseValidator
       validate_on_or_after(@record.earliest_date_before_reporder - 2.years, :date, :too_long_before_earliest_reporder)
     end
     validate_on_or_after(Settings.earliest_permitted_date, :date, :not_before_earliest_permitted_date)
-    validate_on_or_before(Date.today, :date, :not_after_today)
+    validate_not_in_future(:date)
   end
 end

--- a/app/validators/expense_validator.rb
+++ b/app/validators/expense_validator.rb
@@ -83,7 +83,7 @@ class ExpenseValidator < BaseValidator
 
   def validate_date
     validate_presence(:date, :blank)
-    validate_on_or_before(Date.today, :date, :future)
+    validate_not_in_future(:date)
     validate_on_or_after(@record.claim.try(:earliest_representation_order_date),
                          :date, :check_not_earlier_than_rep_order)
   end

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -149,7 +149,7 @@ module Fee
                            :date,
                            :too_long_before_earliest_reporder)
       validate_on_or_after(Settings.earliest_permitted_date, :date, :check_not_too_far_in_past)
-      validate_on_or_before(Date.today, :date, :check_not_in_future)
+      validate_not_in_future(:date)
     end
 
     # local helpers

--- a/app/validators/fee/graduated_fee_validator.rb
+++ b/app/validators/fee/graduated_fee_validator.rb
@@ -24,7 +24,7 @@ class Fee::GraduatedFeeValidator < Fee::BaseFeeValidator
                          :date,
                          :too_long_before_earliest_reporder)
     validate_on_or_after(Settings.earliest_permitted_date, :date, :check_not_too_far_in_past)
-    validate_on_or_before(Time.zone.today, :date, :check_not_in_future)
+    validate_not_in_future(:date)
   end
 
   def validate_quantity

--- a/app/validators/fee/graduated_fee_validator.rb
+++ b/app/validators/fee/graduated_fee_validator.rb
@@ -18,15 +18,6 @@ class Fee::GraduatedFeeValidator < Fee::BaseFeeValidator
     add_error(:claim, :incompatible_case_type) if @record.claim.case_type&.is_fixed_fee?
   end
 
-  def validate_single_attendance_date
-    validate_presence(:date, :blank)
-    validate_on_or_after(@record.claim.try(:earliest_representation_order_date),
-                         :date,
-                         :too_long_before_earliest_reporder)
-    validate_on_or_after(Settings.earliest_permitted_date, :date, :check_not_too_far_in_past)
-    validate_not_in_future(:date)
-  end
-
   def validate_quantity
     validate_numericality(:quantity, :numericality, 0, 99_999)
   end

--- a/app/validators/fee/interim_fee_validator.rb
+++ b/app/validators/fee/interim_fee_validator.rb
@@ -45,13 +45,13 @@ class Fee::InterimFeeValidator < Fee::BaseFeeValidator
     return unless @record.is_interim_warrant?
     validate_presence(:warrant_issued_date, :blank)
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, :check_not_too_far_in_past)
-    validate_on_or_before(Date.today, :warrant_issued_date, :check_not_in_future)
+    validate_not_in_future(:warrant_issued_date)
   end
 
   def validate_warrant_executed_date
     return unless @record.is_interim_warrant?
     validate_on_or_after(@record.warrant_issued_date, :warrant_executed_date, :warrant_executed_before_issued)
-    validate_on_or_before(Date.today, :warrant_executed_date, :check_not_in_future)
+    validate_not_in_future(:warrant_executed_date)
   end
 
   private

--- a/app/validators/fee/warrant_fee_validator.rb
+++ b/app/validators/fee/warrant_fee_validator.rb
@@ -5,7 +5,7 @@ class Fee::WarrantFeeValidator < Fee::BaseFeeValidator
     validate_presence(:warrant_issued_date, :blank)
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, :check_not_too_far_in_past)
     return if @record.warrant_issued_date.nil?
-    validate_on_or_before(Date.today, :warrant_issued_date, :check_not_in_future)
+    validate_not_in_future(:warrant_issued_date)
     validate_on_or_before(MINIMUM_PERIOD_SINCE_ISSUED.ago, :warrant_issued_date, :on_or_before)
     check_date = @record.claim&.earliest_representation_order&.representation_order_date
     validate_on_or_after(check_date, :warrant_issued_date, :check_on_or_after_earliest_representation_order)
@@ -15,7 +15,7 @@ class Fee::WarrantFeeValidator < Fee::BaseFeeValidator
     validate_on_or_after(@record.warrant_issued_date, :warrant_executed_date, :warrant_executed_before_issued)
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_executed_date, :check_not_too_far_in_past)
     return if @record.warrant_executed_date.nil?
-    validate_on_or_before(Date.today, :warrant_executed_date, :check_not_in_future)
+    validate_not_in_future(:warrant_executed_date)
   end
 
   def validate_amount

--- a/app/validators/interim_claim_info_validator.rb
+++ b/app/validators/interim_claim_info_validator.rb
@@ -8,7 +8,7 @@ class InterimClaimInfoValidator < BaseValidator
     validate_presence(:warrant_issued_date, :blank)
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, :check_not_too_far_in_past)
     return if @record.warrant_issued_date.nil?
-    validate_on_or_before(Date.today, :warrant_issued_date, :check_not_in_future)
+    validate_not_in_future(:warrant_issued_date)
   end
 
   def validate_warrant_executed_date
@@ -17,6 +17,6 @@ class InterimClaimInfoValidator < BaseValidator
     validate_on_or_after(@record.warrant_issued_date, :warrant_executed_date, :warrant_executed_before_issued)
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_executed_date, :check_not_too_far_in_past)
     return if @record.warrant_executed_date.nil?
-    validate_on_or_before(Date.today, :warrant_executed_date, :check_not_in_future)
+    validate_not_in_future(:warrant_executed_date)
   end
 end

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -67,7 +67,7 @@ class RepresentationOrderValidator < BaseValidator
     return unless case_type&.requires_maat_reference?
     validate_presence(:maat_reference, :invalid)
     validate_pattern(:maat_reference, Settings.maat_regexp, :invalid)
-    validate_matt_reference_uniqueness(:maat_reference, :unique)
+    validate_maat_reference_uniqueness(:maat_reference, :unique)
   end
 
   # helper methods
@@ -76,7 +76,7 @@ class RepresentationOrderValidator < BaseValidator
     @record.defendant.claim
   end
 
-  def validate_matt_reference_uniqueness(attribute, message)
+  def validate_maat_reference_uniqueness(attribute, message)
     return if attr_blank?(attribute)
     all_maat_references = claim.representation_orders.pluck(:maat_reference)
     add_error(attribute, message) if all_maat_references.count(@record.__send__(attribute)) > 1

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -15,7 +15,7 @@ class RepresentationOrderValidator < BaseValidator
   # must not be earlier than the earliest permitted date
   def validate_representation_order_date
     validate_presence(:representation_order_date, :blank)
-    validate_on_or_before(Date.today, :representation_order_date, :in_future)
+    validate_not_in_future(:representation_order_date)
     validate_on_or_after(earliest_permitted[:date], :representation_order_date, earliest_permitted[:error])
 
     validate_against_agfs_fee_reform_release_date

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -3,6 +3,10 @@ en:
   activerecord:
     errors:
       models:
+        certification:
+          attributes:
+            certification_date:
+              check_not_in_future: Certification date cannot be in the future
         claim/base_claim:
           attributes:
             actual_trial_length:
@@ -134,7 +138,7 @@ en:
           attributes:
             date:
               blank: Enter the date attended
-              not_after_today: Enter a date that is not in the future
+              check_not_in_future: Enter a date that is not in the future
               not_before_earliest_permitted_date: Enter a date later than two years before the earliest representation order date
               too_long_before_earliest_reporder: The fee date cannot not be more than two years before the earliest representation order date
         disbursement:
@@ -165,7 +169,7 @@ en:
             date:
               blank: Enter a date for the expense
               check_not_earlier_than_rep_order: Check the date for the expense
-              future: Date for the expense cannot be in the future
+              check_not_in_future: Date for the expense cannot be in the future
             distance:
               blank: Enter the distance for the expense
               invalid: Enter a valid distance
@@ -394,5 +398,9 @@ en:
               check_on_or_after_earliest_representation_order: Warrant issued date needs to be on or after the earliest representation order date
               on_or_before: Warrant fee cannot be claimed until at least 3 months have passed since warrant was issued
         interim_claim_info: *warrant_fee_errors
+        representation_order:
+          attributes:
+            representation_order_date:
+              check_not_in_future: Representation order date can not be too far in the future
   dictionary:
     enter_valid_quantity: Enter a valid quantity

--- a/spec/validators/representation_order_validator_spec.rb
+++ b/spec/validators/representation_order_validator_spec.rb
@@ -176,6 +176,47 @@ RSpec.describe RepresentationOrderValidator, type: :validator do
         end
       end
     end
+
+    context 'when future dates are allowed' do
+      let(:reporder) { build(:representation_order, defendant:, representation_order_date: rep_order_date) }
+
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('ALLOW_FUTURE_DATES', nil).and_return('true')
+        allow(ENV).to receive(:fetch).with('ENV', nil).and_return('dev')
+      end
+
+      context 'when a future date is entered' do
+        let(:rep_order_date) { 2.days.from_now }
+
+        it { expect(reporder).to be_valid }
+      end
+
+      context 'when a past date is entered' do
+        let(:rep_order_date) { 2.days.ago }
+
+        it { expect(reporder).to be_valid }
+      end
+
+      context 'when on the the production environment' do
+        before do
+          allow(ENV).to receive(:fetch).and_call_original
+          allow(ENV).to receive(:fetch).with('ENV', nil).and_return('production')
+        end
+
+        context 'when a future date is entered' do
+          let(:rep_order_date) { 2.days.from_now }
+
+          it { expect(reporder).not_to be_valid }
+        end
+
+        context 'when a past date is entered' do
+          let(:rep_order_date) { 2.days.ago }
+
+          it { expect(reporder).to be_valid }
+        end
+      end
+    end
   end
 
   context 'for a litigator interim claim' do


### PR DESCRIPTION
#### What

Add a mechanism to temporarily allow the use of future dates when creating claims.

#### Why

There are scenarios where being able to create a future-dated claim would be useful - for example when testing a new fee scheme. At the moment this requires temporary commits/pull requests against both the CCCD and Fee Calculator repos to amend the start date of the scheme, which is risky as there is the potential of accidentally deploying the change to production and also takes more maintenance due to the need to rebase and redeploy frequently.

A better option might be to allow an environment to be temporarily configured to permit claims to be created using future dates. 

#### How

Fee schemes are driven by the representation order date, however many other dates are also validated against being in the future so it is necessary to relax the validation for all such dates.

This pull request take a two-step approach:

1) Adding a new method `validate_not_in_future` to `app/validators/base_validator.rb` and replacing all other calls to `validate_on_or_before(Date.today...` with a call to that method. This also requires some small changes to `config/locales/en/models/claim.yml` to ensure consistency of errors.

2) Adding a clause to that new method to skip the validation if the `ALLOW_FUTURE_DATES` environment variable is true. This can be configured in the `app-config.yaml` file for each environment individually (or in `env.development` for local testing), allowing us to switch the functionality on as required. This PR sets the variable to `true` for `dev` and `false` for all other environments. Additional validation is included to prevent this functioning on production.

