### PR TITLE
Remove some unnecessary configuration options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,9 +25,6 @@ AllCops:
     - 'vendor/**/*'
     - 'storage/**/*'
 
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
-
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 
@@ -117,9 +114,6 @@ RSpec/ImplicitSubject:
 RSpec/NestedGroups:
   Max: 4
 
-Style/DateTime:
-  AllowCoercion: true
-
 Style/Documentation:
   Enabled: false
 
@@ -130,13 +124,6 @@ Style/FormatStringToken:
   EnforcedStyle: template
 
 Style/StringConcatenation:
-  Enabled: false
-
-# Temporarily disable while fixing spec/* directory
-Lint/RedundantCopDisableDirective:
-  Enabled: false
-
-RSpec/Rails/InferredSpecType:
   Enabled: false
 
 RSpec/DescribeClass:

--- a/app/validators/base_sub_model_validator.rb
+++ b/app/validators/base_sub_model_validator.rb
@@ -71,7 +71,6 @@ class BaseSubModelValidator < BaseValidator
     #
     # NOTE: Once form migrations are complete, this conditional can be removed
     #
-    # rubocop:disable Layout/LineLength
     if %i[basic_fees dates_attended defendants disbursements expenses fixed_fees fixed_fee
           graduated_fee hardship_fee interim_fee interim_claim_info misc_fees
           representation_orders transfer_fee warrant_fee].include? association_name
@@ -79,7 +78,6 @@ class BaseSubModelValidator < BaseValidator
     else
       "#{association_name.to_s.singularize}_#{record_num + 1}_#{error.attribute}"
     end
-    # rubocop:enable Layout/LineLength
   end
   public :associated_error_attribute
 


### PR DESCRIPTION
#### What

Remove some options from the `.rubocop.yml` file.

#### Ticket

N/A

#### Why

Some options were added to suppress some `rubocop` alerts but these are no longer required.
