### PR TITLE
CTSKF-710 feedback model refactor

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -6,12 +6,12 @@ class FeedbackController < ApplicationController
   before_action :setup_page
 
   def new
-    @feedback = Feedback.new(type:, referrer: referrer_path)
+    @feedback = Feedback.new({ type:, referrer: referrer_path })
     render "feedback/#{@feedback.type}"
   end
 
   def create
-    @feedback = Feedback.new(merged_feedback_params)
+    @feedback = Feedback.new(merged_feedback_params, sender)
 
     if @feedback.save
       redirect_to after_create_url, notice: @feedback.response_message
@@ -22,6 +22,14 @@ class FeedbackController < ApplicationController
   end
 
   private
+
+  def sender
+    if params['feedback']['type'] == 'feedback' && !Settings.zendesk_feedback_enabled?
+      SurveyMonkeySender
+    else
+      ZendeskSender
+    end
+  end
 
   def type
     %w[feedback bug_report].include?(params[:type]) ? params[:type] : 'feedback'

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -6,12 +6,12 @@ class FeedbackController < ApplicationController
   before_action :setup_page
 
   def new
-    @feedback = Feedback.new({ type:, referrer: referrer_path })
+    @feedback = Feedback.new(nil, { type:, referrer: referrer_path })
     render "feedback/#{@feedback.type}"
   end
 
   def create
-    @feedback = Feedback.new(merged_feedback_params, sender)
+    @feedback = Feedback.new(sender, merged_feedback_params)
 
     if @feedback.save
       redirect_to after_create_url, notice: @feedback.response_message

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -6,12 +6,12 @@ class FeedbackController < ApplicationController
   before_action :setup_page
 
   def new
-    @feedback = Feedback.new(nil, { type:, referrer: referrer_path })
+    @feedback = Feedback.new(type:, referrer: referrer_path)
     render "feedback/#{@feedback.type}"
   end
 
   def create
-    @feedback = Feedback.new(sender, merged_feedback_params)
+    @feedback = Feedback.new(merged_feedback_params)
 
     if @feedback.save
       redirect_to after_create_url, notice: @feedback.response_message
@@ -41,7 +41,8 @@ class FeedbackController < ApplicationController
 
   def merged_feedback_params
     feedback_params.merge(email: user_email_or_anonymous,
-                          user_agent: request.user_agent)
+                          user_agent: request.user_agent,
+                          sender:)
   end
 
   def user_email_or_anonymous

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -19,11 +19,11 @@ class Feedback
   validates :type, inclusion: { in: FEEDBACK_TYPES.keys.map(&:to_s) }
   validates :event, :outcome, presence: true, if: :bug_report?
 
-  def initialize(sender = nil, attributes = {})
+  def initialize(attributes = {})
     attributes.each do |key, value|
       instance_variable_set(:"@#{key}", value)
     end
-    @sender = SENDING_SERVICES.include?(sender) ? sender : nil
+    @sender = SENDING_SERVICES.include?(@sender) ? @sender : nil
 
     @reason.compact_blank! if @reason.present?
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -45,7 +45,7 @@ class Feedback
 
     resp = @sender.call(self)
     @response_message = resp[:response_message]
-    resp[:success?]
+    resp[:success]
   end
 
   def subject

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -41,7 +41,7 @@ class Feedback
   end
 
   def save
-    return unless valid? || @sender.nil?
+    return unless valid? && !@sender.nil?
 
     resp = @sender.call(self)
     @response_message = resp[:response_message]

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -14,10 +14,11 @@ class Feedback
   validates :type, inclusion: { in: FEEDBACK_TYPES.keys.map(&:to_s) }
   validates :event, :outcome, presence: true, if: :bug_report?
 
-  def initialize(attributes = {})
+  def initialize(attributes = {}, sender = nil)
     attributes.each do |key, value|
       instance_variable_set(:"@#{key}", value)
     end
