### PR TITLE
Rubocop: Rails/I18nLocaleTexts - move all outstanding text to translations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -889,9 +889,7 @@ RSpec/ImplicitExpect:
     - 'spec/models/disbursement_spec.rb'
     - 'spec/models/disbursement_type_spec.rb'
     - 'spec/models/expense_spec.rb'
-    - 'spec/models/expense_type_spec.rb'
     - 'spec/models/fee/base_fee_spec.rb'
-    - 'spec/models/fee/base_fee_type_spec.rb'
     - 'spec/models/fee/basic_fee_spec.rb'
     - 'spec/models/fee/fixed_fee_spec.rb'
     - 'spec/models/fee/fixed_fee_type_spec.rb'
@@ -1810,26 +1808,6 @@ Rails/HttpPositionalArguments:
   Exclude:
     - 'spec/support/shared_examples_for_api.rb'
 
-# Offense count: 27
-Rails/I18nLocaleTexts:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/concerns/password_helpers.rb'
-    - 'app/controllers/sessions_controller.rb'
-    - 'app/controllers/super_admins/admin/super_admins_controller.rb'
-    - 'app/models/assessment.rb'
-    - 'app/models/case_stage.rb'
-    - 'app/models/case_worker.rb'
-    - 'app/models/certification_type.rb'
-    - 'app/models/claim_intention.rb'
-    - 'app/models/court.rb'
-    - 'app/models/disbursement_type.rb'
-    - 'app/models/expense_type.rb'
-    - 'app/models/fee/base_fee_type.rb'
-    - 'app/models/location.rb'
-    - 'app/models/message.rb'
-    - 'app/models/offence_class.rb'
-
 # Offense count: 4
 Rails/Inquiry:
   Exclude:
@@ -1926,13 +1904,15 @@ Rails/ReadWriteAttribute:
     - 'app/models/expense.rb'
     - 'app/models/injection_attempt.rb'
 
-# Offense count: 6
+# Offense count: 9
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/RedundantPresenceValidationOnBelongsTo:
   Exclude:
     - 'app/models/case_stage.rb'
+    - 'app/models/case_worker.rb'
     - 'app/models/external_user.rb'
     - 'app/models/injection_attempt.rb'
+    - 'app/models/message.rb'
     - 'app/models/offence.rb'
     - 'app/models/user_message_status.rb'
 
@@ -2514,7 +2494,7 @@ Style/WordArray:
     - 'spec/services/cclf/fee/misc_fee_adapter_spec.rb'
     - 'spec/services/claims/context_mapper_spec.rb'
 
-# Offense count: 762
+# Offense count: 764
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
 # URISchemes: http, https

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do |_exception|
-    redirect_to root_path_url_for_user, alert: 'Unauthorised'
+    redirect_to root_path_url_for_user, alert: t('common.unauthorised')
   end
 
   def user_for_paper_trail

--- a/app/controllers/concerns/password_helpers.rb
+++ b/app/controllers/concerns/password_helpers.rb
@@ -12,7 +12,7 @@ module PasswordHelpers
 
     if user.update_with_password(password_params[:user_attributes])
       bypass_sign_in(user)
-      redirect_to signed_in_user_profile_path, notice: 'Password successfully updated'
+      redirect_to signed_in_user_profile_path, notice: t('shared.password_updated')
     else
       render :change_password
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,8 +12,7 @@ class SessionsController < Devise::SessionsController
     respond_to do |format|
       format.all { head :no_content }
       format.any(*navigational_formats) do
-        redirect_to after_sign_out_path_for(resource_name, user_id: @current_user_id),
-                    notice: 'You have signed out'
+        redirect_to after_sign_out_path_for(resource_name, user_id: @current_user_id)
       end
     end
   end

--- a/app/controllers/super_admins/admin/super_admins_controller.rb
+++ b/app/controllers/super_admins/admin/super_admins_controller.rb
@@ -9,7 +9,7 @@ class SuperAdmins::Admin::SuperAdminsController < ApplicationController
 
   def update
     if @super_admin.update(super_admin_params)
