### PR TITLE
CTSKF-241 Zeitwerk: AGFS/LGFS inflections

### DIFF
--- a/app/services/stats/management_information/agfs_query_set.rb
+++ b/app/services/stats/management_information/agfs_query_set.rb
@@ -1,6 +1,6 @@
 module Stats
   module ManagementInformation
-    class AgfsQuerySet
+    class AGFSQuerySet
       include Enumerable
 
       def each(&)
@@ -10,14 +10,14 @@ module Stats
       private
 
       def set
-        { intake_fixed_fee: Agfs::IntakeFixedFeeQuery,
-          intake_final_fee: Agfs::IntakeFinalFeeQuery,
-          af1_high_value: Agfs::Af1HighValueQuery,
-          af1_disk: Agfs::Af1DiskQuery,
-          af2_redetermination: Agfs::Af2RedeterminationQuery,
-          af2_high_value: Agfs::Af2HighValueQuery,
-          af2_disk: Agfs::Af2DiskQuery,
-          written_reasons: Agfs::WrittenReasonsQuery }
+        { intake_fixed_fee: AGFS::IntakeFixedFeeQuery,
+          intake_final_fee: AGFS::IntakeFinalFeeQuery,
+          af1_high_value: AGFS::Af1HighValueQuery,
+          af1_disk: AGFS::Af1DiskQuery,
+          af2_redetermination: AGFS::Af2RedeterminationQuery,
+          af2_high_value: AGFS::Af2HighValueQuery,
+          af2_disk: AGFS::Af2DiskQuery,
+          written_reasons: AGFS::WrittenReasonsQuery }
       end
     end
   end

--- a/app/services/stats/management_information/lgfs_query_set.rb
+++ b/app/services/stats/management_information/lgfs_query_set.rb
@@ -1,6 +1,6 @@
 module Stats
   module ManagementInformation
-    class LgfsQuerySet
+    class LGFSQuerySet
       include Enumerable
 
       def each(&)
@@ -10,15 +10,15 @@ module Stats
       private
 
       def set
-        { intake_fixed_fee: Lgfs::IntakeFixedFeeQuery,
-          intake_final_fee: Lgfs::IntakeFinalFeeQuery,
-          lf1_high_value: Lgfs::Lf1HighValueQuery,
-          lf1_disk: Lgfs::Lf1DiskQuery,
-          lf2_redetermination: Lgfs::Lf2RedeterminationQuery,
-          lf2_high_value: Lgfs::Lf2HighValueQuery,
-          lf2_disk: Lgfs::Lf2DiskQuery,
-          written_reasons: Lgfs::WrittenReasonsQuery,
-          intake_interim_fee: Lgfs::IntakeInterimFeeQuery }
+        { intake_fixed_fee: LGFS::IntakeFixedFeeQuery,
+          intake_final_fee: LGFS::IntakeFinalFeeQuery,
+          lf1_high_value: LGFS::Lf1HighValueQuery,
+          lf1_disk: LGFS::Lf1DiskQuery,
+          lf2_redetermination: LGFS::Lf2RedeterminationQuery,
+          lf2_high_value: LGFS::Lf2HighValueQuery,
+          lf2_disk: LGFS::Lf2DiskQuery,
+          written_reasons: LGFS::WrittenReasonsQuery,
+          intake_interim_fee: LGFS::IntakeInterimFeeQuery }
       end
     end
   end

--- a/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
@@ -11,7 +11,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class Af1DiskQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
@@ -13,7 +13,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class Af1HighValueQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
@@ -11,7 +11,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class Af2DiskQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
@@ -12,7 +12,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class Af2HighValueQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
@@ -12,7 +12,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class Af2RedeterminationQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
@@ -13,7 +13,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class IntakeFinalFeeQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
@@ -14,7 +14,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class IntakeFixedFeeQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
@@ -10,7 +10,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Agfs
+    module AGFS
       class WrittenReasonsQuery < BaseCountQuery
         acts_as_scheme :agfs
 

--- a/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
@@ -14,7 +14,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class IntakeFinalFeeQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
@@ -13,7 +13,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class IntakeFixedFeeQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
@@ -13,7 +13,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class IntakeInterimFeeQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/lf1_disk_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf1_disk_query.rb
@@ -11,7 +11,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class Lf1DiskQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
@@ -12,7 +12,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class Lf1HighValueQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
@@ -11,7 +11,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class Lf2DiskQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
@@ -12,7 +12,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class Lf2HighValueQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/lf2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_redetermination_query.rb
@@ -12,7 +12,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class Lf2RedeterminationQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
@@ -16,7 +16,7 @@ module Stats
 
         private
 
