### PR TITLE
[CTSKF-574] Configure production for IAM AWS access

### DIFF
--- a/.k8s/live/cron_jobs/archive_stale.yaml
+++ b/.k8s/live/cron_jobs/archive_stale.yaml
@@ -16,6 +16,7 @@ spec:
           labels:
             tier: worker
         spec:
+          serviceAccountName: cccd-production-service
           restartPolicy: Never
           containers:
           - name: cronjob-worker
@@ -43,16 +44,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -20,6 +20,7 @@ spec:
         app: cccd-worker
         tier: worker
     spec:
+      serviceAccountName: cccd-production-service
       containers:
         - name: cccd-worker
           imagePullPolicy: Always
@@ -72,16 +73,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -92,26 +83,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:

--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: cccd
     spec:
+      serviceAccountName: cccd-production-service
       containers:
         - name: cccd-app
           imagePullPolicy: Always
@@ -73,16 +74,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:
@@ -93,26 +84,6 @@ spec:
                 secretKeyRef:
                   name: cccd-messaging
                   key: topic_arn
-            - name: SETTINGS__AWS__SNS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SNS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
-            - name: SETTINGS__AWS__SQS__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: access_key_id
-            - name: SETTINGS__AWS__SQS__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-messaging
-                  key: secret_access_key
             - name: AWS_RESPONSE_QUEUE_NAME
               valueFrom:
                 secretKeyRef:

--- a/app/services/message_queue/aws_client.rb
+++ b/app/services/message_queue/aws_client.rb
@@ -1,7 +1,7 @@
 module MessageQueue
   class AwsClient
     def initialize(queue)
-      @sqs = Aws::SQS::Client.new(aws_credentials)
+      @sqs = Aws::SQS::Client.new(region: Settings.aws.region)
       begin
         @queue_url = queue_url(queue)
       rescue Aws::SQS::Errors::NonExistentQueue
@@ -26,19 +26,6 @@ module MessageQueue
     end
 
     private
-
-    # rubocop:disable Metrics/AbcSize
-    def aws_credentials
-      return { region: Settings.aws.region } if !Settings.aws.sqs.access || Settings.aws.sqs.access.include?('actual')
-
-      # TODO: Remove when IRSA is used in all environments
-      {
-        access_key_id: Settings.aws.sqs.access,
-        secret_access_key: Settings.aws.sqs.secret,
-        region: Settings.aws.region
-      }
-    end
-    # rubocop:enable Metrics/AbcSize
 
     def queue_url(queue)
       return queue if queue.match?(valid_web_url_regex)

--- a/app/services/notification_queue/aws_client.rb
+++ b/app/services/notification_queue/aws_client.rb
@@ -1,26 +1,11 @@
 module NotificationQueue
   class AwsClient
     def send!(claim)
-      client = Aws::SNS::Client.new(aws_credentials)
+      client = Aws::SNS::Client.new(region: Settings.aws.region)
       arn = Settings.aws.sns.submitted_topic_arn
       message = NotificationQueue::MessageTemplate.for_claim(arn, claim)
       client.publish(message)
       true
     end
-
-    private
-
-    # rubocop:disable Metrics/AbcSize
-    def aws_credentials
-      return { region: Settings.aws.region } if !Settings.aws.sns.access || Settings.aws.sns.access.include?('actual')
-
-      # TODO: Remove when IRSA is used in all environments
-      {
-        access_key_id: Settings.aws.sns.access,
-        secret_access_key: Settings.aws.sns.secret,
-        region: Settings.aws.region
-      }
-    end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,5 @@ test:
 
 amazon:
   service: S3
-  access_key_id: <%= Settings.aws.s3.access %>
-  secret_access_key: <%= Settings.aws.s3.secret %>
   region: <%= Settings.aws.region %>
   bucket: <%= Settings.aws.s3.bucket %>

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -19,14 +19,6 @@ else
   printf '\e[33mINFO: Using remote redis-server specified in REDIS_URL\e[0m\n'
 fi
 
-if [ ! $SETTINGS__AWS__S3__ACCESS ]
-then
-  printf '\e[33mINFO: Removing AWS credentials from config/storage.yml\e[0m\n'
-  cat config/storage.yml | grep -v access_key_id | grep -v secret_access_key > config/new_storage.yml && mv config/new_storage.yml config/storage.yml
-else
-  printf '\e[33mINFO: Not removing AWS credentials from config/storage.yml\e[0m\n'
-fi
-
 printf '\e[33mINFO: Starting scheduler_daemon daemon\e[0m\n'
 bundle exec scheduler_daemon start
 


### PR DESCRIPTION
#### What

Switch staging environment to use IAM for AWS access instead of access keys and secrets.

#### Ticket

[How will our systems continue to operate under short lived credentials?](https://dsdmoj.atlassian.net/browse/CTSKF-574)

#### Why

To improve security, stored credentials are no longer being used for access AWS and IAM will be used instead.

#### How

Add a service account to the Kubernetes configuration and remove the access keys and secrets.

Also clean up the temporary configuration from #6013 