### PR TITLE
Hotfix to CTSKF-541

### DIFF
--- a/app/services/stats/fee_scheme_usage_generator.rb
+++ b/app/services/stats/fee_scheme_usage_generator.rb
@@ -84,9 +84,9 @@ module Stats
     def generate_row(month, fee_scheme)
       key_fs = symbol_key(fee_scheme)
       row = [month, fee_scheme,
-             @results[key_fs][:total_claims], @results[key_fs][:total_value], @results[key_fs][:latest]]
+             @results[key_fs][:total_claims], @results[key_fs][:total_value].round(2), @results[key_fs][:latest]]
 
-      case_and_claim_types = case_types + CLAIM_TYPES
+      case_and_claim_types = CLAIM_TYPES + case_types
       case_and_claim_types.each do |type|
         row << @results[key_fs][symbol_key(type)]
       end

--- a/spec/services/stats/fee_scheme_usage_generator_spec.rb
+++ b/spec/services/stats/fee_scheme_usage_generator_spec.rb
@@ -113,44 +113,38 @@ RSpec.describe Stats::FeeSchemeUsageGenerator do
     end
 
     it 'has expected headers' do
-      expect(csv.headers).to match_array(expected_headers)
+      expect(csv.headers).to eq(expected_headers)
     end
 
     context 'when generating all month sections' do
       subject(:call) { described_class.new.call }
 
       it 'returns rows containing the correct numbers of total claims' do
-        expect(csv['Total number of claims']).to match_array(total_claims_array)
+        expect(csv['Total number of claims']).to eq(total_claims_array)
       end
     end
 
     context 'when generating the most recent month' do
       it 'returns rows containing the correct fee schemes' do
-        expect(csv['Fee scheme'][50...59]).to match_array(fee_scheme_array)
+        expect(csv['Fee scheme'][50...59]).to eq(fee_scheme_array)
       end
 
       it 'returns rows containing the correct total value of claims' do
-        expect(csv['Total value of claims'][50...60]).to contain_exactly(
-          '380.0', '0', '0', '0', '0.0', '0', '0', '75.02', '0', nil
-        )
+        expect(csv['Total value of claims'][50...60]).to eq([
+                                                              '380.0', '0', '0', '0', '0.0', '0', '0', '75.02', '0', nil
+                                                            ])
       end
 
       it 'has the correct totals of claim and case types for AGFS 9' do
-        expect(csv[50][5...26]).to contain_exactly(
-          '13', '1', '0', '1', '0', '0', '0', '0', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '2'
-        )
+        expect(csv[50][5...26]).to eq(%w[13 1 0 1 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 2])
       end
 
       it 'has the correct totals of claim and case types for AGFS 13' do
-        expect(csv[54][5...26]).to contain_exactly(
-          '0', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'
-        )
+        expect(csv[54][5...26]).to eq(%w[0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1])
       end
 
       it 'has the correct totals of claim and case types for LGFS 9' do
-        expect(csv[57][5...26]).to contain_exactly(
-          '0', '0', '0', '0', '1', '1', '1', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '2'
-        )
+        expect(csv[57][5...26]).to eq(%w[0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 2])
       end
     end
   end


### PR DESCRIPTION


#### What

case_types and CLAIM_TYPES were being processed in the wrong order.

Added additional .round(2) to improve visual formatting of total claim values.

#### Ticket

[CTSKF-541](https://dsdmoj.atlassian.net/browse/CTSKF-541)

#### Why

#### How




[CTSKF-541]: https://dsdmoj.atlassian.net/browse/CTSKF-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