### PR TITLE
CTSKF-241 Zeitwerk: miscellaneous inflections

### DIFF
--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -31,7 +31,7 @@ module Rails
 end
 
 module ActiveSupport::XmlMini
-  extend Extensions::XmlMiniExtension
+  extend Extensions::XMLMiniExtension
 end
 
 class TrueClass

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,6 +18,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'AGFS'
   inflect.acronym 'LGFS'
   inflect.acronym 'API'
+  inflect.acronym 'XML'
   inflect.human(/af1_lf1_processed_by/, "af1/lf1 processed by")
 end
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,6 +19,12 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'LGFS'
   inflect.acronym 'API'
   inflect.acronym 'XML'
+  inflect.acronym 'MI'
+  inflect.acronym 'CCR'
+  inflect.acronym 'CCLF'
+  inflect.acronym 'CLI'
+  inflect.acronym 'GA'
+  inflect.acronym 'GTM'
   inflect.human(/af1_lf1_processed_by/, "af1/lf1 processed by")
 end
 

--- a/lib/extensions/xml_mini_extension.rb
+++ b/lib/extensions/xml_mini_extension.rb
@@ -1,5 +1,5 @@
 module Extensions
-  module XmlMiniExtension
+  module XMLMiniExtension
     # Rails 4.x doesn't provide any mechanism to configure the output of `nil` attributes when serializing to XML.
     # This patch will make it possible to change `nil` attributes from being serialized as `<submitted_at nil="true"/>`
     # and instead being omitted or serialized as empty strings.

--- a/spec/lib/extensions/xml_mini_extension_spec.rb
+++ b/spec/lib/extensions/xml_mini_extension_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Extensions::XmlMiniExtension do
+describe Extensions::XMLMiniExtension do
   subject { [1, 'a', nil] }
 
   let(:xml_result) { subject.to_xml(options.merge(skip_instruct: true, indent: 0)) }


### PR DESCRIPTION
#### What

As a pre-requisite for upgrading to rails 7, CCCD needs to move from the `classic` autoloader to `zeitwerk`. This requires us to update the CCCD codebase to be compatible with `zeitwerk`.

Zeitwerk requires all acronyms be properly inflected in class and module names. This pull request addresses the way various acronyms are handled. 



#### Ticket

[CTSKF-241](https://dsdmoj.atlassian.net/browse/CTSKF-241) (formerly CFP-179)

#### Why

* To ensure future compatibility with the rails framework.
* To follow the [Ruby Style Guide](https://github.com/rubocop/ruby-style-guide#camelcase-classes) which recommends keeping acronyms uppercase.

#### How

* Adds `XML` to `config/initializers/inflections.rb` and capitalizes all instances in code. 

* `MI`, `CCR`, `CCLF`, `CLI`, `GA`, `GTM` all consistently appear in upper case already, so these acronyms are simply added to `config/initializers/inflections.rb`.


[CTSKF-241]: https://dsdmoj.atlassian.net/browse/CTSKF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