### PR TITLE
[CTSKF-657] Raise on open redirects

### DIFF
--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -22,7 +22,7 @@ module CaseWorkers
         record = Stats::StatsReport.most_recent_by_type(params[:report_type])
 
         if record.document.attached?
-          redirect_to record.document.blob.url(disposition: 'attachment')
+          redirect_to record.document.blob.url(disposition: 'attachment'), allow_other_host: true
         else
           redirect_to case_workers_admin_management_information_url, alert: t('.missing_report')
         end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -12,11 +12,11 @@ class DocumentsController < ApplicationController
   def show
     raise ActiveRecord::RecordNotFound, 'Preview not found' unless document.converted_preview_document.attached?
 
-    redirect_to document.converted_preview_document.blob.url(disposition: :inline)
+    redirect_to document.converted_preview_document.blob.url(disposition: :inline), allow_other_host: true
   end
 
   def download
-    redirect_to document.document.blob.url(disposition: :attachment)
+    redirect_to document.document.blob.url(disposition: :attachment), allow_other_host: true
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -37,7 +37,7 @@ class MessagesController < ApplicationController
   def download_attachment
     raise 'No attachment present on this message' unless message.attachment.attached?
 
-    redirect_to message.attachment.blob.url(disposition: 'attachment')
+    redirect_to message.attachment.blob.url(disposition: 'attachment'), allow_other_host: true
   end
 
   private

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,13 +24,36 @@
       "note": ""
     },
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "463781a59c65a58aad10746c6698db3f169b58a20435304888eff3fe9449b2ec",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/case_workers/admin/management_information_controller.rb",
+      "line": 25,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\"), :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CaseWorkers::Admin::ManagementInformationController",
+        "method": "download"
+      },
+      "user_input": "Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\")",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "8738e8b7994af508882a105d873642c98a284c6139f8c6bcf53ae7e25bf14bfa",
       "check_name": "SendFile",
       "message": "Model attribute used in file name",
       "file": "app/controllers/case_workers/claims_controller.rb",
-      "line": 33,
+      "line": 34,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "send_file(S3ZipDownloader.new(Claim::BaseClaim.active.find(params[:id])).generate!, :filename => (\"#{Claim::BaseClaim.active.find(params[:id]).case_number}-documents.zip\"), :type => \"application/zip\", :disposition => \"attachment\")",
       "render_path": null,
@@ -45,71 +68,8 @@
         22
       ],
       "note": "Caseworkers need to identify the downloads correspond to the cases they are processing"
-    },
-    {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 110,
-      "fingerprint": "bab5d27e503d0a596ece61d08111b11217f5c37e54ce3f9c00cdb20a316c8d93",
-      "check_name": "CookieSerialization",
-      "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
-      "file": "config/initializers/new_framework_defaults_7_0.rb",
-      "line": 123,
-      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
-      "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        565,
-        502
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "bc8de62047e25c98883fb9cfdba7dabd67afb1e2057969ff8f552fae1b91dca5",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/interfaces/api/v2/case_workers/claim.rb",
-      "line": 81,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "send(\"#{params[:status]}_claims\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "API::V2::CaseWorkers::Claim",
-        "method": "claims_scope"
-      },
-      "user_input": "params[:status]",
-      "confidence": "High",
-      "note": ""
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "f864ab7fd11658900179de410a865664137731863114daba2062981f29df068f",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/case_workers/admin/management_information_controller.rb",
-      "line": 25,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "CaseWorkers::Admin::ManagementInformationController",
-        "method": "download"
-      },
-      "user_input": "Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\")",
-      "confidence": "High",
-      "cwe_id": [
-        601
-      ],
-      "note": "params[:report_type] is validated to be one of the acceptable values in a controller before_action"
     }
   ],
-  "updated": "2024-03-27 09:32:52 +0000",
+  "updated": "2024-04-11 12:12:25 +0100",
   "brakeman_version": "6.1.2"
 }

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -61,7 +61,7 @@ Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true
 Rails.application.config.active_record.partial_inserts = false
 
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
-# Rails.application.config.action_controller.raise_on_open_redirects = true
+Rails.application.config.action_controller.raise_on_open_redirects = true
 
 # Change the variant processor for Active Storage.
 # Changing this default means updating all places in your code that

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe MessagesController do
 
       context 'when message has attachment' do
         let(:message) { create(:message) }
-        let(:test_url) { 'https://example/com/attachment.doc#123abc' }
+        let(:test_url) { 'https://document.storage/attachment.doc#123abc' }
 
         before do
           message.attachment.attach(io: StringIO.new, filename: 'attachment.doc')

--- a/spec/requests/case_workers/admin/management_information_spec.rb
+++ b/spec/requests/case_workers/admin/management_information_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Management information administration' do
 
     context 'with a valid report type' do
       let(:report_type) { 'management_information' }
-      let(:test_url) { 'https://example.com/mi_report.csv#123abc' }
+      let(:test_url) { 'https://document.storage/mi_report.csv#123abc' }
 
       before do
         stats_report = create(:stats_report, :with_document, report_name: report_type)

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.shared_examples 'download evidence document' do
   let(:document) { create(:document, :with_preview, external_user: document_owner) }
   let(:document_owner) { external_user }
-  let(:test_url) { 'https://example.com/document.doc#123abc' }
+  let(:test_url) { 'https://document.storage/document.doc#123abc' }
 
   before do
     allow(Document).to receive(:find).with(document.to_param).and_return(document)


### PR DESCRIPTION
#### What

Configure to raise exceptions on open redirects.

#### Ticket

[CCCD - Various post-Rails 7 upgrade configuration settings](https://dsdmoj.atlassian.net/browse/CTSKF-657)

#### Why

Bring the configuration into line with the Rails 7.0 defaults.

#### How

Set `Rails.application.config.action_controller.raise_on_open_redirects = true` in `config/initializers/new_framework_defaults_7_0.rb`.

There were a few tests that required modification. This is because a method used to generate urls for redirection was being mocked with a url including a domain that differed from the host domain used by the tests, and this is precisely what the setting prevents.