### PR TITLE
[CTSKF-297] Task to fix LGFS offences in database

### DIFF
--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -41,7 +41,7 @@ class Offence < ApplicationRecord
   scope :in_scheme_nine, -> { joins(:fee_schemes).merge(FeeScheme.nine).distinct }
   singleton_class.send(:alias_method, :in_scheme_9, :in_scheme_nine)
 
-  scope :in_scheme_ten, -> { joins(:fee_schemes).merge(FeeScheme.ten).distinct }
+  scope :in_scheme_ten, -> { joins(:fee_schemes).merge(FeeScheme.agfs).merge(FeeScheme.ten).distinct }
   singleton_class.send(:alias_method, :in_scheme_10, :in_scheme_ten)
 
   scope :in_scheme_eleven, -> { joins(:fee_schemes).merge(FeeScheme.eleven).distinct }

--- a/app/services/claims/fetch_eligible_advocate_categories.rb
+++ b/app/services/claims/fetch_eligible_advocate_categories.rb
@@ -12,7 +12,7 @@ module Claims
       return unless claim&.agfs?
       return all_categories unless claim.fee_scheme
       return new_monarch_categories if claim.fee_scheme.agfs_scheme_15?
-      return agfs_reform_categories if agfs_reform?
+      return agfs_reform_categories if claim.agfs_reform?
       default_categories
     end
 
@@ -34,12 +34,6 @@ module Claims
 
     def all_categories
       default_categories | agfs_reform_categories | new_monarch_categories
-    end
-
-    # TODO: remove the Offence check from here as this should already
-    # be handled by FeeScheme.for_claim called by agfs_reform?
-    def agfs_reform?
-      claim.agfs_reform? || Offence.in_scheme_ten.include?(claim.offence)
     end
   end
 end

--- a/db/seeds/lgfs_scheme_10.rb
+++ b/db/seeds/lgfs_scheme_10.rb
@@ -1,4 +1,7 @@
 require Rails.root.join('db','seeds', 'schemas', 'add_lgfs_fee_scheme_10')
+require Rails.root.join('db','seeds', 'schemas', 'clean_lgfs_fee_scheme_10')
 
 adder = Seeds::Schemas::AddLgfsFeeScheme10.new(pretend: false)
 adder.up
+fixer = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: false, quiet: true)
+fixer.up

--- a/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
+++ b/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
@@ -7,8 +7,9 @@ module Seeds
       class MissingSchemeNineOffence < StandardError; end
       class SchemeTenOffenceExists < StandardError; end
 
-      def initialize(pretend: false)
+      def initialize(pretend: false, quiet: false)
         @pretend = pretend
+        @quiet = quiet
       end
 
       def status
@@ -37,28 +38,28 @@ module Seeds
 
       def up
         lgfs_scheme_ten_only.each do |offence|
-          puts "Offence: #{offence.unique_code}"
-          puts "  #{offence.description[0, 60]}"
-          puts "  #{offence.offence_class.description[0, 60]}"
+          puts "Offence: #{offence.unique_code}" unless @quiet
+          puts "  #{offence.description[0, 60]}" unless @quiet
+          puts "  #{offence.offence_class.description[0, 60]}" unless @quiet
           Offence.transaction do
             new_offence = scheme_nine_offence_for(offence)
             update_claims(offence.claims, new_offence)
             add_scheme_ten_to(new_offence)
             remove_redundant(offence)
           end
-          puts "-----"
+          puts "-----" unless @quiet
         end
       end
 
       def down
         all_lgfs_offences.each do |offence|
-          puts "Offence: #{offence.unique_code}"
-          puts "  #{offence.description[0, 60]}"
-          puts "  #{offence.offence_class.description[0, 60]}"
+          puts "Offence: #{offence.unique_code}" unless @quiet
+          puts "  #{offence.description[0, 60]}" unless @quiet
+          puts "  #{offence.offence_class.description[0, 60]}" unless @quiet
           Offence.transaction do
             create_scheme_ten_offence_for(offence)
           end
-          puts "-----"
+          puts "-----" unless @quiet
         end
       end
 
@@ -94,28 +95,28 @@ module Seeds
           # claims = offence.claims.select { |claim| claim.fee_scheme == fee_scheme_ten }
           raise SchemeTenOffenceExists unless new_offence.valid?
           if pretending?
