### PR TITLE
CTSKF-148 PreStop sleep workaround for k8s dropped requests

### DIFF
--- a/.k8s/live/api-sandbox/deployment.yaml
+++ b/.k8s/live/api-sandbox/deployment.yaml
@@ -52,6 +52,10 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep","30"]
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev-lgfs/deployment.yaml
+++ b/.k8s/live/dev-lgfs/deployment.yaml
@@ -52,6 +52,10 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep","30"]
 
           # configMapRef: non-secret env vars defined in `app-config.yml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev/deployment.yaml
+++ b/.k8s/live/dev/deployment.yaml
@@ -52,6 +52,10 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep","30"]
 
           # configMapRef: non-secret env vars defined in `app-config.yml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -52,6 +52,10 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep","30"]
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -52,6 +52,10 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep","30"]
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets


### PR DESCRIPTION
#### What

Workaround to prevent users experiencing errors when we deploy the application 

#### Ticket

[CTSKF-148](https://dsdmoj.atlassian.net/browse/CTSKF-148)

#### Why

See: https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes

The above issue refers to `puma` but also affects CCCD which uses the `unicorn` webserver. The way kubernetes terminates pods results in requests being lost, resulting in poor performance and HTTP 5xx errors for users. This is particularly noticeable when we deploy the application or cycle the pods.

#### How

Adds the following code to `deployment.yaml` for all five environments:

```
          lifecycle:
            preStop:
              exec:
                command: ["/bin/sleep","30"]
```

This causes terminating pods to sleep for 30 seconds, allowing all active requests to complete before the pod dies.

#### Further reading

* https://blog.palark.com/graceful-shutdown-in-kubernetes-is-not-always-trivial/
* https://philpearl.github.io/post/k8s_ingress/


#### Testing

Tested by:

* running the following command to simulate a reasonably heavy volume of traffic:

```
while sleep 0.1; do curl -I https://dev.claim-crown-court-defence.service.justice.gov.uk; done
```

and then either running `kubectl -n cccd-staging rollout restart deploy` to cycle the pods, or deploying a new version of the application to that environment, and simultaneously monitoring [grafana](https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?orgId=1&var-namespace=cccd-dev&var-ingress=cccd-app-ingress-v1&from=now-30m&to=now), [kibana](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/discover#/view/94028360-9bd7-11ed-b0c3-034d271bd544?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-20m,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-dev),type:phrase),query:(match_phrase:(log_processed.kubernetes_namespace:cccd-dev))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.status,negate:!f,params:(gte:500,lt:599),type:range),range:(log_processed.status:(gte:500,lt:599)))),index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',interval:auto,query:(language:kuery,query:''),sort:!())), and the #laa-cccd-alerts slack channel for errors. 
* This was repeated across all non-prod environments.
* No 5xx errors occurred.



[CTSKF-148]: https://dsdmoj.atlassian.net/browse/CTSKF-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