### PR TITLE
Set dependency-type all for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       patterns:
         - "*datatables*"
   open-pull-requests-limit: 5
+  allow:
+    - dependency-type: "all"
   reviewers:
   - "ministryofjustice/laa-claim-for-payment"
 - package-ecosystem: bundler


### PR DESCRIPTION
#### What

Ensure all npm packages are updated by Dependabot.

#### Ticket

N/A

#### Why

The Dependabot configuration allows for different strategies to determine which packages to update. By default only packages that are explicitly listed as dependencies in `package.json` and `Gemfile` are updated. This means that sub-dependencies are missed. The `all` options ensures that all packages are updated. We already have this set for Ruby gems and Github actions but it is not set for NPM packages.

#### How

Add `dependency-type: "all"`.
