### PR TITLE
Fix swagger docs post-webpacker

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -12,3 +12,4 @@
 //= link govuk-opengraph-image.png
 //= link application.js
 //= link application.css
+//= link adp_swagger_application.js

--- a/app/views/grape_swagger_rails/application/index.html.haml
+++ b/app/views/grape_swagger_rails/application/index.html.haml
@@ -21,7 +21,6 @@
     = javascript_include_tag 'grape_swagger_rails/application.js'
 
     = stylesheet_link_tag 'application', media: 'all'
-    = stylesheet_link_tag 'govuk-frontend', media: 'all'
 
     = tag :meta, property: 'og:image', content: request.base_url + image_tag('govuk-opengraph-image.png')
     :javascript


### PR DESCRIPTION
#### What

After removing webpacker, the CCCD API [documentation](https://claim-crown-court-defence.service.gov.uk/api/documentation) returns an HTTP 500 error.  

#### Why

So that software vendors can continue to view our API docs.

#### How

* Remove reference to the unused `govuk-frontend.css` from `app/views/grape_swagger_rails/application/index.html.haml`
* Add `adp_swagger_application.js` to `app/assets/config/manifest.js`