### PR TITLE
[CTSKF-233] Use html <template> in place of JQuery template

### DIFF
--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -50,3 +50,19 @@
     .fx-filters-display
       %p
     .fx-results{ 'aria-live': 'polite', role: 'region' }
+
+%template#fx-results-template
+  %div.govuk-grid-row.offence-item.fx-result-item
+    %div.govuk-grid-column-two-thirds
+      %span.govuk-body-s.link-grey
+        %a.fx-filter.category{ href: '#noop' }
+        >
+        %a.fx-filter.band{ href: '#noop' }
+      %br
+      %span.description
+      %br
+      %span.govuk-body-s.link-grey.contrary
+    %div.govuk-grid-column-one-third.align-right
+      %br
+      %a.button.offence-item-button.set-selection{ href: '#', 'data-field': '#claim_offence_id' }
+        Select and continue

--- a/app/webpack/javascripts/modules/Modules.OffenceSearchInput.js
+++ b/app/webpack/javascripts/modules/Modules.OffenceSearchInput.js
@@ -75,16 +75,16 @@ moj.Modules.OffenceSearchInput = {
 
     // dataOptions for the api request
     // defaults, search input and filters
-    const dataOptions = $.extend({}, {
+    const dataOptions = {
       // default value
       fee_scheme: this.$feeScheme.val(),
 
       // Search query text
-      search_offence: this.$input.val()
-    },
+      search_offence: this.$input.val(),
 
-    // filters are applied
-    options)
+      // filters are applied
+      ...options
+    }
 
     this.query(dataOptions).then(function (data) {
       // showing the clear search button

--- a/app/webpack/javascripts/modules/Modules.OffenceSearchView.js
+++ b/app/webpack/javascripts/modules/Modules.OffenceSearchView.js
@@ -121,7 +121,7 @@ moj.Modules.OffenceSearchView = {
       category.setAttribute('data-category', data.category.id);
 
       const band = result.getElementsByClassName('band')[0];
-      band.innerHTML = data.band.description;
+      band.innerHTML = `Band: ${data.band.description}`;
       band.setAttribute('data-category', data.category.id);
       band.setAttribute('data-band', data.band.id);
 

--- a/app/webpack/javascripts/modules/Modules.OffenceSearchView.js
+++ b/app/webpack/javascripts/modules/Modules.OffenceSearchView.js
@@ -110,27 +110,27 @@ moj.Modules.OffenceSearchView = {
    * @param  {object} options results data
    */
   render: function (options) {
-    const results = this.$view.find('.fx-results');
-    results.empty();
-    const card = document.getElementById('fx-results-template');
+    const results = this.$view.find('.fx-results')
+    results.empty()
+    const card = document.getElementById('fx-results-template')
     options.results.forEach((data) => {
-      const result = card.content.cloneNode(true).querySelector('div');
+      const result = card.content.cloneNode(true).querySelector('div')
 
-      const category = result.getElementsByClassName('category')[0];
-      category.innerHTML = data.category.description;
-      category.setAttribute('data-category', data.category.id);
+      const category = result.getElementsByClassName('category')[0]
+      category.innerHTML = data.category.description
+      category.setAttribute('data-category', data.category.id)
 
-      const band = result.getElementsByClassName('band')[0];
-      band.innerHTML = `Band: ${data.band.description}`;
-      band.setAttribute('data-category', data.category.id);
-      band.setAttribute('data-band', data.band.id);
+      const band = result.getElementsByClassName('band')[0]
+      band.innerHTML = `Band: ${data.band.description}`
+      band.setAttribute('data-category', data.category.id)
+      band.setAttribute('data-band', data.band.id)
 
-      result.getElementsByClassName('description')[0].innerHTML = data.description;
-      result.getElementsByClassName('contrary')[0].innerHTML = data.contrary;
-      result.getElementsByClassName('button')[0].setAttribute('data-value', data.id);
+      result.getElementsByClassName('description')[0].innerHTML = data.description
+      result.getElementsByClassName('contrary')[0].innerHTML = data.contrary
+      result.getElementsByClassName('button')[0].setAttribute('data-value', data.id)
 
-      results.append(result);
-    });
+      results.append(result)
+    })
 
     this.$view.find('.fx-filters-display p').empty()
     this.$view.find('.fx-filters-display p').append(this.filterResults(options))

--- a/app/webpack/javascripts/modules/Modules.OffenceSearchView.js
+++ b/app/webpack/javascripts/modules/Modules.OffenceSearchView.js
@@ -11,30 +11,6 @@ moj.Modules.OffenceSearchView = {
   // page controls selector
   pageControls: '.button-holder',
 
-  // template for each result
-  template: function () {
-    return ['<div class="govuk-grid-row offence-item fx-result-item">',
-      '<div class="govuk-grid-column-two-thirds">',
-      '<span class="govuk-body-s link-grey">',
-      '<a href="#noop" class="fx-filter" data-category="{{:category.id}}">',
-      '{{:category.description}}',
-      '</a>&nbsp;&gt;&nbsp;',
-      '<a href="#noop" class="fx-filter" data-category="{{:category.id}}" data-band="{{:band.id}}">',
-      'Band:&nbsp;',
-      '{{:band.description}}',
-      '</a>',
-      '</span></br>',
-      '{{:description}}',
-      '</br>',
-      '<span class="govuk-body-s link-grey">{{:contrary}}</a>',
-      '</div>',
-      '<div class="govuk-grid-column-one-third align-right">',
-      '</br>',
-      '<a href="#" class="button offence-item-button set-selection" data-field="#claim_offence_id" data-value="{{:id}}">Select and continue</a>',
-      '</div></div>'
-    ].join('')
-  },
-
   /**
    * init called my moj.init()
    */
@@ -134,13 +110,27 @@ moj.Modules.OffenceSearchView = {
    * @param  {object} options results data
    */
   render: function (options) {
-    const tmpl = $.templates(this.template()) // Get compiled template
-    const html = tmpl.render(options.results) // Render template using data - as HTML string
+    const results = this.$view.find('.fx-results');
+    results.empty();
+    const card = document.getElementById('fx-results-template');
+    options.results.forEach((data) => {
+      const result = card.content.cloneNode(true).querySelector('div');
 
-    // Gives a number of the results found
-    // this.$view.find('.fx-results-count span').html(data.length)
-    this.$view.find('.fx-results').empty()
-    this.$view.find('.fx-results').append(html)
+      const category = result.getElementsByClassName('category')[0];
+      category.innerHTML = data.category.description;
+      category.setAttribute('data-category', data.category.id);
+
+      const band = result.getElementsByClassName('band')[0];
+      band.innerHTML = data.band.description;
+      band.setAttribute('data-category', data.category.id);
+      band.setAttribute('data-band', data.band.id);
+
+      result.getElementsByClassName('description')[0].innerHTML = data.description;
+      result.getElementsByClassName('contrary')[0].innerHTML = data.contrary;
+      result.getElementsByClassName('button')[0].setAttribute('data-value', data.id);
+
+      results.append(result);
+    });
 
     this.$view.find('.fx-filters-display p').empty()
     this.$view.find('.fx-filters-display p').append(this.filterResults(options))


### PR DESCRIPTION
#### What

A couple of changes to update some old JQuery to more modern javascript:

#### Ticket

[CCCD: Replace Asset bundler (Pre Rails 7)](https://dsdmoj.atlassian.net/browse/CTSKF-233)

#### Why

Keeping the codebase up to latest coding standards and (slowly) moving away from JQuery.

This will help to simplify #4722

#### How

* `$.extend` can be replaced by the new(ish) spread syntax
* `$.template` can be replaced using the `<template>` HTML tag
