### PR TITLE
[CTSKF-64] Add main hearing date to CCLF injection

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1131,7 +1131,6 @@ RSpec/IteratedExpectation:
 RSpec/LeadingSubject:
   Exclude:
     - 'spec/api/v1/external_users/claims/advocates/final_claim_spec.rb'
-    - 'spec/api/v2/cclf_claim_spec.rb'
     - 'spec/controllers/case_workers/admin/case_workers_controller_spec.rb'
     - 'spec/controllers/external_users/admin/external_users_controller_spec.rb'
     - 'spec/controllers/external_users/admin/providers_controller_spec.rb'
@@ -2345,7 +2344,6 @@ Style/BlockDelimiters:
     - 'spec/api/entities/offence_spec.rb'
     - 'spec/api/v1/dropdown_data_spec.rb'
     - 'spec/api/v1/external_users/fee_spec.rb'
-    - 'spec/api/v2/cclf_claim_spec.rb'
     - 'spec/api/v2/mi/injection_errors_spec.rb'
     - 'spec/api/v2/search_spec.rb'
     - 'spec/controllers/case_workers/admin/case_workers_controller_spec.rb'

--- a/app/interfaces/api/entities/cclf/base_claim.rb
+++ b/app/interfaces/api/entities/cclf/base_claim.rb
@@ -9,6 +9,7 @@ module API
                 :retrial_started_at,
                 :case_concluded_at,
                 :last_submitted_at,
+                :main_hearing_date,
                 format_with: :utc
 
         expose :actual_trial_length_or_one, as: :actual_trial_Length, format_with: :string

--- a/config/schemas/cclf_claim_schema.json
+++ b/config/schemas/cclf_claim_schema.json
@@ -44,6 +44,10 @@
       "id": "/properties/last_submitted_at",
       "type": ["string","null"]
     },
