### PR TITLE
Fix classes on dynamic fields

### DIFF
--- a/app/helpers/external_users/claims_helper.rb
+++ b/app/helpers/external_users/claims_helper.rb
@@ -98,4 +98,10 @@ module ExternalUsers::ClaimsHelper
     return ExpenseType::REASON_SET_A if expense_type.blank?
     expense_type.expense_reasons_hash
   end
+
+  def trial_dates_fields_classes(show)
+    return ['govuk-!-padding-top-7'] if show
+
+    ['govuk-!-padding-top-7', 'hidden']
+  end
 end

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -1,4 +1,4 @@
-#cracked-trial-dates{ class: ['govuk-!-padding-top-7', @claim&.case_type&.requires_cracked_dates? ? nil : 'hidden'] }
+#cracked-trial-dates{ class: trial_dates_fields_classes(@claim&.case_type&.requires_cracked_dates?) }
   %h3.govuk-heading-m
     = t('.cracked_trial_details')
 

--- a/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_cracked_trial_fields.html.haml
@@ -1,4 +1,4 @@
-#cracked-trial-dates{ class: @claim&.case_type&.requires_cracked_dates? ? nil : 'hidden', class: "govuk-!-padding-top-7" }
+#cracked-trial-dates{ class: ['govuk-!-padding-top-7', @claim&.case_type&.requires_cracked_dates? ? nil : 'hidden'] }
   %h3.govuk-heading-m
     = t('.cracked_trial_details')
 

--- a/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
@@ -1,4 +1,4 @@
-#retrial-dates{ class: @claim&.case_type&.requires_retrial_dates? ? nil : 'hidden', class: "govuk-!-padding-top-7" }
+#retrial-dates{ class: ['govuk-!-padding-top-7', @claim&.case_type&.requires_retrial_dates? ? nil : 'hidden']  }
   %h3.govuk-heading-m
     = t('.retrial_detail')
 

--- a/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_retrial_detail_fields.html.haml
@@ -1,4 +1,4 @@
-#retrial-dates{ class: ['govuk-!-padding-top-7', @claim&.case_type&.requires_retrial_dates? ? nil : 'hidden']  }
+#retrial-dates{ class: trial_dates_fields_classes(@claim&.case_type&.requires_retrial_dates?) }
   %h3.govuk-heading-m
     = t('.retrial_detail')
 

--- a/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
@@ -1,4 +1,4 @@
-#trial-dates{ class: @claim&.case_type&.requires_trial_dates? ? nil : 'hidden', class: "govuk-!-padding-top-7" }
+#trial-dates{ class: ['govuk-!-padding-top-7', @claim&.case_type&.requires_trial_dates? ? nil : 'hidden'] }
   %h3.govuk-heading-m
     = t('.trial_detail')
 

--- a/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
+++ b/app/views/external_users/claims/case_details/_trial_detail_fields.html.haml
@@ -1,4 +1,4 @@
-#trial-dates{ class: ['govuk-!-padding-top-7', @claim&.case_type&.requires_trial_dates? ? nil : 'hidden'] }
+#trial-dates{ class: trial_dates_fields_classes(@claim&.case_type&.requires_trial_dates?) }
   %h3.govuk-heading-m
     = t('.trial_detail')
 

--- a/spec/helpers/external_users/claims_helper_spec.rb
+++ b/spec/helpers/external_users/claims_helper_spec.rb
@@ -403,4 +403,20 @@ describe ExternalUsers::ClaimsHelper do
       end
     end
   end
+
+  describe '#trial_dates_fields_classes' do
+    subject { helper.trial_dates_fields_classes(show) }
+
+    context 'when fields to be visible' do
+      let(:show) { true }
+
+      it { is_expected.to contain_exactly('govuk-!-padding-top-7') }
+    end
+
+    context 'when fields not to be visible' do
+      let(:show) { false }
+
+      it { is_expected.to contain_exactly('govuk-!-padding-top-7', 'hidden') }
+    end
+  end
 end


### PR DESCRIPTION
#### What

Ensure trial date fields are hidden and shown correctly.

#### Ticket

N/A

#### Why

An recent adjustment to the styling caused the classes on the trial, retrial and cracked date forms to not be set correctly when the page first loads.

#### How

The element in the HAML file should only have a single `class` field, which may take an array.