+    @sender = sender
 
     @reason.compact_blank! if @reason.present?
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -2,38 +2,19 @@ class Feedback
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  FEEDBACK_TYPES = {
-    feedback: %i[task rating comment reason other_reason],
-    bug_report: %i[case_number event outcome email]
-  }.freeze
-
-  SENDING_SERVICES = [
-    SurveyMonkeySender,
-    ZendeskSender
-  ].freeze
-
   attr_accessor :email, :referrer, :user_agent, :type,
                 :event, :outcome, :case_number,
                 :task, :rating, :comment, :reason, :other_reason, :response_message
 
-  validates :type, inclusion: { in: FEEDBACK_TYPES.keys.map(&:to_s) }
-  validates :event, :outcome, presence: true, if: :bug_report?
+  validates :type, inclusion: { in: %w[feedback bug_report] }
+  validates :event, :outcome, presence: true, if: -> { is?(:bug_report) }
 
   def initialize(attributes = {})
     attributes.each do |key, value|
       instance_variable_set(:"@#{key}", value)
     end
-    @sender = SENDING_SERVICES.include?(@sender) ? @sender : nil
 
     @reason.compact_blank! if @reason.present?
-  end
-
-  def feedback?
-    is?(:feedback)
-  end
-
-  def bug_report?
-    is?(:bug_report)
   end
 
   def is?(type)
@@ -46,25 +27,5 @@ class Feedback
     resp = @sender.call(self)
     @response_message = resp[:response_message]
     resp[:success]
-  end
-
-  def subject
-    "#{type.humanize} (#{Rails.host.env})"
-  end
-
-  def description
-    feedback_type_attributes.map { |t| "#{t}: #{send(t)}" }.join("\n")
-  end
-
-  def reporter_email
-    return if email.blank? || email == 'anonymous'
-
-    email
-  end
-
-  private
-
-  def feedback_type_attributes
-    FEEDBACK_TYPES[type.to_sym]
   end
 end

--- a/app/services/survey_monkey_sender.rb
+++ b/app/services/survey_monkey_sender.rb
@@ -15,10 +15,10 @@ class SurveyMonkeySender
     return_hash[:success] = resp[:success]
 
     return_hash[:response_message] = if resp[:success]
-                                'Feedback submitted'
-                              else
-                                "Unable to submit feedback [#{resp[:error_code]}]"
-                              end
+                                       'Feedback submitted'
+                                     else
+                                       "Unable to submit feedback [#{resp[:error_code]}]"
+                                     end
 
     return_hash
   end

--- a/app/services/survey_monkey_sender.rb
+++ b/app/services/survey_monkey_sender.rb
@@ -9,7 +9,18 @@ class SurveyMonkeySender
   end
 
   def call
-    response.submit
+    return_hash = {}
+    resp = response.submit
+
+    return_hash[:success] = resp[:success]
+
+    return_hash[:response_message] = if resp[:success]
+                                'Feedback submitted'
+                              else
+                                "Unable to submit feedback [#{resp[:error_code]}]"
+                              end
+
+    return_hash
   end
 
   private

--- a/app/services/survey_monkey_sender.rb
+++ b/app/services/survey_monkey_sender.rb
@@ -1,6 +1,6 @@
 class SurveyMonkeySender
-  def self.call(feedback)
-    new(feedback).call
+  def self.call(...)
+    new(...).call
   end
 
   def initialize(feedback)
@@ -9,24 +9,34 @@ class SurveyMonkeySender
   end
 
   def call
-    return_hash = {}
-    resp = response.submit
-
-    return_hash[:success] = resp[:success]
-
-    return_hash[:response_message] = if resp[:success]
-                                       'Feedback submitted'
-                                     else
-                                       "Unable to submit feedback [#{resp[:error_code]}]"
-                                     end
-
-    return_hash
+    {
+      success: success?,
+      response_message: message
+    }
   end
 
   private
 
   def response
     @response ||= SurveyMonkey::Response.new
+  end
+
+  def submission_response
+    @submission_response ||= response.submit
+  end
+
+  def success?
+    @success ||= submission_response[:success]
+  end
+
+  def message
+    return 'Feedback submitted' if success?
+
+    "Unable to submit feedback [#{error_code}]"
+  end
+
+  def error_code
+    @error_code ||= submission_response[:error_code]
   end
 
   def payload

