### PR TITLE
Index fees table on uuid to fix slow query

### DIFF
--- a/db/migrate/20240419173039_add_index_to_fees_on_uuid.rb
+++ b/db/migrate/20240419173039_add_index_to_fees_on_uuid.rb
@@ -1,0 +1,7 @@
+class AddIndexToFeesOnUuid < ActiveRecord::Migration[7.0]
+  self.disable_ddl_transaction!
+
+  def change
+     add_index :fees, :uuid, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2023_11_27_130608) do
-
+ActiveRecord::Schema[7.0].define(version: 2024_04_19_173039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -392,6 +391,7 @@ ActiveRecord::Schema[6.1].define(version: 2023_11_27_130608) do
     t.boolean "price_calculated", default: false
     t.index ["claim_id"], name: "index_fees_on_claim_id"
     t.index ["fee_type_id"], name: "index_fees_on_fee_type_id"
+    t.index ["uuid"], name: "index_fees_on_uuid", unique: true
   end
 
   create_table "injection_attempts", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
#### What

Sentry is reporting that the most [time-consuming query](https://ministryofjustice.sentry.io/performance/?project=5436820&statsPeriod=90d&utc=true) in CCCD is

```
SELECT "fees".* FROM "fees" WHERE "fees"."uuid" = $1 ORDER BY "fees"."id" ASC LIMIT $2
```

which takes on average ~400ms to complete.

<img width="1251" alt="image" src="https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/e9d870a1-0f84-4c82-a93f-429a9a86ae82">

This PR attempts to make that query more efficient by indexing the `fees` table on the `uuid` field.

#### Why

To improve the overall performance of CCCD.

#### How

The slow query originates in the following line in `app/interfaces/api/v1/external_users/date_attended.rb`:

```
::Fee::BaseFee.find_by(uuid: params[:attended_item_id])
```

which is executed when a provider uses the API to add a 'date attended' to a fee.

This code looks up the fee record by `uuid`, which is an unindexed field in the `fees` table. In production this table contains over 2.4 million records, and this query is taking increasingly long to run.

The speed of lookup can be improved by adding an index to the `uuid` field.

To prevent this having an impact on users by locking the table when adding the index, the `algorithm` attribute is set to `:concurrently`. This necessitates disabling transactions for the migration. See https://thoughtbot.com/blog/how-to-create-postgres-indexes-concurrently-in for more details.

#### Proof

Tested on an anonymised copy of production running locally.

##### Before

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/21edbf4d-d96b-4067-9d73-e9aa10d7e8e6)

##### After

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/2e03b350-c0c1-410c-b96b-9e8be230b9e1)


There is always a concern when adding indexes to tables that it may have an adverse affect on inserts into that table. In this instance this does not appear to be an issue:

##### Before

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/0d5adf8d-a96e-40f7-bbcf-d97691c2b018)

##### After 

![image](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/assets/28729201/f2a4b127-1e39-4f26-970b-07b8ccdc6a82)