-        # OPTIMIZE: this is the sames as Agfs::WrittenReasonsQuery
+        # OPTIMIZE: this is the sames as AGFS::WrittenReasonsQuery
         def query
           <<~SQL
             WITH days AS (

--- a/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
@@ -10,7 +10,7 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module Lgfs
+    module LGFS
       class WrittenReasonsQuery < BaseCountQuery
         acts_as_scheme :lgfs
 

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -31,7 +31,7 @@ module Stats
             default_args: { query_set: Stats::ManagementInformation::AGFSQuerySet.new, duration: (1.month - 1.day) } },
         lgfs_management_information_statistics:
           { class: Stats::ManagementInformation::DailyReportCountGenerator,
-            default_args: { query_set: Stats::ManagementInformation::LgfsQuerySet.new, duration: (1.month - 1.day) } }
+            default_args: { query_set: Stats::ManagementInformation::LGFSQuerySet.new, duration: (1.month - 1.day) } }
       )[report_type.to_sym]
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/services/stats/stats_report_generator.rb
+++ b/app/services/stats/stats_report_generator.rb
@@ -28,7 +28,7 @@ module Stats
             default_args: { scheme: :lgfs } },
         agfs_management_information_statistics:
           { class: Stats::ManagementInformation::DailyReportCountGenerator,
-            default_args: { query_set: Stats::ManagementInformation::AgfsQuerySet.new, duration: (1.month - 1.day) } },
+            default_args: { query_set: Stats::ManagementInformation::AGFSQuerySet.new, duration: (1.month - 1.day) } },
         lgfs_management_information_statistics:
           { class: Stats::ManagementInformation::DailyReportCountGenerator,
             default_args: { query_set: Stats::ManagementInformation::LgfsQuerySet.new, duration: (1.month - 1.day) } }

--- a/app/validators/fee/agfs/fee_type_rules.rb
+++ b/app/validators/fee/agfs/fee_type_rules.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Fee
-  module Agfs
+  module AGFS
     class FeeTypeRules
       include Fee::Concerns::FeeTypeRulesCreator
 

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -32,7 +32,7 @@ module Fee
     end
 
     def validate_agfs_fee_type_rules
-      rule_sets = Fee::Agfs::FeeTypeRules.where(unique_code: @record.fee_type&.unique_code)
+      rule_sets = Fee::AGFS::FeeTypeRules.where(unique_code: @record.fee_type&.unique_code)
       Rule::Validator.new(@record, rule_sets).validate if rule_sets.present?
     end
 

--- a/app/validators/fee/lgfs/fee_type_rules.rb
+++ b/app/validators/fee/lgfs/fee_type_rules.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Fee
-  module Lgfs
+  module LGFS
     class FeeTypeRules
       include Fee::Concerns::FeeTypeRulesCreator
 

--- a/app/validators/fee/misc_fee_validator.rb
+++ b/app/validators/fee/misc_fee_validator.rb
@@ -22,7 +22,7 @@ module Fee
     end
 
     def validate_lgfs_fee_type_rules
-      rule_sets = Fee::Lgfs::FeeTypeRules.where(unique_code: @record.fee_type&.unique_code)
+      rule_sets = Fee::LGFS::FeeTypeRules.where(unique_code: @record.fee_type&.unique_code)
       Rule::Validator.new(@record, rule_sets).validate if rule_sets.present?
     end
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,6 +16,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'LF1'
   inflect.acronym 'LF2'
   inflect.acronym 'AGFS'
+  inflect.acronym 'LGFS'
   inflect.human(/af1_lf1_processed_by/, "af1/lf1 processed by")
 end
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,6 +15,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'AF2'
   inflect.acronym 'LF1'
   inflect.acronym 'LF2'
+  inflect.acronym 'AGFS'
   inflect.human(/af1_lf1_processed_by/, "af1/lf1 processed by")
 end
 

--- a/db/seeds/lgfs_scheme_10.rb
+++ b/db/seeds/lgfs_scheme_10.rb
@@ -1,7 +1,7 @@
 require Rails.root.join('db','seeds', 'schemas', 'add_lgfs_fee_scheme_10')
 require Rails.root.join('db','seeds', 'schemas', 'clean_lgfs_fee_scheme_10')
 
-adder = Seeds::Schemas::AddLgfsFeeScheme10.new(pretend: false)
+adder = Seeds::Schemas::AddLGFSFeeScheme10.new(pretend: false)
 adder.up
-fixer = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: false, quiet: true)
+fixer = Seeds::Schemas::CleanLGFSFeeScheme10.new(pretend: false, quiet: true)
 fixer.up

--- a/db/seeds/schemas/add_agfs_fee_scheme_12.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_12.rb
@@ -7,7 +7,7 @@
 #
 module Seeds
   module Schemas
-    class AddAgfsFeeScheme12
+    class AddAGFSFeeScheme12
       attr_reader :pretend
       alias_method :pretending?, :pretend
 

--- a/db/seeds/schemas/add_agfs_fee_scheme_13.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_13.rb
@@ -7,7 +7,7 @@
 #
 module Seeds
   module Schemas
-    class AddAgfsFeeScheme13
+    class AddAGFSFeeScheme13
       attr_reader :pretend
       alias_method :pretending?, :pretend
 

--- a/db/seeds/schemas/add_agfs_fee_scheme_14.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_14.rb
@@ -1,6 +1,6 @@
 module Seeds
   module Schemas
-    class AddAgfsFeeScheme14
+    class AddAGFSFeeScheme14
       attr_reader :pretend
       alias_method :pretending?, :pretend
 

--- a/db/seeds/schemas/add_agfs_fee_scheme_15.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_15.rb
@@ -1,6 +1,6 @@
 module Seeds
   module Schemas
-    class AddAgfsFeeScheme15
+    class AddAGFSFeeScheme15
       attr_reader :pretend
       alias_method :pretending?, :pretend
 

--- a/db/seeds/schemas/add_lgfs_fee_scheme_10.rb
+++ b/db/seeds/schemas/add_lgfs_fee_scheme_10.rb
@@ -7,7 +7,7 @@
 #
 module Seeds
   module Schemas
