### PR TITLE
[CTSKF-682] Enable content security policy

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,0 +1,34 @@
+class CspReportsController < ApplicationController
+  skip_load_and_authorize_resource only: %i[create]
+  skip_forgery_protection
+
+  def create
+    slack_notifier.build_payload(
+      icon: ':security:',
+      title: 'Content Security Policy violation',
+      message: report.map { |key, value| "#{key}: #{value}" }.join("\n"),
+      status: :fail
+    )
+    slack_notifier.send_message
+
+    head :ok
+  end
+
+  private
+
+  def slack_notifier
+    @slack_notifier ||= SlackNotifier.new(
+      'laa-cccd-alerts',
+      formatter: SlackNotifier::Formatter::Generic.new,
+      slack_bot_name: 'CSP'
+    )
+  end
+
+  def report
+    @report ||= JSON.parse(body)['csp-report']
+  rescue JSON::ParserError
+    @report ||= { error: 'Unable to parse data' }
+  end
+
+  def body = @body ||= request.body.read
+end

--- a/app/views/external_users/claims/expenses/_expense_reasons.js.haml
+++ b/app/views/external_users/claims/expenses/_expense_reasons.js.haml
@@ -1,5 +1,6 @@
 - data = { A: ExpenseType::REASON_SET_A.values, B: ExpenseType::REASON_SET_B.values, C: ExpenseType::REASON_SET_C.values }
-:javascript
-  var MOJ = MOJ || {};
+= javascript_tag nonce: true do
+  :plain
+    var MOJ = MOJ || {};
 
-  MOJ.ExpenseReasons = #{data.to_json.html_safe}
+    MOJ.ExpenseReasons = #{data.to_json.html_safe}

--- a/app/views/grape_swagger_rails/application/index.html.haml
+++ b/app/views/grape_swagger_rails/application/index.html.haml
@@ -22,44 +22,47 @@
     = stylesheet_link_tag 'application', media: 'all'
 
     = tag :meta, property: 'og:image', content: request.base_url + image_tag('govuk-opengraph-image.png')
