### PR TITLE
CTSKF-241 Zeitwerk: Inflect API

### DIFF
--- a/app/controllers/geckoboard_api/application_controller.rb
+++ b/app/controllers/geckoboard_api/application_controller.rb
@@ -1,4 +1,4 @@
-class GeckoboardApi::ApplicationController < ActionController::Base
+class GeckoboardAPI::ApplicationController < ActionController::Base
   before_action :authenticate_token!
 
   private

--- a/app/controllers/geckoboard_api/statistics_controller.rb
+++ b/app/controllers/geckoboard_api/statistics_controller.rb
@@ -1,4 +1,4 @@
-class GeckoboardApi::StatisticsController < ApplicationController
+class GeckoboardAPI::StatisticsController < ApplicationController
   include DisableViewOnlyActions
 
   skip_load_and_authorize_resource only: [:index]

--- a/app/controllers/geckoboard_api/widgets_controller.rb
+++ b/app/controllers/geckoboard_api/widgets_controller.rb
@@ -1,4 +1,4 @@
-class GeckoboardApi::WidgetsController < GeckoboardApi::ApplicationController
+class GeckoboardAPI::WidgetsController < GeckoboardAPI::ApplicationController
   include DisableViewOnlyActions
 
   # TODO: needed? not linked in statistic/index

--- a/app/interfaces/api/api_response.rb
+++ b/app/interfaces/api/api_response.rb
@@ -1,5 +1,5 @@
 module API
-  class ApiResponse
+  class APIResponse
     attr_accessor :status, :body
 
     def success?(status_code = nil)

--- a/app/interfaces/api/helpers/api_helper.rb
+++ b/app/interfaces/api/helpers/api_helper.rb
@@ -1,6 +1,6 @@
 module API
   module Helpers
-    module ApiHelper
+    module APIHelper
       require_relative '../custom_validations/standard_json_format'
       require_relative '../api_response'
       require_relative '../error_response'

--- a/app/interfaces/api/helpers/authorisation.rb
+++ b/app/interfaces/api/helpers/authorisation.rb
@@ -1,29 +1,31 @@
-module API::Helpers
-  module Authorisation
-    class AuthorisationError < StandardError; end
+module API
+  module Helpers
+    module Authorisation
+      class AuthorisationError < StandardError; end
 
-    def authorise_claim!
-      return unless claim_creator.provider != current_provider || claim_user.provider != current_provider
-      authorisation_error('Creator and advocate/litigator must belong to the provider')
-    end
+      def authorise_claim!
+        return unless claim_creator.provider != current_provider || claim_user.provider != current_provider
+        authorisation_error('Creator and advocate/litigator must belong to the provider')
+      end
 
-    def authenticate_provider_key!
-      authorisation_error if current_provider.nil?
-    end
+      def authenticate_provider_key!
+        authorisation_error if current_provider.nil?
+      end
 
-    def authenticate_key!
-      authorisation_error if current_user.nil?
-    end
+      def authenticate_key!
+        authorisation_error if current_user.nil?
+      end
 
-    def authenticate_user_is?(persona)
-      authorisation_error unless current_user&.persona_type.eql?(persona)
-    end
+      def authenticate_user_is?(persona)
+        authorisation_error unless current_user&.persona_type.eql?(persona)
+      end
 
-    private
+      private
 
-    def authorisation_error(message = 'Unauthorised')
-      Rails.logger.info format('[api authorisation error] %{s}', s: message)
-      raise AuthorisationError, message
+      def authorisation_error(message = 'Unauthorised')
+        Rails.logger.info format('[api authorisation error] %{s}', s: message)
+        raise AuthorisationError, message
+      end
     end
   end
 end

--- a/app/interfaces/api/helpers/formatters.rb
+++ b/app/interfaces/api/helpers/formatters.rb
@@ -1,25 +1,27 @@
-module API::Helpers
-  module Formatters
-    extend Grape::API::Helpers
+module API
+  module Helpers
+    module Formatters
+      extend Grape::API::Helpers
 
-    Grape::Entity.format_with :utc do |date|
-      unless date.nil?
-        date.is_a?(Time) ? date.utc : date.strftime('%Y-%m-%d')
+      Grape::Entity.format_with :utc do |date|
+        unless date.nil?
+          date.is_a?(Time) ? date.utc : date.strftime('%Y-%m-%d')
+        end
       end
-    end
 
-    Grape::Entity.format_with(:string, &:to_s)
+      Grape::Entity.format_with(:string, &:to_s)
 
-    Grape::Entity.format_with :decimal do |number|
-      number.to_f.round(2)
-    end
+      Grape::Entity.format_with :decimal do |number|
+        number.to_f.round(2)
+      end
 
