### PR TITLE
Mark timezone sensitive tests as pending

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -256,9 +256,12 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       let(:refused_at) { 1.week.ago.beginning_of_day + 11.hours + 15.minutes }
       let(:claim) { create(:advocate_final_claim, :authorised) }
 
+      before do
+        pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
+      end
+
       context 'with a completed journey' do
         before do
-          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -276,7 +279,6 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with an uncompleted journey' do
         before do
-          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -302,7 +304,6 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       #
       context 'when handling timezones' do
         before do
-          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           create(:advocate_final_claim, :authorised)
         end
 


### PR DESCRIPTION
#### What

Further fix for the MI bug which occurs during BST 

#### Ticket

N/A

See #5536 

#### Why

These tests use claim data backdated one week, so did not start failing immediately when we moved from GMT to BST. They are now failing. 

#### How

Mark failing tests as `pending`, so they now pass during BST.