### PR TITLE
Allow IPv6 localhost in ctAcceptable list

### DIFF
--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -132,6 +132,7 @@ if (!String.prototype.supplant) {
   }(['au', 'th', 'ent', 'ici', 'ty'].join(''))) // ;-)
 
   const ctAcceptable = [
+    '::1',
     '127.0.0.1',
     'localhost',
     'claim-crown-court-defence.service.gov.uk',


### PR DESCRIPTION
#### What

Allow `::1` as an acceptable hostname for the Canary token.

#### Ticket

N/A

#### Why

`::1` is a valid IPv6 address for localhost and so it may appear in development.

#### How

Add to the `ctAcceptable` list in `application.js`.

