### PR TITLE
CCCD: N+1 Fix - "expense_types"

### DIFF
--- a/app/views/shared/summary/expenses/index.html.haml
+++ b/app/views/shared/summary/expenses/index.html.haml
@@ -24,7 +24,7 @@
         = t('.gross_amount')
 
   = govuk_table_tbody do
-    - expenses = vat ? claim.expenses.with_vat : claim.expenses.without_vat
+    - expenses = vat ? claim.expenses.includes(:expense_type).with_vat : claim.expenses.includes(:expense_type).without_vat
     - present_collection(expenses).each do |expense|
       = render template: 'shared/summary/expenses/show', locals: { claim: claim, expense: expense }
 


### PR DESCRIPTION
**What**
The CCCD application is currently experiencing performance issues and potential errors due to the presence of 'N+1' queries in the ClaimsController. These queries are causing poor database performance and negatively impacting user experience. The purpose of this PR is to address and optimise the 'N+1' queries in the ClaimsController, improving application performance and resolving potential errors.

[CTSKF-466](https://dsdmoj.atlassian.net/browse/CTSKF-466).

**Why**
The 'N+1' queries identified in the ClaimsController are leading to poor performance and potential errors for users. These queries retrieve unnecessary data from the database, resulting in additional round trips and slowing down the application. By optimising these queries, we aim to enhance the application's performance, reduce response times, and eliminate errors caused by inefficient database access.

**How**
To address the 'N+1' queries, the following steps were implemented:

- Identified the specific areas in the ClaimsController where the 'N+1' queries were occurring: CaseWorkers::ClaimsController#show and ExternalUsers::ClaimsController#show.
- Analysed the code and database access patterns to understand the underlying cause of the 'N+1' queries.
- Implemented efficient database access strategies, such as eager loading or proper association handling, to optimise the queries.
- Modified the code to ensure that the required data is loaded in a single query or through optimised database joins, reducing unnecessary round trips.


[CTSKF-466]: https://dsdmoj.atlassian.net/browse/CTSKF-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