--- a/app/services/zendesk_sender.rb
+++ b/app/services/zendesk_sender.rb
@@ -7,17 +7,13 @@ class ZendeskSender
 
   def initialize(ticket_payload)
     @ticket_payload = ticket_payload
-    @return_hash = {}
   end
 
   def call
     create_ticket
-    @return_hash[:success] = true
-    @return_hash[:response_message] = "#{feedback_type.titleize} submitted"
-    @return_hash
+    { success: true, response_message: "#{feedback_type.titleize} submitted" }
   rescue ZendeskAPI::Error::ClientError => e
     catch_error(e)
-    @return_hash
   end
 
   private
@@ -32,11 +28,10 @@ class ZendeskSender
   end
 
   def catch_error(error)
-    @return_hash[:response_message] = "Unable to submit #{feedback_type.downcase}"
-    @return_hash[:success] = false
     LogStuff.error(class: self.class.name, action: 'save', error_class: error.class.name, error: error.to_s) do
       "#{feedback_type.titleize} submission failed!"
     end
+    { success: false, response_message: "Unable to submit #{feedback_type.downcase}" }
   end
 
   def feedback_type

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -68,6 +68,5 @@ Feature: A user can provide feedback
     And I click govuk checkbox 'Other (please specify)'
     And I fill in 'Enter your comment' with 'Something Else'
     And I click the button 'Send'
-
     Then I see a warning that my feedback was not submitted successfully
     And I should be on the feedback page

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -21,7 +21,7 @@ Then(/^I see confirmation that my '(.*?)' was received$/) do |feedback_type|
 end
 
 Then('I see a warning that my feedback was not submitted successfully') do
