### PR TITLE
CTSKF-41 Update ingress controllers to v1.2

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-api-sandbox-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-api-sandbox-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -12,25 +11,27 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
-      SecRule REQUEST_URI "@contains /messages" \
-        "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-api-sandbox
 spec:
+  ingressClassName: modsec
   rules:
     - host: api-sandbox.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - api-sandbox.claim-crown-court-defence.service.justice.gov.uk


### PR DESCRIPTION
#### What

Updates kubernetes configuration for the `api-sandbox` environment to use v1.2 of the ingress controller.

#### Ticket

[CTSKF-49](https://dsdmoj.atlassian.net/browse/CTSKF-49)

#### Why

Software vendors need to test their case management software against the latest version of the ingress in order to identify and fix issues before production is migrated on 15/11/2022.

#### How

Updates the `.k8s/live/api-sandbox/ingress.yaml`.