### PR TITLE
Allow creation of future-dated warrant fees

### DIFF
--- a/app/validators/fee/warrant_fee_validator.rb
+++ b/app/validators/fee/warrant_fee_validator.rb
@@ -6,7 +6,10 @@ class Fee::WarrantFeeValidator < Fee::BaseFeeValidator
     validate_on_or_after(Settings.earliest_permitted_date, :warrant_issued_date, :check_not_too_far_in_past)
     return if @record.warrant_issued_date.nil?
     validate_not_in_future(:warrant_issued_date)
-    validate_on_or_before(MINIMUM_PERIOD_SINCE_ISSUED.ago, :warrant_issued_date, :on_or_before)
+    unless allow_future_dates
+      validate_on_or_before(MINIMUM_PERIOD_SINCE_ISSUED.ago, :warrant_issued_date,
+                            :on_or_before)
+    end
     check_date = @record.claim&.earliest_representation_order&.representation_order_date
     validate_on_or_after(check_date, :warrant_issued_date, :check_on_or_after_earliest_representation_order)
   end


### PR DESCRIPTION
While testing https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/5075 I discovered I could not create a future-dated warrant fee despite having the `ALLOW_FUTURE_DATES` flag set to `true`:

<img width="649" alt="image" src="https://user-images.githubusercontent.com/28729201/187912172-8c62f9a7-2477-4dca-b953-00b55100669a.png">

This change adds an extra check to the validation in `Fee::WarrantFeeValidator` so that the relevant validation is bypassed when the flag is true.