### PR TITLE
Update version of the browser-tools orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.4.8
   slack: circleci/slack@3.4.1
 
 references:


### PR DESCRIPTION
#### What

Update the version of the browser-tools orb used in our CircleCI pipeline.

#### Ticket

N/A

#### Why

Sporadically the 'install chrome driver' stage of the pipeline fails due to mismatched versions. This is fixed in the latest version. See https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.4.8

#### How

Update the browser-tools gem from 1.4.6 to 1.4.8.