-  have_govuk_notification_banner(key: :error, text: /Unable to submit feedback \[\d+\]/)
+  expect(page).to have_govuk_notification_banner(key: :error, text: /Unable to submit feedback/)
 end
 
 Then('I see a warning that my bug report was not submitted successfully') do

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Feedback do
       params.merge(
         type: 'feedback',
         task: '1',
+        sender:,
         rating: '4',
         comment: 'lorem ipsum',
         reason: ['', '1', '2'],
@@ -95,7 +96,7 @@ RSpec.describe Feedback do
 
   context 'with SurveyMonkey Feedback' do
     include_examples 'Feedback submission' do
-      subject(:feedback) { described_class.new(sender, feedback_params) }
+      subject(:feedback) { described_class.new(feedback_params) }
 
       let(:sender) { SurveyMonkeySender }
     end
@@ -103,19 +104,20 @@ RSpec.describe Feedback do
 
   context 'with Zendesk Feedback' do
     include_examples 'Feedback submission' do
-      subject(:feedback) { described_class.new(sender, feedback_params) }
+      subject(:feedback) { described_class.new(feedback_params) }
 
       let(:sender) { ZendeskSender }
     end
   end
 
   context 'with invalid sender passed as an argument' do
-    subject(:feedback) { described_class.new(fake_sender_class, feedback_params) }
+    subject(:feedback) { described_class.new(feedback_params) }
 
     let(:feedback_params) do
       params.merge(
         type: 'feedback',
         task: '1',
+        sender: fake_sender_class,
         rating: '4',
         comment: 'lorem ipsum',
         reason: ['', '1', '2'],
@@ -130,13 +132,33 @@ RSpec.describe Feedback do
     end
   end
 
+  context 'with no sender passed as an argument' do
+    subject(:feedback) { described_class.new(feedback_params) }
+
+    let(:feedback_params) do
+      params.merge(
+        type: 'feedback',
+        task: '1',
+        rating: '4',
+        comment: 'lorem ipsum',
+        reason: ['', '1', '2'],
+        other_reason: 'dolor sit'
+      )
+    end
+
+    it 'defaults to nil' do
+      expect(feedback.instance_variable_get(:@sender)).to be_nil
+    end
+  end
+
   context 'with a bug report' do
-    subject(:bug_report) { described_class.new(ZendeskSender, bug_report_params) }
+    subject(:bug_report) { described_class.new(bug_report_params) }
 
     let(:bug_report_params) do
       params.merge(
         type: 'bug_report',
         case_number: 'XXX',
+        sender: ZendeskSender,
         event: 'lorem',
         outcome: 'ipsum',
         email: 'example@example.com'

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe Feedback do
     it { expect(feedback.comment).to eq 'lorem ipsum' }
     it { expect(feedback.reason).to eq %w[1 2] }
     it { expect(feedback.other_reason).to eq 'dolor sit' }
-    it { is_expected.to be_feedback }
-    it { is_expected.not_to be_bug_report }
 
     describe '#save' do
       let(:save) { feedback.save }
@@ -70,19 +68,6 @@ RSpec.describe Feedback do
       end
     end
 
-    describe '#subject' do
-      it 'returns the subject heading' do
-        expect(feedback.subject).to eq('Feedback (test)')
-      end
-    end
-
-    describe '#description' do
-      it 'returns the description' do
-        expect(feedback.description)
-          .to eq("task: 1\nrating: 4\ncomment: lorem ipsum\nreason: [\"1\", \"2\"]\nother_reason: dolor sit")
-      end
-    end
-
     describe '#is?' do
       context 'with feedback type' do
         it { expect(feedback.is?(:feedback)).to be true }
@@ -95,41 +80,19 @@ RSpec.describe Feedback do
   end
 
   context 'with SurveyMonkey Feedback' do
-    include_examples 'Feedback submission' do
-      subject(:feedback) { described_class.new(feedback_params) }
+    subject(:feedback) { described_class.new(feedback_params) }
 
-      let(:sender) { SurveyMonkeySender }
-    end
+    let(:sender) { SurveyMonkeySender }
+
+    include_examples 'Feedback submission'
   end
 
   context 'with Zendesk Feedback' do
-    include_examples 'Feedback submission' do
-      subject(:feedback) { described_class.new(feedback_params) }
-
-      let(:sender) { ZendeskSender }
-    end
-  end
-
-  context 'with invalid sender passed as an argument' do
     subject(:feedback) { described_class.new(feedback_params) }
 
-    let(:feedback_params) do
-      params.merge(
-        type: 'feedback',
-        task: '1',
-        sender: fake_sender_class,
-        rating: '4',
-        comment: 'lorem ipsum',
-        reason: ['', '1', '2'],
-        other_reason: 'dolor sit'
-      )
-    end
+    let(:sender) { ZendeskSender }
 
-    let(:fake_sender_class) { class_double(Object) }
-
-    it 'defaults to nil' do
-      expect(feedback.instance_variable_get(:@sender)).to be_nil
-    end
+    include_examples 'Feedback submission'
   end
 
   context 'with no sender passed as an argument' do
@@ -176,8 +139,6 @@ RSpec.describe Feedback do
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:outcome) }
     it { is_expected.not_to validate_presence_of(:case_number) }
-    it { is_expected.to be_bug_report }
-    it { is_expected.not_to be_feedback }
 
     describe '#save' do
       context 'when valid and successful' do
@@ -225,47 +186,6 @@ RSpec.describe Feedback do
           bug_report.save
           expect(bug_report.response_message).to eq('Unable to submit bug report')
         end
-      end
-    end
-
-    describe '#subject' do
-      it 'returns the subject heading' do
-        expect(bug_report.subject).to eq('Bug report (test)')
-      end
-    end
-
-    describe '#description' do
-      it 'returns the description' do
-        expect(bug_report.description)
-          .to eq("case_number: XXX\nevent: lorem\noutcome: ipsum\nemail: example@example.com")
-      end
-    end
-
-    describe '#reporter_email' do
-      subject { bug_report.reporter_email }
-
-      context 'with an email' do
-        let(:bug_report_params) { params.merge(type: 'bug_report', email: 'example@example.com') }
-
-        it { is_expected.to eq('example@example.com') }
-      end
-
-      context 'without an email' do
-        let(:bug_report_params) { params.merge(type: 'bug_report') }
-
-        it { is_expected.to be_nil }
-      end
-
-      context 'with a blank email' do
-        let(:bug_report_params) { params.merge(type: 'bug_report', email: '') }
-
-        it { is_expected.to be_nil }
-      end
-
-      context 'with an anonymous email' do
-        let(:bug_report_params) { params.merge(type: 'bug_report', email: 'anonymous') }
-
-        it { is_expected.to be_nil }
       end
     end
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Feedback do
   it { is_expected.to validate_inclusion_of(:type).in_array(%w[feedback bug_report]) }
 
   shared_examples 'Feedback submission' do
-
     let(:feedback_params) do
       params.merge(
         type: 'feedback',
@@ -36,10 +35,10 @@ RSpec.describe Feedback do
 
       context 'when valid and successful' do
         before do
-            allow(sender)
-              .to receive(:call)
-              .and_return({ success: true, response_message: 'Feedback submitted' })
-          end
+          allow(sender)
+            .to receive(:call)
+            .and_return({ success: true, response_message: 'Feedback submitted' })
+        end
 
         it 'calls the correct sender' do
           save
@@ -160,11 +159,10 @@ RSpec.describe Feedback do
 
     describe '#save' do
       context 'when valid and successful' do
-
         before do
           allow(ZendeskSender)
             .to receive(:call)
-            .and_return({ success: true, response_message: 'Feedback submitted' })
+            .and_return({ success: true, response_message: 'Bug Report submitted' })
         end
 
         it 'calls zendesk sender' do
@@ -196,7 +194,7 @@ RSpec.describe Feedback do
         before do
           allow(ZendeskSender)
             .to receive(:call)
-            .and_return({ success: False, response_message: 'Unable to submit bug report' })
+            .and_return({ success: false, response_message: 'Unable to submit bug report' })
         end
 
         it { expect(bug_report.save).to be_falsey }
@@ -260,5 +258,3 @@ RSpec.describe Feedback do
     end
   end
 end
-
-

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -45,29 +45,27 @@ RSpec.describe 'send feedback' do
       }
     end
 
-    context 'when feedback_controller is determining the sender class to use' do
-      context 'with Zendesk feedback enabled' do
-        before do
-          allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(true)
-          allow(Feedback).to receive(:new).and_call_original
-          post_feedback
-        end
-
-        it 'Uses the Zendesk sender' do
-          expect(Feedback).to have_received(:new).with(ZendeskSender, anything)
-        end
+    context 'with Zendesk feedback enabled' do
+      before do
+        allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(true)
+        allow(Feedback).to receive(:new).and_call_original
+        post_feedback
       end
 
-      context 'with Zendesk feedback disabled' do
-        before do
-          allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(false)
-          allow(Feedback).to receive(:new).and_call_original
-          post_feedback
-        end
+      it 'Uses the Zendesk sender' do
+        expect(Feedback).to have_received(:new).with(hash_including(sender: ZendeskSender))
+      end
+    end
 
-        it 'Uses the SurveyMonkey sender' do
-          expect(Feedback).to have_received(:new).with(SurveyMonkeySender, anything)
-        end
+    context 'with Zendesk feedback disabled' do
+      before do
+        allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(false)
+        allow(Feedback).to receive(:new).and_call_original
+        post_feedback
+      end
+
+      it 'Uses the SurveyMonkey sender' do
+        expect(Feedback).to have_received(:new).with(hash_including(sender: SurveyMonkeySender))
       end
     end
 
@@ -137,7 +135,7 @@ RSpec.describe 'send feedback' do
         end
       end
 
-      context 'when feedback_controller is determining the sender class to use' do
+      context 'when determining the sender class' do
         before do
           allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(true)
           allow(Feedback).to receive(:new).and_call_original
@@ -145,7 +143,7 @@ RSpec.describe 'send feedback' do
         end
 
         it 'Uses the Zendesk sender' do
-          expect(Feedback).to have_received(:new).with(ZendeskSender, anything)
+          expect(Feedback).to have_received(:new).with(hash_including(sender: ZendeskSender))
         end
       end
     end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'send feedback' do
         end
       end
 
-      context 'with SurveyMonkey feedback disabled' do
+      context 'with Zendesk feedback disabled' do
         before do
           allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(false)
           allow(Feedback).to receive(:new).and_call_original
@@ -66,7 +66,7 @@ RSpec.describe 'send feedback' do
         end
 
         it 'Uses the SurveyMonkey sender' do
-          expect(Feedback).to have_received(:new).with(anything, SurveyMonkeySender)
+          expect(Feedback).to have_received(:new).with(SurveyMonkeySender, anything)
         end
       end
     end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -45,6 +45,32 @@ RSpec.describe 'send feedback' do
       }
     end
 