-    class AddLgfsFeeScheme10
+    class AddLGFSFeeScheme10
       attr_reader :pretend
       alias_method :pretending?, :pretend
 

--- a/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
+++ b/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
@@ -1,6 +1,6 @@
 module Seeds
   module Schemas
-    class CleanLgfsFeeScheme10
+    class CleanLGFSFeeScheme10
       attr_reader :pretend
       alias_method :pretending?, :pretend
 

--- a/db/seeds/scheme_12.rb
+++ b/db/seeds/scheme_12.rb
@@ -1,4 +1,4 @@
 require Rails.root.join('db','seeds', 'schemas', 'add_agfs_fee_scheme_12')
 
-adder = Seeds::Schemas::AddAgfsFeeScheme12.new(pretend: false)
+adder = Seeds::Schemas::AddAGFSFeeScheme12.new(pretend: false)
 adder.up

--- a/db/seeds/scheme_13.rb
+++ b/db/seeds/scheme_13.rb
@@ -1,4 +1,4 @@
 require Rails.root.join('db','seeds', 'schemas', 'add_agfs_fee_scheme_13')
 
-adder = Seeds::Schemas::AddAgfsFeeScheme13.new(pretend: false)
+adder = Seeds::Schemas::AddAGFSFeeScheme13.new(pretend: false)
 adder.up

--- a/db/seeds/scheme_14.rb
+++ b/db/seeds/scheme_14.rb
@@ -1,4 +1,4 @@
 require Rails.root.join('db','seeds', 'schemas', 'add_agfs_fee_scheme_14')
 
-adder = Seeds::Schemas::AddAgfsFeeScheme14.new(pretend: false)
+adder = Seeds::Schemas::AddAGFSFeeScheme14.new(pretend: false)
 adder.up

--- a/db/seeds/scheme_15.rb
+++ b/db/seeds/scheme_15.rb
@@ -1,4 +1,4 @@
 require Rails.root.join('db','seeds', 'schemas', 'add_agfs_fee_scheme_15')
 
-adder = Seeds::Schemas::AddAgfsFeeScheme15.new(pretend: false)
+adder = Seeds::Schemas::AddAGFSFeeScheme15.new(pretend: false)
 adder.up

--- a/features/page_objects/litigator_claim_form_page.rb
+++ b/features/page_objects/litigator_claim_form_page.rb
@@ -11,14 +11,14 @@ class LitigatorClaimFormPage < ClaimFormPage
 
   section :case_concluded_date, GovukDateSection, '#case_concluded_at'
 
-  sections :miscellaneous_fees, LgfsMiscFeeSection, "div#misc-fees .misc-fee-group"
+  sections :miscellaneous_fees, LGFSMiscFeeSection, "div#misc-fees .misc-fee-group"
   element :add_another_miscellaneous_fee, "div#misc-fees a.add_fields"
 
   sections :disbursements, DisbursementSection, "div#disbursements .disbursement-group"
   element :add_another_disbursement, "div#disbursements a.add_fields"
 
-  section :graduated_fee, LgfsGraduatedFeeSection, ".graduated-fee-group"
-  section :fixed_fee, LgfsFixedFeeSection, ".fixed-fee-group"
+  section :graduated_fee, LGFSGraduatedFeeSection, ".graduated-fee-group"
+  section :fixed_fee, LGFSFixedFeeSection, ".fixed-fee-group"
 
   element :ppe_total, "input.quantity"
   element :actual_trial_length, ".js-fee-calculator-days"

--- a/features/page_objects/litigator_hardship_claim_form_page.rb
+++ b/features/page_objects/litigator_hardship_claim_form_page.rb
@@ -4,5 +4,5 @@ require_relative 'sections/lgfs_hardship_fee_section'
 class LitigatorHardshipClaimFormPage < LitigatorClaimFormPage
   set_url "/litigators/hardship_claims/new"
 
-  section :hardship_fee, LgfsHardshipFeeSection, "#hardship-fee .hardship-fee-group"
+  section :hardship_fee, LGFSHardshipFeeSection, "#hardship-fee .hardship-fee-group"
 end

--- a/features/page_objects/litigator_interim_claim_form_page.rb
+++ b/features/page_objects/litigator_interim_claim_form_page.rb
@@ -4,5 +4,5 @@ require_relative 'sections/lgfs_interim_fee_section'
 class LitigatorInterimClaimFormPage < LitigatorClaimFormPage
   set_url "/litigators/interim_claims/new"
 
-  section :interim_fee, LgfsInterimFeeSection, "#interim-fee .interim-fee-group"
+  section :interim_fee, LGFSInterimFeeSection, "#interim-fee .interim-fee-group"
 end

--- a/features/page_objects/litigator_transfer_claim_form_page.rb
+++ b/features/page_objects/litigator_transfer_claim_form_page.rb
@@ -6,8 +6,8 @@ require_relative 'sections/common_autocomplete_section'
 class LitigatorTransferClaimFormPage < LitigatorClaimFormPage
   set_url "/litigators/transfer_claims/new"
 
