### PR TITLE
Allow Claim for Payment as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
-* @ministryofjustice/laa-claim-for-payment
-* @ministryofjustice/laa-clair-taskforce
+* @ministryofjustice/laa-claim-for-payment @ministryofjustice/laa-clair-taskforce
+
+# Temporarily ensure that this file can be changed in the event of a broken
+# configuration above
+.github/CODEOWNERS @ministryofjustice/laa-claim-for-payment


### PR DESCRIPTION
#### What

Update the code owners to list both Claim for Payment and CLAIR Taskforce as code owners.

#### Ticket

N/A

#### Why

With the previous configuration, the second line making the CLAIR Taskforce the code owner of the whole repository took ownership away from the Claim for Payment team on the previous line.

#### How

Listing both teams on the same line should make both code owners.
