### PR TITLE
CTSKF-494  Centre align the text in the button.

### DIFF
--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -53,7 +53,7 @@
 
 %template#fx-results-template
   %div.govuk-grid-row.offence-item.fx-result-item
-    %div.govuk-grid-column-two-thirds
+    %div.govuk-grid-column-three-quarters
       %span.govuk-body-s.link-grey
         %a.fx-filter.category{ href: '#noop' }
         >
@@ -62,7 +62,7 @@
       %span.description
       %br
       %span.govuk-body-s.link-grey.contrary
-    %div.govuk-grid-column-one-third.align-right
+    %div.govuk-grid-column-one-quarter.align-centre
       %br
       %a.button.offence-item-button.set-selection{ href: '#', 'data-field': '#claim_offence_id' }
         Select and continue

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -460,8 +460,8 @@ form {
     padding: $gutter-one-third;
     border-bottom: 1px solid $border-colour;
 
-    .align-right {
-      text-align: right;
+    .align-centre {
+      text-align: center;
     }
   }
 


### PR DESCRIPTION
#### What
Change the text ‘select and continue’ to be centre-aligned within the button (offence details page)

#### Previously
<img width="498" alt="Screenshot 2023-11-29 at 10 02 05" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/12900007/311c5939-10fa-4a52-b25f-79ee97eb116a">


#### Now
<img width="641" alt="Screenshot 2023-11-29 at 15 05 27" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/12900007/9000841d-ae6a-483f-8eb0-d4e68f77bf3b">


#### Ticket

[CCCD - Change the text ‘select and continue’ to be centre-aligned within the button (offence details page)](https://dsdmoj.atlassian.net/browse/CTSKF-494)

#### Why
To be more consistent

#### How
 - change the class from `align-right` to `align-centre`
- change the gov-grid-column layout to allow the text to display correctly inside the button.

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
