### PR TITLE
Change QC to KC

### DIFF
--- a/app/services/ccr/advocate_category_adapter.rb
+++ b/app/services/ccr/advocate_category_adapter.rb
@@ -1,7 +1,7 @@
 module CCR
   class AdvocateCategoryAdapter
     TRANSLATION_TABLE = {
-      QC: 'QC',
+      KC: 'QC',
       'Led junior': 'LEDJR',
       'Leading junior': 'LEADJR',
       'Junior alone': 'JRALONE',

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,13 +4,13 @@ trial_cracked_at_third:
   - final_third
 
 advocate_categories:
-  - QC
+  - KC
   - Led junior
   - Leading junior
   - Junior alone
 
 agfs_reform_advocate_categories:
-  - QC
+  - KC
   - Leading junior
   - Junior
 

--- a/features/claims/advocate/accessibility.feature
+++ b/features/claims/advocate/accessibility.feature
@@ -28,7 +28,7 @@ Feature: Advocate submits a claim
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_ten/fixed_fee_calculations'
     And I should see a page title "Enter fixed fees for advocate final fees claim"
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I select an advocate category of 'Junior'
     Then the fixed fee checkboxes should consist of 'Appeals to the crown court against conviction,Number of cases uplift,Number of defendants uplift,Standard appearance fee,"Adjourned appeals, committals and breaches"'
     And I select the 'Appeals to the crown court against conviction' fixed fee

--- a/features/claims/advocate/scheme_eleven/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_fixed_fee_claim_submit.feature
@@ -33,7 +33,7 @@ Feature: Advocate tries to submit a claim for a Fixed fee (Appeal against convic
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_eleven/fixed_fee_calculations'
 
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I select an advocate category of 'Junior'
 
     And I select the 'Appeals to the crown court against conviction' fixed fee

--- a/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_hardship_claim_submit.feature
@@ -45,7 +45,7 @@ Feature: Advocate tries to submit a hardship claim for a trial with miscellaneou
     When I select the first search result
     Then I should be in the 'Hardship fees' form page
     And I should see a page title "Enter graduated fees for advocate hardship fees claim"
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I should see the case stage 'Trial started but not concluded'
     And I should see the offence details 'Class : Offences Against the Public Interest, Band : 8.1, Category : Harbouring escaped prisoner'
     And I should see the scheme 11 applicable basic fees based on the govuk checkbox group

--- a/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
+++ b/features/claims/advocate/scheme_eleven/advocate_supplementary_claim_submit.feature
@@ -27,7 +27,7 @@ Feature: Advocate tries to submit a supplementary claim for miscellaneous fees (
     And I should see a page title "Enter defendant details for advocate supplementary fee claim"
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And the following miscellaneous fee checkboxes should exist:
       | section       | fee_description                          |
       | miscellaneous | Confiscation hearings (half day)         |

--- a/features/claims/advocate/scheme_eleven/misc_fee_removal.feature
+++ b/features/claims/advocate/scheme_eleven/misc_fee_removal.feature
@@ -32,7 +32,7 @@ Feature: Advocate can add and remove miscelleaneous fees
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_eleven/misc_fee_removal'
 
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I select an advocate category of 'Junior'
 
     And I select the 'Appeals to the crown court against conviction' fixed fee

--- a/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
@@ -42,7 +42,7 @@ Feature: Advocate admin submits a claim for a Trial case
     And I should see a page title "Enter offence details for advocate final fees claim"
     Then I click "Continue" in the claim form
 
-    And I should see the advocate categories 'Junior alone,Led junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior alone,Led junior,Leading junior,KC'
     And I should see the scheme 9 applicable basic fees based on the govuk checkbox group
     And the basic fee net amount should be populated with '0.00'
 

--- a/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
@@ -26,7 +26,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_ten/fixed_fee_calculations'
 
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I select an advocate category of 'Junior'
     Then the fixed fee checkboxes should consist of 'Appeals to the crown court against conviction,Number of cases uplift,Number of defendants uplift,Standard appearance fee,"Adjourned appeals, committals and breaches"'
 

--- a/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
@@ -39,7 +39,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     When I select the first search result
     Then I should be in the 'Graduated fees' form page
 
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I should see the scheme 10 applicable basic fees based on the govuk checkbox group
 
     And the basic fee net amount should be populated with '0.00'

--- a/features/claims/advocate/scheme_thirteen/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_thirteen/advocate_fixed_fee_claim_submit.feature
@@ -34,7 +34,7 @@ Feature: Advocate tries to submit a fee scheme 13 claim for a Fixed fee (Appeal 
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_thirteen/fixed_fee_calculations'
 
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I select an advocate category of 'Junior'
 
     And I select the 'Appeals to the crown court against conviction' fixed fee

--- a/features/claims/advocate/scheme_thirteen/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_thirteen/advocate_hardship_claim_submit.feature
@@ -45,7 +45,7 @@ Feature: Advocate tries to submit a fee scheme 13 hardship claim for a trial wit
     When I select the first search result
     Then I should be in the 'Hardship fees' form page
     And I should see a page title "Enter graduated fees for advocate hardship fees claim"
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I should see the case stage 'Trial started but not concluded'
     And I should see the offence details 'Class : Offences Against the Public Interest, Band : 8.1, Category : Harbouring escaped prisoner'
     And I should see the scheme 13 applicable basic fees based on the govuk checkbox group

--- a/features/claims/advocate/scheme_thirteen/advocate_supplementary_claim_submit.feature
+++ b/features/claims/advocate/scheme_thirteen/advocate_supplementary_claim_submit.feature
@@ -28,7 +28,7 @@ Feature: Advocate tries to submit a fee scheme 13 supplementary claim for miscel
     And I should see a page title "Enter defendant details for advocate supplementary fee claim"
     When I click "Continue" in the claim form
     Then I should be in the 'Miscellaneous fees' form page
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And the following miscellaneous fee checkboxes should exist:
       | section       | fee_description                          |
       | miscellaneous | Confiscation hearings (half day)         |

--- a/features/claims/advocate/scheme_thirteen/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_thirteen/advocate_trial_claim_edit_submit.feature
@@ -27,7 +27,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I select the first search result
     Then I should be in the 'Graduated fees' form page
     And I should see a page title "Enter graduated fees for advocate final fees claim"
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I should see the scheme 13 applicable basic fees based on the govuk checkbox group
     And the basic fee net amount should be populated with '0.00'
 

--- a/features/claims/advocate/scheme_thirteen/misc_fee_removal.feature
+++ b/features/claims/advocate/scheme_thirteen/misc_fee_removal.feature
@@ -33,7 +33,7 @@ Feature: Advocate can add and remove fee scheme 13 miscelleaneous fees
 
     Given I insert the VCR cassette 'features/claims/advocate/scheme_thirteen/misc_fee_removal'
 
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I select an advocate category of 'Junior'
 
     And I select the 'Appeals to the crown court against conviction' fixed fee

--- a/features/claims/advocate/scheme_twelve/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_twelve/advocate_trial_claim_edit_submit.feature
@@ -26,7 +26,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
     And I select the first search result
     Then I should be in the 'Graduated fees' form page
     And I should see a page title "Enter graduated fees for advocate final fees claim"
-    And I should see the advocate categories 'Junior,Leading junior,QC'
+    And I should see the advocate categories 'Junior,Leading junior,KC'
     And I should see the scheme 12 applicable basic fees based on the govuk checkbox group
     And the basic fee net amount should be populated with '0.00'
 

--- a/features/fee_calculator/advocate/fixed_fee_calculator.feature
+++ b/features/fee_calculator/advocate/fixed_fee_calculator.feature
@@ -37,7 +37,7 @@ Feature: Advocate completes fixed fee page using calculator
       | fixed   | Number of defendants uplift                   | 26.00  | Number of additional defendants | true |
       | fixed   | Standard appearance fee                       | 87.00  | Number of days                  | true |
 
-    When I select an advocate category of 'QC'
+    When I select an advocate category of 'KC'
     Then the following fee details should exist:
       | section | fee_description                               | rate   |
       | fixed   | Appeals to the crown court against conviction | 260.00 |
@@ -92,7 +92,7 @@ Feature: Advocate completes fixed fee page using calculator
       | fixed   | Number of cases uplift      | 38.80  | Number of additional cases      | true |
       | fixed   | Number of defendants uplift | 38.80  | Number of additional defendants | true |
 
-    When I select an advocate category of 'QC'
+    When I select an advocate category of 'KC'
     Then the following fee details should exist:
       | section | fee_description             | rate   | hint                            | help |
       | fixed   | Elected case not proceeded  | 194.00 | Number of days                  | true |

--- a/features/fee_calculator/advocate/graduated_fee_calculator.feature
+++ b/features/fee_calculator/advocate/graduated_fee_calculator.feature
@@ -36,7 +36,7 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     # advocate category impacts "basic" fee
     When I select an advocate category of 'Junior alone'
     And the basic fee net amount should be populated with '1632.00'
-    And I select an advocate category of 'QC'
+    And I select an advocate category of 'KC'
     Then the basic fee net amount should be populated with '2856.00'
 
     When I select the govuk field 'Daily attendance fee (3 to 40)' basic fee with quantity of 38
@@ -131,7 +131,7 @@ Feature: Advocate completes graduated (a.k.a basic) fee page using calculator
     # advocate category impacts "basic" fee (retrial interval within a month, 30% reduction)
     When I select an advocate category of 'Junior alone'
     Then the basic fee net amount should be populated with '1142.40'
-    When I select an advocate category of 'QC'
+    When I select an advocate category of 'KC'
     Then the basic fee net amount should be populated with '1999.20'
 
     When I click "Continue" in the claim form

--- a/features/fee_calculator/advocate/misc_fee_calculator.feature
+++ b/features/fee_calculator/advocate/misc_fee_calculator.feature
@@ -25,7 +25,7 @@ Feature: Advocate completes misc fee page using calculator
 
     Given I insert the VCR cassette 'features/fee_calculator/advocate/misc_fee_calculator'
 
-    And I select an advocate category of 'QC'
+    And I select an advocate category of 'KC'
     And I select the 'Appeals to the crown court against conviction' fixed fee
 
     Then I click "Continue" in the claim form

--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe API::V1::DropdownData do
     let(:parsed_response) { JSON.parse(last_response.body) }
 
     shared_examples 'returns agfs scheme 9 advocate categories' do
-      let(:agfs_scheme_9_advocate_categories) { ['QC', 'Led junior', 'Leading junior', 'Junior alone'] }
+      let(:agfs_scheme_9_advocate_categories) { ['KC', 'Led junior', 'Leading junior', 'Junior alone'] }
 
       it 'returns agfs scheme 9 advocate categories' do
         expect(parsed_response).to match_array(agfs_scheme_9_advocate_categories)
@@ -461,7 +461,7 @@ RSpec.describe API::V1::DropdownData do
     end
 
     shared_examples 'returns agfs scheme 10+ advocate categories' do
-      let(:agfs_scheme_10_plus_advocate_categories) { ['QC', 'Leading junior', 'Junior'] }
+      let(:agfs_scheme_10_plus_advocate_categories) { ['KC', 'Leading junior', 'Junior'] }
 
       it 'returns agfs scheme 10+ advocate categories' do
         expect(parsed_response).to match_array(agfs_scheme_10_plus_advocate_categories)

--- a/spec/api/v2/claim_spec.rb
+++ b/spec/api/v2/claim_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe API::V2::Claim do
     context 'should return the expected details' do
       # it 'claim details' do
       #   details = full_claim[:claim_details]
-      #   expect(details.to_json).to eq '{"uuid":"uuid","type":"Claim::AdvocateClaim","provider_code":"XY666","advocate_category":"QC","additional_information":"This is some important additional information.","apply_vat":true,"state":"redetermination","submitted_at":"2016-03-10T11:44:55Z","originally_submitted_at":"2016-03-10T11:44:55Z","authorised_at":"2016-03-10T11:44:55Z","created_by":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"},"external_user":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"}}'
+      #   expect(details.to_json).to eq '{"uuid":"uuid","type":"Claim::AdvocateClaim","provider_code":"XY666","advocate_category":"KC","additional_information":"This is some important additional information.","apply_vat":true,"state":"redetermination","submitted_at":"2016-03-10T11:44:55Z","originally_submitted_at":"2016-03-10T11:44:55Z","authorised_at":"2016-03-10T11:44:55Z","created_by":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"},"external_user":{"id":1,"uuid":"uuid","first_name":"John","last_name":"Smith","email":"john.smith@example.com"}}'
       # end
 
       context 'case details' do

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController do
             case_type_id: case_type.id,
             offence_id: offence,
             case_number: 'A20161234',
-            advocate_category: 'QC',
+            advocate_category: 'KC',
             expenses_attributes: [expense_params],
             defendants_attributes: [
               {
@@ -318,7 +318,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController do
             case_type_id: case_type.id,
             offence_id: offence,
             case_number: '12345',
-            advocate_category: 'QC',
+            advocate_category: 'KC',
             evidence_checklist_ids: ['2', '3', '']
           }
         end
@@ -512,7 +512,7 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController do
       'case_type_id' => case_type.id.to_s,
       'court_id' => court.id.to_s,
       'case_number' => 'CASE98989-',
-      'advocate_category' => 'QC',
+      'advocate_category' => 'KC',
       'offence_class_id' => '2',
       'offence_id' => offence.id.to_s,
       'first_day_of_trial(3i)' => '13',

--- a/spec/controllers/external_users/fees/prices_controller_spec.rb
+++ b/spec/controllers/external_users/fees/prices_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ExternalUsers::Fees::PricesController do
             price_type: 'GraduatedPrice',
             claim_id: claim.id.to_s,
             fee_type_id: '1',
-            advocate_category: 'QC',
+            advocate_category: 'KC',
             ppe: '',
             pw: '',
             days: '1'

--- a/spec/controllers/external_users/litigators/claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/claims_controller_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe ExternalUsers::Litigators::ClaimsController do
       end
 
       context 'submit to LAA with incomplete/invalid params' do
-        let(:invalid_claim_params) { { advocate_category: 'QC' } }
+        let(:invalid_claim_params) { { advocate_category: 'KC' } }
 
         it 'does not create a claim' do
           expect {

--- a/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
+++ b/spec/controllers/external_users/litigators/interim_claims_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe ExternalUsers::Litigators::InterimClaimsController do
       end
 
       context 'when submitting to LAA with incomplete/invalid params' do
-        let(:invalid_claim_params) { { advocate_category: 'QC' } }
+        let(:invalid_claim_params) { { advocate_category: 'KC' } }
 
         it 'does not create a claim' do
           expect do

--- a/spec/factories/claim/api_claims.rb
+++ b/spec/factories/claim/api_claims.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     case_type
     offence
     case_number { random_case_number }
-    advocate_category { 'QC' }
+    advocate_category { 'KC' }
     source { 'api' }
 
     trait :with_scheme_nine_offence do

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     providers_ref { random_providers_ref }
     case_type
     offence
-    advocate_category { 'QC' }
+    advocate_category { 'KC' }
     sequence(:cms_number) { |n| "CMS-#{Time.now.year}-#{rand(100..199)}-#{n}" }
 
     transient do

--- a/spec/factories/claim/deterministic_claim.rb
+++ b/spec/factories/claim/deterministic_claim.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
 
     uuid { SecureRandom.uuid }
     providers_ref { 'reference-123' }
-    advocate_category { 'QC' }
+    advocate_category { 'KC' }
     cms_number { 'CMS-12345' }
     additional_information { 'This is some important additional information.' }
     evidence_checklist_ids { [1, 3] }

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -1269,7 +1269,7 @@ RSpec.describe Claim::AdvocateClaim do
           'trial_cracked_at_third' => '',
           'court_id' => court.id,
           'case_number' => 'B20161234',
-          'advocate_category' => 'QC',
+          'advocate_category' => 'KC',
           'external_user_id' => external_user.id,
           'offence_id' => offence.id,
           'first_day_of_trial(3i)' => '8',

--- a/spec/services/ccr/advocate_category_adapter_spec.rb
+++ b/spec/services/ccr/advocate_category_adapter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CCR::AdvocateCategoryAdapter, type: :adapter do
     subject { described_class.code_for(advocate_category) }
 
     ADVOCATE_CATEGORY_MAPPINGS = {
-      QC: 'QC',
+      KC: 'QC',
       'Led junior': 'LEDJR',
       'Leading junior': 'LEADJR',
       'Junior alone': 'JRALONE',

--- a/spec/services/claims/fee_calculator/graduated_price_spec.rb
+++ b/spec/services/claims/fee_calculator/graduated_price_spec.rb
@@ -1344,7 +1344,7 @@ RSpec.describe Claims::FeeCalculator::GraduatedPrice, :fee_calc_vcr do
             .to_return(status: 404, body: { error: '"detail": "Not found."' }.to_json, headers: {})
         end
 
-        let(:claim) { instance_double(Claim::BaseClaim, agfs?: true, advocate_category: 'QC', prosecution_evidence?: false, earliest_representation_order_date: Date.today, case_type: nil, retrial_reduction: false) }
+        let(:claim) { instance_double(Claim::BaseClaim, agfs?: true, advocate_category: 'KC', prosecution_evidence?: false, earliest_representation_order_date: Date.today, case_type: nil, retrial_reduction: false) }
         let(:params) { { fee_type_id: create(:graduated_fee_type, :grtrl).id } }
 
         it_returns 'a failed fee calculator response', message: /not found/i

--- a/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
+++ b/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Claims::FetchEligibleAdvocateCategories, type: :service do
-  let(:scheme_9_advocate_categories) { ['QC', 'Led junior', 'Leading junior', 'Junior alone'] }
-  let(:scheme_10_advocate_categories) { ['QC', 'Leading junior', 'Junior'] }
+  let(:scheme_9_advocate_categories) { ['KC', 'Led junior', 'Leading junior', 'Junior alone'] }
+  let(:scheme_10_advocate_categories) { ['KC', 'Leading junior', 'Junior'] }
   let(:all_advocate_categories) { (scheme_9_advocate_categories + scheme_10_advocate_categories).uniq }
 
   describe '.for' do

--- a/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
+++ b/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
@@ -5,8 +5,8 @@ RSpec.shared_examples 'advocate category validations' do |options|
     claim.form_step = options[:form_step]
   end
 
-  default_valid_categories = ['QC', 'Led junior', 'Leading junior', 'Junior alone']
-  fee_reform_valid_categories = ['QC', 'Leading junior', 'Junior']
+  default_valid_categories = ['KC', 'Led junior', 'Leading junior', 'Junior alone']
+  fee_reform_valid_categories = ['KC', 'Leading junior', 'Junior']
   fee_reform_invalid_categories = default_valid_categories - fee_reform_valid_categories
 
   it 'errors if not present' do
@@ -15,7 +15,7 @@ RSpec.shared_examples 'advocate category validations' do |options|
   end
 
   it 'errors if not in the available list' do
-    claim.advocate_category = 'not-a-QC'
+    claim.advocate_category = 'not-a-KC'
     should_error_with(claim, :advocate_category, 'Choose an eligible advocate category')
   end
 

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
   include_examples 'advocate claim supplier number'
 
   context 'advocate_category' do
-    default_valid_categories = ['QC', 'Led junior', 'Leading junior', 'Junior alone']
-    fee_reform_valid_categories = ['QC', 'Leading junior', 'Junior']
+    default_valid_categories = ['KC', 'Led junior', 'Leading junior', 'Junior alone']
+    fee_reform_valid_categories = ['KC', 'Leading junior', 'Junior']
     all_valid_categories = (default_valid_categories + fee_reform_valid_categories).uniq
 
     # API behaviour is different because fixed fees

--- a/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
+++ b/spec/validators/claim/advocate_interim_claim_web_validations_spec.rb
@@ -548,7 +548,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
     let(:warrant_fee_attributes) { valid_warrant_fee_attributes }
     let(:valid_attributes) {
       {
-        advocate_category: 'QC',
+        advocate_category: 'KC',
         warrant_fee_attributes:
       }
     }
@@ -733,7 +733,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           }
         },
         offence_id: offence.id,
-        advocate_category: 'QC',
+        advocate_category: 'KC',
         warrant_fee_attributes: {
           'warrant_issued_date(3i)': warrant_issued_date.day.to_s,
           'warrant_issued_date(2i)': warrant_issued_date.month.to_s,
@@ -944,7 +944,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           }
         },
         offence_id: offence.id,
-        advocate_category: 'QC',
+        advocate_category: 'KC',
         warrant_fee_attributes: {
           'warrant_issued_date(3i)': warrant_issued_date.day.to_s,
           'warrant_issued_date(2i)': warrant_issued_date.month.to_s,
@@ -1088,7 +1088,7 @@ RSpec.describe 'Advocate interim claim WEB validations' do
           }
         },
         offence_id: offence.id,
-        advocate_category: 'QC',
+        advocate_category: 'KC',
         warrant_fee_attributes: {
           'warrant_issued_date(3i)': warrant_issued_date.day.to_s,
           'warrant_issued_date(2i)': warrant_issued_date.month.to_s,


### PR DESCRIPTION
#### What

QCs have now become KCs. This PR is in preparation for the request to make these changes on CCCD.

#### Ticket

[board ticket description](link)

#### Why

#### How

--------

#### TODO

 - [ ] The list of advocate categories (Junior, Leading Junior, KC) is sorted alphabetically. Changing QC to KC results in this ordering changing. Check to see how this should appear.

<img width="233" alt="Screenshot 2022-09-13 at 09 10 33" src="https://user-images.githubusercontent.com/4415912/189847434-dd00db4c-60dd-459e-99b6-bbb703e9deae.png">

- [ ] The `advocate_category` field in the claim model can have the value `QC`. Do we need to update all claim records? Does it make sense to have a new `AdvocateCategory` model with a relation on the claim model, so that name changes can be done in just a single place?