### PR TITLE
TEMP: Set CLAIR start dates to 01/06/2022 for testing

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,8 +102,8 @@ reject_refuse_messaging_released_at: <%= DateTime.new(2018, 4, 24, 23, 05, 0).ch
 agfs_fee_reform_release_date: <%= Date.new(2018, 4, 1) %>
 agfs_scheme_11_release_date: <%= Date.new(2018, 12, 31) %>
 clar_release_date: <%= Date.new(2020, 9, 17) %>
-lgfs_scheme_10_clair_release_date: 2022-09-30
-agfs_scheme_13_clair_release_date: 2022-09-30
+lgfs_scheme_10_clair_release_date: 2022-06-01
+agfs_scheme_13_clair_release_date: 2022-06-01
 
 # number of weeks in one state before automatic transition to archived pending delete
 timed_transition_stale_weeks: 16


### PR DESCRIPTION
#### What

A temporary change to set the start dates of the LGFS and AGFS  CLAIR fee schemes 01/06/2022 to allow integration testing with CCR and CCLF.

This should only be deployed to the `staging` environment.