### PR TITLE
[CTSDK-940] Calculated determination correctly when vat_amount includes commas

### DIFF
--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -16,7 +16,7 @@
 
 class Determination < ApplicationRecord
   include NumberCommaParser
-  numeric_attributes :fees, :expenses, :disbursements
+  numeric_attributes :fees, :expenses, :disbursements, :vat_amount
 
   belongs_to :claim, class_name: 'Claim::BaseClaim'
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -18,6 +18,12 @@ require 'rails_helper'
 RSpec.describe Assessment do
   let(:claim) { create(:claim) }
 
+  describe '#update' do
+    subject { claim.assessment.tap { |assessment| assessment.update(**params) } }
+
+    include_examples 'numeric fields in determinations'
+  end
+
   context 'validations' do
     context 'fees' do
       it 'does not accept negative values' do

--- a/spec/models/redetermination_spec.rb
+++ b/spec/models/redetermination_spec.rb
@@ -18,6 +18,12 @@ require 'rails_helper'
 RSpec.describe Redetermination do
   let(:claim) { create(:claim) }
 
+  describe '#create' do
+    subject { described_class.create(claim:, **params) }
+
+    include_examples 'numeric fields in determinations'
+  end
+
   context 'automatic calculation of total' do
     it 'calculates the total on save' do
       rd = create(:redetermination)

--- a/spec/support/shared_examples/models/shared_examples_for_determination.rb
+++ b/spec/support/shared_examples/models/shared_examples_for_determination.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'numeric fields in determinations' do
+  context 'with a litigator claim' do
+    let(:claim) { create(:litigator_claim) }
+
+    context 'when the fees parameter has a comma' do
+      let(:params) { { fees: '1,000,000' } }
+
+      it { expect(subject.fees).to eq 1_000_000 }
+    end
+
+    context 'when the expenses parameter has a comma' do
+      let(:params) { { expenses: '1,000,000' } }
+
+      it { expect(subject.expenses).to eq 1_000_000 }
+    end
+
+    context 'when the disbursements parameter has a comma' do
+      let(:params) { { disbursements: '1,000,000' } }
+
+      it { expect(subject.disbursements).to eq 1_000_000 }
+    end
+
+    context 'when the vat_amount parameter has a comma' do
+      let(:params) { { vat_amount: '1,000,000' } }
+
+      it { expect(subject.vat_amount).to eq 1_000_000 }
+    end
+  end
+
+  context 'with an advocate claim' do
+    let(:claim) { create(:advocate_claim) }
+
+    context 'when the fees parameter has a comma' do
+      let(:params) { { fees: '1,000,000' } }
+
+      it { expect(subject.fees).to eq 1_000_000 }
+    end
+
+    context 'when the expenses parameter has a comma' do
+      let(:params) { { expenses: '1,000,000' } }
+
+      it { expect(subject.expenses).to eq 1_000_000 }
+    end
+
+    context 'when the disbursements parameter has a comma' do
+      let(:params) { { disbursements: '1,000,000' } }
+
+      it { expect(subject.disbursements).to eq 1_000_000 }
+    end
+
+    context 'when the vat_amount parameter is explicitly set' do
+      let(:params) { { fees: 2121, vat_amount: '1,000,000' } }
+
+      it { expect(subject.vat_amount).to eq 424.20 }
+    end
+  end
+end


### PR DESCRIPTION
#### What

Ensure that VAT added to the determination calculator for LGFS claims are correctly added to the total when submitted.

#### Ticket

[CCCD - VAT truncated in LGFS calculator](https://dsdmoj.atlassian.net/browse/CTSKF-940)

#### Why

Case workers may add figures in the determination calculator with commas for readability, or simply because they are cut-and-pasted from other applications. These should be dealt with in a consistent manner and in a way that does not inconvenience the user. The `vat_amount` value was getting truncated at the first comma but all other fields are interpreted more sensibly.

#### How

Add `vat_amount` to the list of `numeric_attributes` in the `Determination` model.
