### PR TITLE
Improve security of k8s config

### DIFF
--- a/.k8s/live/api-sandbox/deployment-worker.yaml
+++ b/.k8s/live/api-sandbox/deployment-worker.yaml
@@ -40,6 +40,12 @@ spec:
               command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/api-sandbox/deployment.yaml
+++ b/.k8s/live/api-sandbox/deployment.yaml
@@ -46,6 +46,12 @@ spec:
                   value: "on"
             initialDelaySeconds: 30
             periodSeconds: 10
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev-lgfs/deployment-worker.yaml
+++ b/.k8s/live/dev-lgfs/deployment-worker.yaml
@@ -40,6 +40,12 @@ spec:
               command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev-lgfs/deployment.yaml
+++ b/.k8s/live/dev-lgfs/deployment.yaml
@@ -46,6 +46,12 @@ spec:
                   value: "on"
             initialDelaySeconds: 30
             periodSeconds: 10
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev/deployment-worker.yaml
+++ b/.k8s/live/dev/deployment-worker.yaml
@@ -40,6 +40,12 @@ spec:
               command: ['bin/worker_healthcheck']
             initialDelaySeconds: 30
             periodSeconds: 300
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev/deployment.yaml
+++ b/.k8s/live/dev/deployment.yaml
@@ -46,6 +46,12 @@ spec:
                   value: "on"
             initialDelaySeconds: 30
             periodSeconds: 10
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -47,6 +47,12 @@ spec:
             requests:
               cpu: 10m
               memory: 1000Mi
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -46,6 +46,12 @@ spec:
                   value: "on"
             initialDelaySeconds: 30
             periodSeconds: 60
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -47,6 +47,12 @@ spec:
             requests:
               cpu: 10m
               memory: 1000Mi
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -46,6 +46,12 @@ spec:
                   value: "on"
             initialDelaySeconds: 30
             periodSeconds: 60
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets


### PR DESCRIPTION
#### What

We do not currently configure the security context for our kubernetes deployments. This exposes us to several security vulnerabilities, which are being flagged by Snyk's Infrastructure as Code scanning: e.g. https://app.snyk.io/org/legal-aid-agency/project/27f17554-06a1-44f9-a271-9f67bd94928f

This change sets three security configurations for CCCD's `deployment` and `deployment-worker` kubernetes containers which ensure that the containers run:

* with restricted capabilities, so that the container is not running with potentially unnecessary privileges;
* as non-root, so that the container is not running with full admin privileges;
* with privilege escalation control, so that compromised process cannot elevate privileges.

There is one further change that could be made (set `readOnlyRootFilesystem: true`) however this causes deployment failures and will be addressed in a later change. There are also similar improvements that could be made to the `.k8s/live/cron_jobs` and `.k8s/live/jobs` pods, but to keep the size of this PR manageable these will be fixed separately.

#### How 

Add the following block to the container definition in `.k8s/live/<env>/deployment.yaml` and `.k8s/live/<env>/deployment-worker.yaml` for all five CCCD environments:

```        
securityContext:
  capabilities:
    drop:
    - ALL
  runAsNonRoot: true
  allowPrivilegeEscalation: false
```

## Further reading
https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
https://kubesec.io/basics/
https://cloudogu.com/en/blog/k8s-app-ops-part-3-security-context-1