-    Grape::Entity.format_with :integer_string do |number|
-      number.to_i.to_s
-    end
+      Grape::Entity.format_with :integer_string do |number|
+        number.to_i.to_s
+      end
 
-    Grape::Entity.format_with :bool_char do |boolean|
-      boolean.to_s.true? ? 'Y' : 'N'
+      Grape::Entity.format_with :bool_char do |boolean|
+        boolean.to_s.true? ? 'Y' : 'N'
+      end
     end
   end
 end

--- a/app/interfaces/api/helpers/grape_api_helper.rb
+++ b/app/interfaces/api/helpers/grape_api_helper.rb
@@ -2,8 +2,8 @@ require_relative 'api_helper'
 
 module API
   module Helpers
-    class GrapeApiHelper < Grape::API
-      include API::Helpers::ApiHelper
+    class GrapeAPIHelper < Grape::API
+      include API::Helpers::APIHelper
     end
   end
 end

--- a/app/interfaces/api/helpers/resource_helper.rb
+++ b/app/interfaces/api/helpers/resource_helper.rb
@@ -1,70 +1,72 @@
-module API::Helpers
-  module ResourceHelper
-    extend Grape::API::Helpers
+module API
+  module Helpers
+    module ResourceHelper
+      extend Grape::API::Helpers
 
-    def declared_params
-      declared(params, include_missing: false)
-    end
+      def declared_params
+        declared(params, include_missing: false)
+      end
 
-    def claim_source
-      params[:source] || 'api'
-    end
+      def claim_source
+        params[:source] || 'api'
+      end
 
-    def claim_id
-      claim = ::Claim::BaseClaim.active.find_by(uuid: params[:claim_id])
-      raise ArgumentError, 'Claim cannot be blank' unless claim
-      claim&.id
-    end
+      def claim_id
+        claim = ::Claim::BaseClaim.active.find_by(uuid: params[:claim_id])
+        raise ArgumentError, 'Claim cannot be blank' unless claim
+        claim&.id
+      end
 
-    def claim_creator
-      @claim_creator ||= find_user_by_email(email: params.delete(:creator_email), relation: 'Creator')
-    end
+      def claim_creator
+        @claim_creator ||= find_user_by_email(email: params.delete(:creator_email), relation: 'Creator')
+      end
 
-    def claim_user
-      @claim_user ||= find_user_by_email(email: claim_user_email, relation: claim_user_type)
-    end
+      def claim_user
+        @claim_user ||= find_user_by_email(email: claim_user_email, relation: claim_user_type)
+      end
 
-    def current_provider
-      @current_provider ||= Provider.find_by(api_key: params.delete(:api_key))
-    end
+      def current_provider
+        @current_provider ||= Provider.find_by(api_key: params.delete(:api_key))
+      end
 
-    def current_user
-      @current_user ||= User.find_by(api_key: params.delete(:api_key))
-    end
+      def current_user
+        @current_user ||= User.find_by(api_key: params.delete(:api_key))
+      end
 
-    def create_resource(klass)
-      API::Helpers::ApiHelper.create_resource(klass, params, api_response, arguments_proc)
-    end
+      def create_resource(klass)
+        API::Helpers::APIHelper.create_resource(klass, params, api_response, arguments_proc)
+      end
 
-    def validate_resource(klass)
-      API::Helpers::ApiHelper.validate_resource(klass, api_response, arguments_proc)
-    end
+      def validate_resource(klass)
+        API::Helpers::APIHelper.validate_resource(klass, api_response, arguments_proc)
+      end
 
-    def arguments_proc
-      method(:build_arguments).to_proc
-    end
+      def arguments_proc
+        method(:build_arguments).to_proc
+      end
 
-    def api_response
-      @api_response ||= API::ApiResponse.new
-    end
+      def api_response
+        @api_response ||= API::APIResponse.new
+      end
 
-    def find_user_by_email(email:, relation:)
-      user = User.active.external_users.find_by(email: email&.downcase)
-      raise ArgumentError, "#{relation} email is invalid" unless user
-      user&.persona
-    end
+      def find_user_by_email(email:, relation:)
+        user = User.active.external_users.find_by(email: email&.downcase)
+        raise ArgumentError, "#{relation} email is invalid" unless user
+        user&.persona
+      end
 
-    def lgfs_schema?
-      namespace =~ %r{/claims/(final|interim|transfer|hardship)}
-    end
+      def lgfs_schema?
+        namespace =~ %r{/claims/(final|interim|transfer|hardship)}
+      end
 
-    def claim_user_email
-      return params.delete(:user_email) if lgfs_schema?
-      params.delete(:advocate_email) || params.delete(:user_email)
-    end
+      def claim_user_email
+        return params.delete(:user_email) if lgfs_schema?
+        params.delete(:advocate_email) || params.delete(:user_email)
+      end
 
