### PR TITLE
Remove monkey patching of Nil and Integer classes

### DIFF
--- a/app/interfaces/api/entities/base_entity.rb
+++ b/app/interfaces/api/entities/base_entity.rb
@@ -8,6 +8,10 @@ module API
           ->(_instance, opts) { opts.opts_hash.fetch(:export_format, false) }
         end
       end
+
+      def length_or_one(length)
+        [length, 1].compact.max
+      end
     end
   end
 end

--- a/app/interfaces/api/entities/cclf/base_claim.rb
+++ b/app/interfaces/api/entities/cclf/base_claim.rb
@@ -30,7 +30,7 @@ module API
         private
 
         def actual_trial_length_or_one
-          object.actual_trial_length.or_one
+          length_or_one(object.actual_trial_length)
         end
 
         # case type adapter requires access to claim object

--- a/app/interfaces/api/entities/ccr/base_claim.rb
+++ b/app/interfaces/api/entities/ccr/base_claim.rb
@@ -36,19 +36,19 @@ module API
         end
 
         def estimated_trial_length_or_one
-          object.estimated_trial_length.or_one
+          length_or_one(object.estimated_trial_length)
         end
 
         def actual_trial_length_or_one
-          object.actual_trial_length.or_one
+          length_or_one(object.actual_trial_length)
         end
 
         def retrial_actual_length_or_one
-          object.retrial_actual_length.or_one
+          length_or_one(object.retrial_actual_length)
         end
 
         def retrial_estimated_length_or_one
-          object.retrial_estimated_length.or_one
+          length_or_one(object.retrial_estimated_length)
         end
 
         def adapted_advocate_category

--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -41,11 +41,3 @@ end
 class FalseClass
   include Extensions::BooleanExtension::False
 end
-
-class Integer
-  include Extensions::IntegerExtension
-end
-
-class NilClass
-  include Extensions::NilExtension
-end

--- a/lib/extensions/integer_extension.rb
+++ b/lib/extensions/integer_extension.rb
@@ -1,7 +1,0 @@
-module Extensions
-  module IntegerExtension
-    def or_one
-      [self, 1].compact.max
-    end
-  end
-end

--- a/lib/extensions/nil_extension.rb
+++ b/lib/extensions/nil_extension.rb
@@ -1,7 +1,0 @@
-module Extensions
-  module NilExtension
-    def or_one
-      1
-    end
-  end
-end


### PR DESCRIPTION
#### What

Removes the IntegerExtension and NilExtension classes and fixes handling of nil/zero trial lengths in CCR/CCLF API claims.

#### Why

Monkey patching core classes can be confusing and lead to unintended consequences when those classes are used elsewhere.

#### How

Deletes the `lib/extensions/integer_extension.rb` and `lib/extensions/nil_extension.rb` classes and removes reference to them from `config/initializers/00_extensions.rb`

Removing this monkey patching means that an alternative is needed to the `or_one` methods that they defined. This is done by adding a method to `app/interfaces/api/entities/base_entity.rb` which replicates the functionality from the `or_one` method from the Integer class.

This method is called in `app/interfaces/api/entities/cclf/base_claim.rb` and `app/interfaces/api/entities/ccr/base_claim.rb`, both of which inherit from `base_entity.rb` and handles situations where trial lengths are nil or zero, both of which are valid conditions when creating a claim in CCCD but will cause the claim to fail to inject into CCR and CCLF.

For example:

1) An AGFS Final claim with a case type of Committal for Sentence in CCCD does not require a user to enter dates for `estimated_trial_length`, `actual_trial_length`, `retrial_estimated_length` or `retrial_actual_length`, and these default to 0 in the database, however CCR will reject the claim.

2) An AGFS Final claim with a case type of Trial (questionably?) allows a user to enter an `estimated_trial_length` of 0. Again CCR will reject the claim.

3) An LGFS Final claim with a case type of Guilty Plea allows the user to leave the `actual_trial_length` field blank. CCLF will reject the claim.

These three scenarios have been tested in `staging` along with other potential edge cases and no errors have occurred.