### PR TITLE
[CTSKF-716] Fix determination calculator styling

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -75,12 +75,9 @@ module CaseWorkers
         :reject_reason_text,
         :additional_information,
         assessment_attributes: %i[id fees expenses disbursements vat_amount],
-        redeterminations_attributes: %i[id fees expenses disbursements vat_amount]
-      ).merge(params.permit(state_reason: []))
-      # the state_reason needs to be merged because the collection_check_boxes control on the view requires
-      # a claim object to render.  Because state_reason does not belong to claim, it refuses to render and
-      # therefore nil is passed to the object.  This then comes back outside of the claim namespace and has
-      # to be manually merged.
+        redeterminations_attributes: %i[id fees expenses disbursements vat_amount],
+        state_reason: []
+      )
     end
 
     def set_claims

--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -17,7 +17,7 @@ module Claim
     attr_reader :form_step
     alias current_step form_step
 
-    attr_accessor :disable_for_state_transition, :reject_reason_text, :refuse_reason_text
+    attr_accessor :disable_for_state_transition, :reject_reason_text, :refuse_reason_text, :state_reason
     attribute :case_transferred_from_another_court, :boolean
 
     include ::Claims::StateMachine

--- a/app/views/case_workers/claims/_determination_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_fields.html.haml
@@ -8,7 +8,7 @@
 
     = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
       .pound-wrapper
-        = f.text_field :fees, value: number_with_precision(f.object.fees, precision: 2), class: 'form-control js-fees', size: 10, maxlength: 10
+        = f.govuk_text_field :fees, value: number_with_precision(f.object.fees, precision: 2), class: 'form-control js-fees', size: 10, maxlength: 10, label: { hidden: true }, form_group: {class: "govuk-!-margin-bottom-0"}, width: 'one-half'
       = validation_error_message(f.object, :fees)
 
 = govuk_table_row do
@@ -20,7 +20,7 @@
 
   = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     .pound-wrapper
-      = f.text_field :expenses, value: number_with_precision(f.object.expenses, precision: 2), class: 'form-control js-expenses', size: 10, maxlength: 10
+      = f.govuk_text_field :expenses, value: number_with_precision(f.object.expenses, precision: 2), class: 'form-control js-expenses', size: 10, maxlength: 10, label: { hidden: true }, form_group: {class: "govuk-!-margin-bottom-0"}, width: 'one-half'
     = validation_error_message(f.object, :expenses)
 
 - if claim.can_have_disbursements?
@@ -33,7 +33,7 @@
 
     = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
       .pound-wrapper
-        = f.text_field :disbursements, value: number_with_precision(f.object.disbursements, precision: 2), class: 'form-control js-disbursements', size: 10, maxlength: 10
+        = f.govuk_text_field :disbursements, value: number_with_precision(f.object.disbursements, precision: 2), class: 'form-control js-disbursements', size: 10, maxlength: 10, label: { hidden: true }, form_group: {class: "govuk-!-margin-bottom-0"}, width: 'one-half'
       = validation_error_message(f.object, :disbursements)
 
 = govuk_table_row do

--- a/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
+++ b/app/views/case_workers/claims/_determination_lgfs_vat_fields.html.haml
@@ -7,7 +7,7 @@
 
   = govuk_table_td_numeric('data-label': t('shared.determinations_table.laa_heading')) do
     .pound-wrapper
-      = f.text_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control js-lgfs-vat-determination', size: 10, maxlength: 8
+      = f.govuk_text_field :vat_amount, value: number_with_precision(f.object.vat_amount, precision: 2), class: 'form-control js-lgfs-vat-determination', size: 10, maxlength: 8, label: { hidden: true }, form_group: {class: "govuk-!-margin-bottom-0"}, width: 'one-half'
     = validation_error_message(f.object, :vat_amount)
 
 = govuk_table_row do

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -53,3 +53,26 @@
           - else
             // ELSE
             = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.assessment }
