### PR TITLE
[CTSKF-766] Set GOVUKDesignSystemFormBuilder::FormBuilder as default

### DIFF
--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -5,7 +5,7 @@
   .govuk-grid-column-two-thirds
     = render partial: 'layouts/header', locals: { page_heading: t('.page_heading') }
 
-= form_with url: case_workers_admin_allocations_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_with url: case_workers_admin_allocations_path, method: :get do |f|
   = f.hidden_field :tab, id: :tab, value: params[:tab]
   = f.hidden_field :filter, id: :filter, value: params[:filter] if params[:filter]
   = f.hidden_field :page, id: :page, value: params[:page]

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -7,12 +7,12 @@
       .govuk-grid-column-two-thirds
         = govuk_error_summary(@allocation, :allocation)
 
-    = form_with url: case_workers_admin_allocations_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with url: case_workers_admin_allocations_path, method: :get do |f|
       = render partial: 'orig_scheme_filters', locals: { f: f }
 
       = render partial: 'shared/search_form', locals: { search_path: case_workers_admin_allocations_path(anchor: 'search-button'), hint_text: t('hint.search'), button_text: t('search.claims') }
 
-    = form_with model: [:case_workers, :admin, @allocation], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with model: [:case_workers, :admin, @allocation] do |f|
       = hidden_field_tag :scheme, params[:scheme]
       = hidden_field_tag :page, params[:page]
 

--- a/app/views/case_workers/admin/case_workers/_form.html.haml
+++ b/app/views/case_workers/admin/case_workers/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:case_workers, :admin, @case_worker], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_with model: [:case_workers, :admin, @case_worker] do |f|
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary
 

--- a/app/views/case_workers/admin/case_workers/change_password.html.haml
+++ b/app/views/case_workers/admin/case_workers/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with model: [:case_workers, :admin, @case_worker], url: update_password_case_workers_admin_case_worker_path do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
@@ -13,7 +13,7 @@
   %p
     = t('unavailable_report', scope: i18n_scope)
 
-= form_with url: case_workers_admin_management_information_create_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_with url: case_workers_admin_management_information_create_path do |f|
   = f.hidden_field :report_type, value: report_object.name
   = f.govuk_date_field :start_at,
                        legend: { text: t('start_date', scope: i18n_scope) },

--- a/app/views/case_workers/admin/management_information/index.html.haml
+++ b/app/views/case_workers/admin/management_information/index.html.haml
@@ -24,7 +24,7 @@
       %h2.govuk-heading-l
         = t('.provisional_assessments_by_date')
 
-      = form_with builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+      = form_with do |f|
         = f.hidden_field :user_api_key, id: :user_api_key, value: @current_user.api_key
 
         %p= t('.report_information')

--- a/app/views/cookies/new.html.haml
+++ b/app/views/cookies/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: @cookies, url: cookies_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: 'post' do |f|
+    = form_with model: @cookies, url: cookies_path, method: 'post' do |f|
       = f.govuk_error_summary
 
       = t('.intro_html')

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: confirmation_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+    = form_with(model: resource, as: resource_name, url: confirmation_path(resource_name), method: :post) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.hidden_field :confirmation_token

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :put) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.hidden_field :reset_password_token

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+    = form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :post) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.govuk_email_field :email, label: { text: t('.email') }, autofocus: true, autocomplete: 'off'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,6 +1,6 @@
 %h2.govuk-heading-m= t('.edit_resource', resource: resource_name.to_s.humanize)
 
-= form_with(model: resource, as: resource_name, url: registration_path(resource_name), method: :put, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+= form_with(model: resource, as: resource_name, url: registration_path(resource_name), method: :put) do |f|
   = f.error_notification
 
   = f.govuk_text_field :email,

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: registration_path(resource_name), builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+    = form_with(model: resource, as: resource_name, url: registration_path(resource_name)) do |f|
       = f.govuk_error_summary
 
       = f.govuk_check_boxes_fieldset :terms_and_conditions,

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+    = form_with(model: resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }) do |f|
       = f.govuk_text_field :email, label: { text: t('.email') }, autofocus: true
       = f.govuk_password_field :password, label: { text: t('.password') }, autocomplete: 'off'
       = f.govuk_submit t('.sign_in')

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with(model: resource, as: resource_name, url: unlock_path(resource_name), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+    = form_with(model: resource, as: resource_name, url: unlock_path(resource_name), method: :post) do |f|
       = render "devise/shared/error_messages", resource: resource
 
       = f.govuk_email_field :email, label: { text: t('.email') }, autofocus: true, autocomplete: 'off'

--- a/app/views/external_users/admin/external_users/_form.html.haml
+++ b/app/views/external_users/admin/external_users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:external_users, :admin, @external_user], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_with model: [:external_users, :admin, @external_user] do |f|
 
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary

--- a/app/views/external_users/admin/external_users/change_password.html.haml
+++ b/app/views/external_users/admin/external_users/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with model: [:external_users, :admin, @external_user], url: update_password_external_users_admin_external_user_path do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: @certification, url: external_users_claim_certification_path(@claim), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with model: @certification, url: external_users_claim_certification_path(@claim) do |f|
       = f.govuk_error_summary
 
       - if @claim.agfs?

--- a/app/views/external_users/claim_types/new.html.haml
+++ b/app/views/external_users/claim_types/new.html.haml
@@ -5,7 +5,7 @@
 
 = render partial: 'external_users/shared/clair_contingency_banner'
 
-= form_with model: @claim_type, url: external_users_claim_types_path, method: 'post', builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_with model: @claim_type, url: external_users_claim_types_path, method: 'post' do |f|
   = f.govuk_error_summary
 
   = f.govuk_radio_buttons_fieldset :claim_type, legend: { text: t('.choose_claim_type_prompt_text'), size: 'xl', tag: 'h1' } do

--- a/app/views/external_users/claims/_form.html.haml
+++ b/app/views/external_users/claims/_form.html.haml
@@ -1,5 +1,5 @@
 #claim-form{ data: { claim_id: @claim.id } }
-  = form_with model: @claim, scope: :claim, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
+  = form_with model: @claim, scope: :claim, html: { novalidate: true }, multipart: true, authenticity_token: true do |f|
 
     = f.hidden_field :form_id, value: @form_id || params[:claim][:form_id]
     = f.hidden_field :form_step, value: @claim.form_step

--- a/app/views/feedback/bug_report.html.haml
+++ b/app/views/feedback/bug_report.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @feedback, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: feedback_index_path, html: { novalidate: 'novalidate' } do |f|
+    = form_for @feedback, url: feedback_index_path, html: { novalidate: 'novalidate' } do |f|
       = f.hidden_field :type
       = f.hidden_field :referrer
 

--- a/app/views/feedback/feedback.html.haml
+++ b/app/views/feedback/feedback.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @feedback, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: feedback_index_path(email: params[:email]), html: { novalidate: 'novalidate' } do |f|
+    = form_for @feedback, url: feedback_index_path(email: params[:email]), html: { novalidate: 'novalidate' } do |f|
       = f.hidden_field :type
       = f.hidden_field :referrer
       = hidden_field_tag 'ga_client_id', '', class: 'ga-client-id'

--- a/app/views/provider_management/external_users/_form.html.haml
+++ b/app/views/provider_management/external_users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:provider_management, @provider, @external_user], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_with model: [:provider_management, @provider, @external_user] do |f|
 
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary

--- a/app/views/provider_management/external_users/change_availability.html.haml
+++ b/app/views/provider_management/external_users/change_availability.html.haml
@@ -9,7 +9,7 @@
     %h2.govuk-heading-m
       = availability_heading(@external_user)
 
-    = form_with model: [:provider_management, @external_user], url: update_availability_provider_management_provider_external_user_path(@provider, @external_user), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with model: [:provider_management, @external_user], url: update_availability_provider_management_provider_external_user_path(@provider, @external_user) do |f|
       = f.hidden_field :availability, value: @external_user.disabled?
 
       .govuk-button-group

--- a/app/views/provider_management/external_users/change_password.html.haml
+++ b/app/views/provider_management/external_users/change_password.html.haml
@@ -6,7 +6,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
 
-    = form_with model: [:provider_management, @external_user], url: update_password_provider_management_provider_external_user_path(@provider, @external_user), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with model: [:provider_management, @external_user], url: update_password_provider_management_provider_external_user_path(@provider, @external_user) do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/provider_management/external_users/find.html.haml
+++ b/app/views/provider_management/external_users/find.html.haml
@@ -4,7 +4,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
 
-    = form_for :external_user, url: provider_management_external_users_find_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_for :external_user, url: provider_management_external_users_find_path do |f|
       = f.govuk_email_field :email,
         label: { text: t('.page_heading'), tag: 'h1', size: 'l' }
 

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -44,7 +44,7 @@
             = govuk_link_button(t('buttons.edit_draft'), edit_polymorphic_path(claim), class: 'edit-claim')
 
             -if claim.from_api? || claim.api_web_edited?
