### PR TITLE
Remove duplicate step definition

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -173,10 +173,6 @@ And(/^I insert the VCR cassette '(.*?)'(?: and record '(.*?)')?$/) do |name, rec
   end
 end
 
-And(/^pause for (\d+) seconds$/) do |seconds|
-  sleep seconds.to_i
-end
-
 And(/^I eject the VCR cassette$/) do
   VCR.eject_cassette
 end


### PR DESCRIPTION
#### What

Remove the duplication in step definitions.

#### Ticket

N/A

#### Why

The `pause for (\d+) seconds` and `I sleep for {int} seconds` steps are identical and both are not required. Neither is currently used in any tests that are checked in and their purpose is to assist with debugging and development.

#### How

Delete the `pause for (\d+) seconds` step from the step definitions.