+
+    // CASE WORKER ACTIONS
+    - if current_user_is_caseworker?
+      .js-cw-claim-rejection-reasons.hidden{ class: error_class(@error_presenter, :rejected_reason) }
+        %div
+          = validation_error_message(@error_presenter, :rejected_reason)
+        %a#rejected_reason
+        = f.govuk_check_boxes_fieldset :state_reason, legend: { text: t('.reason_for_rejection') } do
+          - ClaimStateTransitionReason.reject_reasons_for(@claim).each do |reason|
+            - if reason.code == 'other'
+              = f.govuk_check_box :state_reason,
+                reason.code,
+                label: { text: reason.description } do
+                %a#rejected_reason_other
+                = f.govuk_text_field :reject_reason_text,
+                  label: { text: t('.reason_text') },
+                  hint: { text: t('.reason_hint') }
+                %div
+                  = validation_error_message(@error_presenter, :rejected_reason_other)
+            - else
+              = f.govuk_check_box :state_reason,
+                reason.code,
+                label: { text: reason.description }

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -7,12 +7,9 @@
 
       - if current_user_is_caseworker?
         .js-cw-claim-action
-          = f.govuk_collection_radio_buttons :state,
-            claim.valid_transitions_for_detail_form,
-            :first,
-            :last,
-            inline: true,
-            legend: { text: t('.update_the_claim_status') }
+          = f.govuk_radio_buttons_fieldset(:state, legend: { text: t('.update_the_claim_status') }, inline: true) do
+            - claim.valid_transitions_for_detail_form.each do |key, label|
+              = f.govuk_radio_button :state, key, label: { text: label }, checked: params['claim'].present? && params['claim']['state']&.to_sym == key
           %div
             = validation_error_message(@error_presenter, :determinations)
 
@@ -65,6 +62,7 @@
             - if reason.code == 'other'
               = f.govuk_check_box :state_reason,
                 reason.code,
+                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
                 label: { text: reason.description } do
                 %a#rejected_reason_other
                 = f.govuk_text_field :reject_reason_text,
@@ -75,6 +73,7 @@
             - else
               = f.govuk_check_box :state_reason,
                 reason.code,
+                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
                 label: { text: reason.description }
 
       .js-cw-claim-refuse-reasons.hidden{ class: error_class(@error_presenter, :refused_reason) }
@@ -86,6 +85,7 @@
             - if reason.code == 'other_refuse'
               = f.govuk_check_box :state_reason,
                 reason.code,
+                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
                 label: { text: reason.description } do
                 %a#refused_reason_other
                 = f.govuk_text_field :refuse_reason_text,
@@ -96,6 +96,7 @@
             - else
               = f.govuk_check_box :state_reason,
                 reason.code,
+                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
                 label: { text: reason.description }
 
 

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -9,7 +9,8 @@
         .js-cw-claim-action
           = f.govuk_radio_buttons_fieldset(:state, legend: { text: t('.update_the_claim_status') }, inline: true) do
             - claim.valid_transitions_for_detail_form.each do |key, label|
-              = f.govuk_radio_button :state, key, label: { text: label }, checked: params['claim'].present? && params['claim']['state']&.to_sym == key
+              .multiple-choice
+                = f.govuk_radio_button :state, key, label: { text: label }, checked: params['claim'].present? && params['claim']['state']&.to_sym == key
           %div
             = validation_error_message(@error_presenter, :determinations)
 
@@ -59,22 +60,23 @@
         %a#rejected_reason
         = f.govuk_check_boxes_fieldset :state_reason, legend: { text: t('.reason_for_rejection') } do
           - ClaimStateTransitionReason.reject_reasons_for(@claim).each do |reason|
