### PR TITLE
Set SecurityContext on kubernetes job pods

### DIFF
--- a/.k8s/live/cron_jobs/archive_stale.yaml
+++ b/.k8s/live/cron_jobs/archive_stale.yaml
@@ -21,6 +21,12 @@ spec:
           - name: cronjob-worker
             image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-latest
             imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
             command:
               - rails
               - claims:archive_stale

--- a/.k8s/live/cron_jobs/clean_ecr.yaml
+++ b/.k8s/live/cron_jobs/clean_ecr.yaml
@@ -24,6 +24,12 @@ spec:
           - name: aws-cli
             image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools:awscli
             imagePullPolicy: IfNotPresent
+            securityContext:
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
             command:
             - /bin/sh
             - -c

--- a/.k8s/live/cron_jobs/vacuum_db.yaml
+++ b/.k8s/live/cron_jobs/vacuum_db.yaml
@@ -21,6 +21,12 @@ spec:
           - name: cronjob-worker
             image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-latest
             imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false           
             command:
               - rails
               - db:vacuum

--- a/.k8s/live/jobs/dump.yaml
+++ b/.k8s/live/jobs/dump.yaml
@@ -13,6 +13,12 @@ spec:
         - name: cccd-job
           imagePullPolicy: Always
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           command:
             - bundle
             - exec

--- a/.k8s/live/jobs/migrate.yaml
+++ b/.k8s/live/jobs/migrate.yaml
@@ -11,6 +11,12 @@ spec:
       containers:
         - name: cccd-job
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-latest
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           command:
             - bundle
             - exec

--- a/.k8s/live/jobs/seed.yaml
+++ b/.k8s/live/jobs/seed.yaml
@@ -11,6 +11,12 @@ spec:
       containers:
         - name: cccd-job
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:app-latest
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           command:
             - bundle
             - exec


### PR DESCRIPTION
#### What

We do not currently configure the security context for kubernetes pods used to run cronjobs and database jobs. This exposes us to several security vulnerabilities, which are being flagged by Snyk's Infrastructure as Code scanning: e.g. https://app.snyk.io/org/legal-aid-agency/project/27f17554-06a1-44f9-a271-9f67bd94928f

This change sets three security configurations for CCCD's kubernetes job pods which ensure that the containers run:

* with restricted capabilities, so that the container is not running with potentially unnecessary privileges;
* as non-root, so that the container is not running with full admin privileges;
* with privilege escalation control, so that compromised process cannot elevate privileges.

There is one further change that could be made (set `readOnlyRootFilesystem: true`) however this causes deployment failures and will be addressed in a later change.

#### How 

Add the following block to the container definitions in `.k8s/live/cronjobs/` and `.k8s/live/jobs/`:

```        
securityContext:
  capabilities:
    drop:
    - ALL
  runAsNonRoot: true
  allowPrivilegeEscalation: false
```

## Further reading
https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
https://kubesec.io/basics/
https://cloudogu.com/en/blog/k8s-app-ops-part-3-security-context-1

#### Testing

Deployed to `dev` and executed the following commands to run updated jobs:

* `.k8s/live/scripts/job.sh dump dev` ✅ 
* `.k8s/live/scripts/job.sh migrate dev` ✅ 
* `.k8s/live/scripts/job.sh seed dev` ✅ (this runs with expected errors as certain data cannot be seeded more than once)

and the following commands to manually trigger updated cronjobs:

* `kubectl create job --from=cronjob/cccd-archive-stale cccd-archive-stale-01 -n cccd-dev` ✅
* `kubectl create job --from=cronjob/ecr-delete-untagged-images-cronjob ecr-delete-untagged-images-cronjob-01 -n cccd-dev` ✅
* `kubectl create job --from=cronjob/cccd-vacuum-db cccd-vacuum-db-01 -n cccd-dev` ✅

Before #5326 , Snyk reported 44 medium and 41 low vulnerabilities with our infrastructure as code:

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/28729201/216333034-30187520-66df-436f-8e74-dfecc3b86458.png">

After this PR we have no medium IAC vulnerabilities:

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/28729201/216333835-3652e708-3376-4e5c-8421-d862d302697b.png">