### PR TITLE
[CFP-642] Update ECNP final fee error message

### DIFF
--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -539,9 +539,9 @@ legal_aid_transfer_date:
 earliest_representation_order_date:
   _seq:  220
   invalid_for_elected_case_not_proceeded:
-    long: Check combination of representation order date and case type, on the previous page
+    long: The representation order date and case type cannot be combined
     short: _
-    api: Check combination of representation order date and case type
+    api: The representation order date and case type cannot be combined
 
 
 

--- a/features/fee_calculator/advocate/fixed_fee_calculator.feature
+++ b/features/fee_calculator/advocate/fixed_fee_calculator.feature
@@ -121,4 +121,4 @@ Feature: Advocate completes fixed fee page using calculator
     And I enter defendant, scheme 13 representation order and MAAT reference
 
     Then I click "Continue" in the claim form
-    And I should see govuk error summary with 'Check combination of representation order date and case type, on the previous page'
+    And I should see govuk error summary with 'The representation order date and case type cannot be combined'

--- a/features/fee_calculator/litigator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/litigator/fixed_fee_calculator.feature
@@ -135,4 +135,4 @@ Feature: litigator completes fixed fee page using calculator
     And I enter defendant, lgfs scheme 10 representation order and MAAT reference
 
     Then I click "Continue" in the claim form
-    And I should see govuk error summary with 'Check combination of representation order date and case type, on the previous page'
+    And I should see govuk error summary with 'The representation order date and case type cannot be combined'


### PR DESCRIPTION
#### What

The error displayed when trying to claim a Final ECNP fee on a claim that falls in the CLAIR fee schemes (LGFS 10 or AGFS 13) currently has a temporary wording.

This change now updates that to the the correct wording.

#### Ticket

[CFP-642](https://dsdmoj.atlassian.net/browse/CFP-642)

#### How

Updates the temporary message `Check combination of representation order date and case type, on the previous page` to the new message `The representation order date and case type cannot be combined` in translation and tests.