-            - if reason.code == 'other'
-              = f.govuk_check_box :state_reason,
-                reason.code,
-                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
-                label: { text: reason.description } do
-                %a#rejected_reason_other
-                = f.govuk_text_field :reject_reason_text,
-                  label: { text: t('.reason_text') },
-                  hint: { text: t('.reason_hint') }
-                %div
-                  = validation_error_message(@error_presenter, :rejected_reason_other)
-            - else
-              = f.govuk_check_box :state_reason,
-                reason.code,
-                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
-                label: { text: reason.description }
+            .multiple-choice
+              - if reason.code == 'other'
+                = f.govuk_check_box :state_reason,
+                  reason.code,
+                  checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
+                  label: { text: reason.description } do
+                  %a#rejected_reason_other
+                  = f.govuk_text_field :reject_reason_text,
+                    label: { text: t('.reason_text') },
+                    hint: { text: t('.reason_hint') }
+                  %div
+                    = validation_error_message(@error_presenter, :rejected_reason_other)
+              - else
+                = f.govuk_check_box :state_reason,
+                  reason.code,
+                  checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
+                  label: { text: reason.description }
 
       .js-cw-claim-refuse-reasons.hidden{ class: error_class(@error_presenter, :refused_reason) }
         %div
@@ -82,22 +84,23 @@
         %a#refused_reason
         = f.govuk_check_boxes_fieldset :state_reason, legend: { text: t('.reason_for_refusal') } do
           - ClaimStateTransitionReason.refuse_reasons_for(@claim).each do |reason|
