### PR TITLE
[CTSKF-127] Update ecnp signposting text

### DIFF
--- a/app/views/external_users/claims/case_details/_case_type_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_case_type_fields.html.haml
@@ -14,7 +14,10 @@
 
 - else
   - if display_elected_not_proceeded_signpost?(@claim)
-    = govuk_warning_text( t('.enp_signpost_html', link: 'https://www.gov.uk/government/publications/crown-court-fee-guidance') )
+    - if Settings.main_hearing_date_enabled?
+      = govuk_warning_text( t('.enp_signpost_contingency_html'))
+    - else
+      = govuk_warning_text( t('.enp_signpost_html'))
 
   = f.govuk_collection_select :case_type_id,
     @case_types.map{ |ct| [ct.name, ct.id, { data: { 'is-fixed-fee': ct.is_fixed_fee?, 'requires-cracked-dates': ct&.requires_cracked_dates?, 'requires-retrial-dates': ct&.requires_retrial_dates?, 'requires-trial-dates': ct&.requires_trial_dates? } }] },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -963,6 +963,15 @@ en:
           enp_signpost_html:
             <p class="govuk-body">You should only select <span class="govuk-!-font-weight-bold">elected cases not proceeded</span> if the representation order is before 30 September 2022.</p>
             <p class="govuk-body">For rep order claims dated on or after 30 September 2022, select <span class="govuk-!-font-weight-bold">guilty plea</span> or <span class="govuk-!-font-weight-bold">cracked trial.</span></p>
+
+          enp_signpost_contingency_html:
+            <p class="govuk-body">You should <span class="govuk-!-font-weight-bold">not</span> select <span class="govuk-!-font-weight-bold">elected cases not proceeded</span> if:</p>
+            <ul class="govuk-list govuk-list--bullet">
+            <li>The representation order is dated on or after 30 September 2022 <span class="govuk-!-font-weight-bold">or</span></li>
+            <li>The representation order is dated on or after 17 September 2020 with a main hearing date on or after 31 October 2022.</li>
+            </ul>
+            <p class="govuk-body"> For these claims, select <span class="govuk-!-font-weight-bold">guilty plea</span> or <span class="govuk-!-font-weight-bold">cracked trial.</span></p>
+
           select_option: Choose a case type
           stage_type: What stage has the case reached?
           agfs_stage_type_hint: For example Trial started but not concluded

--- a/features/fee_calculator/advocate/fixed_fee_calculator.feature
+++ b/features/fee_calculator/advocate/fixed_fee_calculator.feature
@@ -115,8 +115,10 @@ Feature: Advocate completes fixed fee page using calculator
     And I select the fee scheme 'Advocate final fee'
     Then I should be on the new claim page
 
-    And I should see 'You should only select elected cases not proceeded if the representation order is before 30 September 2022.'
-    And I should see 'For rep order claims dated on or after 30 September 2022, select guilty plea or cracked trial.'
+    Then I should see 'You should not select elected cases not proceeded if'
+    And I should see 'The representation order is dated on or after 30 September 2022'
+    And I should see 'The representation order is dated on or after 17 September 2020 with a main hearing date on or after 31 October 2022.'
+    And I should see 'For these claims, select guilty plea or cracked trial.'
     And I select the court 'Blackfriars'
     And I select a case type of 'Elected cases not proceeded'
     And I enter a case number of 'A20161234'

--- a/features/fee_calculator/litigator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/litigator/fixed_fee_calculator.feature
@@ -122,8 +122,10 @@ Feature: litigator completes fixed fee page using calculator
     And I click 'Start a claim'
     And I select the fee scheme 'Litigator final fee'
     Then I should be on the litigator new claim page
-    And I should see 'You should only select elected cases not proceeded if the representation order is before 30 September 2022.'
-    And I should see 'For rep order claims dated on or after 30 September 2022, select guilty plea or cracked trial.'
+    And I should see 'You should not select elected cases not proceeded if'
+    And I should see 'The representation order is dated on or after 30 September 2022'
+    And I should see 'The representation order is dated on or after 17 September 2020 with a main hearing date on or after 31 October 2022.'
+    And I should see 'For these claims, select guilty plea or cracked trial.'
 
     When I choose the supplier number '1A222Z'
     And I enter a providers reference of 'LGFS test fixed fee calculation'


### PR DESCRIPTION
What

When CLAIR phase one was introduced, signposting is used to alert providers to the fact that elected cases not proceeded final fees can no longer be claimed. This text needs to be updated to also include claims that fall under the CLAIR contingency rules

Ticket

[CTSKF-127- Update ecnp signposting text](https://dsdmoj.atlassian.net/browse/CTSKF-127)

Why

So that providers can claim the correct fee

TODO (wip)

 - [x] Testing
 
