### PR TITLE
CTSKF-241 Zeitwerk: Fix ManagementInformation namespace

### DIFF
--- a/app/services/stats/management_information/agfs_query_set.rb
+++ b/app/services/stats/management_information/agfs_query_set.rb
@@ -10,14 +10,14 @@ module Stats
       private
 
       def set
-        { intake_fixed_fee: AGFS::IntakeFixedFeeQuery,
-          intake_final_fee: AGFS::IntakeFinalFeeQuery,
-          af1_high_value: AGFS::Af1HighValueQuery,
-          af1_disk: AGFS::Af1DiskQuery,
-          af2_redetermination: AGFS::Af2RedeterminationQuery,
-          af2_high_value: AGFS::Af2HighValueQuery,
-          af2_disk: AGFS::Af2DiskQuery,
-          written_reasons: AGFS::WrittenReasonsQuery }
+        { intake_fixed_fee: Stats::ManagementInformation::Queries::AGFS::IntakeFixedFeeQuery,
+          intake_final_fee: Stats::ManagementInformation::Queries::AGFS::IntakeFinalFeeQuery,
+          af1_high_value: Stats::ManagementInformation::Queries::AGFS::Af1HighValueQuery,
+          af1_disk: Stats::ManagementInformation::Queries::AGFS::Af1DiskQuery,
+          af2_redetermination: Stats::ManagementInformation::Queries::AGFS::Af2RedeterminationQuery,
+          af2_high_value: Stats::ManagementInformation::Queries::AGFS::Af2HighValueQuery,
+          af2_disk: Stats::ManagementInformation::Queries::AGFS::Af2DiskQuery,
+          written_reasons: Stats::ManagementInformation::Queries::AGFS::WrittenReasonsQuery }
       end
     end
   end

--- a/app/services/stats/management_information/concerns/claim_type_filterable.rb
+++ b/app/services/stats/management_information/concerns/claim_type_filterable.rb
@@ -2,40 +2,42 @@
 
 module Stats
   module ManagementInformation
-    module ClaimTypeFilterable
-      extend ActiveSupport::Concern
+    module Concerns
+      module ClaimTypeFilterable
+        extend ActiveSupport::Concern
 
-      class_methods do
-        def acts_as_scheme(scheme)
-          define_method(:scheme) do
-            scheme&.to_s&.upcase
+        class_methods do
+          def acts_as_scheme(scheme)
+            define_method(:scheme) do
+              scheme&.to_s&.upcase
+            end
           end
         end
-      end
 
-      included do
-        def scheme
-          @scheme&.to_s&.upcase
-        end
+        included do
+          def scheme
+            @scheme&.to_s&.upcase
+          end
 
-        def scheme=(scheme)
-          @scheme = scheme&.to_s&.upcase
-        end
+          def scheme=(scheme)
+            @scheme = scheme&.to_s&.upcase
+          end
 
-        delegate :claim_types, :agfs_claim_types, :lgfs_claim_types, to: :base_claim_klass
+          delegate :claim_types, :agfs_claim_types, :lgfs_claim_types, to: :base_claim_klass
 
-        def base_claim_klass
-          ::Claim::BaseClaim
-        end
+          def base_claim_klass
+            ::Claim::BaseClaim
+          end
 
-        def claim_type_filter
-          return in_statement_for(agfs_claim_types) if scheme.eql?('AGFS')
-          return in_statement_for(lgfs_claim_types) if scheme.eql?('LGFS')
-          in_statement_for(claim_types)
-        end
+          def claim_type_filter
+            return in_statement_for(agfs_claim_types) if scheme.eql?('AGFS')
+            return in_statement_for(lgfs_claim_types) if scheme.eql?('LGFS')
+            in_statement_for(claim_types)
+          end
 
-        def in_statement_for(arr)
-          arr.map(&:to_s).join('\', \'').prepend('(\'').concat('\')')
+          def in_statement_for(arr)
+            arr.map(&:to_s).join('\', \'').prepend('(\'').concat('\')')
+          end
         end
       end
     end

--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -4,198 +4,200 @@ require_relative 'claim_type_filterable'
 
 module Stats
   module ManagementInformation
-    module JourneyQueryable
-      extend ActiveSupport::Concern
+    module Concerns
+      module JourneyQueryable
+        extend ActiveSupport::Concern
 
-      included do
-        def prepare
-          return if journeys_func_exists? && !replace_journeys_func?
-          recreate_journeys_func
-        end
+        included do
+          def prepare
+            return if journeys_func_exists? && !replace_journeys_func?
+            recreate_journeys_func
+          end
 
