### PR TITLE
Replace inline styles with govuk display classes

### DIFF
--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -33,23 +33,23 @@
             reasons_collection.map { |et| [et.reason, et.id, { data: et.data_attributes }] },
             :second,
             :first,
-            form_group: { class: 'fx-travel-reason', style: 'display: none' },
+            form_group: { class: ['fx-travel-reason', 'govuk-!-display-none'] },
             label: { text: t('.travel_reason_html') },
             options: { include_blank: t('.select_option') }
 
           - present(f.object) do |expense|
             = f.govuk_text_field :reason_text,
-              form_group: { class: 'fx-travel-reason-other', style: f.object.reason_id.eql?(5) ? 'display: block' : 'display: none' },
+              form_group: { class: ['fx-travel-reason-other', f.object.reason_id.eql?(5) ? 'govuk-!-display-block' : 'govuk-!-display-none'] },
               label: { text: t('.reason_text_html') },
               width: 'one-half'
 
-          .fx-travel-location{ style: 'display: none' }
+          .fx-travel-location{ class: 'govuk-!-display-none' }
             - if @claim.lgfs?
               = f.govuk_collection_select :location,
                 {},
                 {},
                 {},
-                form_group: { class: 'fx-establishment-select has-select', style: 'display: none' },
+                form_group: { class: ['fx-establishment-select has-select', 'govuk-!-display-none'] },
                 label: { text: nil }
 
             = f.govuk_text_field :location,
@@ -59,13 +59,13 @@
                 width: 'one-half'
 
           = f.govuk_number_field :hours,
-              form_group: { class: 'fx-travel-hours', style: 'display: none' },
+              form_group: { class: ['fx-travel-hours', 'govuk-!-display-none'] },
               label: { text: t('.hours_html') },
               min: 0,
               width: 'one-quarter'
 
           = f.govuk_number_field :distance,
-              form_group: { class: 'fx-travel-distance', style: 'display: none' },
+              form_group: { class: ['fx-travel-distance', 'govuk-!-display-none'] },
               hint: { text: t('.distance_hint_html') },
               label: { text: t('.distance_html') },
               min: 0,
@@ -76,25 +76,25 @@
             = govuk_detail t('.summary_heading') do
               = t('.summary_content')
           = f.govuk_radio_buttons_fieldset :mileage_rate_id,
-            form_group: { class: 'fx-travel-mileage fx-travel-mileage-bike', style: 'display: none' },
+            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-bike', 'govuk-!-display-none'] },
             legend: { text: t('.cost_html') } do
             - Expense::BIKE_MILEAGE_RATES.values.map do | bike_mileage_rate |
               = f.govuk_radio_button :mileage_rate_id, bike_mileage_rate.id, label: { text: bike_mileage_rate.description }
 
           = f.govuk_radio_buttons_fieldset :mileage_rate_id,
-            form_group: { class: 'fx-travel-mileage fx-travel-mileage-car', style: 'display: none' },
+            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-car', 'govuk-!-display-none'] },
             legend: { text: t('.cost_html') } do
             - Expense::CAR_MILEAGE_RATES.values.map do | car_mileage_rate |
               = f.govuk_radio_button :mileage_rate_id, car_mileage_rate.id, label: { text: car_mileage_rate.description }
 
           = f.govuk_date_field :date,
-            form_group: { class: 'fx-travel-date', style: 'display: none' },
+            form_group: { class: ['fx-travel-date', 'govuk-!-display-none'] },
             legend: { text: t('.date_html') },
             hint: { text: t('.date_hint') }
 
           = f.govuk_number_field :amount,
             class: 'rate',
-            form_group: { class: 'fx-travel-net-amount', style: 'display: none' },
+            form_group: { class: ['fx-travel-net-amount', 'govuk-!-display-none'] },
             label: { text: t('.net_amount_html') },
             min: 0,
             prefix_text: '£',
@@ -104,7 +104,7 @@
           - if @claim.lgfs?
             = f.govuk_number_field :vat_amount,
               class: 'vat',
