### PR TITLE
Fix wrapping of 'Judicial apportionment' text on claim summary screen

### DIFF
--- a/app/webpack/stylesheets/components/_card.scss
+++ b/app/webpack/stylesheets/components/_card.scss
@@ -1,4 +1,7 @@
 .app-card--defendant {
+  .govuk-summary-list__key {
+    width: 35%;
+  }
   margin-top: $gutter-half;
   margin-bottom: $gutter-half;
   padding: $gutter-half $gutter-one-third $gutter-half $gutter-half;


### PR DESCRIPTION
#### What

Fixes the incorrect wrapping of the text 'Judicial apportionment' on the summary screen of a submitted claim.

#### Why

In the Defendants section of the summary screen for a submitted claim, the text 'Judicial apportionment' wraps inelegantly, with the last 't' appearing on a new line:

<img width="989" alt="image" src="https://user-images.githubusercontent.com/28729201/208683569-349166ad-c43f-427d-b6a5-0ff1284a256f.png">

After this change the text appears correctly:

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/28729201/208683789-2e277328-31a8-4230-88a9-8d194e088bed.png">


#### How

Adjusts the width of the key in the `app-card--defendant` element to allow the text to appear correctly.