-        def journeys_query
-          <<~SQL
-            SELECT
-              c.*,
-              c2.scheme as scheme,
-              p.name as organisation,
-              coalesce(ct.name, ct2.name) as case_type_name,
-              c2.scheme || ' ' || c2.sub_type as bill_type,
-              round(c.total + c.vat_amount, 4) as claim_total,
-              c.last_submitted_at at time zone 'utc' at time zone 'Europe/London' as last_submitted_at,
-              c.original_submission_date at time zone 'utc' at time zone 'Europe/London' as originally_submitted_at,
-              completion.completed_at as completed_at,
-              main_defendant.name as main_defendant,
-              earliest_representation_order.maat_reference as maat_reference,
-              earliest_representation_order.representation_order_date as rep_order_issued_date,
-              previous_redetermined_decision.author_name as af1_lf1_processed_by,
-              misc_fees.descriptions as misc_fees,
-              j.journey as journey
-            FROM claims c
-            LEFT OUTER JOIN external_users AS creator
-              ON c.creator_id = creator.id
-            LEFT OUTER JOIN providers AS p
-              ON p.id = creator.provider_id
-            LEFT OUTER JOIN case_types AS ct
-              ON ct.id = c.case_type_id
-            LEFT OUTER JOIN case_stages cs
-              ON cs.id = c.case_stage_id
-            LEFT OUTER JOIN case_types AS ct2
-              ON ct2.id = cs.case_type_id
-            LEFT JOIN LATERAL journeys(c.id) j
-              ON TRUE
-            LEFT JOIN LATERAL (
-              select
-                case
-                  when type in #{in_statement_for(agfs_claim_types)} then 'AGFS'
-                  when type in #{in_statement_for(lgfs_claim_types)} then 'LGFS'
-                  else 'Unknown'
-                end as scheme,
-                case
-                  when regexp_replace(type, 'Claim|::|Advocate|Litigator|\s+', '', 'g') = '' then 'Final'
-                  else regexp_replace(type, 'Claim|::|Advocate|Litigator|\s+', '', 'g')
-                end as sub_type
-              from claims
-              where id = c.id
-            ) c2 ON TRUE
-            LEFT JOIN LATERAL (
-              select (transitions ->> 'created_at')::timestamptz at time zone 'Europe/London' as completed_at
-                from jsonb_array_elements(j.journey) transitions
-               where transitions ->> 'to' in ('rejected', 'refused', 'authorised', 'part_authorised')
-              fetch first row only
-            ) completion ON TRUE
-            LEFT JOIN LATERAL (
-              select first_name || ' ' || last_name as name
-              from defendants d
-              where claim_id = c.id
-              order by d.created_at asc
-              fetch first row only
-            ) main_defendant ON TRUE
-            LEFT JOIN LATERAL (
-              select maat_reference,
-                     representation_order_date
-              from representation_orders r, defendants d2
-              where d2.claim_id = c.id
-                and r.defendant_id = d2.id
-              order by r.representation_order_date, r.created_at asc
-              fetch first row only
-            ) earliest_representation_order ON TRUE
-            LEFT JOIN LATERAL (
-              select transitions ->> 'author_name' as author_name
-              from journeys(c.id) j2,
-                   jsonb_array_elements(j2.journey) transitions
-              where j.journey -> 0 ->> 'to' = 'redetermination'
-                and transitions ->> 'to' = j.journey -> 0 ->> 'from'
-                and (transitions ->> 'created_at')::timestamp < (j.journey -> 0 ->> 'created_at')::timestamp
-              order by (transitions ->> 'created_at')::timestamp desc
-              fetch first row only
-            ) previous_redetermined_decision ON TRUE
-            LEFT JOIN LATERAL (
-              select string_agg(ft.description, ' ' order by f.id) as descriptions
-              from fees f, fee_types ft
-              where f.claim_id = c.id
-                and f.fee_type_id = ft.id
-                and ft.type = 'Fee::MiscFeeType'
-              group by f.claim_id
-            ) misc_fees ON TRUE
-            WHERE c.deleted_at IS NULL
-              AND c.state != 'draft'
-              AND c.type IN #{claim_type_filter}
-              AND j.journey::text <> '[]'
-          SQL
-        end
+          def journeys_query
+            <<~SQL
+              SELECT
+                c.*,
+                c2.scheme as scheme,
+                p.name as organisation,
+                coalesce(ct.name, ct2.name) as case_type_name,
+                c2.scheme || ' ' || c2.sub_type as bill_type,
+                round(c.total + c.vat_amount, 4) as claim_total,
+                c.last_submitted_at at time zone 'utc' at time zone 'Europe/London' as last_submitted_at,
+                c.original_submission_date at time zone 'utc' at time zone 'Europe/London' as originally_submitted_at,
+                completion.completed_at as completed_at,
+                main_defendant.name as main_defendant,
+                earliest_representation_order.maat_reference as maat_reference,
+                earliest_representation_order.representation_order_date as rep_order_issued_date,
+                previous_redetermined_decision.author_name as af1_lf1_processed_by,
+                misc_fees.descriptions as misc_fees,
+                j.journey as journey
+              FROM claims c
+              LEFT OUTER JOIN external_users AS creator
+                ON c.creator_id = creator.id
+              LEFT OUTER JOIN providers AS p
+                ON p.id = creator.provider_id
+              LEFT OUTER JOIN case_types AS ct
+                ON ct.id = c.case_type_id
+              LEFT OUTER JOIN case_stages cs
+                ON cs.id = c.case_stage_id
+              LEFT OUTER JOIN case_types AS ct2
+                ON ct2.id = cs.case_type_id
+              LEFT JOIN LATERAL journeys(c.id) j
+                ON TRUE
+              LEFT JOIN LATERAL (
+                select
+                  case
+                    when type in #{in_statement_for(agfs_claim_types)} then 'AGFS'
+                    when type in #{in_statement_for(lgfs_claim_types)} then 'LGFS'
+                    else 'Unknown'
+                  end as scheme,
+                  case
+                    when regexp_replace(type, 'Claim|::|Advocate|Litigator|\s+', '', 'g') = '' then 'Final'
+                    else regexp_replace(type, 'Claim|::|Advocate|Litigator|\s+', '', 'g')
+                  end as sub_type
+                from claims
+                where id = c.id
+              ) c2 ON TRUE
+              LEFT JOIN LATERAL (
+                select (transitions ->> 'created_at')::timestamptz at time zone 'Europe/London' as completed_at
+                  from jsonb_array_elements(j.journey) transitions
+                where transitions ->> 'to' in ('rejected', 'refused', 'authorised', 'part_authorised')
+                fetch first row only
+              ) completion ON TRUE
+              LEFT JOIN LATERAL (
+                select first_name || ' ' || last_name as name
+                from defendants d
+                where claim_id = c.id
+                order by d.created_at asc
+                fetch first row only
+              ) main_defendant ON TRUE
+              LEFT JOIN LATERAL (
+                select maat_reference,
+                      representation_order_date
+                from representation_orders r, defendants d2
+                where d2.claim_id = c.id
+                  and r.defendant_id = d2.id
+                order by r.representation_order_date, r.created_at asc
+                fetch first row only
+              ) earliest_representation_order ON TRUE
+              LEFT JOIN LATERAL (
+                select transitions ->> 'author_name' as author_name
+                from journeys(c.id) j2,
+                    jsonb_array_elements(j2.journey) transitions
+                where j.journey -> 0 ->> 'to' = 'redetermination'
+                  and transitions ->> 'to' = j.journey -> 0 ->> 'from'
+                  and (transitions ->> 'created_at')::timestamp < (j.journey -> 0 ->> 'created_at')::timestamp
+                order by (transitions ->> 'created_at')::timestamp desc
+                fetch first row only
+              ) previous_redetermined_decision ON TRUE
+              LEFT JOIN LATERAL (
+                select string_agg(ft.description, ' ' order by f.id) as descriptions
+                from fees f, fee_types ft
+                where f.claim_id = c.id
+                  and f.fee_type_id = ft.id
+                  and ft.type = 'Fee::MiscFeeType'
+                group by f.claim_id
+              ) misc_fees ON TRUE
+              WHERE c.deleted_at IS NULL
+                AND c.state != 'draft'
+                AND c.type IN #{claim_type_filter}
+                AND j.journey::text <> '[]'
+            SQL
+          end
 
