### PR TITLE
Use the rubocop-capybara extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-capybara
 
 AllCops:
   DisplayCopNames: true

--- a/Gemfile
+++ b/Gemfile
@@ -87,9 +87,10 @@ group :development, :devunicorn, :test do
   gem 'net-ssh', '~> 7.1'
   gem 'net-scp', '>= 4.0.0.rc1'
   gem 'rubocop', '~> 1.50'
-  gem 'rubocop-rspec'
-  gem 'rubocop-rails'
-  gem 'rubocop-performance'
+  gem 'rubocop-capybara', '~> 2.18'
+  gem 'rubocop-rspec', '~> 2.20'
+  gem 'rubocop-rails', '~> 2.19'
+  gem 'rubocop-performance', '~> 1.17'
   gem 'site_prism', '~> 4.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -786,9 +786,10 @@ DEPENDENCIES
   rspec-rails (~> 6.0.1)
   rspec_junit_formatter
   rubocop (~> 1.50)
-  rubocop-performance
-  rubocop-rails
-  rubocop-rspec
+  rubocop-capybara (~> 2.18)
+  rubocop-performance (~> 1.17)
+  rubocop-rails (~> 2.19)
+  rubocop-rspec (~> 2.20)
   ruby-progressbar
   rubyzip
   scheduler_daemon


### PR DESCRIPTION
#### What

Add the `rubocop-capybara` gem.

#### Ticket

[Release of dependency and security patches (Sprint - N)](https://dsdmoj.atlassian.net/browse/CTSKF-346)

#### Why

`rubocop-capybara` has been extracted from the core `rubocop` library but included as a dependency for the moment for backward compatibility. As CCCD uses capybara it makes sense to explicitly include it.

#### How

Add to `Gemfile` and `.rubocop.yml`.
