### PR TITLE
CFP-579 Update ingress controllers to v1.2

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-api-sandbox-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-api-sandbox-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -18,17 +17,21 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-api-sandbox
 spec:
+  ingressClassName: modsec
   rules:
     - host: api-sandbox.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - api-sandbox.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-lgfs-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-dev-lgfs-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -18,24 +17,31 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-dev-lgfs
 spec:
+  ingressClassName: modsec
   rules:
     - host: dev-lgfs.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
     - host: dev-clar.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - dev-lgfs.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -18,17 +17,21 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-dev
 spec:
+  ingressClassName: modsec
   rules:
     - host: dev.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - dev.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -18,17 +17,21 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-production
 spec:
+  ingressClassName: modsec
   rules:
     - host: claim-crown-court-defence.service.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - claim-crown-court-defence.service.gov.uk

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-staging-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -18,17 +17,21 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-staging
 spec:
+  ingressClassName: modsec
   rules:
     - host: staging.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - staging.claim-crown-court-defence.service.justice.gov.uk


### PR DESCRIPTION
#### What

Update ingress controllers to v1.2

#### Ticket

[CFP-579](https://dsdmoj.atlassian.net/browse/CFP-579)

#### Why

To comply with Cloud Platform requirements, remain in service, and benefit from improved security and logging.

#### How

Updates kubernetes configuration for all five environments to use v1.2 of the ingress controller. This has been applied using the zero-downtime guidance provided by the Cloud Platform team: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#introduction. This PR tidies up the configuration in code so that future deployments will be consistent.