### PR TITLE
Minor feature test tweaks

### DIFF
--- a/features/claims/litigator/scheme_nine_a/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine_a/transfer_claim_draft_submit.feature
@@ -112,84 +112,84 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£700.67'
 
 # This scenario does not work yet because ENP cases are not handled correctly with transfer claims
-# @fee_calc_vcr
-# Scenario: I create a transfer claim for an Elected Case Not Proceeded
+@fee_calc_vcr
+Scenario: I create a transfer claim for an Elected Case Not Proceeded
 
-#   Given I am a signed in litigator
-#   And My provider has supplier numbers
-#   And I am on the 'Your claims' page
-#   And I click 'Start a claim'
-#   And I select the fee scheme 'Litigator transfer fee'
-#   Then I should be on the litigator new transfer claim page
-#   And I should see a page title "Enter fees for litigator transfer fees claim"
+  Given I am a signed in litigator
+  And My provider has supplier numbers
+  And I am on the 'Your claims' page
+  And I click 'Start a claim'
+  And I select the fee scheme 'Litigator transfer fee'
+  Then I should be on the litigator new transfer claim page
+  And I should see a page title "Enter fees for litigator transfer fees claim"
 
-#   Then I choose the litigator type option 'New'
-#   And I choose the elected case option 'Yes'
-#   And I select the transfer stage 'Before trial transfer'
-#   And I enter the transfer date '2022-10-21'
+  Then I choose the litigator type option 'New'
+  And I choose the elected case option 'Yes'
+  And I select the transfer stage 'Before trial transfer'
+  And I enter the transfer date '2022-10-21'
 
-#   When I click "Continue" in the claim form
-#   Then I should see a page title "Enter case details for litigator transfer fees claim"
-#   When I choose the supplier number '1A222Z'
-#   And I select the court 'Blackfriars'
-#   And I enter a case number of 'A20161234'
-#   And I enter the case concluded date '2022-10-29'
-#   And I enter lgfs scheme 9a main hearing date
+  When I click "Continue" in the claim form
+  Then I should see a page title "Enter case details for litigator transfer fees claim"
+  When I choose the supplier number '1A222Z'
+  And I select the court 'Blackfriars'
+  And I enter a case number of 'A20161234'
+  And I enter the case concluded date '2022-10-29'
+  And I enter lgfs scheme 9a main hearing date
 
-#   When I click "Continue" in the claim form and move to the 'Defendant details' form page
-#   Then I should see a page title "Enter defendant details for litigator transfer fees claim"
+  When I click "Continue" in the claim form and move to the 'Defendant details' form page
+  Then I should see a page title "Enter defendant details for litigator transfer fees claim"
 
-#   When I save as draft
-#   Then I should see 'Draft claim saved'
+  When I save as draft
+  Then I should see 'Draft claim saved'
 
-#   Given I am later on the Your claims page
-#   Then Claim 'A20161234' should be listed with a status of 'Draft'
+  Given I am later on the Your claims page
+  Then Claim 'A20161234' should be listed with a status of 'Draft'
 
-#   When I click the claim 'A20161234'
-#   And I edit the claim's defendants
-#   And I should see a page title "Enter defendant details for litigator transfer fees claim"
-#   And I enter defendant, LGFS Scheme 9a representation order and MAAT reference
+  When I click the claim 'A20161234'
+  And I edit the claim's defendants
+  And I should see a page title "Enter defendant details for litigator transfer fees claim"
+  And I enter defendant, LGFS Scheme 9a representation order and MAAT reference
 
-#   When I click "Continue" in the claim form
-#   Then I should see a page title "Enter offence details for litigator transfer fees claim"
-#   And I select the offence category 'Handling stolen goods'
-#   And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
+  When I click "Continue" in the claim form
+  Then I should see a page title "Enter offence details for litigator transfer fees claim"
+  And I select the offence category 'Handling stolen goods'
+  And I select the advocate offence class 'G: Other offences of dishonesty between £30,001 and £100,000'
 
