### PR TITLE
Silence CSP alerts for chrome-extensions

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -3,13 +3,15 @@ class CspReportsController < ApplicationController
   skip_forgery_protection
 
   def create
-    slack_notifier.build_payload(
-      icon: ':security:',
-      title: 'Content Security Policy violation',
-      message: report.map { |key, value| "#{key}: #{value}" }.join("\n") + "\n\nUser agent: #{request.env['HTTP_USER_AGENT']}",
-      status: :fail
-    )
-    slack_notifier.send_message
+    unless report['source-file'] == 'chrome-extension'
+      slack_notifier.build_payload(
+        icon: ':security:',
+        title: 'Content Security Policy violation',
+        message: report.map { |key, value| "#{key}: #{value}" }.join("\n") + "\n\nUser agent: #{request.env['HTTP_USER_AGENT']}",
+        status: :fail
+      )
+      slack_notifier.send_message
+    end
 
     head :ok
   end

--- a/spec/requests/csp_report_spec.rb
+++ b/spec/requests/csp_report_spec.rb
@@ -14,12 +14,14 @@ RSpec.describe 'Content Security Policy reports' do
           'blocked-uri': 'ws://example.com:35729/livereload',
           'line-number': 191,
           'column-number': 27,
-          'source-file': 'http://example:com/__rack/livereload.js',
+          'source-file': source_file,
           'status-code': 200,
           'script-sample': ''
         }
       }.to_json
     end
+
+    let(:source_file) { 'http://example:com/__rack/livereload.js' }
 
     before do
       stub_request(:post, 'https://slack').and_return(status: 200)
@@ -34,6 +36,13 @@ RSpec.describe 'Content Security Policy reports' do
       let(:params) { '' }
 
       it { expect(response).to be_successful }
+    end
+
+    context 'when the violation is caused by a chrome extension' do
+      let(:source_file) { 'chrome-extension' }
+
+      it { expect(response).to be_successful }
+      it { expect(a_request(:post, 'https://slack')).not_to have_been_made }
     end
   end
 end


### PR DESCRIPTION
#### What

Silence CSP alerts for chrome-extensions

#### Why

Since introducing a Content Security Policy we have seen a large volume of alerts for CSP violations caused by Chrome extensions (indicated by a `source-file` of `chrome-extension`). This results in a lot of noise in the `laa-cccd-alerts` Slack channel which distracts from other alerts.

#### How

Updates the `CspReportsController` so that Slack notifications are not created and sent when violations are caused by Chrome extensions.