### PR TITLE
Add main hearing date to CCR injection (2nd version)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1714,7 +1714,6 @@ RSpec/NestedGroups:
 RSpec/NotToNot:
   Exclude:
     - 'spec/api/services/resource_adapter_spec.rb'
-    - 'spec/api/v2/ccr_claim_spec.rb'
     - 'spec/controllers/case_conclusions_controller_spec.rb'
     - 'spec/controllers/case_workers/admin/case_workers_controller_spec.rb'
     - 'spec/controllers/claim_intentions_controller_spec.rb'
@@ -2369,7 +2368,6 @@ Style/BlockDelimiters:
     - 'spec/api/v1/dropdown_data_spec.rb'
     - 'spec/api/v1/external_users/fee_spec.rb'
     - 'spec/api/v2/cclf_claim_spec.rb'
-    - 'spec/api/v2/ccr_claim_spec.rb'
     - 'spec/api/v2/mi/injection_errors_spec.rb'
     - 'spec/api/v2/search_spec.rb'
     - 'spec/controllers/case_workers/admin/case_workers_controller_spec.rb'
@@ -2845,7 +2843,6 @@ Style/PercentLiteralDelimiters:
   Exclude:
     - 'spec/api/entities/ccr/adapted_fixed_fee_spec.rb'
     - 'spec/api/v1/dropdown_data_spec.rb'
-    - 'spec/api/v2/ccr_claim_spec.rb'
     - 'spec/api/v2/root_spec.rb'
     - 'spec/controllers/external_users/admin/external_users_controller_spec.rb'
     - 'spec/controllers/external_users/admin/providers_controller_spec.rb'

--- a/app/interfaces/api/entities/ccr/base_claim.rb
+++ b/app/interfaces/api/entities/ccr/base_claim.rb
@@ -6,6 +6,7 @@ module API
         expose :supplier_number
         expose :case_number
         expose :last_submitted_at, format_with: :utc
+        expose :main_hearing_date, format_with: :utc
         expose :adapted_advocate_category, as: :advocate_category
         expose :court, using: API::Entities::CCR::Court
         expose :defendants_with_main_first, using: API::Entities::CCR::Defendant, as: :defendants

--- a/config/schemas/ccr_claim_schema.json
+++ b/config/schemas/ccr_claim_schema.json
@@ -48,6 +48,10 @@
       "id": "/properties/last_submitted_at",
       "type": ["string","null"]
     },