-        private
+          private
 
-        def journeys_func_exists?
-          sql = 'select exists(select * from pg_proc where proname = \'journeys\');'
-          res = ActiveRecord::Base.connection.execute(sql)
-          res.first['exists']
-        end
+          def journeys_func_exists?
+            sql = 'select exists(select * from pg_proc where proname = \'journeys\');'
+            res = ActiveRecord::Base.connection.execute(sql)
+            res.first['exists']
+          end
 
-        def replace_journeys_func?
-          Settings.replace_journeys_func?
-        end
+          def replace_journeys_func?
+            Settings.replace_journeys_func?
+          end
 
-        def recreate_journeys_func
-          ActiveRecord::Base.connection.execute(drop_journeys_func)
-          ActiveRecord::Base.connection.execute(create_journeys_func)
-        end
+          def recreate_journeys_func
+            ActiveRecord::Base.connection.execute(drop_journeys_func)
+            ActiveRecord::Base.connection.execute(create_journeys_func)
+          end
 
-        def drop_journeys_func
-          <<~SQL
-            DROP FUNCTION IF EXISTS journeys(integer);
-          SQL
-        end
+          def drop_journeys_func
+            <<~SQL
+              DROP FUNCTION IF EXISTS journeys(integer);
+            SQL
+          end
 
-        def create_journeys_func
-          <<~SQL
-            CREATE OR REPLACE FUNCTION journeys(in_claim_id int)
-            RETURNS TABLE(journey jsonb)
-            COST 100
-            STABLE
-            AS
-            $BODY$
-            DECLARE
-              rec record;
-              transition jsonb;
-              slice jsonb := '[]'::jsonb;
-              filtered_states constant varchar[] := array['draft', 'archived_pending_delete' , 'archived_pending_review'];
-              completed_states constant varchar[] := array['rejected', 'refused', 'authorised', 'part_authorised'];
-            BEGIN
-              for rec in (
-                with transitions as (
+          def create_journeys_func
+            <<~SQL
+              CREATE OR REPLACE FUNCTION journeys(in_claim_id int)
+              RETURNS TABLE(journey jsonb)
+              COST 100
+              STABLE
+              AS
+              $BODY$
+              DECLARE
+                rec record;
+                transition jsonb;
+                slice jsonb := '[]'::jsonb;
+                filtered_states constant varchar[] := array['draft', 'archived_pending_delete' , 'archived_pending_review'];
+                completed_states constant varchar[] := array['rejected', 'refused', 'authorised', 'part_authorised'];
+              BEGIN
+                for rec in (
+                  with transitions as (
+                    select t.claim_id,
+                          t.from,
+                          t.to,
+                          t.created_at at time zone 'utc' at time zone 'Europe/London' as created_at,
+                          t.reason_code,
+                          t.reason_text,
+                          (authors.first_name || ' ' || authors.last_name) as author_name,
+                          (subjects.first_name || ' ' || subjects.last_name) as subject_name
+                    from claim_state_transitions t
+                    left outer join users as authors
+                      on t.author_id = authors.id
+                    left outer join users as subjects
+                      on t.subject_id = subjects.id
+                    where t.claim_id = in_claim_id
+                    and t.to not in (select * from unnest(filtered_states))
+                    and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')
+                  )
                   select t.claim_id,
-                         t.from,
-                         t.to,
-                         t.created_at at time zone 'utc' at time zone 'Europe/London' as created_at,
-                         t.reason_code,
-                         t.reason_text,
-                         (authors.first_name || ' ' || authors.last_name) as author_name,
-                         (subjects.first_name || ' ' || subjects.last_name) as subject_name
-                  from claim_state_transitions t
-                  left outer join users as authors
-                    on t.author_id = authors.id
-                  left outer join users as subjects
-                    on t.subject_id = subjects.id
-                  where t.claim_id = in_claim_id
-                  and t.to not in (select * from unnest(filtered_states))
-                  and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')
-                )
-                select t.claim_id,
-                       jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions
-                from transitions t
-                group by t.claim_id
-              ) loop
-                slice := '[]'::jsonb;
+                        jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions
+                  from transitions t
+                  group by t.claim_id
+                ) loop
+                  slice := '[]'::jsonb;
 
