### PR TITLE
[CTSKF-682] Add 'unsafe-inline' option for CSP for styles

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
     policy.object_src  :none
     # TODO: unsafe_inline should be removed but this cannot be done until some Javascript is refactored.
     policy.script_src  :self, :unsafe_inline, :https
-    policy.style_src   :self, :https
+    policy.style_src   :self, :unsafe_inline, :https
     # Specify URI for violation reports
     policy.report_uri "/csp_report"
   end


### PR DESCRIPTION
#### What

Add 'unsafe-inline' option for content security policy for CSS.

#### Ticket

[CCCD - Configure Rails Content Security Policy](https://dsdmoj.atlassian.net/browse/CTSKF-682)

#### Why

Some of the Javascript depends on inline styles to function correctly. This could be fixed with some refactoring.

A couple of examples are;

* In the allocation table (see app/views/case_workers/admin/allocations/_allocation.html.haml) the table has `width: 100%` as in inline style. The table, from GDS, does already have this set but the Datatable library changes this and breaks the responsive behaviour.
* In the expenses form (see app/views/external_users/claims/expenses/_expense_fields.html.haml) `display: none` and `display: block` are used by the block helper module (see app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js) to show and hide fields as required. The classes `govuk-!-display-none` and `govuk-!-display-block` can be used instead but this results in errors in the tests and it is unclear whether these failures are genuine or a result of the test not being able to tests visibility correctly. See #6823

A nonce cannot be used to mark acceptable use of inline styles because the nonce generation has already been disabled (see #6815).

#### How

Add `unsafe-inline` to the `style-src` policy.
