### PR TITLE
[CTSKF-656] Set cookies_serializer to :json

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,5 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -120,7 +120,7 @@ Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA
 # have been converted to JSON. To keep using `:hybrid` long term, move this config to its own
 # initializer or to `config/application.rb`.
 #
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json
 #
 #
 # If your cookies can't yet be serialized to JSON, keep using `:marshal` for backward-compatibility.


### PR DESCRIPTION
#### What

Set cookies_serializer to the default for Rails 7.0.

#### Ticket

[CCCD - Update cookie serializer](https://dsdmoj.atlassian.net/browse/CTSKF-656)

#### Why

Following the upgrade to Rails 7.0 we are aligning the settings to the Rails 7.0 defaults.

#### How

In `config/initializers/new_framework_defaults_7_0.rb`:

```ruby
Rails.application.config.action_dispatch.cookies_serializer = :json
```

The file `config/initializers/cookies_serializer.rb` was created automatically when creating a new Rails app prior to version 7.0 and the setting of `cookes_serializer` was set to `:json` even though the default value was `:marshal`. This file is removed from version 7.0 so it is removed here to avoid confusion.
