### PR TITLE
[do not merge] Test Modsecurity audit logs in cloud platform

### DIFF
--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecDefaultAction "phase:2,pass,log,tag:github_team=github:crime-billing-online"
+      SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
-      SecRule ARGS "message[body]" "id:1001,phase:2,log,t:base64Encode"
+        SecRule ARGS "message[body]" "id:1001,phase:2,log,t:base64Encode"
 
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" \
         "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
-      SecRule ARGS:message[body] "phase:2,log,t:base64Encode,id:1001"
+        SecRule ARGS:message[body] "phase:2,log,t:base64Encode,id:1001"
 
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -12,9 +12,7 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
-      SecRule REQUEST_URI "@contains /messages" \
-        "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
-        SecRule ARGS:message[body] "phase:2,log,t:base64Encode,id:1001"
+      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
 
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" \
-        "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110"
+        "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" \
         "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
-      SecRule ARGS:message[body] "id:92,phase:2,t:base64Encode"
+      SecRule ARGS:message[body] "phase:2,log,t:base64Encode,id:1001"
 
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule ARGS "message[body]" "id:1001,phase:2,log,t:base64Encode"
 
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -12,8 +12,7 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
-      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
-        SecRule ARGS "message[body]" "id:1001,phase:2,log,t:base64Encode"
+      SecRule ARGS "message[body]" "id:1001,phase:2,log,t:base64Encode"
 
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -14,6 +14,8 @@ metadata:
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" \
         "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule ARGS:message[body] "phase:2,t:base64Encode"
+
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" \
         "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
-      SecRule ARGS:message[body] "phase:2,t:base64Encode"
+      SecRule ARGS:message[body] "id:92,phase:2,t:base64Encode"
 
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=github:crime-billing-online"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -16,11 +16,10 @@
 
 class MessagesController < ApplicationController
   include ActiveStorage::SetCurrent
-
   respond_to :html
 
   def create
-    @message = Message.new(message_params.merge(sender_id: current_user.id))
+    @message = Message.new(message_params.merge(sender_id: current_user.id, body: encode_message_body))
 
     @notification = if @message.save
                       { notice: 'Message successfully sent' }
@@ -49,6 +48,10 @@ class MessagesController < ApplicationController
   def redirect_to_url
     method = "#{current_user.persona.class.to_s.pluralize.underscore}_claim_path"
     __send__(method, @message.claim, messages: true) + '#claim-accordion'
+  end
+
+  def encode_message_body
+    Base64.encode64(message_params[:body])
   end
 
   def refresh_required?

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,7 +19,7 @@ class MessagesController < ApplicationController
   respond_to :html
 
   def create
-    @message = Message.new(message_params.merge(sender_id: current_user.id, body: encode_message_body))
+    @message = Message.new(message_params.merge(sender_id: current_user.id))
 
     @notification = if @message.save
                       { notice: 'Message successfully sent' }
@@ -50,9 +50,9 @@ class MessagesController < ApplicationController
     __send__(method, @message.claim, messages: true) + '#claim-accordion'
   end
 
-  def encode_message_body
-    Base64.encode64(message_params[:body])
-  end
+  # def encode_message_body
+  #   Base64.encode64(message_params[:body])
+  # end
 
   def refresh_required?
     Settings.claim_actions.include?(message_params[:claim_action])

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -7,7 +7,7 @@ class MessagePresenter < BasePresenter
 
   def body
     h.tag.div do
-      h.concat(simple_format(message.body))
+      h.concat(simple_format(decoded_message_body))
       attachment_field if message.attachment.present?
     end
   end
@@ -22,6 +22,14 @@ class MessagePresenter < BasePresenter
   end
 
   private
+
+  def decoded_message_body
+    base64?(message.body) ? Base64.decode64(message.body) : message.body
+  end
+
+  def base64?(value)
+    value.is_a?(String) && Base64.strict_encode64(Base64.decode64(value)) == value.strip
+  end
 
   def attachment_field
     h.concat('Attachment: ')

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -7,7 +7,7 @@ class MessagePresenter < BasePresenter
 
   def body
     h.tag.div do
-      h.concat(simple_format(decoded_message_body))
+      h.concat(simple_format(message.body))
       attachment_field if message.attachment.present?
     end
   end
@@ -23,9 +23,9 @@ class MessagePresenter < BasePresenter
 
   private
 
-  def decoded_message_body
-    base64?(message.body) ? Base64.decode64(message.body) : message.body
-  end
+  # def decoded_message_body
+  #   base64?(message.body) ? Base64.decode64(message.body) : message.body
+  # end
 
   def base64?(value)
     value.is_a?(String) && Base64.strict_encode64(Base64.decode64(value)) == value.strip

--- a/vcr/cassettes/spec/requests/feedback_spec.yml
+++ b/vcr/cassettes/spec/requests/feedback_spec.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ministryofjustice.zendesk.com/api/v2/tickets
+    body:
+      encoding: UTF-8
+      string: '{"ticket":{"subject":"Feedback (test)","description":"task: 1\nrating:
+        4\ncomment: lorem ipsum\nreason: [\"1\", \"2\"]\nother_reason: dolor sit","custom_fields":[{"id":"26047167","value":null},{"id":"23757677","value":"advocate_defence_payments"},{"id":"23791776","value":null},{"id":"32342378","value":"test"}],"comment":null}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - ZendeskAPI Ruby 1.37.0
+      Authorization:
+      - Basic Og==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Tue, 11 Jul 2023 12:34:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '37'
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Basic realm="Web Password"
+      Strict-Transport-Security:
+      - max-age=31536000;
+      Cache-Control:
+      - no-cache
+      X-Zendesk-Origin-Server:
+      - classic-app-server-79d6c5f89d-tgldp
+      Set-Cookie:
+      - __cfruid=91580d7c80468c0657e833928428b7334ed3166d-1689078845; path=/; domain=.ministryofjustice.zendesk.com;
+        HttpOnly; Secure; SameSite=None
+      - _zendesk_cookie=BAhJIhl7ImRldmljZV90b2tlbnMiOnt9fQY6BkVU--0bf2100788cb010d0183feca16aaf88ccaf719ca;
+        path=/; expires=Thu, 11 Jul 2024 06:49:54 GMT; secure; HttpOnly; SameSite=None
+      X-Request-Id:
+      - 7e511421cd787695-LHR
+      - 7e511421cd787695-LHR
+      X-Runtime:
+      - '0.053085'
+      X-Zendesk-Zorg:
+      - 'yes'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Bz1WEdfljdG6mRZ0%2FaeO8whpYNFkGxU85NNI6k%2BPpGgUNgl%2FPSkc27I32rVHTwpFQN5wEjxukq8bqn7M8Jl02oIER47rlFL9L2f8p1AZ4olmKQ46VqMRrLbsHPSWHNeH6gX264ubwTk6Lal1kjrb"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 7e511421cd787695-LHR
+    body:
+      encoding: UTF-8
+      string: '{"error":"Couldn''t authenticate you"}'
+  recorded_at: Tue, 11 Jul 2023 12:34:05 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION


#### What
[Allow access to ModSecurity audit logs in DEV](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#false-positives)

Test out encoding and decoding chat messages in order to circumnavigate sql injection issues. The data must be saved as encoded and then decoded when being viewed to prevent the sql injection and ModSecurity 403 forbidden response.


#### Ticket

[board ticket description](link)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
