### PR TITLE
Remove temporary fix for REDIS_URL

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,10 +9,6 @@
 #
 # https://github.com/mperham/sidekiq/wiki/Using-Redis
 
-url = ENV.fetch('REDIS_URL', '').gsub(%r{(://).*:(.*@.*:.*)}, '\1:\2')
-Sidekiq.configure_client { |config| config.redis = { url: } if url.present? }
-Sidekiq.configure_server { |config| config.redis = { url: } if url.present? }
-
 Sidekiq.default_job_options = { retry: 5 }
 
 # Perform Sidekiq jobs immediately in development,

--- a/lib/caching/redis_store.rb
+++ b/lib/caching/redis_store.rb
@@ -3,8 +3,7 @@ require_relative 'abstract_store'
 class Caching
   class RedisStore < AbstractStore
     def initialize
-      url = ENV.fetch('REDIS_URL').gsub(%r{(://).*:(.*@.*:.*)}, '\1:\2')
-      self.store = Redis.new(url:)
+      self.store = Redis.new(url: ENV.fetch('REDIS_URL'))
     end
 
     def self.current


### PR DESCRIPTION
#### What

Revert 2ab8ba312a0646ff301e4de7e73356614ad74c31

#### Why

After updating the redis gem and removing the username from the REDIS_URL environment variable in cloud-platform-environments the commit 2ab8ba312a0646ff301e4de7e73356614ad74c31 can be reverted to remove the temporary modification of the url.

