### PR TITLE
Remove bury method

### DIFF
--- a/lib/extensions/hash_extension.rb
+++ b/lib/extensions/hash_extension.rb
@@ -25,11 +25,5 @@ module Extensions
         end
       end
     end
-
-    def bury(value, *keys)
-      keys[0...-1].inject(self) do |acc, key|
-        acc.public_send(:[], key)
-      end.public_send(:[]=, keys.last, value)
-    end
   end
 end


### PR DESCRIPTION
#### What

Remove `Extension::HashExtensions.bury`.

#### Ticket

N/A

#### Why

`Extensions::HashExtensions.bury` was added in #2327 and its only use was removed in #2649.
