### PR TITLE
[CTSKF-450] Format unclaimed fees notice as list

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -57,12 +57,9 @@ module ClaimsHelper
     {
       claim:, header: t('external_users.claims.misc_fees.summary.header'),
       collection: claim.misc_fees, step: :miscellaneous_fees,
+      unclaimed_fees: unclaimed_fees_for(claim),
       **args
-    }.tap do |locals|
-      if display_unused_materials_notice?(claim)
-        locals[:unclaimed_fees_notice] = t('external_users.claims.misc_fees.unclaimed_fees.notice.long')
-      end
-    end
+    }
   end
 
   def display_unused_materials_notice?(claim)

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -57,7 +57,7 @@ module ClaimsHelper
     {
       claim:, header: t('external_users.claims.misc_fees.summary.header'),
       collection: claim.misc_fees, step: :miscellaneous_fees,
-      unclaimed_fees: unclaimed_fees_for(claim),
+      unclaimed_fees: unclaimed_fees_list(claim),
       **args
     }
   end
@@ -67,9 +67,12 @@ module ClaimsHelper
       claim.fees.none? { |f| f.fee_type.unique_code == 'MIUMU' }
   end
 
-  def unclaimed_fees_for(claim)
-    (claim.eligible_misc_fee_types - claim.misc_fees.map(&:fee_type))
-      .select { |ft| SIGNPOST_FEES.include?(ft.unique_code) }
+  def unclaimed_fees_list(claim)
+    unclaimed_fees = (claim.eligible_misc_fee_types - claim.misc_fees.map(&:fee_type))
+                     .select { |ft| SIGNPOST_FEES.include?(ft.unique_code) }
+    return if unclaimed_fees.blank?
+
+    unclaimed_fees.map { |fee_type| "'#{fee_type.description}'" }.to_sentence
   end
 
   def display_elected_not_proceeded_signpost?(claim)

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -9,6 +9,8 @@ module ClaimsHelper
     awaiting_written_reasons
   ].freeze
 
+  SIGNPOST_FEES = %w[MIUMU MIAPF].freeze
+
   def claim_allocation_checkbox_helper(claim, case_worker)
     checked = claim.is_allocated_to_case_worker?(case_worker) ? 'checked="checked"' : nil
     element_id = "id=\"case_worker_claim_ids_#{claim.id}\""
@@ -69,7 +71,8 @@ module ClaimsHelper
   end
 
   def unclaimed_fees_for(claim)
-    display_unused_materials_notice?(claim) ? [Fee::MiscFeeType.find_by(unique_code: 'MIUMU')] : []
+    (claim.eligible_misc_fee_types - claim.misc_fees.map(&:fee_type))
+      .select { |ft| SIGNPOST_FEES.include?(ft.unique_code) }
   end
 
   def display_elected_not_proceeded_signpost?(claim)

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -46,7 +46,7 @@ module ClaimsHelper
       page_header: t('page_header', scope:),
       page_hint: t('page_hint', scope:)
     }.tap do |headings|
-      headings[:page_notice] = t('unused_materials_fee.notice.short', scope:) if display_unused_materials_notice?(claim)
+      headings[:page_notice] = t('unclaimed_fees.notice.short', scope:) if display_unused_materials_notice?(claim)
       headings[:fees_calculator_html] = fees_calculator_html unless fees_calculator_html.nil?
     end
   end
@@ -58,7 +58,7 @@ module ClaimsHelper
       **args
     }.tap do |locals|
       if display_unused_materials_notice?(claim)
-        locals[:unclaimed_fees_notice] = t('external_users.claims.misc_fees.unused_materials_fee.notice.long')
+        locals[:unclaimed_fees_notice] = t('external_users.claims.misc_fees.unclaimed_fees.notice.long')
       end
     end
   end
@@ -66,6 +66,10 @@ module ClaimsHelper
   def display_unused_materials_notice?(claim)
     claim.eligible_misc_fee_types.map(&:unique_code).include?('MIUMU') &&
       claim.fees.none? { |f| f.fee_type.unique_code == 'MIUMU' }
