### PR TITLE
BUGFIX: Make API email address lookup case insensitive

### DIFF
--- a/app/interfaces/api/helpers/resource_helper.rb
+++ b/app/interfaces/api/helpers/resource_helper.rb
@@ -51,7 +51,7 @@ module API::Helpers
     end
 
     def find_user_by_email(email:, relation:)
-      user = User.active.external_users.find_by(email:)
+      user = User.active.external_users.find_by(email: email.downcase)
       raise ArgumentError, "#{relation} email is invalid" unless user
       user&.persona
     end

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -207,6 +207,16 @@ RSpec.shared_examples 'a claim validate endpoint' do |options|
       it { expect_error_response("#{claim_user_type} email is invalid") }
     end
 
+    context 'when user email is valid but contains upper case characters' do
+      before do
+        valid_params[:user_email].upcase!
+        post_to_validate_endpoint
+      end
+
+      it { expect(last_response.status).to eq(200) }
+      it { expect(JSON.parse(last_response.body)['valid']).to be_truthy }
+    end
+
     context 'when required params are missing' do
       before do
         valid_params.delete(:case_number)


### PR DESCRIPTION
#### What

A provider user is experiencing an issue submitting a claim through the API due to CCCD not correctly cleansing email addresses included in claim creation requests. This is not the first time this has been reported. This PR fixes the underlying problem.

#### Ticket

Fixes zendesk ticket: https://ministryofjustice.zendesk.com/agent/tickets/301897

#### Why

When a user is created, their email address is automatically downcased by Devise through the setting `config.case_insensitive_keys = [ :email ]` in `config/initializers/devise.rb`.

When external users create a claim through the API, the `find_user_by_email` method in `app/interfaces/api/helpers/resource_helper.rb` is called, using the email address provided by the provider's case management system. This method does _not_ downcase the email address before searching for the user. ActiveRecord queries are case sensitive. As a result, if the email address in the provider's CMS contains upper case letters, CCCD cannot find the user and returns an error.

#### How

Alters the `find_user_by_email` method in `app/interfaces/api/helpers/resource_helper.rb` so that the email address is downcased before searching, preventing errors occurring.