### PR TITLE
Disable LGFS main hearing date flag in production

### DIFF
--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -22,4 +22,4 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   MAIN_HEARING_DATE_ENABLED_FOR_AGFS: 'true'
-  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'true'
+  MAIN_HEARING_DATE_ENABLED_FOR_LGFS: 'false'


### PR DESCRIPTION
#### What

Disable LGFS main hearing date flag in production to allow for investigation of injection failures into CCLF.
