### PR TITLE
Set up Sentry Crons to monitor the uptime and performance of scheduled jobs in sidekick

### DIFF
--- a/lib/schedule/document_cleaner.rb
+++ b/lib/schedule/document_cleaner.rb
@@ -1,6 +1,9 @@
 module Schedule
   class DocumentCleaner
     include Sidekiq::Job
+    include Sentry::Cron::MonitorCheckIns
+
+    sentry_monitor_check_ins
 
     def perform
       logger.info('Document Cleaner started')

--- a/lib/schedule/poll_injection_responses.rb
+++ b/lib/schedule/poll_injection_responses.rb
@@ -1,6 +1,9 @@
 module Schedule
   class PollInjectionResponses
     include Sidekiq::Job
+    include Sentry::Cron::MonitorCheckIns
+
+    sentry_monitor_check_ins
 
     def perform
       queue = Settings.aws.response_queue

--- a/lib/schedule/report_generation.rb
+++ b/lib/schedule/report_generation.rb
@@ -1,6 +1,9 @@
 module Schedule
   class ReportGeneration
     include Sidekiq::Job
+    include Sentry::Cron::MonitorCheckIns
+
+    sentry_monitor_check_ins
 
     def perform(report_type)
       LogStuff.info { "#{report_type.to_s.humanize} generation started" }


### PR DESCRIPTION
What
To test on staging only. Follow documentations setup in [Sentry- Set Up Crons ](https://docs.sentry.io/platforms/ruby/guides/sidekiq/crons/l)as one approach to monitoring scheduled tasks which run in the background.

Ticket
[CCCD: Investigate monitoring/alerting on scheduled tasks](https://dsdmoj.atlassian.net/browse/CTSKF-410)

Why
A recent [incident](https://dsdmoj.atlassian.net/browse/CTSKF-404) caused these to silently fail. It might be useful to be alerted to such failures automatically

How
By implementing Sentry Crons 