### PR TITLE
[CTSKF-151] Seed fee schemes once at the start of all tests

### DIFF
--- a/spec/api/v1/dropdown_data_spec.rb
+++ b/spec/api/v1/dropdown_data_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe API::V1::DropdownData do
     end
 
     before do
-      seed_fee_schemes
       seed_case_types
       seed_case_stages
       create_list(:court, 2)
@@ -115,10 +114,6 @@ RSpec.describe API::V1::DropdownData do
     subject(:returned_offences) do
       response = get OFFENCE_ENDPOINT, params
       JSON.parse(response.body, symbolize_names: true)
-    end
-
-    before do
-      seed_fee_schemes
     end
 
     let!(:scheme_9_offence) { create(:offence, :with_fee_scheme_nine) }

--- a/spec/api/v1/external_users/claims/integration/advocate_claim_creation_spec.rb
+++ b/spec/api/v1/external_users/claims/integration/advocate_claim_creation_spec.rb
@@ -152,7 +152,6 @@ RSpec.describe 'API claim creation for AGFS' do
   include ApiSpecHelper
 
   before do
-    seed_fee_schemes
     seed_case_types
     seed_fee_types
     seed_expense_types

--- a/spec/api/v1/external_users/claims/integration/litigator_claim_creation_spec.rb
+++ b/spec/api/v1/external_users/claims/integration/litigator_claim_creation_spec.rb
@@ -269,7 +269,6 @@ RSpec.describe 'API claim creation for LGFS' do
   include ApiSpecHelper
 
   before do
-    seed_fee_schemes
     seed_case_types
     seed_fee_types
     seed_expense_types

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe API::V1::ExternalUsers::Fee do
   let!(:graduated_fee_type) { create(:graduated_fee_type) }
   let!(:transfer_fee_type) { create(:transfer_fee_type) }
 
-  before { seed_fee_schemes }
-
   let!(:claim) { create(:claim, source: 'api').reload }
   let(:valid_params) { { api_key: provider.api_key, claim_id: claim.uuid, fee_type_id: misc_fee_type.id, quantity: 3, rate: 50.00 } }
   let(:json_error_response) { [{ 'error' => 'Type of fee not found by ID or Unique Code' }].to_json }

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -725,8 +725,6 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
       end
 
       context 'hardship fees' do
-        before { seed_fee_schemes }
-
         let(:claim) { create(:advocate_hardship_claim, :agfs_scheme_9, case_stage: build(:case_stage, :trial_not_concluded)) }
 
         it { is_expected.to be_valid_ccr_claim_json }

--- a/spec/controllers/external_users/fees/prices_controller_spec.rb
+++ b/spec/controllers/external_users/fees/prices_controller_spec.rb
@@ -37,8 +37,6 @@ RSpec.shared_examples 'a failed price calculation response' do
 end
 
 RSpec.describe ExternalUsers::Fees::PricesController do
-  before(:all) { seed_fee_schemes }
-
   after(:all) { clean_database }
 
   let!(:advocate) { create(:external_user, :advocate) }

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -110,8 +110,6 @@ RSpec.describe Claim::AdvocateClaim do
       end
 
       context 'when claim has fee reform scheme' do
-        before { seed_fee_schemes }
-
         let(:claim) { create(:claim, :agfs_scheme_10) }
 
         it 'returns only basic fee types for AGFS excluding the ones that are not part of the fee reform' do

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe FeeScheme do
-  before do
-    seed_fee_schemes
-  end
-
   let(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) }
   let(:lgfs_scheme_ten) { FeeScheme.find_by(name: 'LGFS', version: 10) }
   let(:agfs_scheme_nine) { FeeScheme.find_by(name: 'AGFS', version: 9) }

--- a/spec/models/timed_transitions/transitioner_spec.rb
+++ b/spec/models/timed_transitions/transitioner_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe TimedTransitions::Transitioner do
               @first_defendant_id = claim.defendants.first.id
             end
 
