### PR TITLE
Add case sensitive false in validations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ApplicationRecord
   has_many :user_message_statuses
 
   validates :first_name, :last_name, presence: true, length: { maximum: 40 }
-  validates :email, confirmation: true, length: { maximum: 80 }
+  validates :email, confirmation: { case_sensitive: false }, length: { maximum: 80 }
   validates :terms_and_conditions,
             acceptance: ['1', true],
             allow_nil: false,


### PR DESCRIPTION
#### What
<img width="300" alt="Screenshot 2024-04-19 at 14 54 10" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/12900007/fc187518-e110-4cff-bed0-f41f11be57e0">

When new accounts are created containing miss matching capitals an error is reported. This ticket fixes that. 

#### Ticket

[CCCD - Account creation fails with capitals in email address](https://dsdmoj.atlassian.net/browse/CTSKF-644)

#### Why
Email addresses are not case sensitive so capitals should not cause any problem. This error occurs even if the email and confirmation are the same. 

#### How
Rails allows you to customise its validations in the model - overriding them to allow case-insensitive matching.  