+    "main_hearing_date": {
+      "id": "/properties/main_hearing_date",
+      "type": ["string","null"]
+    },
     "additional_information": {
       "id": "/properties/additional_information",
       "type": ["string","null"]

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -18,6 +18,23 @@ RSpec::Matchers.define :be_valid_ccr_claim_json do
   end
 end
 
+RSpec.shared_examples 'base CCR exposed attributes' do
+  it { is_expected.to expose :uuid }
+  it { is_expected.to expose :supplier_number }
+  it { is_expected.to expose :case_number }
+  it { is_expected.to expose :last_submitted_at }
+  it { is_expected.to expose :main_hearing_date }
+  it { is_expected.to expose :advocate_category }
+  it { is_expected.to expose :court }
+  it { is_expected.to expose :defendants }
+  it { is_expected.to expose :actual_trial_Length }
+  it { is_expected.to expose :estimated_trial_length }
+  it { is_expected.to expose :retrial_actual_length }
+  it { is_expected.to expose :retrial_estimated_length }
+  it { is_expected.to expose :additional_information }
+  it { is_expected.to expose :bills }
+end
+
 RSpec.describe API::V2::CCRClaim, feature: :injection do
   include Rack::Test::Methods
   include ApiSpecHelper
@@ -119,31 +136,18 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
     context 'advocate "final" claims' do
       subject(:response) { do_request.body }
 
-      it { is_expected.to expose :uuid }
-      it { is_expected.to expose :supplier_number }
-      it { is_expected.to expose :case_number }
+      include_examples 'base CCR exposed attributes'
+
       it { is_expected.to expose :first_day_of_trial }
       it { is_expected.to expose :trial_fixed_notice_at }
       it { is_expected.to expose :trial_fixed_at }
       it { is_expected.to expose :trial_cracked_at }
       it { is_expected.to expose :retrial_started_at }
       it { is_expected.to expose :trial_cracked_at_third }
-      it { is_expected.to expose :last_submitted_at }
 
-      it { is_expected.to expose :advocate_category }
       it { is_expected.to expose :case_type }
-      it { is_expected.to expose :court }
       it { is_expected.to expose :offence }
-      it { is_expected.to expose :defendants }
       it { is_expected.to expose :retrial_reduction }
-
-      it { is_expected.to expose :actual_trial_Length }
-      it { is_expected.to expose :estimated_trial_length }
-      it { is_expected.to expose :retrial_actual_length }
-      it { is_expected.to expose :retrial_estimated_length }
-
-      it { is_expected.to expose :additional_information }
-      it { is_expected.to expose :bills }
     end
 
     context 'advocate interim claim' do
@@ -153,31 +157,18 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       let(:offence) { create(:offence, :with_fee_scheme_ten) }
       let(:claim) { create_claim(:advocate_interim_claim, :without_fees, :submitted, offence:, warrant_fee:) }
 
-      it { is_expected.to expose :uuid }
-      it { is_expected.to expose :supplier_number }
-      it { is_expected.to expose :case_number }
+      include_examples 'base CCR exposed attributes'
+
       it { is_expected.not_to expose :first_day_of_trial }
       it { is_expected.not_to expose :trial_fixed_notice_at }
       it { is_expected.not_to expose :trial_fixed_at }
       it { is_expected.not_to expose :trial_cracked_at }
       it { is_expected.not_to expose :retrial_started_at }
       it { is_expected.not_to expose :trial_cracked_at_third }
-      it { is_expected.to expose :last_submitted_at }
 
-      it { is_expected.to expose :advocate_category }
       it { is_expected.to expose :case_type }
-      it { is_expected.to expose :court }
       it { is_expected.to expose :offence }
-      it { is_expected.to expose :defendants }
       it { is_expected.not_to expose :retrial_reduction }
-
-      it { is_expected.to expose :actual_trial_Length }
-      it { is_expected.to expose :estimated_trial_length }
-      it { is_expected.to expose :retrial_actual_length }
-      it { is_expected.to expose :retrial_estimated_length }
-
-      it { is_expected.to expose :additional_information }
-      it { is_expected.to expose :bills }
     end
 
     context 'advocate supplementary claim' do
@@ -185,31 +176,18 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
 
       let(:claim) { create_claim(:advocate_supplementary_claim, :submitted) }
 
-      it { is_expected.to expose :uuid }
-      it { is_expected.to expose :supplier_number }
-      it { is_expected.to expose :case_number }
+      include_examples 'base CCR exposed attributes'
+
       it { is_expected.not_to expose :first_day_of_trial }
       it { is_expected.not_to expose :trial_fixed_notice_at }
       it { is_expected.not_to expose :trial_fixed_at }
       it { is_expected.not_to expose :trial_cracked_at }
       it { is_expected.not_to expose :retrial_started_at }
       it { is_expected.not_to expose :trial_cracked_at_third }
-      it { is_expected.to expose :last_submitted_at }
 
-      it { is_expected.to expose :advocate_category }
       it { is_expected.to expose :case_type }
-      it { is_expected.to expose :court }
       it { is_expected.not_to expose :offence }
-      it { is_expected.to expose :defendants }
       it { is_expected.not_to expose :retrial_reduction }
-
-      it { is_expected.to expose :actual_trial_Length }
-      it { is_expected.to expose :estimated_trial_length }
-      it { is_expected.to expose :retrial_actual_length }
-      it { is_expected.to expose :retrial_estimated_length }
-
-      it { is_expected.to expose :additional_information }
-      it { is_expected.to expose :bills }
     end
 
     context 'advocate hardship claims' do
@@ -217,32 +195,17 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
 
       let(:claim) { create(:advocate_hardship_claim, case_stage: build(:case_stage, :trial_not_concluded)) }
 
-      it { is_expected.to expose :uuid }
-      it { is_expected.to expose :supplier_number }
-      it { is_expected.to expose :case_number }
+      include_examples 'base CCR exposed attributes'
+
       it { is_expected.to expose :first_day_of_trial }
       it { is_expected.to expose :trial_fixed_notice_at }
       it { is_expected.to expose :trial_fixed_at }
       it { is_expected.to expose :trial_cracked_at }
       it { is_expected.to expose :retrial_started_at }
       it { is_expected.to expose :trial_cracked_at_third }
-      it { is_expected.to expose :last_submitted_at }
-
-      it { is_expected.to expose :advocate_category }
       it { is_expected.to expose :case_type }
-      it { is_expected.to expose :court }
       it { is_expected.to expose :offence }
-      it { is_expected.to expose :defendants }
       it { is_expected.to expose :retrial_reduction }
-
-      it { is_expected.to expose :actual_trial_Length }
-      it { is_expected.to expose :estimated_trial_length }
-      it { is_expected.to expose :retrial_actual_length }
-      it { is_expected.to expose :retrial_estimated_length }
-
-      it { is_expected.to expose :additional_information }
-
-      it { is_expected.to expose :bills }
       it { is_expected.to have_json_size(1).at_path('bills') }
     end
 
@@ -261,12 +224,12 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
 
       context 'representation orders' do
-        let(:defendants) {
+        let(:defendants) do
           [
             create(:defendant, representation_orders: create_list(:representation_order, 2, representation_order_date: 5.days.ago)),
             create(:defendant, representation_orders: [create(:representation_order, representation_order_date: 2.days.ago)])
           ]
-        }
+        end
 
         it 'returns the earliest of the representation orders' do
           is_expected.to have_json_size(1).at_path('defendants/0/representation_orders')
@@ -320,7 +283,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           let(:basic_fee) { build(:basic_fee, :pcm_fee, quantity: 2, amount: 2, rate: 1) }
 
           it 'not added to bills array' do
-            expect(response).to_not include('"bill_type":"AGFS_FEE"')
+            expect(response).not_to include('"bill_type":"AGFS_FEE"')
           end
         end
 
@@ -421,12 +384,12 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           context 'when there is some defendant uplifts' do
-            let(:basic_fees) {
+            let(:basic_fees) do
               [
                 build(:basic_fee, :baf_fee, quantity: 1),
                 build(:basic_fee, :ndr_fee, quantity: 2)
               ]
-            }
+            end
 
             it 'calculated from sum of Number of defendant uplift fee quantities plus one for main defendant' do
               expect(response).to be_json_eql('3'.to_json).at_path 'bills/0/number_of_defendants'
@@ -460,14 +423,14 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           context 'upper bound value' do
-            let(:basic_fees) {
+            let(:basic_fees) do
               [
                 build(:basic_fee, :baf_fee, quantity: 1),
                 build(:basic_fee, :daf_fee, quantity: 38, rate: 1.0),
                 build(:basic_fee, :dah_fee, quantity: 10, rate: 1.0),
                 build(:basic_fee, :daj_fee, quantity: 1, rate: 1.0)
               ]
-            }
+            end
             let(:claim) { create_claim(:submitted_claim, :without_fees, case_type:, basic_fees:, misc_fees: [misc_fee], actual_trial_length: 53) }
 
             it 'calculated from Daily Attendanance Fee quantities if they exist' do
@@ -542,7 +505,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
 
           it 'fee does not impact the bill' do
             is_expected.to have_json_size(1).at_path('bills')
-            is_expected.to_not be_json_eql('13'.to_json).at_path 'bills/0/daily_attendances'
+            is_expected.not_to be_json_eql('13'.to_json).at_path 'bills/0/daily_attendances'
           end
         end
 
@@ -604,7 +567,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
             end
 
             it 'consolidated list of UNIQUE additional case numbers for all uplift fees of the applicable variety' do
-              %w{S20170001 S20170002 S20170003}.each do |case_number|
+              %w[S20170001 S20170002 S20170003].each do |case_number|
                 is_expected.to include_json(case_number.to_json).at_path 'bills/0/case_numbers'
               end
             end
@@ -828,7 +791,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'does not add CCR advocate fee to bills array' do
-            expect(response).to_not include('"bill_subtype":"AGFS_FEE"')
+            expect(response).not_to include('"bill_subtype":"AGFS_FEE"')
           end
 
           it 'converts CCCD BASAF to CCR misc fee AGFS_STD_APPRNC to bills array' do
@@ -840,7 +803,7 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
           end
 
           it 'ignores CCCD BACAV fee' do
-            expect(response).to_not include('"bill_subtype":"AGFS_CONFERENCE"')
+            expect(response).not_to include('"bill_subtype":"AGFS_CONFERENCE"')
           end
         end
       end


### PR DESCRIPTION
#### What

Add main hearing date to the CCR injection data.

#### Ticket

[CCCD: Add main hearing date to CCR injection data](https://dsdmoj.atlassian.net/browse/CTSKF-65)

#### Why

Main hearing date will be required in addition to representation order date for determining the fee scheme.

#### How

Expose the `main_hearing_date` attribute for the CCR base claim entity.