### PR TITLE
Enable LGFS main hearing date feature on Staging

### DIFF
--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -22,4 +22,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
-  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'false'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'


### PR DESCRIPTION
#### What

Sets `MAIN_HEARING_DATE_ENABLED_FOR_LGFS` to `true` in `.k8s/live/staging/app-config.yaml` to allow end-to-end testing to take place.