-                for transition in (select jsonb_array_elements(rec.transitions))
-                loop
-                  -- remove "deallocated" allocations as not wanted for report
-                  if transition ->> 'to' = 'deallocated' then
-                    slice := slice - -1;
-                  else
-                    slice := slice || transition;
-                  end if;
+                  for transition in (select jsonb_array_elements(rec.transitions))
+                  loop
+                    -- remove "deallocated" allocations as not wanted for report
+                    if transition ->> 'to' = 'deallocated' then
+                      slice := slice - -1;
+                    else
+                      slice := slice || transition;
+                    end if;
 
-                  -- pipe out completed slice as row
-                  if transition ->> 'to' in (select * from unnest(completed_states)) then
+                    -- pipe out completed slice as row
+                    if transition ->> 'to' in (select * from unnest(completed_states)) then
+                      journey := slice;
+                      return next;
+                      slice := '[]'::jsonb;
+                    end if;
+                  end loop;
+
+                  -- pipe out last slice for claim unless it already has been above (because it has a completed status)
+                  if transition ->> 'to' not in (select * from unnest(completed_states)) then
                     journey := slice;
                     return next;
-                    slice := '[]'::jsonb;
                   end if;
                 end loop;
-
-                -- pipe out last slice for claim unless it already has been above (because it has a completed status)
-                if transition ->> 'to' not in (select * from unnest(completed_states)) then
-                  journey := slice;
-                  return next;
-                end if;
-              end loop;
-            END
-            $BODY$
-            LANGUAGE plpgsql;
-          SQL
+              END
+              $BODY$
+              LANGUAGE plpgsql;
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/daily_report_query.rb
+++ b/app/services/stats/management_information/daily_report_query.rb
@@ -6,8 +6,8 @@ Dir[File.join(__dir__, 'queries', '*.rb')].each { |f| require_dependency f }
 module Stats
   module ManagementInformation
     class DailyReportQuery
-      include JourneyQueryable
-      include ClaimTypeFilterable
+      include Concerns::JourneyQueryable
+      include Concerns::ClaimTypeFilterable
 
       def self.call(...)
         new(...).call

--- a/app/services/stats/management_information/lgfs_query_set.rb
+++ b/app/services/stats/management_information/lgfs_query_set.rb
@@ -10,15 +10,15 @@ module Stats
       private
 
       def set
-        { intake_fixed_fee: LGFS::IntakeFixedFeeQuery,
-          intake_final_fee: LGFS::IntakeFinalFeeQuery,
-          lf1_high_value: LGFS::Lf1HighValueQuery,
-          lf1_disk: LGFS::Lf1DiskQuery,
-          lf2_redetermination: LGFS::Lf2RedeterminationQuery,
-          lf2_high_value: LGFS::Lf2HighValueQuery,
-          lf2_disk: LGFS::Lf2DiskQuery,
-          written_reasons: LGFS::WrittenReasonsQuery,
-          intake_interim_fee: LGFS::IntakeInterimFeeQuery }
+        { intake_fixed_fee: Stats::ManagementInformation::Queries::LGFS::IntakeFixedFeeQuery,
+          intake_final_fee: Stats::ManagementInformation::Queries::LGFS::IntakeFinalFeeQuery,
+          lf1_high_value: Stats::ManagementInformation::Queries::LGFS::Lf1HighValueQuery,
+          lf1_disk: Stats::ManagementInformation::Queries::LGFS::Lf1DiskQuery,
+          lf2_redetermination: Stats::ManagementInformation::Queries::LGFS::Lf2RedeterminationQuery,
+          lf2_high_value: Stats::ManagementInformation::Queries::LGFS::Lf2HighValueQuery,
+          lf2_disk: Stats::ManagementInformation::Queries::LGFS::Lf2DiskQuery,
+          written_reasons: Stats::ManagementInformation::Queries::LGFS::WrittenReasonsQuery,
+          intake_interim_fee: Stats::ManagementInformation::Queries::LGFS::IntakeInterimFeeQuery }
       end
     end
   end

