### PR TITLE
Use ActiveRecord query in place of raw SQL

### DIFF
--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -17,12 +17,8 @@ class FeeScheme < ApplicationRecord
   scope :eleven, -> { where(version: FeeScheme::ELEVEN) }
   scope :twelve, -> { where(version: FeeScheme::TWELVE) }
   scope :thirteen, -> { where(version: FeeScheme::THIRTEEN) }
-  scope :current, lambda {
-    where('(:now BETWEEN start_date AND end_date) OR (start_date <= :now AND end_date IS NULL)', now: Time.zone.now)
-  }
-  scope :for, lambda { |check_date|
-    where('(:date BETWEEN start_date AND end_date) OR (start_date <= :date AND end_date IS NULL)', date: check_date)
-  }
+  scope :current, -> { self.for(Time.zone.now) }
+  scope :for, ->(check_date) { where(start_date: ..check_date, end_date: [nil, check_date..]) }
 
   def agfs?
     name.eql?('AGFS')


### PR DESCRIPTION
#### What

Replace the raw SQL for finding the correct fee scheme with an ActiveRecord query.

#### Ticket

N/A

#### Why

From a security perspective, while this is not particularly complex, it is recommended not to use SQL if possible. When this was originally it may not have been simple to write this with the version of Ruby and Active Record at the time.

#### How

Infinite ranges, which have been around since Ruby 2.6, allow for a `between` in raw SQL to be replaced by simpler ActiveRecord queries.

The resulting SQL is slightly different but equivalent;

```sql
-- Old
SELECT "fee_schemes".* FROM "fee_schemes"
  WHERE (('2022-10-10 16:03:31.295615' BETWEEN start_date AND end_date) OR (start_date <= '2022-10-10 16:03:31.295615' AND end_date IS NULL));

-- New
SELECT "fee_schemes".* FROM "fee_schemes"
  WHERE "fee_schemes"."start_date" <= '2022-10-10 16:04:43.819958' AND ("fee_schemes"."end_date" IS NULL OR "fee_schemes"."end_date" >= '2022-10-10 16:04:43.819958')
```
