### PR TITLE
[CTSKF-930] Rake tasks to fix offence records in the database

### DIFF
--- a/docs/offences_cleanup.md
+++ b/docs/offences_cleanup.md
@@ -63,8 +63,13 @@ records in line with those in the `offences.csv` file created by the
 `offences:extract` task. It is called as:
 
 ```bash
-rails 'offences:fix_ids[tmp/dumps]'
+rails 'offences:fix_ids[tmp/dumps,true]'
 ```
+
+The second argument indicates if changes should be saved in the database
+(`true`) or if a dry run is requied (`false`). The changes are made in a
+single database transaction and for a dry run the transaction is rolled back at
+the end. This argument is optional and defaults to `false`.
 
 The corrections are made in 4 stages;
 

--- a/docs/offences_cleanup.md
+++ b/docs/offences_cleanup.md
@@ -1,0 +1,89 @@
+# Offence Data Cleanup
+
+Over time the offence data across various environments has diverged. Some tools have been created to facilitate reconciling this data.
+
+## Offence Data
+
+Offences in CCCD are stored in the `Offence` model. Each offence record has
+either an `OffenceBand` or an `OffenceClass` depending on the fee scheme. Each
+`OffenceBand` has an `OffenceCategory`.
+
+## `offences:extract` Rake task
+
+The `offences:extract` Rake task fetches all the offences data in the four
+models mentioned above and writes the data into four CSV files; `offence.csv`,
+`band.csv`, `class.csv` and `category.csv`. A directory, specified by the
+single argument to the task, is created to contain these files;
+
+```bash
+rails 'offences:extract[tmp/dumps]'
+```
+
+If the directory already exists then the Rake task will fail.
+
+Running this on a pod in the production environment will create the files that
+can later be used on other environment to check and update.
+
+To copy the files from the production environment pod:
+
+```bash
+kubectl cp cccd-production/<pod>:tmp/dumps/offence.csv offence.csv
+```
+
+Then, to copy the files onto another environment pod:
+
+```bash
+kubectl cp offence.csv cccd-dev-lgfs/<pod>:tmp/dumps/offence.csv
+```
+
+## `offences:check` Rake task
+
+The `offences:check` Rake tasks uses the CSV files created by
+`offences:extract` to check the state of the tables in the current environment.
+
+```bash
+rails 'offences:check[tmp/dumps]'
+```
+
+This will display the number of records in the CSV file and the database table
+for each model, indicating whether they are the same or not. It will then
+display;
+
+* How many records are in the CSV file that are not found in the database
+* How many records in the CSV file can be found in the database but with a
+  different id
+* How many records are in the database that are not found in the CSV file
+
+It will also create a file `output.txt` with details.
+
+## `offences:fix_ids` Rake task
+
+The `offences:fix_ids` Rake task attempts to fix the ids of the `Offence`
+records in line with those in the `offences.csv` file created by the
+`offences:extract` task. It is called as:
+
+```bash
+rails 'offences:fix_ids[tmp/dumps]'
+```
+
+The corrections are made in 4 stages;
+
+1) The first stage works on the list of offences that are found in both the CSV
+   file and the database but have different ids. In the database, the ids of
+   these are changed to an id above the current highest id. These database
+   records are stored for stage 4. Claims linked to these offences are updated
+   accordingly.
+2) The second stage works on the offences that exist in the database but not in
+   the CSV file. These offences are removed.
+3) The third stage works on the offences that exist in the CSV file but not in
+   the database. These offences are created.
+4) The offences that had their ids modified in the first stage are modified
+   again to their correct value. Again, claims linked to these offences are
+   updated accordingly.
+
+The ids of offences are modified in two steps, in stages 1 and 4, to avoid
+failures due to duplicate keys.
+
+***Note:*** The above process is executed in a database transaction so any
+errors will result in no modifications.
+

