### PR TITLE
Group related dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     day: wednesday
     time: "03:00"
     timezone: Europe/London
+  groups:
+    babel:
+      patterns:
+        - "*babel*"
   open-pull-requests-limit: 5
   reviewers:
   - "ministryofjustice/laa-claim-for-payment"
@@ -17,6 +21,10 @@ updates:
     day: wednesday
     time: "03:00"
     timezone: Europe/London
+  groups:
+    aws:
+      patterns:
+        - "aws-*"
   open-pull-requests-limit: 5
   rebase-strategy: "disabled"
   allow:


### PR DESCRIPTION
#### What

Adds dependabot `group` definitions for `aws` bundle updates and `babel` npm updates.

#### Why

We frequently see multiple PRs for these dependencies, which require multiple CircleCI pipeline runs to test and often lead to conflicts which require rebasing to resolve.

For example we may see updates for `aws-partitions` and`aws-sdk-core`, or `@babel/core` and `@babel/preset-env` on the same day.

By grouping updates for those dependencies, a single PR will be opened containing the changes, resulting in fewer pipeline runs.

We could possibly also include a group for `rubocop` updates but that might make resolving failures caused by updates more complex.

#### How

Defines groups for those dependencies in `.github/dependabot.yml`.

See: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/