-      redirect_to super_admins_admin_super_admin_path(@super_admin), notice: 'Super Administrator successfully updated'
+      redirect_to super_admins_admin_super_admin_path(@super_admin), notice: t('.success')
     else
       render :edit
     end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -29,7 +29,7 @@ class Assessment < Determination
 
   after_initialize :set_default_values
   before_save :set_paper_trail_event!
-  validates :claim_id, uniqueness: { message: 'This claim already has an assessment' }
+  validates :claim_id, uniqueness: true
 
   def set_default_values
     zeroize if new_record?

--- a/app/models/case_stage.rb
+++ b/app/models/case_stage.rb
@@ -7,9 +7,9 @@ class CaseStage < ApplicationRecord
   delegate_missing_to :case_type
 
   validates :case_type_id, presence: true
-  validates :unique_code, presence: { message: 'Case stage unique_code must exist' }
-  validates :unique_code, uniqueness: { case_sensitve: false, message: 'Case stage unique_code must be unique' }
-  validates :description, presence: { message: 'Case stage description must exist' }
+  validates :unique_code, presence: true
+  validates :unique_code, uniqueness: true
+  validates :description, presence: true
 
   scope :chronological, -> { order(position: :asc) }
   scope :active, -> { where.not("unique_code LIKE 'OBSOLETE%'") }

--- a/app/models/case_worker.rb
+++ b/app/models/case_worker.rb
@@ -29,8 +29,8 @@ class CaseWorker < ApplicationRecord
 
   default_scope { includes(:user) }
 
-  validates :location, presence: { message: 'Location cannot be blank' }
-  validates :user, presence: { message: 'User cannot be blank' }
+  validates :location, presence: true
+  validates :user, presence: true
 
   accepts_nested_attributes_for :user
 

--- a/app/models/certification_type.rb
+++ b/app/models/certification_type.rb
@@ -16,8 +16,7 @@ class CertificationType < ApplicationRecord
 
   has_many :certifications
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false,
-                                                 message: 'Certification type name has already been taken' }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   scope :pre_may_2015,              -> { where(pre_may_2015: true) }
   scope :post_may_2015,             -> { where(pre_may_2015: false) }

--- a/app/models/claim_intention.rb
+++ b/app/models/claim_intention.rb
@@ -10,7 +10,7 @@
 #
 
 class ClaimIntention < ApplicationRecord
-  validates :form_id, presence: true, uniqueness: { message: 'There is already a claim with this form-id' }
+  validates :form_id, presence: true, uniqueness: true
 
   belongs_to :user
 end

--- a/app/models/court.rb
+++ b/app/models/court.rb
@@ -17,8 +17,8 @@ class Court < ApplicationRecord
 
   has_many :claims, -> { active }, class_name: 'Claim::BaseClaim', dependent: :nullify
 
-  validates :code, presence: true, uniqueness: { case_sensitve: false, message: 'Court code must be unique' }
-  validates :name, presence: true, uniqueness: { case_sensitve: false, message: 'Court name must be unique' }
+  validates :code, presence: true, uniqueness: { case_sensitve: false }
+  validates :name, presence: true, uniqueness: { case_sensitve: false }
   validates :court_type, presence: true, inclusion: { in: COURT_TYPES }
 
   scope :alphabetical, -> { order(name: :asc) }

--- a/app/models/disbursement_type.rb
+++ b/app/models/disbursement_type.rb
@@ -19,10 +19,6 @@ class DisbursementType < ApplicationRecord
 
   has_many :disbursements, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false,
-                                                 message: 'A disbursement type of this name already exists' }
-  validates :unique_code,
-            presence: true,
-            uniqueness: { case_sensitive: false,
-                          message: 'A disbursement type with this unique code already exists' }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :unique_code, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/models/expense_type.rb
+++ b/app/models/expense_type.rb
@@ -44,12 +44,8 @@ class ExpenseType < ApplicationRecord
 
   has_many :expenses, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false,
