### PR TITLE
Use user and message instead of user_id and message_id

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -81,7 +81,7 @@ class Message < ApplicationRecord
 
   def generate_statuses
     users_for_statuses.each do |user|
-      UserMessageStatus.create!(user_id: user.id, message_id: id, read: user == sender)
+      UserMessageStatus.create!(user:, message: self, read: user == sender)
     end
   end
 


### PR DESCRIPTION
#### What

Improve the performance of creating user message statuses.

#### Ticket

N/A

#### Why

Due to the way Active Record works with references, using reference ids when creating new records causes extra database queries.

#### How

Use the instance of references instead of their ids when creating new instances of `UserMessageStatus`.