-            it 'destroys all associated records', delete: true do
+            it 'destroys all associated records' do
               check_associations
               described_class.new(claim).run
               expect_claim_and_all_associations_to_be_gone

--- a/spec/presenters/claim/advocate_claim_presenter_spec.rb
+++ b/spec/presenters/claim/advocate_claim_presenter_spec.rb
@@ -23,8 +23,6 @@ RSpec.describe Claim::AdvocateClaimPresenter, type: :presenter do
   describe '#requires_interim_claim_info?' do
     subject { presenter.requires_interim_claim_info? }
 
-    before { seed_fee_schemes }
-
     context 'when claim is pre agfs reform' do
       let(:claim) { create(:advocate_claim, :agfs_scheme_9) }
 

--- a/spec/presenters/fee/basic_fee_presenter_spec.rb
+++ b/spec/presenters/fee/basic_fee_presenter_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Fee::BasicFeePresenter, type: :presenter do
   let(:claim_9) { create(:advocate_claim, :agfs_scheme_9) }
   let(:fee) { build(:basic_fee, claim:) }
 
-  before { seed_fee_schemes }
-
   subject(:presenter) { described_class.new(fee, view) }
 
   describe '#display_amount?' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -165,6 +165,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
     FactoryBot.create(:vat_rate, :for_2011_onward)
+    SeedHelpers.seed_fee_schemes
   end
 
   config.after(:suite) do
@@ -178,7 +179,7 @@ RSpec.configure do |config|
 
   config.before do |example|
     DatabaseCleaner.strategy = if example.metadata[:delete]
-                                 [:truncation, { except: ['vat_rates'] }]
+                                 [:truncation, { except: %w[vat_rates fee_schemes] }]
                                else
                                  :transaction
                                end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -105,7 +105,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   Shoulda::Matchers.configure do |shoulda_matchers_config|
     shoulda_matchers_config.integrate do |with|
@@ -163,6 +163,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
     FactoryBot.create(:vat_rate, :for_2011_onward)
     SeedHelpers.seed_fee_schemes
@@ -177,16 +178,7 @@ RSpec.configure do |config|
     VatRate.delete_all
   end
 
-  config.before do |example|
-    DatabaseCleaner.strategy = if example.metadata[:delete]
-                                 [:truncation, { except: %w[vat_rates fee_schemes] }]
-                               else
-                                 :transaction
-                               end
-    DatabaseCleaner.start unless example.metadata[:no_database_cleaner]
-  end
-
-  config.after do |example|
-    DatabaseCleaner.clean unless example.metadata[:no_database_cleaner]
+  config.around do |example|
+    example.metadata[:no_database_cleaner] ? example.run : (DatabaseCleaner.cleaning { example.run })
   end
 end

--- a/spec/requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples.rb
+++ b/spec/requests/api/v1/external_users/claims/advocates/agfs_api_shared_examples.rb
@@ -26,7 +26,6 @@ end
 
 RSpec.shared_examples 'claim with AGFS reform advocate categories' do
   before do
-    seed_fee_schemes
     submit_request
   end
 
@@ -107,7 +106,6 @@ end
 
 RSpec.shared_examples 'claim with pre-AGFS reform advocate categories' do
   before do
-    seed_fee_schemes
     submit_request
   end
 
@@ -131,7 +129,6 @@ RSpec.shared_examples 'claim with pre-AGFS reform advocate categories' do
     subject(:submit_request) { post(endpoint.validate, params:) }
 
     before do
-      seed_fee_schemes
       submit_request
     end
 

--- a/spec/services/ccr/daily_attendance_adapter_spec.rb
+++ b/spec/services/ccr/daily_attendance_adapter_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe CCR::DailyAttendanceAdapter, type: :adapter do
   let(:retrial) { create(:case_type, :retrial) }
 
-  before { seed_fee_schemes }
-
   describe '#attendances' do
     subject { described_class.new(claim).attendances }
 