-  section :transfer_detail, LgfsTransferDetailSection, "#transfer-detail"
-  section :transfer_fee, LgfsTransferFeeSection, "#transfer-fee"
+  section :transfer_detail, LGFSTransferDetailSection, "#transfer-detail"
+  section :transfer_fee, LGFSTransferFeeSection, "#transfer-fee"
   section :transfer_stage, CommonAutocomplete, "#cc-transfer-stage"
   section :case_conclusion, CommonAutocomplete, "#cc-case-conclusion"
 end

--- a/features/page_objects/sections/lgfs_fixed_fee_section.rb
+++ b/features/page_objects/sections/lgfs_fixed_fee_section.rb
@@ -1,4 +1,4 @@
-class LgfsFixedFeeSection < SitePrism::Section
+class LGFSFixedFeeSection < SitePrism::Section
   element :quantity, "input.quantity"
   element :quantity_hint, ".quantity_wrapper .govuk-hint"
   element :rate, "input.rate"

--- a/features/page_objects/sections/lgfs_graduated_fee_section.rb
+++ b/features/page_objects/sections/lgfs_graduated_fee_section.rb
@@ -1,4 +1,4 @@
-class LgfsGraduatedFeeSection < SitePrism::Section
+class LGFSGraduatedFeeSection < SitePrism::Section
   section :date, CommonDateSection, ".form-date"
   element :actual_trial_length, "input#actual_trial_length"
   element :quantity, "input.quantity"

--- a/features/page_objects/sections/lgfs_hardship_fee_section.rb
+++ b/features/page_objects/sections/lgfs_hardship_fee_section.rb
@@ -1,7 +1,7 @@
 class SelectOptionSection < SitePrism::Section
 end
 
-class LgfsHardshipFeeSection < SitePrism::Section
+class LGFSHardshipFeeSection < SitePrism::Section
 
   # common hardship fee fields
   element :ppe_total, '.quantity'

--- a/features/page_objects/sections/lgfs_interim_fee_section.rb
+++ b/features/page_objects/sections/lgfs_interim_fee_section.rb
@@ -1,7 +1,7 @@
 class SelectOptionSection < SitePrism::Section
 end
 
-class LgfsInterimFeeSection < SitePrism::Section
+class LGFSInterimFeeSection < SitePrism::Section
   include SelectHelper
 
   sections :fee_type_select_options, SelectOptionSection, 'select#claim_interim_fee_attributes_fee_type_id option', visible: false

--- a/features/page_objects/sections/lgfs_misc_fee_section.rb
+++ b/features/page_objects/sections/lgfs_misc_fee_section.rb
@@ -12,7 +12,7 @@ class FeeTypeSection < SitePrism::Section
   end
 end
 
-class LgfsMiscFeeSection < SitePrism::Section
+class LGFSMiscFeeSection < SitePrism::Section
   section :fee_type, FeeTypeSection, '.fee-type'
   element :amount, 'input.total'
 

--- a/features/page_objects/sections/lgfs_transfer_detail_section.rb
+++ b/features/page_objects/sections/lgfs_transfer_detail_section.rb
@@ -1,4 +1,4 @@
-class LgfsTransferDetailSection < SitePrism::Section
+class LGFSTransferDetailSection < SitePrism::Section
   include SelectHelper
 
   element :litigator_type_original, "#claim-litigator-type-original-field"

--- a/features/page_objects/sections/lgfs_transfer_fee_section.rb
+++ b/features/page_objects/sections/lgfs_transfer_fee_section.rb
@@ -1,4 +1,4 @@
-class LgfsTransferFeeSection < SitePrism::Section
+class LGFSTransferFeeSection < SitePrism::Section
   element :days_total, "input.js-fee-calculator-days"
   element :ppe_total, "input.js-fee-calculator-ppe"
   element :amount, "input.fee-amount"

--- a/lib/demo_data/base_claim_generator.rb
+++ b/lib/demo_data/base_claim_generator.rb
@@ -17,7 +17,7 @@ module DemoData
       @states = options[:states] == :all ? Claims::StateMachine.dashboard_displayable_states : options[:states]
       @num_external_users = options[:num_external_users].to_i
       @num_claims = options[:num_claims_per_state].to_i
-      @external_user_persona = self.kind_of?(DemoData::LgfsSchemeClaimGenerator) ? :litigator : :advocate
+      @external_user_persona = self.kind_of?(DemoData::LGFSSchemeClaimGenerator) ? :litigator : :advocate
     end
 
     def run

--- a/lib/demo_data/interim_claim_generator.rb
+++ b/lib/demo_data/interim_claim_generator.rb
@@ -2,7 +2,7 @@ require_relative 'lgfs_scheme_claim_generator'
 require_relative 'interim_fee_generator'
 
 module DemoData
-  class InterimClaimGenerator < LgfsSchemeClaimGenerator
+  class InterimClaimGenerator < LGFSSchemeClaimGenerator
 
     def generate_claim(litigator)
       super(Claim::InterimClaim, litigator)

--- a/lib/demo_data/lgfs_scheme_claim_generator.rb
+++ b/lib/demo_data/lgfs_scheme_claim_generator.rb
@@ -3,7 +3,7 @@ require_relative 'disbursement_generator'
 
 module DemoData
   # For claims: litigator, interim, transfer...
