### PR TITLE
Remove state_machine gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem 'scheduler_daemon',       git: 'https://github.com/jalkoby/scheduler_daemon.
 gem 'sentry-rails', '~> 5.5', '>= 5.5.0'
 gem 'sentry-sidekiq', '~> 5.8'
 gem 'sprockets-rails', '~> 3.4.2'
-gem 'state_machine',          '~> 1.2.0'
 gem 'state_machines-activerecord'
 gem 'state_machines-audit_trail'
 gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -639,7 +639,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    state_machine (1.2.0)
     state_machines (0.5.0)
     state_machines-activemodel (0.8.0)
       activemodel (>= 5.1)
@@ -804,7 +803,6 @@ DEPENDENCIES
   simplecov
   site_prism (~> 3.7, >= 3.7.3)
   sprockets-rails (~> 3.4.2)
-  state_machine (~> 1.2.0)
   state_machines-activerecord
   state_machines-audit_trail
   timecop

--- a/config/initializers/state_machine_patch.rb
+++ b/config/initializers/state_machine_patch.rb
@@ -1,8 +1,0 @@
-# See https://github.com/pluginaweek/state_machine/issues/251
-module StateMachine
-  module Integrations
-     module ActiveModel
-        public :around_validation
-     end
-  end
-end


### PR DESCRIPTION
#### What

Remove the `state_machine` gem.

#### Ticket

N/A

#### Why

The [`state_machine`](https://github.com/pluginaweek/state_machine) gem was already abandoned when it was added in 2192ec7f7caf442f1eacb6d1ef5e511e8c2bfb27. The supported fork, [`state_machines`](https://github.com/state-machines/state_machines) is already installed as a dependency of other gems when they were added in 7d85626d0b25d8cfb5da13b49e2aada8857f1f11.

Up to this point `state_machine` has not caused any problems but now it is preventing updating Ruby to version 3.2.

For reference: https://github.com/pluginaweek/state_machine/issues/343

#### How

Remove `state_machine` from `Gemfile` and also remove the monkey patch in `config/initializers/state_machine_patch.rb`.