### PR TITLE
Remove diskspace check

### DIFF
--- a/.k8s/live/api-sandbox/prometheus-custom-rules.yaml
+++ b/.k8s/live/api-sandbox/prometheus-custom-rules.yaml
@@ -34,10 +34,3 @@ spec:
       annotations:
         message: cccd-api-sandbox An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-api-sandbox),query:(match:(log_processed.kubernetes_namespace:(query:cccd-api-sandbox,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="cccd-api-sandbox"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-api-sandbox"})
-      for: 1m
-      labels:
-        severity: laa-cccd-alerts
-      annotations:
-        message: cccd-api-sandbox Container disk space usage is more than 1Gi or is not reported

--- a/.k8s/live/dev-lgfs/prometheus-custom-rules.yaml
+++ b/.k8s/live/dev-lgfs/prometheus-custom-rules.yaml
@@ -34,10 +34,3 @@ spec:
       annotations:
         message: cccd-dev-lgfs An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev-lgfs),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev-lgfs,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="cccd-dev-lgfs"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-dev-lgfs"})
-      for: 1m
-      labels:
-        severity: laa-cccd-alerts
-      annotations:
-        message: cccd-dev-lgfs Container disk space usage is more than 1Gi or is not reported

--- a/.k8s/live/dev/prometheus-custom-rules.yaml
+++ b/.k8s/live/dev/prometheus-custom-rules.yaml
@@ -34,13 +34,6 @@ spec:
       annotations:
         message: cccd-dev An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="cccd-dev"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-dev"})
-      for: 1m
-      labels:
-        severity: laa-cccd-alerts
-      annotations:
-        message: cccd-dev Container disk space usage is more than 1Gi or is not reported
     - alert: DEV-SQS-Responses-For-CCCD-oldest-message
       annotations:
         message: DEV SQS queue 'laa-get-paid-dev-responses-for-cccd' has messages older than or equal to 10 mins, check consumers are healthy.

--- a/.k8s/live/production/prometheus-custom-rules.yaml
+++ b/.k8s/live/production/prometheus-custom-rules.yaml
@@ -34,13 +34,6 @@ spec:
       annotations:
         message: cccd-production An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-production),query:(match:(log_processed.kubernetes_namespace:(query:cccd-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="cccd-production"} / 1024 / 1024 > 2048 or absent(container_fs_usage_bytes{namespace="cccd-production"})
-      for: 1m
-      labels:
-        severity: laa-cccd-alerts
-      annotations:
-        message: cccd-production Container disk space usage is more than 2Gi or is not reported
     - alert: Production-SQS-Responses-For-CCCD-oldest-message
       annotations:
         message: Production SQS queue 'laa-get-paid-production-responses-for-cccd' has messages older than or equal to 10 mins, check consumers are healthy.

--- a/.k8s/live/staging/prometheus-custom-rules.yaml
+++ b/.k8s/live/staging/prometheus-custom-rules.yaml
@@ -34,13 +34,6 @@ spec:
       annotations:
         message: cccd-staging An HTTP 5xx error has occurred
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-staging),query:(match:(log_processed.kubernetes_namespace:(query:cccd-staging,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
-    - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="cccd-staging"} / 1024 / 1024 > 2048 or absent(container_fs_usage_bytes{namespace="cccd-staging"})
-      for: 1m
-      labels:
-        severity: laa-cccd-alerts
-      annotations:
-        message: cccd-staging Container disk space usage is more than 2Gi or is not reported
     - alert: Staging-SQS-Responses-For-CCCD-oldest-message
       annotations:
         message: Staging SQS queue 'laa-get-paid-staging-responses-for-cccd' has messages older than or equal to 10 mins, check consumers are healthy.


### PR DESCRIPTION
#### What

Remove the alert for disk space from Prometheus

#### Ticket

N/A

#### Why

The container_fs_usage_bytes metric is no longer available in k8s so this alert is just reporting false positives. It is possible that this metric can be re-enabled via a plugin but 

#### How

Remove the `DiskSpace-Threshold-Reached` alert from each of the Prometheus configuration files.