-  class LgfsSchemeClaimGenerator < BaseClaimGenerator
+  class LGFSSchemeClaimGenerator < BaseClaimGenerator
 
     def generate_claim(klass, litigator)
       claim = klass.new(

--- a/lib/demo_data/litigator_claim_generator.rb
+++ b/lib/demo_data/litigator_claim_generator.rb
@@ -3,7 +3,7 @@ require_relative 'fixed_fee_generator'
 require_relative 'fee_generator'
 
 module DemoData
-  class LitigatorClaimGenerator < LgfsSchemeClaimGenerator
+  class LitigatorClaimGenerator < LGFSSchemeClaimGenerator
 
     def generate_claim(litigator)
       super(Claim::LitigatorClaim, litigator)

--- a/lib/demo_data/transfer_claim_generator.rb
+++ b/lib/demo_data/transfer_claim_generator.rb
@@ -3,7 +3,7 @@ require_relative 'transfer_fee_generator'
 require_relative 'transfer_detail_generator'
 
 module DemoData
-  class TransferClaimGenerator < LgfsSchemeClaimGenerator
+  class TransferClaimGenerator < LGFSSchemeClaimGenerator
 
     def generate_claim(litigator)
       super(Claim::TransferClaim, litigator)

--- a/lib/tasks/agfs_scheme_fifteen.rake
+++ b/lib/tasks/agfs_scheme_fifteen.rake
@@ -4,7 +4,7 @@ namespace :db do
   namespace :agfs_scheme_fifteen do
     desc 'Display the status of db structures and records for AGFS Fee Scheme 15'
     task status: :environment do
-      adder = Seeds::Schemas::AddAgfsFeeScheme15.new(pretend: false)
+      adder = Seeds::Schemas::AddAGFSFeeScheme15.new(pretend: false)
       puts adder.status
     end
 
@@ -21,7 +21,7 @@ namespace :db do
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
-      adder = Seeds::Schemas::AddAgfsFeeScheme15.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme15.new(pretend: pretend)
       adder.up
       ActiveRecord::Base.logger.level = log_level
     end
@@ -38,7 +38,7 @@ namespace :db do
       continue?('This will destroy AGFS Fee Scheme 15 (Additional Preparation Fee & KC - April 2023), offences and fee types. Are you sure?') if not_pretend
       puts "#{pretend ? 'pretending' : 'working'}...".yellow
 
-      adder = Seeds::Schemas::AddAgfsFeeScheme15.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme15.new(pretend: pretend)
       adder.down
     end
   end

--- a/lib/tasks/agfs_scheme_fourteen.rake
+++ b/lib/tasks/agfs_scheme_fourteen.rake
@@ -4,7 +4,7 @@ namespace :db do
   namespace :agfs_scheme_fourteen do
     desc 'Display the status of db structures and records for AGFS Fee Scheme 14'
     task status: :environment do
-      adder = Seeds::Schemas::AddAgfsFeeScheme14.new(pretend: false)
+      adder = Seeds::Schemas::AddAGFSFeeScheme14.new(pretend: false)
       puts adder.status
     end
 
@@ -21,7 +21,7 @@ namespace :db do
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
-      adder = Seeds::Schemas::AddAgfsFeeScheme14.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme14.new(pretend: pretend)
       adder.up
       ActiveRecord::Base.logger.level = log_level
     end
@@ -38,7 +38,7 @@ namespace :db do
       continue?('This will destroy AGFS Fee Scheme 14 (Section 28 - February 2023), offences and fee types. Are you sure?') if not_pretend
       puts "#{pretend ? 'pretending' : 'working'}...".yellow
 
-      adder = Seeds::Schemas::AddAgfsFeeScheme14.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme14.new(pretend: pretend)
       adder.down
     end
   end

--- a/lib/tasks/agfs_scheme_thirteen.rake
+++ b/lib/tasks/agfs_scheme_thirteen.rake
@@ -6,7 +6,7 @@ namespace :db do
   namespace :agfs_scheme_thirteen do
     desc 'Display status of db structures and records for AGFS Fee Scheme 13 (CLAIR - September 2022)'
     task :status => :environment do
-      adder = Seeds::Schemas::AddAgfsFeeScheme13.new(pretend: false)
+      adder = Seeds::Schemas::AddAGFSFeeScheme13.new(pretend: false)
       puts adder.status
     end
 
@@ -23,7 +23,7 @@ namespace :db do
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
-      adder = Seeds::Schemas::AddAgfsFeeScheme13.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme13.new(pretend: pretend)
       adder.up
       ActiveRecord::Base.logger.level = log_level
     end
@@ -39,7 +39,7 @@ namespace :db do
       continue?('This will destroy AGFS Fee Scheme 13 (CLAIR - September 2022), offences and fee types. Are you sure?') if not_pretend
       puts "#{pretend ? 'pretending' : 'working'}...".yellow
 
-      adder = Seeds::Schemas::AddAgfsFeeScheme13.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme13.new(pretend: pretend)
       adder.down
     end
   end

--- a/lib/tasks/lgfs_scheme_ten.rake
+++ b/lib/tasks/lgfs_scheme_ten.rake
@@ -6,7 +6,7 @@ namespace :db do
   namespace :lgfs_scheme_ten do
     desc 'Display status of db structures and records for LGFS Fee Scheme 10 (CLAIR - September 2022)'
     task :status => :environment do
-      adder = Seeds::Schemas::AddLgfsFeeScheme10.new(pretend: false)
+      adder = Seeds::Schemas::AddLGFSFeeScheme10.new(pretend: false)
       puts adder.status
     end
 
@@ -23,7 +23,7 @@ namespace :db do
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
-      adder = Seeds::Schemas::AddLgfsFeeScheme10.new(pretend: pretend)
+      adder = Seeds::Schemas::AddLGFSFeeScheme10.new(pretend: pretend)
       adder.up
       ActiveRecord::Base.logger.level = log_level
     end
@@ -39,7 +39,7 @@ namespace :db do
       continue?('This will destroy LGFS Fee Scheme 10 (CLAIR - September 2022), offences and fee types. Are you sure?') if not_pretend
       puts "#{pretend ? 'pretending' : 'working'}...".yellow
 
-      adder = Seeds::Schemas::AddLgfsFeeScheme10.new(pretend: pretend)
+      adder = Seeds::Schemas::AddLGFSFeeScheme10.new(pretend: pretend)
       adder.down
     end
   end

--- a/lib/tasks/lgfs_scheme_ten_clean.rake
+++ b/lib/tasks/lgfs_scheme_ten_clean.rake
@@ -4,7 +4,7 @@ namespace :db do
   namespace :lgfs_scheme_ten_clean do
     desc 'Display status of db structures and records for LGFS Fee Scheme 10 (CLAIR - September 2022)'
     task :status => :environment do
-      cleaner = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: false)
+      cleaner = Seeds::Schemas::CleanLGFSFeeScheme10.new(pretend: false)
       cleaner.status
     end
 
