### PR TITLE
CTSKF-456 Add Prometheus Alerts for SQS queues on Staging

### DIFF
--- a/.k8s/live/staging/prometheus-custom-rules.yaml
+++ b/.k8s/live/staging/prometheus-custom-rules.yaml
@@ -41,3 +41,76 @@ spec:
         severity: laa-cccd-alerts
       annotations:
         message: cccd-staging Container disk space usage is more than 2Gi or is not reported
+    - alert: Staging-SQS-Responses-For-CCCD-oldest-message
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-responses-for-cccd' has messages older than or equal to 10 mins, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_age_of_oldest_message_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-responses-for-cccd%5C%22%7D%20%3E%3D%20bool%2010%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: |-
+          aws_sqs_approximate_age_of_oldest_message_maximum{queue_name=~"laa-get-paid-staging-responses-for-cccd"} >= 10 * 60
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-Responses-For-CCCD-Message-Threshold-Reached
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-responses-for-cccd' has more than or equal to 10 messages, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22queryMode%22:%22Metrics%22,%22namespace%22:%22%22,%22metricName%22:%22%22,%22expression%22:%22%22,%22dimensions%22:%7B%7D,%22region%22:%22default%22,%22id%22:%22%22,%22statistic%22:%22Average%22,%22period%22:%22%22,%22metricQueryType%22:0,%22metricEditorMode%22:0,%22sqlExpression%22:%22%22,%22matchExact%22:true,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_number_of_messages_visible_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-responses-for-cccd%5C%22%7D%20%3E%3D%20bool%2010%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false,%22label%22:%22%22,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="laa-get-paid-staging-responses-for-cccd"} >= 10
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-CCCD-Claims-For-CCR-oldest-message
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-cccd-claims-for-ccr' has messages older than or equal to 10 mins, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_age_of_oldest_message_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-cccd-claims-for-ccr%5C%22%7D%20%3E%3D%20bool%2010%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_age_of_oldest_message_maximum{queue_name=~"laa-get-paid-staging-cccd-claims-for-ccr"} >= 10 * 60
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-CCCD-Claims-For-CCR-Message-Threshold-Reached
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-cccd-claims-for-ccr' has more than or equal to 10 messages, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22queryMode%22:%22Metrics%22,%22namespace%22:%22%22,%22metricName%22:%22%22,%22expression%22:%22%22,%22dimensions%22:%7B%7D,%22region%22:%22default%22,%22id%22:%22%22,%22statistic%22:%22Average%22,%22period%22:%22%22,%22metricQueryType%22:0,%22metricEditorMode%22:0,%22sqlExpression%22:%22%22,%22matchExact%22:true,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_number_of_messages_visible_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-cccd-claims-for-ccr%5C%22%7D%20%3E%3D%20bool%2010%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false,%22label%22:%22%22,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="laa-get-paid-staging-cccd-claims-for-ccr"} >= 10
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-CCCD-Claims-For-CCLF-oldest-message
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-cccd-claims-for-cclf' has messages older than or equal to 10 mins, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_age_of_oldest_message_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-cccd-claims-for-cclf%5C%22%7D%20%3E%3D%20bool%2010%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_age_of_oldest_message_maximum{queue_name=~"laa-get-paid-staging-cccd-claims-for-cclf"} >= 10 * 60
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-CCCD-Claims-For-CCLF-Message-Threshold-Reached
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-cccd-claims-for-cclf' has more than or equal to 10 messages, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22queryMode%22:%22Metrics%22,%22namespace%22:%22%22,%22metricName%22:%22%22,%22expression%22:%22%22,%22dimensions%22:%7B%7D,%22region%22:%22default%22,%22id%22:%22%22,%22statistic%22:%22Average%22,%22period%22:%22%22,%22metricQueryType%22:0,%22metricEditorMode%22:0,%22sqlExpression%22:%22%22,%22matchExact%22:true,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_number_of_messages_visible_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-cccd-claims-for-cclf%5C%22%7D%20%3E%3D%20bool%2010%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false,%22label%22:%22%22,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="laa-get-paid-staging-cccd-claims-for-cclf"} >= 10
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-CCCD-Dead-Letter-Queue-Threshold-Reached
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-reponses-for-cccd-dlq' has more than or equal to 1 message, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22queryMode%22:%22Metrics%22,%22namespace%22:%22%22,%22metricName%22:%22%22,%22expression%22:%22%22,%22dimensions%22:%7B%7D,%22region%22:%22default%22,%22id%22:%22%22,%22statistic%22:%22Average%22,%22period%22:%22%22,%22metricQueryType%22:0,%22metricEditorMode%22:0,%22sqlExpression%22:%22%22,%22matchExact%22:true,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_number_of_messages_visible_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-reponses-for-cccd-dlq%5C%22%7D%20%3E%3D%20bool%201%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false,%22label%22:%22%22,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_number_of_messages_visible_maximum{queue_name="laa-get-paid-staging-reponses-for-cccd-dlq"} >= 1
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-CCR-Dead-Letter-Queue-Threshold-Reached
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-cccd-claims-submitted-ccr-dlq' has more than or equal to 1 message, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22queryMode%22:%22Metrics%22,%22namespace%22:%22%22,%22metricName%22:%22%22,%22expression%22:%22%22,%22dimensions%22:%7B%7D,%22region%22:%22default%22,%22id%22:%22%22,%22statistic%22:%22Average%22,%22period%22:%22%22,%22metricQueryType%22:0,%22metricEditorMode%22:0,%22sqlExpression%22:%22%22,%22matchExact%22:true,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_number_of_messages_visible_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-cccd-claims-submitted-ccr-dlq%5C%22%7D%20%3E%3D%20bool%201%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false,%22label%22:%22%22,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_age_of_oldest_message_maximum{queue_name="laa-get-paid-staging-cccd-claims-submitted-ccr-dlq"} >= 1
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts
+    - alert: Staging-SQS-CCLF-Dead-Letter-Queue-Threshold-Reached
+      annotations:
+        message: Staging SQS queue 'laa-get-paid-staging-cccd-claims-submitted-cclf-dlq' has more than or equal to 1 message, check consumers are healthy.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/explore?orgId=1&left=%7B%22datasource%22:%22prometheus%22,%22queries%22:%5B%7B%22queryMode%22:%22Metrics%22,%22namespace%22:%22%22,%22metricName%22:%22%22,%22expression%22:%22%22,%22dimensions%22:%7B%7D,%22region%22:%22default%22,%22id%22:%22%22,%22statistic%22:%22Average%22,%22period%22:%22%22,%22metricQueryType%22:0,%22metricEditorMode%22:0,%22sqlExpression%22:%22%22,%22matchExact%22:true,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22prometheus%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22aws_sqs_approximate_number_of_messages_visible_maximum%7Bqueue_name%3D%5C%22laa-get-paid-staging-cccd-claims-submitted-cclf-dlq%5C%22%7D%20%3E%3D%20bool%201%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:false,%22label%22:%22%22,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-10m%22,%22to%22:%22now%22%7D%7D
+      expr: aws_sqs_approximate_age_of_oldest_message_maximum{queue_name="laa-get-paid-staging-cccd-claims-submitted-cclf-dlq"} >= 1
+      for: 1m
+      labels:
+        severity: laa-cccd-alerts


