### PR TITLE
Add user agent to CSP alert

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -6,7 +6,7 @@ class CspReportsController < ApplicationController
     slack_notifier.build_payload(
       icon: ':security:',
       title: 'Content Security Policy violation',
-      message: report.map { |key, value| "#{key}: #{value}" }.join("\n"),
+      message: report.map { |key, value| "#{key}: #{value}" }.join("\n") + "\n\nUser agent: #{request.env['HTTP_USER_AGENT']}",
       status: :fail
     )
     slack_notifier.send_message


### PR DESCRIPTION
#### What

Add user agent to the alerts generated by the content security policy.

#### Ticket

N/A

#### Why

The content security policy is set to 'report only'. It is flagging a few issues and it is not clear what is causing this. To diagnose this a [new page has been created in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/CT/pages/4920377359/Summary+of+Content+Security+Policy+alerts+on+CCCD) to record these. To add extra information, this PR adds the user agent to the alert so this can also be recorded.

#### How

Add the user agent, taken from the request to `/csp_report`, to the CSP report message.
