### PR TITLE
[CTSKF-488] Replace RestClient with Faraday

### DIFF
--- a/app/services/distance_calculator_service/google_api.rb
+++ b/app/services/distance_calculator_service/google_api.rb
@@ -27,7 +27,7 @@ class DistanceCalculatorService
     end
 
     def directions
-      @directions ||= RestClient.get(Rails.application.config.google_directions_api_url, params:).body
+      @directions ||= Faraday.get(Rails.application.config.google_directions_api_url, **params).body
     end
 
     def params

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -12,7 +12,7 @@ class SlackNotifier
   def send_message
     raise 'Unable to send without payload' unless @ready_to_send
 
-    RestClient.post(@slack_url, @payload.to_json, content_type: :json)
+    Faraday.post(@slack_url, @payload.to_json, { 'Content-Type': 'application/json' })
   end
 
   def build_payload(**)


### PR DESCRIPTION
#### What

Replace `rest-client` with `faraday`.

#### Ticket

[Remove `rest_client`](https://dsdmoj.atlassian.net/browse/CTSKF-488)

#### Why

`rest_client` is being removed to reduce required dependencies.

#### How

`RestClient.get` and `RestClient.post` in `app/services/distance_calculator_service/google_api.rb and app/services/slack_notifier.rb` can be replaced almost exactly with `Faraday.get` and `Faraday.post`.