### PR TITLE
Remove rc versions from dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :development, :devunicorn, :test do
   gem 'rspec-collection_matchers'
   gem 'rspec_junit_formatter'
   gem 'net-ssh', '~> 7.1'
-  gem 'net-scp', '>= 4.0.0.rc1'
+  gem 'net-scp', '~> 4.0'
   gem 'rubocop', '~> 1.50'
   gem 'rubocop-rspec'
   gem 'rubocop-rails'
@@ -105,7 +105,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec-html-matchers', '~> 0.10.0'
   gem 'rspec-mocks'
-  gem 'shoulda-matchers', '>= 4.0.0.rc1'
+  gem 'shoulda-matchers', '~> 5.3'
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -764,7 +764,7 @@ DEPENDENCIES
   meta_request
   net-imap
   net-pop
-  net-scp (>= 4.0.0.rc1)
+  net-scp (>= 4.0.0)
   net-smtp
   net-ssh (~> 7.1)
   nokogiri (~> 1.14)
@@ -795,7 +795,7 @@ DEPENDENCIES
   sentry-rails (~> 5.9)
   sentry-sidekiq (~> 5.8, >= 5.8.0)
   shell-spinner (~> 1.0, >= 1.0.4)
-  shoulda-matchers (>= 4.0.0.rc1)
+  shoulda-matchers (~> 5.3)
   sidekiq (~> 7.0)
   sidekiq-failures (~> 1.0, >= 1.0.4)
   simplecov


### PR DESCRIPTION
#### What

Remove rc versions from dependencies in `Gemfile`.

#### Ticket

[Release of dependency and security patches (Sprint - N)](https://dsdmoj.atlassian.net/browse/CTSKF-346)

#### Why

At certain points the release candidate versions of two gems were included because of compatibility issues and these are listed explicitly in `Gemfile`. This is no longer necessary. This has no effect on the currently installed dependencies as the latest versions of both gems are already being used.

#### How

Update the versioning information of these two gems in `Gemfile`.