### PR TITLE
Re-enable time-zone sensitive tests

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with a completed journey' do
         before do
-          pending 'Bug with timezones in BST'
+          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -276,7 +276,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with an uncompleted journey' do
         before do
-          pending 'Bug with timezones in BST'
+          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do


### PR DESCRIPTION
#### What

Followup to https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6196

Enables two MI tests which pass during GMT but fails during BST, and vice versa. These tests use claims back-dated 1 week, which is why they fail now and not when the clocks go back.