### PR TITLE
Improve speed of cucumber test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ jobs:
   cucumber-tests:
     executor: test-executor
     resource_class: small
-    parallelism: 6
+    parallelism: 8
     steps:
       - checkout
       - run:

--- a/db/seeds/scheme_11.rb
+++ b/db/seeds/scheme_11.rb
@@ -10,7 +10,8 @@ agfs_fee_scheme_eleven = FeeScheme.find_or_create_by(name: 'AGFS', version: 11, 
 ActiveRecord::Base.connection.set_pk_sequence!('offences', 3000) if Offence.order(:id).last.id < 3000
 
 # create new offences (from csv)
-file_path = Rails.root.join('lib', 'assets', 'data', 'scheme_11_offences.csv')
+file_name = ENV.fetch('RAILS_ENV', 'development') == 'test' ? 'scheme_11_offences_for_testing.csv' : 'scheme_11_offences.csv'
+file_path = Rails.root.join('lib', 'assets', 'data', file_name)
 csv_file = File.open(file_path, 'r:ISO-8859-1')
 csv = CSV.parse(csv_file, headers: true)
 

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -22,8 +22,9 @@ When(/^I choose '(.*)' as the trial advocate$/) do |text|
 end
 
 When(/^I select the advocate offence class '(.*)'$/) do |offence_class|
-  sleep 1
-  @claim_form_page.select_offence_class(offence_class)
+  using_wait_time 1 do
+    @claim_form_page.select_offence_class(offence_class)
+  end
 end
 
 When(/I enter (.*?)(retrial|trial) start and end dates(?: with (\d+) day interval)?$/i) do |scheme_text, trial_type, interval|
@@ -167,7 +168,6 @@ Then("I add a govuk calculated miscellaneous fee {string} without a quantity") d
   @claim_form_page.miscellaneous_fees.last.govuk_fee_type_autocomplete.choose_autocomplete_option(fee_name)
   @claim_form_page.miscellaneous_fees.last.govuk_fee_type_autocomplete_input.send_keys(:tab)
 
-  sleep(2)
   wait_for_debounce
   wait_for_ajax
 end

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -130,34 +130,36 @@ When(/^I click "Continue" in the claim form$/) do
 end
 
 When(/^I click "Continue" I should be on the 'Case details' page and see a "([^"]*)" error$/) do |error_message|
-  sleep 3
-  @claim_form_page.continue_button.click
-  wait_for_ajax
-  using_wait_time(6) do
-    if !page.has_content?(error_message)
-      #clicking again because the first one didn't work
-      @claim_form_page.continue_button.click
-      wait_for_ajax
-    end
-    within('div.govuk-error-summary') do
-      expect(page).to have_content(error_message)
+  using_wait_time 3 do
+    @claim_form_page.continue_button.click
+    wait_for_ajax
+    using_wait_time(6) do
+      if !page.has_content?(error_message)
+        #clicking again because the first one didn't work
+        @claim_form_page.continue_button.click
+        wait_for_ajax
+      end
+      within('div.govuk-error-summary') do
+        expect(page).to have_content(error_message)
+      end
     end
   end
 end
 
 When(/^I click "Continue" in the claim form and move to the '(.*?)' form page$/) do |page_title|
   original_header = page.first('h2.govuk-heading-l').text
-  sleep 3
-  @claim_form_page.continue_button.click
-  wait_for_ajax
-  using_wait_time(6) do
-    if page.first('h2.govuk-heading-l').text.eql?(original_header)
-      #clicking again because the first one didn't work
-      @claim_form_page.continue_button.click
-      wait_for_ajax
-    end
-    within('#claim-form') do
-      expect(page.first('h2.govuk-heading-l')).to have_content(page_title)
+  using_wait_time 3 do
+    @claim_form_page.continue_button.click
+    wait_for_ajax
+    using_wait_time(6) do
+      if page.first('h2.govuk-heading-l').text.eql?(original_header)
+        #clicking again because the first one didn't work
+        @claim_form_page.continue_button.click
+        wait_for_ajax
+      end
+      within('#claim-form') do
+        expect(page.first('h2.govuk-heading-l')).to have_content(page_title)
+      end
     end
   end
 end

--- a/features/step_definitions/messaging_steps.rb
+++ b/features/step_definitions/messaging_steps.rb
@@ -46,7 +46,6 @@ end
 
 When(/^I click send$/) do
   @external_user_claim_show_page.messages_panel.send.click
-  sleep 1
 end
 
 Then(/^the claim should be visible with 1 new message$/) do

--- a/features/step_definitions/offence_steps.rb
+++ b/features/step_definitions/offence_steps.rb
@@ -21,7 +21,7 @@ end
 
 # AGFS 10/11 only
 Then(/^I select the first search result$/) do
-  sleep Capybara.default_max_wait_time
+  sleep 1
   find(:xpath, '//*[@id="offence-list"]/div[3]/div').hover
   find(:xpath, '//*[@id="offence-list"]/div[3]/div/div[2]/a').click
   wait_for_ajax

--- a/features/step_definitions/offence_steps.rb
+++ b/features/step_definitions/offence_steps.rb
@@ -21,9 +21,10 @@ end
 
 # AGFS 10/11 only
 Then(/^I select the first search result$/) do
-  sleep 1
-  find(:xpath, '//*[@id="offence-list"]/div[3]/div').hover
-  find(:xpath, '//*[@id="offence-list"]/div[3]/div/div[2]/a').click
+  using_wait_time 1 do
+    find(:xpath, '//*[@id="offence-list"]/div[3]/div').hover
+    find(:xpath, '//*[@id="offence-list"]/div[3]/div/div[2]/a').click
+  end
   wait_for_ajax
 end
 

--- a/lib/assets/data/scheme_11_offences_for_testing.csv
+++ b/lib/assets/data/scheme_11_offences_for_testing.csv
@@ -1,0 +1,10 @@
+category,band,description,contrary_to,year_chapter
+3,3.4,Possession of offensive weapon on school premises,"Criminal Justice Act 1988, s.139A",1996 c. 26
+3,3.5,Racially or religiously aggravated common assault,"Crime and Disorder Act 1998, s.29(1)(c ) and (3)",1998 c. 37
+5,5.3,Solicitation by men,"Sexual Offences Act 1956, s.32",1956 c. 69
+8,8.1,Harbouring escaped prisoner,"Criminal Justice Act 1961, s.22(2)",1961 c. 39
+8,8.1,Have in possession or  control identity documents with improper intent,"Identity Documents Act 2010, s.4",2010 c. 40
+11,11.2,Burglary (domestic),"Theft Act 1968, s.9(3)(a)",1968 c. 60
+11,11.2,Burglary (non-domestic),"Theft Act 1968, s.9(3)(b)",1968 c. 60
+16,16.3,Unlicensed or unauthorised air traffic controllers,Air Navigation Order 2016,2016 No. 765
+17,17.1,Absconding from lawful custody,Common Law,


### PR DESCRIPTION
#### What

A speculative attempt to speed up the CCCD feature test suite

#### Why

The test suite is regularly taking 13+ minutes to run on CircleCI, and has taken over 15 minutes. It would be nice if it was quicker...

#### How

Various attempts, including:
* reduce use of `sleep` statements in feature tests (this appears to casuse only a small improvement)
* increase CircleCI parallelism from 6 to 8
* ~~increase CircleCI resource class size~~ (this appear to have no affect on runtime)
* reduce the volume of data seeded when tests start

#### Outcome

Rough timings:

8x parellel + same seed data = ~10 minutes
6x parellel + reduced seed data = ~8 minutes
8x parellel + reduced seed data = ~7 minutes
