### PR TITLE
Remove webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,5 @@ group :test do
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'vcr'
-  gem 'webdrivers', '~> 5.2', require: false
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -691,10 +691,6 @@ GEM
       descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -820,7 +816,6 @@ DEPENDENCIES
   unicorn-worker-killer (~> 0.4.5)
   utf8-cleaner (~> 1.0)
   vcr
-  webdrivers (~> 5.2)
   webmock
   zendesk_api (= 1.37.0)
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,7 +9,6 @@ ENV["ENV"] ||= 'test'
 require 'capybara'
 require 'capybara/cucumber'
 require 'selenium/webdriver'
-require 'webdrivers'
 require 'cucumber/rails'
 require 'cucumber/rspec/doubles'
 require 'site_prism'
@@ -21,26 +20,6 @@ require 'axe-cucumber-steps'
 # enable forgery protection in feature tests so as not to obscure
 # loss of signed in user
 ActionController::Base.allow_forgery_protection = true
-
-# Activate to view chromedriver detailed output
-# Webdrivers.logger.level = :DEBUG
-
-# version Pinning
-# remove specific version
-#  and explicitly trigger the update for latest (stable) driver
-Webdrivers::Chromedriver.update
-
-# The `webdriver` gem's requests to download drivers is being blocked by Webmock
-# without this.
-# see https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock
-# for details
-allowed_sites = [
-  "https://chromedriver.storage.googleapis.com",
-  "https://github.com/mozilla/geckodriver/releases",
-  "https://selenium-release.storage.googleapis.com",
-  "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
-]
-WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
 
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -114,18 +114,6 @@ RSpec.configure do |config|
     end
   end
 
-  # The `webdriver` gem's requests to download drivers is being blocked by Webmock
-  # without this.
-  # see https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock
-  # for details
-  allowed_sites = [
-    'https://chromedriver.storage.googleapis.com',
-    'https://github.com/mozilla/geckodriver/releases',
-    'https://selenium-release.storage.googleapis.com',
-    'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver'
-  ]
-  WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
-
   config.before :each, geckoboard: true do
     stub_request(:get, 'https://api.geckoboard.com/')
       .with(

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -42,18 +42,6 @@ VCR.configure do |c|
     ].any?
   end
 
-  # The `webdriver` gem's requests to download drivers can be blocked by VCR
-  # without this.
-  # see https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock
-  # for details
-  #
-  c.ignore_hosts(
-    'chromedriver.storage.googleapis.com',
-    'github.com/mozilla/geckodriver/releases',
-    'selenium-release.storage.googleapis.com',
-    'developer.microsoft.com/en-us/microsoft-edge/tools/webdriver'
-  )
-
   # replace sensitive data in cassettes with placeholder and apply secrets on the fly
   c.filter_sensitive_data('<GOOGLE_API_KEY>') { Rails.application.secrets.google_api_key }
   c.filter_sensitive_data('<SURVEY_MONKEY_BEARER_TOKEN>') { Rails.application.secrets.survey_monkey_bearer_token }


### PR DESCRIPTION
#### What

Cucumber tests are failing locally due to the `webdrivers` gem not being able to recognise the latest version of Chrome (v115).

See discussion here: https://github.com/titusfortner/webdrivers/issues/247

This can be resolved by removing `webdrivers` and all code necessary to run it, and instead falling back on `selenium-webdriver`.

#### Why

To allow the feature test suite to be run locally.

#### How

* Remove the `webdrivers` gem
* Remove configuration for `webdrivers` from `features/support/env.rb`
* Remove `webmock` workarounds that were put in place to allow `webdrivers` to function correctly from `features/support/env.rb`, `spec/rails_helper.rb` and `spec/vcr_helper.rb`