### PR TITLE
[CTSKF-682] Relax Content Security Policy

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -3,13 +3,14 @@ class CspReportsController < ApplicationController
   skip_forgery_protection
 
   def create
-    slack_notifier.build_payload(
-      icon: ':security:',
-      title: 'Content Security Policy violation',
-      message: report.map { |key, value| "#{key}: #{value}" }.join("\n"),
-      status: :fail
-    )
-    slack_notifier.send_message
+    # slack_notifier.build_payload(
+    #   icon: ':security:',
+    #   title: 'Content Security Policy violation',
+    #   message: report.map { |key, value| "#{key}: #{value}" }.join("\n"),
+    #   status: :fail
+    # )
+    # slack_notifier.send_message
+    Rails.logger.info("CSP violation: #{report}")
 
     head :ok
   end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,15 +10,17 @@ Rails.application.configure do
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.object_src  :none
-    policy.script_src  :self, :https
+    # TODO: unsafe_inline should be removed but this cannot be done until some Javascript is refactored.
+    policy.script_src  :self, :unsafe_inline, :https
     policy.style_src   :self, :https
     # Specify URI for violation reports
-    # policy.report_uri "/csp_report"
+    policy.report_uri "/csp_report"
   end
 
   # Generate session nonces for permitted importmap and inline scripts
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w(script-src)
+  # TODO: Enable these options. This can only be done when unsafe_inline is removed above.
+  # config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # config.content_security_policy_nonce_directives = %w(script-src)
 
   # Report violations without enforcing the policy.
   config.content_security_policy_report_only = true


### PR DESCRIPTION
#### What

Permit inline script without nonce.

#### Ticket

[CCCD - Configure Rails Content Security Policy](https://dsdmoj.atlassian.net/browse/CTSKF-682)

#### Why

Much of the custom Javascript in CCCD is triggering alerts from the CSP as inline script with a nonce. This may be due to JQuery and so this issue may be resolved when the code is refactored.

#### How

Enable `unsafe-inline` for the `script-src` policy. Also, for the moment alerts are not reporting to Slack and are written to the log file in the pod instead.