### PR TITLE
Rename CircleCI job to smoke-test-app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ jobs:
     steps:
       - smoke-test
 
-  smoke-test-dev:
+  smoke-test-app:
     executor:
       name: smoke-test-executor
       tag: app-${CIRCLE_SHA1}
@@ -650,7 +650,7 @@ workflows:
             - hold-branch-build
           context:
             - cccd-live-base
-      - smoke-test-dev:
+      - smoke-test-app:
           requires:
             - build-app-container
           context:


### PR DESCRIPTION
#### What

Rename CircleCI job to `smoke-test-app`

#### Ticket

[board ticket description](link)

#### Why

This is because the `smoke-test-dev` / `smoke-test-app` tests the docker container with a `RAILS_ENV=test` . It does not test the live pre-prod/prod services e.g. `dev.cccd.co.uk`

#### How

Rename references to `smoke-test-dev` in the `.circleci/config.yml` file to `smoke-test-app`