--- a/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_disk_query.rb
@@ -11,30 +11,32 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class Af1DiskQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class Af1DiskQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND j.disk_evidence
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND j.disk_evidence
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af1_high_value_query.rb
@@ -13,31 +13,33 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class Af1HighValueQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class Af1HighValueQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float >= 20000.00
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float >= 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_disk_query.rb
@@ -11,30 +11,32 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class Af2DiskQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class Af2DiskQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND j.journey -> 0 ->> 'to' = 'redetermination'
-              AND j.disk_evidence
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND j.journey -> 0 ->> 'to' = 'redetermination'
+                AND j.disk_evidence
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_high_value_query.rb
@@ -12,31 +12,33 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class Af2HighValueQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class Af2HighValueQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND j.journey -> 0 ->> 'to' = 'redetermination'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float >= 20000.00
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND j.journey -> 0 ->> 'to' = 'redetermination'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float >= 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/agfs/af2_redetermination_query.rb
@@ -12,31 +12,33 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class Af2RedeterminationQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class Af2RedeterminationQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND j.journey -> 0 ->> 'to' = 'redetermination'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float < 20000.00
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND j.journey -> 0 ->> 'to' = 'redetermination'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float < 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_final_fee_query.rb
@@ -13,44 +13,46 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class IntakeFinalFeeQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class IntakeFinalFeeQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        # NOTE: on time zone edge cases:
-        # `completed_at` and `originally_submitted_at` have already been converted to
-        # be in 'Europe/London' time but as UTC (i.e. WITHOUT time zone information).
-        # Therefore we do not need to use AT TIME ZONE here to handle boundaries issues.
-        # see https://www.enterprisedb.com/postgres-tutorials/postgres-time-zone-explained
-        #
-        # To check details being retrieved you can use this:
-        # puts ActiveRecord::Base.connection.execute("WITH journeys AS (#{journeys_query}) select scheme, case_type_name, journey -> 0 ->> 'to' as to_state, date_trunc('day', j.originally_submitted_at) as submitted_at, date_trunc('day', j.completed_at) as completed_at, j.disk_evidence, j.claim_total::float from journeys j").to_a
-        #
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND (
-                  trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
-                  OR j.case_type_name is NULL
-                  )
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float < 20000.00
-            GROUP BY day
-          SQL
+          # NOTE: on time zone edge cases:
+          # `completed_at` and `originally_submitted_at` have already been converted to
+          # be in 'Europe/London' time but as UTC (i.e. WITHOUT time zone information).
+          # Therefore we do not need to use AT TIME ZONE here to handle boundaries issues.
+          # see https://www.enterprisedb.com/postgres-tutorials/postgres-time-zone-explained
+          #
+          # To check details being retrieved you can use this:
+          # puts ActiveRecord::Base.connection.execute("WITH journeys AS (#{journeys_query}) select scheme, case_type_name, journey -> 0 ->> 'to' as to_state, date_trunc('day', j.originally_submitted_at) as submitted_at, date_trunc('day', j.completed_at) as completed_at, j.disk_evidence, j.claim_total::float from journeys j").to_a
+          #
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND (
+                    trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
+                    OR j.case_type_name is NULL
+                    )
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float < 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/agfs/intake_fixed_fee_query.rb
@@ -14,32 +14,34 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class IntakeFixedFeeQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class IntakeFixedFeeQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded')
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float < 20000.00
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded')
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float < 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/agfs/written_reasons_query.rb
@@ -10,29 +10,31 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module AGFS
-      class WrittenReasonsQuery < BaseCountQuery
-        acts_as_scheme :agfs
+    module Queries
+      module AGFS
+        class WrittenReasonsQuery < BaseCountQuery
+          acts_as_scheme :agfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'AGFS'
-              AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'AGFS'
+                AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/base_count_query.rb
+++ b/app/services/stats/management_information/queries/base_count_query.rb
@@ -2,33 +2,35 @@
 
 module Stats
   module ManagementInformation
-    class BaseCountQuery
-      include JourneyQueryable
-      include ClaimTypeFilterable
+    module Queries
+      class BaseCountQuery
+        include Concerns::JourneyQueryable
+        include Concerns::ClaimTypeFilterable
 
-      def self.call(...)
-        new(...).call
-      end
+        def self.call(...)
+          new(...).call
+        end
 
-      def initialize(date_range:, date_column_filter:)
-        @start_at = date_range.first.iso8601
-        @end_at = date_range.last.iso8601
-        @date_column_filter = sql_quote(date_column_filter)
-      end
+        def initialize(date_range:, date_column_filter:)
+          @start_at = date_range.first.iso8601
+          @end_at = date_range.last.iso8601
+          @date_column_filter = sql_quote(date_column_filter)
+        end
 
-      def call
-        prepare
-        ActiveRecord::Base.connection.execute(query)
-      end
+        def call
+          prepare
+          ActiveRecord::Base.connection.execute(query)
+        end
 
-      private
+        private
 
-      def sql_quote(column_name)
-        ActiveRecord::Base.connection.quote_column_name(column_name)
-      end
+        def sql_quote(column_name)
+          ActiveRecord::Base.connection.quote_column_name(column_name)
+        end
 
-      def query
-        raise RuntimeError
+        def query
+          raise RuntimeError
+        end
       end
     end
   end

