### PR TITLE
[CTSKF-124] Update CLAIR warning component on the 'Choose Your Bill Type' page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,6 +43,7 @@ class UsersController < ApplicationController
   private
 
   def settings_params
-    params.except(:id).permit(:api_promo_seen, :timed_retention_banner_seen, :hardship_claims_banner_seen)
+    params.except(:id).permit(:api_promo_seen, :timed_retention_banner_seen, :hardship_claims_banner_seen,
+                              :clair_contingency_banner_seen)
   end
 end

--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -68,6 +68,12 @@ module ExternalUsers::ClaimsHelper
       current_user.setting?(:hardship_claims_banner_seen).nil?
   end
 
+  def show_clair_contingency_banner_to_user?
+    Settings.clair_contingency_banner_enabled? &&
+      current_user_is_external_user? &&
+      current_user.setting?(:clair_contingency_banner_seen).nil?
+  end
+
   def supplier_number_hint
     if current_user.persona.admin?
       path = edit_external_users_admin_provider_path(current_user.provider)

--- a/app/views/external_users/shared/_clair_contingency_banner.html.haml
+++ b/app/views/external_users/shared/_clair_contingency_banner.html.haml
@@ -1,3 +1,8 @@
-.js-callout-banner{'data-setting': 'clair_contingency_banner_seen'}
-  = govuk_warning_text t('callout_banner.clair_contingency_text_one') do
-    = t('callout_banner.clair_contingency_text_two')
+- if show_clair_contingency_banner_to_user?
+  .js-callout-banner{'data-setting': 'clair_contingency_banner_seen'}
+    = govuk_warning_text t('callout_banner.clair_contingency_text_one') do
+      = t('callout_banner.clair_contingency_text_two')
+
+    %ul.govuk-list
+      %li.hide-link
+        = govuk_link_to t('callout_banner.clair_contingency_hide_banner'), settings_user_path(current_user.id, clair_contingency_banner_seen: 1), method: :put, remote: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2715,5 +2715,6 @@ en:
     time_retention_information: More information on time-limited retention
     time_retention_warning_text: Time-limited retention of claims is being introduced from 19th September 2016.
 
+    clair_contingency_hide_banner: Do not show main hearing date information again
     clair_contingency_text_one: Claims with a main hearing date on or after 31 October 2022 may qualify for uplifted fees.
     clair_contingency_text_two: Any increase due will be calculated and added during assessment.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2715,7 +2715,5 @@ en:
     time_retention_information: More information on time-limited retention
     time_retention_warning_text: Time-limited retention of claims is being introduced from 19th September 2016.
 
-    clair_contingency_text_one: Claims with a rep order date no earlier than 17 September 2020 and a main hearing date
-                                on or after 31 October 2022 may qualify for uplifted fees.
-    clair_contingency_text_two: Any increase due will be calculated
-                                and added during assessment.
+    clair_contingency_text_one: Claims with a main hearing date on or after 31 October 2022 may qualify for uplifted fees.
+    clair_contingency_text_two: Any increase due will be calculated and added during assessment.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,6 +80,9 @@ expense_schema_version: 2
 # If enabled, external users will see it, and will have a 'dismiss' link to hide and do not show it again
 hardship_claims_banner_enabled?: true
 
+#Feature flag to enable or disable clair contingency banner
+clair_contingency_banner_enabled?: true
+
 # Feature flag to enable or disable the downtime warning
 # If enabled, all users will see it up until "downtime_warning_date"
 downtime_warning_enabled?: false

