### PR TITLE
CTSKF-260 Add validation to main hearing date

### DIFF
--- a/app/validators/claim/advocate_claim_validator.rb
+++ b/app/validators/claim/advocate_claim_validator.rb
@@ -24,6 +24,7 @@ class Claim::AdvocateClaimValidator < Claim::BaseClaimValidator
         retrial_concluded_at
         case_concluded_at
         supplier_number
+        main_hearing_date
       ],
       defendants: [],
       offence_details: %i[offence],

--- a/app/validators/claim/advocate_hardship_claim_validator.rb
+++ b/app/validators/claim/advocate_hardship_claim_validator.rb
@@ -20,6 +20,7 @@ class Claim::AdvocateHardshipClaimValidator < Claim::BaseClaimValidator
         trial_fixed_at
         trial_cracked_at
         supplier_number
+        main_hearing_date
       ],
       defendants: [],
       offence_details: %i[offence],

--- a/app/validators/claim/advocate_interim_claim_validator.rb
+++ b/app/validators/claim/advocate_interim_claim_validator.rb
@@ -10,6 +10,7 @@ class Claim::AdvocateInterimClaimValidator < Claim::BaseClaimValidator
         transfer_court_id
         transfer_case_number
         supplier_number
+        main_hearing_date
       ],
       defendants: %i[earliest_representation_order],
       offence_details: %i[offence],

--- a/app/validators/claim/advocate_supplementary_claim_validator.rb
+++ b/app/validators/claim/advocate_supplementary_claim_validator.rb
@@ -12,6 +12,7 @@ class Claim::AdvocateSupplementaryClaimValidator < Claim::BaseClaimValidator
         transfer_case_number
         case_concluded_at
         supplier_number
+        main_hearing_date
       ],
       defendants: [],
       miscellaneous_fees: %i[advocate_category defendant_uplifts_misc_fees total],

--- a/app/validators/claim/base_claim_validator.rb
+++ b/app/validators/claim/base_claim_validator.rb
@@ -251,6 +251,10 @@ class Claim::BaseClaimValidator < BaseValidator
     validate_retrial_start_and_end(:retrial_started_at, :retrial_concluded_at, true)
   end
 
+  def validate_main_hearing_date
+    validate_too_far_in_past(:main_hearing_date)
+  end
+
   # local helpers
   # ---------------------------
   def method_missing(method, *args)

--- a/app/validators/claim/interim_claim_validator.rb
+++ b/app/validators/claim/interim_claim_validator.rb
@@ -12,6 +12,7 @@ module Claim
           transfer_court_id
           transfer_case_number
           case_concluded_at
+          main_hearing_date
         ],
         defendants: [],
         offence_details: %i[offence],

--- a/app/validators/claim/litigator_claim_validator.rb
+++ b/app/validators/claim/litigator_claim_validator.rb
@@ -11,6 +11,7 @@ class Claim::LitigatorClaimValidator < Claim::BaseClaimValidator
         transfer_court_id
         transfer_case_number
         case_concluded_at
+        main_hearing_date
       ],
       defendants: [],
       offence_details: %i[offence],

--- a/app/validators/claim/litigator_hardship_claim_validator.rb
+++ b/app/validators/claim/litigator_hardship_claim_validator.rb
@@ -11,6 +11,7 @@ class Claim::LitigatorHardshipClaimValidator < Claim::BaseClaimValidator
         case_transferred_from_another_court
         transfer_court_id
         transfer_case_number
+        main_hearing_date
       ],
       defendants: [],
       offence_details: %i[offence],

--- a/app/validators/claim/transfer_claim_validator.rb
+++ b/app/validators/claim/transfer_claim_validator.rb
@@ -28,6 +28,7 @@ class Claim::TransferClaimValidator < Claim::BaseClaimValidator
         supplier_number
         amount_assessed
         evidence_checklist_ids
+        main_hearing_date
       ],
       defendants: [],
       offence_details: %i[offence],

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -547,6 +547,12 @@ earliest_representation_order_date:
     short: _
     api: The representation order date, main hearing date and case type cannot be combined
 
