### PR TITLE
CTSKF-330 Fix misc fee error message

### DIFF
--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -142,7 +142,7 @@ en:
               blank: Enter the date attended
               check_not_in_future: Enter a date that is not in the future
               not_before_earliest_permitted_date: Enter a date later than two years before the earliest representation order date
-              too_long_before_earliest_reporder: The fee date cannot not be more than two years before the earliest representation order date
+              too_long_before_earliest_reporder: The fee date cannot be more than two years before the earliest representation order date
         disbursement:
           attributes:
             disbursement_type_id:

--- a/spec/validators/date_attended_validator_spec.rb
+++ b/spec/validators/date_attended_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DateAttendedValidator, type: :validator do
 
   context 'date' do
     it { should_error_if_not_present(date_attended, :date, 'Enter the date attended') }
-    it { should_error_if_before_specified_date(date_attended, :date, earliest_reporder_date - 2.years - 1.day, 'The fee date cannot not be more than two years before the earliest representation order date') }
+    it { should_error_if_before_specified_date(date_attended, :date, earliest_reporder_date - 2.years - 1.day, 'The fee date cannot be more than two years before the earliest representation order date') }
     it { should_error_if_too_far_in_the_past(date_attended, :date, 'Enter a date later than two years before the earliest representation order date') }
     it { should_error_if_in_future(date_attended, :date, 'Enter a date that is not in the future') }
 


### PR DESCRIPTION
#### What

Fixes a poorly worded error message

#### Ticket

[CTSKF-330](https://dsdmoj.atlassian.net/browse/CTSKF-330)

#### Why

Entering a misc fee date > 2 years before the earliest representation order date results in an error which contains a double-negative:

![image](https://user-images.githubusercontent.com/28729201/229483431-fb2f27a2-3aa8-48dc-a8ed-a968e98a1ea7.png)

This is confusing for users and reputationally damaging.

#### How

Updates the error wording to remove the extra `not`

<img width="656" alt="image" src="https://user-images.githubusercontent.com/28729201/229491100-92933bc8-0751-4da9-b803-c6a6021c9421.png">



[CTSKF-330]: https://dsdmoj.atlassian.net/browse/CTSKF-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