### PR TITLE
[CTSKF-657] Config changes for Rails 7.0 part 2

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -41,7 +41,7 @@ Rails.application.config.active_support.remove_deprecated_time_with_zone_name = 
 Rails.application.config.active_support.executor_around_test_case = true
 
 # Set both the `:open_timeout` and `:read_timeout` values for `:smtp` delivery method.
-# Rails.application.config.action_mailer.smtp_timeout = 5
+Rails.application.config.action_mailer.smtp_timeout = 5
 
 # The ActiveStorage video previewer will now use scene change detection to generate
 # better preview images (rather than the previous default of using the first frame

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -58,7 +58,7 @@ Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true
 # Disable partial inserts.
 # This default means that all columns will be referenced in INSERT queries
 # regardless of whether they have a default or not.
-# Rails.application.config.active_record.partial_inserts = false
+Rails.application.config.active_record.partial_inserts = false
 
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
 # Rails.application.config.action_controller.raise_on_open_redirects = true

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -50,7 +50,7 @@ Rails.application.config.active_storage.video_preview_arguments =
   "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"
 
 # Automatically infer `inverse_of` for associations with a scope.
-# Rails.application.config.active_record.automatic_scope_inversing = true
+Rails.application.config.active_record.automatic_scope_inversing = true
 
 # Raise when running tests if fixtures contained foreign key violations
 Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -135,7 +135,7 @@ Rails.application.config.action_dispatch.cookies_serializer = :json
 # Active Storage `has_many_attached` relationships will default to replacing the current collection instead of appending to it.
 # Thus, to support submitting an empty collection, the `file_field` helper will render an hidden field `include_hidden` by default when `multiple_file_field_include_hidden` is set to `true`.
 # See https://guides.rubyonrails.org/configuring.html#config-active-storage-multiple-file-field-include-hidden for more information.
-# Rails.application.config.active_storage.multiple_file_field_include_hidden = true
+Rails.application.config.active_storage.multiple_file_field_include_hidden = true
 
 # ** Please read carefully, this must be configured in config/application.rb (NOT this file) **
 # Disables the deprecated #to_s override in some Ruby core classes

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -83,14 +83,14 @@ Rails.application.config.active_storage.variant_processor = :vips
 # Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
 
 # Change the default headers to disable browsers' flawed legacy XSS protection.
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Download-Options" => "noopen",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-XSS-Protection" => "0",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Download-Options" => "noopen",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
+}
 
 
 # ** Please read carefully, this must be configured in config/application.rb **


### PR DESCRIPTION
#### What

Configure various settings in line with Rails 7.0 defaults.

#### Ticket

[CCCD - Various post-Rails 7 upgrade configuration settings](https://dsdmoj.atlassian.net/browse/CTSKF-657)

#### Why

Bring the configuration into line with the Rails 7.0 defaults.

#### How

* `Rails.application.config.action_mailer.smtp_timeout = 5`: Set timeout values for Action Mailer.
* `Rails.application.config.active_record.automatic_scope_inversing = true`: Infer `inverse_of` from scope.
* `Rails.application.config.active_record.partial_inserts = false`: Disable partial inserts, so that database inserts include all fields even for default values.
* `Rails.application.config.action_dispatch.default_headers = {...}`: Set headers to disable some browers' flawed XSS protection.
* `Rails.application.config.active_storage.multiple_file_field_include_hidden = true`: See https://guides.rubyonrails.org/configuring.html#config-active-storage-multiple-file-field-include-hidden

The setting of `multiple_file_field_include_hidden` changes the file input drop-box from:

```
<div class="govuk-form-group dropzone dropzone-enhanced">
  <label for="claim-documents-field" class="govuk-label">Upload file</label>
  <input id="claim-documents-field" class="govuk-file-upload" multiple="multiple" type="file" name="claim[documents][]">
  <div aria-live="polite" role="status" class="govuk-visually-hidden"></div>
</div>
```

to

```
<div class="govuk-form-group dropzone dropzone-enhanced">
  <label for="claim-documents-field" class="govuk-label">Upload file</label>
  <input name="claim[documents][]" type="hidden" value="" autocomplete="off">
  <input id="claim-documents-field" class="govuk-file-upload" multiple="multiple" type="file" name="claim[documents][]">
  <div aria-live="polite" role="status" class="govuk-visually-hidden"></div>
</div>
```

This means that the `documents` parameter will be an array with an empty string if no documents are uploaded. Previously the parameter would not be present.