### PR TITLE
Allow CircleCI to correctly split cucumber tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,8 +408,8 @@ jobs:
 
   cucumber-tests:
     executor: test-executor
-    resource_class: medium
-    parallelism: 4
+    resource_class: small
+    parallelism: 6
     steps:
       - checkout
       - build-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,8 +209,8 @@ commands:
 
             RUBYOPT='-W0' bundle exec cucumber \
             --format pretty \
-            --format json \
-            --out /tmp/test-results/cucumber/tests.cucumber \
+            --format junit,fileattribute=true \
+            --out /tmp/test-results/cucumber \
             -- ${TESTFILES}
       - store_artifacts:
           path: tmp/capybara


### PR DESCRIPTION
#### What

#### Why

CircleCI is configured to split cucumber tests by timings to allow for more efficient parallelisation:

`circleci tests split --split-by=timings --timings-type=filename`

However this does not work correctly. All tests result in the message:

<img width="904" alt="image" src="https://user-images.githubusercontent.com/28729201/208727950-b428ea22-0724-42ec-be7e-48c9ff2e8e8e.png">


#### How

This is occurring because the test results are output using the `json` formatter, which is not supported by CircleCI for splitting by timings (and additionally is now deprecated).

To fix the problem:

* switch from using the `json` formatter to using the `junit` formatter, which is required by CircleCI for splitting on timings: https://circleci.com/docs/use-the-circleci-cli-to-split-tests/#junit-xml-reports;
* add the `fileattribute=true` flag to include filenames in the xml output, which is needed for splitting accurately;
* write the xml output to a directory rather than a file (a requirement of the `junit` formatter).

#### Proof

This has the effect of dropping the run time of the feature test suite by approximately two minutes from ~15 minutes to ~13 minutes, which isn't huge but brings it closer to the runtime of the rpsec suite and saves us a few credits.

Before:

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/28729201/208737840-4ae37683-3eec-4972-ba2e-e767b5370a46.png">

After:

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/28729201/208738185-94095d59-bdd3-4092-b830-dec8ba8fbb87.png">



