### PR TITLE
CTSKF-492 Remove line break from Miscellaneous fees page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ yarn-debug.log*
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# ignore Brewfile changes
+Brewfile.lock.json

--- a/app/views/external_users/claims/interim_claim_info/_fields.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_fields.html.haml
@@ -1,5 +1,5 @@
 - if claim.requires_interim_claim_info?
-  #interim-claim-info
+  #interim-claim-info.interim-claim
     %h2.govuk-heading-m
       = t('.warrant_fee')
 

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -61,5 +61,3 @@
           = render 'date_attended_fields', f: date_attended, submodel_count: date_attended.index+1, parent_model_prefix: "misc_fee_#{@misc_fee_count}"
 
       = link_to_add_association t('.add_date_attended'), f, :dates_attended, class: 'govuk-link', partial: 'date_attended_fields', data: { 'association-insertion-method': 'append', 'association-insertion-node': 'div', 'association-insertion-traversal': 'prev' }
-
-  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_misc_fee_fields.html.haml
@@ -20,5 +20,3 @@
       prefix_text: '£',
       value: number_with_precision(f.object.amount, precision: 2),
       width: 'one-quarter'
-
-  %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/webpack/stylesheets/_interim-claim.scss
+++ b/app/webpack/stylesheets/_interim-claim.scss
@@ -1,0 +1,3 @@
+.interim-claim {
+  @include govuk-responsive-margin(9, "top");
+}

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -63,6 +63,7 @@ $govuk-font-url-function: frontend-font-url;
 @import "~datatables.net-dt/css/jquery.dataTables";
 @import "~jquery-datatables-checkboxes/css/dataTables.checkboxes";
 @import "navigation";
+@import "interim-claim";
 
 // Ported from v1 stylesheets
 @import "layout";

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -849,7 +849,7 @@ en:
           page_title_chamber: Edit your chambers' account
         regenerate_api_key:
           notice: API key successfully updated
-        update: 
+        update:
           notice: Provider successfully updated
     all_claims: Your claims
     your_claims: Your claims


### PR DESCRIPTION
#### What
Remove the line break and increase the spacing on the advocate and the litigators miscellaneous fee page
#### Before (with the line break)

<img width="482" alt="Screenshot 2023-11-21 at 12 14 20" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/12900007/d2488cfa-d59c-4263-b301-e350075fdc6d">

#### After -  on the advocate miscellaneous fees page
<img width="677" alt="Screenshot 2023-11-28 at 11 38 54" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/12900007/6f8aaa8c-1334-47e7-befd-7060a0448ff2">


#### After - on the litigator miscellaneous fees page
<img width="797" alt="Screenshot 2023-11-28 at 09 18 50" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/12900007/1d670f11-e027-4676-ab02-6e1fe1be62d4">

This also includes adding Brewfile.lock to gitignore but this is unrelated.

#### Ticket

[CCCD - Remove line breaks to avoid visually grouping the ‘add another fee’ button with the warrant fees section](https://dsdmoj.atlassian.net/browse/CTSKF-492)


#### Why
There is a line break and dividing line on the miscellaneous fees page that is not in the right place. It comes before the ‘add another fee’ button which visually groups the button with the warrant fees section below it. 

#### How

Delete it.

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2