### PR TITLE
Fix format of IPv6 localhost in ctAcceptable list

### DIFF
--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -132,7 +132,7 @@ if (!String.prototype.supplant) {
   }(['au', 'th', 'ent', 'ici', 'ty'].join(''))) // ;-)
 
   const ctAcceptable = [
-    '::1',
+    '[::1]',
     '127.0.0.1',
     'localhost',
     'claim-crown-court-defence.service.gov.uk',


### PR DESCRIPTION
#### What

Followup to https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/5664. Adds square brackets around `::1` in the `ctAcceptable` array in `app/webpack/javascripts/application.js`.

#### Why

So that IPv6 localhost is correctly identified and permitted, and CanaryToken does not alert.