--- a/lib/tasks/offences.rake
+++ b/lib/tasks/offences.rake
@@ -54,9 +54,11 @@ namespace :offences do
   end
 
   desc 'Fix the ids of offences in the database based on data in a CSV file'
-  task :fix_ids, [:dir] => :environment do |_task, args|
+  task :fix_ids, [:dir, :live_run] => :environment do |_task, args|
+    args.with_defaults(live_run: 'false')
     dir = args.dir
+    live_run = ActiveRecord::Type::Boolean.new.deserialize(args.live_run)
 
-    Tasks::RakeHelpers::FixOffences.new(dir).fix_ids
+    Tasks::RakeHelpers::FixOffences.new(dir, dry_run: !live_run).fix_ids
   end
 end

--- a/lib/tasks/offences.rake
+++ b/lib/tasks/offences.rake
@@ -1,4 +1,5 @@
 require_relative 'rake_helpers/repair_offences'
+require_relative 'rake_helpers/fix_offences'
 require_relative 'rake_helpers/rake_utils'
 require 'fileutils'
 
@@ -43,5 +44,19 @@ namespace :offences do
       data = table[:class].all.sort_by(&:id).pluck(*table[:fields])
       csv_writer(File.expand_path(table[:name], dir), data:, headers: table[:fields])
     end
+  end
+
+  desc 'Check details of offences against data in CSV files'
+  task :check, [:dir] => :environment do |_task, args|
+    dir = args.dir
+
+    Tasks::RakeHelpers::FixOffences.new(dir).check
+  end
+
+  desc 'Fix the ids of offences in the database based on data in a CSV file'
+  task :fix_ids, [:dir] => :environment do |_task, args|
+    dir = args.dir
+
+    Tasks::RakeHelpers::FixOffences.new(dir).fix_ids
   end
 end

