### PR TITLE
[Bugfix] Fix injection failure caused by removal of `NilClass` extension

### DIFF
--- a/app/interfaces/api/entities/cclf/base_claim.rb
+++ b/app/interfaces/api/entities/cclf/base_claim.rb
@@ -30,7 +30,7 @@ module API
         private
 
         def actual_trial_length_or_one
-          object.actual_trial_length.or_one
+          object.actual_trial_length || 1
         end
 
         # case type adapter requires access to claim object

--- a/app/interfaces/api/entities/ccr/base_claim.rb
+++ b/app/interfaces/api/entities/ccr/base_claim.rb
@@ -36,19 +36,19 @@ module API
         end
 
         def estimated_trial_length_or_one
-          object.estimated_trial_length.or_one
+          object.estimated_trial_length || 1
         end
 
         def actual_trial_length_or_one
-          object.actual_trial_length.or_one
+          object.actual_trial_length || 1
         end
 
         def retrial_actual_length_or_one
-          object.retrial_actual_length.or_one
+          object.retrial_actual_length || 1
         end
 
         def retrial_estimated_length_or_one
-          object.retrial_estimated_length.or_one
+          object.retrial_estimated_length || 1
         end
 
         def adapted_advocate_category

--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -42,7 +42,3 @@ class FalseClass
   include Extensions::BooleanExtension::False
 end
 
-class Integer
-  include Extensions::IntegerExtension
-end
-

--- a/lib/extensions/integer_extension.rb
+++ b/lib/extensions/integer_extension.rb
@@ -1,7 +1,0 @@
-module Extensions
-  module IntegerExtension
-    def or_one
-      [self, 1].compact.max
-    end
-  end
-end


### PR DESCRIPTION
#### What

Fix injection failure caused by removal of `NilClass` extension.

#### Why

Removing the NilExtension class has caused a [failure](https://ministryofjustice.sentry.io/share/issue/1a73c3eb6020473ebbd43be773f14a93/) when an API call was made by CCLF on a claim with a nil `actual_trial_length`, as this was relying on the `or_one` method which was defined in the extension.


#### How

Replaces the failing call to `or_one` with `object.actual_trial_length || 1` in `app/interfaces/api/entities/cclf/base_claim.rb`, which has the same effect without needing to monkeypatch core classes.

This also updates other places where `or_one` is called (specifically `app/interfaces/api/entities/ccr/base_claim.rb`) and deletes the other place where `or_one` is defined (`lib/extensions/integer_extension.rb`).

(Note: `IntegerExtension` defined `or_one` as
```    
def or_one
  [self, 1].compact.max
end
```
which handles negative trial lengths as well as nils. It would be possible to replicate this method in the `base_claim` classes, but validation on the API and CCCD front end ensures that negative values are not permitted, so this feels like overkill and the `||` operator has been used instead).