-    def claim_user_type
-      lgfs_schema? ? 'Litigator' : 'Advocate'
+      def claim_user_type
+        lgfs_schema? ? 'Litigator' : 'Advocate'
+      end
     end
   end
 end

--- a/app/interfaces/api/v1/dropdown_data.rb
+++ b/app/interfaces/api/v1/dropdown_data.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class DropdownData < API::Helpers::GrapeApiHelper
+    class DropdownData < API::Helpers::GrapeAPIHelper
       params do
         optional :api_key, type: String, desc: 'REQUIRED: The API authentication key of the provider'
       end

--- a/app/interfaces/api/v1/root.rb
+++ b/app/interfaces/api/v1/root.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class Root < API::Helpers::GrapeApiHelper
+    class Root < API::Helpers::GrapeAPIHelper
       version 'v1', using: :accept_version_header, cascade: false
       format :json
       content_type :json, 'application/json'

--- a/app/interfaces/api/v2/root.rb
+++ b/app/interfaces/api/v2/root.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class Root < API::Helpers::GrapeApiHelper
+    class Root < API::Helpers::GrapeAPIHelper
       version 'v2', using: :accept_version_header, cascade: false
       format :json
       content_type :json, 'application/json'

--- a/app/services/distance_calculator_service/directions.rb
+++ b/app/services/distance_calculator_service/directions.rb
@@ -12,7 +12,7 @@ class DistanceCalculatorService
     private
 
     def routes
-      @routes ||= DistanceCalculatorService::GoogleApi.new(@origin, @destination)
+      @routes ||= DistanceCalculatorService::GoogleAPI.new(@origin, @destination)
     end
   end
 end

--- a/app/services/distance_calculator_service/google_api.rb
+++ b/app/services/distance_calculator_service/google_api.rb
@@ -1,5 +1,5 @@
 class DistanceCalculatorService
-  class GoogleApi
+  class GoogleAPI
     def initialize(origin, destination)
       @origin = origin
       @destination = destination

--- a/app/services/remote/http_client.rb
+++ b/app/services/remote/http_client.rb
@@ -30,7 +30,7 @@ module Remote
 
     def execute_request(method, path, **query)
       endpoint = build_endpoint(path, **query)
-      response = Caching::ApiRequest.cache(endpoint) do
+      response = Caching::APIRequest.cache(endpoint) do
         # We have added the headers { 'X-Forwarded-Proto': 'https', 'X-Forwarded-Ssl': 'on' } in order to bypass the config.force_ssl
         # This is because this API call is now being routed internally and does not access the internet. HTTPS is not supported within the Kubernetes Cluster.
         # TODO: Decouple these headers from the HTTP Client or Find a new solution to route these internal calls without being affected by SSL/TLS.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -17,6 +17,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'LF2'
   inflect.acronym 'AGFS'
   inflect.acronym 'LGFS'
+  inflect.acronym 'API'
   inflect.human(/af1_lf1_processed_by/, "af1/lf1 processed by")
 end
 

--- a/lib/caching/api_request.rb
+++ b/lib/caching/api_request.rb
@@ -2,7 +2,7 @@ require 'digest/sha1'
 require 'uri'
 
 class Caching
-  class ApiRequest
+  class APIRequest
     attr_accessor :url, :options
 
     # Cache version, not necessarily matching API version

--- a/lib/google_analytics/api.rb
+++ b/lib/google_analytics/api.rb
@@ -1,7 +1,7 @@
 require 'rest_client'
 
 module GoogleAnalytics
-  class Api
+  class API
     def self.event(category, action, label = nil, client_id = fallback_client_id)
       return if tracker_id.blank?
       params = { v: version, tid: tracker_id, cid: client_id, t: 'event', ec: category, ea: action }

--- a/lib/thinkst_canary/api_queryable.rb
+++ b/lib/thinkst_canary/api_queryable.rb
@@ -1,7 +1,7 @@
 require 'forwardable'
 
 module ThinkstCanary
-  module ApiQueryable
+  module APIQueryable
     extend Forwardable
 
     def_delegator :configuration, :query

--- a/lib/thinkst_canary/factory.rb
+++ b/lib/thinkst_canary/factory.rb
@@ -1,6 +1,6 @@
 module ThinkstCanary
   class Factory
-    include ThinkstCanary::ApiQueryable
+    include ThinkstCanary::APIQueryable
 
     attr_reader :factory_auth, :flock_id, :memo
 

--- a/lib/thinkst_canary/factory_generator.rb
+++ b/lib/thinkst_canary/factory_generator.rb
@@ -1,6 +1,6 @@
 module ThinkstCanary
   class FactoryGenerator
-    include ThinkstCanary::ApiQueryable
+    include ThinkstCanary::APIQueryable
 
     def create_factory(memo:, flock_id:)
       params = { memo:, flock_id: }

