### PR TITLE
[CTSKF-62] Update Cronjobs to use latest k8s version

### DIFF
--- a/.k8s/live/cron_jobs/archive_stale.yaml
+++ b/.k8s/live/cron_jobs/archive_stale.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cccd-archive-stale

--- a/.k8s/live/cron_jobs/clean_ecr.yaml
+++ b/.k8s/live/cron_jobs/clean_ecr.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: ecr-delete-untagged-images-cronjob

--- a/.k8s/live/cron_jobs/vacuum_db.yaml
+++ b/.k8s/live/cron_jobs/vacuum_db.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cccd-vacuum-db


### PR DESCRIPTION
#### What

All three CronJobs in CCCD use the Kubernetes API `batch/v1beta1`. This is now deprecated, replaced with `batch/v1`, and will eventually be removed, which will result in failures.

#### Ticket

[CTSKF-62](https://dsdmoj.atlassian.net/browse/CTSKF-62)

#### Why

To ensure the system remains usable in future.

#### How
Replace `batch/v1beta1` with `batch/v1`  in all three config files:
 * `.k8s/live/cron_jobs/archive_stale.yaml`
 * `.k8s/live/cron_jobs/clean_ecr.yaml`
 * `.k8s/live/cron_jobs/vacuum_db.yaml`
