### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @ministryofjustice/laa-claim-for-payment
+* @ministryofjustice/laa-clair-taskforce


### PR DESCRIPTION
#### What & Why

Adds a `CODEOWNERS` file to control responsibility for code reviews. 

We currently have `Require review from Code Owners` enabled for branch protection on `master`, so I'm surprised that this doesn't currently exist. Adding the file makes responsibilities clearer and improves security.

<img width="548" alt="image" src="https://user-images.githubusercontent.com/28729201/195863550-57a83c3d-7225-4e66-832f-e509882f3f77.png">
 

#### How

Adds the file to the `.github` directory. This file currently includes the `laa-claim-for-payment` and `laa-clair-taskforce` teams; the latter should be removed at the conclusion of the CLAIR project.
