### PR TITLE
Addition of Additional Prep Fee (MIAPF) to mapping exclusion list

### DIFF
--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -46,7 +46,7 @@ module CCR
         MIAPF: zip(%w[AGFS_MISC_FEES AGFS_PREP_FEE]) # Additional preparation fee - AGFS 15+ only
       }.freeze
 
-      MISC_FEE_BILL_MAPPING_EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO].freeze
+      MISC_FEE_BILL_MAPPING_EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO MIAPF].freeze
 
       def claimed?
         maps? && charges?

--- a/spec/services/ccr/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/misc_fee_adapter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
 
   it_behaves_like 'a mapping fee adapter'
 
-  EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO].freeze
+  EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO MIAPF].freeze
 
   MAPPINGS = {
     BACAV: %w[AGFS_MISC_FEES AGFS_CONFERENCE], # Conferences and views (basic fee)


### PR DESCRIPTION
#### What
Add Additional Prep Fee to the exclusion list for injection into CCR

#### Ticket

[CTSKF-718](https://dsdmoj.atlassian.net/browse/CTSKF-718)

#### Why

Business Request

#### How

Existing exclusion list


[CTSKF-718]: https://dsdmoj.atlassian.net/browse/CTSKF-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