### PR TITLE
Ctskf 278 multi line additional information

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,6 +143,10 @@ module ApplicationHelper
      on_home_page?].all?
   end
 
+  def format_multiline(html_string)
+    simple_format(html_string, {}, sanitize: false)
+  end
+
   private
 
   def on_home_page?

--- a/app/views/external_users/claims/supporting_evidence/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_evidence/_summary.html.haml
@@ -26,7 +26,7 @@
               = dt.name
 
       - if claim.additional_information.present?
-        = govuk_summary_list_row_collection( t('external_users.claims.additional_information.summary.header') ) { claim.additional_information }
+        = govuk_summary_list_row_collection( t('external_users.claims.additional_information.summary.header') ) { format_multiline(claim.additional_information) }
 
   - else
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -38,4 +38,4 @@
     %h2.govuk-heading-l
       = t('.additional_information')
     %p
-      = claim.additional_information
+      = format_multiline(claim.additional_information)


### PR DESCRIPTION
What
[Display multi-line text for additional claim information](https://dsdmoj.atlassian.net/browse/CTSKF-278)

Why
When adding additional claim information onto a claim in CCCD, a user can utilise newlines in the text box to make the information more legible, however when anyone goes to the claim’s summary view to review the information, all newlines are removed, making the information hard to read (particularly as they’re not replaced with anything)

How
Use [simple_format](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-simple_format) function on text where additional information is being displayed in view mode