-              form_group: {class: 'fx-travel-vat-amount', style: 'display: none' },
+              form_group: {class: ['fx-travel-vat-amount', 'govuk-!-display-none'] },
               label: { text: t('.vat_amount_html') },
               min: 0,
               prefix_text: '£',

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -33,7 +33,7 @@
             reasons_collection.map { |et| [et.reason, et.id, { data: et.data_attributes }] },
             :second,
             :first,
-            form_group: { class: ['fx-travel-reason', 'govuk-!-display-block'] },
+            form_group: { class: ['fx-travel-reason', 'govuk-!-display-none'] },
             label: { text: t('.travel_reason_html') },
             options: { include_blank: t('.select_option') }
 
@@ -43,13 +43,13 @@
               label: { text: t('.reason_text_html') },
               width: 'one-half'
 
-          .fx-travel-location{ class: 'govuk-!-display-block' }
+          .fx-travel-location{ class: 'govuk-!-display-none' }
             - if @claim.lgfs?
               = f.govuk_collection_select :location,
                 {},
                 {},
                 {},
-                form_group: { class: ['fx-establishment-select has-select', 'govuk-!-display-block'] },
+                form_group: { class: ['fx-establishment-select has-select', 'govuk-!-display-none'] },
                 label: { text: nil }
 
             = f.govuk_text_field :location,
@@ -59,13 +59,13 @@
                 width: 'one-half'
 
           = f.govuk_number_field :hours,
-              form_group: { class: ['fx-travel-hours', 'govuk-!-display-block'] },
+              form_group: { class: ['fx-travel-hours', 'govuk-!-display-none'] },
               label: { text: t('.hours_html') },
               min: 0,
               width: 'one-quarter'
 
           = f.govuk_number_field :distance,
-              form_group: { class: ['fx-travel-distance', 'govuk-!-display-block'] },
+              form_group: { class: ['fx-travel-distance', 'govuk-!-display-none'] },
               hint: { text: t('.distance_hint_html') },
               label: { text: t('.distance_html') },
               min: 0,
@@ -76,25 +76,25 @@
             = govuk_detail t('.summary_heading') do
               = t('.summary_content')
           = f.govuk_radio_buttons_fieldset :mileage_rate_id,
-            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-bike', 'govuk-!-display-block'] },
+            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-bike', 'govuk-!-display-none'] },
             legend: { text: t('.cost_html') } do
             - Expense::BIKE_MILEAGE_RATES.values.map do | bike_mileage_rate |
               = f.govuk_radio_button :mileage_rate_id, bike_mileage_rate.id, label: { text: bike_mileage_rate.description }
 
           = f.govuk_radio_buttons_fieldset :mileage_rate_id,
-            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-car', 'govuk-!-display-block'] },
+            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-car', 'govuk-!-display-none'] },
             legend: { text: t('.cost_html') } do
             - Expense::CAR_MILEAGE_RATES.values.map do | car_mileage_rate |
               = f.govuk_radio_button :mileage_rate_id, car_mileage_rate.id, label: { text: car_mileage_rate.description }
 
           = f.govuk_date_field :date,
-            form_group: { class: ['fx-travel-date', 'govuk-!-display-block'] },
+            form_group: { class: ['fx-travel-date', 'govuk-!-display-none'] },
             legend: { text: t('.date_html') },
             hint: { text: t('.date_hint') }
 
           = f.govuk_number_field :amount,
             class: 'rate',
-            form_group: { class: ['fx-travel-net-amount', 'govuk-!-display-block'] },
+            form_group: { class: ['fx-travel-net-amount', 'govuk-!-display-none'] },
             label: { text: t('.net_amount_html') },
             min: 0,
             prefix_text: '£',
@@ -104,7 +104,7 @@
           - if @claim.lgfs?
             = f.govuk_number_field :vat_amount,
               class: 'vat',
-              form_group: {class: ['fx-travel-vat-amount', 'govuk-!-display-block'] },
+              form_group: {class: ['fx-travel-vat-amount', 'govuk-!-display-none'] },
               label: { text: t('.vat_amount_html') },
               min: 0,
               prefix_text: '£',

--- a/app/views/external_users/claims/expenses/_expense_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_expense_fields.html.haml
@@ -33,7 +33,7 @@
             reasons_collection.map { |et| [et.reason, et.id, { data: et.data_attributes }] },
             :second,
             :first,
