### PR TITLE
[CTSKF-394] Support chronological assessment of expenses by Date

### DIFF
--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -54,7 +54,7 @@ class ExpensePresenter < BasePresenter
   end
 
   def pretty_date
-    expense.date.nil? ? 'Date not set' : expense.date.strftime(Settings.date_format)
+     expense.date.strftime(Settings.date_format)
   end
 
   def display_reason_text_css

--- a/app/presenters/expense_presenter.rb
+++ b/app/presenters/expense_presenter.rb
@@ -54,7 +54,7 @@ class ExpensePresenter < BasePresenter
   end
 
   def pretty_date
-     expense.date.strftime(Settings.date_format)
+    expense.date.strftime(Settings.date_format)
   end
 
   def display_reason_text_css

--- a/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
@@ -71,20 +71,21 @@ moj.Modules.ExpensesDataTable = {
   },
 
   setOrder: function () {
-    const order = this.dataTable.order()
-    const columnIndex = order[0][0]
-    const direction = order[0][1]
+    const order = this.dataTable.order();
+    const columnIndex = order[0][0];
+    const direction = order[0][1];
+
     // this check is to ensure only type of expense (index 0)
     // and reason for travel (index 1) have secondary order column
     // set to date of expense (index 3) as the current configuration
     // for columnDefs does not support setting sorting direction
     if (columnIndex === 0 || columnIndex === 1) {
-      this.dataTable.order([columnIndex, direction], [3, 'asc'])
+      this.dataTable.order([columnIndex, direction], [3, 'desc']);
+    } else if (columnIndex === 3) {
+      // Sort the date column as a date object
+      this.dataTable.order([columnIndex, direction]);
     }
-    if (columnIndex === 3) {
-      this.dataTable.order([columnIndex, direction], [0, 'asc'], [1, 'asc'])
-    }
-  }
+  },
 }
 
 function parseDate(dateString, _format) {

--- a/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
@@ -33,19 +33,7 @@ moj.Modules.ExpensesDataTable = {
       targets: 3,
       width: '1%',
       type: 'date',
-      render: function (data, type, row) {
-        if (type === 'sort') {
-          // Check for invalid dates before conversion
-          if (!data || isNaN(parseDate(data, 'dd/mm/yyyy'))) {
-            return ''
-          }
-
-          // Convert the valid date string to a sortable format (e.g., '2023-04-29')
-          return parseDate(data, 'dd/mm/yyyy')
-        }
-
-        return data
-      }
+      render: renderDate
     }, {
       targets: 4,
       width: '1%'
@@ -86,6 +74,21 @@ moj.Modules.ExpensesDataTable = {
       this.dataTable.order([columnIndex, direction])
     }
   }
+}
+
+// Define the named render function
+function renderDate(data, type, row) {
+  if (type === 'sort') {
+    // Check for invalid dates before conversion
+    if (!data || isNaN(parseDate(data, 'dd/mm/yyyy'))) {
+      return ''
+    }
+
+    // Convert the valid date string to a sortable format
+    return parseDate(data, 'dd/mm/yyyy')
+  }
+
+  return data
 }
 
 function parseDate (dateString, _format) {

--- a/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
@@ -41,7 +41,7 @@ moj.Modules.ExpensesDataTable = {
           }
 
           // Convert the valid date string to a sortable format (e.g., '2023-04-29')
-          return formatDate(parseDate(data, 'dd/mm/yyyy'), 'yyyy-mm-dd');
+          return parseDate(data, 'dd/mm/yyyy');
         }
 
         return data;
@@ -100,19 +100,4 @@ function parseDate(dateString, _format) {
   // Create a new JavaScript Date object using the extracted values
   // Note: Months in JavaScript Date objects are zero-based, so we subtract 1 from the month value
   return new Date(year, month - 1, day);
-}
-
-function formatDate(date, format) {
-  // Extract the year, month, and day from the Date object
-  var year = date.getFullYear();
-  var month = (date.getMonth() + 1).toString().padStart(2, '0');
-  var day = date.getDate().toString().padStart(2, '0');
-
-  // Replace the format placeholders with the actual date values
-  format = format.replace('yyyy', year);
-  format = format.replace('mm', month);
-  format = format.replace('dd', day);
-
-  // Return the formatted date string
-  return format;
 }

