### PR TITLE
Remove the orig_scheme_filters partial

### DIFF
--- a/app/views/case_workers/admin/allocations/_orig_scheme_filters.html.haml
+++ b/app/views/case_workers/admin/allocations/_orig_scheme_filters.html.haml
@@ -1,4 +1,0 @@
-.allocation-filter-form
-  = f.govuk_radio_buttons_fieldset :scheme, legend: { text: t('.scheme_types'), size: 'm' } do
-    - allocation_scheme_filters.each do | filter_scheme |
-      = f.govuk_radio_button :scheme, filter_scheme, label: { text: filter_scheme.upcase }

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -8,7 +8,7 @@
         = govuk_error_summary(@allocation, :allocation)
 
     = form_with url: case_workers_admin_allocations_path, method: :get, builder: GdsAdpFormBuilder do |f|
-      = render partial: 'orig_scheme_filters', locals: { f: f }
+      = render partial: 'scheme_filters', locals: { f: f }
 
       = render partial: 'shared/search_form', locals: { search_path: case_workers_admin_allocations_path(anchor: 'search-button'), hint_text: t('hint.search'), button_text: t('search.claims') }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2558,10 +2558,6 @@ en:
           claim_total: 'Claim total'
           defendants: Defendants
           no_of_claims: 'Number of claims'
-        orig_scheme_filters:
-          scheme_types: 'Scheme types'
-          filter: Filter
-          filter_scheme_label: Filter by scheme %{scheme}
         re_allocation:
           allocation_pool_label: Allocate to allocation pool
           case_worker_label: Allocate to a caseworker


### PR DESCRIPTION
This partial appears to be part of an incomplete refactor and does not seem to serve any useful purpose. The result is slightly different from the scheme_filters partial so the this will change the display of the reallocation page.

#### What

#### Ticket

[board ticket description](link)

#### Why

#### How


#### Before

<img width="502" alt="Screenshot 2023-09-29 at 13 08 21" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/ff0e96b4-9ad8-4544-b445-dcb1b3f0e99d">


#### After

<img width="469" alt="Screenshot 2023-09-29 at 13 08 50" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/a050ce23-fb95-4657-9494-9781ca4dd1d5">

This is consistent with the allocation page.

--------

#### TODO (wip)

 - [ ] The list of claims is updated automatically when AGFS or LGFS is selected but the two forms do this in different ways;
   * In the reallocation form the page is reloaded via app/webpack/javascripts/modules/Modules.ReAllocationFilterSubmit.js
   * In the allocation form the table is updated via an AJAX request in app/webpack/javascripts/modules/Modules.AllocationDataTable.js using app/webpack/javascripts/modules/Modules.AllocationScheme.js
