### PR TITLE
[CTSKF-574] Configure staging for IAM AWS access

### DIFF
--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -20,6 +20,7 @@ spec:
         app: cccd-worker
         tier: worker
     spec:
+      serviceAccountName: cccd-staging-service
       containers:
         - name: cccd-worker
           imagePullPolicy: Always
@@ -72,16 +73,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -92,26 +83,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:

--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: cccd
     spec:
+      serviceAccountName: cccd-staging-service
       containers:
         - name: cccd-app
           imagePullPolicy: Always
@@ -73,16 +74,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -93,26 +84,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
#### What

Switch staging environment to use IAM for AWS access instead of access keys and secrets.

#### Ticket

[How will our systems continue to operate under short lived credentials?](https://dsdmoj.atlassian.net/browse/CTSKF-574)

#### Why

To improve security, stored credentials are no longer being used for access AWS and IAM will be used instead.

#### How

Add a service account to the Kubernetes configuration and remove the access keys and secrets.