-#   Given I insert the VCR cassette 'features/claims/litigator/transfer_fee_calculations'
-#   When I click "Continue" in the claim form
-#   Then I should see a page title "Enter fees for litigator transfer fees claim"
-#   And the transfer fee amount should be populated with '257.85'
-#   And I should not see the days claimed field
-#   And I should see the ppe field
-#   When I enter '50' in the PPE total graduated fee field
-#   Then the transfer fee amount should be populated with '257.85'
-#   When I enter '51' in the PPE total graduated fee field
-#   Then the transfer fee amount should be populated with '262.27'
+  Given I insert the VCR cassette 'features/claims/litigator/transfer_fee_calculations'
+  When I click "Continue" in the claim form
+  Then I should see a page title "Enter fees for litigator transfer fees claim"
+  And the transfer fee amount should be populated with '257.85'
+  And I should not see the days claimed field
+  And I should see the ppe field
+  When I enter '50' in the PPE total graduated fee field
+  Then the transfer fee amount should be populated with '257.85'
+  When I enter '51' in the PPE total graduated fee field
+  Then the transfer fee amount should be populated with '262.27'
 
-#   Given I eject the VCR cassette
-#   When I click "Continue" in the claim form
-#   Then I should see a page title "Enter miscellaneous fees for litigator transfer fees claim"
-#   When I click "Continue" in the claim form
-#   Then I should see a page title "Enter disbursements for litigator transfer fees claim"
-#   When I click "Continue" in the claim form
-#   Then I should see a page title "Enter travel expenses for litigator transfer fees claim"
-#   When I click "Continue" in the claim form
-#   Then I should see a page title "Upload supporting evidence for litigator transfer fees claim"
+  Given I eject the VCR cassette
+  When I click "Continue" in the claim form
+  Then I should see a page title "Enter miscellaneous fees for litigator transfer fees claim"
+  When I click "Continue" in the claim form
+  Then I should see a page title "Enter disbursements for litigator transfer fees claim"
+  When I click "Continue" in the claim form
+  Then I should see a page title "Enter travel expenses for litigator transfer fees claim"
+  When I click "Continue" in the claim form
+  Then I should see a page title "Upload supporting evidence for litigator transfer fees claim"
 
-#   When I upload 1 document
-#   And I check the boxes for the uploaded documents
-#   And I check the evidence boxes for 'A copy of the indictment'
-#   And I add some additional information
-#   And I click Submit to LAA
-#   Then I should be on the check your claim page
-#   And I should see a page title "View claim summary for litigator transfer fees claim"
-#   And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
+  When I upload 1 document
+  And I check the boxes for the uploaded documents
+  And I check the evidence boxes for 'A copy of the indictment'
+  And I add some additional information
+  And I click Submit to LAA
+  Then I should be on the check your claim page
+  And I should see a page title "View claim summary for litigator transfer fees claim"
+  And I should see 'G: Other offences of dishonesty between £30,001 and £100,000'
 
-#   When I click "Continue"
-#   Then I should see a page title "Certify and submit the litigator transfer fees claim"
-#   When I click Certify and submit claim
-#   Then I should be on the claim confirmation page
+  When I click "Continue"
+  Then I should see a page title "Certify and submit the litigator transfer fees claim"
+  When I click Certify and submit claim
+  Then I should be on the claim confirmation page
 
-#   When I click View your claims
-#   Then I should be on the your claims page
-#   And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£262.27'
+  When I click View your claims
+  Then I should be on the your claims page
+  And Claim 'A20161234' should be listed with a status of 'Submitted' and a claimed amount of '£262.27'

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -17,10 +17,10 @@ Capybara.register_server :puma do |app, port, host|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Chrome::Options.new(
+  options = Selenium::WebDriver::Chrome::Options.new(
     args: %w[headless disable-gpu window-size=1366,768]
   )
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: capabilities)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end
 
 # use headless chrome for javascript