@@ -21,7 +21,7 @@ namespace :db do
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
-      cleaner = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: pretend)
+      cleaner = Seeds::Schemas::CleanLGFSFeeScheme10.new(pretend: pretend)
       cleaner.up
       ActiveRecord::Base.logger.level = log_level
     end
@@ -40,7 +40,7 @@ namespace :db do
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
-      cleaner = Seeds::Schemas::CleanLgfsFeeScheme10.new(pretend: pretend)
+      cleaner = Seeds::Schemas::CleanLGFSFeeScheme10.new(pretend: pretend)
       cleaner.down
       ActiveRecord::Base.logger.level = log_level
     end

--- a/lib/tasks/scheme_twelve.rake
+++ b/lib/tasks/scheme_twelve.rake
@@ -6,7 +6,7 @@ namespace :db do
   namespace :scheme_twelve do
     desc 'Display status of db structures and records for AGFS fee scheme 12'
     task :status => :environment do
-      adder = Seeds::Schemas::AddAgfsFeeScheme12.new(pretend: false)
+      adder = Seeds::Schemas::AddAGFSFeeScheme12.new(pretend: false)
       puts adder.status
     end
 
@@ -23,7 +23,7 @@ namespace :db do
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
-      adder = Seeds::Schemas::AddAgfsFeeScheme12.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme12.new(pretend: pretend)
       adder.up
       ActiveRecord::Base.logger.level = log_level
     end
@@ -39,7 +39,7 @@ namespace :db do
       continue?('This will destroy CLAR scheme, offences and fee types. Are you sure?') if not_pretend
       puts "#{pretend ? 'pretending' : 'working'}...".yellow
 
-      adder = Seeds::Schemas::AddAgfsFeeScheme12.new(pretend: pretend)
+      adder = Seeds::Schemas::AddAGFSFeeScheme12.new(pretend: pretend)
       adder.down
     end
   end

--- a/scheduled_tasks/agfs_management_information_generation_task.rb
+++ b/scheduled_tasks/agfs_management_information_generation_task.rb
@@ -1,7 +1,7 @@
 require 'chronic'
 
 # https://github.com/ssoroka/scheduler_daemon for help
-class AgfsManagementInformationGenerationTask < Scheduler::SchedulerTask
+class AGFSManagementInformationGenerationTask < Scheduler::SchedulerTask
   every '1d', first_at: Chronic.parse('next 2:00 am')
 
   def run

--- a/scheduled_tasks/agfs_management_information_v2_generation_task.rb
+++ b/scheduled_tasks/agfs_management_information_v2_generation_task.rb
@@ -1,7 +1,7 @@
 require 'chronic'
 
 # https://github.com/ssoroka/scheduler_daemon for help
-class AgfsManagementInformationV2GenerationTask < Scheduler::SchedulerTask
+class AGFSManagementInformationV2GenerationTask < Scheduler::SchedulerTask
   every '1d', first_at: Chronic.parse('next 1:50 am')
 
   def run

--- a/scheduled_tasks/lgfs_management_information_generation_task.rb
+++ b/scheduled_tasks/lgfs_management_information_generation_task.rb
@@ -1,7 +1,7 @@
 require 'chronic'
 
 # https://github.com/ssoroka/scheduler_daemon for help
-class LgfsManagementInformationGenerationTask < Scheduler::SchedulerTask
+class LGFSManagementInformationGenerationTask < Scheduler::SchedulerTask
   every '1d', first_at: Chronic.parse('next 2:30 am')
 
   def run

--- a/scheduled_tasks/lgfs_management_information_v2_generation_task.rb
+++ b/scheduled_tasks/lgfs_management_information_v2_generation_task.rb
@@ -1,7 +1,7 @@
 require 'chronic'
 
 # https://github.com/ssoroka/scheduler_daemon for help
-class LgfsManagementInformationV2GenerationTask < Scheduler::SchedulerTask
+class LGFSManagementInformationV2GenerationTask < Scheduler::SchedulerTask
   every '1d', first_at: Chronic.parse('next 2:20 am')
 
   def run

