### PR TITLE
Fix QC/KC as appropriate for fee scheme

### DIFF
--- a/app/models/claim/advocate_interim_claim.rb
+++ b/app/models/claim/advocate_interim_claim.rb
@@ -85,5 +85,11 @@ module Claim
     def fee_scheme_factory
       FeeSchemeFactory::AGFS
     end
+
+    private
+
+    def cleaner
+      Cleaners::AdvocateInterimClaimCleaner.new(self)
+    end
   end
 end

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -574,7 +574,7 @@ module Claim
     def fee_scheme
       return offence&.fee_schemes&.find_by(name: agfs? ? 'AGFS' : 'LGFS') if earliest_representation_order_date.nil?
 
-      @fee_scheme ||= fee_scheme_factory.call(
+      fee_scheme_factory.call(
         representation_order_date: earliest_representation_order_date,
         main_hearing_date:
       )

--- a/app/services/cleaners/advocate_category_cleanable.rb
+++ b/app/services/cleaners/advocate_category_cleanable.rb
@@ -1,0 +1,12 @@
+module Cleaners
+  module AdvocateCategoryCleanable
+    private
+
+    def fix_advocate_categories
+      return if fee_scheme.nil?
+
+      @claim.advocate_category = 'KC' if fee_scheme.version >= 15 && @claim.advocate_category == 'QC'
+      @claim.advocate_category = 'QC' if fee_scheme.version < 15 && @claim.advocate_category == 'KC'
+    end
+  end
+end

--- a/app/services/cleaners/advocate_claim_cleaner.rb
+++ b/app/services/cleaners/advocate_claim_cleaner.rb
@@ -1,8 +1,10 @@
 module Cleaners
   class AdvocateClaimCleaner < BaseClaimCleaner
     include CrackedDetailCleanable
+    include AdvocateCategoryCleanable
 
     def call
+      fix_advocate_categories
       destroy_invalid_fees
       clear_inapplicable_fields
     end

--- a/app/services/cleaners/advocate_hardship_claim_cleaner.rb
+++ b/app/services/cleaners/advocate_hardship_claim_cleaner.rb
@@ -1,8 +1,10 @@
 module Cleaners
   class AdvocateHardshipClaimCleaner < BaseClaimCleaner
     include CrackedDetailCleanable
+    include AdvocateCategoryCleanable
 
     def call
+      fix_advocate_categories
       clear_inapplicable_fields
     end
 

--- a/app/services/cleaners/advocate_interim_claim_cleaner.rb
+++ b/app/services/cleaners/advocate_interim_claim_cleaner.rb
@@ -1,0 +1,9 @@
+module Cleaners
+  class AdvocateInterimClaimCleaner < BaseClaimCleaner
+    include AdvocateCategoryCleanable
+
+    def call
+      fix_advocate_categories
+    end
+  end
+end

--- a/app/services/cleaners/advocate_supplementary_claim_cleaner.rb
+++ b/app/services/cleaners/advocate_supplementary_claim_cleaner.rb
@@ -1,6 +1,9 @@
 module Cleaners
   class AdvocateSupplementaryClaimCleaner < BaseClaimCleaner
+    include AdvocateCategoryCleanable
+
     def call
+      fix_advocate_categories
       destroy_invalid_fees
     end
 

--- a/spec/models/claim/advocate_claim_spec.rb
+++ b/spec/models/claim/advocate_claim_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Claim::AdvocateClaim do
   subject(:claim) { create(:advocate_claim) }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::AGFS
+  it_behaves_like 'a claim with an AGFS fee scheme factory', FeeSchemeFactory::AGFS
   it_behaves_like 'a claim delegating to case type'
   it_behaves_like 'uses claim cleaner', Cleaners::AdvocateClaimCleaner
 

--- a/spec/models/claim/advocate_hardship_claim_spec.rb
+++ b/spec/models/claim/advocate_hardship_claim_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Claim::AdvocateHardshipClaim do
   subject(:claim) { build(:advocate_hardship_claim) }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::AGFS
+  it_behaves_like 'a claim with an AGFS fee scheme factory', FeeSchemeFactory::AGFS
   it_behaves_like 'a claim delegating to case type'
   it_behaves_like 'uses claim cleaner', Cleaners::AdvocateHardshipClaimCleaner
 

--- a/spec/models/claim/advocate_interim_claim_spec.rb
+++ b/spec/models/claim/advocate_interim_claim_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Claim::AdvocateInterimClaim do
+  subject(:claim) { build(:advocate_interim_claim) }
+
   it_behaves_like 'a base claim'
   it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::AGFS
   it_behaves_like 'a claim delegating to case type'

--- a/spec/models/claim/advocate_interim_claim_spec.rb
+++ b/spec/models/claim/advocate_interim_claim_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Claim::AdvocateInterimClaim do
   subject(:claim) { build(:advocate_interim_claim) }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::AGFS
+  it_behaves_like 'a claim with an AGFS fee scheme factory', FeeSchemeFactory::AGFS
   it_behaves_like 'a claim delegating to case type'
   it_behaves_like 'uses claim cleaner', Cleaners::AdvocateInterimClaimCleaner
 

--- a/spec/models/claim/advocate_interim_claim_spec.rb
+++ b/spec/models/claim/advocate_interim_claim_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Claim::AdvocateInterimClaim do
   it_behaves_like 'a base claim'
   it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::AGFS
   it_behaves_like 'a claim delegating to case type'
-  it_behaves_like 'uses claim cleaner', Cleaners::NullClaimCleaner
+  it_behaves_like 'uses claim cleaner', Cleaners::AdvocateInterimClaimCleaner
 
   it { is_expected.to have_one(:warrant_fee) }
 

--- a/spec/models/claim/advocate_supplementary_claim_spec.rb
+++ b/spec/models/claim/advocate_supplementary_claim_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Claim::AdvocateSupplementaryClaim do
   subject(:claim) { create(:advocate_supplementary_claim) }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::AGFS
+  it_behaves_like 'a claim with an AGFS fee scheme factory', FeeSchemeFactory::AGFS
   it_behaves_like 'a claim delegating to case type'
   it_behaves_like 'uses claim cleaner', Cleaners::AdvocateSupplementaryClaimCleaner
 

--- a/spec/models/claim/interim_claim_spec.rb
+++ b/spec/models/claim/interim_claim_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Claim::InterimClaim do
   let(:options) { {} }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::LGFS
+  it_behaves_like 'a claim with an LGFS fee scheme factory', FeeSchemeFactory::LGFS
   it_behaves_like 'a claim delegating to case type'
   it_behaves_like 'uses claim cleaner', Cleaners::InterimClaimCleaner
 

--- a/spec/models/claim/litigator_claim_spec.rb
+++ b/spec/models/claim/litigator_claim_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Claim::LitigatorClaim do
   subject(:claim) { build(:litigator_claim) }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::LGFS
+  it_behaves_like 'a claim with an LGFS fee scheme factory', FeeSchemeFactory::LGFS
   it_behaves_like 'a claim delegating to case type'
   it_behaves_like 'uses claim cleaner', Cleaners::LitigatorClaimCleaner
 

--- a/spec/models/claim/litigator_hardship_claim_spec.rb
+++ b/spec/models/claim/litigator_hardship_claim_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Claim::LitigatorHardshipClaim do
   subject(:claim) { build(:litigator_hardship_claim) }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::LGFS
+  it_behaves_like 'a claim with an LGFS fee scheme factory', FeeSchemeFactory::LGFS
   it_behaves_like 'a claim delegating to case type'
   it_behaves_like 'uses claim cleaner', Cleaners::LitigatorHardshipClaimCleaner
 

--- a/spec/models/claim/transfer_claim_spec.rb
+++ b/spec/models/claim/transfer_claim_spec.rb
@@ -7,7 +7,7 @@ describe Claim::TransferClaim do
   let(:options) { {} }
 
   it_behaves_like 'a base claim'
-  it_behaves_like 'a claim with a fee scheme factory', FeeSchemeFactory::LGFS
+  it_behaves_like 'a claim with an LGFS fee scheme factory', FeeSchemeFactory::LGFS
   it_behaves_like 'uses claim cleaner', Cleaners::TransferClaimCleaner
 
   it { is_expected.not_to delegate_method(:requires_trial_dates?).to(:case_type) }

--- a/spec/services/cleaners/advocate_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/advocate_claim_cleaner_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Cleaners::AdvocateClaimCleaner do
     end
 
     let(:basic_fee_rate) { 99.99 }
+    let(:case_type) { build(:case_type, :trial) }
 
     before do
       claim.misc_fees = [create(:misc_fee, :miaph_fee, rate: 9.99)]
@@ -117,5 +118,7 @@ RSpec.describe Cleaners::AdvocateClaimCleaner do
       include_examples 'does not clear basic fees'
       include_examples 'does not clear cracked details'
     end
+
+    include_examples 'fix advocate category'
   end
 end

--- a/spec/services/cleaners/advocate_hardship_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/advocate_hardship_claim_cleaner_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Cleaners::AdvocateHardshipClaimCleaner do
       }
     end
 
