### PR TITLE
Create a new groups for DataTables and related modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     babel:
       patterns:
         - "*babel*"
+    datatables:
+      patterns:
+        - "*datatables*"
   open-pull-requests-limit: 5
   reviewers:
   - "ministryofjustice/laa-claim-for-payment"


### PR DESCRIPTION
#### What

Group datatables related npm dependabot updates.

#### Ticket

N/A

#### Why

CCCD uses the following related npm packages:

* datatables.net-buttons-dt
* datatables.net-dt
* datatables.net-fixedheader-dt
* datatables.net-select
* jquery-datatables-checkboxes

When there are updates for more than one it is simpler and cleaner to update them together.

#### How

Add configuration to `.github/dependabot.yml`.