### PR TITLE
Amend logging of API requests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2173,7 +2173,6 @@ Rails/SkipsModelValidations:
 # SupportedStyles: strict, flexible
 Rails/TimeZone:
   Exclude:
-    - 'app/interfaces/api/logger.rb'
     - 'app/models/claim_state_transition.rb'
     - 'app/models/claims/financial_summary.rb'
     - 'app/models/claims/state_machine.rb'
@@ -2356,7 +2355,6 @@ Style/ClassAndModuleChildren:
     - 'app/interfaces/api/helpers/json_error_formatter.rb'
     - 'app/interfaces/api/helpers/resource_helper.rb'
     - 'app/interfaces/api/helpers/xml_formatter.rb'
-    - 'app/interfaces/api/logger.rb'
     - 'app/interfaces/api/v2/criteria_helper.rb'
     - 'app/interfaces/api/v2/query_helper.rb'
     - 'app/models/claims/allocation_filters.rb'

--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -4,7 +4,7 @@ class API::Logger < Grape::Middleware::Base
   end
 
   def after
-    log_api_response(@app_response.first.to_s) if @app_response
+    log_api_response(JSON.parse(env['api.request.input'].to_s))
     @app_response # this must return @app_response or nil
   end
 
@@ -14,11 +14,19 @@ class API::Logger < Grape::Middleware::Base
     log_api('api-request', method:, path:, data:)
   end
 
-  def log_api_response(status)
-    log_api('api-response', status:, response_body:)
+  def log_api_response(inputs)
+    log_api('api-response', inputs:, status: response_status, response_body:)
+  end
+
+  def response_status
+    return if @app_response.blank?
+
+    @app_response.first.to_s
   end
 
   def response_body
+    return if @app_response.blank?
+
     JSON.parse(@app_response[2].first)
   rescue JSON::ParserError
     Rails.logger.error "JSON::Parser error parsing: \n#{@app_response[2].first}"

--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -5,7 +5,7 @@ module API
     end
 
     def after
-      log_api_response(JSON.parse(env['api.request.input'].to_s))
+      log_api_response
       @app_response # this must return @app_response or nil
     end
 
@@ -15,8 +15,14 @@ module API
       log_api('api-request', method:, path:, data:)
     end
 
-    def log_api_response(inputs)
-      log_api('api-response', inputs:, status: response_status, response_body:)
+    def log_api_response
+      log_api('api-response', inputs: input_params, status: response_status, response_body:)
+    end
+
+    def input_params
+      JSON.parse(env['api.request.input'].to_s)
+    rescue JSON::ParserError
+      {}
     end
 
     def response_status

--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -1,39 +1,41 @@
-class API::Logger < Grape::Middleware::Base
-  def before
-    log_api_request(env['REQUEST_METHOD'], env['PATH_INFO'], env['rack.request.form_hash'])
-  end
+module API
+  class Logger < Grape::Middleware::Base
+    def before
+      log_api_request(env['REQUEST_METHOD'], env['PATH_INFO'], env['rack.request.form_hash'])
+    end
 
-  def after
-    log_api_response(JSON.parse(env['api.request.input'].to_s))
-    @app_response # this must return @app_response or nil
-  end
+    def after
+      log_api_response(JSON.parse(env['api.request.input'].to_s))
+      @app_response # this must return @app_response or nil
+    end
 
-  private
+    private
 
-  def log_api_request(method, path, data)
-    log_api('api-request', method:, path:, data:)
-  end
+    def log_api_request(method, path, data)
+      log_api('api-request', method:, path:, data:)
+    end
 
-  def log_api_response(inputs)
-    log_api('api-response', inputs:, status: response_status, response_body:)
-  end
+    def log_api_response(inputs)
+      log_api('api-response', inputs:, status: response_status, response_body:)
+    end
 
-  def response_status
-    return if @app_response.blank?
+    def response_status
+      return if @app_response.blank?
 
-    @app_response.first.to_s
-  end
+      @app_response.first.to_s
+    end
 
-  def response_body
-    return if @app_response.blank?
+    def response_body
+      return if @app_response.blank?
 
-    JSON.parse(@app_response[2].first)
-  rescue JSON::ParserError
-    Rails.logger.error "JSON::Parser error parsing: \n#{@app_response[2].first}"
-  end
+      JSON.parse(@app_response[2].first)
+    rescue JSON::ParserError
+      Rails.logger.error "JSON::Parser error parsing: \n#{@app_response[2].first}"
+    end
 
-  def log_api(api_type, data)
-    api_request = { log_type: api_type, timestamp: Time.now }.merge!(data)
-    Rails.logger.info api_request.to_json
+    def log_api(api_type, data)
+      api_request = { log_type: api_type, timestamp: Time.zone.now }.merge!(data)
+      Rails.logger.info api_request.to_json
+    end
   end
 end


### PR DESCRIPTION
#### What

Add the inputs to the response log for the API.

#### Ticket

[CCCD - Zendesk #311681 - unable to submit claims via Leap](https://dsdmoj.atlassian.net/browse/CTSKF-296)

#### Why

Formerly, the parameters for a request were only being logged as `env['rack.request.form_hash']`. This only shows fields in a form submission but requests from vendor software has the data as JSON in the body, so the logs do not show anything in the production environment.

#### How

During the processing of a request `env['api.request.input']` gets set to the input values. As this is blank at the start of the request processing it needs to be logged together with details of the response at the end.