+main_hearing_date:
+  _seq: 225
+  main_hearing_date_cannot_be_too_far_in_the_past:
+    long: Main hearing date cannot be too far in the past
+    short: _
+    api: Main hearing date cannot be too far in the past
 
 
 #################################################################################

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -62,6 +62,8 @@ en:
               invalid: Enter a valid legal aid transfer date
               invalid_date: Enter a valid legal aid transfer date
               present: The date legal aid was transferred is not allowed
+            main_hearing_date:
+              check_not_too_far_in_past: Main hearing date cannot be too far in the past
             misc_fees:
               blank: You must select at least one miscellaneous fee
             offence:

--- a/spec/validators/claim/advocate_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_claim_validator_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Claim::AdvocateClaimValidator, type: :validator do
       retrial_concluded_at
       case_concluded_at
       supplier_number
+      main_hearing_date
     ],
     defendants: [],
     offence_details: %i[offence],

--- a/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_hardship_claim_validator_spec.rb
@@ -306,6 +306,7 @@ RSpec.describe Claim::AdvocateHardshipClaimValidator, type: :validator do
       trial_fixed_at
       trial_cracked_at
       supplier_number
+      main_hearing_date
     ],
     defendants: [],
     offence_details: %i[offence],

--- a/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
+++ b/spec/validators/claim/advocate_supplementary_claim_validator_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Claim::AdvocateSupplementaryClaimValidator, type: :validator do
       transfer_case_number
       case_concluded_at
       supplier_number
+      main_hearing_date
     ],
     defendants: [],
     miscellaneous_fees: %i[advocate_category defendant_uplifts_misc_fees total],

--- a/spec/validators/claim/interim_claim_validator_spec.rb
+++ b/spec/validators/claim/interim_claim_validator_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Claim::InterimClaimValidator, type: :validator do
       transfer_court_id
       transfer_case_number
       case_concluded_at
+      main_hearing_date
     ],
     defendants: [],
     offence_details: %i[offence],

--- a/spec/validators/claim/litigator_claim_validator_spec.rb
+++ b/spec/validators/claim/litigator_claim_validator_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Claim::LitigatorClaimValidator, type: :validator do
       transfer_court_id
       transfer_case_number
       case_concluded_at
+      main_hearing_date
     ],
     defendants: [],
     offence_details: %i[offence],

--- a/spec/validators/claim/shared_examples_for_advocate_litigator.rb
+++ b/spec/validators/claim/shared_examples_for_advocate_litigator.rb
@@ -135,6 +135,16 @@ RSpec.shared_examples 'common advocate litigator validations' do |external_user_
       end
     end
   end
+
+  context 'when main hearing date is too far in past' do
+    it { should_error_if_too_far_in_the_past(claim, :main_hearing_date, 'Main hearing date cannot be too far in the past') }
+  end
+
+  context 'when main hearing date is blank' do
+    before { claim.main_hearing_date = nil }
+
+    it { should_not_error(claim, :main_hearing_date) }
+  end
 end
 
 RSpec.shared_examples 'common litigator validations' do |*flags|

--- a/spec/validators/claim/transfer_claim_validator_spec.rb
+++ b/spec/validators/claim/transfer_claim_validator_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Claim::TransferClaimValidator, type: :validator do
       supplier_number
       amount_assessed
       evidence_checklist_ids
+      main_hearing_date
     ],
     defendants: [],
     offence_details: %i[offence],


### PR DESCRIPTION
#### What

Add validation to the main hearing date field for AGFS and LGFS claims to prevent very old dates being entered

#### Ticket

[CTSKF-260](https://dsdmoj.atlassian.net/browse/CTSKF-260)

#### Why

The main hearing date field currently allows users to enter dates in the format `01/01/23` which results in dates such as `01/01/0023` being saved to the database. This causes errors on injection to CCR and CCLF.

#### How

* Adds a new validation method `validate_main_hearing_date` to the `Claim::BaseClaimValidator` class which utilises the `validate_too_far_in_past` method to ensure that dates older than 10 years ago (as configured in `config/settings.yml`) cannot be entered.
* Adds `main_hearing_date` as a field to be validated to all  LGFS and AGFS claim types

#### Proof 

<img width="422" alt="image" src="https://user-images.githubusercontent.com/28729201/217802965-9008f43c-24db-4869-927b-56153622bddd.png">


[CTSKF-260]: https://dsdmoj.atlassian.net/browse/CTSKF-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