### PR TITLE
Change secondary button from blue to grey

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -37,7 +37,7 @@
         = render partial: 'filter_value_bands', locals: { f: f }
 
       .govuk-grid-column-one-third{ class: 'govuk-!-padding-top-6' }
-        = govuk_button t('.clear_filters'), class: 'clear-filters app-button--blue'
+        = govuk_button t('.clear_filters'), class: 'clear-filters govuk-button--secondary'
 
   %h2.govuk-heading-m
     = t('.allocation_queue')

--- a/app/views/external_users/claims/defendants/_fields.html.haml
+++ b/app/views/external_users/claims/defendants/_fields.html.haml
@@ -8,4 +8,4 @@
 
 .form-actions.defendants-actions
   %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
-  = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields', class: 'govuk-button app-button--blue', render_options: { }, data: { 'association-insertion-method': 'append', 'association-insertion-node': '.fx-numberedList-hook', module: 'govuk-button' }, role: 'button', draggable: 'false'
+  = link_to_add_association t('.add_another_defendant'), f, :defendants, partial: 'external_users/claims/defendants/defendant_fields', class: 'govuk-button govuk-button--secondary', render_options: { }, data: { 'association-insertion-method': 'append', 'association-insertion-node': '.fx-numberedList-hook', module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/external_users/claims/disbursements/_fields.html.haml
+++ b/app/views/external_users/claims/disbursements/_fields.html.haml
@@ -4,4 +4,4 @@
       - @disbursement_count += 1
       = render partial: 'external_users/claims/disbursements/disbursement_fields', locals: { f: disbursement_fields }
 
-  = link_to_add_association t('.add_disbursement'), f, :disbursements, partial: 'external_users/claims/disbursements/disbursement_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-traversal': 'prev', 'association-insertion-node': 'div', module: 'govuk-button' }, role: 'button', draggable: 'false'
+  = link_to_add_association t('.add_disbursement'), f, :disbursements, partial: 'external_users/claims/disbursements/disbursement_fields', class: 'govuk-button govuk-button--secondary', data: { 'association-insertion-method': 'append', 'association-insertion-traversal': 'prev', 'association-insertion-node': 'div', module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/external_users/claims/expenses/_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_fields.html.haml
@@ -8,7 +8,7 @@
     = f.fields_for :expenses do |expense|
       = render 'external_users/claims/expenses/expense_fields', f: expense
 
-  = link_to_add_association t('.add_another_expense'), f, :expenses, partial: 'external_users/claims/expenses/expense_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.js-cocoon-expenses', module: 'govuk-button' }, role: 'button', draggable: 'false'
+  = link_to_add_association t('.add_another_expense'), f, :expenses, partial: 'external_users/claims/expenses/expense_fields', class: 'govuk-button govuk-button--secondary', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.js-cocoon-expenses', module: 'govuk-button' }, role: 'button', draggable: 'false'
 
   = govuk_link_button_secondary(t('.duplicate'), nil, class: 'fx-duplicate-expense')
 

--- a/app/views/external_users/claims/misc_fees/advocates/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_fields.html.haml
@@ -4,4 +4,4 @@
       - @misc_fee_count += 1
       = render partial: 'external_users/claims/misc_fees/advocates/misc_fee_fields', locals: { f: misc_fee_fields }
 
-  = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/advocates/misc_fee_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
+  = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/advocates/misc_fee_fields', class: 'govuk-button govuk-button--secondary', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/litigators/_fields.html.haml
@@ -7,4 +7,4 @@
       - @misc_fee_count += 1
       = render partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', locals: { f: misc_fee_fields }
 
-  = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
+  = link_to_add_association t('.add_misc_fee'), f, :misc_fees, partial: 'external_users/claims/misc_fees/litigators/misc_fee_fields', class: 'govuk-button govuk-button--secondary', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.misc-fee-group-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -36,4 +36,4 @@
       %span.filename
       = govuk_link_to t('.remove_file_html'), '#'
 
-    = f.govuk_submit t('.send'), class: 'app-button--blue'
+    = f.govuk_submit t('.send'), class: 'govuk-button--secondary'

--- a/app/views/shared/_supplier_numbers.html.haml
+++ b/app/views/shared/_supplier_numbers.html.haml
@@ -7,7 +7,7 @@
         = render partial: 'shared/supplier_number_fields', locals: { f: snf }
 
     .govuk-form-group.form-actions
-      = link_to_add_association t('.add_supplier'), f, :lgfs_supplier_numbers, partial: 'shared/supplier_number_fields', class: 'govuk-button app-button--blue', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.supplier-numbers-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
+      = link_to_add_association t('.add_supplier'), f, :lgfs_supplier_numbers, partial: 'shared/supplier_number_fields', class: 'govuk-button govuk-button--secondary', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.supplier-numbers-wrapper', module: 'govuk-button' }, role: 'button', draggable: 'false'
 
     = govuk_detail t('.postcode_help.heading') do
       = t('.postcode_help.text_html')

--- a/app/webpack/stylesheets/_buttons.scss
+++ b/app/webpack/stylesheets/_buttons.scss
@@ -1,35 +1,6 @@
 // Buttons
 // stylelint-disable declaration-no-important
 
-// Blue button variables
-$app-blue-button-colour: govuk-colour("blue");
-$app-blue-button-hover-colour: govuk-shade($app-blue-button-colour, 20%);
-$app-blue-button-shadow-colour: govuk-shade($app-blue-button-colour, 60%);
-$app-blue-button-text-colour: govuk-colour("white");
-
-$button-shadow-size: $govuk-border-width-form-element;
-
-.app-button--blue {
-  background-color: $app-blue-button-colour !important;
-  box-shadow: 0 $button-shadow-size 0 $app-blue-button-shadow-colour !important;
-
-  &,
-  &:link,
-  &:visited,
-  &:active,
-  &:hover {
-    color: $app-blue-button-text-colour !important;
-  }
-
-  &:hover {
-    background-color: $app-blue-button-hover-colour !important;
-
-    &[disabled] {
-      background-color: $app-blue-button-colour !important;
-    }
-  }
-}
-
 .button-holder {
   @include govuk-clearfix;
 


### PR DESCRIPTION
#### What
Changed the secondary buttons from blue to grey.

#### Ticket

[CCCD - Change secondary button colours from blue to grey to be in line with the design system](https://dsdmoj.atlassian.net/browse/CTSKF-493)

#### Why
To be inline with the design system.

#### How
Removing the class `app-button--blue` and replacing it with`govuk-button--secondary`

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
