### PR TITLE
Use Singleton class for Remote::HttpClient

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -874,7 +874,6 @@ RSpec/DescribedClass:
     - 'spec/services/claims/value_bands_spec.rb'
     - 'spec/services/document_cleaner_spec.rb'
     - 'spec/services/message_queue/aws_client_spec.rb'
-    - 'spec/services/remote/http_client_spec.rb'
     - 'spec/services/simple_bill_adapter_spec.rb'
     - 'spec/services/stats/claim_creation_source_data_generator_spec.rb'
     - 'spec/services/stats/claim_percentage_authorised_generator_spec.rb'
@@ -2585,7 +2584,6 @@ Style/ClassEqualityComparison:
 Style/ClassVars:
   Exclude:
     - 'app/models/google_analytics/data_tracking.rb'
-    - 'app/services/remote/http_client.rb'
 
 # Offense count: 2
 Style/CombinableLoops:
@@ -3179,7 +3177,6 @@ Layout/LineLength:
     - 'spec/services/fee_reform/search_offences_spec.rb'
     - 'spec/services/injection_response_service_spec.rb'
     - 'spec/services/message_queue/aws_client_spec.rb'
-    - 'spec/services/remote/http_client_spec.rb'
     - 'spec/services/remote/injection_attempt_spec.rb'
     - 'spec/services/reports/performance_platform/quarterly_volume_spec.rb'
     - 'spec/services/reports/performance_platform/transactions_by_channel_spec.rb'

--- a/app/services/remote/base.rb
+++ b/app/services/remote/base.rb
@@ -30,7 +30,7 @@ module Remote
       private
 
       def client
-        Remote::HttpClient.current
+        Remote::HttpClient.instance
       end
 
       def parse_result(result)

--- a/app/services/remote/http_client.rb
+++ b/app/services/remote/http_client.rb
@@ -1,24 +1,21 @@
 module Remote
   class HttpClient
-    cattr_accessor :instance, :logger, :base_url, :api_key, :timeout, :open_timeout
-    private_class_method :new
+    include Singleton
 
-    class << self
-      def configure
-        yield(self)
-      end
+    attr_accessor :api_key, :timeout, :open_timeout
+    attr_reader :logger
+    attr_writer :base_url
 
-      def current
-        self.instance ||= new
-      end
+    def self.configure
+      yield(instance)
+    end
 
-      def logger=(log)
-        @@logger = RestClient.log = log
-      end
+    def logger=(log)
+      @logger = RestClient.log = log
+    end
 
-      def base_url
-        @@base_url ||= Settings.remote_api_url
-      end
+    def base_url
+      @base_url ||= Settings.remote_api_url
     end
 
     def get(path, **query)
@@ -28,7 +25,7 @@ module Remote
     private
 
     def build_endpoint(path, **query)
-      [self.class.base_url, path].join('/') + '?' + { api_key: }.merge(**query).to_query
+      [base_url, path].join('/') + '?' + { api_key: }.merge(**query).to_query
     end
 
     def execute_request(method, path, **query)

--- a/spec/services/remote/case_worker_spec.rb
+++ b/spec/services/remote/case_worker_spec.rb
@@ -16,7 +16,7 @@ module Remote
 
     before do
       client = double Remote::HttpClient
-      allow(Remote::HttpClient).to receive(:current).and_return(client)
+      allow(Remote::HttpClient).to receive(:instance).and_return(client)
       allow(client)
         .to receive(:get)
         .with('case_workers', 'query_key' => 'query value', api_key: 'my_api_key')

--- a/spec/services/remote/claim_spec.rb
+++ b/spec/services/remote/claim_spec.rb
@@ -60,7 +60,7 @@ module Remote
 
       before do
         client = double Remote::HttpClient
-        allow(Remote::HttpClient).to receive(:current).and_return(client)
+        allow(Remote::HttpClient).to receive(:instance).and_return(client)
         allow(client).to receive(:get).with('case_workers/claims', **query_params).and_return(claim_collection)
       end
 

--- a/spec/services/remote/http_client_spec.rb
+++ b/spec/services/remote/http_client_spec.rb
@@ -1,71 +1,58 @@
 require 'rails_helper'
 
-module Remote
-  describe Remote::HttpClient do
-    describe '.current' do
-      context 'when self.instance already exists' do
-        it 'returns the instance' do
-          client = described_class.current
-          expect(client).to be_instance_of(described_class)
-        end
-      end
+describe Remote::HttpClient do
+  subject(:client) { described_class.instance }
 
