### PR TITLE
[CTSKF-682] Temporarily silence Slack alerts

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
     policy.script_src  :self, :https
     policy.style_src   :self, :https
     # Specify URI for violation reports
-    policy.report_uri "/csp_report"
+    # policy.report_uri "/csp_report"
   end
 
   # Generate session nonces for permitted importmap and inline scripts


### PR DESCRIPTION
#### What

Silencing alerts until the alerts are fixed

#### Ticket

[CCCD - Configure Rails Content Security Policy](https://dsdmoj.atlassian.net/browse/CTSKF-682)

#### Why

There are alerts that need to be addressed.

#### How

Temporarily remove the `report_uri` setting.