### PR TITLE
[CTSKF-830] Rake task to create CSV of offence data

### DIFF
--- a/lib/tasks/rake_helpers/rake_utils.rb
+++ b/lib/tasks/rake_helpers/rake_utils.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 module Tasks
   module RakeHelpers
     module RakeUtils
@@ -32,6 +34,13 @@ module Tasks
 
       def production_protected
         raise 'This operation was aborted because the result might destroy production data' if Rails.host.production?
+      end
+
+      def csv_writer(filename, data:, headers: nil)
+        CSV.open(filename, 'w') do |csv|
+          csv << headers if headers
+          data.each { |row| csv << row }
+        end
       end
     end
   end


### PR DESCRIPTION
#### What

Create a rake task to dump all offence data into CSV files.

#### Ticket

[CCCD: Standardise offences across all environments (dev-lgfs)](https://dsdmoj.atlassian.net/browse/CTSKF-830)

#### Why

The offences data on the different environments differ and this can cause confusion with testing. As a first step towards bringing them into line this rake task will allow a copy of the production data to be generated as a CSV file that can then be added, with another rake task (to be written), into other environments.

#### How

The task `rails 'offences:extract[tmp/dumps]'` will create a new directory `tmp/dumps` and save four files from the offences, offence classes, offence bands and offence categories tables.