+    context 'when feedback_controller is determining the sender class to use' do
+      context 'with Zendesk feedback enabled' do
+        before do
+          allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(true)
+          allow(Feedback).to receive(:new).and_call_original
+          post_feedback
+        end
+
+        it 'Uses the Zendesk sender' do
+          expect(Feedback).to have_received(:new).with(anything, ZendeskSender)
+        end
+      end
+
+      context 'with SurveyMonkey feedback disabled' do
+        before do
+          allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(false)
+          allow(Feedback).to receive(:new).and_call_original
+          post_feedback
+        end
+
+        it 'Uses the SurveyMonkey sender' do
+          expect(Feedback).to have_received(:new).with(anything, SurveyMonkeySender)
+        end
+      end
+    end
+
     context 'when posting to Survey Monkey is successful' do
       before { allow(SurveyMonkeySender).to receive(:call).and_return({ id: 123, success: true }) }
 
@@ -108,6 +134,18 @@ RSpec.describe 'send feedback' do
 
         it 'redirects to the sign in page' do
           expect(response).to redirect_to(new_user_session_url)
+        end
+      end
+
+      context 'when feedback_controller is determining the sender class to use' do
+        before do
+          allow(Settings).to receive(:zendesk_feedback_enabled?).and_return(true)
+          allow(Feedback).to receive(:new).and_call_original
+          post_feedback
+        end
+
+        it 'Uses the Zendesk sender' do
+          expect(Feedback).to have_received(:new).with(anything, ZendeskSender)
         end
       end
     end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'send feedback' do
         end
 
         it 'Uses the Zendesk sender' do
