### PR TITLE
Govuk frontend deprecation

### DIFF
--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -3,14 +3,6 @@ p {
   @extend %govuk-body-m;
 }
 
-.bold-xsmall {
-  @include govuk-font(14, $weight: bold);
-}
-
-.bold-normal {
-  @include govuk-font(16, $weight: bold);
-}
-
 .unique-id-small {
   @include govuk-font(14);
   display: block;
@@ -56,7 +48,7 @@ p {
     font-weight: 800;
   }
 
-  h2 ~ h2 {
+  h2~h2 {
     margin-top: $govuk-gutter * 2;
   }
 }

--- a/app/webpack/stylesheets/components/_tag.scss
+++ b/app/webpack/stylesheets/components/_tag.scss
@@ -2,39 +2,39 @@
 
 .app-tag--authorised,
 .app-tag--accepted {
-  color: govuk-shade(govuk-colour("green"), 20) !important;
-  background: govuk-tint(govuk-colour("green"), 80) !important;
+  color: govuk-shade(govuk-colour("green"), 20%) !important;
+  background: govuk-tint(govuk-colour("green"), 80%) !important;
 }
 
 .app-tag--allocated {
-  color: govuk-shade(govuk-colour("purple"), 20) !important;
-  background: govuk-tint(govuk-colour("purple"), 80) !important;
+  color: govuk-shade(govuk-colour("purple"), 20%) !important;
+  background: govuk-tint(govuk-colour("purple"), 80%) !important;
 }
 
 .app-tag--draft {
-  color: govuk-shade(govuk-colour("blue"), 30) !important;
-  background: govuk-tint(govuk-colour("blue"), 80) !important;
+  color: govuk-shade(govuk-colour("blue"), 30%) !important;
+  background: govuk-tint(govuk-colour("blue"), 80%) !important;
 }
 
 .app-tag--rejected,
 .app-tag--refused,
 .app-tag--unverified {
-  color: govuk-shade(govuk-colour("red"), 30) !important;
-  background: govuk-tint(govuk-colour("red"), 80) !important;
+  color: govuk-shade(govuk-colour("red"), 30%) !important;
+  background: govuk-tint(govuk-colour("red"), 80%) !important;
 }
 
 .app-tag--archived-pending-delete,
 .app-tag--submitted {
-  color: govuk-shade(govuk-colour("dark-grey"), 30) !important;
-  background: govuk-tint(govuk-colour("dark-grey"), 90) !important;
+  color: govuk-shade(govuk-colour("dark-grey"), 30%) !important;
+  background: govuk-tint(govuk-colour("dark-grey"), 90%) !important;
 }
 
 .app-tag--redermination {
-  color: govuk-shade(govuk-colour("black"), 30) !important;
-  background: govuk-tint(govuk-colour("black"), 80) !important;
+  color: govuk-shade(govuk-colour("black"), 30%) !important;
+  background: govuk-tint(govuk-colour("black"), 80%) !important;
 }
 
 .app-tag--part-authorised {
-  color: govuk-shade(govuk-colour("blue"), 30) !important;
-  background: govuk-tint(govuk-colour("blue"), 80) !important;
+  color: govuk-shade(govuk-colour("blue"), 30%) !important;
+  background: govuk-tint(govuk-colour("blue"), 80%) !important;
 }

--- a/app/webpack/stylesheets/components/_tag.scss
+++ b/app/webpack/stylesheets/components/_tag.scss
@@ -25,8 +25,8 @@
 
 .app-tag--archived-pending-delete,
 .app-tag--submitted {
-  color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30) !important;
-  background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90) !important;
+  color: govuk-shade(govuk-colour("dark-grey"), 30) !important;
+  background: govuk-tint(govuk-colour("dark-grey"), 90) !important;
 }
 
 .app-tag--redermination {


### PR DESCRIPTION
#### What

Fix some deprecation warnings in `rails assets:precomile`.

#### Ticket

N/A

#### Why

Update in line with upstream changes.

#### How

* The `$legacy` argument in `govuk-colour` is deprecated and has no effect.
* 14 is no longer an option for `govuk-font`, as used in `bold-xsmall`. However, `bold-xsmall` is no longer used so it can be removed rather than fixed. Additionally, `bold-normal` is not used so is also removed.
* As in https://github.com/alphagov/govuk-frontend/commit/7a3fa4c893fd06d40c41bbae935fcfe479c7b466, the second argument of `govuk-shade` is changed to a percentage.
