### PR TITLE
Remove special rule for this file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
 * @ministryofjustice/laa-claim-for-payment @ministryofjustice/laa-clair-taskforce
-
-# Temporarily ensure that this file can be changed in the event of a broken
-# configuration above
-.github/CODEOWNERS @ministryofjustice/laa-claim-for-payment


### PR DESCRIPTION
#### What

Clean up previous PR.

#### Ticket

N/A

#### Why

A 'code owner' rule was added specifically for this file in the event that other changes accidentally made the repository inaccessible. The other configuration worked so this rule is no longer required.

#### How

Remove

```
.github/CODEOWNERS @ministryofjustice/laa-claim-for-payment
```
