### PR TITLE
Set up Sentry Crons to monitor scheduled jobs in sidekick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'remotipart',             '~> 1.4'
 gem 'rest-client',            '~> 2.1' # needed for scheduled smoke testing plus others
 gem 'sentry-rails', '~> 5.16'
 gem 'sentry-sidekiq', '~> 5.16'
+gem "sentry-ruby"
 gem 'sprockets-rails', '~> 3.4.2'
 gem 'state_machines-activerecord'
 gem 'state_machines-audit_trail'
@@ -63,8 +64,6 @@ gem 'active_storage_validations'
 gem 'faraday', '~> 1.10'
 gem 'faraday_middleware', '~> 1.2'
 gem 'puma'
-gem "sentry-ruby"
-gem "sentry-rails"
 
 group :development, :test do
   gem 'annotate'

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem 'active_storage_validations'
 gem 'faraday', '~> 1.10'
 gem 'faraday_middleware', '~> 1.2'
 gem 'puma'
+gem "sentry-ruby"
+gem "sentry-rails"
 
 group :development, :test do
   gem 'annotate'

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,35 +11,35 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
    end
 
    # Create a config from a crontab schedule (every 10 minutes)
-   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
-     10,
-     :minute,
-     checkin_margin: 5, # Optional check-in margin in minutes
-     max_runtime: 15, # Optional max runtime in minutes
-     timezone: 'Europe/London', # Optional timezone
-     )
-
-   # 🟡 Notify Sentry your job is running:
-   check_in_id = Sentry.capture_check_in(
-     'monitor-sidekiq-in-progress',
-     :in_progress,
-     monitor_config: monitor_config
-   )
-
-   # Execute your scheduled task here...
-
-   # 🟢 Notify Sentry your job has completed successfully:
-   Sentry.capture_check_in(
-     'monitor-sidekiq-ok',
-     :ok,
-     check_in_id: check_in_id,
-     monitor_config: monitor_config
-   )
-
-   Sentry.capture_check_in(
-     'monitor-sidekiq-error',
-     :error,
-     check_in_id: check_in_id,
-     monitor_config: monitor_config
-   )
-end
+#    monitor_config = Sentry::Cron::MonitorConfig.from_interval(
+#      10,
+#      :minute,
+#      checkin_margin: 5, # Optional check-in margin in minutes
+#      max_runtime: 15, # Optional max runtime in minutes
+#      timezone: 'Europe/London', # Optional timezone
+#      )
+#
+#    # 🟡 Notify Sentry your job is running:
+#    check_in_id = Sentry.capture_check_in(
+#      '<monitor-slug>',
+#      :in_progress,
+#      monitor_config: monitor_config
+#    )
+#
+#    # Execute your scheduled task here...
+#
+#    # 🟢 Notify Sentry your job has completed successfully:
+#    Sentry.capture_check_in(
+#      '<monitor-slug>',
+#      :ok,
+#      check_in_id: check_in_id,
+#      monitor_config: monitor_config
+#    )
+#
+#    Sentry.capture_check_in(
+#      '<monitor-slug>',
+#      :error,
+#      check_in_id: check_in_id,
+#      monitor_config: monitor_config
+#    )
+ end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -21,7 +21,7 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
 
    # 🟡 Notify Sentry your job is running:
    check_in_id = Sentry.capture_check_in(
-     '<monitor-slug>',
+     slug,
      :in_progress,
      monitor_config: monitor_config
    )