-              = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'evidence_upload'), builder: GOVUKDesignSystemFormBuilder::FormBuilder, multipart: true, authenticity_token: true do |f|
+              = form_for @claim, as: :claim, url:polymorphic_path(claim, anchor: 'evidence_upload'), multipart: true, authenticity_token: true do |f|
                 = f.hidden_field :form_step, value: 'offence_details'
                 = f.hidden_field :form_id, value: @claim.form_id
                 = f.submit t('buttons.add_evidence'), name: 'commit_continue', class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button' }, role: 'button', draggable: 'false'

--- a/app/views/shared/_determinations_form.html.haml
+++ b/app/views/shared/_determinations_form.html.haml
@@ -1,4 +1,4 @@
-= form_for(claim, url: case_workers_claim_path(claim), as: :claim, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f|
+= form_for(claim, url: case_workers_claim_path(claim), as: :claim) do |f|
   = hidden_field_tag :messages, 'true'
   .fx-assesment-hook
     #claim-status
@@ -36,12 +36,12 @@
           // CASEWORKER
           - if current_user_is_caseworker? && @claim.enable_assessment_input?
             // ASSESSMENT INPUT
-            = f.fields_for :assessment, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |af|
+            = f.fields_for :assessment do |af|
               = render partial: 'case_workers/claims/determination_fields', locals: { f: af, claim: claim }
 
           - elsif current_user_is_caseworker? && @claim.enable_determination_input?
             // DETERMINATION INPUT
-            = f.fields_for :redeterminations, claim.redeterminations.build, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |rf|
+            = f.fields_for :redeterminations, claim.redeterminations.build do |rf|
               = render partial: 'case_workers/claims/determination_fields', locals: { f: rf, claim: claim }
 
           - elsif claim.redeterminations.any?

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: message, authenticity_token: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: false) do |f|
+= form_with(model: message, authenticity_token: true, local: false) do |f|
   = f.hidden_field :claim_id, value: @claim.id
 
   = f.govuk_error_summary

--- a/app/views/shared/_search_form.html.haml
+++ b/app/views/shared/_search_form.html.haml
@@ -1,6 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with url: search_path, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with url: search_path, method: :get do |f|
       = f.hidden_field :tab, id: :tab, value: params[:tab]
       = f.hidden_field :sort, id: :sort, value: params[:sort]
       = f.hidden_field :direction, id: :direction, value: params[:direction]

--- a/app/views/shared/providers/_form.html.haml
+++ b/app/views/shared/providers/_form.html.haml
@@ -1,6 +1,6 @@
 = govuk_error_summary(@provider, :provider, presenter: @error_presenter)
 
-= form_with model: @provider, url: form_url, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f|
+= form_with model: @provider, url: form_url, html: { novalidate: true } do |f|
 
   = f.govuk_text_field :name,
     hint: { text: t('.provider_name_hint') },

--- a/app/views/super_admins/admin/super_admins/_form.html.haml
+++ b/app/views/super_admins/admin/super_admins/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [:super_admins, :admin, @super_admin], builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+= form_with model: [:super_admins, :admin, @super_admin] do |f|
   = f.fields_for :user do |user_fields|
     = user_fields.govuk_error_summary
 

--- a/app/views/super_admins/admin/super_admins/change_password.html.haml
+++ b/app/views/super_admins/admin/super_admins/change_password.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_with model: [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f|
+    = form_with model: [:super_admins, :admin, @super_admin], url: update_password_super_admins_admin_super_admin_path do |f|
       = f.fields_for :user do |user_fields|
         = user_fields.govuk_error_summary
 

--- a/app/views/super_admins/stats/show.html.haml
+++ b/app/views/super_admins/stats/show.html.haml
@@ -11,7 +11,7 @@
 
 .govuk-width-container
   .govuk-grid-row
-  = form_with url: super_admins_stats_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: 'post' do |f|
+  = form_with url: super_admins_stats_path, method: 'post' do |f|
     .govuk-grid-column-one-third
       = f.govuk_date_field :date_from, legend: { size: 'm',
                                                  tag: 'h2',

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,5 +64,7 @@ module AdvocateDefencePayments
     config.exceptions_app = self.routes
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
   end
 end


### PR DESCRIPTION
#### What

Set the default form builder to `GOVUKDesignSystemFormBuilder::FormBuilder`.

#### Ticket

[Set GOVUKDesignSystemFormBuilder as the default FormBuilder](https://dsdmoj.atlassian.net/browse/CTSKF-766)

#### Why

All forms have been converted to use the `govuk_design_system_formbuilder` gem and custom form elements have been removed. For consistency with the GovUK Design System all form should now be using `GOVUKDesignSystemFormBuilder::FormBuilder` as their form builder so for simplicity it can be set as the default instead of being explicitly set each time.

#### How

Add

```ruby
  config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
```

to `config/application.rb`. The explicit `builder` option is then removed from all forms.