### PR TITLE
[CTSKF 658] Update cache format version, step 2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module AdvocateDefencePayments
 
     # These two options can be removed after load_defaults is updated to 7.0
     config.active_support.disable_to_s_conversion = true
-    config.active_support.cache_format_version = 6.1
+    config.active_support.cache_format_version = 7.0
     ###
 
     config.middleware.use Rack::Deflater


### PR DESCRIPTION
#### What

Set the cache serialization format to version 7.0.

#### Ticket

[CCCD - Update cache format version](https://dsdmoj.atlassian.net/browse/CTSKF-658)

#### Why

See https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format

Rails 7.0 introduces a a faster and more compact serialization. Rails 6.1 is incompatible with this new serialization and so there is no rollback step.

The first step was to fix the serialization format to version 6.1. This step now is to update the format version to 7.0

#### How

Set `config.active_support.cache_format_version` to `7.0` in `config/application.rb`.