### PR TITLE
Ctskf 535 reduce duplication in claim presenters

### DIFF
--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -56,14 +56,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
     raw_fixed_fees_total + raw_basic_fees_total + raw_misc_fees_total
   end
 
-  def misc_fees_vat
-    h.number_to_currency(raw_misc_fees_vat)
-  end
-
-  def misc_fees_gross
-    h.number_to_currency(raw_misc_fees_gross)
-  end
-
   def summary_sections
     SUMMARY_SECTIONS
   end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -56,11 +56,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
     raw_fixed_fees_total + raw_basic_fees_total + raw_misc_fees_total
   end
 
-
-  def fixed_fees_gross
-    h.number_to_currency(raw_fixed_fees_gross)
-  end
-
   def raw_misc_fees_vat
     VatRate.vat_amount(raw_misc_fees_total, claim.created_at, calculate: claim.apply_vat?)
   end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -56,14 +56,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
     raw_fixed_fees_total + raw_basic_fees_total + raw_misc_fees_total
   end
 
-  def raw_misc_fees_vat
-    VatRate.vat_amount(raw_misc_fees_total, claim.created_at, calculate: claim.apply_vat?)
-  end
-
-  def raw_misc_fees_gross
-    raw_misc_fees_total + raw_misc_fees_vat
-  end
-
   def misc_fees_vat
     h.number_to_currency(raw_misc_fees_vat)
   end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -56,10 +56,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
     raw_fixed_fees_total + raw_basic_fees_total + raw_misc_fees_total
   end
 
-  def raw_fixed_fees_gross
-    raw_fixed_fees_total + raw_fixed_fees_vat
-  end
-
   def fixed_fees_vat
     h.number_to_currency(raw_fixed_fees_vat)
   end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -56,10 +56,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
     raw_fixed_fees_total + raw_basic_fees_total + raw_misc_fees_total
   end
 
-  def raw_fixed_fees_vat
-    VatRate.vat_amount(raw_fixed_fees_total, claim.created_at, calculate: claim.apply_vat?)
-  end
-
   def raw_fixed_fees_gross
     raw_fixed_fees_total + raw_fixed_fees_vat
   end

--- a/app/presenters/claim/advocate_claim_presenter.rb
+++ b/app/presenters/claim/advocate_claim_presenter.rb
@@ -56,9 +56,6 @@ class Claim::AdvocateClaimPresenter < Claim::BaseClaimPresenter
     raw_fixed_fees_total + raw_basic_fees_total + raw_misc_fees_total
   end
 
-  def fixed_fees_vat
-    h.number_to_currency(raw_fixed_fees_vat)
-  end
 
   def fixed_fees_gross
     h.number_to_currency(raw_fixed_fees_gross)

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -81,10 +81,6 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
     !claim.fixed_fee_case?
   end
 
-  def fixed_fees_vat
-    h.number_to_currency(raw_fixed_fees_vat)
-  end
-
   def fixed_fees_gross
     h.number_to_currency(raw_fixed_fees_gross)
   end

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -81,10 +81,6 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
     !claim.fixed_fee_case?
   end
 
-  def fixed_fees_gross
-    h.number_to_currency(raw_fixed_fees_gross)
-  end
-
   def raw_warrant_fees_vat
     VatRate.vat_amount(raw_warrant_fees_total, claim.created_at, calculate: claim.apply_vat?)
   end

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -81,10 +81,6 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
     !claim.fixed_fee_case?
   end
 
-  def raw_fixed_fees_vat
-    VatRate.vat_amount(raw_fixed_fees_total, claim.created_at, calculate: claim.apply_vat?)
-  end
-
   def raw_fixed_fees_gross
     raw_fixed_fees_total + raw_fixed_fees_vat
   end

--- a/app/presenters/claim/litigator_claim_presenter.rb
+++ b/app/presenters/claim/litigator_claim_presenter.rb
@@ -81,10 +81,6 @@ class Claim::LitigatorClaimPresenter < Claim::BaseClaimPresenter
     !claim.fixed_fee_case?
   end
 
-  def raw_fixed_fees_gross
-    raw_fixed_fees_total + raw_fixed_fees_vat
-  end
-
   def fixed_fees_vat
     h.number_to_currency(raw_fixed_fees_vat)
   end


### PR DESCRIPTION
#### What
Remove some duplicated methods from presenter classes

#### Ticket

[CTSKF-535](https://dsdmoj.atlassian.net/browse/CTSKF-535)

#### Why
Guard against potential issues in the future if these methods were updated in base_claim_presenter, but then unintentionally overwritten in child classes by the duplicated methods. 


[CTSKF-535]: https://dsdmoj.atlassian.net/browse/CTSKF-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