### PR TITLE
[CFP-653] FormBuilder migration - Determinations

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -73,6 +73,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
       :refuse_reason_text,
       :reject_reason_text,
       :additional_information,
+      state_reason: [],
       assessment_attributes: %i[
         id
         fees
@@ -87,7 +88,7 @@ class CaseWorkers::ClaimsController < CaseWorkers::ApplicationController
         disbursements
         vat_amount
       ]
-    ).merge(params.permit(state_reason: []))
+    )
     # the state_reason needs to be merged because the collection_check_boxes control on the view requires
     # a claim object to render.  Because state_reason does not belong to claim, it refuses to render and
     # therefore nil is passed to the object.  This then comes back outside of the claim namespace and has

--- a/app/views/case_workers/claims/_determination_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_fields.html.haml
@@ -1,40 +1,52 @@
 - unless claim.lgfs? && claim.interim? && claim.disbursement_only?
   = govuk_table_row do
     = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
-      = f.label :fees, t('.fees')
+      = t('.fees')
 
     = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
       = claim.fees_total
 
     = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
-      .pound-wrapper
-        = f.text_field :fees, value: number_with_precision(f.object.fees, precision: 2), class: 'form-control js-fees', size: 10, maxlength: 10
-      = validation_error_message(f.object, :fees)
+      = f.govuk_text_field :fees,
+        class: 'js-fees',
+        form_group: { classes: 'govuk-!-margin-bottom-0' },
+        label: { class: 'govuk-visually-hidden', text: t('.fees') },
+        prefix_text: '£',
+        value: number_with_precision(f.object.fees, precision: 2),
+        width: 'one-third'
 
 = govuk_table_row do
   = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
-    = f.label :expenses, t('.expenses')
+    = t('.expenses')
 
   = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.expenses_total
 
   = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
-    .pound-wrapper
-      = f.text_field :expenses, value: number_with_precision(f.object.expenses, precision: 2), class: 'form-control js-expenses', size: 10, maxlength: 10
-    = validation_error_message(f.object, :expenses)
+    = f.govuk_text_field :expenses,
+      class: 'js-expenses',
+      form_group: { classes: 'govuk-!-margin-bottom-0' },
+      label: { class: 'govuk-visually-hidden', text: t('.expenses') },
+      prefix_text: '£',
+      value: number_with_precision(f.object.expenses, precision: 2),
+      width: 'one-third'
 
 - if claim.can_have_disbursements?
   = govuk_table_row do
     = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
-      = f.label :disbursements, t('.disbursements')
+      = t('.disbursements')
 
     = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
       = claim.disbursements_total
 
     = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
-      .pound-wrapper
-        = f.text_field :disbursements, value: number_with_precision(f.object.disbursements, precision: 2), class: 'form-control js-disbursements', size: 10, maxlength: 10
-      = validation_error_message(f.object, :disbursements)
+      = f.govuk_text_field :disbursements,
+        class: 'js-disbursements',
+        form_group: { classes: 'govuk-!-margin-bottom-0' },
+        label: { class: 'govuk-visually-hidden', text: t('.disbursements') },
+        prefix_text: '£',
+        value: number_with_precision(f.object.disbursements, precision: 2),
+        width: 'one-third'
 
 = govuk_table_row do
   = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do

--- a/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
@@ -1,14 +1,18 @@
 = govuk_table_row do
   = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do
-    = f.label :vat_amount, t('.vat')
+    = t('.vat')
 
   = govuk_table_td_numeric('data-label': t('shared.determinations_table.claimed_by', type: claim.external_user_description)) do
     = claim.vat_amount
 
   = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
-    .pound-wrapper
-      = f.text_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control js-lgfs-vat-determination', size: 10, maxlength: 8
-    = validation_error_message(f.object, :vat_amount)
+    = f.govuk_text_field :vat_amount,
+      class: 'js-lgfs-vat-determination',
+      form_group: { classes: 'govuk-!-margin-bottom-0' },
+      label: { class: 'govuk-visually-hidden', text: t('.vat') },
+      prefix_text: '£',
+      value: number_with_precision(f.object.vat_amount, precision: 2),
+      width: 'one-third'
 
 = govuk_table_row do
   = govuk_table_th(scope: 'row', 'data-label': t('shared.description')) do