+    let(:case_stage) { create(:case_stage, :cracked_trial) }
+
     before do
       claim.trial_fixed_notice_at = cracked[:trial_fixed_notice_at]
       claim.trial_fixed_at = cracked[:trial_fixed_at]
@@ -43,5 +45,7 @@ RSpec.describe Cleaners::AdvocateHardshipClaimCleaner do
 
       include_examples 'does not clear cracked details'
     end
+
+    include_examples 'fix advocate category'
   end
 end

--- a/spec/services/cleaners/advocate_interim_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/advocate_interim_claim_cleaner_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'services/cleaners/cleaner_shared_examples'
+
+RSpec.describe Cleaners::AdvocateInterimClaimCleaner do
+  subject(:cleaner) { described_class.new(claim) }
+
+  describe '#call' do
+    subject(:call_cleaner) { cleaner.call }
+
+    let(:claim) { create(:advocate_interim_claim) }
+
+    include_examples 'fix advocate category'
+  end
+end

--- a/spec/services/cleaners/advocate_supplementary_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/advocate_supplementary_claim_cleaner_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Cleaners::AdvocateSupplementaryClaimCleaner do
     subject(:call_cleaner) { cleaner.call }
 
     let(:claim) { create(:advocate_supplementary_claim, with_misc_fee: false) }