-                                                 message: 'An expense type with this name already exists' }
-  validates :unique_code,
-            presence: true,
-            uniqueness: { case_sensitive: false,
-                          message: 'An expense type with this unique code already exists' }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :unique_code, presence: true, uniqueness: { case_sensitive: false }
   validates :reason_set, inclusion: { in: %w[A B C] }
 
   def self.reason_sets

--- a/app/models/fee/base_fee_type.rb
+++ b/app/models/fee/base_fee_type.rb
@@ -42,11 +42,9 @@ module Fee
     has_many :fees, dependent: :destroy, class_name: 'Fee::BaseFee', foreign_key: :fee_type_id
     has_many :claims, -> { active }, through: :fees
 
-    validates :description,
-              presence: { message: 'Fee type description cannot be blank' },
-              uniqueness: { case_sensitive: false, scope: :type, message: 'Fee type description must be unique' }
-    validates :code, presence: { message: 'Fee type code cannot be blank' }
-    validates :unique_code, presence: { message: 'Fee type unique code cannot be blank' }
+    validates :description, presence: true, uniqueness: { case_sensitive: false, scope: :type }
+    validates :code, presence: true
+    validates :unique_code, presence: true
 
     after_initialize :ensure_not_abstract_class
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,7 +13,7 @@ class Location < ApplicationRecord
 
   has_many :case_workers
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false, message: 'This location already exists' }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   def to_s
     name

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -42,9 +42,9 @@ class Message < ApplicationRecord
               image/x-bitmap
             ]
 
-  validates :sender, presence: { message: 'Message sender cannot be blank' }
-  validates :body, presence: { message: 'Message body cannot be blank' }
-  validates :claim_id, presence: { message: 'Message claim_id cannot be blank' }
+  validates :sender, presence: true
+  validates :body, presence: true
+  validates :claim_id, presence: true
 
   scope :most_recent_first, -> { includes(:user_message_statuses).order(created_at: :desc) }
 

--- a/app/models/offence_class.rb
+++ b/app/models/offence_class.rb
@@ -16,9 +16,7 @@ class OffenceClass < ApplicationRecord
 
   has_many :offences, dependent: :destroy
 
-  validates :class_letter, presence: true,
-                           uniqueness: { message: 'Offence class letter must be unique' },
-                           inclusion: { in: CLASS_LETTERS }
+  validates :class_letter, presence: true, uniqueness: true, inclusion: { in: CLASS_LETTERS }
   validates :description, presence: true
 
   default_scope -> { order(class_letter: :asc) }

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -92,9 +92,10 @@ en:
         page_heading: Sign in
         password: Password
         sign_in: Sign in
-      signed_in: ""
-      signed_out: ""
-      already_signed_out: ""
+      user:
+        signed_in: Signed in successfully
+        signed_out: You have signed out
+        already_signed_out: You have signed out
     shared:
       error_messages:
         error_summary_title: There is a problem

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,6 +316,10 @@ en:
               blank: Message claim_id cannot be blank
             sender:
               blank: Message sender cannot be blank
+        offence_class:
+          attributes:
+            class_letter:
+              taken: Offence class letter must be unique
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,8 @@ en:
           submit: *change_password
           page_title: Change %{super_admin}'s password
           page_heading: Change password
+        update:
+          success: Super Administrator successfully updated
     providers:
       provider_type: &provider_type 'Provider type'
       provider_name: &provider_name 'Provider name'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,6 +295,15 @@ en:
               taken: An expense type with this name already exists
             unique_code:
               taken: An expense type with this unique code already exists
+        fee/base_fee_type:
+          attributes:
+            code:
+              blank: Fee type code cannot be blank
+            description:
+              blank: Fee type description cannot be blank
+              taken: Fee type description must be unique
+            unique_code:
+              blank: Fee type unique code cannot be blank
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,6 +273,10 @@ en:
           attributes:
             name:
               taken: Certification type name has already been taken