-            puts "    [WOULD-CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".yellow
-            puts "    [WOULD-REMOVE] Fee scheme 10 from offence #{offence.unique_code}".yellow
-            # puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".yellow
+            puts "    [WOULD-CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".yellow unless @quiet
+            puts "    [WOULD-REMOVE] Fee scheme 10 from offence #{offence.unique_code}".yellow unless @quiet
+            # puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".yellow unless @quiet
           else
-            puts "    [CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".green
+            puts "    [CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".green unless @quiet
             new_offence.save!
-            puts "      [SUCCESS]".green
-            puts "    [REMOVE] Fee scheme 10 from offence #{offence.unique_code}".green
+            puts "      [SUCCESS]".green unless @quiet
+            puts "    [REMOVE] Fee scheme 10 from offence #{offence.unique_code}".green unless @quiet
             offence.fee_schemes.delete(fee_scheme_ten)
-            # puts "    [UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".green
+            # puts "    [UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".green unless @quiet
             # # It should be possible to do update_claims(claims, new_offence) but claims is an array instead of an ActiveRecord collection
             # offence.claims.each do |claim|
             #   if claim.offence == offence
             #     claim.offence = new_offence
             #     claim.save
             #   else
-            #     puts "    [ERROR] Claim #{claim.id} does not have offence #{offence.unique_code}".red
+            #     puts "    [ERROR] Claim #{claim.id} does not have offence #{offence.unique_code}".red unless @quiet
             #   end
             # end
           end
         rescue SchemeTenOffenceExists, ActiveRecord::RecordNotUnique
-          puts "      [FAILED]".red
+          puts "      [FAILED]".red unless @quiet
         end
       end
 
@@ -127,22 +128,22 @@ module Seeds
 
       def update_claims(claims, new_offence)
         if pretending?
-          puts "    [WOULD-UPDATE] #{claims.count} claims".yellow
+          puts "    [WOULD-UPDATE] #{claims.count} claims".yellow unless @quiet
         else
-          puts "    [UPDATE] #{claims.count} claims".green
+          puts "    [UPDATE] #{claims.count} claims".green unless @quiet
           claims.update_all(offence_id: new_offence.id)
         end
       end
 
       def add_scheme_ten_to(offence)
         if pretending?
-          puts "    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".yellow
+          puts "    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".yellow unless @quiet
         else
-          puts "    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".green
-          puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green
+          puts "    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".green unless @quiet
+          puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
           offence.fee_schemes << fee_scheme_ten
           offence.reload
-          puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green
+          puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
         end
       end
 
@@ -152,9 +153,9 @@ module Seeds
 
       def remove_redundant(offence)
         if pretending?
-          puts "    [WOULD-REMOVE] Offence #{offence.unique_code}".yellow
+          puts "    [WOULD-REMOVE] Offence #{offence.unique_code}".yellow unless @quiet
         else
-          puts "    [REMOVE] Offence #{offence.unique_code}".green
+          puts "    [REMOVE] Offence #{offence.unique_code}".green unless @quiet
           offence.destroy
         end
       end

--- a/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
+++ b/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
@@ -91,28 +91,28 @@ module Seeds
           new_offence.id = 7999 + offence.id # lib/tasks/lgfs_scheme_ten.rake starts adding ids at 8000
           new_offence.unique_code = new_offence.unique_code + '~10'
           new_offence.fee_schemes = [fee_scheme_ten]
-          claims = offence.claims.select { |claim| claim.fee_scheme == fee_scheme_ten }
+          # claims = offence.claims.select { |claim| claim.fee_scheme == fee_scheme_ten }
           raise SchemeTenOffenceExists unless new_offence.valid?
           if pretending?
             puts "    [WOULD-CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".yellow
             puts "    [WOULD-REMOVE] Fee scheme 10 from offence #{offence.unique_code}".yellow
-            puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".yellow
+            # puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".yellow
           else
             puts "    [CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".green
             new_offence.save!
             puts "      [SUCCESS]".green
             puts "    [REMOVE] Fee scheme 10 from offence #{offence.unique_code}".green
             offence.fee_schemes.delete(fee_scheme_ten)
