### PR TITLE
Add reporter's email address to Zendesk ticket

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -201,7 +201,6 @@ Metrics/MethodLength:
     - 'app/services/message_queue/message_template.rb'
     - 'app/services/reports/provisional_assessments_by_dates.rb'
     - 'app/services/stats/management_information_generator.rb'
-    - 'app/services/zendesk_sender.rb'
     - 'app/validators/claim/advocate_claim_validator.rb'
     - 'app/validators/claim/advocate_hardship_claim_validator.rb'
     - 'app/validators/claim/advocate_interim_claim_validator.rb'
@@ -556,7 +555,6 @@ RSpec/ContextWording:
     - 'spec/models/fee/shared_examples_for_case_uplifts.rb'
     - 'spec/models/fee/shared_examples_for_defendant_uplifts.rb'
     - 'spec/models/fee/transfer_fee_spec.rb'
-    - 'spec/models/feedback_spec.rb'
     - 'spec/models/google_analytics/data_tracking_spec.rb'
     - 'spec/models/google_analytics/ga_data_adapter_spec.rb'
     - 'spec/models/google_analytics/gtm_data_adapter_spec.rb'
@@ -1448,7 +1446,6 @@ RSpec/NotToNot:
     - 'spec/models/claim/transfer_detail_spec.rb'
     - 'spec/models/claims/cloner_spec.rb'
     - 'spec/models/claims/financial_summary_spec.rb'
-    - 'spec/models/feedback_spec.rb'
     - 'spec/models/offence_spec.rb'
     - 'spec/models/stats/mi_data_spec.rb'
     - 'spec/services/claims/case_worker_claim_updater_spec.rb'
@@ -1861,7 +1858,6 @@ Rails/WhereEquals:
 Style/AccessorGrouping:
   Exclude:
     - 'app/interfaces/api/error_response.rb'
-    - 'app/models/feedback.rb'
     - 'app/services/cclf/mapping_bill_adapter.rb'
     - 'app/services/ccr/fee/base_fee_adapter.rb'
 
@@ -2208,7 +2204,6 @@ Style/PercentLiteralDelimiters:
     - 'spec/models/court_spec.rb'
     - 'spec/models/expense_type_spec.rb'
     - 'spec/models/fee/basic_fee_type_spec.rb'
-    - 'spec/models/feedback_spec.rb'
     - 'spec/models/provider_spec.rb'
     - 'spec/models/stats/gecko_widgets/line_graph_spec.rb'
     - 'spec/models/user_spec.rb'

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -7,9 +7,9 @@ class Feedback
     bug_report: %i[case_number event outcome email]
   }.freeze
 
-  attr_accessor :email, :referrer, :user_agent, :type
-  attr_accessor :event, :outcome, :case_number
-  attr_accessor :task, :rating, :comment, :reason, :other_reason, :response_message
+  attr_accessor :email, :referrer, :user_agent, :type,
+                :event, :outcome, :case_number,
+                :task, :rating, :comment, :reason, :other_reason, :response_message
 
   validates :type, inclusion: { in: FEEDBACK_TYPES.keys.map(&:to_s) }
   validates :event, :outcome, presence: true, if: :bug_report?
@@ -46,6 +46,12 @@ class Feedback
 
   def description
     feedback_type_attributes.map { |t| "#{t}: #{send(t)}" }.join("\n")
+  end
+
+  def reporter_email
+    return if email.blank? || email == 'anonymous'
+
+    email
   end
 
   private

--- a/app/services/zendesk_sender.rb
+++ b/app/services/zendesk_sender.rb
@@ -14,14 +14,35 @@ class ZendeskSender
   def send!
     ZendeskAPI::Ticket.create!(
       ZENDESK_CLIENT,
+      **base_params,
+      **email_params,
+      **custom_params
+    )
+  end
+
+  private
+
+  def base_params
+    {
       subject: ticket_payload.subject,
-      description: ticket_payload.description,
+      description: ticket_payload.description
+    }
+  end
+
+  def email_params
+    return {} if ticket_payload.reporter_email.blank?
+
+    { email_ccs: [{ user_email: ticket_payload.reporter_email }] }
+  end
+
+  def custom_params
+    {
       custom_fields: [
         { id: '26047167', value: ticket_payload.referrer },
         { id: '23757677', value: 'advocate_defence_payments' },
         { id: '23791776', value: ticket_payload.user_agent },
         { id: '32342378', value: Rails.host.env }
       ]
-    )
+    }
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Feedback do
     }
   end
 