-            form_group: { class: ['fx-travel-reason', 'govuk-!-display-none'] },
+            form_group: { class: ['fx-travel-reason', 'govuk-!-display-block'] },
             label: { text: t('.travel_reason_html') },
             options: { include_blank: t('.select_option') }
 
@@ -43,13 +43,13 @@
               label: { text: t('.reason_text_html') },
               width: 'one-half'
 
-          .fx-travel-location{ class: 'govuk-!-display-none' }
+          .fx-travel-location{ class: 'govuk-!-display-block' }
             - if @claim.lgfs?
               = f.govuk_collection_select :location,
                 {},
                 {},
                 {},
-                form_group: { class: ['fx-establishment-select has-select', 'govuk-!-display-none'] },
+                form_group: { class: ['fx-establishment-select has-select', 'govuk-!-display-block'] },
                 label: { text: nil }
 
             = f.govuk_text_field :location,
@@ -59,13 +59,13 @@
                 width: 'one-half'
 
           = f.govuk_number_field :hours,
-              form_group: { class: ['fx-travel-hours', 'govuk-!-display-none'] },
+              form_group: { class: ['fx-travel-hours', 'govuk-!-display-block'] },
               label: { text: t('.hours_html') },
               min: 0,
               width: 'one-quarter'
 
           = f.govuk_number_field :distance,
-              form_group: { class: ['fx-travel-distance', 'govuk-!-display-none'] },
+              form_group: { class: ['fx-travel-distance', 'govuk-!-display-block'] },
               hint: { text: t('.distance_hint_html') },
               label: { text: t('.distance_html') },
               min: 0,
@@ -76,25 +76,25 @@
             = govuk_detail t('.summary_heading') do
               = t('.summary_content')
           = f.govuk_radio_buttons_fieldset :mileage_rate_id,
-            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-bike', 'govuk-!-display-none'] },
+            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-bike', 'govuk-!-display-block'] },
             legend: { text: t('.cost_html') } do
             - Expense::BIKE_MILEAGE_RATES.values.map do | bike_mileage_rate |
               = f.govuk_radio_button :mileage_rate_id, bike_mileage_rate.id, label: { text: bike_mileage_rate.description }
 
           = f.govuk_radio_buttons_fieldset :mileage_rate_id,
-            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-car', 'govuk-!-display-none'] },
+            form_group: { class: ['fx-travel-mileage', 'fx-travel-mileage-car', 'govuk-!-display-block'] },
             legend: { text: t('.cost_html') } do
             - Expense::CAR_MILEAGE_RATES.values.map do | car_mileage_rate |
               = f.govuk_radio_button :mileage_rate_id, car_mileage_rate.id, label: { text: car_mileage_rate.description }
 
           = f.govuk_date_field :date,
-            form_group: { class: ['fx-travel-date', 'govuk-!-display-none'] },
+            form_group: { class: ['fx-travel-date', 'govuk-!-display-block'] },
             legend: { text: t('.date_html') },
             hint: { text: t('.date_hint') }
 
           = f.govuk_number_field :amount,
             class: 'rate',
-            form_group: { class: ['fx-travel-net-amount', 'govuk-!-display-none'] },
+            form_group: { class: ['fx-travel-net-amount', 'govuk-!-display-block'] },
             label: { text: t('.net_amount_html') },
             min: 0,
             prefix_text: '£',
@@ -104,7 +104,7 @@
           - if @claim.lgfs?
             = f.govuk_number_field :vat_amount,
               class: 'vat',
-              form_group: {class: ['fx-travel-vat-amount', 'govuk-!-display-none'] },
+              form_group: {class: ['fx-travel-vat-amount', 'govuk-!-display-block'] },
               label: { text: t('.vat_amount_html') },
               min: 0,
               prefix_text: '£',

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -34,7 +34,7 @@
 
     - if GoogleAnalytics::DataTracking.tag_manager? && !@disable_analytics
       %noscript
