### PR TITLE
Add edit and delete links

### DIFF
--- a/app/views/external_users/admin/external_users/_edit_delete_links.html.haml
+++ b/app/views/external_users/admin/external_users/_edit_delete_links.html.haml
@@ -1,0 +1,3 @@
+.app-link-group
+  = govuk_link_to t('.edit_html', context: advocate.name), edit_external_users_admin_external_user_path(advocate)
+  = govuk_link_to t('.delete_html', context: advocate.name), external_users_admin_external_user_path(advocate), method: :delete, data: { confirm: t('.confirmation') }

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -39,8 +39,9 @@
 
         = govuk_table_td('data-label': t('.actions')) do
           - if advocate.active? && advocate.enabled?
-            .app-link-group
-              = govuk_link_to t('.edit_html', context: advocate.name), edit_external_users_admin_external_user_path(advocate)
-              = govuk_link_to t('.delete_html', context: advocate.name), external_users_admin_external_user_path(advocate), method: :delete, data: { confirm: t('.confirmation') }
+            = render partial: 'edit_delete_links', locals: { advocate: advocate }
+          - elsif advocate.active? && !advocate.enabled?
+            Inactive
+            = render partial: 'edit_delete_links', locals: { advocate: advocate }
           - else
             Inactive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -740,10 +740,8 @@ en:
           advocates: 'Users'
           add_advocate: 'Add User'
           edit: *edit
-          edit_html: Edit<span class="govuk-visually-hidden"> user %{context}</span>
           email: 'Email'
           delete: *delete
-          delete_html: Delete<span class="govuk-visually-hidden"> user %{context}</span>
           confirm_delete: 'Are you sure?'
           first_name: 'Name'
           last_name: 'Surname'
@@ -756,8 +754,11 @@ en:
           option_no: *global_no
           email_title: Email %{external_user}
           email_confirmation: Email notifications of messages?
-          confirmation: Are you sure?
           table_caption: "%{provider_name} users"
+        edit_delete_links:
+          delete_html: Delete<span class="govuk-visually-hidden"> user %{context}</span>
+          edit_html: Edit<span class="govuk-visually-hidden"> user %{context}</span>
+          confirmation: Are you sure?
         new:
           error: 'error'
           page_heading: Add a new user to %{provider_name}

--- a/features/enable_disable_users.feature
+++ b/features/enable_disable_users.feature
@@ -73,10 +73,44 @@ Feature: Super admin can enable and disable users
     And I should see 'Live, Enabled'
     And I should see link 'Disable account'
 
-  Scenario: Provider admin can identify disabled users
-    Given I am a signed in advocate admin
+  # Provider admin logged in...
+  Scenario: Inactive users with live account
     And an "advocate" user account exists
     And the advocate is disabled
+    Given I am a signed in advocate admin
+    And both users belong to the same firm
+    When I click the link 'Manage users'
+    Then I am on the manage users page
+    And I should see 'Inactive'
+    And I should see link 'Edit'
+    And I should see link 'Delete'
+
+  Scenario: Active user with live account
+    Given an "advocate" user account exists
+    And the advocate is enabled
+    Given I am a signed in advocate admin
+    And both users belong to the same firm
+    When I click the link 'Manage users'
+    Then I am on the manage users page
+    And I should not see 'Inactive'
+    And I should see link 'Edit'
+    And I should see link 'Delete'
+
+  Scenario: Active users with deleted account
+    Given an "advocate" user account exists
+    And the advocate is enabled
+    And the advocate user account is deleted
+    Given I am a signed in advocate admin
+    And both users belong to the same firm
+    When I click the link 'Manage users'
+    Then I am on the manage users page
+    And I should see 'Inactive'
+
+  Scenario: Inactive users with deleted account
+    Given an "advocate" user account exists
+    And the advocate is disabled
+    And the advocate user account is deleted
+    Given I am a signed in advocate admin
     And both users belong to the same firm
     When I click the link 'Manage users'
     Then I am on the manage users page

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -35,6 +35,10 @@ Given(/an? "(.*?)" user account exists$/) do |role|
   instance_variable_set("@#{role.gsub(' ', '_')}", accounts.first)
 end
 
+Given('the advocate user account is deleted')  do
+  @advocate.soft_delete
+end
+
 Given(/^I am a signed in advocate$/) do
   @advocate = @current_user = create(:external_user, :advocate)
   visit new_user_session_path


### PR DESCRIPTION
#### What
Allow provider admin to edit inactive users

#### Ticket

[CCCD - Admin unable to edit inactivate accounts](https://dsdmoj.atlassian.net/browse/CTSKF-822)

#### Why
An account is disabled when it is still live, so that claims can still be created for this user, but the claims are created by another user.

It appears that when an account is disabled then the admin of the user’s provider is also unable to edit this account. As the user still needs to have claims it should be possible for the admin to edit the details, as appropriate.

#### How

Only hide links for inactive users.
