### PR TITLE
[SPIKE] Disable ModSecurity rule 920120 for evidence uploads

### DIFF
--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
+      SecRuleRemoveById 920120
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;


### PR DESCRIPTION
#### What

ModSecurity rule 920120 is causing false positives when users upload files with names that contain single quotes, semi-colons and equals symbols.

This disables the rule on the evidence upload page so that users are not disrupted.

#### Ticket

[board ticket description](link)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
