### PR TITLE
[CTSKF 658] Update cache format version, step 1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,12 @@ require_relative '../lib/govuk_component'
 module AdvocateDefencePayments
   class Application < Rails::Application
     config.load_defaults 6.1
+
+    # These two options can be removed after load_defaults is updated to 7.0
     config.active_support.disable_to_s_conversion = true
+    config.active_support.cache_format_version = 6.1
+    ###
+
     config.middleware.use Rack::Deflater
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
#### What

Set the cache serialization format to version 6.1.

#### Ticket

[CCCD - Update cache format version](https://dsdmoj.atlassian.net/browse/CTSKF-658)

#### Why

See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format

Rails 7.0 introduces a a faster and more compact serialization. Rails 6.1 is incompatible with this new serialization and so there is no rollback step.

The first step is to fix the serialization format to version 6.1 and then deploy this. Once all Rails instances have been updated the format version can be changed to 7.0.

#### How

Set `config.active_support.cache_format_version` to `6.1` in `config/application.rb`.