### PR TITLE
Fix password reset url in emails

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: ENV["CASEWORKER_API_URL"] || 'http://localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/devunicorn.rb
+++ b/config/environments/devunicorn.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.action_mailer.default_url_options = { host: ENV["CASEWORKER_API_URL"] || 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # enable the ability to preview devise emails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "advocate_defence_payments_production"
 
-  config.action_mailer.default_url_options = { host: ENV['CASEWORKER_API_URL'] }
+  config.action_mailer.default_url_options = { host: ENV['GRAPE_SWAGGER_ROOT_URL'] }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: ENV["CASEWORKER_API_URL"] || 'http://localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV["GRAPE_SWAGGER_ROOT_URL"] || 'http://localhost:3000' }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Raise exceptions instead of rendering exception templates.


### PR DESCRIPTION
#### What

bb9ccebc5b513f6029b accidentally changed the url used for password reset links in emails sent following the use of the forgotten password feature. This means that users cannot change their passwords.

This commit puts the url back to the correct value.

Broken:

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/00765d29-602e-4f3a-906c-93032983a004)

Fixed:

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/95f06acb-8ac4-4715-95d0-89cc6be75d5f)
