### PR TITLE
Fix API smoke tests by defaulting to QC advocate role

### DIFF
--- a/spec/support/api/claims/advocate_claim_test/base.rb
+++ b/spec/support/api/claims/advocate_claim_test/base.rb
@@ -17,7 +17,7 @@ module AdvocateClaimTest
         advocate_email: 'advocate@example.com',
         case_number: 'B20161234',
         providers_ref: SecureRandom.uuid[3..15].upcase,
-        advocate_category: fetch_value(ADVOCATE_CATEGORY_ENDPOINT),
+        advocate_category: fetch_value(ADVOCATE_CATEGORY_ENDPOINT, index: 3), # QC
         apply_vat: true,
         main_hearing_date: '2015-06-02'
       )


### PR DESCRIPTION
#### What

Get the API smoke tests passing

#### Why

The API smoke tests select the first available advocate role. Previously the list of advocate categories was:

  - `QC`
  - `Led junior`
  - `Leading junior`
  - `Junior alone`

and so `QC` was always selected.

Commit c5658a8f47 changed the order of these categories to:

  - `Junior alone`
  - `Leading junior`
  - `Led junior`
  - `QC`

which means that `Junior alone` is now always used as the advocate category.

`Junior alone` was removed as an advocate category after fee scheme 9, so when the API smoke tests test a fee scheme 10 claim, the test fails due to the use of an invalid advocate category.

#### How

This forces `AdvocateClaimTest::Base` to use `QC` as an advocate category, essentially returning to the previous format, so that tests now always pass. This isn't ideal but is a stop-gap until these tests can be reworked, as this has revealed that they are fragile. There are also issues with the hardcoded dates used throughout the tests which need to be fixed.