### PR TITLE
BUGFIX: Allow for nil API email addresses

### DIFF
--- a/app/interfaces/api/helpers/resource_helper.rb
+++ b/app/interfaces/api/helpers/resource_helper.rb
@@ -51,7 +51,7 @@ module API::Helpers
     end
 
     def find_user_by_email(email:, relation:)
-      user = User.active.external_users.find_by(email: email.downcase)
+      user = User.active.external_users.find_by(email: email&.downcase)
       raise ArgumentError, "#{relation} email is invalid" unless user
       user&.persona
     end


### PR DESCRIPTION
#### What

This change https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/5283 neglected the fact that provider emails for claims submitted through the API can be nil, resulting in errors such as 

<img width="682" alt="image" src="https://user-images.githubusercontent.com/28729201/206870345-31894e62-1aab-4e8f-bd01-6b2d710c21ae.png">


This fixes the problem by adding a safe navigation operator so that emails addresses are downcased if they exist and ignored otherwise.