### PR TITLE
Add consumes option to the Grape configuration

### DIFF
--- a/app/interfaces/api/v1/root.rb
+++ b/app/interfaces/api/v1/root.rb
@@ -31,7 +31,8 @@ module API
         doc_version: 'v1',
         hide_documentation_path: true,
         mount_path: '/api/v1/swagger_doc',
-        hide_format: true
+        hide_format: true,
+        consumes: ['application/json', 'application/x-www-form-urlencoded']
       )
     end
   end

--- a/app/interfaces/api/v2/root.rb
+++ b/app/interfaces/api/v2/root.rb
@@ -37,7 +37,8 @@ module API
         doc_version: 'v2',
         hide_documentation_path: true,
         mount_path: '/api/v2/swagger_doc',
-        hide_format: true
+        hide_format: true,
+        consumes: ['application/json', 'application/x-www-form-urlencoded']
       )
     end
   end


### PR DESCRIPTION
#### What

Add a global `consume` option for Grape.

#### Ticket

N/A

#### Why

See https://github.com/ruby-grape/grape-swagger/pull/872

The `consumes` option allows non-JSON formatted inputs to be accepted. With version 2.1.0 of `grape-swagger` this option is used to determine how the form in the Swagger documentation is displayed and `application/x-www-form-urlencoded` is required to ensure that each field is shown in a form rather than a single free-text field for JSON.

#### How

Add the `consumes` option to the two `root.rb` files.