--- a/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_final_fee_query.rb
@@ -14,36 +14,38 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class IntakeFinalFeeQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class IntakeFinalFeeQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND trim(lower(j.bill_type)) = 'lgfs final'
-              AND (
-                  trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
-                  OR j.case_type_name is NULL
-                  )
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float < 20000.00
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND trim(lower(j.bill_type)) = 'lgfs final'
+                AND (
+                    trim(lower(j.case_type_name)) in ('cracked before retrial', 'cracked trial', 'discontinuance', 'guilty plea', 'retrial', 'trial')
+                    OR j.case_type_name is NULL
+                    )
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float < 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_fixed_fee_query.rb
@@ -13,32 +13,34 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class IntakeFixedFeeQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class IntakeFixedFeeQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded', 'hearing subsequent to sentence')
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float < 20000.00
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND trim(lower(j.case_type_name)) in ('appeal against conviction', 'appeal against sentence', 'breach of crown court order', 'committal for sentence', 'contempt', 'elected cases not proceeded', 'hearing subsequent to sentence')
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float < 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/intake_interim_fee_query.rb
@@ -13,32 +13,34 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class IntakeInterimFeeQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class IntakeInterimFeeQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND trim(lower(j.bill_type)) = 'lgfs interim'
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float < 20000.00
-            GROUP BY day
-          SQL
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND trim(lower(j.bill_type)) = 'lgfs interim'
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float < 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/lf1_disk_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf1_disk_query.rb
@@ -11,31 +11,33 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class Lf1DiskQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class Lf1DiskQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        # OPTIMIZE: this is the sames as Af1DiskQuery
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND j.disk_evidence
-            GROUP BY day
-          SQL
+          # OPTIMIZE: this is the sames as Af1DiskQuery
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND j.disk_evidence
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf1_high_value_query.rb
@@ -12,32 +12,34 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class Lf1HighValueQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class Lf1HighValueQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        # OPTIMIZE: this is the sames as Af1HighValueQuery
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND j.journey -> 0 ->> 'to' = 'submitted'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float >= 20000.00
-            GROUP BY day
-          SQL
+          # OPTIMIZE: this is the sames as Af1HighValueQuery
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND j.journey -> 0 ->> 'to' = 'submitted'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float >= 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_disk_query.rb
@@ -11,31 +11,33 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class Lf2DiskQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class Lf2DiskQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        # OPTIMIZE: this is the sames as Af2DiskQuery
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND j.journey -> 0 ->> 'to' = 'redetermination'
-              AND j.disk_evidence
-            GROUP BY day
-          SQL
+          # OPTIMIZE: this is the sames as Af2DiskQuery
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND j.journey -> 0 ->> 'to' = 'redetermination'
+                AND j.disk_evidence
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_high_value_query.rb
@@ -12,32 +12,34 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class Lf2HighValueQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class Lf2HighValueQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        # OPTIMIZE: this is the sames as Af2HighValueQuery
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND j.journey -> 0 ->> 'to' = 'redetermination'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float >= 20000.00
-            GROUP BY day
-          SQL
+          # OPTIMIZE: this is the sames as Af2HighValueQuery
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND j.journey -> 0 ->> 'to' = 'redetermination'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float >= 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/lf2_redetermination_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/lf2_redetermination_query.rb
@@ -12,32 +12,34 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class Lf2RedeterminationQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class Lf2RedeterminationQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        # OPTIMIZE: this is the sames as Af2RedeterminationQuery
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND j.journey -> 0 ->> 'to' = 'redetermination'
-              AND NOT j.disk_evidence
-              AND j.claim_total::float < 20000.00
-            GROUP BY day
-          SQL
+          # OPTIMIZE: this is the sames as Af2RedeterminationQuery
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND j.journey -> 0 ->> 'to' = 'redetermination'
+                AND NOT j.disk_evidence
+                AND j.claim_total::float < 20000.00
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
+++ b/app/services/stats/management_information/queries/lgfs/written_reasons_query.rb
@@ -10,30 +10,32 @@ Dir.glob(File.join(__dir__, '..', 'base_count_query.rb')).each { |f| require_dep
 
 module Stats
   module ManagementInformation
-    module LGFS
-      class WrittenReasonsQuery < BaseCountQuery
-        acts_as_scheme :lgfs
+    module Queries
+      module LGFS
+        class WrittenReasonsQuery < BaseCountQuery
+          acts_as_scheme :lgfs
 
-        private
+          private
 
-        # OPTIMIZE: this is the sames as AGFS::WrittenReasonsQuery
-        def query
-          <<~SQL
-            WITH days AS (
-              SELECT day::date
-              FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
-            ),
-            journeys AS (
-              #{journeys_query}
-            )
-            SELECT count(j.*), date_trunc('day', d.day) as day
-            FROM days d
-            LEFT OUTER JOIN journeys j
-              ON date_trunc('day', j.#{@date_column_filter}) = d.day
-              AND j.scheme = 'LGFS'
-              AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
-            GROUP BY day
-          SQL
+          # OPTIMIZE: this is the sames as AGFS::WrittenReasonsQuery
+          def query
+            <<~SQL
+              WITH days AS (
+                SELECT day::date
+                FROM generate_series('#{@start_at}', '#{@end_at}', '1 day'::interval) day
+              ),
+              journeys AS (
+                #{journeys_query}
+              )
+              SELECT count(j.*), date_trunc('day', d.day) as day
+              FROM days d
+              LEFT OUTER JOIN journeys j
+                ON date_trunc('day', j.#{@date_column_filter}) = d.day
+                AND j.scheme = 'LGFS'
+                AND j.journey -> 0 ->> 'to' = 'awaiting_written_reasons'
+              GROUP BY day
+            SQL
+          end
         end
       end
     end

--- a/spec/services/stats/management_information/concerns/claim_type_filterable_spec.rb
+++ b/spec/services/stats/management_information/concerns/claim_type_filterable_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
+RSpec.describe Stats::ManagementInformation::Concerns::ClaimTypeFilterable do
   let(:agfs_in_statement) do
     <<~STATEMENT.squish.squeeze(' ')
       ('Claim::AdvocateClaim',
@@ -41,7 +41,7 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
 
     let(:mock_claim_type_filter) do
       Class.new do
-        include Stats::ManagementInformation::ClaimTypeFilterable
+        include Stats::ManagementInformation::Concerns::ClaimTypeFilterable
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
 
     let(:mock_claim_type_filter_with_initilizer) do
       Class.new do
-        include Stats::ManagementInformation::ClaimTypeFilterable
+        include Stats::ManagementInformation::Concerns::ClaimTypeFilterable
 
         def initialize(**kwargs)
           @scheme = kwargs[:scheme]
@@ -139,7 +139,7 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
 
     let(:mock_agfs_claim_type_filter) do
       Class.new do
-        include Stats::ManagementInformation::ClaimTypeFilterable
+        include Stats::ManagementInformation::Concerns::ClaimTypeFilterable
 
         acts_as_scheme :agfs
       end
@@ -174,7 +174,7 @@ RSpec.describe Stats::ManagementInformation::ClaimTypeFilterable do
 
     let(:mock_lgfs_claim_type_filter) do
       Class.new do
-        include Stats::ManagementInformation::ClaimTypeFilterable
+        include Stats::ManagementInformation::Concerns::ClaimTypeFilterable
 
         acts_as_scheme :lgfs
       end

--- a/spec/services/stats/management_information/queries/agfs/af1_disk_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/af1_disk_query_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_journey_queryable'
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_journey_queryable'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::Af1DiskQuery do
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::Af1DiskQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/queries/agfs/af1_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/af1_high_value_query_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::Af1HighValueQuery do
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::Af1HighValueQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/queries/agfs/af2_disk_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/af2_disk_query_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::Af2DiskQuery do
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::Af2DiskQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/queries/agfs/af2_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/af2_high_value_query_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::Lf2HighValueQuery do
-  it_behaves_like 'a base count query', 'LGFS'
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::Af2HighValueQuery do
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today
     let(:claim) do
-      create(:litigator_final_claim, :refused, disk_evidence: false).tap do |claim|
+      create(:advocate_final_claim, :refused, disk_evidence: false).tap do |claim|
         claim.update!(total: 20_000)
         claim.redetermine!
       end
@@ -18,7 +18,7 @@ RSpec.describe Stats::ManagementInformation::LGFS::Lf2HighValueQuery do
   it_behaves_like 'a completed_at filterable query' do
     # [submitted, allocated, refused] and [redetermination, allocated, refused] today
     let(:claim) do
-      create(:litigator_final_claim, :refused, disk_evidence: false).tap do |claim|
+      create(:advocate_final_claim, :refused, disk_evidence: false).tap do |claim|
         claim.update!(total: 20_000)
         claim.redetermine!
         claim.allocate!

--- a/spec/services/stats/management_information/queries/agfs/af2_redetermination_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/af2_redetermination_query_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::Af2HighValueQuery do
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::Af2RedeterminationQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today
     let(:claim) do
       create(:advocate_final_claim, :refused, disk_evidence: false).tap do |claim|
-        claim.update!(total: 20_000)
+        claim.update!(total: 19_999)
         claim.redetermine!
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe Stats::ManagementInformation::AGFS::Af2HighValueQuery do
     # [submitted, allocated, refused] and [redetermination, allocated, refused] today
     let(:claim) do
       create(:advocate_final_claim, :refused, disk_evidence: false).tap do |claim|
-        claim.update!(total: 20_000)
+        claim.update!(total: 19_999)
         claim.redetermine!
         claim.allocate!
         claim.refuse!

--- a/spec/services/stats/management_information/queries/agfs/intake_final_fee_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/intake_final_fee_query_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::IntakeFixedFeeQuery do
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::IntakeFinalFeeQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do
       create(:advocate_final_claim,
              :submitted,
-             case_type: build(:case_type, :appeal_against_conviction))
+             case_type: build(:case_type, :trial))
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Stats::ManagementInformation::AGFS::IntakeFixedFeeQuery do
     let(:claim) do
       create(:advocate_final_claim,
              :refused,
-             case_type: build(:case_type, :appeal_against_conviction))
+             case_type: build(:case_type, :trial))
     end
   end
 end

--- a/spec/services/stats/management_information/queries/agfs/intake_fixed_fee_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/intake_fixed_fee_query_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::IntakeFinalFeeQuery do
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::IntakeFixedFeeQuery do
   it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do
       create(:advocate_final_claim,
              :submitted,
-             case_type: build(:case_type, :trial))
+             case_type: build(:case_type, :appeal_against_conviction))
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Stats::ManagementInformation::AGFS::IntakeFinalFeeQuery do
     let(:claim) do
       create(:advocate_final_claim,
              :refused,
-             case_type: build(:case_type, :trial))
+             case_type: build(:case_type, :appeal_against_conviction))
     end
   end
 end