+        claim_intention:
+          attributes:
+            form_id:
+              taken: There is already a claim with this form-id
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,18 +215,17 @@ en:
               blank: Select a case worker
             claim_ids:
               blank: Select at least one claim to re-allocate
-        fee/graduated_fee:
+        assessment:
           attributes:
-            claim:
-              incompatible_case_type: Fixed fee invalid on non-fixed fee case types
-        external_user:
+            claim_id:
+              taken: This claim already has an assessment
+        case_stage:
           attributes:
-            roles:
-              blank: Choose at least one role
-              inclusion: *inclusion
-            supplier_number:
-              blank: Enter a supplier number
-              invalid: Enter a valid supplier number
+            unique_code:
+              blank: Case stage unique_code must exist
+              taken: Case stage unique_code must be unique
+            description:
+              blank: Case stage description must exist
         case_worker:
           attributes:
             location:
@@ -235,6 +234,69 @@ en:
               blank: cannot be blank
             user:
               blank: User cannot be blank
+        certification_type:
+          attributes:
+            name:
+              taken: Certification type name has already been taken
+        claim_intention:
+          attributes:
+            form_id:
+              taken: There is already a claim with this form-id
+        court:
+          attributes:
+            code:
+              taken: Court code must be unique
+            name:
+              taken: Court name must be unique
+        disbursement_type:
+          attributes:
+            name:
+              taken: A disbursement type of this name already exists
+            unique_code:
+              taken: A disbursement type with this unique code already exists
+        expense_type:
+          attributes:
+            name:
+              taken: An expense type with this name already exists
+            unique_code:
+              taken: An expense type with this unique code already exists
+        external_user:
+          attributes:
+            roles:
+              blank: Choose at least one role
+              inclusion: *inclusion
+            supplier_number:
+              blank: Enter a supplier number
+              invalid: Enter a valid supplier number
+        fee/base_fee_type:
+          attributes:
+            code:
+              blank: Fee type code cannot be blank
+            description:
+              blank: Fee type description cannot be blank
+              taken: Fee type description must be unique
+            unique_code:
+              blank: Fee type unique code cannot be blank
+        fee/graduated_fee:
+          attributes:
+            claim:
+              incompatible_case_type: Fixed fee invalid on non-fixed fee case types
+        location:
+          attributes:
+            name:
+              taken: This location already exists
+        message:
+          attributes:
+            body:
+              blank: Message body cannot be blank
+            claim_id:
+              blank: Message claim_id cannot be blank
+            sender:
+              blank: Message sender cannot be blank
+        offence_class:
+          attributes:
+            class_letter:
+              taken: Offence class letter must be unique
         user:
           attributes:
             email:
@@ -262,68 +324,6 @@ en:
               too_long: Last name must be 40 characters or less
             terms_and_conditions:
               accepted: You must accept the terms and conditions
-        assessment:
-          attributes:
-            claim_id:
-              taken: This claim already has an assessment
-        case_stage:
-          attributes:
-            unique_code:
-              blank: Case stage unique_code must exist
-              taken: Case stage unique_code must be unique
-            description:
-              blank: Case stage description must exist
-        certification_type:
-          attributes:
-            name:
-              taken: Certification type name has already been taken
-        claim_intention:
-          attributes:
-            form_id:
-              taken: There is already a claim with this form-id
-        court:
-          attributes:
-            code:
-              taken: Court code must be unique
-            name:
-              taken: Court name must be unique
-        disbursement_type:
-          attributes:
-            name:
-              taken: A disbursement type of this name already exists
-            unique_code:
-              taken: A disbursement type with this unique code already exists
-        expense_type:
-          attributes:
-            name:
-              taken: An expense type with this name already exists
-            unique_code:
-              taken: An expense type with this unique code already exists
-        fee/base_fee_type:
-          attributes:
-            code:
-              blank: Fee type code cannot be blank
-            description:
-              blank: Fee type description cannot be blank
-              taken: Fee type description must be unique
-            unique_code:
-              blank: Fee type unique code cannot be blank
-        location:
-          attributes:
-            name:
-              taken: This location already exists
-        message:
-          attributes:
-            body:
-              blank: Message body cannot be blank
-            claim_id:
-              blank: Message claim_id cannot be blank
-            sender:
-              blank: Message sender cannot be blank
-        offence_class:
-          attributes:
-            class_letter:
-              taken: Offence class letter must be unique
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,8 +229,12 @@ en:
               invalid: Enter a valid supplier number
         case_worker:
           attributes:
