### PR TITLE
[CFP-717] Fix display of two misc fee validation errors

### DIFF
--- a/app/validators/fee/agfs/fee_type_rules.rb
+++ b/app/validators/fee/agfs/fee_type_rules.rb
@@ -7,7 +7,7 @@ module Fee
 
       def initialize
         with_set_for_fee_type('MIUMU') do |set|
-          set << add_rule(:quantity, :equal, 1, message: 'miumu_numericality')
+          set << add_rule(:quantity, :equal, 1, message: :miumu_numericality)
           set << add_rule(*graduated_fee_type_only_rule)
         end
 
@@ -19,7 +19,7 @@ module Fee
           set << add_rule('claim.offence.offence_band.offence_category.number',
                           :exclusion,
                           [1, 6, 9],
-                          message: 'offence_category_exclusion',
+                          message: :offence_category_exclusion,
                           attribute_for_error: :fee_type)
         end
       end

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -1040,8 +1040,8 @@ misc_fee:
       long: Enter a valid quantity (1 to 3) for plea and case management hearing fees
       short: _
       api: Enter a valid quantity (1 to 3) for plea and case management hearing fees
-    enter_a_valid_quantity_for_unused_material_up_to_3_hours:
-      long: 'Enter a valid quantity for the #{misc_fee}'
+    enter_a_valid_quantity_(1)_for_unused_material_(up_to_3_hours):
+      long: 'Enter a valid quantity (1) for unused material (up to 3 hours)'
       short: _
       api: Enter a valid quantity (1) for unused material (up to 3 hours)
     the_amount_for_the_miscellaneous_fee_exceeds_the_limit:

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -358,7 +358,7 @@ en:
               integer: You must specify a whole number for this type of fee
               invalid: Enter a valid quantity for the miscellaneous fee
               item_max_amount: The amount for the miscellaneous fee exceeds the limit
-              miumu_numericality: Enter a valid quantity for unused material (up to 3 hours)
+              miumu_numericality: Enter a valid quantity (1) for unused material (up to 3 hours)
               pcm_invalid: Enter a valid quantity for plea and trial preparation hearing
               pcm_numericality: Enter a valid quantity (1 to 3) for plea and case management hearing fees
             rate:

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
 
         it {
           fee.valid?
-          expect(fee.errors[:quantity]).to include('miumu_numericality')
+          expect(fee.errors[:quantity]).to include('Enter a valid quantity (1) for unused material (up to 3 hours)')
         }
       end
 
@@ -162,7 +162,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
 
             before { fee.valid? }
 
-            it { expect(fee.errors[:fee_type]).to include('offence_category_exclusion') }
+            it { expect(fee.errors[:fee_type]).to include('Fee type is not applicable to this offence category') }
           end
         end
       end


### PR DESCRIPTION
#### What

Fix the display of validation errors for two misc fee types (unused materials < 3 hours and paper heavy case fees).

#### Ticket

[CFP-717](https://dsdmoj.atlassian.net/browse/CFP-717)

#### Why

Validation errors for unused materials < 3 hours and paper heavy case fees are not displayed correctly. Possibly they were missed during the GOVUK migration. This fixes them by ensuring the errors are added correctly and the correct translations are in place.

------

## Before:

### Unused materials (supplementary claim):

<img width="988" alt="image" src="https://user-images.githubusercontent.com/28729201/190683290-b5b95139-a072-4965-8022-aabdf66a6ec1.png">

<img width="406" alt="image" src="https://user-images.githubusercontent.com/28729201/190683329-9a7ae706-e093-487a-8cba-4cb5c6f905ee.png">

### Paper heavy case (final fee with an offence band of 1, 6 or 9):

<img width="510" alt="image" src="https://user-images.githubusercontent.com/28729201/190683815-bd253de8-292a-4eef-9518-6bccf04466a3.png">


## After:

### Unused materials (supplementary claim):

<img width="664" alt="image" src="https://user-images.githubusercontent.com/28729201/190687581-0f1d4151-d9c7-4afa-9003-4db87516a248.png">

<img width="656" alt="image" src="https://user-images.githubusercontent.com/28729201/190687609-5d61063d-6fd7-4bbc-86a2-b9cfb38e567f.png">



### Paper heavy case (final fee with an offence band of 1, 6 or 9):

<img width="602" alt="image" src="https://user-images.githubusercontent.com/28729201/190686788-12f491a5-c319-4706-961c-7e0a060de3c9.png">




