### PR TITLE
Fix ordering of fee scheme seeding

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,11 +27,11 @@ SEED_FILES = %w[
   scheme_10
   scheme_11
   scheme_12
-  scheme_13
   super_admins
   supplier_numbers
   vat_rates
   lgfs_scheme_10
+  scheme_13
 ]
 
 SEED_FILES.each do |file|

--- a/db/seeds/schemas/add_agfs_fee_scheme_13.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_13.rb
@@ -136,7 +136,7 @@ module Seeds
 
       def copy_scheme_12_offences
         set_offence_pk_sequence(10000)
-        puts 'Adding scheme 12 offences'.yellow
+        puts 'Adding scheme 13 offences'.yellow
 
         Offence.transaction do
           agfs_scheme_twelve_offences.each do |offence|


### PR DESCRIPTION
#### What

The ordering of the seeding of AGFS fee scheme 13 and LGFS fee scheme 10 causes failures when seeding offence data in new databases due to dependencies on the `offence_id`.

This PR fixes the ordering so that offences are seeded successfully. We may want to change this functionality in future to prevent this problem occurring again. It also fixes a small typo in the AGFS fee scheme 13 seeder.
