### PR TITLE
[CTSKF-147] Separate AGFS & LGFS feature flags

### DIFF
--- a/.k8s/live/api-sandbox/app-config.yaml
+++ b/.k8s/live/api-sandbox/app-config.yaml
@@ -20,3 +20,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'true'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'

--- a/.k8s/live/api-sandbox/app-config.yaml
+++ b/.k8s/live/api-sandbox/app-config.yaml
@@ -19,4 +19,4 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'true'
-  MAIN_HEARING_DATE_ENABLED: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'

--- a/.k8s/live/dev-lgfs/app-config.yaml
+++ b/.k8s/live/dev-lgfs/app-config.yaml
@@ -19,4 +19,4 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'true'
-  MAIN_HEARING_DATE_ENABLED: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'

--- a/.k8s/live/dev-lgfs/app-config.yaml
+++ b/.k8s/live/dev-lgfs/app-config.yaml
@@ -20,3 +20,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'true'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'

--- a/.k8s/live/dev/app-config.yaml
+++ b/.k8s/live/dev/app-config.yaml
@@ -19,4 +19,4 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
-  MAIN_HEARING_DATE_ENABLED: 'false'
+  MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'false'

--- a/.k8s/live/dev/app-config.yaml
+++ b/.k8s/live/dev/app-config.yaml
@@ -20,3 +20,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'false'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'false'

--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -21,4 +21,4 @@ data:
   SURVEY_MONKEY_COLLECTOR_ID: '330140894'
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
-  MAIN_HEARING_DATE_ENABLED: 'false'
+  MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'false'

--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -22,3 +22,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'false'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'false'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -22,4 +22,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
-  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'false'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -21,4 +21,4 @@ data:
   # SURVEY_MONKEY_COLLECTOR_ID: '330142588'
   LAA_FEE_CALCULATOR_HOST: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
-  MAIN_HEARING_DATE_ENABLED: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -22,3 +22,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -72,4 +72,9 @@ module ClaimsHelper
     # This applies to both AGFS fee scheme 13 and LGFS fee scheme 10 but the dates are the same
     claim.final? && Time.zone.today >= Settings.agfs_scheme_13_clair_release_date.beginning_of_day
   end
+
+  def display_main_hearing_date_flag?(claim)
+    (Settings.main_hearing_date_enabled_for_agfs? && claim.agfs?) ||
+      (Settings.main_hearing_date_enabled_for_lgfs? && claim.lgfs?)
+  end
 end

--- a/app/interfaces/api/v1/external_users/claims/advocates/final_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/final_claim.rb
@@ -22,7 +22,7 @@ module API
                        type: String,
                        desc: local_t(:advocate_category),
                        values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories + ['KC']).uniq
-              if Settings.main_hearing_date_enabled?
+              if Settings.main_hearing_date_enabled_for_agfs?
                 optional :main_hearing_date,
                          type: String,
                          desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/interfaces/api/v1/external_users/claims/advocates/hardship_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/hardship_claim.rb
@@ -22,7 +22,7 @@ module API
                        type: String,
                        desc: local_t(:advocate_category),
                        values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories + ['KC']).uniq
-              if Settings.main_hearing_date_enabled?
+              if Settings.main_hearing_date_enabled_for_agfs?
                 optional :main_hearing_date,
                          type: String,
                          desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/interfaces/api/v1/external_users/claims/advocates/interim_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/interim_claim.rb
@@ -29,7 +29,7 @@ module API
                        type: String,
                        desc: local_t(:advocate_category),
                        values: Settings.agfs_reform_advocate_categories + ['KC']
-              if Settings.main_hearing_date_enabled?
+              if Settings.main_hearing_date_enabled_for_agfs?
                 optional :main_hearing_date,
                          type: String, desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',
                          standard_json_format: true

--- a/app/interfaces/api/v1/external_users/claims/advocates/supplementary_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/supplementary_claim.rb
@@ -28,7 +28,7 @@ module API
                        type: String,
                        desc: local_t(:advocate_category),
                        values: (Settings.advocate_categories + Settings.agfs_reform_advocate_categories + ['KC']).uniq
-              if Settings.main_hearing_date_enabled?
+              if Settings.main_hearing_date_enabled_for_agfs?
                 optional :main_hearing_date,
                          type: String,
                          desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/interfaces/api/v1/external_users/claims/final_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/final_claim.rb