-          expect(Feedback).to have_received(:new).with(anything, ZendeskSender)
+          expect(Feedback).to have_received(:new).with(ZendeskSender, anything)
         end
       end
 
@@ -145,7 +145,7 @@ RSpec.describe 'send feedback' do
         end
 
         it 'Uses the Zendesk sender' do
-          expect(Feedback).to have_received(:new).with(anything, ZendeskSender)
+          expect(Feedback).to have_received(:new).with(ZendeskSender, anything)
         end
       end
     end

--- a/spec/services/survey_monkey_sender_spec.rb
+++ b/spec/services/survey_monkey_sender_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe SurveyMonkeySender do
 
     context 'with all feedback options' do
       let(:feedback) do
-        Feedback.new(described_class,
-                     { task: '1', rating: '1', comment: 'A comment', reason: %w[1 3], other_reason: 'Another reason' })
+        Feedback.new(task: '1', rating: '1', comment: 'A comment',
+                     reason: %w[1 3], other_reason: 'Another reason')
       end
 
       it do
@@ -33,8 +33,7 @@ RSpec.describe SurveyMonkeySender do
 
     context 'with only a comment' do
       let(:feedback) do
-        Feedback.new(described_class,
-                     { task: nil, rating: nil, comment: 'A comment', reason: [], other_reason: nil })
+        Feedback.new(task: nil, rating: nil, comment: 'A comment', reason: [], other_reason: nil)
       end
 
       it { expect(survey_monkey).to have_received(:add_page).with(:feedback, comments: 'A comment') }
@@ -42,8 +41,7 @@ RSpec.describe SurveyMonkeySender do
 
     context 'with a nil reason' do
       let(:feedback) do
-        Feedback.new(described_class,
-                     { task: nil, rating: nil, comment: 'A comment', reason: nil, other_reason: nil })
+        Feedback.new(task: nil, rating: nil, comment: 'A comment', reason: nil, other_reason: nil)
       end
 
       it { expect(survey_monkey).to have_received(:add_page).with(:feedback, comments: 'A comment') }

