### PR TITLE
[CTSKF-654] Update encryption for cookies

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -23,12 +23,12 @@
 #
 # See upgrading guide for more information on how to build a rotator.
 # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html
-# Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
 
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
-# Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.


### PR DESCRIPTION
#### What

Set the default encryption to SHA256.

Note; #6647 must be merged first.

#### Ticket

[CCCD - Set ActiveSupport::Digest to SHA256](https://dsdmoj.atlassian.net/browse/CTSKF-654)

#### Why

The default encryption for Rails 7.0 is SHA256 compared with SHA1 for Rails 6.1. This must be updated before the Rails 7.0 defaults can be adopted. See;

* https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#key-generator-digest-class-change-requires-a-cookie-rotator
* https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#digest-class-for-activesupport-digest-changing-to-sha256

#### How

Update accordingly in `config/initializers/new_framework_defaults_7_0.rb`.