-      context 'when self.instance does not already exist' do
-        it 'calls new and returns the new instance' do
-          client = described_class.current
-          expect(described_class.current).to eq client
-        end
+  describe '#base_url' do
+    context 'when base_url is specified in configure clause' do
+      before { described_class.configure { |client| client.base_url = 'my_base_url' } }
+
+      it 'uses the base url suppllied in the configure clause' do
+        expect(client.base_url).to eq 'my_base_url'
       end
     end
 
-    describe 'base_url' do
-      context 'when base_url is specified in configure clause' do
-        before { described_class.configure { |client| client.base_url = 'my_base_url' } }
-
-        it 'uses the base url suppllied in the configure clause' do
-          expect(described_class.base_url).to eq 'my_base_url'
-        end
-      end
-
-      context 'when base_url _NOT_ specified in configure block' do
-        before do
-          described_class.configure { |c| c.base_url = nil }
-          allow(Settings).to receive(:remote_api_url).and_return('default_base_url')
-        end
-
-        it 'uses the base url from Settings' do
-          expect(described_class.base_url).to eq 'default_base_url'
-        end
-      end
-    end
-
-    describe '.get' do
-      let(:api_url)  { 'my_api_url' }
-      let(:api_key)  { 'my_key' }
-      let(:path)     { 'my_path' }
-      let(:query)    { { 'key' => 'value' } }
-      let(:endpoint) { 'my_api_url/my_path?api_key=my_key&key=value' }
-
+    context 'when base_url _NOT_ specified in configure block' do
       before do
-        described_class.configure do |client|
-          client.base_url = api_url
-          client.api_key = api_key
-          client.logger = Rails.logger
-          client.open_timeout = 2
-          client.timeout = 4
-        end
+        described_class.configure { |c| c.base_url = nil }
+        allow(Settings).to receive(:remote_api_url).and_return('default_base_url')
       end
 
-      it 'calls execute on RestClient::Request' do
-        response = double('HTTPResponse', body: 'body', headers: {})
-        expect(Caching::ApiRequest).to receive(:cache).with(endpoint).and_call_original
-        expect(JSON).to receive(:parse).with('body', symbolize_names: true).and_return({ key: 'value' })
-        expect(RestClient::Request).to receive(:execute).with(method: :get, url: endpoint, timeout: 4, open_timeout: 2).and_return(response)
-
-        result = HttpClient.current.get(path, **query)
-
-        expect(result).to eq({ key: 'value' })
+      it 'uses the base url from Settings' do
+        expect(client.base_url).to eq 'default_base_url'
       end
+    end
+  end
+
+  describe '#get' do
+    let(:api_url)  { 'my_api_url' }
+    let(:api_key)  { 'my_key' }
+    let(:path)     { 'my_path' }
+    let(:query)    { { 'key' => 'value' } }
+    let(:endpoint) { 'my_api_url/my_path?api_key=my_key&key=value' }
+
+    before do
+      described_class.configure do |client|
+        client.base_url = api_url
+        client.api_key = api_key
+        client.logger = Rails.logger
+        client.open_timeout = 2
+        client.timeout = 4
+      end
+    end
+
+    it 'calls execute on RestClient::Request' do
+      response = double('HTTPResponse', body: 'body', headers: {})
+      expect(Caching::ApiRequest).to receive(:cache).with(endpoint).and_call_original
+      expect(JSON).to receive(:parse).with('body', symbolize_names: true).and_return({ key: 'value' })
+      expect(RestClient::Request)
+        .to receive(:execute)
+        .with(method: :get, url: endpoint, timeout: 4, open_timeout: 2)
+        .and_return(response)
+
+      result = client.get(path, **query)
+
+      expect(result).to eq({ key: 'value' })
     end
   end
 end


### PR DESCRIPTION
#### What

Use the `Singleton` class for `Remote::HttpClient`.

~Note, this will probably conflict with #5200, which should have priority.~ #5200 still needs more work and it is not a priority at the moment.

A further point of discussion is whether we should be using singletons at all. Some consider it to be an anti-pattern.

#### Ticket

N/A

#### Why

`Remote::HttpClient` is a singleton class but it is using a custom implementation of the singleton pattern instead of the built-in Singleton module.

#### How

* The `Singleton` module deals with making `new` private and defining `instance`
* It is now not necessary to test the singleton `instance` method
* The class variables are changed to instance variables
* The configure method sets the singleton's instance variables instead of class variables
