### PR TITLE
Pass class to serialize as keyword argument

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -12,7 +12,7 @@ module Claim
 
     auto_strip_attributes :case_number, :cms_number, :supplier_number, squish: true, nullify: true
 
-    serialize :evidence_checklist_ids, Array
+    serialize :evidence_checklist_ids, type: Array
 
     attr_reader :form_step
     alias current_step form_step

--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -20,7 +20,7 @@ class ClaimStateTransition < ApplicationRecord
   belongs_to :author, class_name: 'User'
   belongs_to :subject, class_name: 'User'
 
-  serialize :reason_code, Array
+  serialize :reason_code, type: Array
   alias_attribute :reason_codes, :reason_code
 
   def reason

--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -3,7 +3,7 @@ module Roles
 
   included do |klass|
     klass.extend(ClassMethods)
-    klass.serialize :roles, Array
+    klass.serialize :roles, type: Array
     klass.before_validation :strip_empty_role
     klass.validate :roles_valid
 


### PR DESCRIPTION
#### What

Update `serialize` in three places to pass the class as a keyword argument.

#### Ticket

N/A (but related to [CCCD: Upgrade Rails to 7.1](https://dsdmoj.atlassian.net/browse/CTSKF-769))

#### Why

Passing the class as a positional argument is deprecated and will be removed in Rails 7.2.

#### How

Use the `type` keyword argument instead of a positional argument.