+            location:
+              blank: Location cannot be blank
             roles:
               blank: cannot be blank
+            user:
+              blank: User cannot be blank
         user:
           attributes:
             email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,7 @@ en:
     description: Description
     warning: 'Warning'
     send: &send Send
+    unauthorised: Unauthorised
   link:
     add_claim: Start a claim
     back: Back

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,6 +304,10 @@ en:
               taken: Fee type description must be unique
             unique_code:
               blank: Fee type unique code cannot be blank
+        location:
+          attributes:
+            name:
+              taken: This location already exists
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,6 +289,12 @@ en:
               taken: A disbursement type of this name already exists
             unique_code:
               taken: A disbursement type with this unique code already exists
+        expense_type:
+          attributes:
+            name:
+              taken: An expense type with this name already exists
+            unique_code:
+              taken: An expense type with this unique code already exists
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,6 +277,12 @@ en:
           attributes:
             form_id:
               taken: There is already a claim with this form-id
+        court:
+          attributes:
+            code:
+              taken: Court code must be unique
+            name:
+              taken: Court name must be unique
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2386,6 +2386,7 @@ en:
     summary_totals: 'Summary totals'
     vat: 'VAT'
     position_and_count: 'Showing %{position} claims'
+    password_updated: 'Password successfully updated'
   case_workers:
     table_headings:
       your_claims: Your claims

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,6 +269,10 @@ en:
               taken: Case stage unique_code must be unique
             description:
               blank: Case stage description must exist
+        certification_type:
+          attributes:
+            name:
+              taken: Certification type name has already been taken
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,13 @@ en:
               too_long: Last name must be 40 characters or less
             terms_and_conditions:
               accepted: You must accept the terms and conditions
+        case_stage:
+          attributes:
+            unique_code:
+              blank: Case stage unique_code must exist
+              taken: Case stage unique_code must be unique
+            description:
+              blank: Case stage description must exist
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,6 +262,10 @@ en:
               too_long: Last name must be 40 characters or less
             terms_and_conditions:
               accepted: You must accept the terms and conditions
+        assessment:
+          attributes:
+            claim_id:
+              taken: This claim already has an assessment
         case_stage:
           attributes:
             unique_code:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,6 +283,12 @@ en:
               taken: Court code must be unique
             name:
               taken: Court name must be unique
+        disbursement_type:
+          attributes:
+            name:
+              taken: A disbursement type of this name already exists
+            unique_code:
+              taken: A disbursement type with this unique code already exists
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,6 +308,14 @@ en:
           attributes:
             name:
               taken: This location already exists
+        message:
+          attributes:
+            body:
+              blank: Message body cannot be blank
+            claim_id:
+              blank: Message claim_id cannot be blank
+            sender:
+              blank: Message sender cannot be blank
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -158,6 +158,8 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController do
       it 'redirects to case_worker show action' do
         expect(response).to redirect_to(case_workers_admin_case_worker_path(subject))
       end
+
+      it { expect(flash[:notice]).to eq('Password successfully updated') }
     end
 
     context 'when mandatory params for case worker are not provided' do

--- a/spec/controllers/super_admins/admin/super_admins_controller_spec.rb
+++ b/spec/controllers/super_admins/admin/super_admins_controller_spec.rb
@@ -95,6 +95,10 @@ RSpec.describe SuperAdmins::Admin::SuperAdminsController do
       it 'redirects to super admin show page' do
         expect(response).to redirect_to(super_admins_admin_super_admin_path(subject))
       end
