### PR TITLE
CTSKF-241 Zeitwerk: Fix Extensions namespace

### DIFF
--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -1,51 +1,51 @@
 Dir[File.join(Rails.root, 'lib', 'extensions', '*.rb')].each { |file| require file }
 
 class Array
-  include ArrayExtension
-  include RemoteExtension
+  include Extensions::ArrayExtension
+  include Extensions::RemoteExtension
 end
 
 class Hash
-  include HashExtension
+  include Extensions::HashExtension
 end
 
 class String
-  include StringExtension
+  include Extensions::StringExtension
 end
 
 class ActiveRecord::Base
-  include NestedAttributesExtension
-  include RemoteExtension
+  include Extensions::NestedAttributesExtension
+  include Extensions::RemoteExtension
 end
 
 class ActiveRecord::Relation
-  include RemoteExtension
+  include Extensions::RemoteExtension
 end
 
 module Devise::Models::Lockable
-  include DeviseExtension
+  include Extensions::DeviseExtension
 end
 
 module Rails
-  extend RailsModuleExtension
+  extend Extensions::RailsModuleExtension
 end
 
 module ActiveSupport::XmlMini
-  extend XmlMiniExtension
+  extend Extensions::XmlMiniExtension
 end
 
 class TrueClass
-  include BooleanExtension::True
+  include Extensions::BooleanExtension::True
 end
 
 class FalseClass
-  include BooleanExtension::False
+  include Extensions::BooleanExtension::False
 end
 
 class Integer
-  include IntegerExtension
+  include Extensions::IntegerExtension
 end
 
 class NilClass
-  include NilExtension
+  include Extensions::NilExtension
 end

--- a/lib/extensions/array_extension.rb
+++ b/lib/extensions/array_extension.rb
@@ -1,17 +1,19 @@
-module ArrayExtension
-  def zeroize_nils(value = 0.00)
-    map { |element| element.blank? ? value : element }
-  end
+module Extensions
+  module ArrayExtension
+    def zeroize_nils(value = 0.00)
+      map { |element| element.blank? ? value : element }
+    end
 
-  def zeroize_nils!(value = 0.00)
-    replace(zeroize_nils(value))
-  end
+    def zeroize_nils!(value = 0.00)
+      replace(zeroize_nils(value))
+    end
 
-  def average(total = size)
-    any? ? sum.to_f / total : 0
-  end
+    def average(total = size)
+      any? ? sum.to_f / total : 0
+    end
 
-  def flat_select(&)
-    flatten.compact.select(&)
+    def flat_select(&)
+      flatten.compact.select(&)
+    end
   end
 end

--- a/lib/extensions/boolean_extension.rb
+++ b/lib/extensions/boolean_extension.rb
@@ -1,13 +1,15 @@
-module BooleanExtension
-  module True
-    def to_i
-      1
+module Extensions
+  module BooleanExtension
+    module True
+      def to_i
+        1
+      end
     end
-  end
 
-  module False
-    def to_i
-      0
+    module False
+      def to_i
+        0
+      end
     end
   end
 end

--- a/lib/extensions/devise_extension.rb
+++ b/lib/extensions/devise_extension.rb
@@ -1,9 +1,11 @@
-module DeviseExtension
-  def override_paranoid_setting(value)
-    previous_value = Devise.paranoid
-    Devise.paranoid = value
-    result = yield
-    Devise.paranoid = previous_value
-    result
+module Extensions
+  module DeviseExtension
+    def override_paranoid_setting(value)
+      previous_value = Devise.paranoid
+      Devise.paranoid = value
+      result = yield
+      Devise.paranoid = previous_value
+      result
+    end
   end
 end

--- a/lib/extensions/hash_extension.rb
+++ b/lib/extensions/hash_extension.rb
@@ -1,33 +1,35 @@
-module HashExtension
-  def all_keys
-    each_with_object([]) do |(k, v), keys|
-      keys << k
-      keys.concat(v.select { |el| el.is_a?(Hash) }.flat_map(&:all_keys)) if v.is_a? Array
-      keys.concat(v.all_keys) if v.is_a? Hash
-    end
-  end
-
-  def all_values_for(key)
-    each_with_object([]) do |(k, v), values|
-      values << v if k.eql?(key)
-      values.concat(v.select { |el| el.is_a?(Hash) }.flat_map { |el| el.all_values_for(key) }) if v.is_a? Array
-      values.concat(v.all_values_for(key)) if v.is_a? Hash
-    end
-  end
-
-  def key_paths(path = [])
-    each_with_object([]) do |(k, v), items|
-      if v.is_a?(Hash)
-        items.push(*v.key_paths(path + [k]))
-      else
-        items << (path + [k])
+module Extensions
+  module HashExtension
+    def all_keys
+      each_with_object([]) do |(k, v), keys|
+        keys << k
+        keys.concat(v.select { |el| el.is_a?(Hash) }.flat_map(&:all_keys)) if v.is_a? Array
+        keys.concat(v.all_keys) if v.is_a? Hash
       end
     end
