### PR TITLE
N+1 fix for external user claim summary page - eager loading attachments and blobs

### DIFF
--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -7,7 +7,7 @@ class S3ZipDownloader
 
   def generate!
     "./tmp/#{@claim.case_number}-#{SecureRandom.uuid}-documents.zip".tap do |bundle|
-      build_zip_file @@claim.documents.includes(:document_blob, :converted_preview_document_attachment), bundle
+      build_zip_file @claim.documents.includes(:document_blob, :converted_preview_document_attachment), bundle
     end
   end
 

--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -14,6 +14,7 @@ class S3ZipDownloader
   private
 
   def build_zip_file(documents, bundle)
+    documents.includes(:document_blob, :converted_preview_document_attachment) # Eager load associations
     Dir.mktmpdir("#{@claim.case_number}-") do |tmp_dir|
       Zip::File.open(bundle, Zip::File::CREATE) do |zip_file|
         documents.map(&:document).each_with_index do |document, i|

--- a/app/services/s3_zip_downloader.rb
+++ b/app/services/s3_zip_downloader.rb
@@ -7,14 +7,13 @@ class S3ZipDownloader
 
   def generate!
     "./tmp/#{@claim.case_number}-#{SecureRandom.uuid}-documents.zip".tap do |bundle|
-      build_zip_file @claim.documents, bundle
+      build_zip_file @@claim.documents.includes(:document_blob, :converted_preview_document_attachment), bundle
     end
   end
 
   private
 
   def build_zip_file(documents, bundle)
-    documents.includes(:document_blob, :converted_preview_document_attachment) # Eager load associations
     Dir.mktmpdir("#{@claim.case_number}-") do |tmp_dir|
       Zip::File.open(bundle, Zip::File::CREATE) do |zip_file|
         documents.map(&:document).each_with_index do |document, i|

--- a/app/views/external_users/claims/supporting_documents/_new.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_new.html.haml
@@ -5,7 +5,7 @@
   = render partial: 'external_users/claims/supporting_documents/disk_evidence', locals: { f: f }
 
 .document-ids
-  - @claim.documents.each do |document|
+  - @claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
     = f.hidden_field :document_ids, multiple: true, value: document.id, id: "claim_document_ids_#{document.id}"
 
 %h3.govuk-heading-m

--- a/app/views/external_users/claims/supporting_evidence/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_evidence/_summary.html.haml
@@ -12,7 +12,7 @@
 
       = govuk_summary_list_row_collection( t('shared.summary.supporting_evidence') ) do
         %ul.govuk-list
-          - claim.documents.each do |document|
+          - claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
             %li
               = govuk_link_to document.document_file_name,
                         download_document_path(document),


### PR DESCRIPTION
**What**
The CCCD application is currently experiencing performance issues and potential errors due to the presence of 'N+1' queries in the ClaimsController. These queries are causing poor database performance and negatively impacting user experience. The purpose of this PR is to address and optimise the 'N+1' queries in the ClaimsController, improving application performance and resolving potential errors.

**Why**
The 'N+1' queries identified in the ClaimsController are leading to poor performance and potential errors for users. These queries retrieve unnecessary data from the database, resulting in additional round trips and slowing down the application. By optimising these queries, we aim to enhance the application's performance, reduce response times, and eliminate errors caused by inefficient database access.

**How**
To address the 'N+1' queries, the following steps were implemented:

- Identified the specific areas in the ClaimsController where the 'N+1' queries were occurring: ExternalUsers::ClaimsController#Summary.
- Analysed the code and database access patterns to understand the underlying cause of the 'N+1' queries.
- Implemented efficient database access strategies, such as eager loading or proper association handling, to optimise the queries.
- Modified the code to ensure that the required data is loaded in a single query or through optimised database joins, reducing unnecessary round trips.