### PR TITLE
CTSKF-433 Fix clashing allocation table text

### DIFF
--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -93,13 +93,13 @@ moj.Modules.AllocationDataTable = {
 
     // translations and custom text
     language: {
-      loadingRecords: '',
+      loadingRecords: 'Table loading, please wait a moment.',
       zeroRecords: 'No matching records found. Try clearing your filter.',
       info: 'Showing _START_ to _END_ of _TOTAL_ entries',
       lengthMenu: 'Claims per page: _MENU_',
       emptyTable: '',
       infoFiltered: '',
-      processing: 'Table loading, please wait a moment.'
+      processing: ''
     },
     initComplete: function (settings, json) {
       $('.app-jq-datatable tbody').addClass('govuk-table__body')

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -155,6 +155,10 @@ tr {
       font-weight: bold;
     }
   }
+
+  .dataTables_processing {
+    margin-top: govuk-spacing(3);
+  }
 }
 
 table.dataTable {

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -100,13 +100,13 @@ describe('Modules.AllocationDataTable.js', function () {
 
     it('...should have `language`', function () {
       expect(options.language).toEqual({
-        loadingRecords: '',
+        loadingRecords: 'Table loading, please wait a moment.',
         zeroRecords: 'No matching records found. Try clearing your filter.',
         info: 'Showing _START_ to _END_ of _TOTAL_ entries',
         lengthMenu: 'Claims per page: _MENU_',
         emptyTable: '',
         infoFiltered: '',
-        processing: 'Table loading, please wait a moment.'
+        processing: ''
       })
     })
 


### PR DESCRIPTION
#### What

On the allocations table on `case_workers/admin/allocations`, when the table is loading there is a clash of text. The table attempts to display a message indicating that the page is loading and a message to indicate that there are no records found, in the same place. There is also an overlap with the table header. This change means that only one piece of text is displayed at a time.

#### Ticket

[board ticket description](link)

#### Why

To improve the visual appearance of the service for users.

#### How

This issues occurs because the `datatables` library has not been properly configured in `app/webpack/javascripts/modules/Modules.AllocationDataTable.js`. The loading text is configured in the `processing` language element, when it should be defined in `loadingRecords` element. When `loadingRecords` is displayed, it blocks  other messages from being displayed by `datatables`, unlike `processing` which is used in combination with other messages leading to this clash.

By moving the desired text to `loadingRecord`, only one of the messages is displayed at a time - `loadingRecords` when the table is loading, and `zeroRecords` when no records are found. A processing widget is still displayed during loading to give visual feedback to the user that something is happening.

After fixing this there is still a small issue with the processing widget overlapping the table header. This is fixed by adding a top margin to it in `app/webpack/stylesheets/components/_table.scss`.

#### Before

https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/f6c809f5-8d0c-4a13-bb07-2cd62e511c78


#### After

https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/1029b83b-bcd6-495f-a8b7-a115cf9f8a7f