-  end
 
-  def bury(value, *keys)
-    keys[0...-1].inject(self) do |acc, key|
-      acc.public_send(:[], key)
-    end.public_send(:[]=, keys.last, value)
+    def all_values_for(key)
+      each_with_object([]) do |(k, v), values|
+        values << v if k.eql?(key)
+        values.concat(v.select { |el| el.is_a?(Hash) }.flat_map { |el| el.all_values_for(key) }) if v.is_a? Array
+        values.concat(v.all_values_for(key)) if v.is_a? Hash
+      end
+    end
+
+    def key_paths(path = [])
+      each_with_object([]) do |(k, v), items|
+        if v.is_a?(Hash)
+          items.push(*v.key_paths(path + [k]))
+        else
+          items << (path + [k])
+        end
+      end
+    end
+
+    def bury(value, *keys)
+      keys[0...-1].inject(self) do |acc, key|
+        acc.public_send(:[], key)
+      end.public_send(:[]=, keys.last, value)
+    end
   end
 end

--- a/lib/extensions/integer_extension.rb
+++ b/lib/extensions/integer_extension.rb
@@ -1,5 +1,7 @@
-module IntegerExtension
-  def or_one
-    [self, 1].compact.max
+module Extensions
+  module IntegerExtension
+    def or_one
+      [self, 1].compact.max
+    end
   end
 end

--- a/lib/extensions/nested_attributes_extension.rb
+++ b/lib/extensions/nested_attributes_extension.rb
@@ -1,11 +1,13 @@
-module NestedAttributesExtension
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
+module Extensions
+  module NestedAttributesExtension
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
 
-  module ClassMethods
-    def all_blank_or_zero
-      ->(attributes) { attributes.all? { |key, value| key == '_destroy' || (value.blank? || value.zero?) } }
+    module ClassMethods
+      def all_blank_or_zero
+        ->(attributes) { attributes.all? { |key, value| key == '_destroy' || (value.blank? || value.zero?) } }
+      end
     end
   end
 end

--- a/lib/extensions/nil_extension.rb
+++ b/lib/extensions/nil_extension.rb
@@ -1,5 +1,7 @@
-module NilExtension
-  def or_one
-    1
+module Extensions
+  module NilExtension
+    def or_one
+      1
+    end
   end
 end

--- a/lib/extensions/rails_module_extension.rb
+++ b/lib/extensions/rails_module_extension.rb
@@ -1,7 +1,9 @@
 require Rails.root.join('lib', 'rails_host.rb')
 
-module RailsModuleExtension
-  def host
-    RailsHost
+module Extensions
+  module RailsModuleExtension
+    def host
+      RailsHost
+    end
   end
 end

--- a/lib/extensions/remote_extension.rb
+++ b/lib/extensions/remote_extension.rb
@@ -1,5 +1,7 @@
-module RemoteExtension
-  def remote?
-    false
+module Extensions
+  module RemoteExtension
+    def remote?
+      false
+    end
   end
 end

--- a/lib/extensions/string_extension.rb
+++ b/lib/extensions/string_extension.rb
@@ -1,67 +1,69 @@
-module StringExtension
-  def zero?
-    present? && to_f == 0.0
-  end
-
-  def true?
-    /(true|t|yes|y|1)$/i.match(to_s).present?
-  end
-
-  def false?
-    to_s.strip.empty? || /(false|f|no|n|0)$/i.match(to_s).present?
-  end
-
-  def to_bool
-    return true if true?
-    return false if false?
-    raise ArgumentError, "invalid value for Boolean: \"#{self}\""
-  end
-
-  def alpha?
-    !match(/^[[:alpha:]]+$/).nil?
-  end
-
-  def digit?
-    !match(/^[[:digit:]]+$/).nil?
-  end
-
-  def strftime(format)
-    Time.zone.parse(self).strftime(format)
-  end
-
-  def abbreviate(target_length = 6)
-    words = clean_and_split_sentence
-    acronym = first_word_char_or_chars(words, target_length)
-
-    words.each do |word|
-      acronym << first_char_or_number(word)
+module Extensions
+  module StringExtension
+    def zero?
+      present? && to_f == 0.0
     end
-    acronym.upcase
-  end
 
