### PR TITLE
Prepare AWS access for move to IAM

### DIFF
--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -1,11 +1,7 @@
 module MessageQueue
   class AwsClient
     def initialize(queue)
-      @sqs = Aws::SQS::Client.new(
-        access_key_id: Settings.aws.sqs.access,
-        secret_access_key: Settings.aws.sqs.secret,
-        region: Settings.aws.region
-      )
+      @sqs = Aws::SQS::Client.new(aws_credentials)
       begin
         @queue_url = queue_url(queue)
       rescue Aws::SQS::Errors::NonExistentQueue
@@ -30,6 +26,17 @@ module MessageQueue
     end
 
     private
+
+    def aws_credentials
+      return { region: Settings.aws.region } unless Settings.aws.sqs.access
+
+      # TODO: Remove when IRSA is used in all environments
+      {
+        access_key_id: Settings.aws.sqs.access,
+        secret_access_key: Settings.aws.sqs.secret,
+        region: Settings.aws.region
+      }
+    end
 
     def queue_url(queue)
       return queue if queue.match?(valid_web_url_regex)

--- a/app/services/notification_queue/aws_client.rb
+++ b/app/services/notification_queue/aws_client.rb
@@ -11,5 +11,18 @@ module NotificationQueue
       client.publish(message)
       true
     end
+
+    private
+
+    def aws_credentials
+      return { region: Settings.aws.region } unless Settings.aws.sns.access
+
+      # TODO: Remove when IRSA is used in all environments
+      {
+        access_key_id: Settings.aws.sns.access,
+        secret_access_key: Settings.aws.sns.secret,
+        region: Settings.aws.region
+      }
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = Settings.aws&.s3&.access ? :amazon : :amazon_with_iam
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,9 +6,15 @@ test:
   service: Disk
   root: <%= Rails.root.join('tmp/storage') %>
 
+# This can be removed when IAM is used in all environments
 amazon:
   service: S3
   access_key_id: <%= Settings.aws.s3.access %>
   secret_access_key: <%= Settings.aws.s3.secret %>
+  region: <%= Settings.aws.region %>
+  bucket: <%= Settings.aws.s3.bucket %>
+
+amazon_with_iam:
+  service: S3
   region: <%= Settings.aws.region %>
   bucket: <%= Settings.aws.s3.bucket %>

--- a/lib/tasks/rake_helpers/s3_bucket.rb
+++ b/lib/tasks/rake_helpers/s3_bucket.rb
@@ -36,10 +36,11 @@ class S3Bucket
   end
 
   def client
-    @client ||= Aws::S3::Client.new(
-      access_key_id: credentials.access_key_id,
-      secret_access_key: credentials.secret_access_key
-    )
+    # TODO: Clean this up when IAM is used in all environments
+    @client ||= credentials.access_key_id ? Aws::S3::Client.new(
+        access_key_id: credentials.access_key_id,
+        secret_access_key: credentials.secret_access_key
+      ) : Aws::S3::Client.new
   end
 
   private
@@ -53,21 +54,23 @@ class S3Bucket
   end
 
   def load_from_settings
-    @credentials ||= Credentials.new(
-                   Settings.aws.s3.access,
-                   Settings.aws.s3.secret,
-                   Settings.aws.s3.bucket
-                 )
+    # TODO: Clean this up when IAM is used in all environments
+    @credentials ||= Settings.aws&.s3&.access ? Credentials.new(
+                      Settings.aws.s3.access,
+                      Settings.aws.s3.secret,
+                      Settings.aws.s3.bucket
+                    ) : Credentials.new(Settings.aws.s3.bucket)
   end
 
   def load_from_secrets
     secrets = YAML.safe_load(`#{s3_secrets_cmd}`.chomp)
     secrets['data'].transform_values! { |v| Base64.decode64(v) unless v.nil? }
-    @credentials ||= Credentials.new(
+    # TODO: Clean this up when IAM is used in all environments
+    @credentials ||= secrets['data']['access_key_id'] ? Credentials.new(
                        secrets['data']['access_key_id'],
                        secrets['data']['secret_access_key'],
                        secrets['data']['bucket_name']
-                     )
+                     ) : Credentials.new(secrets['data']['bucket_name'])
   rescue StandardError => e
     raise StandardError, "error retrieving secrets. do you have access?: #{e.message}"
   end


### PR DESCRIPTION
#### What

Allow AWS access to use access keys and secrets if they exist and to use IAM if they do not.

#### Ticket

[How will our systems continue to operate under short lived credentials?](https://dsdmoj.atlassian.net/browse/CTSKF-574)

#### Why

The configuration of our environments is being changed to use IAM instead of credentials. To allow this change to be made gradually both methods will be allowed temporarily.

#### How

At each place where AWS is accessed the presence of an access key is tested. If it is present then it will be used.