--- a/spec/services/stats/management_information/agfs/af1_disk_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af1_disk_query_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../shared_examples_for_journey_queryable'
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::Af1DiskQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::Af1DiskQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/agfs/af1_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af1_high_value_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::Af1HighValueQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::Af1HighValueQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/agfs/af2_disk_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af2_disk_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::Af2DiskQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::Af2DiskQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/agfs/af2_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af2_high_value_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::Af2HighValueQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::Af2HighValueQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/agfs/af2_redetermination_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/af2_redetermination_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::Af2RedeterminationQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::Af2RedeterminationQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/agfs/intake_final_fee_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/intake_final_fee_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::IntakeFinalFeeQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::IntakeFinalFeeQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/agfs/intake_fixed_fee_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/intake_fixed_fee_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::IntakeFixedFeeQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::IntakeFixedFeeQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/agfs/written_reasons_query_spec.rb
+++ b/spec/services/stats/management_information/agfs/written_reasons_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Agfs::WrittenReasonsQuery do
+RSpec.describe Stats::ManagementInformation::AGFS::WrittenReasonsQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/claim_type_filterable_spec.rb
+++ b/spec/services/stats/management_information/claim_type_filterable_spec.rb
@@ -132,9 +132,9 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
     end
   end
 
-  describe 'MockAgfsClaimTypeFilter' do
+  describe 'MockAGFSClaimTypeFilter' do
     before do
-      stub_const('MockAgfsClaimTypeFilter', mock_agfs_claim_type_filter)
+      stub_const('MockAGFSClaimTypeFilter', mock_agfs_claim_type_filter)
     end
 
     let(:mock_agfs_claim_type_filter) do
@@ -145,7 +145,7 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
       end
     end
 
-    let(:instance) { MockAgfsClaimTypeFilter.new }
+    let(:instance) { MockAGFSClaimTypeFilter.new }
 
     describe '#scheme' do
       subject { instance.scheme }

--- a/spec/services/stats/management_information/claim_type_filterable_spec.rb
+++ b/spec/services/stats/management_information/claim_type_filterable_spec.rb
@@ -167,9 +167,9 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
     end
   end
 
-  describe 'MockLgfsClaimTypeFilter' do
+  describe 'MockLGFSClaimTypeFilter' do
     before do
-      stub_const('MockLgfsClaimTypeFilter', mock_lgfs_claim_type_filter)
+      stub_const('MockLGFSClaimTypeFilter', mock_lgfs_claim_type_filter)
     end
 
     let(:mock_lgfs_claim_type_filter) do
@@ -180,7 +180,7 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
       end
     end
 
-    let(:instance) { MockLgfsClaimTypeFilter.new }
+    let(:instance) { MockLGFSClaimTypeFilter.new }
 
     describe '#scheme' do
       subject { instance.scheme }

--- a/spec/services/stats/management_information/daily_report_count_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_count_generator_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
       end
 
       let(:kwargs) { { query_set:, start_at: start_date } }
-      let(:query_set) { Stats::ManagementInformation::AgfsQuerySet.new }
+      let(:query_set) { Stats::ManagementInformation::AGFSQuerySet.new }
       let(:start_date) { 1.month.ago.to_date }
       let(:rows) { CSV.parse(result.content, headers: true) }
 
@@ -145,7 +145,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
       before { allow(LogStuff).to receive(:info) }
 
       let(:kwargs) { { query_set:, start_at: Date.current } }
-      let(:query_set) { Stats::ManagementInformation::AgfsQuerySet.new }
+      let(:query_set) { Stats::ManagementInformation::AGFSQuerySet.new }
 
       it 'logs start and end' do
         call
@@ -160,7 +160,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
       end
 
       let(:kwargs) { { query_set:, start_at: Date.current } }
-      let(:query_set) { Stats::ManagementInformation::AgfsQuerySet.new }
+      let(:query_set) { Stats::ManagementInformation::AGFSQuerySet.new }
 
       it 'uses LogStuff to log error' do
         call

--- a/spec/services/stats/management_information/daily_report_count_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_count_generator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
 
     context 'without start_at' do
       let(:kwargs) { { query_set: } }
-      let(:query_set) { Stats::ManagementInformation::LgfsQuerySet.new }
+      let(:query_set) { Stats::ManagementInformation::LGFSQuerySet.new }
 
       it { expect { call }.to raise_error ArgumentError, 'start_at must be provided' }
     end
@@ -44,7 +44,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
       subject(:result) { described_class.new(**kwargs).call }
 
       let(:kwargs) { { query_set:, start_at: start_date } }
-      let(:query_set) { Stats::ManagementInformation::LgfsQuerySet.new }
+      let(:query_set) { Stats::ManagementInformation::LGFSQuerySet.new }
       let(:start_date) { 1.month.ago.to_date }
       let(:duration) { 1.month - 1.day }
 
@@ -69,7 +69,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
     context 'with valid scheme, start_at and duration' do
       subject(:result) { described_class.new(**kwargs).call }
 
-      let(:query_set) { Stats::ManagementInformation::LgfsQuerySet.new }
+      let(:query_set) { Stats::ManagementInformation::LGFSQuerySet.new }
       let(:start_date) { 1.week.ago.to_date }
       let(:duration) { 1.month - 1.day }
 

