### PR TITLE
Fix button sizes on travel expenses page

### DIFF
--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -1,9 +1,4 @@
 // Ported from v1 stylesheets
-.fx-duplicate-expense {
-  display: inline-block;
-  padding: $gutter-one-sixth $gutter-half;
-}
-
 .dz-error-message {
   color: $govuk-error-colour;
 }
@@ -42,7 +37,7 @@
   }
 }
 
-#claims-list > li {
+#claims-list>li {
   padding: 1rem;
   clear: both;
   overflow: hidden;
@@ -120,7 +115,7 @@ form {
     font-size: 1em;
   }
 
-  h2 + fieldset {
+  h2+fieldset {
     margin-top: 0;
     padding-top: 0;
   }
@@ -360,6 +355,7 @@ form {
     margin-top: $gutter-one-sixth;
   }
 }
+
 // Dropzone end
 
 .b {


### PR DESCRIPTION
#### What

Remove some old CSS from `_shame.scss`.

#### Ticket

N/A

#### Why

Following the removal of the deprecated govuk_frontend_toolkit and govuk-elements-sass the buttons for 'Add another expense' and 'Duplicate last expense' were different sizes. This was due to the CSS attached to the `fx-duplicate-expense` class in `_shame.scss`.

#### How

Remove the CSS tweak for `fx-duplicate-expense', which is no longer required.

##### Before

<img width="442" alt="Screenshot 2024-03-04 at 12 50 40" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/a0711389-778b-47ae-80ba-53e552771577">

##### After

<img width="430" alt="Screenshot 2024-03-04 at 12 51 28" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/4415912/b0dc6f05-8e2e-4f0a-8e8b-4370e6500a48">
