### PR TITLE
[CTSKF-488] Use Faraday instead of RestClient

### DIFF
--- a/spec/support/api/api_test_client.rb
+++ b/spec/support/api/api_test_client.rb
@@ -77,13 +77,13 @@ class ApiTestClient
   # don't raise exceptions but, instead, return the
   # response for analysis.
   #
-  def get_dropdown_endpoint(resource, api_key, **kwargs)
+  def get_dropdown_endpoint(resource, **kwargs)
     path = "api/#{resource}"
     debug("GETTING FROM #{path}")
     debug("Params: #{kwargs}")
 
     body = Caching::APIRequest.cache("#{path}?#{kwargs.to_query}") do
-      connection.get(path, api_key:, **kwargs).tap { |response| handle_response(response, resource) }
+      connection.get(path, **kwargs).tap { |response| handle_response(response, resource) }
     end
     JSON.parse(body)
   rescue JSON::ParserError

--- a/spec/support/api/api_test_client.rb
+++ b/spec/support/api/api_test_client.rb
@@ -100,7 +100,7 @@ class ApiTestClient
     return if response.success?
 
     @success = false
-    @full_error_messages << "#{resource} Endpoint raised error - #{response}"
+    @full_error_messages << "#{resource} Endpoint raised error [HTTP status #{response.status}]"
   end
 
   def api_root_url

--- a/spec/support/api/claims/advocate_claim_test/final.rb
+++ b/spec/support/api/claims/advocate_claim_test/final.rb
@@ -16,6 +16,7 @@ module AdvocateClaimTest
 
       # CREATE miscellaneous fee
       response = @client.post_to_endpoint('fees', misc_fee_data)
+      return if @client.failure
 
       # add date attended to miscellaneous fee
       @attended_item_id = response['id']

--- a/spec/support/api/claims/advocate_claim_test/hardship.rb
+++ b/spec/support/api/claims/advocate_claim_test/hardship.rb
@@ -16,6 +16,7 @@ module AdvocateClaimTest
 
       # CREATE miscellaneous fee
       response = @client.post_to_endpoint('fees', misc_fee_data)
+      return if @client.failure
 
       # add date attended to miscellaneous fee
       @attended_item_id = response['id']

--- a/spec/support/api/claims/advocate_claim_test/interim.rb
+++ b/spec/support/api/claims/advocate_claim_test/interim.rb
@@ -20,6 +20,7 @@ module AdvocateClaimTest
 
       # CREATE miscellaneous fee
       response = @client.post_to_endpoint('fees', misc_fee_data)
+      return if @client.failure
 
       # add date attended to miscellaneous fee
       @attended_item_id = response['id']

--- a/spec/support/api/claims/advocate_claim_test/supplementary.rb
+++ b/spec/support/api/claims/advocate_claim_test/supplementary.rb
@@ -13,6 +13,7 @@ module AdvocateClaimTest
 
       # CREATE miscellaneous fee
       response = @client.post_to_endpoint('fees', misc_fee_data)
+      return if @client.failure
 
       # add date attended to miscellaneous fee
       @attended_item_id = response['id']

--- a/spec/support/api/claims/base_claim_test.rb
+++ b/spec/support/api/claims/base_claim_test.rb
@@ -71,11 +71,11 @@ class BaseClaimTest
   end
 
   def fetch_id(endpoint, index: 0, key: 'id', **)
-    @client.get_dropdown_endpoint(endpoint, api_key, **).pluck(key)[index]
+    @client.get_dropdown_endpoint(endpoint, api_key:, **).pluck(key)[index]
   end
 
   def fetch_value(endpoint, index: 0, **)
-    @client.get_dropdown_endpoint(endpoint, api_key, **)[index]
+    @client.get_dropdown_endpoint(endpoint, api_key:, **)[index]
   end
 
   def clean_up


### PR DESCRIPTION
#### What

Replace `rest-client` with `faraday`.

#### Ticket

[Remove `rest_client`](https://dsdmoj.atlassian.net/browse/CTSKF-488)

#### Why

`rest_client` is being removed to reduce required dependencies.

#### How

`RestClient` is replaced with `Faraday` with some modifications of arguments and responses, as appropriate.

With `RestClient`, a failed requests raises an exception and this causes the tests to fail. With `Faraday`, however, an exception is not raised and the response can be checked for the http status and for `success?`. This changes how tests are executed;

* When a misc fee is created in for example, `spec/support/api/claims/advocate_claim_test/final.rb`, a failure does not stop the test with an exception and attempting to find `id` from the response fails. To remedy this the test is halted if `@client.failure` is `true` at this point.
* When a request fails the test should display a list of errors. However, the exception from `RestClient` prevents this. When switching to `Faraday` these errors are seen but the error appears as `#<Faraday::Response:0x0000000163312860>`. This is replaced by the https status.