### PR TITLE
Replace IgnoredMethods with AllowedMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,10 +38,10 @@ Layout/LineLength:
   AllowHeredoc: true
 
 Lint/AmbiguousBlockAssociation:
-  IgnoredMethods: [change]
+  AllowedMethods: [change]
 
 Metrics/BlockLength:
-  IgnoredMethods:
+  AllowedMethods:
     - included
     - class_methods
     - namespace


### PR DESCRIPTION
#### What

Replace `IgnoredMethods` with `AllowedMethods` in `rubocop.yml`

#### Ticket

N/A

#### Why

Rubocop has changed the the `IgnoredMethods` setting for clarity.

#### How

`IgnoredMethods` is changed in two places in `rubocop.yml`.