### PR TITLE
Add prometheus rules to deploy script

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -85,6 +85,9 @@ function _circleci_deploy() {
   -f .k8s/${cluster_dir}/${environment}/service.yaml \
   -f .k8s/${cluster_dir}/${environment}/ingress.yaml
 
+  # apply rules for prometheus alerts
+  kubectl apply -f .k8s/${cluster_dir}/${environment}/prometheus-custom-rules.yaml
+
   kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag via CircleCI"
   kubectl annotate deployments/claim-for-crown-court-defence-worker kubernetes.io/change-cause="$(date +%Y-%m-%dT%H:%M:%S%z) - deploying: $docker_image_tag via CircleCI"
 

--- a/.k8s/live/scripts/deploy.sh
+++ b/.k8s/live/scripts/deploy.sh
@@ -80,6 +80,9 @@ function _deploy() {
     -f .k8s/${context}/${environment}/service.yaml \
     -f .k8s/${context}/${environment}/ingress.yaml
 
+  # apply rules for prometheus alerts
+  kubectl apply -f .k8s/${context}/${environment}/prometheus-custom-rules.yaml
+
   kubectl annotate deployments/claim-for-crown-court-defence kubernetes.io/change-cause="$(date) - deploying: $docker_image_tag via local machine to ${context}/cccd-${environment}"
   kubectl annotate deployments/claim-for-crown-court-defence-worker kubernetes.io/change-cause="$(date) - deploying: $docker_image_tag via local machine to ${context}/cccd-${environment}"
 


### PR DESCRIPTION
#### What

https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6127 removed the `DiskSpace-Threshold-Reached` alert from each of the Prometheus configuration files and has been deployed to all environments, however we are still seeing the alert failing.

This is because Prometheus rules are not automatically applied as part of the CCCD deployment process. It is necessary to run `kubectl apply -f .k8s/live/<env>/prometheus-custom-rules.yaml --namespace <env>` for each environment to apply the updated rules.

Instead of a manual process, this PR updates the scripts used to deploy CCCD so that the change occurs automatically.

#### Why

To remove the need for a manual step when deploying changes to Prometheus alert rules.

#### How

Adds the relevant `kubectl` command to the `.circleci/deploy.sh` and `.k8s/live/scripts/deploy.sh` deployment scripts, used to deploy via CircleCI and the local command line respectively.


--------

Tested deploying to `dev-lgfs`. Pre-release the `DiskSpace-Threshold-Reached` alert is present. Post-release it is not, demonstrating that the prometheus rules have been reapplied and the latest version of the rules is now being used:

#### Before

```
❯ kubectl describe prometheusrules -n cccd-dev-lgfs
Name:         prometheus-custom-rules-cccd
Namespace:    cccd-dev-lgfs
Labels:       prometheus=cloud-platform
              role=alert-rules
Annotations:  <none>
API Version:  monitoring.coreos.com/v1
Kind:         PrometheusRule
Metadata:
  Creation Timestamp:  2022-01-10T10:39:49Z
  Generation:          1
  Resource Version:    150822180
  UID:                 64b716d7-dddb-40bd-99d6-85ccd1dd2873
Spec:
  Groups:
    Name:  application-rules
    Rules:
      Alert:  Quota-Exceeded
      Annotations:
        Message:      cccd-dev-lgfs is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
        runbook_url:  https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
      Expr:           100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-dev-lgfs"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-dev-lgfs"} > 0) > 90
      For:            1m
      Labels:
        Severity:  laa-cccd-alerts
      Alert:       NotFound-Threshold-Reached
      Annotations:
        Message:      cccd-dev-lgfs More than a hundred 404 errors in one day
        runbook_url:  https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-dev-lgfs,type:phrase),type:phrase,value:cccd-dev-lgfs),query:(match:(kubernetes.namespace_name:(query:cccd-dev-lgfs,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
      Expr:           sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status="400"}[86400s])) * 86400 > 100
      For:            1m
      Labels:
        Severity:  laa-cccd-alerts
      Alert:       nginx-5xx-error
      Annotations:
        Message:      cccd-dev-lgfs An HTTP 5xx error has occurred
        runbook_url:  https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev-lgfs),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev-lgfs,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
      Expr:           sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status=~"5.."}[5m])) * 300 > 5
      For:            1m
      Labels:
        Severity:  laa-cccd-alerts
      Alert:       DiskSpace-Threshold-Reached
      Annotations:
        Message:  cccd-dev-lgfs Container disk space usage is more than 1Gi or is not reported
      Expr:       container_fs_usage_bytes{namespace="cccd-dev-lgfs"} / 1024 / 1024 > 1024 or absent(container_fs_usage_bytes{namespace="cccd-dev-lgfs"})
      For:        1m
      Labels:
        Severity:  laa-cccd-alerts
```

#### After
```
❯ kubectl describe prometheusrules -n cccd-dev-lgfs
Name:         prometheus-custom-rules-cccd
Namespace:    cccd-dev-lgfs
Labels:       prometheus=cloud-platform
              role=alert-rules
Annotations:  <none>
API Version:  monitoring.coreos.com/v1
Kind:         PrometheusRule
Metadata:
  Creation Timestamp:  2022-01-10T10:39:49Z
  Generation:          2
  Resource Version:    1370755405
  UID:                 64b716d7-dddb-40bd-99d6-85ccd1dd2873
Spec:
  Groups:
    Name:  application-rules
    Rules:
      Alert:  Quota-Exceeded
      Annotations:
        Message:      cccd-dev-lgfs is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
        runbook_url:  https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
      Expr:           100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="cccd-dev-lgfs"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="cccd-dev-lgfs"} > 0) > 90
      For:            1m
      Labels:
        Severity:  laa-cccd-alerts
      Alert:       NotFound-Threshold-Reached
      Annotations:
        Message:      cccd-dev-lgfs More than a hundred 404 errors in one day
        runbook_url:  https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:cccd-dev-lgfs,type:phrase),type:phrase,value:cccd-dev-lgfs),query:(match:(kubernetes.namespace_name:(query:cccd-dev-lgfs,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
      Expr:           sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status="400"}[86400s])) * 86400 > 100
      For:            1m
      Labels:
        Severity:  laa-cccd-alerts
      Alert:       nginx-5xx-error
      Annotations:
        Message:      cccd-dev-lgfs An HTTP 5xx error has occurred
        runbook_url:  https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:cccd-production),type:phrase,value:cccd-dev-lgfs),query:(match:(log_processed.kubernetes_namespace:(query:cccd-dev-lgfs,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
      Expr:           sum(rate(nginx_ingress_controller_requests{exported_namespace="cccd-dev-lgfs", status=~"5.."}[5m])) * 300 > 5
      For:            1m
      Labels:
        Severity:  laa-cccd-alerts
```