### PR TITLE
Minor layout improvements to caseworker expense table

### DIFF
--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -166,6 +166,11 @@ table.dataTable {
 
   &.expenses-data-table {
     margin-bottom: govuk-spacing(6);
+
+    .govuk-table__header--numeric,
+    .govuk-table__cell--numeric {
+      text-align: right;
+    }
   }
 }
 

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -163,6 +163,10 @@ table.dataTable {
   &.no-footer {
     border-bottom: none;
   }
+
+  &.expenses-data-table {
+    margin-bottom: govuk-spacing(6);
+  }
 }
 
 .app-jq-datatable {


### PR DESCRIPTION
#### What

When a caseworker views a submitted claim with expense data, there are a couple of small issues with the expenses table that is displayed:

1) no margin is rendered below the table, meaning that the 'Additional claim information' section appears directly below the table with no spacing. 

2) Numeric cells are left-justified, while GDS guidance states that they (and their column headers) should be right justified for readability.

Both these are caused by the use of the datatables library to sort the data in the expenses table. This has the affect of overriding govuk table styling.

#### Why

To improve the appearance of the service.

#### How

Adds custom styling to `app/webpack/stylesheets/components/_table.scss` to explicitly set the `margin-bottom` and `text-align` properties for the `expenses-data-table` class.

#### Before

<img width="1090" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/91255760-e129-4845-9837-a91e624a3a7c">



#### After

<img width="1090" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/7288b3f5-87d0-4541-a5ea-fb4a0cd6fb55">

