### PR TITLE
Fix acronym inflection in migration classes

### DIFF
--- a/db/migrate/20151019203522_add_api_key_to_chambers.rb
+++ b/db/migrate/20151019203522_add_api_key_to_chambers.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToChambers < ActiveRecord::Migration[4.2]
+class AddAPIKeyToChambers < ActiveRecord::Migration[4.2]
   def change
     add_column :chambers, :api_key, :uuid, default: 'uuid_generate_v4()', index: true
   end

--- a/db/migrate/20160315090300_add_lgfs_roles_to_expense_types.rb
+++ b/db/migrate/20160315090300_add_lgfs_roles_to_expense_types.rb
@@ -1,4 +1,4 @@
-class AddLgfsRolesToExpenseTypes < ActiveRecord::Migration[4.2]
+class AddLGFSRolesToExpenseTypes < ActiveRecord::Migration[4.2]
   def up
     expense_types.each do |et|
       et.update(roles: ['agfs', 'lgfs'])

--- a/db/migrate/20160930085910_add_api_key_to_users.rb
+++ b/db/migrate/20160930085910_add_api_key_to_users.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToUsers < ActiveRecord::Migration[4.2]
+class AddAPIKeyToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :api_key, :uuid, default: 'uuid_generate_v4()', index: true
   end

--- a/db/migrate/20180702141736_create_mi_data.rb
+++ b/db/migrate/20180702141736_create_mi_data.rb
@@ -1,4 +1,4 @@
-class CreateMiData < ActiveRecord::Migration[5.0]
+class CreateMIData < ActiveRecord::Migration[5.0]
   def change
     create_table :mi_data do |t|
       t.boolean   'disk_evidence'

--- a/db/migrate/20180822130536_add_assessment_break_down_to_mi_data.rb
+++ b/db/migrate/20180822130536_add_assessment_break_down_to_mi_data.rb
@@ -1,4 +1,4 @@
-class AddAssessmentBreakDownToMiData < ActiveRecord::Migration[5.0]
+class AddAssessmentBreakDownToMIData < ActiveRecord::Migration[5.0]
   def change
     add_column :mi_data, :assessment_fees, :decimal
     add_column :mi_data, :assessment_expenses, :decimal


### PR DESCRIPTION
#### What

Previous commits changed the inflection of certain acronyms. The `rails` `zeitwerk` check did not pick up the fact that those acronyms are used in migration classes, and so they were not changed. However the fact that they are present in those classes in camel case form (instead of upper case) is now causing database migrations to fail.

This is causing the daily smoke test to fail, and will cause issues for any developer who wants to build the database locally.

#### Ticket

[CTSKF-241](https://dsdmoj.atlassian.net/browse/CTSKF-241)

#### Why

To allow continued support of CCCD.

#### How

Updates the class names of five affected migrations to capitalise acronyms.

I'm always wary of touching old migration files however I have tested by migrating and rolling back both the individual migrations and the whole database and this doesn't seem to cause any problems 🤞 

[CTSKF-241]: https://dsdmoj.atlassian.net/browse/CTSKF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