### PR TITLE
Claims by fee scheme

### DIFF
--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -50,4 +50,8 @@ class FeeScheme < ApplicationRecord
   def agfs_scheme_15?
     agfs? && version.eql?(15)
   end
+
+  def claims
+    Claim::BaseClaim.all.select { |claim| claim.fee_scheme == self }
+  end
 end

--- a/spec/factories/claim/base_claims.rb
+++ b/spec/factories/claim/base_claims.rb
@@ -53,6 +53,7 @@ FactoryBot.define do
     disable_for_state_transition { nil }
 
     transient do
+      create_defendant_and_rep_order { true }
       create_defendant_and_rep_order_for_scheme_9 { false }
       create_defendant_and_rep_order_for_scheme_9a { false }
       create_defendant_and_rep_order_for_scheme_10 { false }
@@ -71,7 +72,7 @@ FactoryBot.define do
         add_defendant_and_reporder(claim, Settings.lgfs_scheme_10_clair_release_date)
       end
 
-      if claim.defendants.blank?
+      if claim.defendants.blank? && evaluator.create_defendant_and_rep_order
         defendant = create(:defendant, claim:)
         create(:representation_order, defendant:, representation_order_date: 380.days.ago)
         claim.reload

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -1,5 +1,37 @@
 require 'rails_helper'
 
+RSpec.shared_examples 'find claims for fee scheme' do |name, version|
+  let(:fee_scheme) { FeeScheme.find_by(name:, version:) }
+
+  let!(:expected_claims) do
+    expected_claims_details.map do |details|
+      create(details[:factory], create_defendant_and_rep_order: false).tap do |claim|
+        rep_order = create(:representation_order, representation_order_date: details[:rep_order_date])
+        create(:defendant, claim:, representation_orders: [rep_order])
+        if details[:main_hearing_date]
+          claim.main_hearing_date = details[:main_hearing_date]
+          claim.save
+        end
+      end
+    end
+  end
+
+  before do
+    other_claims_details.each do |details|
+      create(details[:factory], create_defendant_and_rep_order: false).tap do |claim|
+        rep_order = create(:representation_order, representation_order_date: details[:rep_order_date])
+        create(:defendant, claim:, representation_orders: [rep_order])
+        if details[:main_hearing_date]
+          claim.main_hearing_date = details[:main_hearing_date]
+          claim.save
+        end
+      end
+    end
+  end
+
+  it { is_expected.to match_array(expected_claims) }
+end
+
 RSpec.describe FeeScheme do
   let(:lgfs_scheme_nine) { FeeScheme.find_by(name: 'LGFS', version: 9) }
   let(:lgfs_scheme_ten) { FeeScheme.find_by(name: 'LGFS', version: 10) }
@@ -119,6 +151,138 @@ RSpec.describe FeeScheme do
       let(:claim) { create(:litigator_claim) }
 
       it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#claims' do