--- a/app/views/errors/_error_summary.html.haml
+++ b/app/views/errors/_error_summary.html.haml
@@ -1,14 +1,1 @@
-- if ep.errors.any?
-  .error-summary{ role: 'group', 'aria-labelledby': 'error-summary-heading', tabindex:'-1' }
-    %h2.govuk-heading-m.error-summary-heading{id: 'error-summary-heading'}
-      = error_summary
-      = pluralize(ep.errors.count , t('shared.errors.error'))
-
-    %span.form-hint
-      = t('shared.errors.form_error_hint')
-
-    %ul.error-summary-list
-      - ep.errors.each do |error|
-        %li
-          = link_to ['#', error.attribute].join do
-            = ep.errors.full_message(error.attribute, error.message)
+= govuk_error_summary(@claim, :claim, presenter: @error_presenter)

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -1,24 +1,61 @@
-= form_for(claim, url: case_workers_claim_path(claim), as: :claim) do |f|
+= form_with model: claim, authenticity_token: true, builder: GdsAdpFormBuilder, method: :patch, scope: :claim, url: case_workers_claim_path(claim) do |f|
   = hidden_field_tag :messages, 'true'
+
   .fx-assesment-hook
     #claim-status
       %h2#radio-control-heading.govuk-heading-l{ 'aria-describedby': 'radio-control-heading radio-control-legend' }
         = t('.assessment_summary')
 
-
       - if current_user_is_caseworker?
-        .js-cw-claim-action
-          %fieldset.form-group.inline.spacer{ class: error_class?(@error_presenter, :determinations), 'aria-describedby': 'radio-control-legend' }
-            %legend#radio-control-legend.bold-normal.form-label
-              = t('.update_the_claim_status')
-            = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last) do |b|
-              .multiple-choice
-                = b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state]&.to_sym), 'aria-labelledby': "radio-control-legend #{b.text.to_css_class}")
-                = b.label(id: b.text.to_css_class) { b.text }
-            %div
-              = validation_error_message(@error_presenter, :determinations)
+        = f.govuk_radio_buttons_fieldset :determinations,
+          form_group: { classes: 'js-cw-claim-action' },
+          legend: { size: 'm', text: t('.update_the_claim_status') } do
 
-      = govuk_table( id: 'determinations', class: 'js-cw-claim-assessment', data: { apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }) do
+          - claim.valid_transitions_for_detail_form.each_with_index do |state, index|
+            = f.govuk_radio_button :state,
+              state.first,
+              checked: params[:claim].present? && state.first.eql?(params[:claim][:state]&.to_sym),
+              label: { text: state.second }, link_errors: index.zero? do
+
+              - if state.first.to_s.eql?('refused')
+                = f.govuk_check_boxes_fieldset :refused_reason,
+                  form_group: { classes: 'js-cw-claim-refuse-reasonsxx hiddenxx' },
+                  legend: { size: 's', text: t('.reason_for_refusal') } do
+
+                  - ClaimStateTransitionReason.refuse_reasons_for(@claim).each_with_index do |reason, index|
+                    = f.govuk_check_box :state_reason,
+                      reason.code,
+                      checked: params[:claim].present? && params[:claim][:state_reason]&.include?(reason.code),
+                      label: { text: reason.description },
+                      link_errors: index.zero? do
+
+                      - if reason.code.eql?('other_refuse')
+                        = f.govuk_text_field :refuse_reason_text,
+                          form_group: { classes: 'js-refuse-reason-textxx hiddenxx' },
+                          hint: { text: t('.reason_hint') },
+                          label: { text: t('.reason_text') },
+                          width: 'one-half'
+
+              - if state.first.to_s.eql?('rejected')
+                = f.govuk_check_boxes_fieldset :rejected_reason,
+                  form_group: { classes: 'js-cw-claim-rejection-reasonsxx hiddenxx' },
+                  legend: { size: 's', text: t('.reason_for_rejection') } do
+
+                  - ClaimStateTransitionReason.reject_reasons_for(@claim).each_with_index do |reason, index|
+                    = f.govuk_check_box :state_reason,
+                      reason.code,
+                      checked: params[:claim].present? && params[:claim][:state_reason]&.include?(reason.code),
+                      label: { text: reason.description },
+                      link_errors: index.zero? do
+
+                      - if reason.code.eql?('other')
+                        = f.govuk_text_field :reject_reason_text,
+                          form_group: { classes: 'js-reject-reason-textxx hiddenxx' },
+                          hint: { text: t('.reason_hint') },
+                          label: { text: t('.reason_text') },
+                          width: 'one-half'
+
+      = govuk_table( id: 'determinations', class: 'js-cw-claim-assessment app-form-datatable', data: { apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }) do
         = govuk_table_caption(class: 'govuk-visually-hidden') do
           %h3.govuk-heading-m
             = t('.assessment_summary')