@@ -12,7 +12,7 @@ module API::V1::ExternalUsers
         optional :actual_trial_length,
                  type: Integer,
                  desc: 'REQUIRED/UNREQUIRED: The actual trial length in days, required for graduated fees.'
-        if Settings.main_hearing_date_enabled?
+        if Settings.main_hearing_date_enabled_for_lgfs?
           optional :main_hearing_date,
                    type: String,
                    desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/interfaces/api/v1/external_users/claims/interim_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/interim_claim.rb
@@ -15,7 +15,7 @@ module API::V1::ExternalUsers
                  type: String,
                  desc: 'REQUIRED/UNREQUIRED: YYYY-MM-DD',
                  standard_json_format: true
-        if Settings.main_hearing_date_enabled?
+        if Settings.main_hearing_date_enabled_for_lgfs?
           optional :main_hearing_date,
                    type: String,
                    desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/interfaces/api/v1/external_users/claims/litigators/hardship_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/litigators/hardship_claim.rb
@@ -7,7 +7,7 @@ module API::V1::ExternalUsers
         params do
           use :lgfs_hardship_params
           use :common_lgfs_params
-          if Settings.main_hearing_date_enabled?
+          if Settings.main_hearing_date_enabled_for_lgfs?
             optional :main_hearing_date,
                      type: String,
                      desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/transfer_claim.rb
@@ -23,7 +23,7 @@ module API::V1::ExternalUsers
         optional :actual_trial_length,
                  type: Integer,
                  desc: I18n.t('api.v1.external_users.claims.transfer_claim.params.actual_trial_length')
-        if Settings.main_hearing_date_enabled?
+        if Settings.main_hearing_date_enabled_for_lgfs?
           optional :main_hearing_date,
                    type: String,
                    desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/views/external_users/claims/case_details/_case_type_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_case_type_fields.html.haml
@@ -14,7 +14,7 @@
 
 - else
   - if display_elected_not_proceeded_signpost?(@claim)
-    - if Settings.main_hearing_date_enabled_for_agfs? && @claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && @claim.lgfs?
+    - if display_main_hearing_date_flag?(@claim)
       = govuk_warning_text( t('.enp_signpost_contingency_html'))
     - else
       = govuk_warning_text( t('.enp_signpost_html'))

--- a/app/views/external_users/claims/case_details/_case_type_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_case_type_fields.html.haml
@@ -14,7 +14,7 @@
 
 - else
   - if display_elected_not_proceeded_signpost?(@claim)
-    - if Settings.main_hearing_date_enabled?
+    - if Settings.main_hearing_date_enabled_for_agfs? && @claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && @claim.lgfs?
       = govuk_warning_text( t('.enp_signpost_contingency_html'))
     - else
       = govuk_warning_text( t('.enp_signpost_html'))

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -24,7 +24,7 @@
     label: { text: t('.case_number_or_urn') },
     width: 'one-half'
 
-  - if Settings.main_hearing_date_enabled?
+  - if Settings.main_hearing_date_enabled_for_agfs? && @claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && @claim.lgfs?
     = f.govuk_date_field :main_hearing_date,
       form_group: { id: 'main_hearing_date' },
       hint: { text: t('.date_hint') },

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -24,7 +24,7 @@
     label: { text: t('.case_number_or_urn') },
     width: 'one-half'
 
-  - if Settings.main_hearing_date_enabled_for_agfs? && @claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && @claim.lgfs?
+  - if display_main_hearing_date_flag?(@claim)
     = f.govuk_date_field :main_hearing_date,
       form_group: { id: 'main_hearing_date' },
       hint: { text: t('.date_hint') },

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -86,7 +86,7 @@
 
           = govuk_summary_list_row_collection( t('retrial_reduction', scope: retrial_detail_fields) ) { claim&.retrial_reduction? ? t('.answer_yes') : t('.answer_no') }
 
-      - if Settings.main_hearing_date_enabled?
+      - if Settings.main_hearing_date_enabled_for_agfs? && claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && claim.lgfs?
         = govuk_summary_list_row_collection( t('main_hearing_date', scope: claim_fields) ) do
           %time{ 'aria-label': claim&.main_hearing_date&.strftime(Settings.date_format_label), datetime: claim&.main_hearing_date&.strftime(Settings.datetime_attribute) }
             = claim&.main_hearing_date&.strftime(Settings.date_format)

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -86,7 +86,7 @@
 
           = govuk_summary_list_row_collection( t('retrial_reduction', scope: retrial_detail_fields) ) { claim&.retrial_reduction? ? t('.answer_yes') : t('.answer_no') }
 