+    let(:misc_fee) { build(:misc_fee, :mispf_fee) }
 
     before do
       seed_fee_types
@@ -26,5 +27,7 @@ RSpec.describe Cleaners::AdvocateSupplementaryClaimCleaner do
 
       it { expect { call_cleaner }.to change { claim.misc_fees.size }.by(-1) }
     end
+
+    include_examples 'fix advocate category'
   end
 end

--- a/spec/services/cleaners/cleaner_shared_examples.rb
+++ b/spec/services/cleaners/cleaner_shared_examples.rb
@@ -11,3 +11,89 @@ RSpec.shared_examples 'does not clear cracked details' do
   it { expect { call_cleaner }.not_to change(claim, :trial_cracked_at).from(cracked[:trial_cracked_at]) }
   it { expect { call_cleaner }.not_to change(claim, :trial_cracked_at_third).from(cracked[:trial_cracked_at_third]) }
 end
+
+RSpec.shared_examples 'fix advocate category' do
+  context 'with no advocate category' do
+    before { claim.advocate_category = nil }
+
+    context 'with a fee scheme 13 representation order' do
+      before do
+        claim.defendants = [
+          build(:defendant, scheme: 'scheme 13')
+        ]
+      end
+
+      it { expect { call_cleaner }.not_to change(claim, :advocate_category) }
+    end
+
+    context 'with a fee scheme 15 representation order' do
+      before do
+        claim.defendants = [
+          build(:defendant, scheme: 'scheme 15')
+        ]
+      end
+
+      it { expect { call_cleaner }.not_to change(claim, :advocate_category) }
+    end
+  end
+
+  context 'with a QC advocate category' do
+    before { claim.advocate_category = 'QC' }
+
+    context 'with no defendants' do
+      before { claim.defendants = [] }
+
+      it { expect { call_cleaner }.not_to change(claim, :advocate_category) }
+    end
+
+    context 'with a fee scheme 13 representation order' do
+      before do
+        claim.defendants = [
+          build(:defendant, scheme: 'scheme 13')
+        ]
+      end
+
+      it { expect { call_cleaner }.not_to change(claim, :advocate_category) }
+    end
+
+    context 'with a fee scheme 15 representation order' do
+      before do
+        claim.defendants = [
+          build(:defendant, scheme: 'scheme 15')
+        ]
+      end
+
+      it { expect { call_cleaner }.to change(claim, :advocate_category).to 'KC' }
+    end
+  end
+
+  context 'with a KC advocate category' do
+    before { claim.advocate_category = 'KC' }
+
+    context 'with no defendants' do
+      before { claim.defendants = [] }
+
+      it { expect { call_cleaner }.not_to change(claim, :advocate_category) }
+    end
+
+    context 'with a fee scheme 13 representation order' do
+      before do
+        claim.defendants = [
+          build(:defendant, scheme: 'scheme 13')
+        ]
+      end
+
+      it { expect { call_cleaner }.to change(claim, :advocate_category).to 'QC' }
+    end
+
+    context 'with a fee scheme 15 representation order' do
+      before do
+        claim.defendants = [
+          build(:defendant, scheme: 'scheme 15')
+        ]
+      end
+
+      it { expect { call_cleaner }.not_to change(claim, :advocate_category) }
+    end
+  end
+end