-            puts "    [UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".green
-            # It should be possible to do update_claims(claims, new_offence) but claims is an array instead of an ActiveRecord collection
-            offence.claims.each do |claim|
-              if claim.offence == offence
-                claim.offence = new_offence
-                claim.save
-              else
-                puts "    [ERROR] Claim #{claim.id} does not have offence #{offence.unique_code}".red
-              end
-            end
+            # puts "    [UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".green
+            # # It should be possible to do update_claims(claims, new_offence) but claims is an array instead of an ActiveRecord collection
+            # offence.claims.each do |claim|
+            #   if claim.offence == offence
+            #     claim.offence = new_offence
+            #     claim.save
+            #   else
+            #     puts "    [ERROR] Claim #{claim.id} does not have offence #{offence.unique_code}".red
+            #   end
+            # end
           end
         rescue SchemeTenOffenceExists, ActiveRecord::RecordNotUnique
           puts "      [FAILED]".red

--- a/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
+++ b/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
@@ -1,0 +1,119 @@
+module Seeds
+  module Schemas
+    class CleanLgfsFeeScheme10
+      attr_reader :pretend
+      alias_method :pretending?, :pretend
+
+      class MissingSchemeNineOffence < StandardError; end
+
+      def initialize(pretend: false)
+        @pretend = pretend
+      end
+
+      def status
+        puts "Offences linked to any LGFS fee scheme:     #{all_lgfs_offences.count}"
+        puts "Offences linked only to LGFS scheme 9:      #{lgfs_scheme_nine_only.count}"
+        puts "Offences linked only to LGFS scheme 10:     #{lgfs_scheme_ten_only.count}"
+        puts "Offences linked to LGFS scheme 9 and 10:    #{lgfs_scheme_nine_or_ten.count}"
+        puts
+        puts "LGFS scheme 10 offences attached to claims: #{lgfs_scheme_ten_only_with_claims.count}"
+        lgfs_scheme_ten_only_with_claims.each do |offence|
+          puts "  Offence: #{offence.description}"
+          puts "    #{offence.offence_class.description}"
+          puts "    Unique code:                  #{offence.unique_code}"
+          begin
+            scheme_nine_offence_for(offence)
+            puts '    Scheme 9 offence exists:      Yes'
+          rescue MissingSchemeNineOffence
+            puts '    Scheme 9 offence exists:      No'
+          end
+          puts "    Claim ids:"
+          offence.claims.each do |claim|
+            puts "      #{claim.id}"
+          end
+        end
+      end
+
+      def up
+        lgfs_scheme_ten_only.each do |offence|
+          puts "Offence: #{offence.unique_code}"
+          puts "  #{offence.description[0, 60]}"
+          puts "  #{offence.offence_class.description[0, 60]}"
+          Offence.transaction do
+            new_offence = scheme_nine_offence_for(offence)
+            update_claims_for(offence, new_offence)
+            add_scheme_ten_to(new_offence)
+            remove_redundant(offence)
+          end
+          puts "-----"
+        end
+      end
+
+    #   def down
+    #   end
+
+      private
+
+      def fee_scheme_nine = @fee_scheme_nine ||= FeeScheme.lgfs.nine.first
+      def fee_scheme_ten = @fee_scheme_ten ||= FeeScheme.lgfs.ten.first
+
+      def all_lgfs_offences = @all_lgfs_offences ||= Offence.joins(:fee_schemes).merge(FeeScheme.lgfs).distinct
+      def lgfs_scheme_nine_only = all_lgfs_offences.select { |o| o.fee_schemes & [fee_scheme_nine, fee_scheme_ten] == [fee_scheme_nine] }
+      def lgfs_scheme_ten_only = all_lgfs_offences.select { |o| o.fee_schemes & [fee_scheme_nine, fee_scheme_ten] == [fee_scheme_ten] }
+      def lgfs_scheme_nine_or_ten = all_lgfs_offences.select { |o| (o.fee_schemes & [fee_scheme_nine, fee_scheme_ten]).sort == [fee_scheme_nine, fee_scheme_ten].sort }
+
+      def lgfs_scheme_ten_only_with_claims = lgfs_scheme_ten_only.select { |o| o.claims.count.positive? }
+
+      def scheme_nine_offence_for(offence)
+        code = offence.unique_code.gsub(/~.*$/, '')
+        Offence.find_by(unique_code: code).tap do |new_offence|
+          raise MissingSchemeNineOffence unless offences_match?(offence, new_offence)
+        end
+      end
+
+      def offences_match?(first, second)
+        return false if first.nil? || second.nil?
+
+        (first.description == second.description) && (first.offence_class_id == second.offence_class_id)
+      end
+
+      def update_claims_for(offence, new_offence)
+        puts "  Claims to update: #{offence.claims.count}"
+        offence.claims.each do |claim|
+          if pretending?
+            puts "    [WOULD-UPDATE] Claim id #{claim.id}".yellow
+          else
+            puts "    [UPDATE] Claim id #{claim.id}".green
+            claim.offence = new_offence
+            claim.save!
+          end
+        end
+      end
+
+      def add_scheme_ten_to(offence)
+        if pretending?
+          puts "    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".yellow
+        else
+          puts "    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".green
+          puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green
+          offence.fee_schemes << fee_scheme_ten
+          offence.reload
+          puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green
+        end
+      end
+
+      def display_fee_schemes(*fee_schemes)
+        fee_schemes.map { |fs| "#{fs.name} #{fs.version}" }.join(', ')
+      end
+
+      def remove_redundant(offence)
+        if pretending?
+          puts "    [WOULD-REMOVE] Offence #{offence.unique_code}".yellow
+        else
+          puts "    [REMOVE] Offence #{offence.unique_code}".green
+          offence.destroy
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/lgfs_scheme_ten_clean.rake
+++ b/lib/tasks/lgfs_scheme_ten_clean.rake
@@ -1,0 +1,44 @@
+require Rails.root.join('db','seeds', 'schemas', 'clean_lgfs_fee_scheme_10')
+
+namespace :db do
+  namespace :lgfs_scheme_ten_clean do
+    desc 'Display status of db structures and records for LGFS Fee Scheme 10 (CLAIR - September 2022)'
+    task :status => :environment do
+      cleaner = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: false)
+      cleaner.status
+    end
+
+    desc 'Merge LGFS scheme 10 offences into LGFS scheme 9 offences'
+    task :merge, [:not_pretend] => :environment do |_task, args|
+
+      # seed['true'] should seed, otherwise pretend
+      args.with_defaults(not_pretend: 'false')
+      not_pretend = !args.not_pretend.to_s.downcase.eql?('false')
+      pretend = !not_pretend
+
+      continue?('This will merge LGFS fee scheme 10 offences into LGFS fee scheme 9. Are you sure?') if not_pretend
+      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+
+      log_level = ActiveRecord::Base.logger.level
+      ActiveRecord::Base.logger.level = 1
+      cleaner = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: pretend)
+      cleaner.up
+      ActiveRecord::Base.logger.level = log_level
+    end
+
+
+    # desc 'Revert LGFS fee scheme 10 offences'
+    # task :rollback, [:not_pretend] => :environment do |_task, args|
+
+    #   # rollback['true'] should rollback, otherwise pretend
+    #   args.with_defaults(not_pretend: 'false')
+    #   not_pretend = !args.not_pretend.to_s.downcase.eql?('false')
+    #   pretend = !not_pretend
+
+    #   continue?('This will destroy LGFS Fee Scheme 10 (CLAIR - September 2022), offences and fee types. Are you sure?') if not_pretend
+    #   puts "#{pretend ? 'pretending' : 'working'}...".yellow
+
+    #   TODO
+    # end
+  end
+end

