### PR TITLE
Create a helper drop down for miscellaneous fees 

### DIFF
--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -38,4 +38,10 @@ module CaseWorkers::ClaimsHelper
   def claim_count
     session[:claim_count]
   end
+
+  def format_miscellaneous_fee_names(claim)
+    claim.eligible_misc_fee_types.map do |fees|
+      fees.description.split('(')[0].strip
+    end.uniq
+  end
 end

--- a/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_misc_fee_fields.html.haml
@@ -8,6 +8,8 @@
     = link_to_remove_association f, wrapper_class: 'misc-fee-group', class: 'govuk-link govuk-!-display-none fx-numberedList-action' do
       = t('common.remove_html', context: t('.misc_fee'))
 
+    = render partial: 'external_users/claims/misc_fees/advocates/miscellaneous_fees', locals: { claim: claim}
+
     = f.govuk_collection_select :fee_type_id,
       claim.eligible_misc_fee_type_options_for_select.map{ |ft| [ft.first, ft.second, { 'data-unique-code': ft.third[:data][:unique_code] }] },
       :second,

--- a/app/views/external_users/claims/misc_fees/advocates/_miscellaneous_fees.html.haml
+++ b/app/views/external_users/claims/misc_fees/advocates/_miscellaneous_fees.html.haml
@@ -1,0 +1,4 @@
+= govuk_detail t('.type_of_fee_helper') do
+  %ul
+  - format_miscellaneous_fee_names(claim).each do |fee|
+    %li= fee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1483,6 +1483,8 @@ en:
           hint_html: If eligible, go to %{link} to add this to your claim.
           hint_link: miscellaneous fees
         advocates:
+          miscellaneous_fees:
+            type_of_fee_helper: Types of miscellaneous fees you can claim
           fields:
             add_misc_fee: Add another fee
           misc_fee_fields:

