### PR TITLE
[CTSKF-574] Configure dev and dev-lgfs for IAM AWS access

### DIFF
--- a/.k8s/live/dev-lgfs/deployment-worker.yaml
+++ b/.k8s/live/dev-lgfs/deployment-worker.yaml
@@ -20,6 +20,7 @@ spec:
         app: cccd-worker
         tier: worker
     spec:
+      serviceAccountName: cccd-dev-lgfs-service
       containers:
         - name: cccd-worker
           imagePullPolicy: Always
@@ -65,16 +66,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -85,26 +76,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:

--- a/.k8s/live/dev-lgfs/deployment.yaml
+++ b/.k8s/live/dev-lgfs/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: cccd
     spec:
+      serviceAccountName: cccd-dev-lgfs-service
       containers:
         - name: cccd-app
           imagePullPolicy: Always
@@ -75,16 +76,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -95,26 +86,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:

--- a/.k8s/live/dev/deployment-worker.yaml
+++ b/.k8s/live/dev/deployment-worker.yaml
@@ -20,6 +20,7 @@ spec:
         app: cccd-worker
         tier: worker
     spec:
+      serviceAccountName: cccd-dev-service
       containers:
         - name: cccd-worker
           imagePullPolicy: Always
@@ -65,16 +66,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -85,26 +76,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:

--- a/.k8s/live/dev/deployment.yaml
+++ b/.k8s/live/dev/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: cccd
     spec:
+      serviceAccountName: cccd-dev-service
       containers:
         - name: cccd-app
           imagePullPolicy: Always
@@ -75,16 +76,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -95,26 +86,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:

--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -27,8 +27,9 @@ module MessageQueue
 
     private
 
+    # rubocop:disable Metrics/AbcSize
     def aws_credentials
-      return { region: Settings.aws.region } unless Settings.aws.sqs.access
+      return { region: Settings.aws.region } if !Settings.aws.sqs.access || Settings.aws.sqs.access.include?('actual')
 
       # TODO: Remove when IRSA is used in all environments
       {
@@ -37,6 +38,7 @@ module MessageQueue
         region: Settings.aws.region
       }
     end
+    # rubocop:enable Metrics/AbcSize
 
     def queue_url(queue)
       return queue if queue.match?(valid_web_url_regex)

--- a/app/services/notification_queue/aws_client.rb
+++ b/app/services/notification_queue/aws_client.rb
@@ -1,11 +1,7 @@
 module NotificationQueue
   class AwsClient
     def send!(claim)
-      client = Aws::SNS::Client.new(
-        access_key_id: Settings.aws.sns.access,
-        secret_access_key: Settings.aws.sns.secret,
-        region: Settings.aws.region
-      )
+      client = Aws::SNS::Client.new(aws_credentials)
       arn = Settings.aws.sns.submitted_topic_arn
       message = NotificationQueue::MessageTemplate.for_claim(arn, claim)
       client.publish(message)
@@ -14,8 +10,9 @@ module NotificationQueue
 
     private
 
+    # rubocop:disable Metrics/AbcSize
     def aws_credentials
-      return { region: Settings.aws.region } unless Settings.aws.sns.access
+      return { region: Settings.aws.region } if !Settings.aws.sns.access || Settings.aws.sns.access.include?('actual')
 
       # TODO: Remove when IRSA is used in all environments
       {
@@ -24,5 +21,6 @@ module NotificationQueue
         region: Settings.aws.region
       }
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,8 +44,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = Settings.aws&.s3&.access ? :amazon : :amazon_with_iam
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/initializers/02_hack_storage.rb
+++ b/config/initializers/02_hack_storage.rb
@@ -1,0 +1,5 @@
+# TODO: Remove this once config/storage.yml has had these two lines removed
+
+if !ENV['SETTINGS__AWS__S3__ACCESS']
+  system("cat config/storage.yml | grep -v access_key_id | grep -v secret_access_key > config/new_storage.yml && mv config/new_storage.yml config/storage.yml")
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,15 +6,9 @@ test:
   service: Disk
   root: <%= Rails.root.join('tmp/storage') %>
 
-# This can be removed when IAM is used in all environments
 amazon:
   service: S3
   access_key_id: <%= Settings.aws.s3.access %>
   secret_access_key: <%= Settings.aws.s3.secret %>
-  region: <%= Settings.aws.region %>
-  bucket: <%= Settings.aws.s3.bucket %>
-
-amazon_with_iam:
-  service: S3
   region: <%= Settings.aws.region %>
   bucket: <%= Settings.aws.s3.bucket %>


### PR DESCRIPTION
#### What

Switch dev and dev-lgfs environments to use IAM for AWS access instead of access keys and secrets.

#### Ticket

[How will our systems continue to operate under short lived credentials?](https://dsdmoj.atlassian.net/browse/CTSKF-574)

#### Why

To improve security, stored credentials are no longer being used for access AWS and IAM will be used instead.

#### How

Add a service account to the Kubernetes configuration and remove the access keys and secrets.