--- a/spec/services/survey_monkey_sender_spec.rb
+++ b/spec/services/survey_monkey_sender_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe SurveyMonkeySender do
 
     context 'with all feedback options' do
       let(:feedback) do
-        Feedback.new(task: '1', rating: '1', comment: 'A comment', reason: %w[1 3], other_reason: 'Another reason')
+        Feedback.new(described_class,
+                     { task: '1', rating: '1', comment: 'A comment', reason: %w[1 3], other_reason: 'Another reason' })
       end
 
       it do
@@ -31,13 +32,19 @@ RSpec.describe SurveyMonkeySender do
     end
 
     context 'with only a comment' do
-      let(:feedback) { Feedback.new(task: nil, rating: nil, comment: 'A comment', reason: [], other_reason: nil) }
+      let(:feedback) do
+        Feedback.new(described_class,
+                     { task: nil, rating: nil, comment: 'A comment', reason: [], other_reason: nil })
+      end
 
       it { expect(survey_monkey).to have_received(:add_page).with(:feedback, comments: 'A comment') }
     end
 
     context 'with a nil reason' do
-      let(:feedback) { Feedback.new(task: nil, rating: nil, comment: 'A comment', reason: nil, other_reason: nil) }
+      let(:feedback) do
+        Feedback.new(described_class,
+                     { task: nil, rating: nil, comment: 'A comment', reason: nil, other_reason: nil })
+      end
 
       it { expect(survey_monkey).to have_received(:add_page).with(:feedback, comments: 'A comment') }
     end
@@ -46,16 +53,16 @@ RSpec.describe SurveyMonkeySender do
   describe '#call' do
     subject(:call) { sender.call }
 
-    context 'with a sucessful submission' do
+    context 'with a successful submission' do
       before { allow(survey_monkey).to receive(:submit).and_return({ id: 123, success: true }) }
 
-      it { is_expected.to eq({ id: 123, success: true }) }
+      it { is_expected.to eq({ success: true, response_message: 'Feedback submitted' }) }
     end
 
-    context 'with an unsucessful submission' do
+    context 'with an unsuccessful submission' do
       before { allow(survey_monkey).to receive(:submit).and_return({ success: false, error_code: 1011 }) }
 
-      it { is_expected.to eq({ success: false, error_code: 1011 }) }
+      it { is_expected.to eq({ success: false, response_message: 'Unable to submit feedback [1011]' }) }
     end
   end
 end

--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe ZendeskSender do
-  shared_examples 'Zendesk send' do
-    let(:ticket_payload) do
+  describe '#call' do
+    subject(:zen_call) { described_class.call(ticket_payload) }
+
+    let(:bug_report_ticket_payload) do
       instance_double(
         Feedback,
         subject: 'Bug report',
@@ -11,7 +13,7 @@ RSpec.describe ZendeskSender do
       )
     end
 