-    :javascript
-      (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
+    = javascript_tag nonce: true do
+      :plain
+        (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
 
-    :javascript
-      $(function () {
-      var options = $("html").data('swagger-options');
-      var headers = {};
-      window.swaggerUi = new SwaggerUi({
-      url: options.app_url + options.url,
-      dom_id: "swagger-ui-container",
-      supportHeaderParams: true,
-      supportedSubmitMethods: options.supported_submit_methods || [],
-      authorizations: headers,
-      onComplete: function(swaggerApi, swaggerUi){
-      if('console' in window) {
-      console.log("Loaded SwaggerUI")
-      console.log(swaggerApi);
-      console.log(swaggerUi);
-      }
-      $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
-      },
-      onFailure: function(data) {
-      if('console' in window) {
-      console.log("Unable to Load SwaggerUI");
-      console.log(data);
-      }
-      },
-      docExpansion: options.doc_expansion,
-      validatorUrl: options.validator_url,
-      apisSorter: "alpha"
-      });
+    = javascript_tag nonce: true do
+      :plain
+        $(function () {
+        var options = $("html").data('swagger-options');
+        var headers = {};
+        window.swaggerUi = new SwaggerUi({
+        url: options.app_url + options.url,
+        dom_id: "swagger-ui-container",
+        supportHeaderParams: true,
+        supportedSubmitMethods: options.supported_submit_methods || [],
+        authorizations: headers,
+        onComplete: function(swaggerApi, swaggerUi){
+        if('console' in window) {
+        console.log("Loaded SwaggerUI")
+        console.log(swaggerApi);
+        console.log(swaggerUi);
+        }
+        $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
+        },
+        onFailure: function(data) {
+        if('console' in window) {
+        console.log("Unable to Load SwaggerUI");
+        console.log(data);
+        }
+        },
+        docExpansion: options.doc_expansion,
+        validatorUrl: options.validator_url,
+        apisSorter: "alpha"
+        });
 
-      window.swaggerUi.load();
-      });
+        window.swaggerUi.load();
+        });
 
   %body.govuk-frontend-supported.govuk-template__body.swagger-section
-    :javascript
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    = javascript_tag nonce: true do
+      :plain
+        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 
     = govuk_skip_link_to(t('layouts.skip_content'), '#main-content')
 

--- a/app/views/layouts/_analytics.js.haml
+++ b/app/views/layouts/_analytics.js.haml
@@ -1,16 +1,18 @@
 - if adapter == :gtm
-  :javascript
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer',"#{ENV['GTM_TRACKER_ID']}");
+  = javascript_tag nonce: true do
+    :plain
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer',"#{ENV['GTM_TRACKER_ID']}");
 
 - if adapter == :ga
-  :javascript
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-    ga('create', "#{ENV['GA_TRACKER_ID']}", 'auto');
-    ga('set', 'anonymizeIp', true);
+  = javascript_tag nonce: true do
+    :plain
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', "#{ENV['GA_TRACKER_ID']}", 'auto');
+      ga('set', 'anonymizeIp', true);

--- a/app/views/layouts/_body_end.html.haml
+++ b/app/views/layouts/_body_end.html.haml
@@ -1,8 +1,9 @@
 = javascript_include_tag 'application.js'
 
 - if GoogleAnalytics::DataTracking.analytics? && !@disable_analytics
-  :javascript
-    ga(function(tracker) {
-      var clientId = tracker.get('clientId');
-      $('.ga-client-id').val(clientId);
-    });
+  = javascript_tag nonce: true do
+    :plain
+      ga(function(tracker) {
+        var clientId = tracker.get('clientId');
+        $('.ga-client-id').val(clientId);
+      });

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,12 +20,13 @@
     - if GoogleAnalytics::DataTracking.enabled? && !@disable_analytics
       = render partial: 'layouts/analytics', formats: :js, locals: { adapter: GoogleAnalytics::DataTracking.adapter_name }
       - if GoogleAnalytics::DataTracking.analytics?
-        %script
+        = javascript_tag nonce: true do
           != ga_outlet
 
   %body.govuk-frontend-supported{ class: "govuk-template__body controller-#{controller.controller_name}" }
-    :javascript
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    = javascript_tag nonce: true do
+      :plain
+        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 
     = render partial: 'layouts/cookie_banner'
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,22 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w(script-src)
+
+  # Report violations without enforcing the policy.
+  config.content_security_policy_report_only = true
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
     policy.script_src  :self, :https
     policy.style_src   :self, :https
     # Specify URI for violation reports
-    # policy.report_uri "/csp-violation-report-endpoint"
+    policy.report_uri "/csp_report"
   end
 
   # Generate session nonces for permitted importmap and inline scripts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,6 +208,8 @@ Rails.application.routes.draw do
   end
   get '/help/cookie-details', to: 'cookies#cookie_details'
 
+  resource :csp_report, only: %i[create]
+
   # catch-all route
   # -------------------------------------------------
   # WARNING: do not put routes below this point

--- a/spec/requests/csp_report_spec.rb
+++ b/spec/requests/csp_report_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Content Security Policy reports' do
+  describe 'POST /csp_report' do
+    let(:params) do
+      {
+        'csp-report': {
+          'document-uri': 'https://example.com',
+          referrer: '',
+          'violated-directive': 'connect-src',
+          'effective-directive': 'connect-src',
+          'original-policy': "default-src 'self' https:; script-src 'self' https: 'nonce-123'",
+          disposition: 'report',
+          'blocked-uri': 'ws://example.com:35729/livereload',
+          'line-number': 191,
+          'column-number': 27,
+          'source-file': 'http://example:com/__rack/livereload.js',
+          'status-code': 200,
+          'script-sample': ''
+        }
+      }.to_json
+    end
+
+    before do
+      stub_request(:post, 'https://slack').and_return(status: 200)
+      allow(Settings).to receive(:slack).and_return(Struct.new(:bot_url).new('https://slack'))
+
+      post csp_report_url, params:
+    end
+
+    it { expect(response).to be_successful }
+
+    context 'with an empty body' do
+      let(:params) { '' }
+
+      it { expect(response).to be_successful }
+    end
+  end
+end


### PR DESCRIPTION
#### What

Enable content security policy in 'report only' mode.

#### Ticket

[CCCD - Configure Rails Content Security Policy](https://dsdmoj.atlassian.net/browse/CTSKF-682)

#### Why

The Content Security Policy ensures that unauthorised scripts are not executed. In 'report only' mode then possible violations will be reported but not blocked. This can be monitored to ensure that the policy has been configured correctly before being enabled fully.

#### How

The recommended settings are enabled together with:

```ruby
config.content_security_policy_report_only = true
```

A new endpoint, `/csp_report`, is created to capture reports and post them to Slack in the `laa-cccd-alerts` channel.

The `rack-livereload` gem, which is used when running in a development environment, results in CSP violations. This will need to be resolved before the policy can be enabled.