--- a/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
@@ -14,7 +14,7 @@ moj.Modules.ExpensesDataTable = {
     searching: false,
 
     // by default orders by
-    //date of expense (index 3) desc
+    // date of expense (index 3) desc
     order: [
       [3, 'desc']
     ],
@@ -37,14 +37,14 @@ moj.Modules.ExpensesDataTable = {
         if (type === 'sort') {
           // Check for invalid dates before conversion
           if (!data || isNaN(parseDate(data, 'dd/mm/yyyy'))) {
-            return '';
+            return ''
           }
 
           // Convert the valid date string to a sortable format (e.g., '2023-04-29')
-          return parseDate(data, 'dd/mm/yyyy');
+          return parseDate(data, 'dd/mm/yyyy')
         }
 
-        return data;
+        return data
       }
     }, {
       targets: 4,
@@ -71,33 +71,33 @@ moj.Modules.ExpensesDataTable = {
   },
 
   setOrder: function () {
-    const order = this.dataTable.order();
-    const columnIndex = order[0][0];
-    const direction = order[0][1];
+    const order = this.dataTable.order()
+    const columnIndex = order[0][0]
+    const direction = order[0][1]
 
     // this check is to ensure only type of expense (index 0)
     // and reason for travel (index 1) have secondary order column
     // set to date of expense (index 3) as the current configuration
     // for columnDefs does not support setting sorting direction
     if (columnIndex === 0 || columnIndex === 1) {
-      this.dataTable.order([columnIndex, direction], [3, 'desc']);
+      this.dataTable.order([columnIndex, direction], [3, 'desc'])
     } else if (columnIndex === 3) {
       // Sort the date column as a date object
-      this.dataTable.order([columnIndex, direction]);
+      this.dataTable.order([columnIndex, direction])
     }
-  },
+  }
 }
 
