### PR TITLE
CCCD: N+1 Fix - "determinations"

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -34,7 +34,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
 
     @claims = @claims_context
               .dashboard_displayable_states
-              .includes(:defendants, :case_type, :external_user, :assessment, :messages)
+              .includes(:defendants, :case_type, :external_user, :assessment, :messages, :determinations)
     search if params[:search].present?
     sort_and_paginate(column: 'last_submitted_at', direction: 'asc')
   end
@@ -48,7 +48,7 @@ class ExternalUsers::ClaimsController < ExternalUsers::ApplicationController
   def outstanding
     @claims = @financial_summary
               .outstanding_claims
-              .includes(:defendants, :case_type, :external_user, :assessment, :messages)
+              .includes(:defendants, :case_type, :external_user, :assessment, :messages, :determinations)
     sort_and_paginate(column: 'last_submitted_at', direction: 'asc')
     @total_value = @financial_summary.total_outstanding_claim_value
   end

--- a/app/models/claims/sort.rb
+++ b/app/models/claims/sort.rb
@@ -64,7 +64,7 @@ module Claims::Sort
   # NOTE: amount assessed is the most recent determinations' total including vat
   def sort_amount_assessed(direction)
     select('claims.*, (determinations.total + determinations.vat_amount) AS total_inc_vat')
-      .joins(:determinations)
+      .left_outer_joins(:determinations)
       .where('determinations.created_at = (SELECT MAX(d.created_at) FROM ' \
              '"determinations" d WHERE d."claim_id" = "claims"."id")')
       .order(sort_field_by('total_inc_vat', direction))


### PR DESCRIPTION
What
The CCCD application is currently experiencing performance issues and potential errors due to the presence of 'N+1' queries in the ClaimsController. These queries are causing poor database performance and negatively impacting user experience. The purpose of this PR is to address and optimise the 'N+1' queries in the ClaimsController, improving application performance and resolving potential errors.

[CTSKF-468](https://dsdmoj.atlassian.net/browse/CTSKF-468).

Why
The 'N+1' queries identified in the ClaimsController are leading to poor performance and potential errors for users. These queries retrieve unnecessary data from the database, resulting in additional round trips and slowing down the application. By optimising these queries, we aim to enhance the application's performance, reduce response times, and eliminate errors caused by inefficient database access.

How
To address the 'N+1' queries, the following steps were implemented:

- Identified the specific areas in the ClaimsController where the 'N+1' queries were occurring: ExternalUsers::ClaimsController#index.
- Analysed the code and database access patterns to understand the underlying cause of the 'N+1' queries.
- Implemented efficient database access strategies, such as eager loading or proper association handling, to optimise the queries.
- Modified the code to ensure that the required data is loaded in a single query or through optimised database joins, reducing unnecessary round trips.


[CTSKF-468]: https://dsdmoj.atlassian.net/browse/CTSKF-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