### PR TITLE
[CTSKF-591] Fix anonymised db dump

### DIFF
--- a/.k8s/live/api-sandbox/dump.yaml
+++ b/.k8s/live/api-sandbox/dump.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-dump
+spec:
+  template:
+    metadata:
+      name: db-dump
+    spec:
+      serviceAccountName: cccd-api-sandbox-service
+      restartPolicy: OnFailure
+      BackoffLimit: 1
+      containers:
+        - name: cccd-job
+          imagePullPolicy: Always
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          command:
+            - bundle
+            - exec
+            - rake
+            - db:dump:anonymised
+
+          envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-rds
+                  key: url
+            - name: SETTINGS__AWS__S3__BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: bucket_name
+

--- a/.k8s/live/dev-lgfs/dump.yaml
+++ b/.k8s/live/dev-lgfs/dump.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-dump
+spec:
+  template:
+    metadata:
+      name: db-dump
+    spec:
+      serviceAccountName: cccd-dev-lgfs-service
+      restartPolicy: OnFailure
+      BackoffLimit: 1
+      containers:
+        - name: cccd-job
+          imagePullPolicy: Always
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          command:
+            - bundle
+            - exec
+            - rake
+            - db:dump:anonymised
+
+          envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-rds
+                  key: url
+            - name: SETTINGS__AWS__S3__BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: bucket_name
+

--- a/.k8s/live/dev/dump.yaml
+++ b/.k8s/live/dev/dump.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-dump
+spec:
+  template:
+    metadata:
+      name: db-dump
+    spec:
+      serviceAccountName: cccd-dev-service
+      restartPolicy: OnFailure
+      BackoffLimit: 1
+      containers:
+        - name: cccd-job
+          imagePullPolicy: Always
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          command:
+            - bundle
+            - exec
+            - rake
+            - db:dump:anonymised
+
+          envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-rds
+                  key: url
+            - name: SETTINGS__AWS__S3__BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: bucket_name
+

--- a/.k8s/live/production/dump.yaml
+++ b/.k8s/live/production/dump.yaml
@@ -7,6 +7,7 @@ spec:
     metadata:
       name: db-dump
     spec:
+      serviceAccountName: cccd-production-service
       restartPolicy: OnFailure
       BackoffLimit: 1
       containers:
@@ -37,16 +38,6 @@ spec:
                 secretKeyRef:
                   name: cccd-rds
                   key: url
-            - name: SETTINGS__AWS__S3__ACCESS
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: access_key_id
-            - name: SETTINGS__AWS__S3__SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: cccd-s3-bucket
-                  key: secret_access_key
             - name: SETTINGS__AWS__S3__BUCKET
               valueFrom:
                 secretKeyRef:

--- a/.k8s/live/scripts/job.sh
+++ b/.k8s/live/scripts/job.sh
@@ -47,11 +47,14 @@ function _job() {
   docker_registry=754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd
   docker_image_tag=${docker_registry}:${component}-${current_version}
   job_name=db-$task
+  job_directory=jobs
+
+  if [ $task = 'dump' ]; then job_directory=${environment}; fi
 
   printf "\e[33m--------------------------------------------------\e[0m\n"
   printf "\e[33mTask: $task\e[0m\n"
   printf "\e[33mJob name: $job_name\e[0m\n"
-  printf "\e[33mJob config: .k8s/${context}/jobs/${task}.yaml\e[0m\n"
+  printf "\e[33mJob config: .k8s/${context}/${job_directory}/${task}.yaml\e[0m\n"
   printf "\e[33mcontext: $context\e[0m\n"
   printf "\e[33mEnvironment: $environment\e[0m\n"
   printf "\e[33mDocker image: $docker_image_tag\e[0m\n"
@@ -66,7 +69,7 @@ function _job() {
   kubectl apply -f .k8s/${context}/${environment}/app-config.yaml
 
   # apply image
-  kubectl set image -f .k8s/${context}/jobs/${task}.yaml cccd-job=${docker_image_tag} --local -o yaml | kubectl apply -f -
+  kubectl set image -f .k8s/${context}/${job_directory}/${task}.yaml cccd-job=${docker_image_tag} --local -o yaml | kubectl apply -f -
 
   # wait for job pod container to be ready before tailing logs
   kubectl wait --for=condition=ContainersReady --timeout=240s pod --selector job-name=$job_name

--- a/.k8s/live/staging/dump.yaml
+++ b/.k8s/live/staging/dump.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-dump
+spec:
+  template:
+    metadata:
+      name: db-dump
+    spec:
+      serviceAccountName: cccd-staging-service
+      restartPolicy: OnFailure
+      BackoffLimit: 1
+      containers:
+        - name: cccd-job
+          imagePullPolicy: Always
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/cccd:set-me
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          command:
+            - bundle
+            - exec
+            - rake
+            - db:dump:anonymised
+
+          envFrom:
+            - configMapRef:
+                name: cccd-app-config
+            - secretRef:
+                name: cccd-secrets
+
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-rds
+                  key: url
+            - name: SETTINGS__AWS__S3__BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: cccd-s3-bucket
+                  key: bucket_name
+

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -30,7 +30,7 @@ namespace :db do
         exit(1)
       end
 
-      unless File.exists?(dump_file)
+      unless File.exist?(dump_file)
         puts 'File %s not found.' % dump_file
         exit(1)
       end
@@ -89,7 +89,7 @@ namespace :db do
   desc 'Restores the database from a backup'
   task :restore, [:file] => :environment do |_task, args|
     production_protected
-    include IdSequenceResettable
+    include Tasks::RakeHelpers::IdSequenceResettable
 
     dump_file = args.file
 
@@ -99,7 +99,7 @@ namespace :db do
       exit(1)
     end
 
-    unless File.exists?(dump_file)
+    unless File.exist?(dump_file)
       puts 'File %s not found.' % dump_file
       exit(1)
     end

--- a/lib/tasks/dump.rake
+++ b/lib/tasks/dump.rake
@@ -32,9 +32,6 @@ namespace :db do
         end
         raise ['Failure'.red, ': ', cmd].join unless wait_thr.value.success?
       end
-
-      continue?'Do you want to delete all but the latest dump file from s3?'
-      Rake::Task['db:dump:delete_s3_dumps'].invoke(host)
     end
 
     desc 'Create anonymised database dump, compress (gzip) and upload to s3 - run on host via job (see run_job)'
@@ -135,6 +132,11 @@ namespace :db do
       end
 
       decompress_file(local_filename)
+
+      dump_files = s3_bucket.list('tmp').select { |item| item.key.match?('dump') }
+
+      continue?"There are #{dump_files.size} database dump files in this S3 bucket. Do you want to delete all but the latest dump file from s3?"
+      Rake::Task['db:dump:delete_s3_dumps'].invoke(host)
     end
 
     desc 'Export anonymised providers data'


### PR DESCRIPTION
#### What

Fixes the anonymised database dump task

#### Ticket

[CTSKF-591](https://dsdmoj.atlassian.net/browse/CTSKF-591)

#### Why

Moving to short-lived AWS credentials has broken the anonymised database dump process as the job relies on long-lived credentials to access the S3 bucket used to store the dumps. This task is useful when debugging production issues and it is valuable to restore it to aid with resolving incidents.

#### How

* Moves to using service accounts to access s3 buckets by creating a new `dump.yaml` config file for each CCCD environment, which removes references to the old AWS S3 keys/secrets and instead instructs the job to use the relevant service account for authentication.

* This also necessitates changes to `.k8s/live/scripts/job.sh` as `dump.yaml` files are now stored in environment directories instead of the `jobs` directory.

#### Notes

* ideally we would continue using a single `dump.yml` file, with the `serviceAccountName` populated dynamically based on the environment where the dump job is run, however this is not possible with our current setup. This is something to consider if we move to `helm` to manage our kubernetes configuration.

* this fix slightly changes the way the dump/restore process is run. It is now not possible to run rake tasks locally that interact with the S3 bucket. This includes commands to list/copy/delete dumps. Instead a developer needs to log on to a kubernetes pod to run those commands. Documentation has been updated to reflect this. We might want to look at future improvements to this.

[CTSKF-591]: https://dsdmoj.atlassian.net/browse/CTSKF-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