### PR TITLE
CTSKF-675 Add govuk error summary styling to warning summary

### DIFF
--- a/app/views/warnings/_injection_warnings_summary.html.haml
+++ b/app/views/warnings/_injection_warnings_summary.html.haml
@@ -1,7 +1,7 @@
 - if claim&.last_injection_attempt&.succeeded && claim.has_conference_and_views?
   .js-callout-injection-warning
-    .warning-summary{ role: 'group', 'aria-labelledby': 'warning-summary-heading', tabindex: '-1' }
-      %h2.govuk-heading-m.warning-summary-heading{ id: 'warning-summary-heading' }
+    .warning-summary.govuk-error-summary{ role: 'group', 'aria-labelledby': 'warning-summary-heading', tabindex: '-1' }
+      %h2.govuk-heading-m.govuk-error-summary__title{ id: 'warning-summary-heading' }
         = t('shared.injection_errors.cav_warning.header')
 
       %span.form-hint
@@ -9,9 +9,9 @@
 
 - if claim&.last_injection_attempt&.succeeded && claim.has_clar_fees?
   .js-callout-injection-warning
-    .warning-summary{ role: 'group', 'aria-labelledby': 'warning-summary-heading', tabindex: '-1' }
-      %h2.govuk-heading-m.warning-summary-heading{ id: 'warning-summary-heading' }
+    .warning-summary.govuk-error-summary{ role: 'group', 'aria-labelledby': 'warning-summary-heading', tabindex: '-1' }
+      %h2.govuk-heading-m.govuk-error-summary__title{ id: 'warning-summary-heading' }
         = t('shared.injection_errors.clar_fees_warning.header')
 
-      %span.form-hint
+      %span.form-hint.govuk-error-summary__body
         = t('shared.injection_errors.clar_fees_warning.message')


### PR DESCRIPTION
#### What

Add govuk-error-summary styling to the warning notification that is viewed by Caseworkers

#### Ticket

[CTSKF-675](https://dsdmoj.atlassian.net/browse/CTSKF-675)

#### Why

This was revealed after testing deploying [CTSKF-681](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6520) to staging.

#### How

Add `govuk-error-summary`  class names found on the [GovUK design system](https://design-system.service.gov.uk/components/error-summary/)

--------

From:

<img width="1301" alt="before adding the govuk error styling" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/25043924/b9a5cdae-f53e-4f92-a38e-19500af68e6d">


To:

<img width="1311" alt="after adding the govuk error styling" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/25043924/5f19f6db-713b-4842-a732-f81da3b4d0fa">

[CTSKF-675]: https://dsdmoj.atlassian.net/browse/CTSKF-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CTSKF-681]: https://dsdmoj.atlassian.net/browse/CTSKF-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