### PR TITLE
Restore `IntegerExtension` and `NilExtension`

### DIFF
--- a/app/interfaces/api/entities/cclf/base_claim.rb
+++ b/app/interfaces/api/entities/cclf/base_claim.rb
@@ -30,7 +30,7 @@ module API
         private
 
         def actual_trial_length_or_one
-          object.actual_trial_length || 1
+          object.actual_trial_length.or_one
         end
 
         # case type adapter requires access to claim object

--- a/app/interfaces/api/entities/ccr/base_claim.rb
+++ b/app/interfaces/api/entities/ccr/base_claim.rb
@@ -36,19 +36,19 @@ module API
         end
 
         def estimated_trial_length_or_one
-          object.estimated_trial_length || 1
+          object.estimated_trial_length.or_one
         end
 
         def actual_trial_length_or_one
-          object.actual_trial_length || 1
+          object.actual_trial_length.or_one
         end
 
         def retrial_actual_length_or_one
-          object.retrial_actual_length || 1
+          object.retrial_actual_length.or_one
         end
 
         def retrial_estimated_length_or_one
-          object.retrial_estimated_length || 1
+          object.retrial_estimated_length.or_one
         end
 
         def adapted_advocate_category

--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -42,3 +42,10 @@ class FalseClass
   include Extensions::BooleanExtension::False
 end
 
+class Integer
+  include Extensions::IntegerExtension
+end
+
+class NilClass
+  include Extensions::NilExtension
+end

--- a/lib/extensions/integer_extension.rb
+++ b/lib/extensions/integer_extension.rb
@@ -1,0 +1,7 @@
+module Extensions
+  module IntegerExtension
+    def or_one
+      [self, 1].compact.max
+    end
+  end
+end

--- a/lib/extensions/nil_extension.rb
+++ b/lib/extensions/nil_extension.rb
@@ -1,0 +1,7 @@
+module Extensions
+  module NilExtension
+    def or_one
+      1
+    end
+  end
+end


### PR DESCRIPTION
#### What

Restore `IntegerExtension` and `NilExtension` classes

#### Why

Removing `IntegerExtension` and `NilExtension` in https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6273 and https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6279 is causing issues injecting claims into CCR and CCLF.

This restores those classes to prevent disruption to users while we work out how to safely remove them.