### PR TITLE
Rake tasks for repairing missing offences on claims

### DIFF
--- a/lib/tasks/offences.rake
+++ b/lib/tasks/offences.rake
@@ -1,0 +1,21 @@
+require_relative 'rake_helpers/repair_offences'
+require 'csv'
+
+namespace :offences do
+  desc 'Generate repair input file of claim id against offence id based on data from CCR'
+  task :generate_repair_input, [:filename, :output, :interactive] => :environment do |_task, args|
+    interactive = args.interactive != 'false'
+
+    repair = Tasks::RakeHelpers::RepairOffences.new(file: args.filename, output: args.output, interactive:)
+    repair.generate
+  end
+
+  desc 'Repair claims by reattaching offencees'
+  task :repair, [:filename, :output, :dry_run, :interactive] => :environment do |_task, args|
+    interactive = args.interactive != 'false'
+    dry_run = args.dry_run != 'false'
+
+    repair = Tasks::RakeHelpers::RepairOffences.new(file: args.filename, output: args.output, interactive:, dry_run:)
+    repair.repair
+  end
+end

--- a/lib/tasks/rake_helpers/repair_offences.rb
+++ b/lib/tasks/rake_helpers/repair_offences.rb
@@ -1,0 +1,105 @@
+require_relative 'rake_utils'
+include Tasks::RakeHelpers::RakeUtils
+
+module Tasks
+  module RakeHelpers
+    class RepairOffences
+      def initialize(**kwargs)
+        @data = CSV.read(kwargs[:file], headers: true)
+        @output = File.open(kwargs[:output], 'a')
+        @interactive = kwargs[:interactive]
+        @dry_run = kwargs[:dry_run]
+      end
+
+      # Generate a repair file based on an input file with data from CCF
+      #
+      # Input file format;
+      #
+      #   CASE_NO,REP_ORD_NO,UNIQUE_CODE
+      #   A12345678,9876543,UNIQUE_17.1
+      def generate
+        @output.puts 'cccd_id,case_no,maat_reference,cccd_offence_id'
+
+        @data.each do |row|
+          rep_orders = RepresentationOrder.includes(defendant: :claim).where(maat_reference: row['REP_ORD_NO'])
+          claims = rep_orders.map(&:claim)
+
+          offence = Offence.find_by(unique_code: row['UNIQUE_CODE'])
+
+          if @interactive
+            puts "Representation order: #{row['REP_ORD_NO']}"
+            puts "Expected case number: #{row['CASE_NO']}"
+            puts 'Found claims:'
+            claims.each do |claim|
+              puts "  Claim id: #{claim.id}"
+              puts "  Case number: #{claim.case_number}"
+              if claim.offence_id
+                puts "  Existing offence: #{claim.offence_id} [#{claim.offence.unique_code}]"
+              else
+                puts '  No existing offence'
+              end
+            end
+            puts "Intended offence: #{offence.id} [#{offence.unique_code}]"
+
+            continue?
+          end
+
+          claims.each do |claim|
+            next unless claim.case_number == row['CASE_NO']
+            @output.puts("#{claim&.id},#{row['CASE_NO']},#{row['REP_ORD_NO']},#{offence&.id}")
+          end
+        end    
+      end
+
+      # Apply a repair file to add offences to claims
+      #
+      # Input file format;
+      #
+      #   cccd_id,case_no,maat_reference,cccd_offence_id
+      #   1,A12345678,9876543,99
+      def repair
+        @data.each do |row|
+          claim = Claim::BaseClaim.find_by(id: row['cccd_id'])
+          next unless claim
+
+          if @interactive
+            puts "Claim id: #{claim.id}"
+            puts "Case number: #{claim.case_number}"
+            puts "Expected case number: #{row['case_no']}"
+            puts "Offence to add: #{row['cccd_offence_id']}"
+            if claim.offence_id
+              puts "  Existing offence: #{claim.offence_id} [#{claim.offence.unique_code}]"
+            else
+              puts '  No existing offence'
+            end
+
+            continue?
+            puts
+          end
+
+          @output.puts "Case number: #{claim.case_number}"
+          @output.puts "Offence id: #{row['cccd_offence_id']}"
+          if claim.offence.nil?
+            offence = Offence.find(row['cccd_offence_id'])
+            if @dry_run
+              @output.puts '  Would update [dry run]'
+            else
+              @output.puts '  Updating'
+              claim.offence = offence
+              claim.save
+            end
+          else
+            @output.puts '  Not updating'
+            if claim.offence_id != row['cccd_offence_id'].to_i
+              @output.puts 'Offence mismatch:'
+              @output.puts "  Expected id: #{row['cccd_offence_id']}"
+              @output.puts "  Actual id: #{claim.offence_id}"
+            end
+          end
+          @output.puts '-------'
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
#### What

Add two Rake tasks that will;

* Generate a CSV file containing a list of claim ids together with offence ids
* Use the CSV file in the format of the above to update the claims with the offences

#### Ticket

[CCCD Offences Incident](https://dsdmoj.atlassian.net/browse/CTSKF-613)

#### Why

In November 2023 an update to the database caused the offence information of a number of AGFS claims to be lost. This information for many of these claims could be found in the most recent snapshot of the database and for most of the remainder could be found from CCR. The information from CCR contains the case number, MAAT reference and offence unique code.

#### How

##### `generate_repair_input[input_file.csv, output_file.csv, interactive(default=true)]`

The first Rake task, `offences:generate_repair_input[input.csv,output.csv]`, expects an input file in this format:

```
CASE_NO,REP_ORD_NO,UNIQUE_CODE
S20111160,7629353,COOIWGWIOCPAAELE_8.1
T19954489,6194144,COTCPM_8.1
```

and will write out a file in this format:

```
cccd_id,case_no,maat_reference,cccd_offence_id
2,S20111160,7629353,1604
8,T19954489,6194144,1582
```

The id of a claim in CCCD is found by searching for the representation order using the MAAT reference (`REP_ORD_NO`) and finding all the claims for that representation order. Details for those claims with a matching case id are written to the output file. The offence id is found by looking up the unique code of the offence.

By default the task will ask for confirmation to continue with each row. To disable interactive mode add `false` as the third argument.

##### `offences:repair[input_file.csv, output_file.csv, dry_run(default=true), interactive(default=true)]`

The second Rake task, `offences:repair[input.csv,output_log.txt]`, expects an input file in this format:

```
cccd_id,case_no,maat_reference,cccd_offence_id
2,S20111160,7629353,1604
8,T19954489,6194144,1582
```

(as generated by the first rake task, above). For each row the claim is found with `cccd_id` and the offence is found with `cccd_offence_id`. If the offence for the claim is `nil` then it is set to the required offence.

A log is written to `output_log.txt`.

If the claim for a row is found to already have an offence then it is not changed. If the offence already attached to a claim is different from the required offence then it is still not changed but a not is added to the log.

* By default the task will run a dry run, without making any changes to the database. To disable the dry run, so that changes are applied, add `false` as the third argument.
* By default the task will ask for confirmation to continue with each row. To disable interactive mode add `false` as the fourth argument.