### PR TITLE
CTSKF-305 API Logging bugfix

### DIFF
--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -13,12 +13,13 @@ module API
     end
 
     def after
-      if response_status == '200'
+      return if response_status.nil?
+
+      if response_status.between?(200, 399)
         log_api(:info, 'api-response',
-                { request_id:, path:, status: response_status,
-                  claim_id: response_param('claim_id'), case_number: response_param('case_number'),
-                  id: response_param('id') })
-      elsif response_status
+                { request_id:, path:, status: response_status, claim_id: response_param('claim_id'),
+                  case_number: response_param('case_number'), id: response_param('id') })
+      else
         log_error('api-error',
                   { request_id:, path:, status: response_status }, response_param('error'))
       end
@@ -68,7 +69,7 @@ module API
     def response_status
       return if @app_response.blank?
 
-      @app_response.first.to_s
+      @app_response.first
     end
 
     def response_param(param)

--- a/spec/api/logger_spec.rb
+++ b/spec/api/logger_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe API::Logger do
       end
     end
 
-    context 'when a 200 status code is provided' do
+    shared_examples 'valid response' do
       before do
-        logger.instance_variable_set(:@app_response, [200, '', body])
+        logger.instance_variable_set(:@app_response, [status, '', body])
         allow(LogStuff).to receive(:send)
         logger.after
       end
@@ -148,7 +148,7 @@ RSpec.describe API::Logger do
         let(:empty_payload) do
           { request_id: nil,
             path: nil,
-            status: '200',
+            status:,
             claim_id: nil,
             case_number: nil,
             id: nil }
@@ -174,7 +174,7 @@ RSpec.describe API::Logger do
         let(:payload) do
           { request_id: '123',
             path: 'api/valid/path',
-            status: '200',
+            status:,
             claim_id: '456',
             case_number: '789',
             id: '1' }
@@ -186,6 +186,18 @@ RSpec.describe API::Logger do
                                                         data: payload)
         end
       end
+    end
+
+    context 'when a 200 status code is provided' do
+      let(:status) { 200 }
+
+      include_examples 'valid response'
+    end
+
+    context 'when a 201 status code is provided' do
+      let(:status) { 201 }
+
+      include_examples 'valid response'
     end
 
     context 'when a non-200 status is provided' do
@@ -207,7 +219,7 @@ RSpec.describe API::Logger do
         expect(LogStuff).to have_received(:send).once.with(:error, type: 'api-error',
                                                                    data: { request_id: '123',
                                                                            path: 'api/valid/path',
-                                                                           status: '400' },
+                                                                           status: 400 },
                                                                    error: 'Test error')
       end
     end


### PR DESCRIPTION

#### What
Bugfix for where logger.rb was incorrectly categorising 201 response codes as errors.

#### Ticket

[CTSKF-305](https://dsdmoj.atlassian.net/browse/CTSKF-305)



[CTSKF-305]: https://dsdmoj.atlassian.net/browse/CTSKF-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