### PR TITLE
[CTSKF-574] Modify config/storage.yml in docker entrypoint

### DIFF
--- a/config/initializers/02_hack_storage.rb
+++ b/config/initializers/02_hack_storage.rb
@@ -1,5 +1,0 @@
-# TODO: Remove this once config/storage.yml has had these two lines removed
-
-if !ENV['SETTINGS__AWS__S3__ACCESS']
-  system("cat config/storage.yml | grep -v access_key_id | grep -v secret_access_key > config/new_storage.yml && mv config/new_storage.yml config/storage.yml")
-end

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -19,6 +19,14 @@ else
   printf '\e[33mINFO: Using remote redis-server specified in REDIS_URL\e[0m\n'
 fi
 
+if [ ! $SETTINGS__AWS__S3__ACCESS ]
+then
+  printf '\e[33mINFO: Removing AWS credentials from config/storage.yml\e[0m\n'
+  cat config/storage.yml | grep -v access_key_id | grep -v secret_access_key > config/new_storage.yml && mv config/new_storage.yml config/storage.yml
+else
+  printf '\e[33mINFO: Not removing AWS credentials from config/storage.yml\e[0m\n'
+fi
+
 printf '\e[33mINFO: Starting scheduler_daemon daemon\e[0m\n'
 bundle exec scheduler_daemon start
 


### PR DESCRIPTION
#### What

Use the docker entrypoint file to modify the storage configuration.

#### Ticket

[How will our systems continue to operate under short lived credentials?](https://dsdmoj.atlassian.net/browse/CTSKF-574)

#### Why

The initializer in `config/initializers` gets run multiple times when the pods are started up and in at least one case the environment variables are not set correctly which means that the storage configuration can be modified incorrectly.

#### How

Add to `docker/docker-entrypoint.sh`
