### PR TITLE
Revert "Bump sentry-rails and sentry-sidekiq"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,8 @@ gem 'config',                 '~> 5.0' # this gem provides our Settings.xxx mech
 gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
 gem 'scheduler_daemon'
-gem 'sentry-rails', '~> 5.13'
-gem 'sentry-sidekiq', '~> 5.13'
+gem 'sentry-rails', '~> 5.12'
+gem 'sentry-sidekiq', '~> 5.12'
 gem 'sprockets-rails', '~> 3.4.2'
 gem 'state_machines-activerecord'
 gem 'state_machines-audit_trail'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ GEM
     logstuff (0.0.2)
       logstash-event (~> 1.1.0)
       request_store
-    loofah (2.22.0)
+    loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -604,13 +604,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.13.0)
+    sentry-rails (5.12.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.13.0)
-    sentry-ruby (5.13.0)
+      sentry-ruby (~> 5.12.0)
+    sentry-ruby (5.12.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.13.0)
-      sentry-ruby (~> 5.13.0)
+    sentry-sidekiq (5.12.0)
+      sentry-ruby (~> 5.12.0)
       sidekiq (>= 3.0)
     shell-spinner (1.0.4)
       colorize
@@ -794,8 +794,8 @@ DEPENDENCIES
   ruby-progressbar
   rubyzip
   scheduler_daemon
-  sentry-rails (~> 5.13)
-  sentry-sidekiq (~> 5.13)
+  sentry-rails (~> 5.12)
+  sentry-sidekiq (~> 5.12)
   shell-spinner (~> 1.0, >= 1.0.4)
   shoulda-matchers (~> 5.3)
   sidekiq (~> 7.2)


### PR DESCRIPTION
Reverts ministryofjustice/Claim-for-Crown-Court-Defence#6228

This is failing to deploy to `dev` with the below error on the worker pod. Backing it out to unblock the pipeline and so we can investigate properly.

```
2023-11-14T09:04:45.060Z pid=7 tid=4az INFO: Sidekiq 7.2.0 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>"rediss://:REDACTED@master.cp-861a3c4590e1ecb8.iwfvzo.euw2.cache.amazonaws.com:6379"}
WRONGPASS invalid username-password pair or user is disabled.
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client/connection_mixin.rb:61:in `call_pipelined'
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client.rb:745:in `block in connect'
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client/middlewares.rb:16:in `call'
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client.rb:744:in `connect'
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client.rb:706:in `raw_connection'
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client.rb:673:in `ensure_connected'
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client.rb:254:in `call'
/usr/local/bundle/gems/redis-client-0.18.0/lib/redis_client/decorator.rb:26:in `call'
/usr/local/bundle/gems/sidekiq-7.2.0/lib/sidekiq/config.rb:144:in `block in redis_info'
/usr/local/bundle/gems/sidekiq-7.2.0/lib/sidekiq/config.rb:163:in `block in redis'
/usr/local/bundle/gems/connection_pool-2.4.1/lib/connection_pool.rb:110:in `block (2 levels) in with'
/usr/local/bundle/gems/connection_pool-2.4.1/lib/connection_pool.rb:109:in `handle_interrupt'
/usr/local/bundle/gems/connection_pool-2.4.1/lib/connection_pool.rb:109:in `block in with'
/usr/local/bundle/gems/connection_pool-2.4.1/lib/connection_pool.rb:106:in `handle_interrupt'
/usr/local/bundle/gems/connection_pool-2.4.1/lib/connection_pool.rb:106:in `with'
/usr/local/bundle/gems/sidekiq-7.2.0/lib/sidekiq/config.rb:160:in `redis'
/usr/local/bundle/gems/sidekiq-7.2.0/lib/sidekiq/config.rb:143:in `redis_info'
/usr/local/bundle/gems/sidekiq-7.2.0/lib/sidekiq/cli.rb:75:in `run'
/usr/local/bundle/gems/sidekiq-7.2.0/bin/sidekiq:31:in `<top (required)>'
/usr/local/bundle/bin/sidekiq:25:in `load'
/usr/local/bundle/bin/sidekiq:25:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:486:in `exec'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
/usr/local/bundle/bin/bundle:25:in `load'
/usr/local/bundle/bin/bundle:25:in `<main>'
```