### PR TITLE
[CTSKF-263] Update contact email address

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -140,7 +140,7 @@ remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') +
 replace_journeys_func?: false
 
 # contact email address
-laa_contact_email: crowncourtdefence@legalaid.gsi.gov.uk
+laa_contact_email: crowncourtdefence@justice.gov.uk
 advocates_email: advocates-fee@justice.gov.uk
 litigators_email: litigators-fee@justice.gov.uk
 advocate_phone_contact: '03002002020'


### PR DESCRIPTION
#### What

Change the LAA contact email address from @legalaid.gsi.gov.uk to @justice.gov.uk.

#### Ticket

[Update outdated case management email address on CCCD](https://dsdmoj.atlassian.net/browse/CTSKF-263)

#### Why

The @legalaid.gsi.gov.uk email address is outdated and should not be used.

#### How

The email address is configured in `config/settings.yml`. It appears here: https://claim-crown-court-defence.service.gov.uk/timed_retention

[CTSKF-263]: https://dsdmoj.atlassian.net/browse/CTSKF-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