### PR TITLE
CTSKF-415 Amend Instructed Advocate to Trial Advocate

### DIFF
--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -51,8 +51,8 @@ en:
         long: We rejected your claim because you didn’t attach the final invoice. Please submit the claim again with the final invoice clearly stating the breakdown of costs and defendant’s name. We cannot accept estimated costs.
     refused_advocate_claims:
       wrong_ia:
-        short: &wrong_ia_short Not Trial Advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was the Trial Advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
+        short: &wrong_ia_short Not trial advocate
+        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
       duplicate_claim:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
@@ -117,8 +117,8 @@ en:
         long: *blank
     refused_advocate_hardship_claims:
       wrong_ia:
-        short: &wrong_ia_short Not Trial Advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was the Trial Advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
+        short: &wrong_ia_short Not trial advocate
+        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
     refused_litigator_hardship_claims:
       duplicate_claim:
         short: *duplicate_claim_short

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -51,7 +51,7 @@ en:
         long: We rejected your claim because you didn’t attach the final invoice. Please submit the claim again with the final invoice clearly stating the breakdown of costs and defendant’s name. We cannot accept estimated costs.
     refused_advocate_claims:
       wrong_ia:
-        short: &wrong_ia_short Not trial advocate
+        short: &wrong_ia_short Incorrect trial advocate
         long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
       duplicate_claim:
         short: *duplicate_claim_short
@@ -117,7 +117,7 @@ en:
         long: *blank
     refused_advocate_hardship_claims:
       wrong_ia:
-        short: &wrong_ia_short Not trial advocate
+        short: &wrong_ia_short Incorrect trial advocate
         long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
     refused_litigator_hardship_claims:
       duplicate_claim:

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -51,8 +51,8 @@ en:
         long: We rejected your claim because you didn’t attach the final invoice. Please submit the claim again with the final invoice clearly stating the breakdown of costs and defendant’s name. We cannot accept estimated costs.
     refused_advocate_claims:
       wrong_ia:
-        short: &wrong_ia_short Wrong Instructed Advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was instructed for the case. Please submit the claim again with the correct advocate details or include evidence to support why you think the court records are wrong.
+        short: &wrong_ia_short Not Trial Advocate
+        long: &wrong_ia_long We refused your claim because court records show a different advocate was the Trial Advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
       duplicate_claim:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
@@ -117,8 +117,8 @@ en:
         long: *blank
     refused_advocate_hardship_claims:
       wrong_ia:
-        short: &wrong_ia_short Wrong Instructed Advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was instructed for the case. Please submit the claim again with the correct advocate details or include evidence to support why you think the court records are wrong.
+        short: &wrong_ia_short Not Trial Advocate
+        long: &wrong_ia_long We refused your claim because court records show a different advocate was the Trial Advocate for the case. Please submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
     refused_litigator_hardship_claims:
       duplicate_claim:
         short: *duplicate_claim_short

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -949,10 +949,10 @@ en:
           section_help_text: 'You must enter the following before adding %{section}:'
       case_details:
         advocate_fields:
-          advocate: Instructed advocate
-          advocate_hint: The instructed advocate for the case
+          advocate: Trial Advocate
+          advocate_hint: The trial advocate for the case
           help_missing_advocates_summary_body_html: You can add more advocates in settings under the <a class="govuk-link" href="%{link}">%{link_text}</a> section
-          help_missing_advocates_summary_heading: Help with missing instructed advocates
+          help_missing_advocates_summary_heading: Help with missing trial advocates
           help_missing_advocates_summary_link_text: manage users
         case_concluded_date:
           case_concluded_at: 'Date case concluded'

--- a/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_nine/advocate_admin_trial_claim_edit_submit.feature
@@ -10,7 +10,7 @@ Feature: Advocate admin submits a claim for a Trial case
     And I select the fee scheme 'Advocate final fee'
     Then I should be on the new claim page
 
-    When I choose 'Doe, John (AC135)' as the instructed advocate
+    When I choose 'Doe, John (AC135)' as the trial advocate
     And I enter a case number of 'A20161234'
     And I select the court 'Blackfriars'
     And I select a case type of 'Retrial'

--- a/features/refuse_claim.feature
+++ b/features/refuse_claim.feature
@@ -38,7 +38,7 @@ Feature: Case worker rejects a claim, providing a reason
     When I am signed in as the case worker
     And I select the claim
     And I click the refused radio button
-    And I select the refusal reason 'Not Trial Advocate'
+    And I select the refusal reason 'Not trial advocate'
     And I select the refusal reason 'Other'
     And I enter refusal reason text 'Whatever I like'
     And I click update
@@ -46,7 +46,7 @@ Feature: Case worker rejects a claim, providing a reason
     Then the messages should not contain 'Total (inc VAT): £0.00'
     Then message 7 contains 'Claim refused'
     Then the last message contains 'Your claim has been refused'
