### PR TITLE
CTSKF-241 Enable zeitwerk autoloader

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,6 @@ module AdvocateDefencePayments
     # This is config that if not set here will accept different
     # defaults from the `config.load_defaults 6.1` command above
     #
-    config.autoloader = :classic
     config.action_mailer.deliver_later_queue_name = :mailers
     config.active_record.belongs_to_required_by_default = false
     config.active_record.yaml_column_permitted_classes = [


### PR DESCRIPTION
#### What

As a pre-requisite for upgrading to rails 7, CCCD needs to move from the `classic` autoloader to `zeitwerk`. This requires us to update the CCCD codebase to be compatible with `zeitwerk`.

This change enables the `zeitwerk` autoloader.

#### Ticket

[CTSKF-241](https://dsdmoj.atlassian.net/browse/CTSKF-241) (formerly CFP-179)

#### Why

To ensure future compatibility with the rails framework.

#### How

Removes the configuration of the classic autoloader from `config/application.rb`. This defaults the application to the `zeitwerk` autoloader.

#### Note 
To be released after https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6164


[CTSKF-241]: https://dsdmoj.atlassian.net/browse/CTSKF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