### PR TITLE
[CTSKF-652] Update initializers to avoid autoloading constants

### DIFF
--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -3,4 +3,6 @@
 #   :ga  -> Google Analytics
 #   :gtm -> Google Tag Manager
 #
-GoogleAnalytics::DataTracking.adapter = ENV['GTM_TRACKER_ID'].present? ? :gtm : :ga
+Rails.application.reloader.to_prepare do
+  GoogleAnalytics::DataTracking.adapter = ENV['GTM_TRACKER_ID'].present? ? :gtm : :ga
+end

--- a/config/initializers/remote_client.rb
+++ b/config/initializers/remote_client.rb
@@ -4,10 +4,12 @@
 # Ticket CFP-587 has been created to further investigate
 # the root cause and therefore reduce the open_timeout
 #
-Remote::HttpClient.configure do |client|
-  client.base_url = Settings.remote_api_url
-  client.api_key = Settings.remote_api_key
-  client.logger = Rails.logger
-  client.open_timeout = 10
-  client.timeout = 15
+Rails.application.reloader.to_prepare do
+  Remote::HttpClient.configure do |client|
+    client.base_url = Settings.remote_api_url
+    client.api_key = Settings.remote_api_key
+    client.logger = Rails.logger
+    client.open_timeout = 10
+    client.timeout = 15
+  end
 end

--- a/config/initializers/survey_monkey.rb
+++ b/config/initializers/survey_monkey.rb
@@ -1,10 +1,12 @@
-SurveyMonkey.configure do |config|
-  config.root_url = 'https://api.eu.surveymonkey.com/v3/'
-  config.bearer = Rails.application.secrets.survey_monkey_bearer_token.to_s
-  config.collector_id = ENV['SURVEY_MONKEY_COLLECTOR_ID']
-  config.logger = Rails.logger
-  config.verbose_logging = true
+Rails.application.reloader.to_prepare do
+  SurveyMonkey.configure do |config|
+    config.root_url = 'https://api.eu.surveymonkey.com/v3/'
+    config.bearer = Rails.application.secrets.survey_monkey_bearer_token.to_s
+    config.collector_id = ENV['SURVEY_MONKEY_COLLECTOR_ID']
+    config.logger = Rails.logger
+    config.verbose_logging = true
 
-  page = FeedbackForm.new
-  config.register_page(page.name, page.id, **page.template)
+    page = FeedbackForm.new
+    config.register_page(page.name, page.id, **page.template)
+  end
 end

--- a/config/initializers/thinkst_canary.rb
+++ b/config/initializers/thinkst_canary.rb
@@ -1,4 +1,6 @@
-ThinkstCanary.configure do |config|
-  config.account_id = ENV['CANARY_ACCOUNT_ID']
-  config.auth_token = ENV['CANARY_AUTH_TOKEN']
+Rails.application.reloader.to_prepare do
+  ThinkstCanary.configure do |config|
+    config.account_id = ENV['CANARY_ACCOUNT_ID']
+    config.auth_token = ENV['CANARY_AUTH_TOKEN']
+  end
 end

--- a/lib/govuk_component/railtie.rb
+++ b/lib/govuk_component/railtie.rb
@@ -5,51 +5,75 @@ require 'rails'
 module GOVUKComponent
   class Railtie < Rails::Railtie
     initializer 'govuk_component.shared_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::SharedHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::SharedHelpers }
+      end
     end
 
     initializer 'govuk_component.button_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::ButtonHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::ButtonHelpers }
+      end
     end
 
     initializer 'govuk_component.detail_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::DetailHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::DetailHelpers }
+      end
     end
 
     initializer 'govuk_component.inset_text_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::InsetTextHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::InsetTextHelpers }
+      end
     end
 
     initializer 'govuk_component.link_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::LinkHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::LinkHelpers }
+      end
     end
 
     initializer 'govuk_component.notification_banner_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::NotificationBannerHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::NotificationBannerHelpers }
+      end
     end
 
     initializer 'govuk_component.panel_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::PanelHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::PanelHelpers }
+      end
     end
 
     initializer 'govuk_component.phase_banner_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::PhaseBannerHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::PhaseBannerHelpers }
+      end
     end
 
     initializer 'govuk_component.summary_list_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::SummaryListHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::SummaryListHelpers }
+      end
     end
 
     initializer 'govuk_component.table_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::TableHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::TableHelpers }
+      end
     end
 
     initializer 'govuk_component.tag_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::TagHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::TagHelpers }
+      end
     end
 
     initializer 'govuk_component.warning_text_helpers' do
-      ActiveSupport.on_load(:action_view) { include GOVUKComponent::WarningTextHelpers }
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GOVUKComponent::WarningTextHelpers }
+      end
     end
   end
 end


### PR DESCRIPTION
#### What

Prevent autoloading of constants in the initialization of the server.

#### Ticket

[CCCD - Fix issues with autoloading during initialization](https://dsdmoj.atlassian.net/browse/CTSKF-652)

#### Why

From Ruby 6.1 the autoloading of constants in initializers is deprecated. see:

* https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots

This needs to be fixed before upgrading to Rails 7.0 is possible.

#### How

1) Some initializers include the configuration of certain modules. This configuration is added to the `Rails.applicaiton.reloader.to_prepare` so that it is executed each time the server reloads.
2) The `railtie.rb` file for the `govuk_component` library adds includes for the helper modules in the views. The `config.after_initialize` hook is used to ensure that this is done outside of the initialization.

This is deployed on [dev-lgfs](https://dev-lgfs.claim-crown-court-defence.service.justice.gov.uk/) for testing.