### PR TITLE
CTSKF-61 Update ingress controllers to v1.2

### DIFF
--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-lgfs-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-dev-lgfs-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -20,24 +19,31 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-dev-lgfs
 spec:
+  ingressClassName: modsec
   rules:
     - host: dev-lgfs.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
     - host: dev-clar.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - dev-lgfs.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-dev-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -20,17 +19,21 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-dev
 spec:
+  ingressClassName: modsec
   rules:
     - host: dev.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - dev.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -20,17 +19,21 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-production
 spec:
+  ingressClassName: modsec
   rules:
     - host: claim-crown-court-defence.service.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - claim-crown-court-defence.service.gov.uk

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -1,10 +1,9 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-cccd-staging-green
+    external-dns.alpha.kubernetes.io/set-identifier: cccd-app-ingress-v1-cccd-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    kubernetes.io/ingress.class: "modsec01"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -20,17 +19,21 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
-  name: cccd-app-ingress
+  name: cccd-app-ingress-v1
   namespace: cccd-staging
 spec:
+  ingressClassName: modsec
   rules:
     - host: staging.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: cccd-app-service
-              servicePort: 80
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - staging.claim-crown-court-defence.service.justice.gov.uk


### PR DESCRIPTION
#### What

Updates kubernetes configuration for the following environments to use v1.2 of the ingress controller:

- `dev`
- `dev-lgfs`
- `staging`
- `production`

`api-sandbox` has already been updated to allow testing by software vendors.

#### Ticket

[CTSKF-61](https://dsdmoj.atlassian.net/browse/CTSKF-61)
