### PR TITLE
Fix cucmber_opts warning message

### DIFF
--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -18,7 +18,7 @@ begin
       t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'default'
-      t.cucumber_opts = '--format progress --color'
+      t.cucumber_opts = %w[--format progress --color]
     end
 
     Cucumber::Rake::Task.new({:wip => 'test:prepare'}, 'Run features that are being worked on') do |t|


### PR DESCRIPTION
#### What

Running any rake task currently results in the following message being displayed:

```
WARNING: consider using an array rather than a space-delimited string with cucumber_opts to avoid undesired behavior.
```

This changes the parameters passed to `cucumber_opts` in `cucumber.rake` from strings to an array of strings to prevent this message being displayed.

(I've never used this rake task. If no one else does then a better alternative might be to simply delete it.)