--- a/spec/services/stats/management_information/queries/agfs/written_reasons_query_spec.rb
+++ b/spec/services/stats/management_information/queries/agfs/written_reasons_query_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::WrittenReasonsQuery do
-  it_behaves_like 'a base count query', 'LGFS'
+RSpec.describe Stats::ManagementInformation::Queries::AGFS::WrittenReasonsQuery do
+  it_behaves_like 'a base count query', 'AGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [awaiting_written_reasons] today
     let(:claim) do
-      create(:litigator_final_claim, :refused).tap(&:await_written_reasons!)
+      create(:advocate_final_claim, :refused).tap(&:await_written_reasons!)
     end
   end
 
   it_behaves_like 'a completed_at filterable query' do
     # [submitted, allocated, refused] and [awaiting_written_reasons allocated, refused] today
     let(:claim) do
-      create(:litigator_final_claim, :refused).tap do |claim|
+      create(:advocate_final_claim, :refused).tap do |claim|
         claim.await_written_reasons!
         claim.allocate!
         claim.refuse!

--- a/spec/services/stats/management_information/queries/lgfs/intake_final_fee_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/intake_final_fee_query_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::IntakeFixedFeeQuery do
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::IntakeFinalFeeQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do
       create(:litigator_final_claim,
              :submitted,
-             case_type: build(:case_type, :hearing_subsequent_to_sentence))
+             case_type: build(:case_type, :trial))
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Stats::ManagementInformation::LGFS::IntakeFixedFeeQuery do
     let(:claim) do
       create(:litigator_final_claim,
              :refused,
-             case_type: build(:case_type, :hearing_subsequent_to_sentence))
+             case_type: build(:case_type, :trial))
     end
   end
 end

