### PR TITLE
Pre-load fee schemes when loading offences

### DIFF
--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -104,7 +104,7 @@ module API
             offences = FeeSchemeFactory::AGFS.call(
               representation_order_date: scheme_date,
               main_hearing_date: params[:main_hearing_date]
-            ).offences.includes(:fee_schemes)
+            ).offences.includes(:fee_schemes, :offence_band, :offence_class)
             offences = offences.where(description:) if description.present?
             offences = offences.where(unique_code:) if unique_code.present?
 

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -104,7 +104,7 @@ module API
             offences = FeeSchemeFactory::AGFS.call(
               representation_order_date: scheme_date,
               main_hearing_date: params[:main_hearing_date]
-            ).offences
+            ).offences.includes(:fee_schemes)
             offences = offences.where(description:) if description.present?
             offences = offences.where(unique_code:) if unique_code.present?
 

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -90,6 +90,6 @@ class Offence < ApplicationRecord
   end
 
   def post_agfs_reform?
-    fee_schemes.agfs.map(&:version).any? { |s| s > FeeScheme::NINE }
+    fee_schemes.any? { |fs| fs.name == 'AGFS' && fs.version > FeeScheme::NINE }
   end
 end


### PR DESCRIPTION
#### What

Optimize requests to `api/offences`.

#### Ticket

Related to [CCCD: Add main hearing date to /api/offences endpoint](https://dsdmoj.atlassian.net/browse/CTSKF-156)

#### Why

The offence entity in `app/interfaces/api/entities/offence.rb` checks if the fee scheme is version 9 or after the AGFS reform and this involves a database look-up for each offence. Fetching offences with `api/offences` can return thousands of records and this results in thousands of individual database queries.

See https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/c5b8fcf40326d6e2bbba2287452a0b5885c60711/app/interfaces/api/entities/offence.rb#L9-L21

#### How

* Pre-fetch fee schemes for offences (04ca2d595f26c6f161993cce14be600ce82a86bb). This reduces the number of requests required for all the `Offence#scheme_nine?` calls.
* Change `post_agfs_reform?` to not use the `agfs` scope but instead test `fs.name == 'AGFS'` for each record. Together with the pre-fetched fee schemes, this further reduces database requests.
* Also pre-fetch offence class and offence band (4e24239dd5d38d010d64c0e2c498da19998cd8c1).

#### Results

Test query:

```bash
time curl -X GET --header 'Accept: application/json' 'https://dev-lgfs.claim-crown-court-defence.service.justice.gov.uk/api/offences?api_key=<REMOVED>&rep_order_date=2023-01-01&main_hearing_date=2023-01-02'
```

##### Before changes

```
0.02s user 0.02s system 0% cpu 7.912 total
0.02s user 0.02s system 0% cpu 6.596 total
0.02s user 0.02s system 0% cpu 6.829 total
0.02s user 0.02s system 0% cpu 8.268 total
```

##### After 04ca2d595f26c6f161993cce14be600ce82a86bb

```
0.02s user 0.02s system 0% cpu 6.659 total
0.02s user 0.02s system 0% cpu 6.199 total
0.02s user 0.02s system 0% cpu 5.038 total
0.02s user 0.02s system 0% cpu 5.291 total
```

##### After 430591159bbc3a8dd6f28fe89a283843592c35df

```
0.02s user 0.03s system 1% cpu 3.389 total
0.02s user 0.02s system 1% cpu 2.449 total
0.02s user 0.02s system 1% cpu 2.308 total
0.02s user 0.02s system 1% cpu 2.460 total
```

##### After 4e24239dd5d38d010d64c0e2c498da19998cd8c1

```
0.02s user 0.02s system 1% cpu 1.842 total
0.02s user 0.02s system 4% cpu 0.846 total
0.02s user 0.02s system 2% cpu 1.183 total
0.02s user 0.02s system 3% cpu 0.951 total
```