-            - if reason.code == 'other_refuse'
-              = f.govuk_check_box :state_reason,
-                reason.code,
-                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
-                label: { text: reason.description } do
-                %a#refused_reason_other
-                = f.govuk_text_field :refuse_reason_text,
-                  label: { text: t('.reason_text') },
-                  hint: { text: t('.reason_hint') }
-                %div
-                  = validation_error_message(@error_presenter, :refused_reason_other)
-            - else
-              = f.govuk_check_box :state_reason,
-                reason.code,
-                checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
-                label: { text: reason.description }
+            .multiple-choice
+              - if reason.code == 'other_refuse'
+                = f.govuk_check_box :state_reason,
+                  reason.code,
+                  checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
+                  label: { text: reason.description } do
+                  %a#refused_reason_other
+                  = f.govuk_text_field :refuse_reason_text,
+                    label: { text: t('.reason_text') },
+                    hint: { text: t('.reason_hint') }
+                  %div
+                    = validation_error_message(@error_presenter, :refused_reason_other)
+              - else
+                = f.govuk_check_box :state_reason,
+                  reason.code,
+                  checked: params[:claim].present? && params[:claim][:state_reason].include?(reason.code),
+                  label: { text: reason.description }
 
 
       %p

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -1,22 +1,20 @@
-= form_for(claim, url: case_workers_claim_path(claim), as: :claim) do |f|
+= form_for(claim, url: case_workers_claim_path(claim), as: :claim, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
   = hidden_field_tag :messages, 'true'
   .fx-assesment-hook
     #claim-status
       %h2#radio-control-heading.govuk-heading-l{ 'aria-describedby': 'radio-control-heading radio-control-legend' }
         = t('.assessment_summary')
 
-
       - if current_user_is_caseworker?
         .js-cw-claim-action
-          %fieldset.form-group.inline.spacer{ class: error_class(@error_presenter, :determinations), 'aria-describedby': 'radio-control-legend' }
-            %legend#radio-control-legend.bold-normal.form-label
-              = t('.update_the_claim_status')
-            = f.collection_radio_buttons(:state, claim.valid_transitions_for_detail_form, :first, :last) do |b|
-              .multiple-choice
-                = b.radio_button(checked: params[:claim].present? && b.value.eql?(params[:claim][:state]&.to_sym), 'aria-labelledby': "radio-control-legend #{b.text.to_css_class}")
-                = b.label(id: b.text.to_css_class) { b.text }
-            %div
-              = validation_error_message(@error_presenter, :determinations)
+          = f.govuk_collection_radio_buttons :state,
+            claim.valid_transitions_for_detail_form,
+            :first,
+            :last,
+            inline: true,
+            legend: { text: t('.update_the_claim_status') }
+          %div
+            = validation_error_message(@error_presenter, :determinations)
 
       = govuk_table( id: 'determinations', class: 'js-cw-claim-assessment', data: { apply_vat: "#{claim.apply_vat}", vat_url: vat_path(format: :json), submitted_date: claim.vat_date(:db), scheme: claim.agfs? ? 'agfs' : 'lgfs' }) do
         = govuk_table_caption(class: 'govuk-visually-hidden') do
@@ -40,12 +38,12 @@
           // CASEWORKER
           - if current_user_is_caseworker? && @claim.enable_assessment_input?
             // ASSESSMENT INPUT
-            = f.fields_for :assessment do |af|
+            = f.fields_for :assessment, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |af|
               = render partial: 'case_workers/claims/determination_fields', locals: { f: af, claim: claim }
 
           - elsif current_user_is_caseworker? && @claim.enable_determination_input?
             // DETERMINATION INPUT
-            = f.fields_for :redeterminations, claim.redeterminations.build do |rf|
+            = f.fields_for :redeterminations, claim.redeterminations.build, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |rf|
               = render partial: 'case_workers/claims/determination_fields', locals: { f: rf, claim: claim }
 
           - elsif claim.redeterminations.any?
@@ -55,56 +53,3 @@
           - else
             // ELSE
             = render partial: 'shared/determination_amounts', locals: { claim: claim, determination: claim.assessment }
-
-    // CASE WORKER ACTIONS
-    - if current_user_is_caseworker?
-      .js-cw-claim-rejection-reasons.hidden{ class: error_class(@error_presenter, :rejected_reason) }
-        %fieldset.form-group.nested-fields.indent-fieldset.spacer{ 'aria-describedby': 'checkbox-control-legend-1' }
-          %div
-            = validation_error_message(@error_presenter, :rejected_reason)
-          %a#rejected_reason
-          %legend#checkbox-control-legend-1.bold-normal.form-label
-            = t('.reason_for_rejection')
-          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.reject_reasons_for(@claim), :code, :description) do |b|
-            .multiple-choice
-              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), 'aria-labelledby': "checkbox-control-legend-1 #{b.text.to_css_class}")
-              = b.label { b.text }
-
-          .form-group.panel.nested-fields.fieldset.spacer.js-reject-reason-text.hidden{ class: error_class(@error_presenter, :rejected_reason_other) }
-            %div
-              %a#rejected_reason_other
-              = f.label :reject_reason_text, class: 'form-label' do
-                = t('.reason_text')
-                .form-hint.xsmall
-                  = t('.reason_hint')
-              = f.text_field :reject_reason_text, class: 'form-control'
-              %div
-                = validation_error_message(@error_presenter, :rejected_reason_other)
-
-      .js-cw-claim-refuse-reasons.hidden{ class: error_class(@error_presenter, :refused_reason) }
-        %div
-          = validation_error_message(@error_presenter, :refused_reason)
-
-        %fieldset.form-group.nested-fields.indent-fieldset.spacer{ 'aria-describedby': 'checkbox-control-legend-2' }
-          %legend#checkbox-control-legend-2.bold-normal.form-label
-            = t('.reason_for_refusal')
-
-          %a#refused_reason
-          = collection_check_boxes(nil, :state_reason, ClaimStateTransitionReason.refuse_reasons_for(@claim), :code, :description) do |b|
-            .multiple-choice
-              = b.check_box(checked: params[:state_reason].present? && params[:state_reason].include?(b.value), 'aria-labelledby': "checkbox-control-legend-2 #{b.text.to_css_class}")
-              = b.label { b.text }
-
-          .form-group.panel.nested-fields.fieldset.spacer.js-refuse-reason-text.hidden{ class: error_class(@error_presenter, :refused_reason_other) }
-            %div
-              %a#refused_reason_other
-              = f.label :refuse_reason_text, class: 'form-label' do
-                = t('.reason_text')
-                .form-hint.xsmall
-                  = t('.reason_hint')
-              = f.text_field :refuse_reason_text, class: 'form-control'
-              %div
-                = validation_error_message(@error_presenter, :refused_reason_other)
-
-      %p
-        = govuk_button(t('.update'), id: 'button')

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -76,3 +76,28 @@
               = f.govuk_check_box :state_reason,
                 reason.code,
                 label: { text: reason.description }
