### PR TITLE
[CTSKF-69] - Add main hearing date to lgfs API claims 

### DIFF
--- a/app/interfaces/api/v1/external_users/claims/final_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/final_claim.rb
@@ -12,6 +12,10 @@ module API::V1::ExternalUsers
         optional :actual_trial_length,
                  type: Integer,
                  desc: 'REQUIRED/UNREQUIRED: The actual trial length in days, required for graduated fees.'
+        optional :main_hearing_date,
+                 type: String,
+                 desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                 standard_json_format: true
       end
 
       namespace :final do

--- a/app/interfaces/api/v1/external_users/claims/final_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/final_claim.rb
@@ -12,10 +12,12 @@ module API::V1::ExternalUsers
         optional :actual_trial_length,
                  type: Integer,
                  desc: 'REQUIRED/UNREQUIRED: The actual trial length in days, required for graduated fees.'
-        optional :main_hearing_date,
-                 type: String,
-                 desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
-                 standard_json_format: true
+        if Settings.main_hearing_date_enabled?
+          optional :main_hearing_date,
+                   type: String,
+                   desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                   standard_json_format: true
+        end
       end
 
       namespace :final do

--- a/app/interfaces/api/v1/external_users/claims/interim_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/interim_claim.rb
@@ -15,10 +15,12 @@ module API::V1::ExternalUsers
                  type: String,
                  desc: 'REQUIRED/UNREQUIRED: YYYY-MM-DD',
                  standard_json_format: true
-        optional :main_hearing_date,
-                 type: String,
-                 desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
-                 standard_json_format: true
+        if Settings.main_hearing_date_enabled?
+          optional :main_hearing_date,
+                   type: String,
+                   desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                   standard_json_format: true
+        end
       end
 
       namespace :interim do

--- a/app/interfaces/api/v1/external_users/claims/interim_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/interim_claim.rb
@@ -15,6 +15,10 @@ module API::V1::ExternalUsers
                  type: String,
                  desc: 'REQUIRED/UNREQUIRED: YYYY-MM-DD',
                  standard_json_format: true
+        optional :main_hearing_date,
+                 type: String,
+                 desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                 standard_json_format: true
       end
 
       namespace :interim do

--- a/app/interfaces/api/v1/external_users/claims/litigators/hardship_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/litigators/hardship_claim.rb
@@ -7,6 +7,10 @@ module API::V1::ExternalUsers
         params do
           use :lgfs_hardship_params
           use :common_lgfs_params
+          optional :main_hearing_date,
+                   type: String,
+                   desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                   standard_json_format: true
         end
 
         namespace :litigators do

--- a/app/interfaces/api/v1/external_users/claims/litigators/hardship_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/litigators/hardship_claim.rb
@@ -7,10 +7,12 @@ module API::V1::ExternalUsers
         params do
           use :lgfs_hardship_params
           use :common_lgfs_params
-          optional :main_hearing_date,
-                   type: String,
-                   desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
-                   standard_json_format: true
+          if Settings.main_hearing_date_enabled?
+            optional :main_hearing_date,
+                     type: String,
+                     desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                     standard_json_format: true
+          end
         end
 
         namespace :litigators do

--- a/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
@@ -23,6 +23,10 @@ module API::V1::ExternalUsers
         optional :actual_trial_length,
                  type: Integer,
                  desc: I18n.t('api.v1.external_users.claims.transfer_claim.params.actual_trial_length')
+        optional :main_hearing_date,
+                 type: String,
+                 desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                 standard_json_format: true
       end
 
       namespace :transfer do

--- a/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
@@ -23,10 +23,12 @@ module API::V1::ExternalUsers
         optional :actual_trial_length,
                  type: Integer,
                  desc: I18n.t('api.v1.external_users.claims.transfer_claim.params.actual_trial_length')
-        optional :main_hearing_date,
-                 type: String,
-                 desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
-                 standard_json_format: true
+        if Settings.main_hearing_date_enabled?
+          optional :main_hearing_date,
+                   type: String,
+                   desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
+                   standard_json_format: true
+        end
       end
 
       namespace :transfer do

--- a/spec/api/v1/external_users/claims/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/final_claim_spec.rb
@@ -30,8 +30,20 @@ RSpec.describe API::V1::ExternalUsers::Claims::FinalClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
-  it_behaves_like 'a claim endpoint', relative_endpoint: :final
-  it_behaves_like 'a claim validate endpoint', relative_endpoint: :final
-  it_behaves_like 'a claim create endpoint', relative_endpoint: :final
+  context 'when CLAIR contingency functionality is disabled' do
+    before { valid_params.except!(:main_hearing_date) }
+
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: :final
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: :final
+    it_behaves_like 'a claim create endpoint', relative_endpoint: :final
+  end
+
+  context 'when CLAIR contingency functionality is enabled',
+          skip: 'Skipped pending removal of the main_hearing_date feature flag' do
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: :final
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: :final
+    it_behaves_like 'a claim create endpoint', relative_endpoint: :final
+  end
 end

--- a/spec/api/v1/external_users/claims/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/final_claim_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::FinalClaim do
       offence_id: offence.id,
       court_id: court.id,
       case_concluded_at: 1.month.ago.as_json,
-      actual_trial_length: 10
+      actual_trial_length: 10,
+      main_hearing_date: '2020-09-17'
     }
   end
 