@@ -30,14 +30,14 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
 
    # 🟢 Notify Sentry your job has completed successfully:
    Sentry.capture_check_in(
-     '<monitor-slug>',
+     slug,
      :ok,
      check_in_id: check_in_id,
      monitor_config: monitor_config
    )
 
    Sentry.capture_check_in(
-     '<monitor-slug>',
+     slug,
      :error,
      check_in_id: check_in_id,
      monitor_config: monitor_config

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,35 +11,35 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
    end
 
    # Create a config from a crontab schedule (every 10 minutes)
-   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
-     10,
-     :minute,
-     checkin_margin: 5, # Optional check-in margin in minutes
-     max_runtime: 15, # Optional max runtime in minutes
-     timezone: 'Europe/London', # Optional timezone
-     )
-
-   # 🟡 Notify Sentry your job is running:
-   check_in_id = Sentry.capture_check_in(
-     '<monitor-slug>',
-     :in_progress,
-     monitor_config: monitor_config
-   )
-
-   # Execute your scheduled task here...
-
-   # 🟢 Notify Sentry your job has completed successfully:
-   Sentry.capture_check_in(
-     '<monitor-slug>',
-     :ok,
-     check_in_id: check_in_id,
-     monitor_config: monitor_config
-   )
-
-   Sentry.capture_check_in(
-     '<monitor-slug>',
-     :error,
-     check_in_id: check_in_id,
-     monitor_config: monitor_config
-   )
- end
+ #   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
+ #     10,
+ #     :minute,
+ #     checkin_margin: 5, # Optional check-in margin in minutes
+ #     max_runtime: 15, # Optional max runtime in minutes
+ #     timezone: 'Europe/London', # Optional timezone
+ #     )
+ #
+ #   # 🟡 Notify Sentry your job is running:
+ #   check_in_id = Sentry.capture_check_in(
+ #     '<monitor-slug>',
+ #     :in_progress,
+ #     monitor_config: monitor_config
+ #   )
+ #
+ #   # Execute your scheduled task here...
+ #
+ #   # 🟢 Notify Sentry your job has completed successfully:
+ #   Sentry.capture_check_in(
+ #     '<monitor-slug>',
+ #     :ok,
+ #     check_in_id: check_in_id,
+ #     monitor_config: monitor_config
+ #   )
+ #
+ #   Sentry.capture_check_in(
+ #     '<monitor-slug>',
+ #     :error,
+ #     check_in_id: check_in_id,
+ #     monitor_config: monitor_config
+ #   )
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -21,7 +21,7 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
 
    # 🟡 Notify Sentry your job is running:
    check_in_id = Sentry.capture_check_in(
-     '<monitor-slug>',
+     'monitor-sidekiq-in-progress',
      :in_progress,
      monitor_config: monitor_config
    )
@@ -30,18 +30,16 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
 
    # 🟢 Notify Sentry your job has completed successfully:
    Sentry.capture_check_in(
-     '<monitor-slug>',
+     'monitor-sidekiq-ok',
      :ok,
      check_in_id: check_in_id,
      monitor_config: monitor_config
    )
 
    Sentry.capture_check_in(
-     '<monitor-slug>',
+     'monitor-sidekiq-error',
      :error,
      check_in_id: check_in_id,
      monitor_config: monitor_config
    )
-
-   Sentry.capture_message("test message")
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,37 +9,4 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
     config.traces_sample_rate = 0.05
     config.enabled_patches += [:sidekiq_scheduler]
    end
-
-   # Create a config from a crontab schedule (every 10 minutes)
-   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
-     10,
-     :minute,
-     checkin_margin: 5, # Optional check-in margin in minutes
-     max_runtime: 15, # Optional max runtime in minutes
-     timezone: 'Europe/London', # Optional timezone
-     )
-
-   # 🟡 Notify Sentry your job is running:
-   check_in_id = Sentry.capture_check_in(
-     slug,
-     :in_progress,
-     monitor_config: monitor_config
-   )
-
-   # Execute your scheduled task here...
-
-   # 🟢 Notify Sentry your job has completed successfully:
-   Sentry.capture_check_in(
-     slug,
-     :ok,
-     check_in_id: check_in_id,
-     monitor_config: monitor_config
-   )
-
-   Sentry.capture_check_in(
-     slug,
-     :error,
-     check_in_id: check_in_id,
-     monitor_config: monitor_config
-   )
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,35 +11,35 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
    end
 
    # Create a config from a crontab schedule (every 10 minutes)
-#    monitor_config = Sentry::Cron::MonitorConfig.from_interval(
-#      10,
-#      :minute,
-#      checkin_margin: 5, # Optional check-in margin in minutes
-#      max_runtime: 15, # Optional max runtime in minutes
-#      timezone: 'Europe/London', # Optional timezone
-#      )
-#
-#    # 🟡 Notify Sentry your job is running:
-#    check_in_id = Sentry.capture_check_in(
-#      '<monitor-slug>',
-#      :in_progress,
-#      monitor_config: monitor_config
-#    )
-#
-#    # Execute your scheduled task here...
-#
-#    # 🟢 Notify Sentry your job has completed successfully:
-#    Sentry.capture_check_in(
-#      '<monitor-slug>',
-#      :ok,
-#      check_in_id: check_in_id,
-#      monitor_config: monitor_config
-#    )
-#
-#    Sentry.capture_check_in(
-#      '<monitor-slug>',
-#      :error,
-#      check_in_id: check_in_id,
-#      monitor_config: monitor_config
-#    )
+   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
+     10,
+     :minute,
+     checkin_margin: 5, # Optional check-in margin in minutes
+     max_runtime: 15, # Optional max runtime in minutes
+     timezone: 'Europe/London', # Optional timezone
+     )
+
+   # 🟡 Notify Sentry your job is running:
+   check_in_id = Sentry.capture_check_in(
+     '<monitor-slug>',
+     :in_progress,
+     monitor_config: monitor_config
+   )
+
+   # Execute your scheduled task here...
+
+   # 🟢 Notify Sentry your job has completed successfully:
+   Sentry.capture_check_in(
+     '<monitor-slug>',
+     :ok,
+     check_in_id: check_in_id,
+     monitor_config: monitor_config
+   )
+
+   Sentry.capture_check_in(
+     '<monitor-slug>',
+     :error,
+     check_in_id: check_in_id,
+     monitor_config: monitor_config
+   )
  end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,35 +11,35 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
    end
 
    # Create a config from a crontab schedule (every 10 minutes)