--- a/lib/tasks/lgfs_scheme_ten_clean.rake
+++ b/lib/tasks/lgfs_scheme_ten_clean.rake
@@ -27,18 +27,22 @@ namespace :db do
     end
 
 
-    # desc 'Revert LGFS fee scheme 10 offences'
-    # task :rollback, [:not_pretend] => :environment do |_task, args|
+    desc 'Revert LGFS fee scheme 10 offences'
+    task :rollback, [:not_pretend] => :environment do |_task, args|
 
-    #   # rollback['true'] should rollback, otherwise pretend
-    #   args.with_defaults(not_pretend: 'false')
-    #   not_pretend = !args.not_pretend.to_s.downcase.eql?('false')
-    #   pretend = !not_pretend
+      # rollback['true'] should rollback, otherwise pretend
+      args.with_defaults(not_pretend: 'false')
+      not_pretend = !args.not_pretend.to_s.downcase.eql?('false')
+      pretend = !not_pretend
 
-    #   continue?('This will destroy LGFS Fee Scheme 10 (CLAIR - September 2022), offences and fee types. Are you sure?') if not_pretend
-    #   puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      continue?('This will recreate spearate offences for LGFS fee scheme 10. Are you sure?') if not_pretend
+      puts "#{pretend ? 'pretending' : 'working'}...".yellow
 
