### PR TITLE
[CTSKF-619] Update to allow 20M file uploads

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRequestBodyLimit 20971520
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRequestBodyLimit 20971520
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRequestBodyLimit 20971520
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRequestBodyLimit 20971520
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecRequestBodyLimit 20971520
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"


### PR DESCRIPTION
#### What

Allow document uploads of up to 20M.

#### Ticket

[Zendesk 340090 - Unable to upload document to CCCD](https://dsdmoj.atlassian.net/browse/CTSKF-619)

#### Why

CCCD has a 20M file limit for evidence documents. However, the WAF has a default setting that blocks request bodies of more than approximately 13M.

#### How

The [SecRequestBodyLimit](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v3.x%29#user-content-SecRequestBodyLimit) defines the maximum upload size.