### PR TITLE
[L&D] Randomise jasmine tests

### DIFF
--- a/app/webpack/javascripts/modules/Modules.OffenceSearchInput.js
+++ b/app/webpack/javascripts/modules/Modules.OffenceSearchInput.js
@@ -21,7 +21,7 @@ moj.Modules.OffenceSearchInput = {
   feeScheme: '.fx-fee-scheme',
 
   // delay in miliseconds
-  debouce: 500,
+  debounce: 500,
 
   // min input length to trigger search
   minLength: 3,

--- a/app/webpack/javascripts/modules/external_users/claims/SideBar.js
+++ b/app/webpack/javascripts/modules/external_users/claims/SideBar.js
@@ -81,7 +81,7 @@ moj.Modules.SideBar = {
     const self = this
     let selector
     let value
-    this.sanitzeFeeToFloat()
+    this.sanitizeFeeToFloat()
     $.each(this.totals, function (key, val) {
       selector = '.total-' + key
       value = moj.Helpers.Blocks.formatNumber(val)
@@ -136,7 +136,7 @@ moj.Modules.SideBar = {
     })
   },
 
-  sanitzeFeeToFloat: function () {
+  sanitizeFeeToFloat: function () {
     const self = this
     $.each(this.totals, function (key, val) {
       if (typeof self.totals[key] === 'string') {

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -1,10 +1,9 @@
 describe('Modules.AllocationDataTable.js', function () {
-  // tooooo long to type
   const module = moj.Modules.AllocationDataTable
   const options = module.options
 
   it('...should exist', function () {
-    expect(moj.Modules.AllocationDataTable).toBeDefined()
+    expect(module).toBeDefined()
   })
 
   it('...should have options set', function () {
@@ -111,6 +110,7 @@ describe('Modules.AllocationDataTable.js', function () {
     })
 
     it('...should have `ajax`', function () {
+      module.init()
       expect(options.ajax).toEqual({
         url: '/api/search/unallocated?api_key={0}&scheme=agfs',
         dataSrc: '' // this is the important setting
@@ -203,6 +203,10 @@ describe('Modules.AllocationDataTable.js', function () {
         }).appendTo('body')
       })
 
+      beforeEach(function () {
+        module.init()
+      })
+
       afterAll(function () {
         $('#api-key').remove()
       })
@@ -216,24 +220,21 @@ describe('Modules.AllocationDataTable.js', function () {
       })
 
       it('...should use `defaultScheme` as a fallback', function () {
-        // call init again
-        module.init()
-
-        expect(module.options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=agfs')
+        expect(options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=agfs')
 
         module.setAjaxURL('abcd')
 
-        expect(module.options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=abcd')
+        expect(options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=abcd')
 
         module.setAjaxURL()
 
-        expect(module.options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=agfs')
+        expect(options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=agfs')
       })
 
       it('...should set the scheme as passed in', function () {
         module.setAjaxURL('abcd')
 
-        expect(module.options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=abcd')
+        expect(options.ajax.url).toEqual('/api/search/unallocated?api_key=1234567890&scheme=abcd')
       })
 
       it('...should return a string', function () {

--- a/spec/javascripts/Modules.AllocationScheme_spec.js
+++ b/spec/javascripts/Modules.AllocationScheme_spec.js
@@ -40,5 +40,9 @@ describe('Modules.AllocationScheme.js', function () {
     $('#allocation-filters input').trigger('change')
 
     expect($.publish).toHaveBeenCalledWith('/scheme/change/', { scheme: 'input-value' })
+
+    // reset the filter for future tests
+    $(filtersFixtureDOM).append($('<input name="myname" value="agfs" type="radio" />'))
+    $('#allocation-filters input').trigger('change')
   })
 })

--- a/spec/javascripts/Modules.DisbursementCtrl_spec.js
+++ b/spec/javascripts/Modules.DisbursementCtrl_spec.js
@@ -17,7 +17,7 @@ describe('Modules.DisbursementCtrl.js', function () {
   })
 
   afterEach(function () {
-    $('body #offence-view').remove()
+    $('body #disbursements-view').remove()
   })
 
   describe('...defaults', function () {

--- a/spec/javascripts/Modules.OffenceSearchInput_spec.js
+++ b/spec/javascripts/Modules.OffenceSearchInput_spec.js
@@ -41,8 +41,8 @@ describe('Modules.OffenceSearchInput.js', function () {
     it('`this.feeScheme`', function () {
       expect(module.feeScheme).toEqual('.fx-fee-scheme')
     })
-    it('`this.debouce`', function () {
-      expect(module.debouce).toEqual(500)
+    it('`this.debounce`', function () {
+      expect(module.debounce).toEqual(500)
     })
     it('`this.subscribers`', function () {
       expect(module.subscribers).toEqual({

--- a/spec/javascripts/Modules.OffenceSearchInput_spec.js
+++ b/spec/javascripts/Modules.OffenceSearchInput_spec.js
@@ -21,8 +21,11 @@ describe('Modules.OffenceSearchInput.js', function () {
   }
 
   beforeEach(function () {
-    $('body .mod-search-input').remove()
     $('body').append(view())
+  })
+
+  afterEach(function () {
+    $('body .mod-search-input').remove()
   })
 
   describe('...defaults', function () {
@@ -176,9 +179,10 @@ describe('Modules.OffenceSearchInput.js', function () {
     describe('...trackUserInput', function () {
       it('should use `moj.Modules.Debounce`', function () {
         spyOn(moj.Modules.Debounce, 'init')
-        module.$input.val('mudr')
 
         module.init()
+
+        module.$input.val('mudr')
 
         // trigger keyup
         module.$input.trigger($.Event('keyup', {

--- a/spec/javascripts/helpers-sidebar_spec.js
+++ b/spec/javascripts/helpers-sidebar_spec.js
@@ -768,6 +768,7 @@ describe('Helpers.Blocks.js', function () {
 
         afterEach(function () {
           $('#claim-form').remove()
+          $('.js-block').remove()
         })
 
         describe('...init', function () {

--- a/spec/javascripts/modules-DuplicateExpenseCtrl_spec.js
+++ b/spec/javascripts/modules-DuplicateExpenseCtrl_spec.js
@@ -11,14 +11,14 @@ describe('Modules.DuplicateExpenseCtrl', function () {
   ].join('')
 
   beforeEach(function () {
-    domFixture.empty()
     domFixture.append($(view))
-    // $('body').append(domFixture);
+    $('body').append(domFixture)
+
     // reset to default state
     moj.Modules.DuplicateExpenseCtrl.init()
   })
 
-  afterAll(function () {
+  afterEach(function () {
     domFixture.empty()
   })
 

--- a/spec/javascripts/modules-sidebar_spec.js
+++ b/spec/javascripts/modules-sidebar_spec.js
@@ -232,10 +232,10 @@ describe('Modules.SideBar.js', function () {
         expect($el.find('.total-grandTotal')[0].innerHTML).toBe('£333.00')
       })
 
-      it('should call `sanitzeFeeToFloat`', function () {
-        spyOn(moj.Modules.SideBar, 'sanitzeFeeToFloat')
+      it('should call `sanitizeFeeToFloat`', function () {
+        spyOn(moj.Modules.SideBar, 'sanitizeFeeToFloat')
         moj.Modules.SideBar.render()
-        expect(moj.Modules.SideBar.sanitzeFeeToFloat).toHaveBeenCalled()
+        expect(moj.Modules.SideBar.sanitizeFeeToFloat).toHaveBeenCalled()
       })
     })
 
@@ -388,8 +388,8 @@ describe('Modules.SideBar.js', function () {
       })
     })
 
-    describe('...sanitzeFeeToFloat', function () {
-      it('should sanitze the totals correctly', function () {
+    describe('...sanitizeFeeToFloat', function () {
+      it('should sanitize the totals correctly', function () {
         const expected = {
           fees: 10.20,
           disbursements: 4558.99,
@@ -405,7 +405,7 @@ describe('Modules.SideBar.js', function () {
           grandTotal: 0
         }
 
-        moj.Modules.SideBar.sanitzeFeeToFloat()
+        moj.Modules.SideBar.sanitizeFeeToFloat()
         expect(moj.Modules.SideBar.totals).toEqual(expected)
       })
     })

--- a/spec/javascripts/modules-sidebar_spec.js
+++ b/spec/javascripts/modules-sidebar_spec.js
@@ -65,7 +65,7 @@ describe('Modules.SideBar.js', function () {
   })
 
   afterEach(function () {
-    moj.Modules.SideBar.phantomBlockList = ['fixedFees', 'gradFees', 'miscFees', 'warrantFees', 'interimFees', 'transferFees', 'disbursements', 'expenses']
+    moj.Modules.SideBar.phantomBlockList = ['fixedFees', 'gradFees', 'miscFees', 'warrantFees', 'interimFees', 'transferFees', 'hardshipFees', 'disbursements', 'expenses']
     moj.Modules.SideBar.blocks = []
     moj.Modules.SideBar.totals = {
       fixedFees: 0,
@@ -74,6 +74,7 @@ describe('Modules.SideBar.js', function () {
       warrantFees: 0,
       interimFees: 0,
       transferFees: 0,
+      hardshipFees: 0,
       disbursements: 0,
       expenses: 0,
       vat: 0,
@@ -104,6 +105,7 @@ describe('Modules.SideBar.js', function () {
         warrantFees: 0,
         interimFees: 0,
         transferFees: 0,
+        hardshipFees: 0,
         disbursements: 0,
         expenses: 0,
         vat: 0,
@@ -112,7 +114,7 @@ describe('Modules.SideBar.js', function () {
     })
 
     it('should have a `phantomBlockList` property defined', function () {
-      expect(moj.Modules.SideBar.phantomBlockList).toEqual(['fixedFees', 'gradFees', 'miscFees', 'warrantFees', 'interimFees', 'transferFees', 'disbursements', 'expenses'])
+      expect(moj.Modules.SideBar.phantomBlockList).toEqual(['fixedFees', 'gradFees', 'miscFees', 'warrantFees', 'interimFees', 'transferFees', 'hardshipFees', 'disbursements', 'expenses'])
     })
 
     it('should have a `blocks` property defined', function () {
@@ -193,7 +195,7 @@ describe('Modules.SideBar.js', function () {
         moj.Modules.SideBar.loadBlocks()
 
         expect(moj.Modules.SideBar.removePhantomKey).toHaveBeenCalled()
-        expect(moj.Modules.SideBar.phantomBlockList.length).toEqual(6)
+        expect(moj.Modules.SideBar.phantomBlockList.length).toEqual(7)
 
         jsBlockFixtureDOM.empty()
       })
@@ -203,9 +205,9 @@ describe('Modules.SideBar.js', function () {
       it('should remove items from the array', function () {
         const module = moj.Modules.SideBar
         module.removePhantomKey('Hellos')
-        expect(module.phantomBlockList.length).toEqual(8)
+        expect(module.phantomBlockList.length).toEqual(9)
         module.removePhantomKey('fixedFees')
-        expect(module.phantomBlockList.length).toEqual(7)
+        expect(module.phantomBlockList.length).toEqual(8)
       })
     })
 

--- a/spec/javascripts/modules-sidebar_spec.js
+++ b/spec/javascripts/modules-sidebar_spec.js
@@ -158,8 +158,6 @@ describe('Modules.SideBar.js', function () {
         moj.Modules.SideBar.loadBlocks()
 
         expect(moj.Modules.SideBar.blocks.length).toBe(3)
-
-        jsBlockFixtureDOM.empty()
       })
 
       it('should cache an instance of `FeeBlock` for every `.js-block` el', function () {
@@ -173,8 +171,6 @@ describe('Modules.SideBar.js', function () {
 
         moj.Modules.SideBar.loadBlocks()
         expect(moj.Modules.SideBar.blocks.length).toEqual(3)
-
-        jsBlockFixtureDOM.empty()
       })
 
       it('should update the `phantomBlockList` by removing types', function () {
@@ -196,8 +192,6 @@ describe('Modules.SideBar.js', function () {
 
         expect(moj.Modules.SideBar.removePhantomKey).toHaveBeenCalled()
         expect(moj.Modules.SideBar.phantomBlockList.length).toEqual(7)
-
-        jsBlockFixtureDOM.empty()
       })
     })
 
@@ -288,7 +282,8 @@ describe('Modules.SideBar.js', function () {
 
         describe('...calculations', function () {
           it('should add to the correct `this.type` property', function () {
-            $('#claim-form').append(jsBlockViewCalculated())
+            jsBlockFixtureDOM.append(jsBlockViewCalculated())
+            $('body').append(jsBlockFixtureDOM)
 
             moj.Modules.SideBar.init()
 
@@ -359,6 +354,11 @@ describe('Modules.SideBar.js', function () {
     })
 
     describe('...bindListeners', function () {
+      beforeEach(function () {
+        jsBlockFixtureDOM.append(jsBlockViewCalculated())
+        $('body').append(jsBlockFixtureDOM)
+      })
+
       it('should bind the listeners to the dom elements', function () {
         spyOn(jQuery.fn, 'on')
         moj.Modules.SideBar.bindListeners()

--- a/spec/javascripts/supporting-evidence_spec.js
+++ b/spec/javascripts/supporting-evidence_spec.js
@@ -1,6 +1,6 @@
 describe('supportingEvidence', function () {
-  const submitCallback = jasmine.createSpy('submit').and.returnValue(false)
   let confirmAlert
+  let submitCallback
 
   const $form = function () {
     return $('#supporting-evidence-fixture-form')
@@ -40,14 +40,16 @@ describe('supportingEvidence', function () {
         </fieldset>
         <div class="button-holder">
             <button type="submit" name="commit_submit_claim" value="Continue" class="govuk-button" data-module="govuk-button">Save and continue</button>
-            <button class="govuk-button govuk-button--secondary" data-module="govuk-button">Save a draft</button>
+            <button class="govuk-button govuk-button--secondary" name="commit_save_draft" data-module="govuk-button">Save a draft</button>
         </div>
     </form>
   </div>
 `)
+
   beforeEach(function () {
     $('body').append(fixtureDom)
 
+    submitCallback = jasmine.createSpy('submit').and.returnValue(false)
     $form().submit(submitCallback)
     confirmAlert = spyOn(window, 'confirm')
 
@@ -80,6 +82,10 @@ describe('supportingEvidence', function () {
     })
 
     describe('should not alert when copy of the indictment is selected in the supporting evidence checklist', function () {
+      afterEach(function () {
+        $indictmentEvidence().trigger('click')
+      })
+
       it('and submit the form', function () {
         $indictmentEvidence().trigger('click')
 

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -13,7 +13,7 @@
   "env": {
     "stopSpecOnExpectationFailure": false,
     "stopOnSpecFailure": false,
-    "random": false
+    "random": true
   },
   "browser": {
     "name": "headlessChrome"


### PR DESCRIPTION
#### What

CCCD contains a suite of jasmine tests which unit test the javascript code. These run in the same order each time, which hides some issues with the tests. This PR enables randomised running of the tests and fixes those issues.

#### Ticket

[CTSKF-445](https://dsdmoj.atlassian.net/browse/CTSKF-445)

#### Why

It is desirable for tests to run in a random order as each test should be isolated and independent of other tests. Running the tests in a random order causes tests to start failing, highlighting why this is a problem.

#### How

* Sets the `random` attribute in `spec/support/jasmine-browser.json` to `true`. 
* Fixes all failures that occur after enabling random running
* Fix a couple of other minor issues with tests (typos etc).

There are still a number of improvements that could be made to the jasmine tests (eg ensuring that all code is covered by tests; improving consistency between tests; removing jQuery; rewriting the tests in a more modern style as the javascript is modernised - see https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6191 for example) but are out of scope for this PR.


[CTSKF-445]: https://dsdmoj.atlassian.net/browse/CTSKF-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