### PR TITLE
Bump sentry-rails and sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,8 @@ gem 'config',                 '~> 5.0' # this gem provides our Settings.xxx mech
 gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
 gem 'scheduler_daemon'
-gem 'sentry-rails', '~> 5.12'
-gem 'sentry-sidekiq', '~> 5.12'
+gem 'sentry-rails', '~> 5.13'
+gem 'sentry-sidekiq', '~> 5.13'
 gem 'sprockets-rails', '~> 3.4.2'
 gem 'state_machines-activerecord'
 gem 'state_machines-audit_trail'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ GEM
     logstuff (0.0.2)
       logstash-event (~> 1.1.0)
       request_store
-    loofah (2.21.4)
+    loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -604,13 +604,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.12.0)
+    sentry-rails (5.13.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.12.0)
-    sentry-ruby (5.12.0)
+      sentry-ruby (~> 5.13.0)
+    sentry-ruby (5.13.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.12.0)
-      sentry-ruby (~> 5.12.0)
+    sentry-sidekiq (5.13.0)
+      sentry-ruby (~> 5.13.0)
       sidekiq (>= 3.0)
     shell-spinner (1.0.4)
       colorize
@@ -794,8 +794,8 @@ DEPENDENCIES
   ruby-progressbar
   rubyzip
   scheduler_daemon
-  sentry-rails (~> 5.12)
-  sentry-sidekiq (~> 5.12)
+  sentry-rails (~> 5.13)
+  sentry-sidekiq (~> 5.13)
   shell-spinner (~> 1.0, >= 1.0.4)
   shoulda-matchers (~> 5.3)
   sidekiq (~> 7.2)


### PR DESCRIPTION
Recreates dependabot PR ministryofjustice/Claim-for-Crown-Court-Defence#6228, which failed to deploy to dev in CircleCI due to issues with Redis and was reverted.