### PR TITLE
[CFP-720] Allow KC as advocate category

### DIFF
--- a/app/interfaces/api/helpers/resource_helper.rb
+++ b/app/interfaces/api/helpers/resource_helper.rb
@@ -38,6 +38,7 @@ module API::Helpers
     end
 
     def validate_resource(klass)
+      params['advocate_category'] = 'QC' if params['advocate_category'] == 'KC'
       API::Helpers::ApiHelper.validate_resource(klass, api_response, arguments_proc)
     end
 

--- a/app/interfaces/api/helpers/resource_helper.rb
+++ b/app/interfaces/api/helpers/resource_helper.rb
@@ -33,6 +33,7 @@ module API::Helpers
     end
 
     def create_resource(klass)
+      params['advocate_category'] = 'QC' if params['advocate_category'] == 'KC'
       API::Helpers::ApiHelper.create_resource(klass, params, api_response, arguments_proc)
     end
 

--- a/app/interfaces/api/v1/external_users/claims/advocates/final_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/final_claim.rb
@@ -17,7 +17,7 @@ module API::V1::ExternalUsers
           optional :advocate_category,
                    type: String,
                    desc: local_t(:advocate_category),
-                   values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories).uniq
+                   values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories + ['KC']).uniq
 
           use :common_trial_params
           use :common_agfs_params

--- a/app/interfaces/api/v1/external_users/claims/advocates/hardship_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/hardship_claim.rb
@@ -17,7 +17,7 @@ module API::V1::ExternalUsers
           optional :advocate_category,
                    type: String,
                    desc: local_t(:advocate_category),
-                   values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories).uniq
+                   values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories + ['KC']).uniq
 
           use :agfs_hardship_trial_params
           use :common_agfs_params

--- a/app/interfaces/api/v1/external_users/claims/advocates/interim_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/interim_claim.rb
@@ -26,7 +26,7 @@ module API::V1::ExternalUsers
           optional :advocate_category,
                    type: String,
                    desc: local_t(:advocate_category),
-                   values: Settings.agfs_reform_advocate_categories
+                   values: Settings.agfs_reform_advocate_categories + ['KC']
         end
 
         namespace :advocates do

--- a/app/interfaces/api/v1/external_users/claims/advocates/supplementary_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/supplementary_claim.rb
@@ -25,7 +25,7 @@ module API::V1::ExternalUsers
           optional :advocate_category,
                    type: String,
                    desc: local_t(:advocate_category),
-                   values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories).uniq
+                   values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories + ['KC']).uniq
         end
 
         namespace :advocates do

--- a/spec/requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples.rb
@@ -6,7 +6,7 @@ RSpec.shared_context 'with AGFS API users' do
   let(:advocate) { create(:external_user, :advocate, provider: vendor.provider) }
 end
 
-RSpec.shared_examples 'creates claim correctly' do
+RSpec.shared_examples 'API creation successful' do
   it { expect(response).to be_successful }
 
   it 'sets advocate category correctly in the claim' do
@@ -14,7 +14,12 @@ RSpec.shared_examples 'creates claim correctly' do
   end
 end
 
-RSpec.shared_examples 'fail to create claim with ineligible advocate category' do
+RSpec.shared_examples 'API validation successful' do
+  it { expect(response).to be_successful }
+  it { expect(JSON.parse(response.body)['valid']).to be_truthy }
+end
+
+RSpec.shared_examples 'API request fails with ineligible advocate category' do
   it { expect(response).to have_http_status(:bad_request) }
   it { expect(JSON.parse(response.body).first['error']).to eq('Choose an eligible advocate category') }
 end
@@ -22,60 +27,124 @@ end
 RSpec.shared_examples 'claim with AGFS reform advocate categories' do
   before do
     seed_fee_schemes
-    create_claim
+    submit_request
   end
 
-  context 'with a Junior advocate category' do
-    let(:advocate_category) { 'Junior' }
+  context 'when creating' do
+    subject(:submit_request) { post(endpoint.create, params:) }
 
-    include_examples 'creates claim correctly'
-  end
+    context 'with a Junior advocate category' do
+      let(:advocate_category) { 'Junior' }
 
-  context 'with a Leading junior advocate category' do
-    let(:advocate_category) { 'Leading junior' }
+      include_examples 'API creation successful'
+    end
 