-      - if Settings.main_hearing_date_enabled_for_agfs? && claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && claim.lgfs?
+      - if display_main_hearing_date_flag?(claim)
         = govuk_summary_list_row_collection( t('main_hearing_date', scope: claim_fields) ) do
           %time{ 'aria-label': claim&.main_hearing_date&.strftime(Settings.date_format_label), datetime: claim&.main_hearing_date&.strftime(Settings.datetime_attribute) }
             = claim&.main_hearing_date&.strftime(Settings.date_format)

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -75,7 +75,7 @@
   - if claim&.requires_retrial_dates?
     = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
 
-  - if Settings.main_hearing_date_enabled_for_agfs? && claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && claim.lgfs?
+  - if display_main_hearing_date_flag?(claim)
     = govuk_summary_list_row_collection(t('common.main_hearing_date')) do
       = claim.main_hearing_date&.strftime(Settings.date_format)
 

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -75,7 +75,7 @@
   - if claim&.requires_retrial_dates?
     = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
 
-  - if Settings.main_hearing_date_enabled?
+  - if Settings.main_hearing_date_enabled_for_agfs? && claim.agfs? || Settings.main_hearing_date_enabled_for_lgfs? && claim.lgfs?
     = govuk_summary_list_row_collection(t('common.main_hearing_date')) do
       = claim.main_hearing_date&.strftime(Settings.date_format)
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -100,6 +100,12 @@ maintenance_mode_enabled?: <%= ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql
 # Feature flag to enable main hearing for clair contigency
 main_hearing_date_enabled?: <%= ENV.fetch('MAIN_HEARING_DATE_ENABLED', nil)&.downcase&.eql?('true') %>
 
+# Feature flag to enable AGFS main hearing for clair contigency
+main_hearing_date_enabled_for_agfs?: <%= ENV.fetch('MAIN_HEARING_DATE_ENABLED_FOR_AGFS', nil)&.downcase&.eql?('true') %>
+
+# Feature flag to enable LGFS main hearing for clair contigency
+main_hearing_date_enabled_for_lgfs?: <%= ENV.fetch('MAIN_HEARING_DATE_ENABLED_FOR_LGFS', nil)&.downcase&.eql?('true') %>
+
 feature_flags_enabled?: true
 active_features: []
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -97,9 +97,6 @@ scheme_filters_enabled?: <%= ENV['ENV'] == 'demo' %>
 #
 maintenance_mode_enabled?: <%= ENV.fetch('MAINTENANCE_MODE', nil)&.downcase&.eql?('true') %>
 
-# Feature flag to enable main hearing for clair contigency
-main_hearing_date_enabled?: <%= ENV.fetch('MAIN_HEARING_DATE_ENABLED', nil)&.downcase&.eql?('true') %>
-
 # Feature flag to enable AGFS main hearing for clair contigency
 main_hearing_date_enabled_for_agfs?: <%= ENV.fetch('MAIN_HEARING_DATE_ENABLED_FOR_AGFS', nil)&.downcase&.eql?('true') %>
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,7 +5,8 @@
 # files.
 
 ENV["ENV"] ||= 'test'
-ENV['MAIN_HEARING_DATE_ENABLED'] = 'true'
+ENV['MAIN_HEARING_DATE_ENABLED_FOR_AGFS'] = 'true'
+ENV['MAIN_HEARING_DATE_ENABLED_FOR_LGFS'] = 'true'
 
 require 'capybara'
 require 'capybara/cucumber'


### PR DESCRIPTION
#### What

When implementing the changes to CCCD and Fee Calculator around the CLAIR October amendments they were not separated by AGFS and LGFS flags. If we go live with the changes, it will be live for both claim journeys.

#### Ticket

[Ctskf-147- Separate agfs and lgfs feature flags](https://dsdmoj.atlassian.net/browse/CTSKF-147)

#### Why

At present, only CCR has been updated to handle the CLAIR October amendments for AGFS claims. A spike has shown that enabling the functionality for LGFS claims in CCCD without making corresponding changes to CCLF will result in failures when injecting certain LGFS claim types. 

Due to this, we need to change how features are flagged in CCCD to allow the CLAIR October amendments to be released for AGFS claims separately from that of LGFS claims.

#### TODO (wip)

 - [x] Feature and unit test 
 
