### PR TITLE
Hide 'timedout' flashes from Devise

### DIFF
--- a/app/views/layouts/_flashes.html.haml
+++ b/app/views/layouts/_flashes.html.haml
@@ -1,3 +1,3 @@
 - flash.each do |key, value|
-  - unless %w{hidden ga}.include? key
+  - unless %w{hidden ga timedout}.include? key
     = govuk_notification_banner(key.capitalize, value, class: "govuk-notification-banner--#{key}")


### PR DESCRIPTION

#### What

Hide the `timedout` flash message.

#### Ticket

N/A

#### Why

Devise uses `flash[:timedout]` for recording when a session is timed out and this is automatically displayed to the user. 

<img width="660" alt="Screenshot 2022-10-17 at 09 41 51" src="https://user-images.githubusercontent.com/4415912/196136199-4654c471-09c4-4da3-8380-30528e746da7.png">

For reference: https://github.com/heartcombo/devise/issues/1777

#### How

Adding `timedout` to the list of messages to hide in `app/views/layouts/_flashes.html.haml`.