-    include_examples 'creates claim correctly'
-  end
+    context 'with a Leading junior advocate category' do
+      let(:advocate_category) { 'Leading junior' }
 
-  context 'with a QC advocate category' do
-    let(:advocate_category) { 'QC' }
+      include_examples 'API creation successful'
+    end
 
-    include_examples 'creates claim correctly'
-  end
+    context 'with a QC advocate category' do
+      let(:advocate_category) { 'QC' }
 
-  context 'with a KC advocate category' do
-    let(:advocate_category) { 'KC' }
+      include_examples 'API creation successful'
+    end
 
-    it { expect(response).to be_successful }
+    context 'with a KC advocate category' do
+      let(:advocate_category) { 'KC' }
 
-    it 'translates advocate category KC to QC before creating claim' do
-      expect(Claim::BaseClaim.last.advocate_category).to eq 'QC'
+      it { expect(response).to be_successful }
+
+      it 'translates advocate category KC to QC before creating claim' do
+        expect(Claim::BaseClaim.last.advocate_category).to eq 'QC'
+      end
+    end
+
+    context 'with an unknown advocate category' do
+      let(:advocate_category) { 'Unknown' }
+
+      it { expect(response).to have_http_status(:bad_request) }
+      it { expect(JSON.parse(response.body).first['error']).to eq('advocate_category does not have a valid value') }
     end
   end
 
-  context 'with an unknown advocate category' do
-    let(:advocate_category) { 'Unknown' }
+  context 'when validating' do
+    subject(:submit_request) { post(endpoint.validate, params:) }
 
-    it { expect(response).to have_http_status(:bad_request) }
-    it { expect(JSON.parse(response.body).first['error']).to eq('advocate_category does not have a valid value') }
+    context 'with a Junior advocate category' do
+      let(:advocate_category) { 'Junior' }
+
+      include_examples 'API validation successful'
+    end
+
+    context 'with a Leading junior advocate category' do
+      let(:advocate_category) { 'Leading junior' }
+
+      include_examples 'API validation successful'
+    end
+
+    context 'with a QC advocate category' do
+      let(:advocate_category) { 'QC' }
+
+      include_examples 'API validation successful'
+    end
+
+    context 'with a KC advocate category' do
+      let(:advocate_category) { 'KC' }
+
+      include_examples 'API validation successful'
+    end
+
+    context 'with an unknown advocate category' do
+      let(:advocate_category) { 'Unknown' }
+
+      it { expect(response).to have_http_status(:bad_request) }
+      it { expect(JSON.parse(response.body).first['error']).to eq('advocate_category does not have a valid value') }
+    end
   end
 end
 
 RSpec.shared_examples 'claim with pre-AGFS reform advocate categories' do
   before do
     seed_fee_schemes
-    create_claim
+    submit_request
   end
 
-  context 'with a Led junior advocate category' do
-    let(:advocate_category) { 'Led junior' }
+  context 'when creating' do
+    subject(:submit_request) { post(endpoint.create, params:) }
 
-    include_examples 'fail to create claim with ineligible advocate category'
+    context 'with a Led junior advocate category' do
+      let(:advocate_category) { 'Led junior' }
+
+      include_examples 'API request fails with ineligible advocate category'
+    end
+
+    context 'with a Junior alone advocate category' do
+      let(:advocate_category) { 'Junior alone' }
+
+      include_examples 'API request fails with ineligible advocate category'
+    end
   end
 
-  context 'with a Junior alone advocate category' do
-    let(:advocate_category) { 'Junior alone' }
+  context 'when validating' do
+    subject(:submit_request) { post(endpoint.validate, params:) }
 
-    include_examples 'fail to create claim with ineligible advocate category'
+    before do
+      seed_fee_schemes
+      submit_request
+    end
+
+    context 'with a Led junior advocate category' do
+      let(:advocate_category) { 'Led junior' }
+
+      include_examples 'API request fails with ineligible advocate category'
+    end
+
+    context 'with a Junior alone advocate category' do
+      let(:advocate_category) { 'Junior alone' }
+
+      include_examples 'API request fails with ineligible advocate category'
+    end
   end
 end

