### PR TITLE
Remove the binding_of_caller gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ group :development, :test do
   gem 'annotate'
   gem 'brakeman', :require => false
   gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'byebug'
   gem 'listen', '~> 3.9.0'
   gem 'meta_request'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,8 +128,6 @@ GEM
       parser (>= 2.4)
       smart_properties
     bigdecimal (3.1.6)
-    binding_of_caller (1.0.0)
-      debug_inspector (>= 0.0.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     brakeman (6.1.2)
@@ -202,7 +200,6 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.4)
-    debug_inspector (1.2.0)
     deep_merge (1.2.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -685,7 +682,6 @@ DEPENDENCIES
   aws-sdk-sqs (~> 1)
   axe-core-cucumber (~> 4.8)
   better_errors
-  binding_of_caller
   bootsnap
   brakeman
   byebug


### PR DESCRIPTION
#### What

Remove the `binding_of_caller` gem.

#### Ticket

N/A

#### Why

This a gem that was added in a collection of 'standard' gems for development in 0d799707cdfd48a2592249105fc6cc40565925e6 but we never use it.