### PR TITLE
Ctskf 852 cccd spacing between primary and secondary buttons

### DIFF
--- a/app/views/case_workers/admin/management_information/_stats_report.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report.html.haml
@@ -10,10 +10,11 @@
   %p
     = t('unavailable_report', scope: i18n_scope)
 
-- if report_rec&.started_at.present?
-  = govuk_link_button(t('download_html', scope: i18n_scope, report_name: report_name_html),
-                    case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
+.govuk-button-group
+  - if report_rec&.started_at.present?
+    = govuk_link_button(t('download_html', scope: i18n_scope, report_name: report_name_html),
+                      case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
 
-- if report_object.updatable?
-  = govuk_link_button_secondary(t('update_report_html', scope: i18n_scope, report_name: report_name_html),
-                              case_workers_admin_management_information_generate_url(report_type: report_object.name))
+  - if report_object.updatable?
+    = govuk_link_button_secondary(t('update_report_html', scope: i18n_scope, report_name: report_name_html),
+                                case_workers_admin_management_information_generate_url(report_type: report_object.name))

--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -15,8 +15,9 @@
           = govuk_summary_list_row_collection(t('.firm_agfs_supplier_number')) { @provider.firm_agfs_supplier_number }
       = govuk_summary_list_row_collection(t('.vat_registered')) { @provider.vat_registered == true ? t('global_yes') : t('global_no') }
 
-    .app-link-group
-      = button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation'), module: 'govuk-button' }, class: 'govuk-button', draggable: false
+    .govuk-button-group
+      .app-link-group
+        = button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation'), module: 'govuk-button' }, class: 'govuk-button', draggable: false
 
-      - if can? :edit, @provider
-        = govuk_link_button_secondary(t('.edit_provider'), edit_external_users_admin_provider_path(@provider))
+        - if can? :edit, @provider
+          = govuk_link_button_secondary(t('.edit_provider'), edit_external_users_admin_provider_path(@provider))

--- a/app/views/external_users/certifications/new.html.haml
+++ b/app/views/external_users/certifications/new.html.haml
@@ -37,6 +37,6 @@
         maxlength_enabled: true,
         legend: { text: t('.date'), size: 's' },
         form_group: { id: 'certification_date' }
-
-      = f.govuk_submit t('.submit')
-      = govuk_link_button_secondary t('.return'), edit_polymorphic_path(@claim)
+      .govuk-button-group
+        = f.govuk_submit t('.submit')
+        = govuk_link_button_secondary t('.return'), edit_polymorphic_path(@claim)

--- a/app/views/external_users/claim_types/new.html.haml
+++ b/app/views/external_users/claim_types/new.html.haml
@@ -13,5 +13,6 @@
       - claim_type_hint = t(".#{claim_type}_hint_html", default: t(".#{claim_type}_hint", default: ''))
       = f.govuk_radio_button :id, claim_type, label: { text: t(".#{claim_type}_rb") }, hint: { text: claim_type_hint }, link_errors: index.zero?
 
-  = f.govuk_submit t('.continue')
-  = govuk_link_button_secondary t('.cancel'), external_users_root_path
+  .govuk-button-group
+    = f.govuk_submit t('.continue')
+    = govuk_link_button_secondary t('.cancel'), external_users_root_path

--- a/app/views/external_users/claims/buttons/_continue.html.haml
+++ b/app/views/external_users/claims/buttons/_continue.html.haml
@@ -1,6 +1,6 @@
 .form-section
   .form-group.form-buttons.button-holder
     - commit = claim.next_step? ? 'commit_continue' : 'commit_submit_claim'
-    = govuk_button(t('buttons.continue'), id: 'save_continue', name: commit)
-
-    = govuk_button_secondary(t('buttons.save_a_draft'), name: 'commit_save_draft')
+    .govuk-button-group
+      = govuk_button(t('buttons.continue'), id: 'save_continue', name: commit)
+      = govuk_button_secondary(t('buttons.save_a_draft'), name: 'commit_save_draft')

--- a/app/views/external_users/claims/confirmation.html.haml
+++ b/app/views/external_users/claims/confirmation.html.haml
@@ -17,5 +17,6 @@
         = render partial: 'shared/disk_evidence_info', locals: { f: claim }
 
       .button-holder
-        = govuk_link_button(t('link.file_another_claim'), new_external_users_claim_types_path)
-        = govuk_link_button_secondary(t('link.view_claim'), external_users_root_url)
+        .govuk-button-group
+          = govuk_link_button(t('link.file_another_claim'), new_external_users_claim_types_path)
+          = govuk_link_button_secondary(t('link.view_claim'), external_users_root_url)

--- a/app/views/external_users/claims/expenses/_fields.html.haml
+++ b/app/views/external_users/claims/expenses/_fields.html.haml
@@ -8,9 +8,9 @@
     = f.fields_for :expenses do |expense|
       = render 'external_users/claims/expenses/expense_fields', f: expense
 
-  = link_to_add_association t('.add_another_expense'), f, :expenses, partial: 'external_users/claims/expenses/expense_fields', class: 'govuk-button govuk-button--secondary', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.js-cocoon-expenses', module: 'govuk-button' }, role: 'button', draggable: 'false'
-
-  = govuk_link_button_secondary(t('.duplicate'), nil, class: 'fx-duplicate-expense')
+  .govuk-button-group
+    = link_to_add_association t('.add_another_expense'), f, :expenses, partial: 'external_users/claims/expenses/expense_fields', class: 'govuk-button govuk-button--secondary', data: { 'association-insertion-method': 'append', 'association-insertion-node': '.js-cocoon-expenses', module: 'govuk-button' }, role: 'button', draggable: 'false'
+    = govuk_link_button_secondary(t('.duplicate'), nil, class: 'fx-duplicate-expense')
 
   .fx-additional-info
     = render 'external_users/claims/expenses/textarea_additional_info', f: f

--- a/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_fields.html.haml
@@ -12,11 +12,10 @@
           %p
             %em
               = "#{selected_offence.offence_category.description} &gt; #{selected_offence.offence_band.description} &gt; #{selected_offence.description}".html_safe
-
-        .form-group
-          = govuk_button(t('buttons.continue'), name: 'commit_continue')
-
-          = govuk_link_button_secondary(t('clear_selection', scope: "#{locale_scope}.actions"), '#', class: 'fx-clear-selection')
+        .govuk-button-group
+          .form-group
+            = govuk_button(t('buttons.continue'), name: 'commit_continue')
+            = govuk_link_button_secondary(t('clear_selection', scope: "#{locale_scope}.actions"), '#', class: 'fx-clear-selection')
 
 = f.govuk_text_field :offence_search,
   value: nil,

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -79,8 +79,8 @@ class ClaimFormPage < BasePage
 
   element :additional_information, "textarea#claim-additional-information-field"
   element :continue, "div.button-holder > input:nth-of-type(1)"
-  element :submit_to_laa, "div.button-holder > button:nth-of-type(1)" # this maps to Save and continue too
-  element :save_to_drafts, "div.button-holder > button:nth-of-type(2)"
+  element :submit_to_laa, "div.govuk-button-group > button:nth-of-type(1)" # this maps to Save and continue too
+  element :save_to_drafts, "div.govuk-button-group > button:nth-of-type(2)"
 
   sections :errors, "div.error-summary > ul > li" do
     element :message, "a"


### PR DESCRIPTION
#### What
Adds spacing between primary and secondary buttons to the following pages:

- [x] Offence details
- [x] Manage provider
- [x] Confirmation
- [x] Certification
- [x] Supporting evidence
- [x] Travel expenses
- [x] Miscellaneous fees
- [x] Fixed fees
- [x] Defendant details
- [x] Case details
- [x] Choose your bill type
- [x] management_information

#### Ticket

[CCCD- Spacing between primary and secondary buttons](https://dsdmoj.atlassian.net/browse/CTSKF-852)

#### Why
To align with GDS default of 15px

#### How

It uses the `govuk-button-group` component from the gov design system that has a margin-right: -15px. 

On the management information page (caseworker) it displays two buttons `Download` and `Update report`. These either display on their own but also together. Therefore I had to change the sequence of the if statement to add the 'govuk-button-group'

--------

#### TODO (wip)
I could not find this one though. 

- [ ] Disbursements
 