### PR TITLE
[CFP-713] Add 'case concluded at' to transfer details view

### DIFF
--- a/app/views/shared/_claim_transfer_details.html.haml
+++ b/app/views/shared/_claim_transfer_details.html.haml
@@ -3,3 +3,7 @@
 
 = govuk_summary_list_row_collection(t('common.transfer_date')) do
   = claim.transfer_date
+
+= govuk_summary_list_row_collection(t('common.case_concluded_at')) do
+  = claim.case_concluded_at
+  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,6 +301,7 @@ en:
     transfer_case_number: Transfer case number
     transfer_detail_summary: Transfer details
     transfer_date: Transfer date
+    case_concluded_at: Date case concluded
     defendant: Defendant
     expenses: Expenses
     disbursements: Disbursements


### PR DESCRIPTION
#### What

Add the 'case concluded at' date to the caseworker's view for a transfer claim.

#### Ticket

[Case Concluded date does not appear on Caseworker Summary view](https://dsdmoj.atlassian.net/browse/CFP-713)

#### Why

When reviewing transfer claims caseworkers need to know the case conclusion date to assess whether the claim has been submitted within the required time period.

#### How

Add the field to `app/views/shared/_claim_transfer_details.html.haml`.

##### Before

![Screenshot 2022-09-16 at 09 29 28](https://user-images.githubusercontent.com/4415912/190593706-2baf45dd-ee65-4622-9bd4-fb0ffa0db398.png)

##### After

![Screenshot 2022-09-16 at 09 28 41](https://user-images.githubusercontent.com/4415912/190593743-07c0908c-d681-41e3-9b4b-9a966d7a8fae.png)