-  it { is_expected.to validate_inclusion_of(:type).in_array(%w(feedback bug_report)) }
+  it { is_expected.to validate_inclusion_of(:type).in_array(%w[feedback bug_report]) }
 
-  context 'survey monkey feedback' do
+  context 'with survey monkey feedback' do
     subject(:feedback) { described_class.new(feedback_params) }
 
     before do
@@ -18,7 +18,14 @@ RSpec.describe Feedback do
     end
 
     let(:feedback_params) do
-      params.merge(type: 'feedback', task: '1', rating: '4', comment: 'lorem ipsum', reason: ['', '1', '2'], other_reason: 'dolor sit')
+      params.merge(
+        type: 'feedback',
+        task: '1',
+        rating: '4',
+        comment: 'lorem ipsum',
+        reason: ['', '1', '2'],
+        other_reason: 'dolor sit'
+      )
     end
 
     it { expect(feedback.task).to eq '1' }
@@ -53,11 +60,17 @@ RSpec.describe Feedback do
     end
   end
 
-  context 'bug report' do
+  context 'with a bug report' do
     subject(:bug_report) { described_class.new(bug_report_params) }
 
     let(:bug_report_params) do
-      params.merge(type: 'bug_report', case_number: 'XXX', event: 'lorem', outcome: 'ipsum', email: 'example@example.com')
+      params.merge(
+        type: 'bug_report',
+        case_number: 'XXX',
+        event: 'lorem',
+        outcome: 'ipsum',
+        email: 'example@example.com'
+      )
     end
 
     it { expect(bug_report.email).to eq('example@example.com') }
@@ -67,10 +80,10 @@ RSpec.describe Feedback do
     it { expect(bug_report.user_agent).to eq('Firefox') }
     it { expect(bug_report.referrer).to eq('/index') }
 
-    it { is_expected.to_not validate_inclusion_of(:rating).in_array(('1'..'5').to_a) }
+    it { is_expected.not_to validate_inclusion_of(:rating).in_array(('1'..'5').to_a) }
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:outcome) }
-    it { is_expected.to_not validate_presence_of(:case_number) }
+    it { is_expected.not_to validate_presence_of(:case_number) }
     it { is_expected.to be_bug_report }
     it { is_expected.not_to be_feedback }
 
@@ -110,7 +123,9 @@ RSpec.describe Feedback do
 
       context 'when zendesk submission fails' do
         before do
-          allow(ZendeskAPI::Ticket).to receive(:create!).and_raise ZendeskAPI::Error::ClientError, 'oops, something went wrong'
+          allow(ZendeskAPI::Ticket)
+            .to receive(:create!)
+            .and_raise ZendeskAPI::Error::ClientError, 'oops, something went wrong'
           allow(LogStuff).to receive(:error)
         end
 
@@ -136,7 +151,36 @@ RSpec.describe Feedback do
 
     describe '#description' do
       it 'returns the description' do
-        expect(bug_report.description).to eq("case_number: XXX\nevent: lorem\noutcome: ipsum\nemail: example@example.com")
+        expect(bug_report.description)
+          .to eq("case_number: XXX\nevent: lorem\noutcome: ipsum\nemail: example@example.com")
+      end
+    end
+
+    describe '#reporter_email' do
+      subject { bug_report.reporter_email }
+
+      context 'with an email' do
+        let(:bug_report_params) { params.merge(type: 'bug_report', email: 'example@example.com') }
+
+        it { is_expected.to eq('example@example.com') }
+      end
+
+      context 'without an email' do
+        let(:bug_report_params) { params.merge(type: 'bug_report') }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'with a blank email' do
+        let(:bug_report_params) { params.merge(type: 'bug_report', email: '') }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'with an anonymous email' do
+        let(:bug_report_params) { params.merge(type: 'bug_report', email: 'anonymous') }
+
+        it { is_expected.to be_nil }
       end
     end
 
