### PR TITLE
Check updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     day: wednesday
     time: "03:00"
     timezone: Europe/London
@@ -14,7 +14,7 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     day: wednesday
     time: "03:00"
     timezone: Europe/London
@@ -29,7 +29,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     day: tuesday
     time: "03:00"
     timezone: Europe/London


### PR DESCRIPTION
#### What

Set dependabot to check daily instead of weekly.

#### Ticket

N/A

#### Why

We seem only to get a limited number of dependabot PRs each Wednesday and some libraries are not getting updated. By changing the schedule to daily should work though more of them.

#### How

Change the `interval` setting for each package ecosystem.