### PR TITLE
[CTSKF-682] Send CSP reports to Slack

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -3,14 +3,13 @@ class CspReportsController < ApplicationController
   skip_forgery_protection
 
   def create
-    # slack_notifier.build_payload(
-    #   icon: ':security:',
-    #   title: 'Content Security Policy violation',
-    #   message: report.map { |key, value| "#{key}: #{value}" }.join("\n"),
-    #   status: :fail
-    # )
-    # slack_notifier.send_message
-    Rails.logger.info("CSP violation: #{report}")
+    slack_notifier.build_payload(
+      icon: ':security:',
+      title: 'Content Security Policy violation',
+      message: report.map { |key, value| "#{key}: #{value}" }.join("\n"),
+      status: :fail
+    )
+    slack_notifier.send_message
 
     head :ok
   end


### PR DESCRIPTION
#### What

Send alerts generated by the Content Security Policy to Slack.

#### Ticket

[CCCD - Configure Rails Content Security Policy](https://dsdmoj.atlassian.net/browse/CTSKF-682)

#### Why

Alerts generated by the Content Security Policy need to be visible. Currently they can only be seen in the log files on the pods. This was done because of the number of alerts being generated by code that will take considerable work to resolve. Now that these have been masked out the alerts can be redirected back to Slack.

#### How

Restore the code in `CspReportController` to send messages to Slack.
