### PR TITLE
Increase Sidekiq logging level for tests

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -19,3 +19,7 @@ if ENV['INLINE_SIDEKIQ'].eql?('true')
   require 'sidekiq/testing'
   Sidekiq::Testing.inline!
 end
+
+if Rails.env.test?
+  Sidekiq.logger.level = Logger::WARN
+end


### PR DESCRIPTION
#### What

Sidekiq defaults to logging `INFO` for all environments. Recently (since moving to Sidekiq v7?) this has resulted in connection info being output when running tests.

#### Why

This has no impact on the way tests run but is visually noisy and a little distracting.

#### How

Updates the Sidekiq initializer to increase the logging level for the test environment to `WARN` so that only more important information is logged when running tests.

#### Evidence

Tested by running `bundle exec rspec spec/api/v2`.

**Before**

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/919b0d4d-0e1e-47f5-a463-a330ec5e18da)

**After**

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/8c06c44d-2240-4476-bbb8-6d4b633c8fd4)
