### PR TITLE
Fix Chrome version for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,11 @@ commands:
 
   install-chrome:
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          # There is no version of Chromedriver for the current latest version of Chrome (116)
+          chrome-version: 114.0.5735.90
+          replace-existing: true
       - browser-tools/install-chromedriver
-
   precompile-assets:
     description: >
       Precompile assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.4.4
   slack: circleci/slack@3.4.1
 
 references:


### PR DESCRIPTION
#### What

Fix Chrome version for tests.

#### Ticket

N/A

#### Why

The 'install chromedriver' step of the pipeline has started failing. This is because there is no Chromedriver version for the latest version of Chrome (on 31 August 2023).

#### How

* Update the cirecleci/browser-tools orb from 1.2.3 to 1.4.4.
* Add the `chrome-version` option to the `install-chrome` command.
