### PR TITLE
[CTSKF-153] Enable main hearing date for LGFS in dev

### DIFF
--- a/.k8s/live/dev/app-config.yaml
+++ b/.k8s/live/dev/app-config.yaml
@@ -20,4 +20,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
-  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'false'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'


### PR DESCRIPTION
#### What

Enable the main hearing date for LGFS in the dev environment.

#### Ticket

[CCCD: Enable main_hearing_date feature flag in production for LGFS](https://dsdmoj.atlassian.net/browse/CTSKF-153)

#### Why

Allow providers to enter a main hearing date for LGFS claims in the dev environment.

#### How

Set `MAIN_HEARING_DATE_ENABLED_FOR_LGFS` to `true` in `.k8s/live/dev/app-config.yaml`.