-    let(:zendesk_payload) do
+    let(:bug_report_zendesk_payload) do
       {
         subject: 'Bug report',
         description: 'event - outcome - email address',
@@ -30,8 +32,8 @@ RSpec.describe ZendeskSender do
     end
 
     it 'calls ZendeskAPI::Ticket.create!' do
-      zen_send
-      expect(ZendeskAPI::Ticket).to have_received(:create!).with(ZENDESK_CLIENT, hash_including(zendesk_payload))
+      zen_call
+      expect(ZendeskAPI::Ticket).to have_received(:create!).with(ZENDESK_CLIENT, hash_including(bug_report_zendesk_payload))
     end
 
     context 'with a reporter email' do
@@ -47,23 +49,17 @@ RSpec.describe ZendeskSender do
       end
 
       it 'includes the reporter email' do
-        zen_send
+        zen_call
         expect(ZendeskAPI::Ticket)
           .to have_received(:create!)
-          .with(ZENDESK_CLIENT, hash_including(email_ccs: [{ user_email: 'example@example.com' }]))
+                .with(ZENDESK_CLIENT, hash_including(email_ccs: [{ user_email: 'example@example.com' }]))
+      end
+
+      it 'returns a success value and a response message' do
+        expect(zen_call).to eq({ success: kind_of(Boolean), response_message: kind_of(String) })
       end
     end
-  end
 
-  describe '.send!' do
-    include_examples 'Zendesk send' do
-      subject(:zen_send) { described_class.send!(ticket_payload) }
-    end
-  end
-
-  describe '#send!' do
-    include_examples 'Zendesk send' do
-      subject(:zen_send) { described_class.new(ticket_payload).send! }
-    end
+    #TODO: write a test here to test error reporting, removed from feedback spec
   end
 end

--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe ZendeskSender do
   describe '#call' do
-    subject(:zen_call) { described_class.call(ticket_payload) }
+    subject(:zen_call) { described_class.call(bug_report_ticket_payload) }
 
     let(:bug_report_ticket_payload) do
       instance_double(
         Feedback,
         subject: 'Bug report',
+        type: 'bug_report',
         description: 'event - outcome - email address',
         referrer: '/claims',
         user_agent: 'chrome',
@@ -33,14 +34,17 @@ RSpec.describe ZendeskSender do
 
     it 'calls ZendeskAPI::Ticket.create!' do
       zen_call
-      expect(ZendeskAPI::Ticket).to have_received(:create!).with(ZENDESK_CLIENT, hash_including(bug_report_zendesk_payload))
+      expect(ZendeskAPI::Ticket)
+        .to have_received(:create!)
+        .with(ZENDESK_CLIENT, hash_including(bug_report_zendesk_payload))
     end
 
-    context 'with a reporter email' do
-      let(:ticket_payload) do
+    context 'with a valid ticket and reporter email' do
+      let(:bug_report_ticket_payload) do
         instance_double(
           Feedback,
           subject: 'Bug report',
+          type: 'bug_report',
           description: 'event - outcome - email address',
           referrer: '/claims',
           user_agent: 'chrome',
@@ -52,14 +56,33 @@ RSpec.describe ZendeskSender do
         zen_call
         expect(ZendeskAPI::Ticket)
           .to have_received(:create!)
-                .with(ZENDESK_CLIENT, hash_including(email_ccs: [{ user_email: 'example@example.com' }]))
+          .with(ZENDESK_CLIENT, hash_including(email_ccs: [{ user_email: 'example@example.com' }]))
       end
 
       it 'returns a success value and a response message' do
-        expect(zen_call).to eq({ success: kind_of(Boolean), response_message: kind_of(String) })
+        expect(zen_call).to eq({ success: true, response_message: 'Bug Report submitted' })
       end
     end
 
-    #TODO: write a test here to test error reporting, removed from feedback spec
+    context 'when an error occurs' do
+      before do
+        allow(ZendeskAPI::Ticket)
+          .to receive(:create!)
+          .and_raise ZendeskAPI::Error::ClientError, 'oops, something went wrong'
+        allow(LogStuff).to receive(:error)
+      end
+
+      it 'returns a failure value and message' do
+        expect(zen_call).to eq({ success: false, response_message: 'Unable to submit bug report' })
+      end
+
+      it 'logs error details' do
+        zen_call
+        expect(LogStuff)
+          .to have_received(:error)
+          .with(class: described_class.to_s, action: 'save',
+                error_class: 'ZendeskAPI::Error::ClientError', error: 'oops, something went wrong')
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What
Refactor the Feedback model/controller, ZendeskSender and SurveyMonkey sender to remove responsibility for error handling and decision of what sending service to use from the model. 

#### Ticket

[CTSKF-710](https://dsdmoj.atlassian.net/browse/CTSKF-710)

#### Why

- Make the Feedback model conform to SOLID principles and follow the model > services design pattern. 
- Simplify the process for adding new sending services and/or switching between zendesk and surveymonkey for feedback. 

#### How

Model, Controller and Service files refactored to move logic around and use dependency inversion to provide the sender class for each piece of feedback.



[CTSKF-710]: https://dsdmoj.atlassian.net/browse/CTSKF-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