-        %iframe{ src: "https://www.googletagmanager.com/ns.html?id=#{ENV['GTM_TRACKER_ID']}", style: 'display: none; visibility: hidden', height: '0', width: '0' }
+        %iframe.govuk-!-display-none{ src: "https://www.googletagmanager.com/ns.html?id=#{ENV['GTM_TRACKER_ID']}", height: '0', width: '0' }
 
     %header.govuk-header.with-proposition{ data: { module: 'govuk-header' } }
       .govuk-header__container.govuk-width-container

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -178,7 +178,7 @@
               AGFS Final, Supplementary and Hardship claims
             = govuk_table_td('data-label': 'Validations') do
               Not claimable on claims with offences in Bands 1, 6 and 9
-              %sup{ style: "font-size: 10px"}
+              %sup.govuk-body-s
                 1
 
           = govuk_table_row do
@@ -200,7 +200,7 @@
               %br
               %br
               Only claimable on claims with a Graduated case type
-              %sup{ style: "font-size: 10px"}
+              %sup.govuk-body-s
                 2
           = govuk_table_row do
             = govuk_table_td('data-label': 'Unique code') do
@@ -219,12 +219,12 @@
               %code
                 quantity
               of over 0 (not required for LGFS)
-              %sup{ style: "font-size: 10px"}
+              %sup.govuk-body-s
                 3
               %br
               %br
               Only claimable on claims with a Graduated case type
-              %sup{ style: "font-size: 10px"}
+              %sup.govuk-body-s
                 2
               %br
               %br
@@ -232,19 +232,19 @@
         = govuk_table_tfoot do
           = govuk_table_row do
             = govuk_table_td('data-label': 'Notes', colspan: '5') do
-              %sup{ style: "font-size: 10px"}
+              %sup.govuk-body-s
                 1
               %code
                 offence_band.offence_category.number
               \. See
               %a{ href: '/api/documentation?v=1#!/api/getApiOffences', target: '_blank' } api/offences
               %br
-              %sup{ style: "font-size: 10px"}
+              %sup.govuk-body-s
                 2
               graduated case types include Trial, Retrial, Cracked Trial and Cracked before retrial. See
               %a{ href: '/api/documentation#!/api/getApiCaseTypes', target: '_blank' } api/case_types
               %br
-              %sup{ style: "font-size: 10px"}
+              %sup.govuk-body-s
                 3
               The number of hours in excess of the first 3 hours
     %li

--- a/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -18,7 +18,7 @@ moj.Helpers.Blocks = {
         if (this.$el.find(selector).is(':visible') === state) {
           return
         }
-        return this.$el.find(selector).css('display', state ? 'block' : 'none')
+        return moj.Helpers.Blocks.setDisplay(this.$el.find(selector), state ? 'block' : 'none')
       }
       throw new Error('Selector did not return an element: ' + selector)
     }
