### PR TITLE
Set SQS polling for every 30 seconds

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,7 +17,7 @@ production:
 :scheduler:
   :schedule:
     poll_injection_responses:
-      cron: '0 * * * * *'
+      cron: '0/30 * * * * *'
       class: Schedule::PollInjectionResponses
     document_cleaner:
       cron: '0 0 4 * * *'


### PR DESCRIPTION
#### What

Poll the SQS queue for injection responses twice each minute instead of once.

#### Ticket

N/A

#### Why

To avoid the SQS queue building up too much.

#### How

Set the schedule to `*/30 * * * * *`
