### PR TITLE
Fix K8s warnings

### DIFF
--- a/.k8s/live/api-sandbox/deployment-worker.yaml
+++ b/.k8s/live/api-sandbox/deployment-worker.yaml
@@ -47,6 +47,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/api-sandbox/deployment.yaml
+++ b/.k8s/live/api-sandbox/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           lifecycle:
             preStop:
               exec:

--- a/.k8s/live/api-sandbox/dump.yaml
+++ b/.k8s/live/api-sandbox/dump.yaml
@@ -20,6 +20,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - bundle
             - exec

--- a/.k8s/live/cron_jobs/archive_stale.yaml
+++ b/.k8s/live/cron_jobs/archive_stale.yaml
@@ -28,6 +28,8 @@ spec:
                 - ALL
               runAsNonRoot: true
               allowPrivilegeEscalation: false
+              seccompProfile:
+                type: RuntimeDefault
             command:
               - rails
               - claims:archive_stale

--- a/.k8s/live/cron_jobs/vacuum_db.yaml
+++ b/.k8s/live/cron_jobs/vacuum_db.yaml
@@ -26,7 +26,9 @@ spec:
                 drop:
                 - ALL
               runAsNonRoot: true
-              allowPrivilegeEscalation: false           
+              allowPrivilegeEscalation: false
+              seccompProfile:
+                type: RuntimeDefault
             command:
               - rails
               - db:vacuum

--- a/.k8s/live/dev-lgfs/deployment-worker.yaml
+++ b/.k8s/live/dev-lgfs/deployment-worker.yaml
@@ -47,6 +47,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev-lgfs/deployment.yaml
+++ b/.k8s/live/dev-lgfs/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           lifecycle:
             preStop:
               exec:

--- a/.k8s/live/dev-lgfs/dump.yaml
+++ b/.k8s/live/dev-lgfs/dump.yaml
@@ -20,6 +20,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - bundle
             - exec

--- a/.k8s/live/dev/deployment-worker.yaml
+++ b/.k8s/live/dev/deployment-worker.yaml
@@ -47,6 +47,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/dev/deployment.yaml
+++ b/.k8s/live/dev/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           lifecycle:
             preStop:
               exec:

--- a/.k8s/live/dev/dump.yaml
+++ b/.k8s/live/dev/dump.yaml
@@ -20,6 +20,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - bundle
             - exec

--- a/.k8s/live/jobs/migrate.yaml
+++ b/.k8s/live/jobs/migrate.yaml
@@ -17,6 +17,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - bundle
             - exec

--- a/.k8s/live/jobs/seed.yaml
+++ b/.k8s/live/jobs/seed.yaml
@@ -17,6 +17,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - bundle
             - exec

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -54,6 +54,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           lifecycle:
             preStop:
               exec:

--- a/.k8s/live/production/dump.yaml
+++ b/.k8s/live/production/dump.yaml
@@ -20,6 +20,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - bundle
             - exec

--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -54,6 +54,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
 
           # configMapRef: non-secret env vars defined in `app-config.yaml`
           # secretRef: secret env vars defined by app secrets

--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           lifecycle:
             preStop:
               exec:

--- a/.k8s/live/staging/dump.yaml
+++ b/.k8s/live/staging/dump.yaml
@@ -20,6 +20,8 @@ spec:
               - ALL
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - bundle
             - exec


### PR DESCRIPTION
#### What

Update kubernetes securityContexts to reduce warnings


#### Why

The Cloud Platform upgrade of the kubernetes cluster to v1.26 has resulted in warnings of a missing security context being displayed when deploying the application, eg:

```
Warning: would violate PodSecurity "restricted:latest": seccompProfile (pod or container "cccd-app" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Warning: would violate PodSecurity "restricted:latest": seccompProfile (pod or container "cccd-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

#### How

Defines `seccompProfile` in all kubernetes config files with a value of `RuntimeDefault`, which allows us to default to the container's security profile.

#### Screenshots

Before:

<img width="1162" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/b93a7cdd-d45f-48f9-8913-a8f0a085d596">


After: 

<img width="1006" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/5146abc4-09e9-401d-9cff-8943a822cb0b">

