### PR TITLE
[CTSKF-182] Remove dead code in the Transfer Brain

### DIFF
--- a/app/models/claim/transfer_brain.rb
+++ b/app/models/claim/transfer_brain.rb
@@ -73,10 +73,6 @@ module Claim
       CASE_CONCLUSIONS[detail.case_conclusion_id]
     end
 
-    def self.data_attributes
-      TransferBrain::DataItemCollection.instance.to_json.chomp
-    end
-
     #
     # only new litigators that transfered onto unelected cases at specific stages
     # are required to specify case conclusions.

--- a/app/models/claim/transfer_brain/data_item.rb
+++ b/app/models/claim/transfer_brain/data_item.rb
@@ -7,25 +7,6 @@ module Claim
       attr_accessor :transfer_fee_full_name, :allocation_type, :bill_scenario, :ppe_required, :days_claimable,
                     :transfer_stage_id, :case_conclusion_id, :validity, :claim
 
-      def to_h
-        {
-          litigator_type => {
-            elected_case => {
-              transfer_stage_id => {
-                case_conclusion_id => {
-                  validity:,
-                  transfer_fee_full_name:,
-                  allocation_type:,
-                  bill_scenario:,
-                  ppe_required:,
-                  days_claimable:
-                }
-              }
-            }
-          }
-        }
-      end
-
       def litigator_type=(value)
         @litigator_type = value&.downcase
       end

--- a/app/models/claim/transfer_brain/data_item_collection.rb
+++ b/app/models/claim/transfer_brain/data_item_collection.rb
@@ -18,14 +18,6 @@ module Claim
 
       data_item_delegate :transfer_fee_full_name, :allocation_type, :bill_scenario, :ppe_required, :days_claimable
 
-      def to_h
-        collection_hash
-      end
-
-      def to_json(opts = nil)
-        collection_hash.to_json(opts)
-      end
-
       def detail_valid?(detail)
         return false if detail.unpopulated?
         data_item = data_item_for(detail)
@@ -72,12 +64,6 @@ module Claim
 
       def data_items
         @data_items ||= csv.map { |row| TransferBrain::DataItem.new(**row) }
-      end
-
-      def collection_hash
-        @collection_hash ||= data_items.each_with_object({}) do |item, collection_hash|
-          collection_hash.deep_merge!(item.to_h)
-        end
       end
     end
   end

--- a/spec/models/claim/transfer_brain/data_item_collection_spec.rb
+++ b/spec/models/claim/transfer_brain/data_item_collection_spec.rb
@@ -63,28 +63,6 @@ RSpec.describe Claim::TransferBrain::DataItemCollection do
     end
   end
 
-  describe '#collection_hash' do
-    subject(:collection_hash) { collection.send(:collection_hash) }
-
-    it { is_expected.to be_a Hash }
-    it { is_expected.not_to be_empty }
-
-    it 'assigns deep nested hash with expected keys' do
-      expect(collection_hash.dig('new', true, 10, '*').keys).to include(:validity, :transfer_fee_full_name, :allocation_type, :bill_scenario, :ppe_required, :days_claimable)
-    end
-
-    it 'adds one nested hash for each data item' do
-      expect(collection_hash.all_values_for(:validity).size).to eq 33
-    end
-  end
-
-  describe '#to_h' do
-    subject { collection.to_h }
-
-    it { is_expected.to be_a Hash }
-    it { is_expected.to match_hash(data_item_collection_hash) }
-  end
-
   describe '#data_item_for' do
     subject(:data_item) { collection.data_item_for(detail) }
 

--- a/spec/models/claim/transfer_brain/data_item_spec.rb
+++ b/spec/models/claim/transfer_brain/data_item_spec.rb
@@ -3,52 +3,6 @@ require 'rails_helper'
 RSpec.describe Claim::TransferBrain::DataItem do
   subject(:data_item) { described_class.new(**data) }
 
-  describe '#to_h' do
-    subject { data_item.to_h }
-
-    let(:data) do
-      {
-        litigator_type: 'NEW',
-        elected_case: 'FALSE',
-        transfer_stage: 'Up to and including PCMH transfer',
-        conclusion: 'Guilty plea',
-        valid: 'TRUE',
-        transfer_fee_full_name: 'up to and including PCMH transfer (new) - guilty plea',
-        allocation_type: 'Grad',
-        bill_scenario: 'ST3TS1T2',
-        ppe_required: 'FALSE',
-        days_claimable: 'FALSE'
-      }
-    end
-
-    let(:expected_hash) do
-      {
-        'new' => {
-          false => {
-            10 => {
-              50 => {
-                validity: true,
-                transfer_fee_full_name: 'up to and including PCMH transfer (new) - guilty plea',
-                allocation_type: 'Grad',
-                bill_scenario: 'ST3TS1T2',
-                ppe_required: 'FALSE',
-                days_claimable: 'FALSE'
-              }
-            }
-          }
-        }
-      }
-    end
-
-    it 'returns a hash' do
-      is_expected.to be_a(Hash)
-    end
-
-    it 'returns expected nested key value pairs' do
-      is_expected.to eql expected_hash
-    end
-  end
-
   describe '#litigator_type' do
     subject { data_item.litigator_type }
 

--- a/spec/models/claim/transfer_brain_spec.rb
+++ b/spec/models/claim/transfer_brain_spec.rb
@@ -157,14 +157,6 @@ RSpec.describe Claim::TransferBrain do
     end
   end
 
-  describe '.data_attributes' do
-    subject { described_class.data_attributes }
-
-    it 'returns a JSON representation of the data items collection hash' do
-      is_expected.to be_json_eql(data_item_collection_hash.to_json)
-    end
-  end
-
   describe '.allocation_type' do
     it 'returns a string describing an allocation filtering type' do
       td = transfer_detail('new', true, 10)

--- a/spec/services/stats/management_information/daily_report_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_generator_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportGenerator do
                            lgfs_claim.earliest_representation_order_date.strftime('%d/%m/%Y')])
       }
 
-      it { expect(rows['AF1/LF1 processed by']).to eql([nil, nil, 'Case Worker-one']) }
+      it { expect(rows['AF1/LF1 processed by']).to match_array([nil, nil, 'Case Worker-one']) }
 
       it {
         expect(rows['Misc fees'])


### PR DESCRIPTION
#### What

Remove some dead code

#### Ticket

[CCCD - Transfer Brain code cleanup](https://dsdmoj.atlassian.net/browse/CTSKF-182)

#### Why

The "Transfer Brain" is already complicated and this is compounded by code that is no longer required.

* `Claim::TransferBrain::DataItem#to_h` is only used in two places;
  * the private method `Claim::TransferBrain::DataItemCollection#collection_hash`
  * a unit test
* `Claim::TransferBrain::DataItemCollection#collection_hash` is only used in the methods `#to_h`, which is never used, and `#to_json`
* `Claim::TransferBrain::DataItemCollection#to_h` is only used in the class `Claim::TransferBrain.data_attributes`
* `Claim::TransferBrain.data_attributes` is only used in a unit test

#### How

Cut it out
