### PR TITLE
Increase the number of open dependabot PRs for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     datatables:
       patterns:
         - "*datatables*"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 10
   allow:
     - dependency-type: "all"
   reviewers:


### PR DESCRIPTION
#### What

Increase the limit of PRs that Dependabot can open for NPM packages.

#### Ticket

N/A

#### Why

There are currently a large number of npm packages that queued up for updating after setting `dependency-type: "all"`. This will take some time to run through with 5 PRs per day, particularly as there are two that cannot be merged at the moment. An option is to update all in one go but it is useful to have a relatively staged update.

#### How

Increase the number of PRs that Dependabot can open for npm to 10.
