### PR TITLE
[CFP-630] Add final claim ECNP signposting

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -67,4 +67,9 @@ module ClaimsHelper
     claim.eligible_misc_fee_types.map(&:unique_code).include?('MIUMU') &&
       claim.fees.select { |f| f.fee_type.unique_code == 'MIUMU' }.empty?
   end
+
+  def display_elected_not_proceeded_signpost?(claim)
+    # This applies to both AGFS fee scheme 13 and LGFS fee scheme 10 but the dates are the same
+    claim.final? && Time.zone.today >= Settings.agfs_scheme_13_clair_release_date.beginning_of_day
+  end
 end

--- a/app/views/external_users/claims/case_details/_case_type_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_case_type_fields.html.haml
@@ -13,6 +13,9 @@
     = f.hidden_field(:case_stage_id, value: @case_stages.first.id)
 
 - else
+  - if display_elected_not_proceeded_signpost?(@claim)
+    = govuk_warning_text( t('.enp_signpost_html', link: 'https://www.gov.uk/government/publications/crown-court-fee-guidance') )
+
   = f.govuk_collection_select :case_type_id,
     @case_types.map{ |ct| [ct.name, ct.id, { data: { 'is-fixed-fee': ct.is_fixed_fee?, 'requires-cracked-dates': ct&.requires_cracked_dates?, 'requires-retrial-dates': ct&.requires_retrial_dates?, 'requires-trial-dates': ct&.requires_trial_dates? } }] },
     :second,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -959,6 +959,9 @@ en:
         case_type_fields:
           case_type: Case type
           case_type_hint: For example Trial
+          enp_signpost_html:
+            <p class="govuk-body">You should only select <span class="govuk-!-font-weight-bold">elected cases not proceeded</span> if the representation order is before 30 September 2022.</p>
+            <p class="govuk-body">For rep order claims dated on or after 30 September 2022, select <span class="govuk-!-font-weight-bold">guilty plea</span> or <span class="govuk-!-font-weight-bold">cracked trial.</span></p>
           select_option: Choose a case type
           stage_type: What stage has the case reached?
           agfs_stage_type_hint: For example Trial started but not concluded

--- a/features/fee_calculator/advocate/fixed_fee_calculator.feature
+++ b/features/fee_calculator/advocate/fixed_fee_calculator.feature
@@ -104,14 +104,17 @@ Feature: Advocate completes fixed fee page using calculator
 
     And all the fixed fees should have their price_calculated values set to true
 
-  Scenario: I create attempt to create a post-CLAIR elected cases not proceeded claim
+  Scenario: I attempt to create a post-CLAIR elected cases not proceeded claim
 
     Given I am a signed in advocate
+    And the current date is '2022-09-30'
     And I am on the 'Your claims' page
     And I click 'Start a claim'
     And I select the fee scheme 'Advocate final fee'
     Then I should be on the new claim page
 
+    And I should see 'You should only select elected cases not proceeded if the representation order is before 30 September 2022.'
+    And I should see 'For rep order claims dated on or after 30 September 2022, select guilty plea or cracked trial.'
     And I select the court 'Blackfriars'
     And I select a case type of 'Elected cases not proceeded'
     And I enter a case number of 'A20161234'

--- a/features/fee_calculator/litigator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/litigator/fixed_fee_calculator.feature
@@ -113,7 +113,7 @@ Feature: litigator completes fixed fee page using calculator
 
     And the fixed fee should have its price_calculated value set to true
 
-  Scenario: I create attempt to create a post-CLAIR elected cases not proceeded claim
+  Scenario: I attempt to create a post-CLAIR elected cases not proceeded claim
 
     Given I am a signed in litigator
     And the current date is '2022-10-30'
@@ -122,6 +122,8 @@ Feature: litigator completes fixed fee page using calculator
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
     Then I should be on the litigator new claim page
+    And I should see 'You should only select elected cases not proceeded if the representation order is before 30 September 2022.'
+    And I should see 'For rep order claims dated on or after 30 September 2022, select guilty plea or cracked trial.'
 
     When I choose the supplier number '1A222Z'
     And I enter a providers reference of 'LGFS test fixed fee calculation'

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -269,4 +269,42 @@ RSpec.describe ClaimsHelper do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#display_elected_not_proceeded_signpost?' do
+    subject { display_elected_not_proceeded_signpost?(claim) }
+
+    let(:claim) { build(:claim) }
+
+    context 'with a final claim' do
+      before { allow(claim).to receive(:final?).and_return true }
+
+      context 'when the date is on or after the start of the CLAIR fee scheme' do
+        before { travel_to(Settings.lgfs_scheme_10_clair_release_date.end_of_day) }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when the date is before the start of the CLAIR fee scheme' do
+        before { travel_to(Settings.lgfs_scheme_10_clair_release_date - 1) }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context 'with a non-final claim' do
+      before { allow(claim).to receive(:final?).and_return false }
+
+      context 'when the date is on or after the start of the CLAIR fee scheme' do
+        before { travel_to(Settings.lgfs_scheme_10_clair_release_date.end_of_day) }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the date is before the start of the CLAIR fee scheme' do
+        before { travel_to(Settings.lgfs_scheme_10_clair_release_date - 1) }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What

Add signposting for Final Elected Case Not Proceeded claims.

#### Ticket

[CFP-630](https://dsdmoj.atlassian.net/browse/CFP-630)

#### Why

As a result of changes being introduced by CLAIR in AGFS fee scheme 13 and LGFS fee scheme 10, it will no longer be possible to claim ECNP fees for Final claims.

To prevent users claiming these fees, a warning 'signpost' will be displayed on the case type page after the start of the new schemes. 

#### How

Adds a method to the `ClaimsHelper` class to control the display of the warning based on date and claim type.

~Note: The signposting text is yet to be signed-off. This PR should not be merged until the correct wording has been agreed.~ The text has been decided here; https://dsdmoj.atlassian.net/browse/CFP-632

The signpost appears as;

<img width="659" alt="Screenshot 2022-09-26 at 15 39 55" src="https://user-images.githubusercontent.com/4415912/192305529-6cd8feed-fde6-47ac-b55a-67be46a48d06.png">