### PR TITLE
[CTSKF-747] Add the @no-seed tag to the Cookies feature

### DIFF
--- a/features/cookies.feature
+++ b/features/cookies.feature
@@ -1,3 +1,4 @@
+@no-seed
 Feature: Cookies
 
   Scenario: Accepting default cookies


### PR DESCRIPTION
#### What

Remove loading of seed data before cookie banner feature tests.

#### Ticket

[CCCD - Cucumber tests failing in CircleCI](https://dsdmoj.atlassian.net/browse/CTSKF-747)

#### Why

The seed data is not required for the cookie banner feature tests.

When the cookie banner feature test is followed by another feature test that uses the `@javascript` tag then the database is reset and not re-seeded causing this following tests to fail.

#### How

Add the `@no-seed` tag to the Cookies feature tests.
