### PR TITLE
Enable rerunning of intermittently failing cucumber tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,10 +218,6 @@ commands:
       - install-chrome
       - precompile-assets
       - run:
-          name: Make cucumber test storage dir
-          command: |
-            mkdir -p /tmp/test-results/cucumber
-      - run:
           name: Run cucumber tests
           command: |
             circleci tests glob "features/**/*.feature" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,13 +224,13 @@ commands:
       - run:
           name: Run cucumber tests
           command: |
-            TESTFILES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings --timings-type=filename)
-
-            RUBYOPT='-W0' bundle exec cucumber \
-            --format pretty \
-            --format junit,fileattribute=true \
-            --out /tmp/test-results/cucumber \
-            -- ${TESTFILES}
+            circleci tests glob "features/**/*.feature" \
+              | circleci tests run --command="xargs bundle exec cucumber \
+                                                      --format pretty \
+                                                      --format junit,fileattribute=true \
+                                                      --out /tmp/test-results/cucumber" \
+                                   --split-by=timings \
+                                   --timings-type=filename
       - store_artifacts:
           path: tmp/capybara
       - store_test_results:
@@ -432,6 +432,13 @@ jobs:
     parallelism: 6
     steps:
       - checkout
+      - run:
+          name: Halt if no cucumber tests to run
+          command: |
+            mkdir -p ./tmp && \
+            >./tmp/tests.txt && \
+            circleci tests glob "features/**/*.feature" | circleci tests run --command ">./tmp/tests.txt xargs echo" --split-by=timings
+            [ -s tmp/tests.txt ] || circleci-agent step halt
       - build-base
       - *wait-for-db
       - *load-db


### PR DESCRIPTION
#### What

At the moment, if a cucumber test fails when run in CircleCI, all feature tests must be rerun. This takes ~10 minutes and costs credits.

CircleCI has [introduced](https://discuss.circleci.com/t/product-launch-rerun-failed-tests-circleci-tests-run/47775) the ability to only rerun failed tests, which will save time and money when experiencing flaky tests which fail intermittently.

This commit implements the necessary change to enable that functionality following guidance here https://circleci.com/docs/rerun-failed-tests/.

Note: this only works for tests that are intermittently failing. If a test fails because of issues in code and is resolved by a subsequent commit, the whole test pipeline will run as usual.

#### Why

To save money and developer time.

#### How

 - Amends the `run-cucumber` job to include the `circleci tests run` command, which is necessary to enable the rerunning of tests
 - Adds a 'halt' step to the `cucumber-tests` job to prevent unnecessary use of test containers when there are no tests to run. As we run our feature tests in parallel across six containers, if we subsequently re-run a single failed test, all six containers will still start up, install dependencies, create a database, precompile assets etc, even though there are no tests to run on five of them. This allows us to fail fast, saving additional credits.

#### Evidence

See this run for example: https://app.circleci.com/pipelines/github/ministryofjustice/Claim-for-Crown-Court-Defence/14326

1) In the initial test run, one (deliberately flaky) test failed:
<img width="482" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/a5c35bf6-e9e8-4101-8ca0-01cf75f80dc2">

2) I am now able to select `Rerun failed tests` from the `Rerun` dropdown:
<img width="354" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/0aa8eb1a-ef4c-46a4-804d-43d90774b386">

3) This caused the single failing test to be re-run, which this time passed:
<img width="912" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/6c3b3db6-ccdd-4275-863d-2e9209f75694">

4) The other containers stopped quickly as there were no tests for them to run:
<img width="1268" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/f0c24254-0d5e-46be-847f-741615d4df5e">
