### PR TITLE
Add note about viewing test running in browser

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,13 @@ To execute cucumber feature tests
 bundle exec cucumber
 ```
 
+By default these tests run with a headless browser. To see the tests in a single
+feature file run in a browser use
+
+```bash
+BROWSER=chrome bundle exec cucumber <feature file>
+```
+
 ## API Smoke tests
 
 API smoke tests can be executed with


### PR DESCRIPTION
#### What

Add documentation for viewing Cucumber tests in a browser.

#### Ticket

N/A

#### Why

Cucumber tests run in a headless browser. For debugging it can be useful to watch the tests running.

#### How

Add a note in the documentation to show how to run the test in a browser instead of the default headless browser.