--- a/spec/services/stats/management_information/queries/lgfs/intake_fixed_fee_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/intake_fixed_fee_query_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::IntakeFinalFeeQuery do
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::IntakeFixedFeeQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     let(:claim) do
       create(:litigator_final_claim,
              :submitted,
-             case_type: build(:case_type, :trial))
+             case_type: build(:case_type, :hearing_subsequent_to_sentence))
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Stats::ManagementInformation::LGFS::IntakeFinalFeeQuery do
     let(:claim) do
       create(:litigator_final_claim,
              :refused,
-             case_type: build(:case_type, :trial))
+             case_type: build(:case_type, :hearing_subsequent_to_sentence))
     end
   end
 end

--- a/spec/services/stats/management_information/queries/lgfs/intake_interim_fee_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/intake_interim_fee_query_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::IntakeInterimFeeQuery do
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::IntakeInterimFeeQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/queries/lgfs/lf1_disk_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/lf1_disk_query_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::Lf1DiskQuery do
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::Lf1DiskQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/queries/lgfs/lf1_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/lf1_high_value_query_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::Lf1HighValueQuery do
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::Lf1HighValueQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/queries/lgfs/lf2_disk_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/lf2_disk_query_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::Lf2DiskQuery do
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::Lf2DiskQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do

--- a/spec/services/stats/management_information/queries/lgfs/lf2_high_value_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/lf2_high_value_query_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::LGFS::Lf2RedeterminationQuery do
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::Lf2HighValueQuery do
   it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today
     let(:claim) do
       create(:litigator_final_claim, :refused, disk_evidence: false).tap do |claim|
-        claim.update!(total: 19_999)
+        claim.update!(total: 20_000)
         claim.redetermine!
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe Stats::ManagementInformation::LGFS::Lf2RedeterminationQuery do
     # [submitted, allocated, refused] and [redetermination, allocated, refused] today
     let(:claim) do
       create(:litigator_final_claim, :refused, disk_evidence: false).tap do |claim|
-        claim.update!(total: 19_999)
+        claim.update!(total: 20_000)
         claim.redetermine!
         claim.allocate!
         claim.refuse!

--- a/spec/services/stats/management_information/queries/lgfs/lf2_redetermination_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/lf2_redetermination_query_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::Af2RedeterminationQuery do
-  it_behaves_like 'a base count query', 'AGFS'
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::Lf2RedeterminationQuery do
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [redetermination] today
     let(:claim) do
-      create(:advocate_final_claim, :refused, disk_evidence: false).tap do |claim|
+      create(:litigator_final_claim, :refused, disk_evidence: false).tap do |claim|
         claim.update!(total: 19_999)
         claim.redetermine!
       end
@@ -18,7 +18,7 @@ RSpec.describe Stats::ManagementInformation::AGFS::Af2RedeterminationQuery do
   it_behaves_like 'a completed_at filterable query' do
     # [submitted, allocated, refused] and [redetermination, allocated, refused] today
     let(:claim) do
-      create(:advocate_final_claim, :refused, disk_evidence: false).tap do |claim|
+      create(:litigator_final_claim, :refused, disk_evidence: false).tap do |claim|
         claim.update!(total: 19_999)
         claim.redetermine!
         claim.allocate!

--- a/spec/services/stats/management_information/queries/lgfs/written_reasons_query_spec.rb
+++ b/spec/services/stats/management_information/queries/lgfs/written_reasons_query_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require_relative '../shared_examples_for_base_count_query'
+require_relative '../../shared_examples_for_base_count_query'
 
-RSpec.describe Stats::ManagementInformation::AGFS::WrittenReasonsQuery do
-  it_behaves_like 'a base count query', 'AGFS'
+RSpec.describe Stats::ManagementInformation::Queries::LGFS::WrittenReasonsQuery do
+  it_behaves_like 'a base count query', 'LGFS'
 
   it_behaves_like 'an originally_submitted_at filterable query' do
     # [submitted, allocated, refused] and [awaiting_written_reasons] today
     let(:claim) do
-      create(:advocate_final_claim, :refused).tap(&:await_written_reasons!)
+      create(:litigator_final_claim, :refused).tap(&:await_written_reasons!)
     end
   end
 
   it_behaves_like 'a completed_at filterable query' do
     # [submitted, allocated, refused] and [awaiting_written_reasons allocated, refused] today
     let(:claim) do
-      create(:advocate_final_claim, :refused).tap do |claim|
+      create(:litigator_final_claim, :refused).tap do |claim|
         claim.await_written_reasons!
         claim.allocate!
         claim.refuse!


### PR DESCRIPTION
#### What

As a pre-requisite for upgrading to rails 7, CCCD needs to move from the `classic` autoloader to `zeitwerk`. This requires us to update the CCCD codebase to be compatible with `zeitwerk`.

Zeitwerk requires namespaces for classes and modules to match the file structure of the code. 

#### Ticket

[CTSKF-241](https://dsdmoj.atlassian.net/browse/CTSKF-241) (formerly CFP-179)

#### Why

* To ensure future compatibility with the rails framework.

#### How

Fixes incorrect namespacing in the `app/services/stats/management_information` directory and updates all occurrences in code.Aalso changes the file structure of the related `queries` specs for consistency.

[CTSKF-241]: https://dsdmoj.atlassian.net/browse/CTSKF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