### PR TITLE
[CTSKF-234] Modify install and update scripts in line with templates in Rails

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,9 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
 require 'fileutils'
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/bin/setup
+++ b/bin/setup
@@ -3,7 +3,7 @@ require 'pathname'
 require 'fileutils'
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 require 'pathname'
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
@@ -19,7 +18,7 @@ def copy_sample_file(src, dst)
   end
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 

--- a/bin/update
+++ b/bin/update
@@ -1,9 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
 require 'fileutils'
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/bin/update
+++ b/bin/update
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 require 'pathname'
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
@@ -10,7 +9,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 

--- a/bin/update
+++ b/bin/update
@@ -3,7 +3,7 @@ require 'pathname'
 require 'fileutils'
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")


### PR DESCRIPTION
See https://github.com/rails/rails/pull/34084

After CCCD was created the setup and update script templates in Rails were changed in line with [Style/MixinUsage](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MixinUsage) to avoid including modules in the global namespace. By bringing our scripts more into line with the templates there will be fewer conflicts when upgrading.

#### What

Small modifications to the setup and update scripts.

#### Ticket

[Upgrade CCCD app framework to Rails 7](https://dsdmoj.atlassian.net/browse/CTSKF-234)

#### Why

The Rails upgrade script, for moving between major versions, compares certain files against the Rails templates. Some differences result from changes made to the templates after CCCD was originally set up. By aligning our versions of the scripts more closely to the templates, the upgrading process can be simpler.

#### How

See changes to the Rails templates;

* https://github.com/rails/rails/pull/34084
* https://github.com/rails/rails/pull/29176
* https://github.com/rails/rails/pull/29303
