### PR TITLE
[CTSKF-416] Retry entering autocomplete options in cucumber test step

### DIFF
--- a/features/page_objects/sections/common_autocomplete_section.rb
+++ b/features/page_objects/sections/common_autocomplete_section.rb
@@ -3,7 +3,10 @@ class CommonAutocomplete < SitePrism::Section
   sections :menu_items, '.autocomplete__menu > li' do end
 
   def choose_autocomplete_option(name)
-    auto_input.set(name)
+    3.times do |i|
+      auto_input.set(name)
+      break unless menu_items.first.text == 'No results found'
+    end
     options = menu_items.select { |option| option.text.eql?(name) }
     choice = options.first
     root = choice.root_element


### PR DESCRIPTION
#### What

Add a retry into the autocomplete module for Cucumber tests for the case when a value has been entered but the available options return only `No results found`.

#### Ticket

[CCCD: Investigate increased 'flakey' cucumber tests](https://dsdmoj.atlassian.net/browse/CTSKF-416)

#### Why

The `CommonAutocomplete#choose_autocomplete_option` is used in Cucumber tests to select a known valid option from an autocomplete field. The [accessible-autocomplete](alphagov/accessible-autocomplete) library polls every 100 milliseconds to update the list of valid options after the input has been entered and so there is a possibility that the list of options is checked before it has been updated, resulting in a failure in the test. This is only an issue in the Cucumber tests, and not in the live environment, and so the solution is to catch the error and retry. Three attempts are made so there is still the possibility that the test will fail by chance but based on the number of times we have had to rerun the tests in CircleCI this seems to be a reasonable number of retries.

#### How

Wrap the `auto_input.set(name)` in a loop that will repeat if the first menu item is found to be `No results found`.
