### PR TITLE
Ensure that app/assets/builds/.keep isn't deleted

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -17,7 +17,9 @@ module.exports = {
     filename: '[name].js',
     assetModuleFilename: '[name][ext]',
     path: path.resolve(__dirname, '..', '..', 'app/assets/builds'),
-    clean: true
+    clean: {
+      keep: /.keep/
+    }
   },
   optimization: {
     moduleIds: 'deterministic',


### PR DESCRIPTION
#### What

Add an exception in the webpack configuration to prevent `app/assets/builds/.keep` from being deleted.

#### Ticket

N/A

#### Why

The `.keep` file is used to ensure that the directory exists in Github. When assets are built by Webpack all files in the directory are deleted and the deletion of this file can be committed by accident. Everyone who joins the team encounters this at least once and it results in incomprehensible and difficult to understand errors in the pipeline.

#### How

The `keep` configuration option allows for a files to be excluded from the clean up. This is defined by a regular expression.