### PR TITLE
CTSKF-502 cccd correct various grammar and typing errors

### DIFF
--- a/app/models/doc_type.rb
+++ b/app/models/doc_type.rb
@@ -10,7 +10,7 @@ class DocType
   DOCTYPES = [
     DocType.new(1,  500,  'Representation order'),
     DocType.new(3,  300,  'Committal bundle front sheets'),
-    DocType.new(4,  400,  'A copy of the indictment'),
+    DocType.new(4,  400,  'Copy of the indictment'),
     DocType.new(5,  100,  'Order in respect of judicial apportionment'),
     DocType.new(6,  800,  'Expenses invoices'),
     DocType.new(7,  600,  'Hardship supporting evidence'),

--- a/app/webpack/javascripts/modules/external_users/claims/NewClaim.js
+++ b/app/webpack/javascripts/modules/external_users/claims/NewClaim.js
@@ -10,7 +10,7 @@ moj.Modules.NewClaim = {
   },
   initSubmitValidation: function () {
     //
-    // Warn the user if 'A copy of the indictment' is not selected in the
+    // Warn the user if 'Copy of the indictment' is not selected in the
     // supporting evidence checklist.
     // Tests in /spec/javascripts/supporting-evidence_spec.js
     //

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1074,7 +1074,7 @@ en:
           court: 'Court'
           court_hint: For example Cardiff
           cracked_trial_detail: 'Cracked trial detail'
-          main_hearing_date_hint_html: For multi day hearings, please provide the latest date to receive the correct fee rates<br/><br/>For example, 31 9 2022
+          main_hearing_date_hint_html: For multi day hearings, please provide the latest date to receive the correct fee rates<br/><br/>For example 31 9 2022
           litigator: *litigator
           main_hearing_date: 'Final main hearing date'
           offence_class: 'Offence class'
@@ -1202,7 +1202,7 @@ en:
           representation_order_html: Representation order details <span class="fx-numberedList-number"></span>
           maat_reference_number: MAAT reference
           maat_reference_number_html: MAAT reference <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
-          maat_reference_number_eg: 'this should be 7 digits long, starting with at least a 4'
+          maat_reference_number_eg: 'This should be 7 digits long, starting with at least a 4'
           remove: Remove
         summary:
           caption: 'Defendants: This section contains details about each defendant.'
@@ -1492,7 +1492,7 @@ en:
             quantity_hint: Enter a quantity
             quantity_html: Quantity <span class="govuk-visually-hidden">for %{context} <span class="fx-numberedList-number"></span></span>
             fee_type: *fee_type
-            fee_type_html: Fee of type <span class="govuk-visually-hidden">for %{context} <span class="fx-numberedList-number"></span></span>
+            fee_type_html: Type of fee <span class="govuk-visually-hidden">for %{context} <span class="fx-numberedList-number"></span></span>
             add_date_attended: Add dates
             remove: Remove
             no_dates: No dates currently selected.

--- a/features/claims/advocate/accessibility.feature
+++ b/features/claims/advocate/accessibility.feature
@@ -66,7 +66,7 @@ Feature: Advocate submits a claim
     And I should see a page title "Upload supporting evidence for advocate final fees claim"
     And I upload the document 'indictment.pdf'
     And I should see 10 evidence check boxes
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
     Then the page should be accessible skipping 'aria-allowed-attr'
     Then I click Submit to LAA
@@ -83,7 +83,7 @@ Feature: Advocate submits a claim
     And I should see 'Noting brief fee'
     And I should see 'Parking'
     And I should see 'indictment.pdf'
-    And I should see 'A copy of the indictment'
+    And I should see 'Copy of the indictment'
     And I should see 'Bish bosh bash'
     Then the page should be accessible
     When I click "Continue"

--- a/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_fixed_fee_claim_submit.feature
@@ -66,7 +66,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     And I should be in the 'Supporting evidence' form page
     And I upload the document 'indictment.pdf'
     And I should see 10 evidence check boxes
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for advocate final fees claim"
@@ -86,7 +86,7 @@ Feature: Advocate submits a claim for a Fixed fee (Appeal against conviction)
     And I should see 'Parking'
 
     And I should see 'indictment.pdf'
-    And I should see 'A copy of the indictment'
+    And I should see 'Copy of the indictment'
     And I should see 'Bish bosh bash'
 
     And I should see a page title "View claim summary for advocate final fees claim"

--- a/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
+++ b/features/claims/advocate/scheme_ten/advocate_trial_claim_edit_submit.feature
@@ -73,7 +73,7 @@ Feature: Advocate creates, saves, edits then submits a claim for a final fee tri
 
     And I upload the document 'judicial_appointment_order.pdf'
     And I should see 10 evidence check boxes
-    And I check the evidence boxes for 'Order in respect of judicial apportionment,A copy of the indictment'
+    And I check the evidence boxes for 'Order in respect of judicial apportionment,Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for advocate final fees claim"

--- a/features/claims/litigator/scheme_nine/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine/interim_trial_claim_draft_submit.feature
@@ -64,7 +64,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     Then I click "Continue" in the claim form and move to the 'Supporting evidence' form page
 
     And I upload the document 'indictment.pdf'
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator interim fees claim"
@@ -93,7 +93,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I should see '£0.00'
 
     And I should see 'indictment.pdf'
-    And I should see 'A copy of the indictment'
+    And I should see 'Copy of the indictment'
     And I should see 'Bish bosh bash'
 
     And I should see a page title "View claim summary for litigator interim fees claim"

--- a/features/claims/litigator/scheme_nine/interim_trial_warrant_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine/interim_trial_warrant_claim_draft_submit.feature
@@ -58,7 +58,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     And I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I click Submit to LAA

--- a/features/claims/litigator/scheme_nine/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine/litigator_trial_claim_draft_submit.feature
@@ -101,7 +101,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should see a page title "Upload supporting evidence for litigator final fees claim"
 
     And I upload the document 'indictment.pdf'
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     When I click Submit to LAA

--- a/features/claims/litigator/scheme_nine/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine/transfer_claim_draft_submit.feature
@@ -91,7 +91,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     And I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator transfer fees claim"
@@ -173,7 +173,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     When I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
     And I click Submit to LAA
     Then I should be on the check your claim page

--- a/features/claims/litigator/scheme_nine_a/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine_a/interim_trial_claim_draft_submit.feature
@@ -64,7 +64,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     Then I click "Continue" in the claim form and move to the 'Supporting evidence' form page
 
     And I upload the document 'indictment.pdf'
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator interim fees claim"
@@ -93,7 +93,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I should see '£0.00'
 
     And I should see 'indictment.pdf'
-    And I should see 'A copy of the indictment'
+    And I should see 'Copy of the indictment'
     And I should see 'Bish bosh bash'
 
     And I should see a page title "View claim summary for litigator interim fees claim"

--- a/features/claims/litigator/scheme_nine_a/interim_trial_warrant_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine_a/interim_trial_warrant_claim_draft_submit.feature
@@ -58,7 +58,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     And I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I click Submit to LAA

--- a/features/claims/litigator/scheme_nine_a/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine_a/litigator_trial_claim_draft_submit.feature
@@ -101,7 +101,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should see a page title "Upload supporting evidence for litigator final fees claim"
 
     And I upload the document 'indictment.pdf'
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     When I click Submit to LAA

--- a/features/claims/litigator/scheme_nine_a/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine_a/transfer_claim_draft_submit.feature
@@ -91,7 +91,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     And I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator transfer fees claim"
@@ -178,7 +178,7 @@ Scenario: I create a transfer claim for an Elected Case Not Proceeded
 
   When I upload 1 document
   And I check the boxes for the uploaded documents
-  And I check the evidence boxes for 'A copy of the indictment'
+  And I check the evidence boxes for 'Copy of the indictment'
   And I add some additional information
   And I click Submit to LAA
   Then I should be on the check your claim page

--- a/features/claims/litigator/scheme_ten/interim_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_ten/interim_trial_claim_draft_submit.feature
@@ -65,7 +65,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     Then I click "Continue" in the claim form and move to the 'Supporting evidence' form page
 
     And I upload the document 'indictment.pdf'
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator interim fees claim"
@@ -94,7 +94,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
     And I should see '£0.00'
 
     And I should see 'indictment.pdf'
-    And I should see 'A copy of the indictment'
+    And I should see 'Copy of the indictment'
     And I should see 'Bish bosh bash'
 
     And I should see a page title "View claim summary for litigator interim fees claim"

--- a/features/claims/litigator/scheme_ten/interim_trial_warrant_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_ten/interim_trial_warrant_claim_draft_submit.feature
@@ -59,7 +59,7 @@ Feature: Litigator partially fills out a draft interim claim, then later edits a
 
     And I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I click Submit to LAA

--- a/features/claims/litigator/scheme_ten/litigator_trial_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_ten/litigator_trial_claim_draft_submit.feature
@@ -102,7 +102,7 @@ Feature: Litigator partially fills out a draft final fee claim, then later edits
     And I should see a page title "Upload supporting evidence for litigator final fees claim"
 
     And I upload the document 'indictment.pdf'
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     When I click Submit to LAA

--- a/features/claims/litigator/scheme_ten/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_ten/transfer_claim_draft_submit.feature
@@ -92,7 +92,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     And I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
 
     And I should see a page title "Upload supporting evidence for litigator transfer fees claim"
@@ -178,7 +178,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
 
     When I upload 1 document
     And I check the boxes for the uploaded documents
-    And I check the evidence boxes for 'A copy of the indictment'
+    And I check the evidence boxes for 'Copy of the indictment'
     And I add some additional information
     And I click Submit to LAA
     Then I should be on the check your claim page

--- a/features/claims/no_indictment_warning.feature
+++ b/features/claims/no_indictment_warning.feature
@@ -28,7 +28,7 @@ Feature: Evidence page "no indictment" warning
     When I click "Continue" in the claim form and dismiss "no indictment" popup
     Then I should be in the 'Supporting evidence' form page
 
-    When I check the evidence boxes for 'A copy of the indictment'
+    When I check the evidence boxes for 'Copy of the indictment'
     And I click "Continue" in the claim form
     Then I should be on the check your claim page
 

--- a/spec/javascripts/supporting-evidence_spec.js
+++ b/spec/javascripts/supporting-evidence_spec.js
@@ -27,7 +27,7 @@ describe('supportingEvidence', function () {
                 <div class="govuk-grid-column-one-half">
                     <label class="block-label" for="claim-evidence-checklist-ids-5-field"><input type="checkbox" value="5" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-5-field">Order in respect of judicial apportionment</label>
                     <label class="block-label" for="claim-evidence-checklist-ids-3-field"><input type="checkbox" value="3" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-3-field">Committal bundle front sheet(s)</label>
-                    <label class="block-label" for="claim-evidence-checklist-ids-4-field"><input type="checkbox" value="4" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-4-field">A copy of the indictment</label>
+                    <label class="block-label" for="claim-evidence-checklist-ids-4-field"><input type="checkbox" value="4" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-4-field">Copy of the indictment</label>
                     <label class="block-label" for="claim-evidence-checklist-ids-1-field"><input type="checkbox" value="1" name="claim[evidence_checklist_ids][]" id="claim-evidence-checklist-ids-1-field">Representation order</label>
                 </div>
                 <div class="govuk-grid-column-one-half">

--- a/spec/models/doc_type_spec.rb
+++ b/spec/models/doc_type_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DocType do
     it 'returns a DocTypeInstance with the specified id' do
       dti = DocType.find(4)
       expect(dti.id).to eq 4
-      expect(dti.name).to eq 'A copy of the indictment'
+      expect(dti.name).to eq 'Copy of the indictment'
     end
 
     it 'raises if no record with that id is found' do


### PR DESCRIPTION
#### What
Fix typos and minor inconsistencies in the content used on CCCD.

1. Add capital letter to the hint text underneath ‘MAAT reference’ on the defendant details screen 

2. Change ‘Fee of type’ to 'Type of fee'.

3. Change 'A copy of the indictment' to 'Copy of the indictment. This had to be changed in all the tests as well.

4.  Remove a comma in the hint text ‘For example, 31 9 2022’ underneath.

#### Ticket

[CCCD - Correct various grammar and typing errors throughout the journey](https://dsdmoj.atlassian.net/browse/CTSKF-502)

#### Why
Inconsistent

#### How
Edit content
--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
