### PR TITLE
[CTSKF-682] Permit wasm-eval in CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
     policy.img_src     :self, :https, :data
     policy.object_src  :none
     # TODO: unsafe_inline should be removed but this cannot be done until some Javascript is refactored.
-    policy.script_src  :self, :unsafe_inline, :https
+    policy.script_src  :self, "'wasm-unsafe-eval'", :unsafe_inline, :https
     policy.style_src   :self, :unsafe_inline, :https
     # Specify URI for violation reports
     policy.report_uri "/csp_report"


### PR DESCRIPTION
#### What

Allow `wasm-eval`.

#### Ticket

[CCCD - Configure Rails Content Security Policy](https://dsdmoj.atlassian.net/browse/CTSKF-682)

#### Why

The content security policy, running in monitor-only mode, is flagging `wasm-eval` alerts. Using the `wasm-unsafe-eval` keyword it is possible to permit this without permitting everything that `unsafe-eval` would. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution

#### How

Add `"'wasm-unsafe-eval'"` to the `script_src` policy.

Notes;
1. there is no mapping in Rails for this keyword, so it is not possible to use `:wasm_unsafe_eval`
2. The single quotes are required for the content security policy