+  end
+
+  def unclaimed_fees_for(claim)
+    display_unused_materials_notice?(claim) ? [Fee::MiscFeeType.find_by(unique_code: 'MIUMU')] : []
   end
 
   def display_elected_not_proceeded_signpost?(claim)

--- a/app/views/external_users/claims/_summary_fees.html.haml
+++ b/app/views/external_users/claims/_summary_fees.html.haml
@@ -1,8 +1,9 @@
 %h2.govuk-heading-l
   = local_assigns.has_key?(:header) ? header : t('common.fees')
 
-- if local_assigns.has_key?(:unclaimed_fees_notice)
-  = govuk_warning_text(unclaimed_fees_notice)
+- if local_assigns.has_key?(:unclaimed_fees)
+  = render partial: 'unclaimed_fees_notice_brief', locals: { unclaimed_fees: }
+
 
 - if local_assigns[:editable]
   = govuk_link_to t('common.change_html', context: t('common.fees')), edit_polymorphic_path(claim, step: step, referrer: :summary), class: 'link-change'

--- a/app/views/external_users/claims/_unclaimed_fees_notice.html.haml
+++ b/app/views/external_users/claims/_unclaimed_fees_notice.html.haml
@@ -1,6 +1,6 @@
 - if unclaimed_fees.present?
   = govuk_warning_text(t('external_users.claims.misc_fees.unclaimed_fees.heading')) do
-    = t('external_users.claims.misc_fees.unclaimed_fees.new_notice.short', fee_list: unclaimed_fees.map(&:description).to_sentence)
+    = t('external_users.claims.misc_fees.unclaimed_fees.new_notice.short', fee_list: unclaimed_fees)
     %br
     - misc_fee_link = govuk_link_to t('external_users.claims.misc_fees.unclaimed_fees.hint_link'), link
     = t('external_users.claims.misc_fees.unclaimed_fees.hint_html', link: misc_fee_link)

--- a/app/views/external_users/claims/_unclaimed_fees_notice.html.haml
+++ b/app/views/external_users/claims/_unclaimed_fees_notice.html.haml
@@ -1,0 +1,7 @@
+- if unclaimed_fees.present?
+  = govuk_warning_text(t('external_users.claims.misc_fees.unclaimed_fees.heading')) do
+    = t('external_users.claims.misc_fees.unclaimed_fees.new_notice.short', fee_list: unclaimed_fees.map(&:description).to_sentence)
+    %br
+    - misc_fee_link = govuk_link_to t('external_users.claims.misc_fees.unclaimed_fees.hint_link'), link
+    = t('external_users.claims.misc_fees.unclaimed_fees.hint_html', link: misc_fee_link)
+

--- a/app/views/external_users/claims/_unclaimed_fees_notice_brief.html.haml
+++ b/app/views/external_users/claims/_unclaimed_fees_notice_brief.html.haml
@@ -1,2 +1,2 @@
 - if unclaimed_fees.present?
-  = govuk_warning_text(t('external_users.claims.misc_fees.unclaimed_fees.new_notice.long', fee_list: unclaimed_fees.map(&:description).to_sentence))
+  = govuk_warning_text(t('external_users.claims.misc_fees.unclaimed_fees.new_notice.long', fee_list: unclaimed_fees))

--- a/app/views/external_users/claims/_unclaimed_fees_notice_brief.html.haml
+++ b/app/views/external_users/claims/_unclaimed_fees_notice_brief.html.haml
@@ -1,0 +1,2 @@
+- if unclaimed_fees.present?
+  = govuk_warning_text(t('external_users.claims.misc_fees.unclaimed_fees.new_notice.long', fee_list: unclaimed_fees.map(&:description).to_sentence))

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -6,12 +6,7 @@
 
 - present(@claim) do |claim|
 
-  - if display_unused_materials_notice?(claim)
-    = govuk_warning_text(t('external_users.claims.misc_fees.unused_materials_fee.heading')) do
-      = t('external_users.claims.misc_fees.unused_materials_fee.notice.short')
-      %br
-      - misc_fee_link = govuk_link_to t('external_users.claims.misc_fees.unused_materials_fee.hint_link'), edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary)
-      = t('external_users.claims.misc_fees.unused_materials_fee.hint_html', link: misc_fee_link)
+  = render partial: 'unclaimed_fees_notice', locals: { unclaimed_fees: unclaimed_fees_for(claim), link: edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary) }
 
   %p
     = t('external_users.claims.check_your_claim.help_text')