--- a/features/claims/clair_contingency_banner.feature
+++ b/features/claims/clair_contingency_banner.feature
@@ -1,0 +1,20 @@
+@javascript
+Feature: A clair contingency banner will appear on the choose your bill type page, until the user dismisses it
+
+  Scenario: I go to the 'Choose your bill type page' and the clair contingency banner, dismiss it and do not see it again
+
+    Given I am a signed in advocate
+    And The clair contingency banner feature flag is enabled
+    And I am on the 'Your claims' page
+
+    And I click 'Start a claim'
+    Then The clair contingency banner is visible
+    Then the page should be accessible
+
+    When I click the link 'Do not show main hearing date information again'
+    Then The clair contingency banner is not visible
+
+    When I click the link 'Claim for crown court defence'
+    Then I am on the 'Your claims' page
+    And I click 'Start a claim'
+    Then The clair contingency banner is not visible

--- a/features/step_definitions/clair_contingency_banner_steps.rb
+++ b/features/step_definitions/clair_contingency_banner_steps.rb
@@ -1,0 +1,13 @@
+Given(/^The clair contingency banner feature flag is enabled$/) do
+  allow(Settings).to receive(:clair_contingency_banner_enabled?).and_return(true)
+end
+
+And(/^The clair contingency banner (is|is not) visible$/) do |visibility|
+  selector = 'div.js-callout-banner[data-setting=clair_contingency_banner_seen]'
+
+  if visibility == 'is'
+    expect(page).to have_selector(selector)
+  else
+    expect(page).not_to have_selector(selector)
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -61,5 +61,11 @@ RSpec.describe UsersController, type: :controller do
       expect(assigns(:settings).to_h).to eq({ 'hardship_claims_banner_seen' => 'test' })
       expect(user.settings).to eq({ 'hardship_claims_banner_seen' => 'test' })
     end
+
+    it 'can update the clair_contingency_banner_seen setting' do
+      do_put(clair_contingency_banner_seen: 'test')
+      expect(assigns(:settings).to_h).to eq({ 'clair_contingency_banner_seen' => 'test' })
+      expect(user.settings).to eq({ 'clair_contingency_banner_seen' => 'test' })
+    end
   end
 end

--- a/spec/helpers/external_users/claims_helper_spec.rb
+++ b/spec/helpers/external_users/claims_helper_spec.rb
@@ -130,6 +130,59 @@ describe ExternalUsers::ClaimsHelper do
     end
   end
 
+  describe '#show_clair_contingency_banner_to_user?' do
+    subject { helper.show_clair_contingency_banner_to_user? }
+
+    let(:current_user) { create(:external_user, :advocate).user }
+    let(:user_settings) { {} }
+
+    before do
+      allow(Settings).to receive(:clair_contingency_banner_enabled?).and_return(clair_contingency_banner_enabled)
+      allow(current_user).to receive(:settings).and_return(user_settings)
+      allow(helper).to receive(:current_user).and_return(current_user)
+    end
+
+    context 'when the feature flag is enabled' do
+      let(:clair_contingency_banner_enabled) { true }
+
+      context 'when the user is not an external user' do
+        let(:current_user) { create(:case_worker).user }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the user has not seen yet the banner' do
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when the user has seen/dismissed the banner' do
+        let(:user_settings) { { clair_contingency_banner_seen: '1' } }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context 'when the feature flag is disabled' do
+      let(:clair_contingency_banner_enabled) { false }
+
+      context 'when the user is not an external user' do
+        let(:current_user) { create(:case_worker).user }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the user has not seen yet the banner' do
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the user has seen/dismissed the banner' do
+        let(:user_settings) { { clair_contingency_banner_seen: '1' } }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+
   describe 'url_for_referrer' do
     let(:claim) { create(:advocate_claim) }
 


### PR DESCRIPTION
What

Given the CLAIR Amendments have increased their scope to include fee scheme 11 and 7 (Aka CLAIR Light 2) cases in the court backlog, we need to amend the warning component on CCCD’s ‘Choose your Bill Type’ page.

Ticket

[CTSKF-124](https://dsdmoj.atlassian.net/browse/CTSKF-124)

Why

So providers know if their claim qualifies for an uplifted fee and to reduce visual clutter once the message has been understood.

--------

TODO (wip)

 - [x] Test
