### PR TITLE
[CFP-750] Use default docker version in CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,8 +269,7 @@ commands:
         type: string
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.7
+      - setup_remote_docker
       - run:
           name: deploying to << parameters.environment >> namespace
           command: |
@@ -373,8 +372,7 @@ jobs:
     executor: test-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.7
+      - setup_remote_docker
       - *create-tmp-dir
       - *install-codeclimate
       - *persist-codeclimate
@@ -445,8 +443,7 @@ jobs:
     executor: cloud-platform-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.7
+      - setup_remote_docker
       - *script-build-app-container
 
   hold-build-notification:


### PR DESCRIPTION
#### What

Use default docker version in CircleCI jobs

#### Ticket

[CFP-750](https://dsdmoj.atlassian.net/browse/CFP-750)

#### Why

CircleCI is updating the `setup_remote_docker` feature. This may lead to job failures where an old version of docker is specified for use with the feature.

The version of docker specified in `.circleci/config.yml` (20.10.7) is on the list of at-risk docker versions.

This needs to be completed by **Tuesday October 11th 2022** to prevent risk of failure.

#### How

Remove the `version` flag, causing `setup_remote_docker` to instead use the default docker version (20.10.17).

`setup_remote_docker` is used in three places: the `build-test-container`, `build-app-container`, and `deploy-to` jobs. To test this change I have tested that all three steps of the deployment process complete successfully, using the latest docker version, and that the deployed `dev` application functions correctly.

<img width="249" alt="image" src="https://user-images.githubusercontent.com/28729201/194355426-62d424fb-1cf4-408e-8e7a-29b1795e5cda.png">

<img width="275" alt="image" src="https://user-images.githubusercontent.com/28729201/194354956-30c24470-dc28-4b7d-af9b-0dfc0159d049.png">

<img width="275" alt="image" src="https://user-images.githubusercontent.com/28729201/194353933-515a3e8d-e70a-4812-a5b7-764243481dec.png">

<img width="275" alt="image" src="https://user-images.githubusercontent.com/28729201/194355544-0e7e4185-6875-4cd0-a681-3fcc6db3e909.png">
