### PR TITLE
Group Rubocop dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,9 @@ updates:
     aws:
       patterns:
         - "aws-*"
+    rubocop:
+      patterns:
+        - "rubocop*"
   open-pull-requests-limit: 5
   rebase-strategy: "disabled"
   allow:


### PR DESCRIPTION
#### What

Adds dependabot group definitions for `rubocop` bundle updates.

#### Ticket

N/A

#### Why

The grouping of dependabot PRs in #6391 is working well for aws and babel related updates. There is also the possibility of grouping rubocop updates.

#### How

Defines groups for those dependencies in `.github/dependabot.yml`.

See: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