--- a/lib/tasks/rake_helpers/fix_offences.rb
+++ b/lib/tasks/rake_helpers/fix_offences.rb
@@ -1,0 +1,148 @@
+require_relative 'rake_utils'
+include Tasks::RakeHelpers::RakeUtils
+
+module Tasks
+  module RakeHelpers
+    class FixOffences      
+      def initialize(dir)
+        @dir = dir
+        @data_sets = [
+          { name: 'categories', class: OffenceCategory, fields: %i[id number description] },
+          { name: 'bands', class: OffenceBand, fields: %i[id number description offence_category_id] },
+          { name: 'classes', class: OffenceClass, fields: %i[id class_letter description] },
+          { name: 'offences', class: Offence, fields: %i[id description offence_class_id unique_code offence_band_id contrary year_chapter] },
+        ]
+      end
+
+      def check
+        @data_sets.each do |set|
+          puts set[:name].capitalize.blue
+          output(set[:name].capitalize)
+          check_counts(set)
+          check_records(set)
+          puts '---------------'
+          output('---------------')
+        end
+      end
+
+      def fix_ids
+        csv_data = CSV.read(File.expand_path('offences.csv', @dir), headers: true)
+        offset = Offence.maximum(:id) + 10000
+        Offence.transaction do
+          puts 'FIRST PASS - Move records with incorrect ids out of range'
+          db_records = []
+          new_records = []
+          ids = []
+
+          csv_data.each do |csv_record|
+            db_record = Offence.find_by(csv_record.to_h.except('id'))
+            if db_record.nil?
+              new_records << csv_record
+            else
+              if db_record.id.to_s != csv_record['id']
+                claims = db_record.claims
+
+                puts "Setting id #{db_record.id} to #{csv_record['id'].to_i + offset}"
+                db_record.id = csv_record['id'].to_i + offset
+                db_record.save
+
+                claims.update_all(offence_id: db_record.id)
+
+                db_records << db_record
+              end
+              ids << db_record.id
+            end
+          end
+
+          puts 'SECOND PASS - Remove extra records'
+          extras = Offence.where.not(id: ids)
+          extras.delete_all
+
+          puts 'THIRD PASS - Add missing records'
+          new_records.each do |record|
+            offence = Offence.new(record.to_h.except('id'))
+            offence.save
+            offence.id = record['id']
+            offence.save
+          end
+
+          puts 'FOURTH PASS - Move records that had incorrect ids into their correct range'
+          db_records.each do |db_record|
+            claims = db_record.claims
+
+            puts "Setting id #{db_record.id} to #{db_record.id - offset}"
+            db_record.id = db_record.id - offset
+            db_record.save
+
+            claims.update_all(offence_id: db_record.id)
+          end
+
+          puts "Count after: #{Offence.count}"
+
+          # This prevents any changes being made.
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      private
+
+      def check_counts(set)
+        csv_data = CSV.read(File.expand_path("#{set[:name]}.csv", @dir), headers: true)
+        puts "Number of #{set[:name]} in CSV file: #{csv_data.count}".yellow
+        puts "Number of #{set[:name]} in database: #{set[:class].count}".yellow
+        puts csv_data.count == set[:class].count ? '  [OK]'.green : '  [MISMATCH]'.red
+      end
+
+      def check_records(set)
+        puts "Matches:".yellow
+        csv_data = CSV.read(File.expand_path("#{set[:name]}.csv", @dir), headers: true)
+
+        missing = []
+        incorrect = []
+        extras = []
+        csv_data.each do |csv_record|
+          db_record = set[:class].find_by(csv_record.to_h.except('id'))
+          if db_record
+            if csv_record['id'] != db_record['id'].to_s
+              incorrect << [csv_record, db_record]
+            end
+            extras << db_record['id']
+          else
+            missing << csv_record
+          end
+        end
+        puts "#{missing.count} records in production not found in this environment".yellow
+        puts "#{incorrect.count} records in production found in this environment with an incorrect id".yellow
+        extras = set[:class].where.not(id: extras)
+        puts "#{extras.count} records in this environment and not in production".yellow
+        output('Missing records:') if missing.count.positive?
+        missing.each do |record|
+          output("#{record['id']}")
+          set[:fields].each do |field|
+            output("  #{field}: #{record[field.to_s]}")
+          end
+        end
+        output()
+        output('Extra records:') if extras.count.positive?
+        extras.each do |record|
+          output("#{record['id']}")
+          set[:fields].each do |field|
+            output("  #{field}: #{record[field.to_s]}")
+          end
+          output("  Number of claims with this offence: #{record.claims.count}")
+        end
+        output()
+        output('Incorrect records:') if incorrect.count.positive?
+        incorrect.each do |record|
+          output("#{record[0]['id']} (CSV) - #{record[1]['id']} (DB)")
+          set[:fields].each do |field|
+            output("  #{field}: #{record[0][field.to_s]}")
+          end
+          output("  Number of claims with this offence: #{record[1].claims.count}")
+        end
+      end
+
+      def output(line='') = File.write(File.expand_path('output.log', @dir), "#{line}\n", mode: 'a+')
+    end
+  end
+end


### PR DESCRIPTION
#### What

Rake tasks to facilitate the correction of offence records in the database.

#### Ticket

[CCCD: Standardise offences across all environments (dev-lgfs)](https://dsdmoj.atlassian.net/browse/CTSKF-830)

#### Why

The offence records in each of the CCCD environments differ and this can cause confusion.

#### How

Three new Rake tasks have been created;

* `offences:extract` (this was created in a previous PR)
* `offences:check`
* `offences:fix_ids`

There is documentation in `docs/offences_cleanup.md` explaining how these are to be used. In summary;

1. `offences:extract` creates CSV files from the `offences` table and related tables. This is run in production to generate a guide for use for the following steps.
2. `offences:check` checks the data in the database against the data in a set of CSV files, generated by step 1.
3. `offences:fix_ids` makes changes to the database to bring it in line with the CSV files. At the moment only the `offences` table is modified.