### PR DESCRIPTION
#### What

Add prometheus alerts when an SQS queue on the Staging environment breaks the rules defined in the table in Figure 1 (below)

Send the alert to the slack channel: `laa-cccd-alerts`

#### Ticket

[CTSKF-456](https://dsdmoj.atlassian.net/browse/CTSKF-456)

#### Why

We want to improve our monitoring of SQS queues and alerting on certain rules will help us to react quicker to issues relating to the queue / data injection.

There was a [spike investigation](https://dsdmoj.atlassian.net/wiki/spaces/CT/pages/4426367272/CTSKF-411+Investigate+alerting+on+AWS+SQS+queues) explaining more.

#### How

Update the prometheus rules configuration to add new rules for SQS alerting

- `aws_sqs_approximate_age_of_oldest_message_maximum` which returns the number of seconds the oldest message has been on the queue for
- `>= 10 * 60` is more than or equal to 10 minutes (10 * 60 seconds)
- The Grafana dashboard url which uses prometheus as the data source

-----

The SQS Queues in the Staging environment are:
- [x] laa-get-paid-staging-cccd-claims-for-cclf
- [x] laa-get-paid-staging-cccd-claims-for-ccr
- [x] laa-get-paid-staging-cccd-claims-submitted-cclf-dlq
- [x] laa-get-paid-staging-cccd-claims-submitted-ccr-dlq
- [x] laa-get-paid-staging-reponses-for-cccd-dlq
- [x] laa-get-paid-staging-responses-for-cccd


Figure 1: A table of alert rules that uses [AWS CloudWatch Metrics for SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html) e.g. ApproximateAgeOfOldestMessage
Queue name | Environment | Add alert? | Criteria for alerting | Slack channel for notification
-- | -- | -- | -- | --
claims-for-cclf | staging | Yes | (1) ApproximateAgeOfOldestMessage >= 10 minutes <br/>(2)ApproximateNumberOfMessagesVisible >= 10 | #laa-cccd-alerts
claims-for-ccr | staging | Yes | (1) ApproximateAgeOfOldestMessage >= 10 minutes <br/> (2) ApproximateNumberOfMessagesVisible >= 10 | #laa-cccd-alerts
reponses-for-cccd | staging | Yes | (1) ApproximateAgeOfOldestMessage >= 10 minutes <br/> (2) ApproximateNumberOfMessagesVisible >= 10 | #laa-cccd-alerts
claims-for-cclf-dlq | staging | Yes | ApproximateNumberOfMessagesVisible >= 1 | #laa-cccd-alerts
claims-for-ccr-dlq | staging | Yes | ApproximateNumberOfMessagesVisible >= 1 | #laa-cccd-alerts
reponses-for-cccd-dlq | staging | Yes | ApproximateNumberOfMessagesVisible >= 1 | #laa-cccd-alerts




[CTSKF-456]: https://dsdmoj.atlassian.net/browse/CTSKF-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