-    Then the last message contains 'Not Trial Advocate'
+    Then the last message contains 'Not trial advocate'
     Then the last message contains 'Whatever I like'
 
     When I click your claims

--- a/features/refuse_claim.feature
+++ b/features/refuse_claim.feature
@@ -38,7 +38,7 @@ Feature: Case worker rejects a claim, providing a reason
     When I am signed in as the case worker
     And I select the claim
     And I click the refused radio button
-    And I select the refusal reason 'Wrong Instructed Advocate'
+    And I select the refusal reason 'Not Trial Advocate'
     And I select the refusal reason 'Other'
     And I enter refusal reason text 'Whatever I like'
     And I click update
@@ -46,7 +46,7 @@ Feature: Case worker rejects a claim, providing a reason
     Then the messages should not contain 'Total (inc VAT): £0.00'
     Then message 7 contains 'Claim refused'
     Then the last message contains 'Your claim has been refused'
-    Then the last message contains 'Wrong Instructed Advocate'
+    Then the last message contains 'Not Trial Advocate'
     Then the last message contains 'Whatever I like'
 
     When I click your claims

--- a/features/refuse_claim.feature
+++ b/features/refuse_claim.feature
@@ -38,7 +38,7 @@ Feature: Case worker rejects a claim, providing a reason
     When I am signed in as the case worker
     And I select the claim
     And I click the refused radio button
-    And I select the refusal reason 'Not trial advocate'
+    And I select the refusal reason 'Incorrect trial advocate'
     And I select the refusal reason 'Other'
     And I enter refusal reason text 'Whatever I like'
     And I click update
@@ -46,7 +46,7 @@ Feature: Case worker rejects a claim, providing a reason
     Then the messages should not contain 'Total (inc VAT): £0.00'
     Then message 7 contains 'Claim refused'
     Then the last message contains 'Your claim has been refused'
-    Then the last message contains 'Not trial advocate'
+    Then the last message contains 'Incorrect trial advocate'
     Then the last message contains 'Whatever I like'
 
     When I click your claims

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -17,7 +17,7 @@ When(/^I select an advocate category of '(.*?)'$/) do |name|
   wait_for_ajax
 end
 
-When(/^I choose '(.*)' as the instructed advocate$/) do |text|
+When(/^I choose '(.*)' as the trial advocate$/) do |text|
   @claim_form_page.find('label', text: text).click
 end
 

--- a/spec/services/claims/state_transition_message_builder_spec.rb
+++ b/spec/services/claims/state_transition_message_builder_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Claims::StateTransitionMessageBuilder do
       end
 
       it 'contains short description of reason' do
-        is_expected.to match(/Not Trial Advocate:/)
+        is_expected.to match(/Not trial advocate:/)
         is_expected.to match(/Duplicate claim:/)
         is_expected.to match(/Other:/)
       end
 
       it 'contains long description of reason' do
-        is_expected.to match(/.* refused your claim .* different advocate was the Trial Advocate/)
+        is_expected.to match(/.* refused your claim .* different advocate was the trial advocate/)
         is_expected.to match(/.* refused your claim .* bill has already been paid/)
       end
 

--- a/spec/services/claims/state_transition_message_builder_spec.rb
+++ b/spec/services/claims/state_transition_message_builder_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Claims::StateTransitionMessageBuilder do
       end
 
       it 'contains short description of reason' do
-        is_expected.to match(/Wrong Instructed Advocate:/)
+        is_expected.to match(/Not Trial Advocate:/)
         is_expected.to match(/Duplicate claim:/)
         is_expected.to match(/Other:/)
       end
 
       it 'contains long description of reason' do
-        is_expected.to match(/.* refused your claim .* different advocate was instructed/)
+        is_expected.to match(/.* refused your claim .* different advocate was the Trial Advocate/)
         is_expected.to match(/.* refused your claim .* bill has already been paid/)
       end
 

--- a/spec/services/claims/state_transition_message_builder_spec.rb
+++ b/spec/services/claims/state_transition_message_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Claims::StateTransitionMessageBuilder do
       end
 
       it 'contains short description of reason' do
-        is_expected.to match(/Not trial advocate:/)
+        is_expected.to match(/Incorrect trial advocate:/)
         is_expected.to match(/Duplicate claim:/)
         is_expected.to match(/Other:/)
       end


### PR DESCRIPTION

#### What 

Updated the wording in en.yml, claim_state_transition_reason.en.yml to use the new approved wording for Instructed Advocate (changed to Trial Advocate)

Updated state_transition_message_builder_spec.rb and and refuse_claim.feature to test new functionality

Updated advocate_admin_trial_claim_edit_submit.feature; test not actually changed, but wording updated from advocate to trial to make clear for future.

#### Ticket

[CTSKF-415 CCCD: Amend Instructed Advocate to Trial Advocate ](https://dsdmoj.atlassian.net/browse/CTSKF-415)

#### Why

Current wording has caused confusion between caseworkers and advocates. 

#### How

Updated yml files, unit and feature tests as above