- #   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
- #     10,
- #     :minute,
- #     checkin_margin: 5, # Optional check-in margin in minutes
- #     max_runtime: 15, # Optional max runtime in minutes
- #     timezone: 'Europe/London', # Optional timezone
- #     )
- #
- #   # 🟡 Notify Sentry your job is running:
- #   check_in_id = Sentry.capture_check_in(
- #     '<monitor-slug>',
- #     :in_progress,
- #     monitor_config: monitor_config
- #   )
- #
- #   # Execute your scheduled task here...
- #
- #   # 🟢 Notify Sentry your job has completed successfully:
- #   Sentry.capture_check_in(
- #     '<monitor-slug>',
- #     :ok,
- #     check_in_id: check_in_id,
- #     monitor_config: monitor_config
- #   )
- #
- #   Sentry.capture_check_in(
- #     '<monitor-slug>',
- #     :error,
- #     check_in_id: check_in_id,
- #     monitor_config: monitor_config
- #   )
+   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
+     10,
+     :minute,
+     checkin_margin: 5, # Optional check-in margin in minutes
+     max_runtime: 15, # Optional max runtime in minutes
+     timezone: 'Europe/London', # Optional timezone
+     )
+
+   # 🟡 Notify Sentry your job is running:
+   check_in_id = Sentry.capture_check_in(
+     '<monitor-slug>',
+     :in_progress,
+     monitor_config: monitor_config
+   )
+
+   # Execute your scheduled task here...
+
+   # 🟢 Notify Sentry your job has completed successfully:
+   Sentry.capture_check_in(
+     '<monitor-slug>',
+     :ok,
+     check_in_id: check_in_id,
+     monitor_config: monitor_config
+   )
+
+   Sentry.capture_check_in(
+     '<monitor-slug>',
+     :error,
+     check_in_id: check_in_id,
+     monitor_config: monitor_config
+   )
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -42,4 +42,6 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
      check_in_id: check_in_id,
      monitor_config: monitor_config
    )
+
+   Sentry.capture_message("test message")
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,12 +7,13 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
 
     # Send 5% of transactions for performance monitoring
     config.traces_sample_rate = 0.05
-    config.enabled_patches += [:sidekiq_cron]
+    config.enabled_patches += [:sidekiq_scheduler]
    end
 
    # Create a config from a crontab schedule (every 10 minutes)
