### PR TITLE
CTSKF-279 Update Misc Fee Unit

### DIFF
--- a/app/webpack/javascripts/application.js
+++ b/app/webpack/javascripts/application.js
@@ -105,7 +105,7 @@ if (!String.prototype.supplant) {
   $('#misc-fees').on('cocoon:after-insert', function (e, insertedItem) {
     const $insertedItem = $(insertedItem)
     moj.Modules.FeeCalculator.UnitPrice.miscFeeTypesSelectChange($insertedItem.find('.fx-misc-fee-calculation'))
-    moj.Modules.FeeCalculator.UnitPrice.feeQuantityChange($insertedItem.find('.js-fee-calculator-quantity'))
+    moj.Modules.FeeCalculator.UnitPrice.miscFeeFormRefresh($insertedItem.find('.js-fee-calculator-quantity'))
     moj.Modules.FeeCalculator.UnitPrice.feeRateChange($insertedItem.find('.js-fee-calculator-rate'))
     moj.Modules.FeeTypeCtrl.miscFeeTypesSelectChange($insertedItem)
     moj.Modules.FeeTypeCtrl.miscFeeTypesRadioChange($insertedItem)

--- a/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -97,9 +97,9 @@
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
     feeQuantityChange: function ($el) {
       const self = this
-      const $els = $el || $('.js-fee-quantity')
+      const $els = $el || $('#misc-fees')
       if ($('.calculated-unit-fee').exists()) {
-        $els.on('change keyup', moj.Modules.Debounce.init(function (e) {
+        $els.on('click keyup', moj.Modules.Debounce.init(function (e) {
           self.calculateUnitPrice()
           self.populateNetAmount(this)
         }, 290))

--- a/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -13,6 +13,7 @@
       this.fixedFeeTypeChange()
       this.miscFeeTypeChange()
       this.feeQuantityChange()
+      this.miscFeeFormRefresh()
       this.feeRateChange()
       this.pageLoad()
     },
@@ -97,20 +98,30 @@
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
     feeQuantityChange: function ($el) {
       const self = this
-      const $miscEls = $el || $('#misc-fees')
-      const $fixedEls = $el || $('.js-fee-quantity')
+      const $els = $el || $('.js-fee-quantity')
 
       if ($('.calculated-unit-fee').exists()) {
-        $miscEls.on('click keyup', moj.Modules.Debounce.init(function (e) {
-          self.calculateUnitPrice()
-        }, 290))
-
-        $fixedEls.on('change keyup', moj.Modules.Debounce.init(function (e) {
+        $els.on('change keyup', moj.Modules.Debounce.init(function (e) {
           self.calculateUnitPrice()
           self.populateNetAmount(this)
         }, 290))
       }
     },
+
+    miscFeeFormRefresh: function ($el) {
+      const self = this
+      const $els = $el || $('#misc-fees')
+
+      if ($('.calculated-unit-fee').exists()) {
+        $els.on('click keyup', moj.Modules.Debounce.init(function (e) {
+          self.calculateUnitPrice()
+          console.log("test")
+          self.populateNetAmount(this)
+        }, 290))
+      }
+    },
+
+
 
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
     feeRateChange: function ($el) {

--- a/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -97,15 +97,22 @@
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
     feeQuantityChange: function ($el) {
       const self = this
-      const $miscEls = $el || $('#misc-fees')
-      const $fixedEls = $el || $('.js-fee-quantity')
+      const $els = $el || $('.js-fee-quantity')
 
       if ($('.calculated-unit-fee').exists()) {
-        $miscEls.on('click keyup', moj.Modules.Debounce.init(function (e) {
+        $els.on('change keyup', moj.Modules.Debounce.init(function (e) {
           self.calculateUnitPrice()
+          self.populateNetAmount(this)
         }, 290))
+      }
+    },
 
-        $fixedEls.on('change keyup', moj.Modules.Debounce.init(function (e) {
+    miscFeeFormRefresh: function ($el) {
+      const self = this
+      const $els = $el || $('#misc-fees')
+
+      if ($('.calculated-unit-fee').exists()) {
+        $els.on('click keyup', moj.Modules.Debounce.init(function (e) {
           self.calculateUnitPrice()
           self.populateNetAmount(this)
         }, 290))

--- a/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
+++ b/app/webpack/javascripts/modules/external_users/claims/fee_calculator/FeeCalculator.UnitPrice.js
@@ -97,9 +97,15 @@
     // needs to be usable by cocoon:after-insert so can bind to one or many elements
     feeQuantityChange: function ($el) {
       const self = this
-      const $els = $el || $('#misc-fees')
+      const $miscEls = $el || $('#misc-fees')
+      const $fixedEls = $el || $('.js-fee-quantity')
+
       if ($('.calculated-unit-fee').exists()) {
-        $els.on('click keyup', moj.Modules.Debounce.init(function (e) {
+        $miscEls.on('click keyup', moj.Modules.Debounce.init(function (e) {
+          self.calculateUnitPrice()
+        }, 290))
+
+        $fixedEls.on('change keyup', moj.Modules.Debounce.init(function (e) {
           self.calculateUnitPrice()
           self.populateNetAmount(this)
         }, 290))

--- a/features/fee_calculator/advocate/misc_fee_calculator.feature
+++ b/features/fee_calculator/advocate/misc_fee_calculator.feature
@@ -32,21 +32,22 @@ Feature: Advocate completes misc fee page using calculator
 
     When I add a govuk calculated miscellaneous fee 'Wasted preparation fee'
     And I add a govuk calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '2'
-    And I add a govuk calculated miscellaneous fee 'Hearings relating to disclosure (whole day uplift)' with quantity of '2'
 
     Then the following govuk fee details should exist:
       | section       | fee_description                                    | rate   | hint                            | help |
       | miscellaneous | Wasted preparation fee                             | 74.00  | Number of hours                 | true |
       | miscellaneous | Hearings relating to disclosure (whole day)        | 497.00 | Number of days                  | true |
-      | miscellaneous | Hearings relating to disclosure (whole day uplift) | 198.80 | Number of additional defendants | true |
 
     When I amend the govuk miscellaneous fee 'Hearings relating to disclosure (whole day)' to have a quantity of '3'
+    And I add a govuk calculated miscellaneous fee 'Hearings relating to disclosure (whole day uplift)' without a quantity
+
     Then the following govuk fee details should exist:
       | section       | fee_description                                    | rate   | hint                            | help |
       | miscellaneous | Wasted preparation fee                             | 74.00  | Number of hours                 | true |
       | miscellaneous | Hearings relating to disclosure (whole day)        | 497.00 | Number of days                  | true |
       | miscellaneous | Hearings relating to disclosure (whole day uplift) | 298.20 | Number of additional defendants | true |
 
+    When I amend the govuk miscellaneous fee 'Hearings relating to disclosure (whole day uplift)' to have a quantity of '2'
     And I eject the VCR cassette
 
     Then I click "Continue" in the claim form

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -159,6 +159,19 @@ When(/^I add a govuk calculated miscellaneous fee '(.*?)'(?: with quantity of '(
   wait_for_ajax
 end
 
+Then("I add a govuk calculated miscellaneous fee {string} without a quantity") do |fee_name|
+  quantity = quantity.present? ? quantity : '1'
+  patiently do
+    @claim_form_page.add_govuk_misc_fee_if_required
+  end
+  @claim_form_page.miscellaneous_fees.last.govuk_fee_type_autocomplete.choose_autocomplete_option(fee_name)
+  @claim_form_page.miscellaneous_fees.last.govuk_fee_type_autocomplete_input.send_keys(:tab)
+
+  sleep(2)
+  wait_for_debounce
+  wait_for_ajax
+end
+
 Then(/^I check the section heading to be "([^"]*)"$/) do |num|
   expect(@claim_form_page.miscellaneous_fees.last.numbered.text).to have_content(num)
 end
@@ -405,3 +418,4 @@ def scheme_10_additional_fees
     'Number of cases uplift'
   ].freeze
 end
+

--- a/spec/javascripts/Modules.FeeCalculator_spec.js
+++ b/spec/javascripts/Modules.FeeCalculator_spec.js
@@ -39,6 +39,11 @@ describe('Modules.FeeCalculator.js', function () {
         module.bindEvents()
         expect(module.feeQuantityChange).toHaveBeenCalled()
       })
+      it('...should call `this.miscFeeFormRefresh`', function () {
+        spyOn(module, 'miscFeeFormRefresh')
+        module.bindEvents()
+        expect(module.miscFeeFormRefresh).toHaveBeenCalled()
+      })
       it('...should call `this.pageLoad`', function () {
         spyOn(module, 'pageLoad')
         module.bindEvents()


### PR DESCRIPTION


#### What

Changes made to feeQuantityChange function:

- $els set to refer to the Misc Fees form as a whole (#misc-fees), rather than just the fee quantity field (.js-fee-quantity) 
- changed triggers for els.on from 'change keyup' to 'click keyup'

#### Ticket

[CTSKF 279 CCCD: Show correct misc fee units as soon as misc fee type is selected](https://dsdmoj.atlassian.net/browse/CTSKF-279)

#### Why

When users selected an option in the Misc Fees form the label was not updating until they entered something into the Quantity field

#### How

The label update happens as part of the feeQuantityChange function, which was only triggered by a change keyup listener on the Quantity field. By changing this to a click/keyup listener for the entire form (leaving change in created an infinite loop) this check will happen more often. It is creating some unnecessary requests but these seem to be low impact.

