### PR TITLE
Fix error with occasional nil expense_types

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -144,7 +144,7 @@ class Expense < ApplicationRecord
   end
 
   def establishment
-    return unless expense_type.car_travel?
+    return unless expense_type&.car_travel?
     Establishment.find_by(name: location)
   end
 

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -193,6 +193,12 @@ RSpec.describe Expense do
 
       it { is_expected.to be_nil }
     end
+
+    context 'when there is no expense type' do
+      let(:expense) { build(:expense, expense_type: nil) }
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '#remove_reason_text_unless_other' do


### PR DESCRIPTION
#### Why

We occasionally see [alerts](https://mojdt.slack.com/archives/C02B7LJ5GRK/p1684768085815199) where users attempt to create an expense without an `expense_type`: `undefined method car_travel? for nil:NilClass`

This is thrown by the following method:

```  
def establishment
  return unless expense_type.car_travel?
  Establishment.find_by(name: location)
end
```

This prevents the user saving the claim.

#### How

It's not clear how the user gets the claim in a state to trigger this error - possibly through use of the back button/save as draft?

This fixes it by adding a safe navigation operator to allow exit from the method without the error being thrown. Any errors on the claim should then be identified by validators.
