### PR TITLE
[CTSKF-200] Update cookie rotation initializer

### DIFF
--- a/config/initializers/cookie_rotation.rb
+++ b/config/initializers/cookie_rotation.rb
@@ -17,11 +17,16 @@ Rails.application.configure do
   # but it is to line up with the config below.
   config.action_dispatch.use_authenticated_cookie_encryption = true
 
-  # From:
+  # Originally from:
   # https://www.gitmemory.com/issue/rails/rails/39964/668147345
+  # This page has disappeared but it may have been a reference to:
+  # https://github.com/rails/rails/issues/39964
+  # The official documentation for rotating the cookies, with respect to
+  # upgrading to Rails 7:
+  # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
   # --------------------------------------------------------------------------------
   config.action_dispatch.cookies_rotations.tap do |cookies|
-    salt = config.action_dispatch.encrypted_cookie_salt
+    salt = config.action_dispatch.authenticated_encrypted_cookie_salt
     signed_salt = config.action_dispatch.encrypted_signed_cookie_salt
     cipher = config.action_dispatch.encrypted_cookie_cipher || 'aes-256-gcm'
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,7 +11,7 @@
 # if you're sharing your code publicly.
 
 development:
-  old_secret_key_base: ee63f015ce225c840bf33a4f40e4890398221b394ca5f93e7ca6d4a491acf2f35bedcca677f146b22a6fa212099af990a16a80c7e8c8a8ac28927daa84e091a3
+  # old_secret_key_base: ee63f015ce225c840bf33a4f40e4890398221b394ca5f93e7ca6d4a491acf2f35bedcca677f146b22a6fa212099af990a16a80c7e8c8a8ac28927daa84e091a3
   secret_key_base: ce448bd7c975ec94f925bf2a24dee48427d11f2b81f5944b6dcc541f9d330dc0d60fda8fc1bb6e5c942b86f5a2726161d58cdaa8ebba3ab8088cd31c92094c55
   google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
   currency_api_key: <%= ENV["CURRENCY_API_KEY"] %>

--- a/docs/cookie_rotation.md
+++ b/docs/cookie_rotation.md
@@ -28,7 +28,7 @@ To rotate the `secret_key_base` without inconveniencing users you must:
      secret_key_base: my-new-local-secret-key-base-secret
    ....
    production:
-     old_secret_key_base: ENV["OLD_SECRET_KEY_BASE"]
+     old_secret_key_base: <%= ENV["OLD_SECRET_KEY_BASE"] %>
      secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
    ```
 


### PR DESCRIPTION
#### What

Update the cookie rotation initializer.

#### Ticket

[CCCD: Rotate secrets - Rails Secret Key Base](https://dsdmoj.atlassian.net/browse/CTSKF-200)

#### Why

The wrong salt was being used and so the rotation failed.

#### How

The salt to be rotated needs to be `authenticated_encrypted_cookie_salt` instead of `encrypted_cookie_salt`.

Also added more links to documentation, including a link to the instructions for upgrading to Rails 7.