### PR TITLE
CTSKF-503 - Remove can_inject_kc feature flag

### DIFF
--- a/.k8s/live/api-sandbox/app-config.yaml
+++ b/.k8s/live/api-sandbox/app-config.yaml
@@ -20,4 +20,3 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'true'
-  CAN_INJECT_KC: 'true'

--- a/.k8s/live/dev-lgfs/app-config.yaml
+++ b/.k8s/live/dev-lgfs/app-config.yaml
@@ -20,4 +20,3 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'true'
-  CAN_INJECT_KC: 'true'

--- a/.k8s/live/dev/app-config.yaml
+++ b/.k8s/live/dev/app-config.yaml
@@ -20,4 +20,3 @@ data:
   SETTINGS__AWS__S3__REGION: 'eu-west-2'
   LAA_FEE_CALCULATOR_HOST: https://dev.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
-  CAN_INJECT_KC: 'true'

--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -23,4 +23,3 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   ZENDESK_FEEDBACK: 'true'
-  CAN_INJECT_KC: 'true'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -23,4 +23,3 @@ data:
   LAA_FEE_CALCULATOR_HOST: https://staging.laa-fee-calculator.service.justice.gov.uk/api/v1
   ALLOW_FUTURE_DATES: 'false'
   ZENDESK_FEEDBACK: 'true'
-  CAN_INJECT_KC: 'true'

--- a/app/services/ccr/advocate_category_adapter.rb
+++ b/app/services/ccr/advocate_category_adapter.rb
@@ -1,7 +1,7 @@
 module CCR
   class AdvocateCategoryAdapter
     TRANSLATION_TABLE = {
-      KC: Settings.can_inject_kc ? 'KC' : 'QC',
+      KC: 'KC',
       QC: 'QC',
       'Led junior': 'LEDJR',
       'Leading junior': 'LEADJR',

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -205,5 +205,3 @@ notify_report_errors: <%= ENV["ENV"].in?(%w[api-sandbox production]) %>
 postcode_regexp: !ruby/regexp '/\A([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})\z/'
 
 maat_regexp: !ruby/regexp <%= ENV['MAAT_REGEXP'] || '/^[2-9][0-9]{6}$/' %>
-
-can_inject_kc: <%= ENV['CAN_INJECT_KC'] %>

--- a/spec/services/ccr/advocate_category_adapter_spec.rb
+++ b/spec/services/ccr/advocate_category_adapter_spec.rb
@@ -7,23 +7,7 @@ RSpec.describe CCR::AdvocateCategoryAdapter, type: :adapter do
     context 'with KC' do
       let(:advocate_category) { 'KC' }
 
-      context 'when can_inject_kc is true' do
-        before do
-          allow(Settings).to receive(:can_inject_kc).and_return(true)
-          load Rails.root.join('app', 'services', 'ccr', 'advocate_category_adapter.rb')
-        end
-
-        it { is_expected.to eq 'KC' }
-      end
-
-      context 'when can_inject_kc is false' do
-        before do
-          allow(Settings).to receive(:can_inject_kc).and_return(false)
-          load Rails.root.join('app', 'services', 'ccr', 'advocate_category_adapter.rb')
-        end
-
-        it { is_expected.to eq 'QC' }
-      end
+      it { is_expected.to eq 'KC' }
     end
 
     context 'with QC' do


### PR DESCRIPTION
#### What
To facilitate the change of advocate category from QC to KC, a new feature flag CAN_INJECT_KC was created. This flag has been enabled in all environments for some time now without any issues and so the feature flag can safely be removed.

#### Ticket

[CTSKF-503 - Remove can_inject_kc feature flag](https://dsdmoj.atlassian.net/browse/CTSKF-503)

#### Why
Clean up outdated code

#### How
- remove KC flag from all environments in config files
- Remove rspec tests for flag operations