-function parseDate(dateString, _format) {
+function parseDate (dateString, _format) {
   // Split the date string into day, month, and year parts
-  var parts = dateString.split('/');
+  const parts = dateString.split('/')
 
   // Extract the numeric values for day, month, and year
-  var day = parseInt(parts[0], 10);
-  var month = parseInt(parts[1], 10);
-  var year = parseInt(parts[2], 10);
+  const day = parseInt(parts[0], 10)
+  const month = parseInt(parts[1], 10)
+  const year = parseInt(parts[2], 10)
 
   // Create a new JavaScript Date object using the extracted values
   // Note: Months in JavaScript Date objects are zero-based, so we subtract 1 from the month value
-  return new Date(year, month - 1, day);
+  return new Date(year, month - 1, day)
 }

--- a/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
@@ -31,7 +31,21 @@ moj.Modules.ExpensesDataTable = {
       width: '20%'
     }, {
       targets: 3,
-      width: '1%'
+      width: '1%',
+      type: 'date',
+      render: function (data, type, row) {
+        if (type === 'sort') {
+          // Check for invalid dates before conversion
+          if (!data || isNaN(parseDate(data, 'dd/mm/yyyy'))) {
+            return '';
+          }
+
+          // Convert the valid date string to a sortable format (e.g., '2023-04-29')
+          return formatDate(parseDate(data, 'dd/mm/yyyy'), 'yyyy-mm-dd');
+        }
+
+        return data;
+      }
     }, {
       targets: 4,
       width: '1%'

--- a/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
@@ -77,7 +77,7 @@ moj.Modules.ExpensesDataTable = {
 }
 
 // Define the named render function
-function renderDate(data, type, row) {
+function renderDate (data, type, row) {
   if (type === 'sort') {
     // Check for invalid dates before conversion
     if (!data || isNaN(parseDate(data, 'dd/mm/yyyy'))) {

--- a/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.ExpensesDataTable.js
@@ -14,11 +14,9 @@ moj.Modules.ExpensesDataTable = {
     searching: false,
 
     // by default orders by
-    // type of expense (index 0) asc
-    // and date of expense (index 3) asc
+    //date of expense (index 3) desc
     order: [
-      [0, 'asc'],
-      [3, 'asc']
+      [3, 'desc']
     ],
     columnDefs: [{
       targets: 0,
@@ -73,4 +71,33 @@ moj.Modules.ExpensesDataTable = {
       this.dataTable.order([columnIndex, direction], [0, 'asc'], [1, 'asc'])
     }
   }
+}
+
+function parseDate(dateString, _format) {
+  // Split the date string into day, month, and year parts
+  var parts = dateString.split('/');
+
+  // Extract the numeric values for day, month, and year
+  var day = parseInt(parts[0], 10);
+  var month = parseInt(parts[1], 10);
+  var year = parseInt(parts[2], 10);
+
+  // Create a new JavaScript Date object using the extracted values
+  // Note: Months in JavaScript Date objects are zero-based, so we subtract 1 from the month value
+  return new Date(year, month - 1, day);
+}
+
+function formatDate(date, format) {
+  // Extract the year, month, and day from the Date object
+  var year = date.getFullYear();
+  var month = (date.getMonth() + 1).toString().padStart(2, '0');
+  var day = date.getDate().toString().padStart(2, '0');
+
+  // Replace the format placeholders with the actual date values
+  format = format.replace('yyyy', year);
+  format = format.replace('mm', month);
+  format = format.replace('dd', day);
+
+  // Return the formatted date string
+  return format;
 }

--- a/spec/javascripts/Modules.ExpensesDataTable_spec.js
+++ b/spec/javascripts/Modules.ExpensesDataTable_spec.js
@@ -71,7 +71,7 @@ describe('Modules.ExpensesDataTable.js', function () {
           width: '1%',
           type: 'date',
           render: jasmine.any(Function)
-        }));
+        }))
         expect(getColsDefsByTarget(3).render.toString()).toEqual(module.options.columnDefs[3].render.toString())
         expect(getColsDefsByTarget(4)).toEqual({
           targets: 4,

--- a/spec/javascripts/Modules.ExpensesDataTable_spec.js
+++ b/spec/javascripts/Modules.ExpensesDataTable_spec.js
@@ -21,8 +21,7 @@ describe('Modules.ExpensesDataTable.js', function () {
 
     it('...should have `order`', function () {
       expect(options.order).toEqual([
-        [0, 'asc'],
-        [3, 'asc']
+        [3, 'desc']
       ])
     })
 
@@ -67,10 +66,13 @@ describe('Modules.ExpensesDataTable.js', function () {
           orderable: false,
           width: '20%'
         })
-        expect(getColsDefsByTarget(3)).toEqual({
+        expect(getColsDefsByTarget(3)).toEqual(jasmine.objectContaining({
           targets: 3,
-          width: '1%'
-        })
+          width: '1%',
+          type: 'date',
+          render: jasmine.any(Function)
+        }));
+        expect(getColsDefsByTarget(3).render.toString()).toEqual(module.options.columnDefs[3].render.toString())
         expect(getColsDefsByTarget(4)).toEqual({
           targets: 4,
           width: '1%'


### PR DESCRIPTION
#### What
Provides a solution to the sorting issue with the expenses table in CCCD’s summary page that does not allow caseworkers to organise the list  - the date sort function did sort on dates (it treated them as numbers).

#### Ticket

[CTSKF-394](https://dsdmoj.atlassian.net/browse/CTSKF-394)

#### Why
It will allow the Billing Caseworker to be able to sort the expense tables by date so that they can more easily match the claim to the evidence they are assessing.

#### How
I refactored and added code to the Module.ExpenseDataTable.js file to convert string dates into a sortable JS date format.

```javascript
function parseDate(dateString, _format) {
  // Split the date string into day, month, and year parts
  var parts = dateString.split('/');

  // Extract the numeric values for day, month, and year
  var day = parseInt(parts[0], 10);
  var month = parseInt(parts[1], 10);
  var year = parseInt(parts[2], 10);

  // Create a new JavaScript Date object using the extracted values
  // Note: Months in JavaScript Date objects are zero-based, so we subtract 1 from the month value
  return new Date(year, month - 1, day);
}
```

this would allow the date column to be sorted correctly as JS breaks the date obj down to millisecond when sorting.




[CTSKF-394]: https://dsdmoj.atlassian.net/browse/CTSKF-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