--- a/spec/requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with AGFS API users' do
+  let(:default_params) { { api_key: vendor.provider.api_key } }
+  let(:vendor) { create(:external_user, :admin) }
+  let(:advocate) { create(:external_user, :advocate, provider: vendor.provider) }
+end
+
+RSpec.shared_examples 'creates claim correctly' do
+  it { expect(response).to be_successful }
+
+  it 'sets advocate category correctly in the claim' do
+    expect(Claim::BaseClaim.last.advocate_category).to eq advocate_category
+  end
+end
+
+RSpec.shared_examples 'fail to create claim with ineligible advocate category' do
+  it { expect(response).to have_http_status(:bad_request) }
+  it { expect(JSON.parse(response.body).first['error']).to eq('Choose an eligible advocate category') }
+end
+
+RSpec.shared_examples 'claim with AGFS reform advocate categories' do
+  before do
+    seed_fee_schemes
+    create_claim
+  end
+
+  context 'with a Junior advocate category' do
+    let(:advocate_category) { 'Junior' }
+
+    include_examples 'creates claim correctly'
+  end
+
+  context 'with a Leading junior advocate category' do
+    let(:advocate_category) { 'Leading junior' }
+
+    include_examples 'creates claim correctly'
+  end
+
+  context 'with a QC advocate category' do
+    let(:advocate_category) { 'QC' }
+
+    include_examples 'creates claim correctly'
+  end
+
+  context 'with a KC advocate category' do
+    let(:advocate_category) { 'KC' }
+
+    it { expect(response).to be_successful }
+
+    it 'translates advocate category KC to QC before creating claim' do
+      expect(Claim::BaseClaim.last.advocate_category).to eq 'QC'
+    end
+  end
+
+  context 'with an unknown advocate category' do
+    let(:advocate_category) { 'Unknown' }
+
+    it { expect(response).to have_http_status(:bad_request) }
+    it { expect(JSON.parse(response.body).first['error']).to eq('advocate_category does not have a valid value') }
+  end
+end
+
+RSpec.shared_examples 'claim with pre-AGFS reform advocate categories' do
+  before do
+    seed_fee_schemes
+    create_claim
+  end
+
+  context 'with a Led junior advocate category' do
+    let(:advocate_category) { 'Led junior' }
+
+    include_examples 'fail to create claim with ineligible advocate category'
+  end
+
+  context 'with a Junior alone advocate category' do
+    let(:advocate_category) { 'Junior alone' }
+
+    include_examples 'fail to create claim with ineligible advocate category'
+  end
+end

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/final_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/final_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'creating final AGFS claim for fee scheme 13', type: :request do
   let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
 
   describe 'create new claim' do
