### PR TITLE
CTSKF-650 Fix API ActiveRecord::RecordNotFound error messages

### DIFF
--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -52,6 +52,8 @@ class Disbursement < ApplicationRecord
 
   def disbursement_type_unique_code=(code)
     self.disbursement_type = DisbursementType.find_by!(unique_code: code)
+  rescue ActiveRecord::RecordNotFound => e
+    raise ActiveRecord::RecordNotFound, I18n.t('activerecord.errors.not_found', model_name: e.model)
   end
 
   def vat_absent?

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -128,6 +128,8 @@ class Expense < ApplicationRecord
 
   def expense_type_unique_code=(code)
     self.expense_type = ExpenseType.find_by!(unique_code: code)
+  rescue ActiveRecord::RecordNotFound => e
+    raise e.class, I18n.t('activerecord.errors.not_found', model_name: e.model)
   end
 
   def vat_absent?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,6 +324,7 @@ en:
               too_long: Last name must be 40 characters or less
             terms_and_conditions:
               accepted: You must accept the terms and conditions
+      not_found: "Couldn't find %{model_name}"
   requires_external_user_authorisation: 'Must be signed in as an advocate, litigator or admin user'
   requires_case_worker_authorisation: 'Must be signed in as a case worker or case worker admin'
   requires_super_admin_authorisation: 'Must be signed in as a super admininstrator'


### PR DESCRIPTION
#### What

https://github.com/rails/rails/pull/42454 changes the way that `ActiveRecord::RecordNotFound` error messages returned by the `Model.find_by!` method are formatted. This means that when we upgrade to Rails 7,  where `Couldn't find DisbursementType` was previously returned to API clients, this is now formatted as `Couldn't find DisbursementType with [WHERE "disbursement_types"."unique_code" = $1]`.

We want to continue to use the original format of those error messages.

#### Ticket

[CTSKF-650](https://dsdmoj.atlassian.net/browse/CTSKF-650)

#### Why

To reduce the amount of information about the CCCD database revealed to API clients and present a more readable error message.

#### How

It does not seem (easily) possible to configure `ActiveRecord::RecordNotFound` with bespoke error messages. Instead this changes the two models where this error is generated (`Disbursement` and `Expense`) so that `ActiveRecord::RecordNotFound` errors are caught and immediately re-thrown with a message in our preferred format. This format is defined in a translation file to allow for ease of changing it in future. We could look at improving the wording of those errors now, although that might be better done as part of a wider review of API error messages.

[CTSKF-650]: https://dsdmoj.atlassian.net/browse/CTSKF-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