--- a/features/claims/advocate/scheme_sixteen/advocate_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_sixteen/advocate_fixed_fee_claim_submit.feature
@@ -43,6 +43,31 @@ Feature: Advocate tries to submit a fee scheme 16 claim for a Fixed fee (Appeal 
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
+    When I click on misc fees helper text
+    Then I should see the following miscellaneous fees listed:
+      | Abuse of process hearings                             |
+      | Application to dismiss a charge                       |
+      | Confiscation hearings                                 |
+      | Deferred sentence hearings                            |
+      | Deferred sentence hearings uplift                     |
+      | Further case management hearing                       |
+      | Ground rules hearing                                  |
+      | Hearings relating to admissibility of evidence        |
+      | Hearings relating to disclosure                       |
+      | Noting brief fee                                      |
+      | Proceeds of crime hearings                            |
+      | Public interest immunity hearings                     |
+      | Research of very unusual or novel factual issue       |
+      | Research of very unusual or novel point of law        |
+      | Sentence hearings                                     |
+      | Sentence hearings uplift                              |
+      | Special preparation fee                               |
+      | Standard appearance fee uplift                        |
+      | Trial not proceed                                     |
+      | Trial not proceed uplift                              |
+      | Unsuccessful application to vacate a guilty plea      |
+      | Wasted preparation fee                                |
+      | Written / oral advice                                 |
 
     Then I click the link 'Back'
     And I should be in the 'Fixed fees' form page

--- a/features/claims/advocate/scheme_sixteen/misc_fee_removal.feature
+++ b/features/claims/advocate/scheme_sixteen/misc_fee_removal.feature
@@ -42,6 +42,31 @@ Feature: Advocate can add and remove fee scheme 16 miscelleaneous fees
 
     Then I click "Continue" in the claim form
     And I should be in the 'Miscellaneous fees' form page
+    When I click on misc fees helper text
+    Then I should see the following miscellaneous fees listed:
+      | Abuse of process hearings                             |
+      | Application to dismiss a charge                       |
+      | Confiscation hearings                                 |
+      | Deferred sentence hearings                            |
+      | Deferred sentence hearings uplift                     |
+      | Further case management hearing                       |
+      | Ground rules hearing                                  |
+      | Hearings relating to admissibility of evidence        |
+      | Hearings relating to disclosure                       |
+      | Noting brief fee                                      |
+      | Proceeds of crime hearings                            |
+      | Public interest immunity hearings                     |
+      | Research of very unusual or novel factual issue       |
+      | Research of very unusual or novel point of law        |
+      | Sentence hearings                                     |
+      | Sentence hearings uplift                              |
+      | Special preparation fee                               |
+      | Standard appearance fee uplift                        |
+      | Trial not proceed                                     |
+      | Trial not proceed uplift                              |
+      | Unsuccessful application to vacate a guilty plea      |
+      | Wasted preparation fee                                |
+      | Written / oral advice                                 |
     And I add a govuk calculated miscellaneous fee 'Abuse of process hearings (half day)' with quantity of '1'
     And I add a govuk calculated miscellaneous fee 'Hearings relating to disclosure (whole day)' with quantity of '1'
     And I click "Continue" in the claim form

--- a/features/page_objects/miscellaneous_fee_page.rb
+++ b/features/page_objects/miscellaneous_fee_page.rb
@@ -1,0 +1,4 @@
+class MiscellaneousFeePage < BasePage
+  set_url /advocates\/claims\/\d+\/edit\\?step=miscellaneous_fees/
+  element :misc_fees_id, '.govuk-details__summary', text: 'Types of miscellaneous fees you can claim'
+end

--- a/features/step_definitions/advocate_claim_steps.rb
+++ b/features/step_definitions/advocate_claim_steps.rb
@@ -120,6 +120,18 @@ Then("the pages of prosecution evidence net amount should be populated with {str
   end
 end
 
+When('I click on misc fees helper text') do
+  @misc_fee_page.misc_fees_id.click
+end
+
+Then("I should see the following miscellaneous fees listed:") do |table|
+  expected_fees = table.raw.flatten
+
+  expected_fees.each do |fee|
+    expect(page).to have_content(fee)
+  end
+end
+
 When(/^I add a calculated miscellaneous fee '(.*?)'(?: with quantity of '(.*?)')?(?: with dates attended\s*(.*))?$/) do |name, quantity, date|
   quantity = quantity.present? ? quantity : '1'
   patiently do

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -36,6 +36,7 @@ Before('not @no-site-prism') do
   @provider_users_change_availability_page = ProviderUsersChangeAvailabilityPage.new
 
   @cookie_page = CookiePage.new
+  @misc_fee_page = MiscellaneousFeePage.new
 end
 
 Before('not @no-seed') do

--- a/spec/helpers/case_workers/claims_helper_spec.rb
+++ b/spec/helpers/case_workers/claims_helper_spec.rb
@@ -112,4 +112,58 @@ describe CaseWorkers::ClaimsHelper do
       expect(helper.claim_count).to eq 3
     end
   end
+
+  describe '#format_miscellaneous_fee_names' do
+    subject { format_miscellaneous_fee_names(claim) }
+
+    let(:claim) { create(:claim) }
+
+    before do
+      allow(claim).to receive(:eligible_misc_fee_types).and_return(fee_type)
+    end
+
+    context 'When there are no eligible fee types' do
+      let(:fee_type) { [] }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'When there are brackets in the fee type description' do
+      let(:fee_type) do
+        [instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (half day)')]
+      end
+
+      it { is_expected.to eq ['Abuse of process hearings'] }
+    end
+
+    context 'When there are multiple fee type descriptions of the same fee' do
+      let(:fee_type) do
+        [
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (half day)'),
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (half day uplift)'),
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (Whole day)'),
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (Whole day uplift)')
+        ]
+      end
+
+      it { is_expected.to eq ['Abuse of process hearings'] }
+    end
+
+    context 'When there are multiple fee type descriptions of different fees' do
+      let(:fee_type) do
+        [
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (half day)'),
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (half day uplift)'),
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (whole day)'),
+          instance_double(Fee::MiscFeeType, description: 'Abuse of process hearings (whole day uplift)'),
+          instance_double(Fee::MiscFeeType, description: 'Application to dismiss a charge (half day)'),
+          instance_double(Fee::MiscFeeType, description: 'Application to dismiss a charge (half day uplift)'),
+          instance_double(Fee::MiscFeeType, description: 'Application to dismiss a charge (whole day)'),
+          instance_double(Fee::MiscFeeType, description: 'Application to dismiss a charge (whole day uplift)')
+        ]
+      end
+
+      it { is_expected.to eq ['Abuse of process hearings', 'Application to dismiss a charge'] }
+    end
+  end
 end


### PR DESCRIPTION
#### What
Showing the AGFS miscellaneous fees available for the user to select.
Using the GDS details component[Details](https://design-system.service.gov.uk/components/details/)

#### Ticket

[CCCD - Reduce the cognitive complexity of selecting AGFS Miscellaneous fees](https://dsdmoj.atlassian.net/browse/CTSKF-495)

#### Why
The list of AGFS miscellaneous fee types is lengthy. There are also multiple versions of each fee in the list e.g. abuse of process hearings (half day), abuse of process hearings (half day uplift) etc. This makes it difficult for users to see all their choices in one glance, can create usability problems, and ultimately lead to users not claiming for eligible fees.

#### How

- Use an existing `govuk_detail` helper method that implements the GDS details component.
- Create a partial that renders the drop down on the miscellaneous fees page. 
- Create a method that uses an existing method `eligible_misc_fee_types` that generates the relevant fees for that user -  format the results to remove brackets and duplication.

For example:
 "Abuse of process hearings (half day)",
 "Abuse of process hearings (half day uplift)",
 "Abuse of process hearings (whole day)",
 "Abuse of process hearings (whole day uplift)"

 To this: 
"Abuse of process hearings"
- Refactor this into a helper method