--- a/app/views/external_users/claims/summary.html.haml
+++ b/app/views/external_users/claims/summary.html.haml
@@ -6,7 +6,7 @@
 
 - present(@claim) do |claim|
 
-  = render partial: 'unclaimed_fees_notice', locals: { unclaimed_fees: unclaimed_fees_for(claim), link: edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary) }
+  = render partial: 'unclaimed_fees_notice', locals: { unclaimed_fees: unclaimed_fees_list(claim), link: edit_polymorphic_path(claim, step: :miscellaneous_fees, referrer: :summary) }
 
   %p
     = t('external_users.claims.check_your_claim.help_text')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1395,7 +1395,8 @@ en:
         unclaimed_fees:
           heading: Possible unclaimed fees
           new_notice:
-            short: 'This claim does not include the following fees for which it may be eligible:'
+            short: This claim may be eligible for %{fee_list}
+            long: This claim may be eligible for %{fee_list}, but they have not been claimed
           notice:
             short: This claim should be eligible for unused materials fees (up to 3 hours)
             long: This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1395,12 +1395,12 @@ en:
         unclaimed_fees:
           heading: Possible unclaimed fees
           new_notice:
-            short: This claim may be eligible for %{fee_list}
-            long: This claim may be eligible for %{fee_list}, but they have not been claimed
+            short: This claim may be eligible for %{fee_list}.
+            long: This claim may be eligible for %{fee_list}, but they have not been claimed.
           notice:
             short: This claim should be eligible for unused materials fees (up to 3 hours)
             long: This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed
-          hint_html: If eligible, go to %{link} to add this to your claim
+          hint_html: If eligible, go to %{link} to add this to your claim.
           hint_link: miscellaneous fees
         advocates:
           fields:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1392,12 +1392,14 @@ en:
           <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" class="govuk-link" rel="noreferrer noopener" target="_blank">appropriate special prep form <span class="govuk-visually-hidden">(opens in new tab)</span></a>
           or <a href="https://www.gov.uk/government/publications/af1-claim-for-advocate-graduated-fees" class="govuk-link" rel="noreferrer noopener" target="_blank">unused materials (over 3 hours) form <span class="govuk-visually-hidden">(opens in new tab)</span></a>
           and attach to the claim.
-        unused_materials_fee:
-          heading: Unclaimed fees
+        unclaimed_fees:
+          heading: Possible unclaimed fees
+          new_notice:
+            short: 'This claim does not include the following fees for which it may be eligible:'
           notice:
             short: This claim should be eligible for unused materials fees (up to 3 hours)
             long: This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed
-          hint_html: Go to %{link} to add this to your claim
+          hint_html: If eligible, go to %{link} to add this to your claim
           hint_link: miscellaneous fees
         advocates:
           fields:

--- a/spec/factories/fee_types.rb
+++ b/spec/factories/fee_types.rb
@@ -53,6 +53,10 @@ FactoryBot.define do
       roles { %w[lgfs agfs agfs_scheme_14] }
     end
 
+    trait :agfs_scheme_15 do
+      roles { %w[agfs agfs_scheme_15] }
+    end
+
     trait :agfs_all_schemes do
       roles { %w[agfs agfs_scheme_9 agfs_scheme_10 agfs_scheme_12] }
     end
@@ -359,6 +363,15 @@ FactoryBot.define do
         unique_code { 'MIDSU' }
         calculated { true }
         quantity_is_decimal { false }
+      end
+
+      trait :miapf do
+        description { 'Additional preparation fee' }
+        code { 'APF' }
+        unique_code { 'MIAPF' }
+        calculated { true }
+        quantity_is_decimal { false }
+        agfs_scheme_15
       end
     end
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -270,6 +270,33 @@ RSpec.describe ClaimsHelper do
     end
   end
 
