### PR TITLE
Disable ModSecurity rule 920120

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 920120
       SecRuleEngine On
       SecRequestBodyLimit 29360128
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 920120
       SecRuleEngine On
       SecRequestBodyLimit 29360128
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 920120
       SecRuleEngine On
       SecRequestBodyLimit 29360128
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 920120
       SecRuleEngine On
       SecRequestBodyLimit 29360128
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 920120
       SecRuleEngine On
       SecRequestBodyLimit 29360128
       SecDefaultAction "phase:2,pass,log,tag:github_team=crime-billing-online"


### PR DESCRIPTION
#### What
Disable ModSecurity rule 920120

#### Ticket

[Disable ModSecurity rule 920120](https://dsdmoj.atlassian.net/browse/CTSKF-684)

#### Why
ModSecurity rule [920120](https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/a216353c97dd6ef767a6db4dbf9b724627811c9b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L71) intermittently causes failures for users when they upload supporting evidence documents that contain apostrophes in the filename. Removing the rule will allow these documents to be uploaded. 

#### How
Add a SecRuleRemoveById statement to the nginx.ingress.kubernetes.io/modsecurity-snippet in an environment's ingress.yml file to disable a rule that prevents anything with apostrophes to be uploaded. 