### PR TITLE
CTSKF-63 Add main_hearing_date to claims table

### DIFF
--- a/db/migrate/20221110132804_add_main_hearing_date_to_claims.rb
+++ b/db/migrate/20221110132804_add_main_hearing_date_to_claims.rb
@@ -1,0 +1,5 @@
+class AddMainHearingDateToClaims < ActiveRecord::Migration[6.1]
+  def change
+    add_column :claims, :main_hearing_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_02_141802) do
+ActiveRecord::Schema.define(version: 2022_11_10_132804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 2022_03_02_141802) do
     t.string "travel_expense_additional_information"
     t.boolean "prosecution_evidence"
     t.bigint "case_stage_id"
+    t.date "main_hearing_date"
     t.index ["case_number"], name: "index_claims_on_case_number"
     t.index ["case_stage_id"], name: "index_claims_on_case_stage_id"
     t.index ["cms_number"], name: "index_claims_on_cms_number"


### PR DESCRIPTION
#### What

Add `main_hearing_date` to the `claims` table in the CCCD database.

#### Ticket

[CTSKF-63](https://dsdmoj.atlassian.net/browse/CTSKF-63)

#### Why

Future CLAIR contingency work depends on the existence of a `main_hearing_date`. Adding this field to the database allows further work to take place.

#### How

Creates a migration to add the `main_hearing_date` field to the `claims` table.
