### PR TITLE
Fix open redirect vulnerability in ManagementInformationController

### DIFF
--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -17,7 +17,7 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
 
   def download
     log_download_start
-    record = Stats::StatsReport.most_recent_by_type(params[:report_type])
+    record = Stats::StatsReport.most_recent_by_type(report_params[:report_type])
 
     if record.document.attached?
       redirect_to record.document.blob.url(disposition: 'attachment')
@@ -27,7 +27,7 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
   end
 
   def generate
-    StatsReportGenerationJob.perform_later(report_type: params[:report_type])
+    StatsReportGenerationJob.perform_later(report_type: report_params[:report_type])
     message = t('case_workers.admin.management_information.job_scheduled')
     redirect_to case_workers_admin_management_information_url, flash: { notification: message }
   end
@@ -41,13 +41,13 @@ class CaseWorkers::Admin::ManagementInformationController < CaseWorkers::Admin::
   private
 
   def validate_report_type
-    return if Stats::StatsReport.reports[params[:report_type]]
+    return if Stats::StatsReport.reports[report_params[:report_type]]
 
     redirect_to case_workers_admin_management_information_url, alert: t('.invalid_report_type')
   end
 
   def validate_report_type_is_updatable
-    return if Stats::StatsReport.reports[params[:report_type]].updatable?
+    return if Stats::StatsReport.reports[report_params[:report_type]].updatable?
 
     redirect_to case_workers_admin_management_information_url, alert: t('.report_cannot_be_updated')
   end


### PR DESCRIPTION
#### What

Snyk has a [flagged](https://app.snyk.io/org/legal-aid-agency/project/3c84d1a7-ff1f-4508-87d5-c74b0b4f23df#issue-da65fc4d-0e11-4f22-9e92-e5a13c15b921) an open redirect vulnerability in `CaseWorkers::Admin::ManagementInformationController` due to the use of unsanitized request parameters in a `redirect_to` method call.

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/28729201/225965863-8c89355c-b645-48ac-8b73-c4e3b48281ba.png">

That controller already implements strong parameters but they are not always used in the code. This commit replaces direct access to the parameters (`params[:report_type]`) with use of the strong parameters (`report_params[:report_type]`).

(This isn't strictly necessary as that class uses a `before` hook which validates the `:report_type` parameter before it is used, which mitigates the vulnerability, but this change is more idiomatic and keeps Snyk happy).
