### PR TITLE
Use latest version of Chrome for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,10 +128,7 @@ commands:
 
   install-chrome:
     steps:
-      - browser-tools/install-chrome:
-          # There is no version of Chromedriver for the current latest version of Chrome (116)
-          chrome-version: 114.0.5735.90
-          replace-existing: true
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
   precompile-assets:
     description: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
-  browser-tools: circleci/browser-tools@1.4.4
+  browser-tools: circleci/browser-tools@1.4.6
   slack: circleci/slack@3.4.1
 
 references:


### PR DESCRIPTION
#### What

Use the latest version of Chrome for tests.

#### Ticket

N/A

#### Why

#6012 fixed the version of Chrome because there was no version of Chromedriver released for Chrome 116 and this was causing the pipelines to fail. Ideally we would want tests to run against the latest release.

#### How

The Chrome version is now unrestricted.

If this PR is periodically rebased then it will be possible to see when the latest version can be used again as the tests will run successfully. The quickest way to see this is to check the 'Install Chromedriver' step of the 'other tests' pipeline.