--- a/vcr/cassettes/features/claims/litigator/transfer_fee_calculations.yml
+++ b/vcr/cassettes/features/claims/litigator/transfer_fee_calculations.yml
@@ -1675,4 +1675,356 @@ http_interactions:
       encoding: UTF-8
       string: '{"amount":262.27}'
   recorded_at: Sat, 29 Oct 2022 23:00:00 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2020-09-17&main_hearing_date=2022-10-31&type=LGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Mar 2023 10:36:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '205'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":8,"start_date":"2020-09-17","end_date":"2022-09-29","earliest_main_hearing_date":"2022-10-31","type":"LGFS","description":"LGFS
+        CLAIR contingency"}]}'
+  recorded_at: Fri, 17 Mar 2023 10:36:52 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/8/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Mar 2023 10:36:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4119'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
+        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
+        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
+        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
+        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
+        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
+        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
+        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
+        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
+        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
+        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
+        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
+        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
+        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
+        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
+        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
+        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
+        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
+        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
+        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
+        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
+        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
+        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
+        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
+        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
+        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
+        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
+        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
+        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
+        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
+        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
+        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
+        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
+        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
+        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
+        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
+        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
+        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
+        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
+        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
+        issued - retrial (after trial start)","code":null}]}'
+  recorded_at: Fri, 17 Mar 2023 10:36:52 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/8/calculate/?day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=G&pages_of_prosecuting_evidence=0&scenario=22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Mar 2023 10:36:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '17'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":257.85}'
+  recorded_at: Fri, 17 Mar 2023 10:36:52 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/?case_date=2020-09-17&main_hearing_date=2022-10-31&type=LGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Mar 2023 10:36:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '205'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":8,"start_date":"2020-09-17","end_date":"2022-09-29","earliest_main_hearing_date":"2022-10-31","type":"LGFS","description":"LGFS
+        CLAIR contingency"}]}'
+  recorded_at: Fri, 17 Mar 2023 10:36:53 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/8/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Mar 2023 10:36:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4119'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"count":51,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"ST1TS0T1"},{"id":2,"name":"Guilty
+        plea","code":"ST1TS0T2"},{"id":3,"name":"Cracked trial","code":"ST1TS0T3"},{"id":4,"name":"Trial","code":"ST1TS0T4"},{"id":5,"name":"Appeal
+        against conviction","code":"ST1TS0T5"},{"id":6,"name":"Appeal against sentence","code":"ST1TS0T6"},{"id":7,"name":"Committal
+        for sentence","code":"ST1TS0T7"},{"id":8,"name":"Contempt","code":"ST1TS0T8"},{"id":9,"name":"Breach
+        of crown court order","code":"ST3TS3TB"},{"id":10,"name":"Cracked before retrial","code":"ST1TS0T9"},{"id":11,"name":"Retrial","code":"ST1TS0TA"},{"id":12,"name":"Elected
+        case not proceeded","code":"ST4TS0T1"},{"id":17,"name":"Up to and including
+        PCMH transfer (original solicitor) - cracked trial","code":"ST2TS1T0"},{"id":18,"name":"Up
+        to and including PCMH transfer (new solicitor) - guilty plea","code":"ST3TS1T2"},{"id":19,"name":"Up
+        to and including PCMH transfer (new solicitor) - cracked trial","code":"ST3TS1T3"},{"id":20,"name":"Up
+        to and including PCMH transfer (new solicitor) - trial","code":"ST3TS1T4"},{"id":21,"name":"Before
+        trial transfer (original solicitor) - cracked trial","code":"ST2TS2T0"},{"id":22,"name":"Before
+        trial transfer (new solicitor) - cracked trial","code":"ST3TS2T3"},{"id":23,"name":"Before
+        trial transfer (new solicitor) - trial","code":"ST3TS2T4"},{"id":24,"name":"During
+        trial transfer (original solicitor) - trial","code":"ST2TS3T0"},{"id":25,"name":"During
+        trial transfer (new solicitor) - trial","code":"ST3TS3T4"},{"id":26,"name":"During
+        trial transfer (new solicitor) - retrial","code":"ST3TS3TA"},{"id":27,"name":"Transfer
+        before retrial (original solicitor) - retrial","code":"ST2TS4T0"},{"id":28,"name":"Transfer
+        before retrial (new solicitor) - cracked retrial","code":"ST3TS4T9"},{"id":29,"name":"Transfer
+        before retrial (new solicitor) - retrial","code":"ST3TS4TA"},{"id":30,"name":"Transfer
+        during retrial (original solicitor) - retrial","code":"ST2TS5T0"},{"id":31,"name":"Transfer
+        during retrial (new solicitor) - retrial","code":"ST3TS5TA"},{"id":32,"name":"Hearing
+        subsequent to sentence","code":"ST1TS0TC"},{"id":33,"name":"Transfer after
+        retrial and before sentencing (original)","code":"ST2TS6TA"},{"id":34,"name":"Transfer
+        after retrial and before sentencing (new)","code":"ST3TS6TA"},{"id":35,"name":"Transfer
+        after trial and before sentencing (original)","code":"ST2TS7T4"},{"id":36,"name":"Transfer
+        after trial and before sentencing (new)","code":"ST3TS7T4"},{"id":37,"name":"Elected
+        case not proceeded - up to and including PCMH (original solicitor)","code":"ST4TS0T2"},{"id":38,"name":"Elected
+        case not proceeded - up to and including PCMH (new solicitor)","code":"ST4TS0T3"},{"id":39,"name":"Elected
+        case not proceeded - before trial transfer (original solicitor)","code":"ST4TS0T4"},{"id":40,"name":"Elected
+        case not proceeded - before trial transfer (new solicitor)","code":"ST4TS0T5"},{"id":41,"name":"Elected
+        case not proceeded - transfer before retrial (original solicitor)","code":"ST4TS0T6"},{"id":42,"name":"Elected
+        case not proceeded - transfer before retrial (new solicitor)","code":"ST4TS0T7"},{"id":43,"name":"Interim
+        payment - effective PCMH","code":"ST1TS0T0"},{"id":44,"name":"Interim payment
+        - trial start","code":"ST1TS1T0"},{"id":45,"name":"Interim payment - retrial
+        (new solicitor)","code":"ST1TS2T0"},{"id":46,"name":"Interim payment - retrial
+        start","code":"ST1TS3T0"},{"id":48,"name":"Warrant issued - trial (before
+        plea hearing)","code":null},{"id":49,"name":"Warrant issued - trial (after
+        plea hearing)","code":null},{"id":50,"name":"Warrant issued - trial (after
+        trial start)","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null},{"id":55,"name":"Warrant
+        issued - retrial (after plea hearing)","code":null},{"id":56,"name":"Warrant
+        issued - retrial (after trial start)","code":null}]}'
+  recorded_at: Fri, 17 Mar 2023 10:36:53 GMT
+- request:
+    method: get
+    uri: https://laa-fee-calculator.service.justice.gov.uk/api/v1/fee-schemes/8/calculate/?day=0&fee_type_code=LIT_FEE&number_of_defendants=1&offence_class=G&pages_of_prosecuting_evidence=0&ppe=51&scenario=22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/1.4.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Mar 2023 10:36:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '17'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Origin, Cookie
+      Allow:
+      - GET
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"amount":262.27}'
+  recorded_at: Fri, 17 Mar 2023 10:36:53 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
#### What

* Enable CLAIR contingency ECNP transfer claim feature test
* Fix Selenium deprecation warning

#### Why

I noticed that one feature test was commented out. This was introduced when the LGFS CLAIR contingency fee scheme was created but couldn't be enabled at the time, possibly due to feature-flagging. At the same time I noticed a Selenium deprecation warning that was appearing when we ran the cucumber tests.

#### How

* enable the disabled test
* re-record the VCR cassette to allow the tests to pass
* update the Selenium configuration to use `options` rather than the deprecated `capabilities`