--- a/spec/api/v1/external_users/claims/interim_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/interim_claim_spec.rb
@@ -28,8 +28,20 @@ RSpec.describe API::V1::ExternalUsers::Claims::InterimClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
-  it_behaves_like 'a claim endpoint', relative_endpoint: :interim
-  it_behaves_like 'a claim validate endpoint', relative_endpoint: :interim
-  it_behaves_like 'a claim create endpoint', relative_endpoint: :interim
+  context 'when CLAIR contingency functionality is disabled' do
+    before { valid_params.except!(:main_hearing_date) }
+
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: :interim
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: :interim
+    it_behaves_like 'a claim create endpoint', relative_endpoint: :interim
+  end
+
+  context 'when CLAIR contingency functionality is enabled',
+          skip: 'Skipped pending removal of the main_hearing_date feature flag' do
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: :interim
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: :interim
+    it_behaves_like 'a claim create endpoint', relative_endpoint: :interim
+  end
 end

--- a/spec/api/v1/external_users/claims/interim_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/interim_claim_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::InterimClaim do
       case_type_id: create(:case_type, :trial).id,
       case_number: 'A20161234',
       offence_id: offence.id,
-      court_id: court.id
+      court_id: court.id,
+      main_hearing_date: '2015-02-05'
     }
   end
 

--- a/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::Litigators::HardshipClaim do
       case_stage_unique_code: create(:case_stage, :pre_ptph_or_ptph_adjourned).unique_code,
       case_number: 'A20201234',
       offence_id: offence.id,
-      court_id: court.id
+      court_id: court.id,
+      main_hearing_date: '2020-01-09'
     }
   end
 

--- a/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
@@ -30,8 +30,20 @@ RSpec.describe API::V1::ExternalUsers::Claims::Litigators::HardshipClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
-  it_behaves_like 'a claim endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
-  it_behaves_like 'a claim validate endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
-  it_behaves_like 'a claim create endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+  context 'when CLAIR contingency functionality is disabled' do
+    before { valid_params.except!(:main_hearing_date) }
+
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+    it_behaves_like 'a claim create endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+  end
+
+  context 'when CLAIR contingency functionality is enabled',
+          skip: 'Skipped pending removal of the main_hearing_date feature flag' do
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+    it_behaves_like 'a claim create endpoint', relative_endpoint: LITIGATOR_HARDSHIP_CLAIM_ENDPOINT
+  end
 end

--- a/spec/api/v1/external_users/claims/transfer_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/transfer_claim_spec.rb
@@ -34,8 +34,20 @@ RSpec.describe API::V1::ExternalUsers::Claims::TransferClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
-  it_behaves_like 'a claim endpoint', relative_endpoint: :transfer
-  it_behaves_like 'a claim validate endpoint', relative_endpoint: :transfer
-  it_behaves_like 'a claim create endpoint', relative_endpoint: :transfer
+  context 'when CLAIR contingency functionality is disabled' do
+    before { valid_params.except!(:main_hearing_date) }
+
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: :transfer
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: :transfer
+    it_behaves_like 'a claim create endpoint', relative_endpoint: :transfer
+  end
+
+  context 'when CLAIR contingency functionality is enabled',
+          skip: 'Skipped pending removal of the main_hearing_date feature flag' do
+    include_examples 'litigator claim test setup'
+    it_behaves_like 'a claim endpoint', relative_endpoint: :transfer
+    it_behaves_like 'a claim validate endpoint', relative_endpoint: :transfer
+    it_behaves_like 'a claim create endpoint', relative_endpoint: :transfer
+  end
 end

--- a/spec/api/v1/external_users/claims/transfer_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/transfer_claim_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe API::V1::ExternalUsers::Claims::TransferClaim do
       elected_case: false,
       transfer_stage_id: 10,
       transfer_date: 1.month.ago.as_json,
-      case_conclusion_id: 50
+      case_conclusion_id: 50,
+      main_hearing_date: '2015-02-05'
     }
   end
 

--- a/spec/support/api/claims/litigator_claim_test/base.rb
+++ b/spec/support/api/claims/litigator_claim_test/base.rb
@@ -18,7 +18,8 @@ module LitigatorClaimTest
         case_number: 'A20161234',
         supplier_number:,
         offence_id: fetch_id(OFFENCE_ENDPOINT, offence_description: 'Miscellaneous/other'),
-        case_concluded_at: 1.month.ago.as_json
+        case_concluded_at: 1.month.ago.as_json,
+        main_hearing_date: '2015-05-02'
       )
     end
 


### PR DESCRIPTION
What
Adds a main hearing date to the following LGFS API files and put them behind a feature flag 

/api/external_users/claims/final
/api/external_users/claims/interim
/api/external_users/claims/litigator/hardship
/api/external_users/claims/transfer
/api/external_users/claims/final/validate
/api/external_users/claims/interim/validate
/api/external_users/claims/transfer/validate
/api/external_users/claims/litigator/hardship/validate
Also clears up rubocop offences in the affected files, and refactors the tests for clarity.

Ticket
[CTSKF-69 Add a main hearing date to lgfs API claims ](https://dsdmoj.atlassian.net/browse/CTSKF-69)

Why
To allow the inclusion of a main hearing date in API claims so that providers are paid correctly for their work.

--------

TODO (wip)
 - [x] Testing 
 