+
+      it 'displays a success message' do
+        expect(flash[:notice]).to eq('Super Administrator successfully updated')
+      end
     end
 
     context 'when invalid' do

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe Assessment do
         }.to raise_error ActiveRecord::RecordInvalid, 'Validation failed: Assessed disbursements must be greater than or equal to zero'
       end
     end
+
+    context 'when validating claim_id' do
+      let(:duplicate_claim) { create(:claim) }
+
+      it 'does not accept a duplicate id' do
+        expect do
+          claim.assessment.update!(claim_id: duplicate_claim.id)
+        end.to raise_error ActiveRecord::RecordInvalid, 'Validation failed: Claim This claim already has an assessment'
+      end
+    end
   end
 
   context 'automatic calculation of total' do

--- a/spec/models/case_stage_spec.rb
+++ b/spec/models/case_stage_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CaseStage do
 
   describe '#unique_code' do
     it { is_expected.to validate_presence_of(:unique_code).with_message('Case stage unique_code must exist') }
-    it { is_expected.to validate_uniqueness_of(:unique_code).with_message('Case stage unique_code must be unique') }
+    it { is_expected.to validate_uniqueness_of(:unique_code).ignoring_case_sensitivity.with_message('Case stage unique_code must be unique') }
   end
 
   describe '#description' do

--- a/spec/models/expense_type_spec.rb
+++ b/spec/models/expense_type_spec.rb
@@ -16,10 +16,11 @@ require 'rails_helper'
 RSpec.describe ExpenseType do
   it_behaves_like 'roles', ExpenseType, ExpenseType::ROLES
 
-  it { should have_many(:expenses) }
+  it { is_expected.to have_many(:expenses) }
 
-  it { should validate_presence_of(:name) }
-  it { should validate_uniqueness_of(:name).ignoring_case_sensitivity.with_message('An expense type with this name already exists') }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name).ignoring_case_sensitivity.with_message('An expense type with this name already exists') }
+  it { is_expected.to validate_uniqueness_of(:unique_code).ignoring_case_sensitivity.with_message('An expense type with this unique code already exists') }
 
   context 'ROLES' do
     it 'has "agfs" and "lgfs"' do

--- a/spec/models/fee/base_fee_type_spec.rb
+++ b/spec/models/fee/base_fee_type_spec.rb
@@ -40,14 +40,15 @@ RSpec.describe Fee::BaseFeeType do
   it_behaves_like 'roles', Fee::MiscFeeType, Fee::MiscFeeType::ROLES # using MiscFeeType because the shared examples use a factory, which rules out the use of a class double
   it_behaves_like 'defendant upliftable'
 
-  it { should have_many(:fees) }
+  it { is_expected.to have_many(:fees) }
 
-  it { should validate_presence_of(:description).with_message('Fee type description cannot be blank') }
-  it { should validate_presence_of(:code).with_message('Fee type code cannot be blank') }
-  it { should validate_uniqueness_of(:description).ignoring_case_sensitivity.with_message('Fee type description must be unique').scoped_to(:type) }
+  it { is_expected.to validate_presence_of(:description).with_message('Fee type description cannot be blank') }
+  it { is_expected.to validate_presence_of(:code).with_message('Fee type code cannot be blank') }
+  it { is_expected.to validate_presence_of(:unique_code).with_message('Fee type unique code cannot be blank') }
+  it { is_expected.to validate_uniqueness_of(:description).ignoring_case_sensitivity.with_message('Fee type description must be unique').scoped_to(:type) }
 
-  it { should respond_to(:code) }
-  it { should respond_to(:description) }
+  it { is_expected.to respond_to(:code) }
+  it { is_expected.to respond_to(:description) }
 
   describe '#requires_dates_attended?' do
     it 'returns false' do


### PR DESCRIPTION
#### What

Fixes all outstanding `Rails/I18nLocaleTexts` offences in CCCD by moving text from controllers, helpers and models into locale files. (There's additional work that could be done to structure these locale files better but this PR is already big enough 😬).

#### Why

To improve our overall code quality and maintainability.