-    #   TODO
-    # end
+      log_level = ActiveRecord::Base.logger.level
+      ActiveRecord::Base.logger.level = 1
+      cleaner = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: pretend)
+      cleaner.down
+      ActiveRecord::Base.logger.level = log_level
+    end
   end
 end


### PR DESCRIPTION
#### What

Remove the duplicate set of offence records in the database for LGFS fee scheme 10.

#### Ticket

[CCCD - Fix offence records](https://dsdmoj.atlassian.net/browse/CTSKF-297)

#### Why

The `Offence` model contains details of offences linked linked to fee schemes and this is a one-to-many relation. For example, a sample offence may be linked to both AGFS fee scheme 9 and LGFS fee scheme 9.

```
pry(main)> o = Offence.where.not(offence_class_id: nil).sample
pry(main)> o.fee_schemes.pluck(:name, :version)
=> [["AGFS", 9], ["LGFS", 9]]
```

With the creation of LGFS fee scheme 10 the entire list of LGFS fee scheme 9 offences was duplicated but for simplicity it is better to simply add the new fee scheme to the one-to-many relation on the existing records. This reduces unnecessary duplication.

#### How

A Rake task is created to perform the update in a three step process;

1. Add LGFS fee scheme 10 to all offence records that currently apply to LGFS fee scheme 9. This results in the list of offences as being 'common' to both LGFS fee schemes.
2. Find all LGFS fee scheme 10 claims and update the offence to the equivalent common offence, as updated in step 1. The correct offence can be found by the unique code. The fee scheme 9 (now common) offence has a unique code in an alphanumeric format with a single underscore, such as `OKPDOE_B`, while the fee scheme 10 offence has the same unique code appended with `~10`, such as `OKPDOE_B~10`.
3. Remove all offences that were created new for LGFS fee scheme 10.

Note that due to an oversight when creating LGFS fee scheme 10 the new offences were never used. `app/services/claims/fetch_eligible_offences.rb` is used to get a list of the correct offences but unless `claim.agfs_reform?` is true then the default set is always returned. To test the task completely, therefore, at least one claim should be changed to use an LGFS fee scheme 10 offence and this can be done with;

```ruby
claim = Claim::LitigatorClaim.last
offence = Offence.find_by(unique_code: "#{claim.offence.unique_code}~10")
claim.offence = offence
claim.save
```

#### Result

The `db:lgfs_scheme_ten_clean:status` task shows the current status. Prior to updating the results are;

```
% bundle exec rails db:lgfs_scheme_ten_clean:status
Offences linked to any LGFS fee scheme:     782
Offences linked only to LGFS scheme 9:      391
Offences linked only to LGFS scheme 10:     391
Offences linked to LGFS scheme 9 and 10:    0

LGFS scheme 10 offences attached to claims: 1
  Offence: Unlawful wounding
    Lesser offences involving violence or damage and less serious drug offences
    Unique code:                  UNLAWW_C~10
    Scheme 9 offence exists:      Yes
    Claim ids:
      1474802
```

The task to clean up the offences is `db:lgfs_scheme_ten_clean:merge` which will do a dry-run unless the `true` argument is added;

```
% bundle exec rails 'db:lgfs_scheme_ten_clean:merge[true]'
This will merge LGFS fee scheme 10 offences into LGFS fee scheme 9. Are you sure?: [no/yes] yes
working...
Offence: ABOCUT_C~10
  Abandonment of children under two
  Lesser offences involving violence or damage and less seriou
  Claims to update: 0
    [UPDATE] Add fee scheme 'LGFS 10' to offence ABOCUT_C
      [UPDATE] Before: AGFS 9, LGFS 9
      [UPDATE] After: AGFS 9, LGFS 9, LGFS 10
    [REMOVE] Offence ABOCUT_C~10
(etc)
```

After the update;

```
% bundle exec rails db:lgfs_scheme_ten_clean:status
Offences linked to any LGFS fee scheme:     391
Offences linked only to LGFS scheme 9:      0
Offences linked only to LGFS scheme 10:     0
Offences linked to LGFS scheme 9 and 10:    391

LGFS scheme 10 offences attached to claims: 0
```

#### Rollback

The scheme 10 offences can be recreated using the rollback task; `db:lgfs_scheme_ten_clean:rollback`. Note that this will not update the existing scheme 10 claims to use the new offence although this can be done by uncommented the relevant seconds from `db/seeds/schemas/clean_lgfs_fee_scheme_10.rb`. This can take a long time - over an hour for an anonymised copy of the production database.