--- a/lib/thinkst_canary/token/base.rb
+++ b/lib/thinkst_canary/token/base.rb
@@ -1,7 +1,7 @@
 module ThinkstCanary
   module Token
     class Base
-      include ThinkstCanary::ApiQueryable
+      include ThinkstCanary::APIQueryable
 
       attr_reader :memo, :canarytoken
 

--- a/spec/api/v1/external_users/fee_spec.rb
+++ b/spec/api/v1/external_users/fee_spec.rb
@@ -418,7 +418,7 @@ RSpec.describe API::V1::ExternalUsers::Fee do
 
       context 'unexpected error' do
         it 'returns 400 and JSON error array of error message' do
-          allow(API::Helpers::ApiHelper).to receive(:validate_resource).and_raise(RangeError)
+          allow(API::Helpers::APIHelper).to receive(:validate_resource).and_raise(RangeError)
           post_to_create_endpoint
           expect(last_response.status).to eq(400)
           result_hash = JSON.parse(last_response.body)

--- a/spec/lib/caching/api_request_spec.rb
+++ b/spec/lib/caching/api_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'caching/api_request'
 
-RSpec.describe Caching::ApiRequest do
+RSpec.describe Caching::APIRequest do
   let(:url) { 'http://test.com/ping.json' }
 
   let(:headers) { {} }

--- a/spec/lib/google_analytics/api_spec.rb
+++ b/spec/lib/google_analytics/api_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'google_analytics/api'
 
-describe GoogleAnalytics::Api do
+describe GoogleAnalytics::API do
   subject(:api) { described_class }
 
   let(:endpoint) { 'http://example.com' }

--- a/spec/services/distance_calculator_service/directions_spec.rb
+++ b/spec/services/distance_calculator_service/directions_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DistanceCalculatorService::Directions do
   before do
-    allow(DistanceCalculatorService::GoogleApi).to receive(:new).and_return(OpenStruct.new(distances:))
+    allow(DistanceCalculatorService::GoogleAPI).to receive(:new).and_return(OpenStruct.new(distances:))
   end
 
   describe '#max_distance' do

--- a/spec/services/distance_calculator_service/google_api_spec.rb
+++ b/spec/services/distance_calculator_service/google_api_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 # See https://developers.google.com/maps/documentation/directions/get-directions for example responses from the
 # Google Directions API
 
-RSpec.describe DistanceCalculatorService::GoogleApi do
+RSpec.describe DistanceCalculatorService::GoogleAPI do
   let(:returned_status) { 'OK' }
   let(:returned_routes) { [] }
 

--- a/spec/services/remote/http_client_spec.rb
+++ b/spec/services/remote/http_client_spec.rb
@@ -43,7 +43,7 @@ describe Remote::HttpClient do
 
     it 'calls execute on RestClient::Request' do
       response = double('HTTPResponse', body: 'body', headers: {})
-      expect(Caching::ApiRequest).to receive(:cache).with(endpoint).and_call_original
+      expect(Caching::APIRequest).to receive(:cache).with(endpoint).and_call_original
       expect(JSON).to receive(:parse).with('body', symbolize_names: true).and_return({ key: 'value' })
       expect(RestClient::Request)
         .to receive(:execute)

--- a/spec/support/api/api_test_client.rb
+++ b/spec/support/api/api_test_client.rb
@@ -78,7 +78,7 @@ class ApiTestClient
   #
   def get_dropdown_endpoint(resource, api_key, **params)
     endpoint(resource:, prefix: 'api', api_key:, **params) do |e|
-      body = Caching::ApiRequest.cache(e.url) do
+      body = Caching::APIRequest.cache(e.url) do
         e.get.tap { |response| handle_response(response, resource) }
       end
       JSON.parse(body)


### PR DESCRIPTION
#### What

As a pre-requisite for upgrading to rails 7, CCCD needs to move from the `classic` autoloader to `zeitwerk`. This requires us to update the CCCD codebase to be compatible with `zeitwerk`.

Zeitwerk requires all acronyms be properly inflected in class and module names. This pull request addresses the way acronym `API` is handled. This is currently inconsistent in CCCD, sometimes appearing as `Api` and sometimes as `API`.

#### Ticket

[CTSKF-241](https://dsdmoj.atlassian.net/browse/CTSKF-241) (formerly CFP-179)

#### Why

* To ensure future compatibility with the rails framework.
* To follow the [Ruby Style Guide](https://github.com/rubocop/ruby-style-guide#camelcase-classes) which recommends keeping acronyms uppercase.

#### How

Adds `API` to `config/initializers/inflections.rb` and capitalizes all instances in code. 

[CTSKF-241]: https://dsdmoj.atlassian.net/browse/CTSKF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