### PR TITLE
Remove install-chrome step from cucumber tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,6 @@ commands:
     description: >
       Run cucumber tests and store results
     steps:
-      - install-chrome
       - precompile-assets
       - run:
           name: Run cucumber tests


### PR DESCRIPTION
#### What

Remove `install-chrome` from the setup for cucumber tests in CircleCI.

#### Ticket

N/A

#### Why

Whilst investigating problems with the downloading of chromedriver in the circleci pipelines (see https://github.com/CircleCI-Public/browser-tools-orb/issues/108) it turns out that install-chrome is not required for the cucumber tests.

#### How

Remove `install-chrome` from the steps for the `run-cucumber` pipeline.