+  describe '#unclaimed_fees_for' do
+    subject { unclaimed_fees_for(claim) }
+
+    let(:claim) { build(:claim) }
+    let(:unused_materials_fee) { create(:misc_fee_type, :miumu) }
+    let(:another_fee) { create(:misc_fee_type, :miphc) }
+    let(:eligible_fees) { [another_fee] }
+
+    before { allow(claim).to receive(:eligible_misc_fee_types).and_return Array(eligible_fees) }
+
+    context 'with a claim eligible for unused materials fees' do
+      let(:eligible_fees) { [unused_materials_fee, another_fee] }
+
+      it { is_expected.to contain_exactly(unused_materials_fee) }
+
+      context 'when unused material fees have already been claimed' do
+        before { create(:misc_fee, fee_type: unused_materials_fee, claim:, quantity: 1) }
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    context 'with a claim ineligible for unused materials fees' do
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe '#display_elected_not_proceeded_signpost?' do
     subject { display_elected_not_proceeded_signpost?(claim) }
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe ClaimsHelper do
     context 'with a claim eligible for unused materials fees' do
       let(:eligible_fees) { [unused_materials_fee, additional_preparation_fee, another_fee] }
 
-      it { expect(locals[:unclaimed_fees]).to contain_exactly(unused_materials_fee, additional_preparation_fee) }
+      it { expect(locals[:unclaimed_fees]).to eq("'Unused materials (up to 3 hours)' and 'Additional preparation fee'") }
 
       context 'when unused material fees have already been claimed' do
         before { create(:misc_fee, fee_type: unused_materials_fee, claim:, quantity: 1) }
@@ -271,8 +271,8 @@ RSpec.describe ClaimsHelper do
     end
   end
 
-  describe '#unclaimed_fees_for' do
-    subject { unclaimed_fees_for(claim) }
+  describe '#unclaimed_fees_list' do
+    subject { unclaimed_fees_list(claim) }
 
     let(:claim) { build(:claim) }
     let(:another_fee) { create(:misc_fee_type, :miphc) }
@@ -280,11 +280,11 @@ RSpec.describe ClaimsHelper do
 
     before { allow(claim).to receive(:eligible_misc_fee_types).and_return Array(eligible_fees) }
 
-    context 'with a claim eligible for unused materials fees' do
+    context 'with one fee to be signposted' do
       let(:unused_materials_fee) { create(:misc_fee_type, :miumu) }
       let(:eligible_fees) { [unused_materials_fee, another_fee] }
 
-      it { is_expected.to contain_exactly(unused_materials_fee) }
+      it { is_expected.to eq("'Unused materials (up to 3 hours)'") }
 
       context 'when unused material fees have already been claimed' do
         before do
@@ -292,28 +292,29 @@ RSpec.describe ClaimsHelper do
           claim.reload
         end
 
-        it { is_expected.to be_empty }
+        it { is_expected.to be_nil }
       end
     end
 
-    context 'with a claim eligible for additional preparation fees' do
+    context 'with two fees to be signposted' do
+      let(:unused_materials_fee) { create(:misc_fee_type, :miumu) }
       let(:additional_preparation_fee) { create(:misc_fee_type, :miapf) }
-      let(:eligible_fees) { [additional_preparation_fee, another_fee] }
+      let(:eligible_fees) { [unused_materials_fee, additional_preparation_fee, another_fee] }
 
-      it { is_expected.to contain_exactly(additional_preparation_fee) }
+      it { is_expected.to eq("'Unused materials (up to 3 hours)' and 'Additional preparation fee'") }
 
       context 'when unused material fees have already been claimed' do
         before do
-          create(:misc_fee, fee_type: additional_preparation_fee, claim:, quantity: 1)
+          create(:misc_fee, fee_type: unused_materials_fee, claim:, quantity: 1)
           claim.reload
         end
 
-        it { is_expected.to be_empty }
+        it { is_expected.to eq("'Additional preparation fee'") }
       end
     end
 
     context 'with a claim ineligible for any of the specific fees' do
-      it { is_expected.to be_empty }
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -221,15 +221,16 @@ RSpec.describe ClaimsHelper do
 
     let(:claim) { build(:claim) }
     let(:unused_materials_fee) { create(:misc_fee_type, :miumu) }