-  def to_css_class
-    downcase.strip.tr(' _', '-').tr('()', '')
-  end
-
-  private
-
-  def clean_and_split_sentence
-    tr("\n", ' ')
-      .squeeze("\s\t\n")
-      .strip
-      .split(/\s/)
-  end
-
-  def first_word_char_or_chars(words, target_length)
-    if words.size < target_length
-      chars_from_first_word = target_length - words.size
-      words.shift[0..chars_from_first_word]
-    else
-      words.shift.chr
+    def true?
+      /(true|t|yes|y|1)$/i.match(to_s).present?
     end
-  end
 
-  def first_char_or_number(word)
-    word.match?(/\A\d+\z/) ? word : word.gsub(/\W+/, '').chr
+    def false?
+      to_s.strip.empty? || /(false|f|no|n|0)$/i.match(to_s).present?
+    end
+
+    def to_bool
+      return true if true?
+      return false if false?
+      raise ArgumentError, "invalid value for Boolean: \"#{self}\""
+    end
+
+    def alpha?
+      !match(/^[[:alpha:]]+$/).nil?
+    end
+
+    def digit?
+      !match(/^[[:digit:]]+$/).nil?
+    end
+
+    def strftime(format)
+      Time.zone.parse(self).strftime(format)
+    end
+
+    def abbreviate(target_length = 6)
+      words = clean_and_split_sentence
+      acronym = first_word_char_or_chars(words, target_length)
+
+      words.each do |word|
+        acronym << first_char_or_number(word)
+      end
+      acronym.upcase
+    end
+
+    def to_css_class
+      downcase.strip.tr(' _', '-').tr('()', '')
+    end
+
+    private
+
+    def clean_and_split_sentence
+      tr("\n", ' ')
+        .squeeze("\s\t\n")
+        .strip
+        .split(/\s/)
+    end
+
+    def first_word_char_or_chars(words, target_length)
+      if words.size < target_length
+        chars_from_first_word = target_length - words.size
+        words.shift[0..chars_from_first_word]
+      else
+        words.shift.chr
+      end
+    end
+
+    def first_char_or_number(word)
+      word.match?(/\A\d+\z/) ? word : word.gsub(/\W+/, '').chr
+    end
   end
 end

--- a/lib/extensions/xml_mini_extension.rb
+++ b/lib/extensions/xml_mini_extension.rb
@@ -1,13 +1,15 @@
-module XmlMiniExtension
-  # Rails 4.x doesn't provide any mechanism to configure the output of `nil` attributes when serializing to XML.
-  # This patch will make it possible to change `nil` attributes from being serialized as `<submitted_at nil="true"/>`
-  # and instead being omitted or serialized as empty strings.
-  #
-  def to_tag(key, value, options)
-    if value.nil?
-      return if options[:skip_nils]
-      value = '' if options[:blank_nils]
+module Extensions
+  module XmlMiniExtension
+    # Rails 4.x doesn't provide any mechanism to configure the output of `nil` attributes when serializing to XML.
+    # This patch will make it possible to change `nil` attributes from being serialized as `<submitted_at nil="true"/>`
+    # and instead being omitted or serialized as empty strings.
+    #
+    def to_tag(key, value, options)
+      if value.nil?
+        return if options[:skip_nils]
+        value = '' if options[:blank_nils]
+      end
+      super
     end
-    super
   end
 end

--- a/spec/lib/extensions/devise_extension_spec.rb
+++ b/spec/lib/extensions/devise_extension_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-describe DeviseExtension do
-  let(:example_class) { Class.new { extend DeviseExtension } }
+describe Extensions::DeviseExtension do
+  let(:example_class) { Class.new { extend Extensions::DeviseExtension } }
 
   context '#override_paranoid_setting (original value being true)' do
     before { Devise.paranoid = true }

--- a/spec/lib/extensions/xml_mini_extension_spec.rb
+++ b/spec/lib/extensions/xml_mini_extension_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe XmlMiniExtension do
+describe Extensions::XmlMiniExtension do
   subject { [1, 'a', nil] }
 
   let(:xml_result) { subject.to_xml(options.merge(skip_instruct: true, indent: 0)) }


### PR DESCRIPTION
#### What

As a pre-requisite for upgrading to rails 7, CCCD needs to move from the `classic` autoloader to `zeitwerk`. This requires us to update the CCCD codebase to be compatible with `zeitwerk`.

Zeitwerk requires namespaces for classes and modules to match the file structure of the code. 

#### Ticket

[CTSKF-241](https://dsdmoj.atlassian.net/browse/CTSKF-241) (formerly CFP-179)

#### Why

* To ensure future compatibility with the rails framework.

#### How

Fixes incorrect namespacing in the `lib/extensions` directory and updates all occurrences in code. 

[CTSKF-241]: https://dsdmoj.atlassian.net/browse/CTSKF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