### PR TITLE
[CTSKF-153] Enable main hearing date for LGFS in production

### DIFF
--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -22,4 +22,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
-  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'false'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'


### PR DESCRIPTION
#### What

Enable the main hearing date for LGFS in the production environment.

#### Ticket

[CCCD: Enable main_hearing_date feature flag in production for LGFS](https://dsdmoj.atlassian.net/browse/CTSKF-153)

#### Why

Allow providers to enter a main hearing date for LGFS claims in the production environment.

#### How

Set `MAIN_HEARING_DATE_ENABLED_FOR_LGFS` to `true` in `.k8s/live/production/app-config.yaml`.
