### PR TITLE
CTSKF-417 Internalise calls to V2 Caseworker API and Reduce 5xx errors

### DIFF
--- a/.k8s/live/api-sandbox/app-config.yaml
+++ b/.k8s/live/api-sandbox/app-config.yaml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://api-sandbox.claim-crown-court-defence.service.justice.gov.uk'
+  CASEWORKER_API_URL: 'cccd-app-service'
   GA_TRACKER_ID: 'UA-37377084-48'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'

--- a/.k8s/live/api-sandbox/deployment-worker.yaml
+++ b/.k8s/live/api-sandbox/deployment-worker.yaml
@@ -12,12 +12,12 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: cccd
+      app: cccd-worker
       tier: worker
   template:
     metadata:
       labels:
-        app: cccd
+        app: cccd-worker
         tier: worker
     spec:
       containers:

--- a/.k8s/live/dev-lgfs/app-config.yaml
+++ b/.k8s/live/dev-lgfs/app-config.yaml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://dev-lgfs.claim-crown-court-defence.service.justice.gov.uk'
+  CASEWORKER_API_URL: 'cccd-app-service'
   GA_TRACKER_ID: 'UA-37377084-48'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'

--- a/.k8s/live/dev-lgfs/deployment-worker.yaml
+++ b/.k8s/live/dev-lgfs/deployment-worker.yaml
@@ -12,12 +12,12 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: cccd
+      app: cccd-worker
       tier: worker
   template:
     metadata:
       labels:
-        app: cccd
+        app: cccd-worker
         tier: worker
     spec:
       containers:

--- a/.k8s/live/dev/app-config.yaml
+++ b/.k8s/live/dev/app-config.yaml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://dev.claim-crown-court-defence.service.justice.gov.uk'
+  CASEWORKER_API_URL: 'cccd-app-service'
   GA_TRACKER_ID: 'UA-37377084-48'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'

--- a/.k8s/live/dev/deployment-worker.yaml
+++ b/.k8s/live/dev/deployment-worker.yaml
@@ -12,12 +12,12 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: cccd
+      app: cccd-worker
       tier: worker
   template:
     metadata:
       labels:
-        app: cccd
+        app: cccd-worker
         tier: worker
     spec:
       containers:

--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://claim-crown-court-defence.service.gov.uk'
+  CASEWORKER_API_URL: 'cccd-app-service'
   GA_TRACKER_ID: 'UA-37377084-37'
   GTM_TRACKER_ID: 'GTM-NSB9GWK'
   MAINTENANCE_MODE: 'false'

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -12,12 +12,12 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: cccd
+      app: cccd-worker
       tier: worker
   template:
     metadata:
       labels:
-        app: cccd
+        app: cccd-worker
         tier: worker
     spec:
       containers:

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -9,6 +9,7 @@ data:
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
+  CASEWORKER_API_URL: 'cccd-app-service'
   GA_TRACKER_ID: 'UA-37377084-48'
   GTM_TRACKER_ID: 'GTM-PNZFWQT'
   MAINTENANCE_MODE: 'false'

--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -12,12 +12,12 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: cccd
+      app: cccd-worker
       tier: worker
   template:
     metadata:
       labels:
-        app: cccd
+        app: cccd-worker
         tier: worker
     spec:
       containers:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["CASEWORKER_API_URL"] || 'http://localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/devunicorn.rb
+++ b/config/environments/devunicorn.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["CASEWORKER_API_URL"] || 'localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # enable the ability to preview devise emails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "advocate_defence_payments_production"
 
-  config.action_mailer.default_url_options = { host: ENV['GRAPE_SWAGGER_ROOT_URL'] }
+  config.action_mailer.default_url_options = { host: ENV['CASEWORKER_API_URL'] }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["CASEWORKER_API_URL"] || 'http://localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Raise exceptions instead of rendering exception templates.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -136,7 +136,7 @@ timed_transition_soft_delete_weeks: 16
 # Override them in your settings.local.yml if needed, but DO NOT change these here
 #
 remote_api_key: 'not-provided'
-remote_api_url: <%= (ENV['GRAPE_SWAGGER_ROOT_URL'] || 'http://localhost:3001') + '/api' %>
+remote_api_url: <%= (ENV['CASEWORKER_API_URL'] || 'http://localhost:3001') + '/api' %>
 
 # Postgres DB `journeys` function flag to allow for its "recreation".
 # This is used by MI reports.

--- a/spec/services/remote/http_client_spec.rb
+++ b/spec/services/remote/http_client_spec.rb
@@ -47,7 +47,8 @@ describe Remote::HttpClient do
       expect(JSON).to receive(:parse).with('body', symbolize_names: true).and_return({ key: 'value' })
       expect(RestClient::Request)
         .to receive(:execute)
-        .with(method: :get, url: endpoint, timeout: 4, open_timeout: 2)
+        .with(method: :get, url: endpoint, timeout: 4, open_timeout: 2,
+              headers: { 'X-Forwarded-Proto': 'https', 'X-Forwarded-Ssl': 'on' })
         .and_return(response)
 
       result = client.get(path, **query)


### PR DESCRIPTION
#### What

Fix the intermittent 5xx errors on the CaseWorkers API calls.

#### Ticket

[CCCD: Reduce Time Taken to Run Web Calls Within Its Container](https://dsdmoj.atlassian.net/browse/CTSKF-417)

#### Why

This is so that Caseworker's are be able to access CCCD consistently so that they can process claims and complete their work within time standards

#### How

- Update the selector label for the Sidekiq worker kubernetes deployments
- Replace the CaseWorker API call URL with the Kubernetes Service URL `cccd-app-service`
- Add extra headers to the Caseworker RestClient call to bypass HTTPS requirements as it is now an internal k8s cluster call. Cloud Platforms K8s cluster does not provide TLS/HTTPS internally so a https internal call will fail.
- Replace `GRAPE_SWAGGER_ROOT_URL` with `CASEWORKER_API_URL` where the call is not related to the swagger docs but instead to the caseworker api calls. This is because the swagger root fails to call the k8s service due to CORS and thus the documentation page breaks.


#### Additional Information

[Confluence documentation on the journey to this solution](https://dsdmoj.atlassian.net/wiki/spaces/CT/pages/4415979656/DRAFT+Kubernetes+5xx+errors+SOLVED)

Co-Author: @mpw5 