+    let(:additional_preparation_fee) { create(:misc_fee_type, :miapf) }
     let(:another_fee) { create(:misc_fee_type, :miphc) }
     let(:eligible_fees) { [another_fee] }
 
     before { allow(claim).to receive(:eligible_misc_fee_types).and_return Array(eligible_fees) }
 
     context 'with a claim eligible for unused materials fees' do
-      let(:eligible_fees) { [unused_materials_fee, another_fee] }
+      let(:eligible_fees) { [unused_materials_fee, additional_preparation_fee, another_fee] }
 
-      it { expect(locals[:unclaimed_fees_notice]).to eq "This claim should be eligible for unused materials fees (up to 3 hours) but they haven't been claimed" }
+      it { expect(locals[:unclaimed_fees]).to contain_exactly(unused_materials_fee, additional_preparation_fee) }
 
       context 'when unused material fees have already been claimed' do
         before { create(:misc_fee, fee_type: unused_materials_fee, claim:, quantity: 1) }
@@ -274,25 +275,44 @@ RSpec.describe ClaimsHelper do
     subject { unclaimed_fees_for(claim) }
 
     let(:claim) { build(:claim) }
-    let(:unused_materials_fee) { create(:misc_fee_type, :miumu) }
     let(:another_fee) { create(:misc_fee_type, :miphc) }
     let(:eligible_fees) { [another_fee] }
 
     before { allow(claim).to receive(:eligible_misc_fee_types).and_return Array(eligible_fees) }
 
     context 'with a claim eligible for unused materials fees' do
+      let(:unused_materials_fee) { create(:misc_fee_type, :miumu) }
       let(:eligible_fees) { [unused_materials_fee, another_fee] }
 
       it { is_expected.to contain_exactly(unused_materials_fee) }
 
       context 'when unused material fees have already been claimed' do
-        before { create(:misc_fee, fee_type: unused_materials_fee, claim:, quantity: 1) }
+        before do
+          create(:misc_fee, fee_type: unused_materials_fee, claim:, quantity: 1)
+          claim.reload
+        end
 
         it { is_expected.to be_empty }
       end
     end
 
-    context 'with a claim ineligible for unused materials fees' do
+    context 'with a claim eligible for additional preparation fees' do
+      let(:additional_preparation_fee) { create(:misc_fee_type, :miapf) }
+      let(:eligible_fees) { [additional_preparation_fee, another_fee] }
+
+      it { is_expected.to contain_exactly(additional_preparation_fee) }
+
+      context 'when unused material fees have already been claimed' do
+        before do
+          create(:misc_fee, fee_type: additional_preparation_fee, claim:, quantity: 1)
+          claim.reload
+        end
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    context 'with a claim ineligible for any of the specific fees' do
       it { is_expected.to be_empty }
     end
   end


### PR DESCRIPTION
#### What

Add signposting for additional preparation fees at the top of the claim summary page for external users.

#### Ticket

[CCCD: Improve the signposting of eligible fees on the 'Claim Summary' page](https://dsdmoj.atlassian.net/browse/CTSKF-450)

#### Why

It is important to ensure that the new Additional Preparation Fee is claimed as appropriate. To help with this signposting is added to the claim summary page to highlight when this is available.

#### How

Change the formatting of the notice, currently tailored to the unused materials fee, to include a bullet point list to itemise all available fees that have not been claimed. This list can contain unused materials and additional prepartion.

##### Before

At the top of the page:

![Screenshot 2023-06-19 at 17 10 50](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/d5c76bf3-2052-4013-b145-1de341dfd5a0)

In the 'Miscellaneous Fees' section:

![Screenshot 2023-06-20 at 09 21 11](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/a54cfde6-b8f8-43cf-bd3b-622383da1096)

##### After

At the top of the page:

![Screenshot 2023-06-20 at 15 55 03](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/4c1cb54e-b88a-4c9e-b64a-99bb69eac04b)

In the 'Miscellaneous Fees' section:

![Screenshot 2023-06-20 at 15 55 14](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/77510662-3466-485d-91f5-a5a941885afb)

--------

#### TODO (wip)

 - [x] Update signpost at 'miscellaneous fees' section of the summary
 - [x] Confirm the correct copy for the notices
