### PR TITLE
Revert "CFP-579 Update ingress controllers to v1.2"

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -1,9 +1,10 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-api-sandbox-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-api-sandbox-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -17,21 +18,17 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress-v1
+  name: cccd-app-ingress
   namespace: cccd-api-sandbox
 spec:
-  ingressClassName: modsec
   rules:
     - host: api-sandbox.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
             backend:
-              service:
-                name: cccd-app-service
-                port:
-                  number: 80
+              serviceName: cccd-app-service
+              servicePort: 80
   tls:
     - hosts:
       - api-sandbox.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -1,9 +1,10 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-dev-lgfs-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-lgfs-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -17,31 +18,24 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress-v1
+  name: cccd-app-ingress
   namespace: cccd-dev-lgfs
 spec:
-  ingressClassName: modsec
   rules:
     - host: dev-lgfs.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
             backend:
-              service:
-                name: cccd-app-service
-                port:
-                  number: 80
+              serviceName: cccd-app-service
+              servicePort: 80
     - host: dev-clar.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
             backend:
-              service:
-                name: cccd-app-service
-                port:
-                  number: 80
+              serviceName: cccd-app-service
+              servicePort: 80
   tls:
     - hosts:
       - dev-lgfs.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -1,9 +1,10 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-dev-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -17,21 +18,17 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress-v1
+  name: cccd-app-ingress
   namespace: cccd-dev
 spec:
-  ingressClassName: modsec
   rules:
     - host: dev.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
             backend:
-              service:
-                name: cccd-app-service
-                port:
-                  number: 80
+              serviceName: cccd-app-service
+              servicePort: 80
   tls:
     - hosts:
       - dev.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -1,9 +1,10 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -17,21 +18,17 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress-v1
+  name: cccd-app-ingress
   namespace: cccd-production
 spec:
-  ingressClassName: modsec
   rules:
     - host: claim-crown-court-defence.service.gov.uk
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
             backend:
-              service:
-                name: cccd-app-service
-                port:
-                  number: 80
+              serviceName: cccd-app-service
+              servicePort: 80
   tls:
     - hosts:
       - claim-crown-court-defence.service.gov.uk

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -1,9 +1,10 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-staging-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -17,21 +18,17 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress-v1
+  name: cccd-app-ingress
   namespace: cccd-staging
 spec:
-  ingressClassName: modsec
   rules:
     - host: staging.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
             backend:
-              service:
-                name: cccd-app-service
-                port:
-                  number: 80
+              serviceName: cccd-app-service
+              servicePort: 80
   tls:
     - hosts:
       - staging.claim-crown-court-defence.service.justice.gov.uk


### PR DESCRIPTION
Reverts ministryofjustice/Claim-for-Crown-Court-Defence#5165 due to issues experienced by API users on the new ingress.