--- a/spec/support/shared_examples/models/shared_examples_for_claims.rb
+++ b/spec/support/shared_examples/models/shared_examples_for_claims.rb
@@ -44,12 +44,12 @@ RSpec.shared_examples 'a base claim' do
   end
 end
 
-RSpec.shared_examples 'a claim with a fee scheme factory' do |fee_scheme_factory|
+RSpec.shared_examples 'a claim with an AGFS fee scheme factory' do |fee_scheme_factory|
   describe '#fee_scheme' do
     subject(:fee_scheme) { claim.fee_scheme }
 
-    let(:main_hearing_date) { Date.parse('31 October 2022') }
-    let(:representation_order_date) { Date.parse('1 Apr 2016') }
+    let(:main_hearing_date) { Date.parse('20 April 2023') }
+    let(:representation_order_date) { Date.parse('17 April 2023') }
 
     before do
       claim.main_hearing_date = main_hearing_date
@@ -67,33 +67,63 @@ RSpec.shared_examples 'a claim with a fee scheme factory' do |fee_scheme_factory
       )
     end
 
-    context 'with a fee scheme 15 representation order date' do
-      let(:main_hearing_date) { Date.parse('20 April 2023') }
-      let(:representation_order_date) { Date.parse('17 April 2023') }
+    it { is_expected.to eq(FeeScheme.find_by(name: 'AGFS', version: 15)) }
 
-      before do
-        claim.main_hearing_date = main_hearing_date
-        claim.defendants = [
-          create(:defendant, representation_orders: [create(:representation_order, representation_order_date:)])
-        ]
+    context 'when a fee scheme 13 representation order date is added' do
+      subject do
+        claim.fee_scheme
+        claim.defendants << create(
+          :defendant,
+          representation_orders: [
+            create(:representation_order, representation_order_date: Date.parse('5 January 2023'))
+          ]
+        )
+        claim.fee_scheme
       end
 
-      it { is_expected.to eq(FeeScheme.find_by(name: 'AGFS', version: 15)) }
+      it { is_expected.to eq(FeeScheme.find_by(name: 'AGFS', version: 13)) }
+    end
+  end
+end
 
-      context 'when a fee scheme 13 representation order date is added' do
-        subject do
-          claim.fee_scheme
-          claim.defendants << create(
-            :defendant,
-            representation_orders: [
-              create(:representation_order, representation_order_date: Date.parse('5 January 2023'))
-            ]
-          )
-          claim.fee_scheme
-        end
+RSpec.shared_examples 'a claim with an LGFS fee scheme factory' do |fee_scheme_factory|
+  describe '#fee_scheme' do
+    subject(:fee_scheme) { claim.fee_scheme }
 
-        it { is_expected.to eq(FeeScheme.find_by(name: 'AGFS', version: 13)) }
+    let(:main_hearing_date) { Date.parse('31 January 2023') }
+    let(:representation_order_date) { Date.parse('1 January 2023') }
+
+    before do
+      claim.main_hearing_date = main_hearing_date
+      claim.defendants = [
+        create(:defendant, representation_orders: [create(:representation_order, representation_order_date:)])
+      ]
+      allow(fee_scheme_factory).to receive(:call).and_call_original
+    end
+
+    it do
+      fee_scheme
+      expect(fee_scheme_factory).to have_received(:call).with(
+        main_hearing_date:,
+        representation_order_date:
+      )
+    end
+
+    it { is_expected.to eq(FeeScheme.find_by(name: 'LGFS', version: 10)) }
+
+    context 'when a fee scheme 9 representation order date is added' do
+      subject do
+        claim.fee_scheme
+        claim.defendants << create(
+          :defendant,
+          representation_orders: [
+            create(:representation_order, representation_order_date: Date.parse('5 January 2019'))
+          ]
+        )
+        claim.fee_scheme
       end
+
+      it { is_expected.to eq(FeeScheme.find_by(name: 'LGFS', version: 9)) }
     end
   end
 end


### PR DESCRIPTION
#### What

Update the claim cleaner to change;

* QC advocate category to KC for fee scheme 15 and later
* KC advocate category to QC for fee scheme 14 and earlier

#### Ticket

[CCCD QC to KC](https://dsdmoj.atlassian.net/browse/CTSKF-337)

#### Why

If a claim is created in one fee scheme, a QC or KC advocate category selected, and then the details are changed so that the fee scheme is different then it is possible that the advocate category is invalid.

#### How

Create a new method `fix_advocate_categories` to be called by all the advocate claim cleaners.