### PR TITLE
Remove GdsAdpFormBuilder

### DIFF
--- a/app/form_builders/gds_adp_form_builder.rb
+++ b/app/form_builders/gds_adp_form_builder.rb
@@ -1,7 +1,0 @@
-class GdsAdpFormBuilder < ActionView::Helpers::FormBuilder
-  delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
-
-  include ActionView::Helpers::FormTagHelper
-  include ActionView::Context
-  include GOVUKDesignSystemFormBuilder::Builder
-end

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -5,7 +5,7 @@
   .govuk-grid-column-two-thirds
     = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
-= form_with url: case_workers_admin_allocations_path, method: :get, builder: GdsAdpFormBuilder do |f|
+= form_with url: case_workers_admin_allocations_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
   = f.hidden_field :tab, id: :tab, value: params[:tab]
   = f.hidden_field :filter, id: :filter, value: params[:filter] if params[:filter]
   = f.hidden_field :page, id: :page, value: params[:page]

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -7,12 +7,12 @@
       .govuk-grid-column-two-thirds
         = govuk_error_summary(@allocation, :allocation)
 
-    = form_with url: case_workers_admin_allocations_path, method: :get, builder: GdsAdpFormBuilder do |f|
+    = form_with url: case_workers_admin_allocations_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = render partial: 'orig_scheme_filters', locals: { f: f }
 
       = render partial: 'shared/search_form', locals: { search_path: case_workers_admin_allocations_path(anchor: 'search-button'), hint_text: t('hint.search'), button_text: t('search.claims') }
 
-    = form_with model: [:case_workers, :admin, @allocation], builder: GdsAdpFormBuilder do |f|
+    = form_with model: [:case_workers, :admin, @allocation], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = hidden_field_tag :scheme, params[:scheme]
       = hidden_field_tag :page, params[:page]
 

--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:case_workers, :admin, @case_worker], builder: GdsAdpFormBuilder do |f|
+= form_with model: [:case_workers, :admin, @case_worker], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary
 

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path, builder: GdsAdpFormBuilder do |f|
+    = form_with model: [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/external_users/admin/external_users/_form.html.haml
+++ b/app/views/external_users/admin/external_users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:external_users, :admin, @external_user], builder: GdsAdpFormBuilder do |f|
+= form_with model: [:external_users, :admin, @external_user], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
 
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary

--- a/app/views/external_users/admin/external_users/change_password.html.haml
+++ b/app/views/external_users/admin/external_users/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path, builder: GdsAdpFormBuilder do |f|
+    = form_with model: [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: @certification, url: external_users_claim_certification_path(@claim), builder: GdsAdpFormBuilder do |f|
+    = form_with model: @certification, url: external_users_claim_certification_path(@claim), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.govuk_error_summary
 
       - if @claim.agfs?

--- a/app/views/external_users/claims/_form.html.haml
+++ b/app/views/external_users/claims/_form.html.haml
@@ -1,5 +1,5 @@
 #claim-form{ data: { claim_id: @claim.id } }
-  = form_with model: @claim, scope: :claim, builder: GdsAdpFormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_with model: @claim, scope: :claim, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step

--- a/app/views/provider_management/external_users/_form.html.haml
+++ b/app/views/provider_management/external_users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:provider_management, @provider, @external_user], builder: GdsAdpFormBuilder do |f|
+= form_with model: [:provider_management, @provider, @external_user], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
 
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary

--- a/app/views/provider_management/external_users/change_availability.html.haml
+++ b/app/views/provider_management/external_users/change_availability.html.haml
@@ -9,7 +9,7 @@
     %h2.govuk-heading-m
       = availability_heading(@external_user)
 
-    = form_with model: [:provider_management, @external_user], url: update_availability_provider_management_provider_external_user_path(@provider, @external_user), builder: GdsAdpFormBuilder do |f|
+    = form_with model: [:provider_management, @external_user], url: update_availability_provider_management_provider_external_user_path(@provider, @external_user), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.hidden_field :availability, value: @external_user.disabled?
 
       .govuk-button-group

--- a/app/views/provider_management/external_users/change_password.html.haml
+++ b/app/views/provider_management/external_users/change_password.html.haml
@@ -6,7 +6,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
 
-    = form_with model: [:provider_management, @external_user], url: update_password_provider_management_provider_external_user_path(@provider, @external_user), builder: GdsAdpFormBuilder do |f|
+    = form_with model: [:provider_management, @external_user], url: update_password_provider_management_provider_external_user_path(@provider, @external_user), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/provider_management/external_users/find.html.haml
+++ b/app/views/provider_management/external_users/find.html.haml
@@ -4,7 +4,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
 
-    = form_for :external_user, url: provider_management_external_users_find_path, builder: GdsAdpFormBuilder do |f|
+    = form_for :external_user, url: provider_management_external_users_find_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.govuk_email_field :email,
         label: { text: t('.page_heading'), tag: 'h1', size: 'l' }
 

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -44,7 +44,7 @@
             = govuk_link_button(t('buttons.edit_draft'), edit_polymorphic_path(claim), class: 'edit-claim')
 
             -if claim.from_api? || claim.api_web_edited?
-              = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'evidence_upload'), builder: GdsAdpFormBuilder, multipart: true, authenticity_token: true do |f|
+              = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'evidence_upload'), builder: GOVUKDesignSystemFormBuilder::FormBuilder, multipart: true, authenticity_token: true do |f|
                 = f.hidden_field :form_step, value: 'offence_details'
                 = f.hidden_field :form_id, value: @claim.form_id
                 = f.submit t('buttons.add_evidence'), name: 'commit_continue', class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/shared/providers/_form.html.haml
+++ b/app/views/shared/providers/_form.html.haml
@@ -1,6 +1,6 @@
 = govuk_error_summary(@provider, :provider, presenter: @error_presenter)
 
-= form_with model: @provider, url: form_url, builder: GdsAdpFormBuilder, html: { novalidate: true } do |f|
+= form_with model: @provider, url: form_url, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f|
 
   = f.govuk_text_field :name,
     hint: { text: t('.provider_name_hint') },

--- a/app/views/super_admins/admin/super_admins/_form.html.haml
+++ b/app/views/super_admins/admin/super_admins/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:super_admins, :admin, @super_admin], builder: GdsAdpFormBuilder do |f|
+= form_with model: [:super_admins, :admin, @super_admin], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary
 

--- a/app/views/super_admins/admin/super_admins/change_password.html.haml
+++ b/app/views/super_admins/admin/super_admins/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path, builder: GdsAdpFormBuilder do |f|
+    = form_with model: [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,6 @@ SimpleCov.configure do
   # group functionality for test coverage report
   add_group 'Models', 'app/models'
   add_group 'Controllers', 'app/controllers'
-  add_group 'FormBuilders', 'app/form_builders'
   add_group 'Mailers', '/app/mailers'
   add_group 'Validators', 'app/validators'
   add_group 'Helpers', 'app/helpers'


### PR DESCRIPTION
#### What

Remove `GdsAdpFormBuilder`.

#### Ticket

N/A

#### Why

`GdsAdpFormBuilder` was a stepping-stone in the process of removing `AdpFormBuilder`. Now that has been removed `GdsAdpFormBuilder` is no longer required.

#### How

Replace `GdsAdpFormBuilder` with `GOVUKDesignSystemFormBuilder::FormBuilder` throughout.