### PR TITLE
CTSKF-254 Fix filtering in FeeSchemeFactory::Base

### DIFF
--- a/app/models/fee_scheme_factory/agfs.rb
+++ b/app/models/fee_scheme_factory/agfs.rb
@@ -21,9 +21,9 @@ module FeeSchemeFactory
     end
 
     def scheme_thirteen_range
-      (return Settings.clar_release_date..) if clair_contingency
+      (return Settings.clar_release_date..Time.zone.today) if clair_contingency
 
-      Settings.agfs_scheme_13_clair_release_date..
+      Settings.agfs_scheme_13_clair_release_date..Time.zone.today
     end
   end
 end

--- a/app/models/fee_scheme_factory/lgfs.rb
+++ b/app/models/fee_scheme_factory/lgfs.rb
@@ -18,9 +18,9 @@ module FeeSchemeFactory
     end
 
     def scheme_ten_range
-      return (Settings.clar_release_date..) if clair_contingency
+      return (Settings.clar_release_date..Time.zone.today) if clair_contingency
 
-      Settings.lgfs_scheme_10_clair_release_date..
+      Settings.lgfs_scheme_10_clair_release_date..Time.zone.today
     end
   end
 end


### PR DESCRIPTION
#### What

Prevent `FeeSchemeFactory` classes hanging when called for a claim with rep order dates < 01/04/2012.

#### Ticket

[CTSKF-254](https://dsdmoj.atlassian.net/browse/CTSKF-254)

#### Why

The `FeeSchemeFactory::Base` class selects the correct fee scheme for a claim by filtering from an array of date ranges defined in the classes that inherit from it (ie `FeeSchemeFactory::AGFS` and `FeeSchemeFactory::LGFS`).

The last item in each of those arrays is an endless range, eg `Settings.agfs_scheme_13_clair_release_date..`

Selection of the correct fee scheme is done using the `.include?` method:

`return filter[:scheme] if filter[:range].include?(@representation_order_date)`

When used on an endless range, where the date being evaluated predates the start of the range, `include?` iterates infinitely and never returns a result. See: 

https://bugs.ruby-lang.org/issues/19418
https://github.com/rails/rails/issues/47272

This occurs in CCCD on the very rare occasions that a representation order date is used which predates the earliest date allowed for a fee scheme (ie 01/04/2012). This results in the application hanging. This currently occurs when deleting old claims using the `claims:archive_stale` rake task.

#### How

To prevent this endless looping, add an end date of `Time.zone.today` to all currently endless date ranges. Rep orders must be dated on or before today's date so we do not need to use an endless range to handle future dates.

[CTSKF-254]: https://dsdmoj.atlassian.net/browse/CTSKF-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