-   monitor_config = Sentry::Cron::MonitorConfig.from_crontab(
-     '5 * * * *',
+   monitor_config = Sentry::Cron::MonitorConfig.from_interval(
+     10,
+     :minute,
      checkin_margin: 5, # Optional check-in margin in minutes
      max_runtime: 15, # Optional max runtime in minutes
      timezone: 'Europe/London', # Optional timezone
@@ -31,6 +32,13 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
    Sentry.capture_check_in(
      '<monitor-slug>',
      :ok,
+     check_in_id: check_in_id,
+     monitor_config: monitor_config
+   )
+
+   Sentry.capture_check_in(
+     '<monitor-slug>',
+     :error,
      check_in_id: check_in_id,
      monitor_config: monitor_config
    )

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,7 +23,7 @@ production:
       cron: '0 0 4 * * *'
       class: Schedule::DocumentCleaner
     agfs_management_information_generation:
-      cron: '0 30 16 * * *'
+      cron: '0 0 2 * * *'
       class: Schedule::ReportGeneration
       args: ['agfs_management_information']
     agfs_management_information_v2_generation:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,7 +23,7 @@ production:
       cron: '0 0 4 * * *'
       class: Schedule::DocumentCleaner
     agfs_management_information_generation:
-      cron: '0 35 15 * * *'
+      cron: '0 5 16 * * *'
       class: Schedule::ReportGeneration
       args: ['agfs_management_information']
     agfs_management_information_v2_generation:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,7 +23,7 @@ production:
       cron: '0 0 4 * * *'
       class: Schedule::DocumentCleaner
     agfs_management_information_generation:
-      cron: '0 5 16 * * *'
+      cron: '0 30 16 * * *'
       class: Schedule::ReportGeneration
       args: ['agfs_management_information']
     agfs_management_information_v2_generation:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,7 +23,7 @@ production:
       cron: '0 0 4 * * *'
       class: Schedule::DocumentCleaner
     agfs_management_information_generation:
-      cron: '0 20 15 * * *'
+      cron: '0 35 15 * * *'
       class: Schedule::ReportGeneration
       args: ['agfs_management_information']
     agfs_management_information_v2_generation:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,7 +23,7 @@ production:
       cron: '0 0 4 * * *'
       class: Schedule::DocumentCleaner
     agfs_management_information_generation:
-      cron: '0 0 2 * * *'
+      cron: '0 20 15 * * *'
       class: Schedule::ReportGeneration
       args: ['agfs_management_information']
     agfs_management_information_v2_generation:

--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: 'Schedule::DocumentCleaner'
+    sentry_monitor_check_ins
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -5,13 +5,6 @@ module Schedule
 
     sentry_monitor_check_ins
 
-    def sentry_monitor_slug(name: self.name)
-      @sentry_monitor_slug ||= begin
-                                 slug = name.gsub('::', '-').downcase
-                                 slug[-MAX_SLUG_LENGTH..-1] || slug
-                               end
-    end
-
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: 'DocumentCleaner'
+    sentry_monitor_check_ins slug: 'Schedule::DocumentCleaner'
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -1,6 +1,9 @@
 module Schedule
   class DocumentCleaner
     include Sidekiq::Job
+    include Sentry::Cron::MonitorCheckIns
+
+    sentry_monitor_check_ins
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -3,7 +3,15 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: '<Schedule::DocumentCleaner>'
+    sentry_monitor_check_ins
+
+    def sentry_monitor_slug(name: self.name)
+      @sentry_monitor_slug ||= begin
+                                 slug = name.gsub('::', '-').downcase
+                                 slug[-MAX_SLUG_LENGTH..-1] || slug
+                               end
+    end
+
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins
+    sentry_monitor_check_ins slug: 'DocumentCleaner'
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins
+    sentry_monitor_check_ins slug: '<Schedule::DocumentCleaner>'
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/poll_injection_responses.rb
+++ b/lib/schedule/poll_injection_responses.rb
@@ -1,6 +1,9 @@
 module Schedule
   class PollInjectionResponses
     include Sidekiq::Job
+    include Sentry::Cron::MonitorCheckIns
+
+    sentry_monitor_check_ins
 
     def perform
       queue = Settings.aws.response_queue

--- a/lib/schedule/poll_injection_responses.rb
+++ b/lib/schedule/poll_injection_responses.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: '<Schedule::PollInjectionResponses>'
+    sentry_monitor_check_ins
 
     def perform
       queue = Settings.aws.response_queue

--- a/lib/schedule/poll_injection_responses.rb
+++ b/lib/schedule/poll_injection_responses.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins
+    sentry_monitor_check_ins slug: '<Schedule::PollInjectionResponses>'
 
     def perform
       queue = Settings.aws.response_queue

--- a/lib/schedule/poll_injection_responses.rb
+++ b/lib/schedule/poll_injection_responses.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: `Schedule::PollInjectionResponses`
+    sentry_monitor_check_ins
 
     def perform
       queue = Settings.aws.response_queue

--- a/lib/schedule/poll_injection_responses.rb
+++ b/lib/schedule/poll_injection_responses.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: `PollInjectionResponses`
+    sentry_monitor_check_ins slug: `Schedule::PollInjectionResponses`
 
     def perform
       queue = Settings.aws.response_queue

--- a/lib/schedule/poll_injection_responses.rb
+++ b/lib/schedule/poll_injection_responses.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins
+    sentry_monitor_check_ins slug: `PollInjectionResponses`
 
     def perform
       queue = Settings.aws.response_queue

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -3,7 +3,8 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins
+    sentry_monitor_check_ins slug: 'custom_slug'
+
 
     def perform(report_type)
       raise StandardError, "This is a fake error"

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: 'Schedule::ReportGeneration'
+    sentry_monitor_check_ins
 
     def perform(report_type)
       raise(StandardError, 'This is a fake error')

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -3,16 +3,15 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: 'custom_slug'
+    sentry_monitor_check_ins
 
 
     def perform(report_type)
-      raise StandardError, "This is a fake error"
-    #   LogStuff.info { "#{report_type.to_s.humanize} generation started" }
-    #   Stats::StatsReportGenerator.call(report_type:)
-    #   LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
-    # rescue StandardError => e
-    #   LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
+      LogStuff.info { "#{report_type.to_s.humanize} generation started" }
+      Stats::StatsReportGenerator.call(report_type:)
+      LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
+    rescue StandardError => e
+      LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
     end
   end
 end

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -1,6 +1,9 @@
 module Schedule
   class ReportGeneration
     include Sidekiq::Job
+    include Sentry::Cron::MonitorCheckIns
+
+    sentry_monitor_check_ins
 
     def perform(report_type)
       LogStuff.info { "#{report_type.to_s.humanize} generation started" }

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -6,11 +6,12 @@ module Schedule
     sentry_monitor_check_ins
 
     def perform(report_type)
-      LogStuff.info { "#{report_type.to_s.humanize} generation started" }
-      Stats::StatsReportGenerator.call(report_type:)
-      LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
-    rescue StandardError => e
-      LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
+      raise StandardError, "This is a fake error"
+    #   LogStuff.info { "#{report_type.to_s.humanize} generation started" }
+    #   Stats::StatsReportGenerator.call(report_type:)
+    #   LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
+    # rescue StandardError => e
+    #   LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
     end
   end
 end

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: 'ReportGeneration'
+    sentry_monitor_check_ins slug: 'Schedule::ReportGeneration'
 
     def perform(report_type)
       raise(StandardError, 'This is a fake error')

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -3,7 +3,7 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins
+    sentry_monitor_check_ins slug: '<Schedule::ReportGeneration>'
 
 
     def perform(report_type)

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -3,7 +3,12 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins slug: '<Schedule::ReportGeneration>'
+    sentry_monitor_check_ins slug: 'agfs_management_information_generation'
+    sentry_monitor_check_ins slug: 'agfs_management_information_v2_generation'
+    # sentry_monitor_check_ins slug: 'lgfs_management_information_generation'
+    # sentry_monitor_check_ins slug: 'lgfs_management_information_v2_generation'
+    # sentry_monitor_check_ins slug: 'management_information_generation'
+    # sentry_monitor_check_ins slug: 'management_information_v2_generation'
 
 
     def perform(report_type)

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -6,12 +6,11 @@ module Schedule
     sentry_monitor_check_ins
 
     def perform(report_type)
-      raise(StandardError, 'This is a fake error')
-    #   LogStuff.info { "#{report_type.to_s.humanize} generation started" }
-    #   Stats::StatsReportGenerator.call(report_type:)
-    #   LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
-    # rescue StandardError => e
-    #   LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
+      LogStuff.info { "#{report_type.to_s.humanize} generation started" }
+      Stats::StatsReportGenerator.call(report_type:)
+      LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
+    rescue StandardError => e
+      LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
     end
   end
 end

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -3,14 +3,15 @@ module Schedule
     include Sidekiq::Job
     include Sentry::Cron::MonitorCheckIns
 
-    sentry_monitor_check_ins
+    sentry_monitor_check_ins slug: 'ReportGeneration'
 
     def perform(report_type)
-      LogStuff.info { "#{report_type.to_s.humanize} generation started" }
-      Stats::StatsReportGenerator.call(report_type:)
-      LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
-    rescue StandardError => e
-      LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
+      raise(StandardError, 'This is a fake error')
+    #   LogStuff.info { "#{report_type.to_s.humanize} generation started" }
+    #   Stats::StatsReportGenerator.call(report_type:)
+    #   LogStuff.info { "#{report_type.to_s.humanize} generation finished" }
+    # rescue StandardError => e
+    #   LogStuff.error { "#{report_type.to_s.humanize} generation error: #{e.message}" }
     end
   end
 end


### PR DESCRIPTION
#### What
Follow documentations setup in [ Sentry- Set Up Crons ](https://docs.sentry.io/platforms/ruby/guides/sidekiq/crons/l) as one approach to monitoring scheduled tasks which run in the background.

#### Ticket

[CCCD: Investigate monitoring/alerting on scheduled tasks](https://dsdmoj.atlassian.net/browse/CTSKF-410)

#### Why
A recent [incident](https://dsdmoj.atlassian.net/browse/CTSKF-404) caused these to silently fail. It might be useful to be alerted to such failures automatically

#### How
By implementing Sentry Crons - this allows you to monitor the uptime and performance of any scheduled, recurring job. Once implemented, it'll allow you to get alerts and metrics to help you solve errors, detect timeouts, and prevent disruptions to your service.

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
