### PR TITLE
Allow future rep order dates on api-sandbox

### DIFF
--- a/.k8s/live/api-sandbox/app-config.yaml
+++ b/.k8s/live/api-sandbox/app-config.yaml
@@ -18,4 +18,4 @@ data:
   SETTINGS__AWS__POLL_MESSAGE_WAIT_TIME: '10'
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
-  ALLOW_FUTURE_DATES: 'false'
+  ALLOW_FUTURE_DATES: 'true'


### PR DESCRIPTION
#### What

Allow future rep order dates on api-sandbox.

#### Ticket

N/A

#### Why

This will allow software vendors to test in advance of the new fee scheme change.

#### How

Set `ALLOW_FUTURE_DATES` to true in `.k8s/live/api-sandbox/app-config.yaml`.
