### PR TITLE
CTSKF-355 - Fee Expense Information Removes Line Breaks on Summary View

### DIFF
--- a/app/views/external_users/claims/expenses/_summary.html.haml
+++ b/app/views/external_users/claims/expenses/_summary.html.haml
@@ -57,7 +57,7 @@
     %h3.govuk-heading-m
       = t('.additional_information')
     %p
-      = @claim.travel_expense_additional_information
+      = format_multiline(@claim.travel_expense_additional_information)
 
   - if claim.expenses.empty?.eql?(false)
     %h3.govuk-heading-m

--- a/app/views/shared/summary/_expenses.html.haml
+++ b/app/views/shared/summary/_expenses.html.haml
@@ -10,7 +10,7 @@
       = t('.travel_expense_additional_information')
 
     %p.govuk-body
-      = claim.travel_expense_additional_information
+      = format_multiline(claim.travel_expense_additional_information)
 
 - if claim.expenses.with_vat.any?
   = render template: 'shared/summary/expenses/index', locals: { claim: claim, vat: true }


### PR DESCRIPTION
**What**
This pull request introduces a change to preserve line breaks in travel expense additional information displayed in the provider summary view and caseworker summary view.

**Ticket**
[CTSKF-355](https://dsdmoj.atlassian.net/browse/CTSKF-355)

**Why**
The current behaviour of the system is to remove newline characters from the travel expense additional information, replacing them with spaces. This can make the information difficult to read, especially when providers and caseworkers rely on this information to understand and process claims.

The bug has been identified in the CCCD system where multiline text entered by a user in the travel expense additional information section gets squashed onto one line, thus affecting readability and potentially the quality of claim processing.

**How**
The solution implemented replaces the display of travel expense additional information with a formatted version that preserves line breaks. The function format_multiline has been used to ensure that newline characters are properly rendered in the display.


```
%p.govuk-body
  = format_multiline(claim.travel_expense_additional_information)
```

This change will affect both the provider summary view and the caseworker summary view, ensuring that the information is displayed in the same format as it was entered, improving readability and preserving the original formatting of the information.



[CTSKF-355]: https://dsdmoj.atlassian.net/browse/CTSKF-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