@@ -37,74 +74,18 @@
                 .govuk-hint= t('.laa_heading_hint')
 
         = govuk_table_tbody do
-          // CASEWORKER
           - if current_user_is_caseworker? && @claim.enable_assessment_input?
-            // ASSESSMENT INPUT
             = f.fields_for :assessment do |af|
               = render partial: 'case_workers/claims/determination_fields', locals: { f: af, claim: claim }
 
           - elsif current_user_is_caseworker? && @claim.enable_determination_input?
-            // DETERMINATION INPUT
             = f.fields_for :redeterminations, claim.redeterminations.build do |rf|
               = render partial: 'case_workers/claims/determination_fields', locals: { f: rf, claim: claim }
 
           - elsif claim.redeterminations.any?
-            // REDETERMINATION
             = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.redeterminations.last }
 
           - else
-            // ELSE
             = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.assessment }
 
-    // CASE WORKER ACTIONS
-    - if current_user_is_caseworker?
-      .js-cw-claim-rejection-reasons.hidden{ class: error_class?(@error_presenter, :rejected_reason) }
-        %fieldset.form-group.nested-fields.indent-fieldset.spacer{ 'aria-describedby': 'checkbox-control-legend-1' }
-          %div
-            = validation_error_message(@error_presenter, :rejected_reason)
-          %a#rejected_reason
-          %legend#checkbox-control-legend-1.bold-normal.form-label
-            = t('.reason_for_rejection')
-          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
-            .multiple-choice
-              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), 'aria-labelledby': "checkbox-control-legend-1 #{b.text.to_css_class}")
-              = b.label { b.text }
-
-          .form-group.panel.nested-fields.fieldset.spacer.js-reject-reason-text.hidden{ class: error_class?(@error_presenter, :rejected_reason_other) }
-            %div
-              %a#rejected_reason_other
-              = f.label :reject_reason_text, class: 'form-label' do
-                = t('.reason_text')
-                .form-hint.xsmall
-                  = t('.reason_hint')
-              = f.text_field :reject_reason_text, class: 'form-control'
-              %div
-                = validation_error_message(@error_presenter, :rejected_reason_other)
-
-      .js-cw-claim-refuse-reasons.hidden{ class: error_class?(@error_presenter, :refused_reason) }
-        %div
-          = validation_error_message(@error_presenter, :refused_reason)
-
-        %fieldset.form-group.nested-fields.indent-fieldset.spacer{ 'aria-describedby': 'checkbox-control-legend-2' }
-          %legend#checkbox-control-legend-2.bold-normal.form-label
-            = t('.reason_for_refusal')
-
-          %a#refused_reason
-          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
-            .multiple-choice
-              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), 'aria-labelledby': "checkbox-control-legend-2 #{b.text.to_css_class}")
-              = b.label { b.text }
-
-          .form-group.panel.nested-fields.fieldset.spacer.js-refuse-reason-text.hidden{ class: error_class?(@error_presenter, :refused_reason_other) }
-            %div
-              %a#refused_reason_other
-              = f.label :refuse_reason_text, class: 'form-label' do
-                = t('.reason_text')
-                .form-hint.xsmall
-                  = t('.reason_hint')
-              = f.text_field :refuse_reason_text, class: 'form-control'
-              %div
-                = validation_error_message(@error_presenter, :refused_reason_other)
-
-      %p
-        = govuk_button(t('.update'), id: 'button')
+      = govuk_button(t('.update'), id: 'button')

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -1,4 +1,4 @@
-// stylelint-disable max-nesting-depth, selector-class-pattern, selector-no-qualifying-type
+// stylelint-disable max-nesting-depth, selector-class-pattern, selector-no-qualifying-type, declaration-no-important
 
 tr {
   &.error.injection-error {
@@ -168,5 +168,16 @@ table.dataTable {
 .app-jq-datatable {
   thead th {
     vertical-align: middle;
+  }
+}
+
+.app-form-datatable {
+  .govuk-table__body td,
+  .govuk-table__body th {
+    vertical-align: middle !important;
+
+    .govuk-input__wrapper {
+      justify-content: flex-end;
+    }
   }
 }

--- a/features/001_messaging.feature
+++ b/features/001_messaging.feature
@@ -12,7 +12,7 @@ Feature: Case worker messages advocate and advocate responds
     When I am signed in as the case worker
     And I select the claim
     And I send a message 'More information please'
-    Then the page should be accessible
+    Then the page should be accessible skipping 'aria-allowed-attr'
     And I sign out
     And I sign in as the advocate
     Then the claim should be displayed with a status of Allocated
@@ -32,6 +32,6 @@ Feature: Case worker messages advocate and advocate responds
 
     When I open the claim
     Then the response and uploaded file should be visible
-    Then the page should be accessible
+    Then the page should be accessible skipping 'aria-allowed-attr'
 
     And I eject the VCR cassette

--- a/features/authorise_claim.feature
+++ b/features/authorise_claim.feature
@@ -12,9 +12,9 @@ Feature: Case worker fully authorises claim
     When I am signed in as the case worker
     And I select the claim
     Then I should see a page title "View the claim details"
-    And fill out the Fees Total authorised by Laa with the amount of fees claimed
-    And do the same with expenses
-    And I click the authorised radio button
+    And I fill in 'Fees' with '1.23'
+    And I fill in 'Expenses' with '2.34'
+    And I choose govuk radio 'Authorised' for 'Update the claim status'
     And I click update
     Then the status at top of page should be Authorised
     Then the page should be accessible

--- a/features/injection_errors.feature
+++ b/features/injection_errors.feature
@@ -17,7 +17,7 @@ Feature: Case worker viewing and dismissing a data injection error
     And I select claim "A20161234"
     Then the injection error summary is visible
     And there are "2" injection error messages
-    Then the page should be accessible
+    Then the page should be accessible skipping 'aria-allowed-attr'
 
     When I dismiss the injection error
     Then the injection error summary is not visible

--- a/features/refuse_claim.feature
+++ b/features/refuse_claim.feature
@@ -12,10 +12,10 @@ Feature: Case worker rejects a claim, providing a reason
     When I am signed in as the case worker
     And the reject refuse messaging feature is released
     And I select the claim
-    And I click the refused radio button
-    And I select the refusal reason 'Duplicate claim'
-    And I select the refusal reason 'Other'
-    And I enter refusal reason text 'Whatever will be will be'
+    And I choose govuk radio 'Refused' for 'Update the claim status'
+    And I click govuk checkbox 'Duplicate claim'
+    And I click govuk checkbox 'Other'
+    And I fill in 'Reason text' with 'Whatever will be will be'
     And I click update
     Then the status at top of page should be Refused
     Then message 3 contains 'Claim refused'
@@ -38,10 +38,10 @@ Feature: Case worker rejects a claim, providing a reason
 
     When I am signed in as the case worker
     And I select the claim
-    And I click the refused radio button
-    And I select the refusal reason 'Wrong Instructed Advocate'
-    And I select the refusal reason 'Other'
-    And I enter refusal reason text 'Whatever I like'
+    And I choose govuk radio 'Refused' for 'Update the claim status'
+    And I click govuk checkbox 'Wrong Instructed Advocate'
+    And I click govuk checkbox 'Other'
+    And I fill in 'Reason text' with 'Whatever I like'
     And I click update
     Then the status at top of page should be Refused
     Then the messages should not contain 'Total (inc VAT): £0.00'

--- a/features/reject_claim.feature
+++ b/features/reject_claim.feature
@@ -12,11 +12,11 @@ Feature: Case worker rejects a claim, providing a reason
     When I am signed in as the case worker
     And the reject refuse messaging feature is released
     And I select the claim
-    And I click the rejected radio button
-    And I select the rejection reason 'No indictment attached'
-    And I select the rejection reason 'Other'
-    And I enter rejection reason text 'Whatever will be will be'
-    Then the page should be accessible
+    And I choose govuk radio 'Rejected' for 'Update the claim status'
+    And I click govuk checkbox 'No indictment attached'
+    And I click govuk checkbox 'Other'
+    And I fill in 'Reason text' with 'Whatever will be will be'
+    Then the page should be accessible skipping 'aria-allowed-attr'
     And I click update
     Then the status at top of page should be Rejected
     Then message 3 contains 'Claim rejected'


### PR DESCRIPTION
#### What

Migrate determination form to the GOVUK Design system formbuilder

#### Ticket

[FormBuilder migration - Determination form](https://dsdmoj.atlassian.net/browse/CFP-653)

#### Why

- Update the service to use GOV.UK styles, components and patterns
- To improve and resolve the service's accessibility issues
- To reduce code complexity
- To improve maintainability

--------

#### TODO (wip)

 - [ ] Migrate views
 - [ ] Update validators
 - [ ] Update locales
 - [ ] Update specs
 - [ ] Aob