### PR TITLE
CTSKF-128 Update ECNP Final claim validation

### DIFF
--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -542,6 +542,10 @@ earliest_representation_order_date:
     long: The representation order date and case type cannot be combined
     short: _
     api: The representation order date and case type cannot be combined
+  invalid_for_elected_case_not_proceeded_and_main_hearing_date:
+    long: The representation order date, main hearing date and case type cannot be combined
+    short: _
+    api: The representation order date, main hearing date and case type cannot be combined
 
 
 

--- a/features/fee_calculator/advocate/fixed_fee_calculator.feature
+++ b/features/fee_calculator/advocate/fixed_fee_calculator.feature
@@ -129,4 +129,4 @@ Feature: Advocate completes fixed fee page using calculator
     And I enter defendant, scheme 13 representation order and MAAT reference
 
     Then I click "Continue" in the claim form
-    And I should see govuk error summary with 'The representation order date and case type cannot be combined'
+    And I should see govuk error summary with 'The representation order date, main hearing date and case type cannot be combined'

--- a/features/fee_calculator/litigator/fixed_fee_calculator.feature
+++ b/features/fee_calculator/litigator/fixed_fee_calculator.feature
@@ -139,4 +139,4 @@ Feature: litigator completes fixed fee page using calculator
     And I enter defendant, lgfs scheme 10 representation order and MAAT reference
 
     Then I click "Continue" in the claim form
-    And I should see govuk error summary with 'The representation order date and case type cannot be combined'
+    And I should see govuk error summary with 'The representation order date, main hearing date and case type cannot be combined'


### PR DESCRIPTION
#### What

Update validation of ECNP Final claims so that CLAIR contingency claims are validated in the same way as CLAIR claims

#### Ticket

[CTSKF-128](https://dsdmoj.atlassian.net/browse/CTSKF-128)

#### Why

Claims that fall under CLAIR contingency rules (where the representation order date is on or after 17 September 2020 with a main hearing date on or after 31 October 2022) need to have the same validation for Elected Cases Not Proceeded (ECNP) as claims that fall under CLAIR rules (where the representation order date is on or after 30 September 2022).

#### How

* amend the logic in `Claim::BaseClaimValidator` to also include the main hearing date in the validation.
* update the wording of the error displayed when the validation fails 
* use feature flags to switch between the different versions.