### PR TITLE
Add request spec for API swagger docs

### DIFF
--- a/spec/requests/api/api_documentation_spec.rb
+++ b/spec/requests/api/api_documentation_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe 'API Swagger documentation' do
+  describe 'GET /api/documentation' do
+    before { get grape_swagger_rails_path }
+
+    it { expect(response).to have_http_status :ok }
+    it { expect(response.body).to include('Claim for crown court defence API') }
+  end
+end


### PR DESCRIPTION
#### What

Adds a small request spec to test that the documentation landing page, `/api/documentation`, is available.

#### Why

The PR to remove webpacker from CCCD caused a failure in production due to the interactive API documentation not rendering. We neglected to manually test the page and there is no automated test that the page is working. Adding this test will the reduce the possibility of such failures in future.