-    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/final').create, params:) }
+    let(:endpoint) { ClaimApiEndpoints.for('advocates/final') }
 
     let(:params) do
       default_params.merge(

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/final_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/final_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples'
+
+RSpec.describe 'creating final AGFS claim for fee scheme 13', type: :request do
+  include_context 'with AGFS API users'
+
+  let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
+
+  describe 'create new claim' do
+    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/final').create, params:) }
+
+    let(:params) do
+      default_params.merge(
+        creator_email: vendor.email,
+        user_email: advocate.email,
+        case_type_id: create(:case_type, :trial).id,
+        case_number: 'A20181234',
+        providers_ref: 'A20181234/1',
+        cms_number: 'Meridian',
+        first_day_of_trial: first_date.as_json,
+        estimated_trial_length: 10,
+        actual_trial_length: 9,
+        trial_concluded_at: (first_date + 9.days).as_json,
+        advocate_category:,
+        offence_id: create(:offence, :with_fee_scheme_thirteen).id,
+        court_id: create(:court).id,
+        additional_information: 'Bish bosh bash',
+        prosecution_evidence: true
+      )
+    end
+
+    include_examples 'claim with AGFS reform advocate categories'
+    include_examples 'claim with pre-AGFS reform advocate categories'
+  end
+end

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/hardship_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/hardship_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples'
+
+RSpec.describe 'creating hardship AGFS claim for fee scheme 13', type: :request do
+  include_context 'with AGFS API users'
+
+  let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
+
+  describe 'create new claim' do
+    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/hardship').create, params:) }
+
+    let(:params) do
+      default_params.merge(
+        creator_email: vendor.email,
+        user_email: advocate.email,
+        case_stage_unique_code: create(:case_stage, :trial_not_concluded).unique_code,
+        case_number: 'A20181234',
+        first_day_of_trial: first_date.as_json,
+        trial_concluded_at: (first_date + 9.days).as_json,
+        estimated_trial_length: 10,
+        actual_trial_length: 9,
+        advocate_category:,
+        offence_id: create(:offence, :with_fee_scheme_thirteen).id,
+        court_id: create(:court).id
+      )
+    end
+
+    include_examples 'claim with AGFS reform advocate categories'
+    include_examples 'claim with pre-AGFS reform advocate categories'
+  end
+end

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/hardship_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/hardship_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'creating hardship AGFS claim for fee scheme 13', type: :request 
   let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
 
   describe 'create new claim' do
-    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/hardship').create, params:) }
+    let(:endpoint) { ClaimApiEndpoints.for('advocates/hardship') }
 
     let(:params) do
       default_params.merge(

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/interim_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/interim_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'creating final AGFS claim for fee scheme 13', type: :request do
   let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
 
   describe 'create new claim' do
-    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/interim').create, params:) }
+    let(:endpoint) { ClaimApiEndpoints.for('advocates/interim') }
 
     let(:params) do
       default_params.merge(

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/interim_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/interim_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples'
+
+RSpec.describe 'creating final AGFS claim for fee scheme 13', type: :request do
+  include_context 'with AGFS API users'
+
+  let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
+
+  describe 'create new claim' do
+    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/interim').create, params:) }
+
+    let(:params) do
+      default_params.merge(
+        creator_email: vendor.email,
+        user_email: advocate.email,
+        case_number: 'A20181234',
+        providers_ref: 'A20181234/1',
+        cms_number: 'Meridian',
+        advocate_category:,
+        offence_id: create(:offence, :with_fee_scheme_thirteen).id,
+        court_id: create(:court).id,
+        additional_information: 'Bish bosh bash',
+        prosecution_evidence: true
+      )
+    end
+
+    include_examples 'claim with AGFS reform advocate categories'
+  end
+end

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/supplementary_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/supplementary_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'creating supplementary AGFS claim for fee scheme 13', type: :req
   let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
 
   describe 'create new claim' do
-    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/supplementary').create, params:) }
+    let(:endpoint) { ClaimApiEndpoints.for('advocates/supplementary') }
 
     let(:params) do
       default_params.merge(

--- a/spec/requests/api/v1/external_users/claims/advocates/scheme_13/supplementary_spec.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/scheme_13/supplementary_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples'
+
+RSpec.describe 'creating supplementary AGFS claim for fee scheme 13', type: :request do
+  include_context 'with AGFS API users'
+
+  let(:first_date) { Settings.agfs_scheme_13_clair_release_date.beginning_of_day }
+
+  describe 'create new claim' do
+    subject(:create_claim) { post(ClaimApiEndpoints.for('advocates/supplementary').create, params:) }
+
+    let(:params) do
+      default_params.merge(
+        creator_email: vendor.email,
+        user_email: advocate.email,
+        case_number: 'A20181234',
+        providers_ref: 'A20181234/1',
+        cms_number: 'Meridian',
+        advocate_category:,
+        court_id: create(:court).id,
+        additional_information: 'Bish bosh bash',
+        prosecution_evidence: true
+      )
+    end
+
+    include_examples 'claim with AGFS reform advocate categories'
+  end
+end


### PR DESCRIPTION
#### What

Allow the API to accept KC as an advocate category.

#### Ticket

[Allow KC as advocate category](https://dsdmoj.atlassian.net/browse/CFP-720)

#### Why

It is possible that vendor software will start creating claims with an advocate category 'KC'. These claims should not fail and they should be dealt with correctly.

#### How

When a claim is submitted with an advocate category of 'KC' it is changed to 'QC' before creating the claim instance. This is a temporary measure until the data is changed internally.

The 'KC' option now appears in the API Swagger documentation so it may result in it appearing, alongside 'QC', in some vendor software. Is this a problem?

![Screenshot 2022-10-06 at 09 13 10](https://user-images.githubusercontent.com/4415912/194259034-ea9c28ee-eb20-4a31-bf14-2bbf3fc1da12.png)
