### PR TITLE
[CTSKF-175] Update Main Hearing Date text

### DIFF
--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -27,7 +27,7 @@
   - if display_main_hearing_date_flag?(@claim)
     = f.govuk_date_field :main_hearing_date,
       form_group: { id: 'main_hearing_date' },
-      hint: { text: t('.main_hearing_date_hint') },
+      hint: { text: t('.main_hearing_date_hint_html') },
       legend: { text: t('.main_hearing_date'), size: 's' },
       maxlength_enabled: true
 

--- a/app/views/external_users/claims/case_details/_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_fields.html.haml
@@ -27,7 +27,7 @@
   - if display_main_hearing_date_flag?(@claim)
     = f.govuk_date_field :main_hearing_date,
       form_group: { id: 'main_hearing_date' },
-      hint: { text: t('.date_hint') },
+      hint: { text: t('.main_hearing_date_hint') },
       legend: { text: t('.main_hearing_date'), size: 's' },
       maxlength_enabled: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -997,9 +997,9 @@ en:
           court: 'Court'
           court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
-          date_hint: For example, 31 9 2022
+          date_hint: For example, 31 9 2022. For multi day hearings, please provide the latest date to receive the correct fee rates.
           litigator: *litigator
-          main_hearing_date: 'Main hearing date'
+          main_hearing_date: 'Final main hearing date'
           offence_class: 'Offence class'
           offence_category: 'Offence category'
           select_category: 'Please select'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -997,7 +997,7 @@ en:
           court: 'Court'
           court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
-          date_hint: For example, 31 9 2022. For multi day hearings, please provide the latest date to receive the correct fee rates.
+          main_hearing_date_hint: For example, 31 9 2022. For multi day hearings, please provide the latest date to receive the correct fee rates.
           litigator: *litigator
           main_hearing_date: 'Final main hearing date'
           offence_class: 'Offence class'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -997,7 +997,7 @@ en:
           court: 'Court'
           court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
-          main_hearing_date_hint: For example, 31 9 2022. For multi day hearings, please provide the latest date to receive the correct fee rates.
+          main_hearing_date_hint_html: For multi day hearings, please provide the latest date to receive the correct fee rates<br/><br/>For example, 31 9 2022
           litigator: *litigator
           main_hearing_date: 'Final main hearing date'
           offence_class: 'Offence class'


### PR DESCRIPTION
#### What

Alter the wording on the claim form to make it clear that the Main Hearing Date required is the last or final main hearing day, by amending the name of the field and adding additional hint text. 

#### Ticket

[CTSKF-175](https://dsdmoj.atlassian.net/browse/CTSKF-175)

#### Why

To ensure that providers enter the correct date and are paid the correct amount as a result.

#### How

Update the relevant wordings in `config/locales/en.yml`.

[CTSKF-175]: https://dsdmoj.atlassian.net/browse/CTSKF-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