--- a/spec/services/claims/fee_calculator/fee_type_limit_spec.rb
+++ b/spec/services/claims/fee_calculator/fee_type_limit_spec.rb
@@ -30,8 +30,6 @@ RSpec.describe Claims::FeeCalculator::FeeTypeLimit do
     MIPCM: { from: 1, to: 6 }
   }
 
-  before { seed_fee_schemes }
-
   let(:agfs_scheme_9_claim) do
     create(:draft_claim, create_defendant_and_rep_order_for_scheme_9: true)
   end

--- a/spec/services/claims/fee_calculator/graduated_price_spec.rb
+++ b/spec/services/claims/fee_calculator/graduated_price_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 # IMPORTANT: use specific case type, offence class, fee types and reporder
 # date in order to reduce and afix VCR cassettes required (that have to match
 # on query values), prevent flickering specs (from random offence classes,

--- a/spec/services/claims/fee_calculator/unit_price_spec.rb
+++ b/spec/services/claims/fee_calculator/unit_price_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.shared_examples 'a successful daily attendance fee calculation' do
   context 'daily attendance fees' do
     context 'scheme 9' do
@@ -286,10 +288,6 @@ RSpec.describe Claims::FeeCalculator::UnitPrice, :fee_calc_vcr do
   let(:claim) { build(:draft_claim) }
 
   it { is_expected.to respond_to(:call) }
-
-  before(:all) { seed_fee_schemes }
-
-  after(:all) { clean_database }
 
   context 'AGFS claims' do
     describe '#call' do

--- a/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
+++ b/spec/services/claims/fetch_eligible_advocate_categories_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Claims::FetchEligibleAdvocateCategories, type: :service do
-  before do
-    seed_fee_schemes
-  end
-
   let(:scheme_9_advocate_categories) { ['QC', 'Led junior', 'Leading junior', 'Junior alone'] }
   let(:scheme_10_advocate_categories) { ['QC', 'Leading junior', 'Junior'] }
   let(:all_advocate_categories) { (scheme_9_advocate_categories + scheme_10_advocate_categories).uniq }

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -46,7 +46,6 @@ end
 
 RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
   before(:all) do
-    seed_fee_schemes
     seed_case_types
     seed_fee_types
   end

--- a/spec/services/claims/fetch_eligible_offences_spec.rb
+++ b/spec/services/claims/fetch_eligible_offences_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe Claims::FetchEligibleOffences, type: :service do
   subject(:offences) { described_class.for(claim) }
 
-  before do
-    seed_fee_schemes
-  end
-
   shared_examples_for 'a claim with default offences' do
     context 'when the claim has no associated offence' do
       before do

--- a/spec/services/cleaners/advocate_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/advocate_claim_cleaner_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Cleaners::AdvocateClaimCleaner do
   before do
     seed_case_types
     seed_fee_types
-    seed_fee_schemes
   end
 
   describe '#call' do

