### PR TITLE
Re-enable time-zone sensitive test

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       #
       context 'when handling timezones' do
         before do
-          pending 'Bug with timezones in BST'
+          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           create(:advocate_final_claim, :authorised)
         end
 


### PR DESCRIPTION
#### What

Enables MI test which passes during GMT but fails during BST, and vice versa


Note: there are two other similar tests which use claims back-dated 1 week. These will start to fail in a week's time and will need similarly updating.