### PR TITLE
Group sentry gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,11 @@ updates:
     sentry:
       patterns:
         - "sentry-*"
+    rails:
+      patterns:
+        - "rails"
+        - "action*"
+        - "active*"
   open-pull-requests-limit: 5
   rebase-strategy: "disabled"
   allow:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,9 @@ updates:
     rubocop:
       patterns:
         - "rubocop*"
+    sentry:
+      patterns:
+        - "sentry-*"
   open-pull-requests-limit: 5
   rebase-strategy: "disabled"
   allow:


### PR DESCRIPTION
#### What

Configure Dependabot to group Sentry and Rails gems.

#### Ticket

N/A

#### Why

In each group the gems are usually all released at the same time to ensure that all version numbers remain the same. Therefore, when there is an update for Sentry there are 3 packages to upgrade and for an upgrade to Rails there are many more. In both cases the upgrades need to be done together.

#### How

```
    sentry:
      patterns:
        - "sentry-*"
    rails:
      patterns:
        - "rails"
        - "action*"
        - "active*"
```