--- a/spec/services/fee_reform/search_offences_spec.rb
+++ b/spec/services/fee_reform/search_offences_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe FeeReform::SearchOffences, type: :service do
-  before do
-    seed_fee_schemes
-  end
-
   let!(:scheme_9_offences) {
     [
       create(:offence, :with_fee_scheme, description: 'Offence 1'),

--- a/spec/support/database_housekeeping.rb
+++ b/spec/support/database_housekeeping.rb
@@ -7,7 +7,7 @@ module DatabaseHousekeeping
   # This excludes non application tables (schema_migrations, ar_internal_metadata)
   # we also exclude vat_rates as they are created/destroyed in a before/after(:suite) hook
   def application_tables
-    exclusions = %w[schema_migrations ar_internal_metadata vat_rates]
+    exclusions = %w[schema_migrations ar_internal_metadata vat_rates fee_schemes]
     ActiveRecord::Base.connection.tables.uniq.sort - exclusions
   end
 

--- a/spec/support/seed_helpers.rb
+++ b/spec/support/seed_helpers.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder').expand_path
 
 module SeedHelpers
-  def seed_fee_schemes
+  def self.seed_fee_schemes
     FeeScheme.find_or_create_by(name: 'LGFS', version: 9, start_date: Date.new(2014, 03, 20).beginning_of_day, end_date: Settings.lgfs_scheme_10_clair_release_date - 1.day)
     FeeScheme.find_or_create_by(name: 'LGFS', version: 10, start_date: Settings.lgfs_scheme_10_clair_release_date.beginning_of_day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 9, start_date: Date.new(2012, 04, 01).beginning_of_day, end_date: Date.new(2018, 03, 31).end_of_day)

--- a/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
+++ b/spec/support/shared_examples/validators/shared_examples_for_advocate_claim_validators.rb
@@ -106,14 +106,6 @@ RSpec.shared_examples 'advocate claim supplier number' do
   end
 end
 
-# rubocop:disable RSpec/BeforeAfterAll
-RSpec.shared_context 'seed-fee-schemes' do
-  before(:all) { seed_fee_schemes }
-
-  after(:all) { clean_database }
-end
-# rubocop:enable RSpec/BeforeAfterAll
-
 RSpec.shared_examples 'common defendant uplift fees aggregation validation' do
   let(:midtw) { create(:misc_fee_type, :midtw) }
   let(:midse) { create(:misc_fee_type, :midse) }

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -4,7 +4,6 @@ require_relative 'shared_examples_for_step_validators'
 
 RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
   include_context 'force-validation'
-  include_context 'seed-fee-schemes'
 
   let(:claim) { create(:advocate_claim) }
 

--- a/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
@@ -4,7 +4,6 @@ require_relative 'shared_examples_for_step_validators'
 
 RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
   include_context 'force-validation'
-  include_context 'seed-fee-schemes'
 
   let(:claim) { create(:advocate_hardship_claim) }
 

--- a/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
@@ -4,7 +4,6 @@ require_relative 'shared_examples_for_step_validators'
 
 RSpec.describe Claim::AdvocateSupplementaryClaimValidator, type: :validator do
   include_context 'force-validation'
-  include_context 'seed-fee-schemes'
 
   let(:claim) { create(:advocate_supplementary_claim) }
 

--- a/spec/validators/claim/litigator_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_hardship_claim_validator_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Claim::LitigatorHardshipClaimValidator, type: :validator do
 
   let(:claim) { create(:litigator_hardship_claim, case_type: create(:case_type, :all_roles, is_fixed_fee: false)) }
 
-  before { seed_fee_schemes }
-
   include_examples 'common advocate litigator validations', :litigator, case_type: false
   include_examples 'common litigator validations', :hardship_claim
 

--- a/spec/views/external_users/claims/show_spec.rb
+++ b/spec/views/external_users/claims/show_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'external_users/claims/show.html.haml' do
   before(:all) do
-    seed_fee_schemes
     @external_user = create(:external_user, :litigator_and_admin)
   end
 


### PR DESCRIPTION
#### What

Seed fee schemes at the start of all rspec tests instead of selectively in individual test files.

#### Ticket

[CCCD: Use main hearing date when finding fee scheme for claim](https://dsdmoj.atlassian.net/browse/CTSKF-151)

#### Why

Some tests require the fee schemes in the database and so they are added using the `seed_fee_schemes` when necessary. However, they are always the same and their presence should not affect other tests so they can be added at the start of the suite. This has the following benefits:

* Changes that introduce a dependency on the fee scheme do not automatically cause test failures. (See #5287)
* Start up and tear down times is reduced.

#### How

Add `seed_fee_schemes` to the `config.before(:suite)` block in `rspec_helper.rb` and add `fee_schemes` to the list of excluded tables in the `clean_database` helper.

#### Note

These changes are included in #5287. If that PR is merged then this can be closed. Alternatively, this PR can be merged independently.