@@ -151,7 +195,7 @@ RSpec.describe Feedback do
     end
   end
 
-  context 'zendesk feedback' do
+  context 'with zendesk feedback' do
     subject(:feedback) { described_class.new(feedback_params) }
 
     before do
@@ -159,7 +203,14 @@ RSpec.describe Feedback do
     end
 
     let(:feedback_params) do
-      params.merge(type: 'feedback', task: 'XYZ', rating: 1, comment: 'ipsum', reason: ['Other'], other_reason: 'loren ipsum')
+      params.merge(
+        type: 'feedback',
+        task: 'XYZ',
+        rating: 1,
+        comment: 'ipsum',
+        reason: ['Other'],
+        other_reason: 'loren ipsum'
+      )
     end
 
     it { expect(feedback.task).to eq('XYZ') }
@@ -197,7 +248,9 @@ RSpec.describe Feedback do
 
       context 'when zendesk submission fails' do
         before do
-          allow(ZendeskAPI::Ticket).to receive(:create!).and_raise ZendeskAPI::Error::ClientError, 'oops, something went wrong'
+          allow(ZendeskAPI::Ticket)
+            .to receive(:create!)
+            .and_raise ZendeskAPI::Error::ClientError, 'oops, something went wrong'
           allow(LogStuff).to receive(:error)
         end
 
@@ -223,7 +276,8 @@ RSpec.describe Feedback do
 
     describe '#description' do
       it 'returns the description' do
-        expect(feedback.description).to eq("task: XYZ\nrating: 1\ncomment: ipsum\nreason: [\"Other\"]\nother_reason: loren ipsum")
+        expect(feedback.description)
+          .to eq("task: XYZ\nrating: 1\ncomment: ipsum\nreason: [\"Other\"]\nother_reason: loren ipsum")
       end
     end
 

--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe ZendeskSender do
         subject: 'Bug report',
         description: 'event - outcome - email address',
         referrer: '/claims',
-        user_agent: 'chrome'
+        user_agent: 'chrome',
+        reporter_email: nil
       )
     end
 
@@ -30,7 +31,27 @@ RSpec.describe ZendeskSender do
 
     it 'calls ZendeskAPI::Ticket.create!' do
       zen_send
-      expect(ZendeskAPI::Ticket).to have_received(:create!).with(ZENDESK_CLIENT, **zendesk_payload)
+      expect(ZendeskAPI::Ticket).to have_received(:create!).with(ZENDESK_CLIENT, hash_including(zendesk_payload))
+    end
+
+    context 'with a reporter email' do
+      let(:ticket_payload) do
+        instance_double(
+          Feedback,
+          subject: 'Bug report',
+          description: 'event - outcome - email address',
+          referrer: '/claims',
+          user_agent: 'chrome',
+          reporter_email: 'example@example.com'
+        )
+      end
+
+      it 'includes the reporter email' do
+        zen_send
+        expect(ZendeskAPI::Ticket)
+          .to have_received(:create!)
+          .with(ZENDESK_CLIENT, hash_including(email_ccs: [{ user_email: 'example@example.com' }]))
+      end
     end
   end
 


### PR DESCRIPTION
#### What

Add the reports email address to Zendesk tickets

#### Ticket

N/A

#### Why

Users reporting bugs in CCCD were not getting email responses from Zendesk. This is because they were not added as the requester, who must be a Zendesk user, nor in the list of CC email addresses. Addresses can be added in the Zendesk interface but it is more convenient if they are added automatically.

#### How

When a ticket is raised using the [raise a fault](https://claim-crown-court-defence.service.gov.uk/feedback/new?type=bug_report) form there is an optional field for email address. This is currently added to the ticket in the description. This PR will additionally add it to the `email_ccs` list.
