### PR TITLE
Ensure users' email addresses are unique in tests

### DIFF
--- a/spec/factories/external_users.rb
+++ b/spec/factories/external_users.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
 
     after(:build) do |eu, evaluator|
       if evaluator.build_user
-        eu.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.email, password: 'password', password_confirmation: 'password')
+        eu.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password', password_confirmation: 'password')
       end
     end
 

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     claim
 
     after(:build) do |message|
-      message.sender_id ||= (message.sender || create(:user, email: Faker::Internet.email, password: 'password', password_confirmation: 'password')).id
+      message.sender_id ||= (message.sender || create(:user, email: Faker::Internet.unique.email, password: 'password', password_confirmation: 'password')).id
     end
   end
 

--- a/spec/factories/super_admins.rb
+++ b/spec/factories/super_admins.rb
@@ -10,7 +10,7 @@
 FactoryBot.define do
   factory :super_admin do
     after(:build) do |super_admin|
-      super_admin.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.email, password: 'password', password_confirmation: 'password')
+      super_admin.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password', password_confirmation: 'password')
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,7 +29,7 @@
 
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.email }
+    email { Faker::Internet.unique.email }
     password { 'testing123' }
     password_confirmation { 'testing123' }
     first_name { Faker::Name.first_name }


### PR DESCRIPTION
#### What

Create email addresses in test users with unique email addresses.

#### Ticket

N/A

#### Why

It is possible for `Faker::Internet.email` to generate the same email address twice in a test and this can cause the test to fail. Adding `unique` ensures that this does not happen.

#### How

Use the `unique` feature of the Faker gem.
