### PR TITLE
Uncomment the default behaviour for rails7 button_to and edit files

### DIFF
--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -16,7 +16,7 @@
       = govuk_summary_list_row_collection(t('.vat_registered')) { @provider.vat_registered == true ? t('global_yes') : t('global_no') }
 
     .app-link-group
-      = button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation'), module: 'govuk-button' }, class: 'govuk-button', draggable: 'false'
+      = button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation'), module: 'govuk-button' }, class: 'govuk-button', draggable: false
 
       - if can? :edit, @provider
         = govuk_link_button_secondary(t('.edit_provider'), edit_external_users_admin_provider_path(@provider))

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -58,7 +58,7 @@
 
           .action-wrapper
             - if claim.rejected?
-              = button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: 'patch', class: 'govuk-button resubmit-claim', form_class: 'inline-form', data: { module: 'govuk-button' }, role: 'button', draggable: 'false'
+              = button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: :patch, form_class: 'inline-form', class: 'govuk-button resubmit-claim', data: { module: 'govuk-button' }, role: 'button', draggable: false
 
             = govuk_link_button(t('.archive'), external_users_claim_path(claim), 'data-method': 'delete', 'data-confirm': t('.confirm_text'))
 
@@ -68,4 +68,4 @@
               = t('.actions')
 
           .action-wrapper
-            = button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: 'patch', class: 'govuk-button', form_class: 'inline-form', data: { module: 'govuk-button' }, role: 'button', draggable: 'false'
+            = button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: :patch, form_class: 'inline-form', class: 'govuk-button', data: { module: 'govuk-button' }, role: 'button', draggable: false

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -11,7 +11,7 @@
 
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.
-# Rails.application.config.action_view.button_to_generates_button_tag = true
+Rails.application.config.action_view.button_to_generates_button_tag = true
 
 # `stylesheet_link_tag` view helper will not render the media attribute by default.
 # Rails.application.config.action_view.apply_stylesheet_media_default = false


### PR DESCRIPTION
#### What
The default behaviour for Rails 7 is that the button_to helper renders a button element. This needs to be set in config/initializers/new_framework_defaults_7_0.rb as part of the upgrade process.

Starting from Rails 7.0 button_to renders a form tag with patch HTTP verb if a persisted Active Record object is used to build button URL so this method now needs to be explicitly set in the button_to method. 

#### Ticket
[CCCD - button_to_generates_button_tag](https://dsdmoj.atlassian.net/browse/CTSKF-655)

#### Why
Otherwise button_to helper will no longer render a button element preventing users from submitting forms. 

#### How
- Uncomment the button_to_generates_button_tag in the new framework config. 
- Update the method parameter that are passed to the button_to, as they no longer requires the value to be a string. Instead, in order to keep the current behaviour, explicitly pass methods, by replacing "patch" with :patch for example. 