+
+      .js-cw-claim-refuse-reasons.hidden{ class: error_class(@error_presenter, :refused_reason) }
+        %div
+          = validation_error_message(@error_presenter, :refused_reason)
+        %a#refused_reason
+        = f.govuk_check_boxes_fieldset :state_reason, legend: { text: t('.reason_for_refusal') } do
+          - ClaimStateTransitionReason.refuse_reasons_for(@claim).each do |reason|
+            - if reason.code == 'other_refuse'
+              = f.govuk_check_box :state_reason,
+                reason.code,
+                label: { text: reason.description } do
+                %a#refused_reason_other
+                = f.govuk_text_field :refuse_reason_text,
+                  label: { text: t('.reason_text') },
+                  hint: { text: t('.reason_hint') }
+                %div
+                  = validation_error_message(@error_presenter, :refused_reason_other)
+            - else
+              = f.govuk_check_box :state_reason,
+                reason.code,
+                label: { text: reason.description }
+
+
+      %p
+        = govuk_button(t('.update'), id: 'button')

--- a/features/page_objects/claim_show_page.rb
+++ b/features/page_objects/claim_show_page.rb
@@ -6,24 +6,24 @@ class ClaimShowPage < BasePage
 
   element :status, "div.claim-hgroup strong.govuk-tag"
   element :edit_this_claim, "div.claim-detail-actions a:nth-of-type(1)"
-  element :fees, "#claim_assessment_attributes_fees"
-  element :expenses, "#claim_assessment_attributes_expenses"
-  element :authorised, "label[for='claim_state_authorised']"
+  element :fees, "#claim-assessment-attributes-fees-field"
+  element :expenses, "#claim-assessment-attributes-expenses-field"
+  element :authorised, "label[for='claim-state-authorised-field']"
   element :update, "button#button.govuk-button"
-  element :refused, "label[for='claim_state_refused']"
-  element :rejected, "label[for='claim_state_rejected']"
+  element :refused, "label[for='claim-state-refused-field']"
+  element :rejected, "label[for='claim-state-rejected-field']"
 
   sections :rejection_reasons, '.js-cw-claim-rejection-reasons .multiple-choice' do
     element :label, 'label'
     element :input, 'input'
   end
-  element :reject_reason_text, '#claim_reject_reason_text'
+  element :reject_reason_text, '#claim-reject-reason-text-field'
 
   sections :refusal_reasons, '.js-cw-claim-refuse-reasons .multiple-choice' do
     element :label, 'label'
     element :input, 'input'
   end
-  element :refuse_reason_text, '#claim_refuse_reason_text'
+  element :refuse_reason_text, '#claim-refuse-reason-text-field'
 
   section :messages_panel, "#claim-accordion .messages-container" do
     element :enter_your_message, "textarea#message-body-field"


### PR DESCRIPTION
#### What

Restore the GovUK design to the determination calculator on the case workers' view of claims.

#### Ticket

[CCCD: Fix determination calculator styling](https://dsdmoj.atlassian.net/browse/CTSKF-716)

#### Why

When the unsupported GovUK Frontend Toolkit was removed in #6520 the styling on the determination calculator was broken. Caseworkers have reported that his is causing accessibility issues.

#### How

Use the `govuk_` version of form helpers in views.

Deployed on dev-lgfs