--- a/spec/services/stats/management_information/daily_report_count_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_count_query_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountQuery do
       end
 
       context 'with LGFS query_set' do
-        let(:kwargs) { { query_set: Stats::ManagementInformation::LgfsQuerySet.new, date_range: month_range } }
+        let(:kwargs) { { query_set: Stats::ManagementInformation::LGFSQuerySet.new, date_range: month_range } }
 
         let(:expected_result_names) do
           ['Intake fixed fee', 'Intake final fee',

--- a/spec/services/stats/management_information/daily_report_count_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_count_query_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountQuery do
     context 'with query_set and date range' do
       subject(:result) { described_class.new(**kwargs).call }
 
-      let(:kwargs) { { query_set: Stats::ManagementInformation::AgfsQuerySet.new, date_range: month_range } }
+      let(:kwargs) { { query_set: Stats::ManagementInformation::AGFSQuerySet.new, date_range: month_range } }
 
       let(:expected_result_keys) do
         month_range.to_a.collect(&:iso8601).prepend(:name, :filter)
@@ -66,7 +66,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountQuery do
       end
 
       context 'with AGFS query_set' do
-        let(:kwargs) { { query_set: Stats::ManagementInformation::AgfsQuerySet.new, date_range: month_range } }
+        let(:kwargs) { { query_set: Stats::ManagementInformation::AGFSQuerySet.new, date_range: month_range } }
 
         let(:expected_result_names) do
           ['Intake fixed fee', 'Intake final fee',

--- a/spec/services/stats/management_information/lgfs/intake_final_fee_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/intake_final_fee_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::IntakeFinalFeeQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::IntakeFinalFeeQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/intake_fixed_fee_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/intake_fixed_fee_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::IntakeFixedFeeQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::IntakeFixedFeeQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/intake_interim_fee_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/intake_interim_fee_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::IntakeInterimFeeQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::IntakeInterimFeeQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/lf1_disk_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf1_disk_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::Lf1DiskQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::Lf1DiskQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/lf1_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf1_high_value_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::Lf1HighValueQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::Lf1HighValueQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/lf2_disk_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf2_disk_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::Lf2DiskQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::Lf2DiskQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/lf2_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf2_high_value_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::Lf2HighValueQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::Lf2HighValueQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/lf2_redetermination_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/lf2_redetermination_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::Lf2RedeterminationQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::Lf2RedeterminationQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/lgfs/written_reasons_query_spec.rb
+++ b/spec/services/stats/management_information/lgfs/written_reasons_query_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::Lgfs::WrittenReasonsQuery do
+RSpec.describe Stats::ManagementInformation::LGFS::WrittenReasonsQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
         it_behaves_like 'a successful report generator caller' do
           let(:args) do
             { report_type: 'lgfs_management_information_statistics',
-              query_set: instance_of(Stats::ManagementInformation::LgfsQuerySet),
+              query_set: instance_of(Stats::ManagementInformation::LGFSQuerySet),
               start_at: Time.zone.today,
               duration: 1.month - 1.day }
           end

--- a/spec/services/stats/stats_report_generator_spec.rb
+++ b/spec/services/stats/stats_report_generator_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Stats::StatsReportGenerator, type: :service do
         it_behaves_like 'a successful report generator caller' do
           let(:args) do
             { report_type: 'agfs_management_information_statistics',
-              query_set: instance_of(Stats::ManagementInformation::AgfsQuerySet),
+              query_set: instance_of(Stats::ManagementInformation::AGFSQuerySet),
               start_at: Time.zone.today,
               duration: 1.month - 1.day }
           end

--- a/spec/validators/fee/agfs/fee_type_rules_spec.rb
+++ b/spec/validators/fee/agfs/fee_type_rules_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.describe Fee::Agfs::FeeTypeRules, type: :validator do
+RSpec.describe Fee::AGFS::FeeTypeRules, type: :validator do
   it_behaves_like 'fee_type_rules_creator'
 end

--- a/spec/validators/fee/lgfs/fee_type_rules_spec.rb
+++ b/spec/validators/fee/lgfs/fee_type_rules_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.describe Fee::Lgfs::FeeTypeRules, type: :validator do
+RSpec.describe Fee::LGFS::FeeTypeRules, type: :validator do
   it_behaves_like 'fee_type_rules_creator'
 end


### PR DESCRIPTION
#### What

As a pre-requisite for upgrading to rails 7, CCCD needs to move from the `classic` autoloader to `zeitwerk`. This requires us to update the CCCD codebase to be compatible with `zeitwerk`.

Zeitwerk requires all acronyms be properly inflected in class and module names. This pull request addresses the way acronyms `AGFS` and `LGFS` are handled. This is currently inconsistent in CCCD, for example, sometimes appearing as `Lgfs` and sometimes as `LGFS`.

#### Ticket

[CTSKF-241](https://dsdmoj.atlassian.net/browse/CTSKF-241) (formerly CFP-179)

#### Why

* To ensure future compatibility with the rails framework.
* To follow the [Ruby Style Guide](https://github.com/rubocop/ruby-style-guide#camelcase-classes) which recommends keeping acronyms uppercase.

#### How

Adds `AGFS` and `LGFS` to `config/initializers/inflections.rb` and capitalizes all instances in code. 

[CTSKF-241]: https://dsdmoj.atlassian.net/browse/CTSKF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