@@ -380,7 +380,7 @@ moj.Helpers.Blocks = {
     this.viewErrorHandler = function (message) {
       const el = this.$el.find('.fx-general-errors')
       el.find('span').text(message)
-      el.css('display', 'inline-block')
+      moj.Helpers.Blocks.setDisplay(el, 'inline-block')
     }
 
     // The location elment is an input or a select
@@ -405,8 +405,8 @@ moj.Helpers.Blocks = {
 
     // Display the input and hide the select
     this.displayLocationInput = function () {
-      this.$el.find('.location_wrapper').css('display', 'block')
-      this.$el.find('.fx-establishment-select').css('display', 'none')
+      moj.Helpers.Blocks.setDisplay(this.$el.find('.location_wrapper'), 'block')
+      moj.Helpers.Blocks.setDisplay(this.$el.find('.fx-establishment-select'), 'none')
       return this
     }
 
@@ -424,10 +424,10 @@ moj.Helpers.Blocks = {
         $detachedSelect.find('option').remove()
         $detachedSelect.append(els.join(''))
 
-        self.$el.find('.fx-establishment-select').css('display', 'block')
+        moj.Helpers.Blocks.setDisplay(self.$el.find('.fx-establishment-select', 'block'))
         self.$el.find('.fx-establishment-select').append($detachedSelect)
 
-        self.$el.find('.location_wrapper').css('display', 'none')
+        moj.Helpers.Blocks.setDisplay(self.$el.find('.location_wrapper'), 'none')
         self.$el.find('.fx-travel-location .has-select label').text(staticdata.locationLabel[locationType] || staticdata.locationLabel.default)
       }, function () {
         throw new Error('Attach options failed:', arguments)
@@ -478,13 +478,7 @@ moj.Helpers.Blocks = {
         'reason',
         'vatAmount'
       ].forEach(function (value, idx) {
-        if (state.config[value]) {
-          $detached.find(self.stateLookup[value]).removeClass('govuk-!-display-none')
-          $detached.find(self.stateLookup[value]).addClass('govuk-!-display-block')
-        } else {
-          $detached.find(self.stateLookup[value]).addClass('govuk-!-display-none')
-          $detached.find(self.stateLookup[value]).removeClass('govuk-!-display-block')
-        }
+        moj.Helpers.Blocks.setDisplay($detached.find(self.stateLookup[value]), state.config[value] ? 'block' : 'none')
 
         // Clear out the value for this input
         if (!state.config[value]) {
@@ -493,10 +487,10 @@ moj.Helpers.Blocks = {
       })
 
       // net amount
-      $detached.find(this.stateLookup.netAmount).css('display', (state.config.netAmount ? 'block' : 'none'))
+      moj.Helpers.Blocks.setDisplay($detached.find(this.stateLookup.netAmount), state.config.netAmount ? 'block' : 'none')
 
       // location
-      $detached.find(this.stateLookup.location).css('display', (state.config.location ? 'block' : 'none'))
+      moj.Helpers.Blocks.setDisplay($detached.find(this.stateLookup.location), state.config.location ? 'block' : 'none')
 
       // remove the location data from the form
       if (!state.config.location) {
@@ -602,13 +596,13 @@ moj.Helpers.Blocks = {
 
     this.setRadioState = function ($dom, config) {
       // Car mileage visibility, radio checked & disabled values
-      $dom.find('.fx-travel-mileage-car').css('display', config.car)
+      moj.Helpers.Blocks.setDisplay($dom.find('.fx-travel-mileage-car'), config.car)
       $dom.find('.fx-travel-mileage-car input').is(function () {
         $(this).prop('disabled', !config.carModel)
       })
 
       // Bike mileage visibility, radio checked & disabled values
-      $dom.find('.fx-travel-mileage-bike').css('display', config.bike)
+      moj.Helpers.Blocks.setDisplay($dom.find('.fx-travel-mileage-bike'), config.bike)
       $dom.find('.fx-travel-mileage-bike input[type=radio]').is(function () {
         $(this).prop('checked', config.bikeModel).prop('disabled', !config.bikeModel).trigger('change')
       })
@@ -727,5 +721,11 @@ moj.Helpers.Blocks = {
     const option = { style: 'currency', currency: 'GBP', minimumFractionDigits: 2 }
     const numberFormat = new Intl.NumberFormat('en', option)
     return numberFormat.format(nStr)
+  },
+  setDisplay: function (el, display) {
+    el.removeClass(function (index, css) {
+      return (css.match(/\bgovuk-!-display-\S+/g) || []).join(' ')
+    })
+    el.addClass(`govuk-!-display-${display}`)
   }
 }

--- a/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
+++ b/app/webpack/javascripts/modules/external_users/claims/BlockHelpers.js
@@ -478,7 +478,13 @@ moj.Helpers.Blocks = {
         'reason',
         'vatAmount'
       ].forEach(function (value, idx) {
-        $detached.find(self.stateLookup[value]).css('display', (state.config[value] ? 'block' : 'none'))
+        if (state.config[value]) {
+          $detached.find(self.stateLookup[value]).removeClass('govuk-!-display-none')
+          $detached.find(self.stateLookup[value]).addClass('govuk-!-display-block')
+        } else {
+          $detached.find(self.stateLookup[value]).addClass('govuk-!-display-none')
+          $detached.find(self.stateLookup[value]).removeClass('govuk-!-display-block')
+        }
 
         // Clear out the value for this input
         if (!state.config[value]) {


### PR DESCRIPTION
Inline style in HTML tags are flagged by the content security policy. Inline `display: none` and `display: block` are replaced with classes provided by GDS.

The block helper is updated to switch the class instead of the inline style.

#### What

#### Ticket

[board ticket description](link)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
