### PR TITLE
Remove 'pending' from timezone sensitive test

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -301,10 +301,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       # Note, we cannot stub postgres `current_date`.
       #
       context 'when handling timezones' do
-        before do
-          pending 'Bug with timezones in BST'
-          create(:advocate_final_claim, :authorised)
-        end
+        before { create(:advocate_final_claim, :authorised) }
 
         it 'returns date in same time zone as current time zone for rails' do
           expect(completed_ats.first.utc).to be_within(5.seconds).of(Time.current.utc)


### PR DESCRIPTION
#### What

Reverts the change made in https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/4773/files to allow a timezone sensitive test to continue to pass during BST. Now we are back in GMT the temporary change can be removed, as it is now causing the test to fail.

This will need to be re-added in March 2023 if we do not fix this issue before.