+    subject { fee_scheme.claims }
+
+    it_behaves_like 'find claims for fee scheme', 'AGFS', 9 do
+      let(:expected_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_fee_reform_release_date - 1.day }
+        ]
+      end
+      let(:other_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_fee_reform_release_date },
+          { factory: :litigator_claim, rep_order_date: Settings.lgfs_scheme_10_clair_release_date }
+        ]
+      end
+    end
+
+    it_behaves_like 'find claims for fee scheme', 'AGFS', 10 do
+      let(:expected_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_fee_reform_release_date },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_11_release_date - 1.day }
+        ]
+      end
+      let(:other_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_fee_reform_release_date - 1.day },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_11_release_date },
+          { factory: :litigator_claim, rep_order_date: Settings.lgfs_scheme_10_clair_release_date }
+        ]
+      end
+    end
+
+    it_behaves_like 'find claims for fee scheme', 'AGFS', 11 do
+      let(:expected_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_11_release_date },
+          { factory: :advocate_claim, rep_order_date: Settings.clar_release_date - 1.day }
+        ]
+      end
+      let(:other_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_11_release_date - 1.day },
+          { factory: :advocate_claim, rep_order_date: Settings.clar_release_date },
+          { factory: :litigator_claim, rep_order_date: Settings.lgfs_scheme_10_clair_release_date }
+        ]
+      end
+    end
+
+    it_behaves_like 'find claims for fee scheme', 'AGFS', 12 do
+      let(:expected_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.clar_release_date },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_13_clair_release_date - 1.day },
+          {
+            factory: :advocate_claim,
+            rep_order_date: Settings.clar_release_date,
+            main_hearing_date: Settings.clair_contingency_date - 1.day
+          }
+        ]
+      end
+      let(:other_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.clar_release_date - 1.day },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_13_clair_release_date },
+          {
+            factory: :advocate_claim,
+            rep_order_date: Settings.clar_release_date,
+            main_hearing_date: Settings.clair_contingency_date
+          },
+          { factory: :litigator_claim, rep_order_date: Settings.lgfs_scheme_10_clair_release_date }
+        ]
+      end
+    end
+
+    it_behaves_like 'find claims for fee scheme', 'AGFS', 13 do
+      let(:expected_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_13_clair_release_date },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_14_section_twenty_eight - 1.day },
+          {
+            factory: :advocate_claim,
+            rep_order_date: Settings.clar_release_date,
+            main_hearing_date: Settings.clair_contingency_date
+          }
+        ]
+      end
+      let(:other_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_13_clair_release_date - 1.day },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_14_section_twenty_eight },
+          {
+            factory: :advocate_claim,
+            rep_order_date: Settings.clar_release_date,
+            main_hearing_date: Settings.clair_contingency_date - 1.day
+          },
+          { factory: :litigator_claim, rep_order_date: Settings.lgfs_scheme_10_clair_release_date }
+        ]
+      end
+    end
+
+    it_behaves_like 'find claims for fee scheme', 'AGFS', 14 do
+      let(:expected_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_14_section_twenty_eight },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc - 1.day }
+        ]
+      end
+      let(:other_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_14_section_twenty_eight - 1.day },
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc },
+          { factory: :litigator_claim, rep_order_date: Settings.lgfs_scheme_10_clair_release_date }
+        ]
+      end
+    end
+
+    it_behaves_like 'find claims for fee scheme', 'AGFS', 15 do
+      let(:expected_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc }
+        ]
+      end
+      let(:other_claims_details) do
+        [
+          { factory: :advocate_claim, rep_order_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc - 1.day },
+          { factory: :litigator_claim, rep_order_date: Settings.lgfs_scheme_10_clair_release_date }
+        ]
+      end
     end
   end
 end

--- a/spec/support/seed_helpers.rb
+++ b/spec/support/seed_helpers.rb
@@ -10,7 +10,7 @@ module SeedHelpers
     FeeScheme.find_or_create_by(name: 'AGFS', version: 11, start_date: Settings.agfs_scheme_11_release_date.beginning_of_day, end_date: Settings.clar_release_date.end_of_day - 1.day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 12, start_date: Settings.clar_release_date.beginning_of_day, end_date: Settings.agfs_scheme_13_clair_release_date.end_of_day - 1.day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 13, start_date: Settings.agfs_scheme_13_clair_release_date.beginning_of_day, end_date: Settings.agfs_scheme_14_section_twenty_eight.end_of_day - 1.day)
-    FeeScheme.find_or_create_by(name: 'AGFS', version: 14, start_date: Settings.agfs_scheme_14_section_twenty_eight.beginning_of_day)
+    FeeScheme.find_or_create_by(name: 'AGFS', version: 14, start_date: Settings.agfs_scheme_14_section_twenty_eight.beginning_of_day, end_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc.end_of_day - 1.day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 15, start_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc.beginning_of_day)
   end
 


### PR DESCRIPTION
#### What

Add a way to get the list of all claims for a fee scheme.

#### Ticket

[Add data visualisation to CCCD Superadmin page](https://dsdmoj.atlassian.net/browse/CTSKF-589)

#### Why

This is to help #6171 which is adding a dashboard to the Super Admin section to display the number of claims for each fee scheme.

#### How

The fee scheme of a claim is not stored as references in the database. Instead, it is calculated based on the date of the claim. As a result, fetching a list of claims for a fee scheme involves iterating over all claims and looking up the fee scheme of each individually. The `FeeScheme#claims` method find the list as follows;

* Fetch the list of all representation order with dates within the range of the fee scheme. Pre-fetching is included for;
  * The defendants of these representation orders
  * The claims of these defendants
  * All defendants for these claims
  * All representation orders for these defendants
* This list of representation orders is converted into a unique list of claims
* The list of claims is filtered based on the date range for the representation order date and the main hearing date, as appropriate