### PR TITLE
Ctskf 497 cccd   reduce the cognitive complexity of uploading files on the supporting evidence page

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -56,3 +56,4 @@ exclude_patterns: # customize
 - script/*
 - Gemfile*
 - scheduled_tasks/*_task.rb
+- app/webpack/javascripts/modules/external_users/claims/Dropzone.js

--- a/app/views/external_users/claims/additional_information/_fields.html.haml
+++ b/app/views/external_users/claims/additional_information/_fields.html.haml
@@ -1,4 +1,4 @@
-%h3.govuk-heading-m{ class: "govuk-!-padding-top-7" }
+%h3.govuk-heading-m{ class: 'govuk-!-margin-bottom-1' }
   = t('.additional_information')
 
 = f.govuk_text_area :additional_information,

--- a/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_disk_evidence.html.haml
@@ -1,4 +1,4 @@
-= f.govuk_radio_buttons_fieldset :disk_evidence, legend: { size: 'm', text: t('disk_evidence.question'),  class: "govuk-!-padding-top-7" } do
+= f.govuk_radio_buttons_fieldset :disk_evidence, legend: { size: 'm', text: t('disk_evidence.question'), class: "govuk-!-padding-top-7" }, class: "govuk-!-margin-bottom-2" do
   = f.govuk_radio_button :disk_evidence, 'true', label: { text: t('global_yes') }, link_errors: true do
     = render partial: 'shared/disk_evidence_info'
   = f.govuk_radio_button :disk_evidence, 'false', label: { text: t('global_no') }

--- a/app/views/external_users/claims/supporting_documents/_new.html.haml
+++ b/app/views/external_users/claims/supporting_documents/_new.html.haml
@@ -8,15 +8,19 @@
   - @claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
     = f.hidden_field :document_ids, multiple: true, value: document.id, id: "claim_document_ids_#{document.id}"
 
-%h3.govuk-heading-m{ class: "govuk-!-padding-top-7" }
-  = t('.upload_supporting_evidence')
+%h3.govuk-heading-m{ class:'govuk-!-static-margin-bottom-2' }
+  = t('.supporting_evidence_docs')
+%span
+  = t('.files accepted')
+%p
+  = t('.maximum_file_size')
 
 = f.govuk_file_field :documents,
-  form_group: { class: 'dropzone' },
+  form_group: { class: 'dropzone govuk-!-static-margin-bottom-4' },
   label: { text: t('.upload_file') },
   multiple: true
 
-= govuk_table(id: 'dropzone-files', class: 'files hidden') do
+= govuk_table(id: 'dropzone-files', class: 'files hidden govuk-!-static-margin-bottom-7') do
   = govuk_table_caption do
     = t('.uploading_docs')
 

--- a/app/views/external_users/claims/supporting_evidence/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_evidence/_summary.html.haml
@@ -3,7 +3,7 @@
     = t('external_users.claims.supporting_evidence_checklist.summary.header')
 
   - if local_assigns[:editable]
-    = govuk_link_to t('common.change_html', context: t('external_users.claims.supporting_evidence_checklist.summary.header')), edit_polymorphic_path(claim, step: :supporting_evidence, referrer: :summary), class: 'link-change'
+    = govuk_link_to t('common.change_html', context: t('external_users.claims.supporting_evidence_checklist.summary.header')), edit_polymorphic_path(claim, step: :supporting_evidence, referrer: :summary), class: 'govuk-!-static-margin-bottom-7 link-change'
 
   - if claim.mandatory_supporting_evidence?
     = govuk_summary_list do

--- a/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
+++ b/app/views/external_users/claims/supporting_evidence_checklist/_fields.html.haml
@@ -1,5 +1,5 @@
 = f.govuk_check_boxes_fieldset :evidence_checklist_ids,
-  form_group: { class: 'cc-evidence-checklist', 'data-mute-indictment': @claim.allows_fixed_fees? ? 'true' : 'false' },
+  form_group: { class: 'cc-evidence-checklist govuk-!-static-margin-bottom-7', 'data-mute-indictment': @claim.allows_fixed_fees? ? 'true' : 'false' },
   hint: { text: t('.supporting_evidence_checklist_hint') },
   legend: { text: t('.supporting_evidence_checklist'), size: 's' } do
 

--- a/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
+++ b/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
@@ -168,13 +168,13 @@ moj.Modules.Dropzone = {
       error: function (xhr, status, error) {
         const fileName = file.name
         if (status === 'timeout') {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red', 'Upload timed out'))
+          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red word-wrap', 'Upload timed out'))
           this.status.html('Upload timed out')
         } else if (error === 'Unprocessable Content') {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red', 'Invalid file type'))
+          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red word-wrap', 'Invalid file type'))
           this.status.html('Invalid file type')
         } else {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red', xhr.responseJSON.error))
+          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red word-wrap', xhr.responseJSON.error))
           this.status.html(fileName + ' ' + xhr.responseJSON.error)
         }
       }.bind(this),

--- a/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
+++ b/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
@@ -13,7 +13,7 @@ moj.Modules.Dropzone = {
       self.setupDropzone()
       self.setupFileInput()
       self.setupStatusBox()
-      $('.files').on('click', '.file-remove', this.onFileRemoveClick.bind(this))
+      $('.files').on('click', '.govuk-link', this.onFileRemoveClick.bind(this))
     }
   },
 
@@ -110,9 +110,9 @@ moj.Modules.Dropzone = {
     html += '<td data-label="Status" class="govuk-table__cell"><span class="' + fileStatus + '">' + fileStatusMsg + '</span></td>'
 
     if (fileId) {
-      html += '<td data-label="Action" class="govuk-table__cell"><a aria-label="Remove document: ' + fileName + '" class="file-remove" data-id="' + fileId + '" data-remote="true" data-method="delete" href="/documents/' + fileId + '" rel="nofollow">Remove</a></td></tr>'
+      html += '<td data-label="Action" class="govuk-table__cell"><a aria-label="Remove document: ' + fileName + '" class="govuk-link" data-id="' + fileId + '" data-remote="true" data-method="delete" href="/documents/' + fileId + '" rel="nofollow">Remove</a></td></tr>'
     } else {
-      html += '<td data-label="Action" class="govuk-table__cell"><a aria-label="Remove document: ' + fileName + '" class="file-remove" href="#dropzone-files" rel="nofollow">Remove</a></td>'
+      html += '<td data-label="Action" class="govuk-table__cell"><a aria-label="Remove document: ' + fileName + '" class="govuk-link" href="#dropzone-files" rel="nofollow">Remove</a></td>'
     }
 
     html += '</tr>'
@@ -129,7 +129,7 @@ moj.Modules.Dropzone = {
     for (let i = 0; i < files.length; i++) {
       if (files[i].size >= 20971520) {
         const tableBody = $('#dropzone-files tbody')
-        tableBody.prepend(this.notificationHTML(files[i].name, 'error', 'File is too big.'))
+        tableBody.prepend(this.notificationHTML(files[i].name, 'govuk-tag govuk-tag--red', 'File too large'))
       } else {
         this.uploadFile(files[i])
       }
@@ -161,18 +161,20 @@ moj.Modules.Dropzone = {
         const fileId = response.document.id
 
         this.createDocumentIdInput(response.document.id)
-        tableRow.replaceWith(this.notificationHTML(fileName, 'success', 'File has been uploaded.', fileId))
+        tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--green', 'Uploaded', fileId))
         this.status.html(response.document.filename + ' has been uploaded.')
       }.bind(this),
 
       error: function (xhr, status, error) {
         const fileName = file.name
-
         if (status === 'timeout') {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'error', 'The server failed to process your file.'))
-          this.status.html('The server failed to process your file.')
+          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red', 'Upload timed out'))
+          this.status.html('Upload timed out')
+        } else if (error === 'Unprocessable Content') {
+          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red', 'Invalid file type'))
+          this.status.html('Invalid file type')
         } else {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'error', xhr.responseJSON.error))
+          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red', xhr.responseJSON.error))
           this.status.html(fileName + ' ' + xhr.responseJSON.error)
         }
       }.bind(this),

--- a/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
+++ b/app/webpack/javascripts/modules/external_users/claims/Dropzone.js
@@ -167,15 +167,18 @@ moj.Modules.Dropzone = {
 
       error: function (xhr, status, error) {
         const fileName = file.name
+        const errorMessage = xhr.responseJSON ? xhr.responseJSON.error : xhr.responseText
+        const govukError = 'govuk-tag govuk-tag--red word-wrap'
+
         if (status === 'timeout') {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red word-wrap', 'Upload timed out'))
+          tableRow.replaceWith(this.notificationHTML(fileName, govukError, 'Upload timed out'))
           this.status.html('Upload timed out')
-        } else if (error === 'Unprocessable Content') {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red word-wrap', 'Invalid file type'))
+        } else if (errorMessage.includes('Unprocessable Content') || errorMessage.includes('invalid content type')) {
+          tableRow.replaceWith(this.notificationHTML(fileName, govukError, 'Invalid file type'))
           this.status.html('Invalid file type')
         } else {
-          tableRow.replaceWith(this.notificationHTML(fileName, 'govuk-tag govuk-tag--red word-wrap', xhr.responseJSON.error))
-          this.status.html(fileName + ' ' + xhr.responseJSON.error)
+          tableRow.replaceWith(this.notificationHTML(fileName, govukError, errorMessage))
+          this.status.html(`${fileName} ${errorMessage}`)
         }
       }.bind(this),
 

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -335,6 +335,10 @@ form {
     word-break: break-word;
   }
 
+  .word-wrap {
+    word-break: normal;
+  }
+
   .success {
     color: govuk-colour("green");
     font-weight: 700;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1604,7 +1604,9 @@ en:
           choose_file: 'Choose a file'
           file_name: "File name"
           upload_file: 'Upload file'
-          supporting_evidence_docs: 'Upload supporting evidence'
+          supporting_evidence_docs: 'Upload files'
+          files accepted: 'Files accepted: pdf, doc, docx, xls, xlsx, rtf, jpeg, png, tiff, bmp'
+          maximum_file_size: 'Maximum file size: 20MB'
           supporting_evidence: Supporting evidence
           file_upload_message: Drag and drop files here
           upload_supporting_evidence: Upload supporting evidence


### PR DESCRIPTION
#### What
Update the upload evidence page for all advocate/litigators journeys to be more GDS compliant and easier to comprehend. Update the page to be more accessible by using up to date components and styles.

- [x] Use GDS tags for the status of the upload  [Tag](https://design-system.service.gov.uk/components/tag/) 
The existing ones have been edited but no new ones have been created - such as 'File to large'
- [x] Use GDS link style for ‘remove’ link [Links](https://design-system.service.gov.uk/styles/links/) 
- [x] Check spacing as per design [CLAIR Taskforce s.28 file](https://www.figma.com/design/ji0NwMxvla3H2x8XhXT4ZN/CLAIR-Taskforce-s.28-file?node-id=1894-1455&t=gGPN5c00Dz8UPsPO-1)

#### Ticket

[CCCD - Reduce the cognitive complexity of uploading files on the supporting evidence page](https://dsdmoj.atlassian.net/browse/CTSKF-497)

#### Why
The current situation takes features from both which is confusing for users. Visually it appears that users can only upload one file, when in fact they are able to drag and drop & upload multiple files at the same time.

#### How


#### TODO (wip)

 - [ ] Replace upload component with MOJ multiple file upload component [Upload files - MoJ Design System](https://design-patterns.service.justice.gov.uk/patterns/upload-files/)
 - [ ] Use  GDS error summary to highlight invalid uploads [Error summary](https://design-system.service.gov.uk/components/error-summary/)