+    "main_hearing_date": {
+      "id": "/properties/main_hearing_date",
+      "type": ["string","null"]
+    },
     "additional_information": {
       "id": "/properties/additional_information",
       "type": ["string","null"]

--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -100,47 +100,13 @@ RSpec.describe API::V2::CCLFClaim, feature: :injection do
     include_examples 'returns LGFS claim type', :interim_claim
     include_examples 'returns LGFS claim type', :transfer_claim
 
-    it 'requires an API key' do
-      do_request(api_key: nil)
-      expect(last_response.status).to eq 401
-      expect(last_response.body).to include('Unauthorised')
+    it_behaves_like 'injection response statuses' do
+      let(:invalid_claim) { create(:advocate_claim, :submitted) }
     end
 
-    context 'when accessed by an ExternalUser' do
-      before { do_request(api_key: claim.external_user.user.api_key) }
-
-      it 'returns unauthorised' do
-        expect(last_response.status).to eq 401
-        expect(last_response.body).to include('Unauthorised')
-      end
-    end
-
-    context 'claim not found' do
-      it 'returns not found response when claim uuid does not exist' do
-        do_request(claim_uuid: '123-456-789')
-        expect(last_response.status).to eq 404
-        expect(last_response.body).to include('Claim not found')
-      end
-
-      it 'returns not found response when claim is not an LGFS claim' do
-        claim = create(:advocate_claim, :submitted)
-        do_request(claim_uuid: claim.uuid)
-        is_expected.to eq 404
-        expect(last_response.body).to include('Claim not found')
-      end
-    end
-
-    it 'returns 406, Not Acceptable, if requested API version (via header) is not supported' do
-      header 'Accept-Version', 'v1'
+    it 'returns valid JSON' do
       do_request
-      expect(last_response.status).to eq 406
-      expect(last_response.body).to include('The requested version is not supported.')
-    end
-
-    context 'JSON response' do
-      subject(:response) { do_request }
-
-      it { expect(response).to be_valid_cclf_claim_json }
+      expect(last_response).to be_valid_cclf_claim_json
     end
 
     context 'claim' do

--- a/spec/api/v2/cclf_claim_spec.rb
+++ b/spec/api/v2/cclf_claim_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe API::V2::CCLFClaim, feature: :injection do
       it { is_expected.to expose :retrial_started_at }
       it { is_expected.to expose :case_concluded_at }
       it { is_expected.to expose :last_submitted_at }
+      it { is_expected.to expose :main_hearing_date }
       it { is_expected.to expose :actual_trial_Length }
       it { is_expected.to expose :case_type }
       it { is_expected.to expose :offence }

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -62,37 +62,13 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
   describe 'GET /ccr/claim/:uuid?api_key=:api_key' do
     let(:dsl) { Grape::DSL::InsideRoute }
 
-    context 'response statuses' do
-      it 'returns 200, success, and JSON response when existing claim exists and api key authorised' do
-        do_request
-        expect(last_response.status).to eq 200
-        expect(last_response).to be_valid_ccr_claim_json
-      end
+    it_behaves_like 'injection response statuses' do
+      let(:invalid_claim) { create(:litigator_claim, :submitted) }
+    end
 
-      it 'returns 401 when API key not provided' do
-        do_request(api_key: nil)
-        expect(last_response.status).to eq 401
-        expect(last_response.body).to include('Unauthorised')
-      end
-
-      it 'returns 401, Unauthorised when api key is for an external user' do
-        do_request(api_key: claim.external_user.user.api_key)
-        expect(last_response.status).to eq 401
-        expect(last_response.body).to include('Unauthorised')
-      end
-
-      it 'returns 404, Claim not found when claim does not exist' do
-        do_request(claim_uuid: '123-456-789')
-        expect(last_response.status).to eq 404
-        expect(last_response.body).to include('Claim not found')
-      end
-
-      it 'returns 406, Not Acceptable, if requested API version (via header) is not supported' do
-        header 'Accept-Version', 'v1'
-        do_request
-        expect(last_response.status).to eq 406
-        expect(last_response.body).to include('The requested version is not supported.')
-      end
+    it 'returns valid JSON' do
+      do_request
+      expect(last_response).to be_valid_ccr_claim_json
     end
 
     context 'entities' do

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -209,35 +209,16 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       it { is_expected.to have_json_size(1).at_path('bills') }
     end
 
-    context 'defendants' do
-      subject(:response) { do_request.body }
-
-      let(:defendants) { create_list(:defendant, 2) }
-      let(:claim) { create_claim(:submitted_claim, :without_fees, case_type:, basic_fees: [basic_fee], misc_fees: [misc_fee], defendants:) }
-
-      it 'returns multiple defendants' do
-        is_expected.to have_json_size(2).at_path('defendants')
-      end
-
-      it 'returns defendants in order created marking earliest created as the "main" defendant' do
-        is_expected.to be_json_eql('true').at_path('defendants/0/main_defendant')
-      end
-
-      context 'representation orders' do
-        let(:defendants) do
-          [
-            create(:defendant, representation_orders: create_list(:representation_order, 2, representation_order_date: 5.days.ago)),
-            create(:defendant, representation_orders: [create(:representation_order, representation_order_date: 2.days.ago)])
-          ]
-        end
-
-        it 'returns the earliest of the representation orders' do
-          is_expected.to have_json_size(1).at_path('defendants/0/representation_orders')
-        end
-
-        it 'returns earliest rep order first (per defendant)' do
-          is_expected.to be_json_eql(claim.earliest_representation_order_date.to_json).at_path('defendants/0/representation_orders/0/representation_order_date')
-        end
+    it_behaves_like 'injection data with defendants' do
+      let(:claim) do
+        create_claim(
+          :submitted_claim,
+          :without_fees,
+          case_type:,
+          basic_fees: [basic_fee],
+          misc_fees: [misc_fee],
+          defendants:
+        )
       end
     end
 

--- a/spec/support/shared_examples/api/v2/shared_examples_for_injection.rb
+++ b/spec/support/shared_examples/api/v2/shared_examples_for_injection.rb
@@ -1,0 +1,38 @@
+RSpec.shared_examples 'injection data with defendants' do
+  subject(:response) { do_request.body }
+
+  let(:defendants) { create_list(:defendant, 2) }
+
+  it 'returns multiple defendants' do
+    is_expected.to have_json_size(2).at_path('defendants')
+  end
+
+  it 'returns defendants in order created marking earliest created as the "main" defendant' do
+    is_expected.to be_json_eql('true').at_path('defendants/0/main_defendant')
+  end
+
+  context 'with representation orders' do
+    let(:defendants) do
+      [
+        create(
+          :defendant,
+          representation_orders: create_list(:representation_order, 2, representation_order_date: 5.days.ago)
+        ),
+        create(
+          :defendant,
+          representation_orders: [create(:representation_order, representation_order_date: 2.days.ago)]
+        )
+      ]
+    end
+
+    it 'returns the earliest of the representation orders' do
+      is_expected.to have_json_size(1).at_path('defendants/0/representation_orders')
+    end
+
+    it 'returns earliest rep order first (per defendant)' do
+      is_expected
+        .to be_json_eql(claim.earliest_representation_order_date.to_json)
+        .at_path('defendants/0/representation_orders/0/representation_order_date')
+    end
+  end
+end

--- a/spec/support/shared_examples/api/v2/shared_examples_for_injection.rb
+++ b/spec/support/shared_examples/api/v2/shared_examples_for_injection.rb
@@ -1,3 +1,52 @@
+RSpec.shared_examples 'injection response statuses' do
+  before do
+    headers.each_pair { |key, value| header key, value }
+    do_request(**options)
+  end
+
+  let(:options) { {} }
+  let(:headers) { {} }
+
+  context 'with an existing claim and an authorized api key' do
+    it { expect(last_response.status).to eq 200 }
+  end
+
+  context 'without an API key' do
+    let(:options) { { api_key: nil } }
+
+    it { expect(last_response.status).to eq 401 }
+    it { expect(last_response.body).to include('Unauthorised') }
+  end
+
+  context 'with an unauthorized api key' do
+    let(:options) { { api_key: claim.external_user.user.api_key } }
+
+    it { expect(last_response.status).to eq 401 }
+    it { expect(last_response.body).to include('Unauthorised') }
+  end
+
+  context 'with a claim uuid for an unknown claim' do
+    let(:options) { { claim_uuid: '123-456-789' } }
+
+    it { expect(last_response.status).to eq 404 }
+    it { expect(last_response.body).to include('Claim not found') }
+  end
+
+  context 'with a claim of the wrong type' do
+    let(:options) { { claim_uuid: invalid_claim.uuid } }
+
+    it { expect(last_response.status).to eq 404 }
+    it { expect(last_response.body).to include('Claim not found') }
+  end
+
+  context 'with an invalid API version in header' do
+    let(:headers) { { 'Accept-Version' => 'v1' } }
+
+    it { expect(last_response.status).to eq 406 }
+    it { expect(last_response.body).to include('The requested version is not supported.') }
+  end
+end
+
 RSpec.shared_examples 'injection data with defendants' do
   subject(:response) { do_request.body }
 


### PR DESCRIPTION
#### What

Add main hearing date to the CCLF injection data.

#### Ticket

[CCCD: Add main hearing date to CCLF injection data](https://dsdmoj.atlassian.net/browse/CTSKF-64)

#### Why

Main hearing date will be required in addition to representation order date for determining the fee scheme.

#### How

Expose the `main_hearing_date` attribute for the CCLF base claim entity.