### PR TITLE
Use Dependabot to manage GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,16 @@ updates:
   - "mpw5"
   - "jrmhaig"
   - "ministryofjustice/laa-claim-for-payment"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: tuesday
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 5
+  rebase-strategy: "disabled"
+  allow:
+    - dependency-type: "all"
+  reviewers:
+  - "ministryofjustice/laa-claim-for-payment"


### PR DESCRIPTION
#### What

Dependabot can be used to ensure that GitHub Actions are kept up to date: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

As a result, manual PRs such as https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/5187 will be unnecessary.

#### How

This adds the necessary configuration to `.github/dependabot.yml`. This replicates our dependabot setup for other dependencies, but changes the scheduled day for updates to avoid swamping us even more on Wednesdays.