### PR TITLE
[CTSKF-941] Update Google Analytics Tags

### DIFF
--- a/.k8s/live/api-sandbox/app-config.yaml
+++ b/.k8s/live/api-sandbox/app-config.yaml
@@ -10,7 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://api-sandbox.claim-crown-court-defence.service.justice.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
-  GA_TRACKER_ID: 'UA-37377084-48'
+  GA_TRACKER_ID: 'G-GK279GHP21'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'

--- a/.k8s/live/dev-lgfs/app-config.yaml
+++ b/.k8s/live/dev-lgfs/app-config.yaml
@@ -10,7 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://dev-lgfs.claim-crown-court-defence.service.justice.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
-  GA_TRACKER_ID: 'UA-37377084-48'
+  GA_TRACKER_ID: 'G-GK279GHP21'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'

--- a/.k8s/live/dev/app-config.yaml
+++ b/.k8s/live/dev/app-config.yaml
@@ -10,7 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://dev.claim-crown-court-defence.service.justice.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
-  GA_TRACKER_ID: 'UA-37377084-48'
+  GA_TRACKER_ID: 'G-GK279GHP21'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'

--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -11,7 +11,6 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://claim-crown-court-defence.service.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
   GA_TRACKER_ID: 'G-MRKGHQ51SQ'
-  GTM_TRACKER_ID: 'GTM-NSB9GWK'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'

--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -10,7 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://claim-crown-court-defence.service.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
-  GA_TRACKER_ID: 'UA-37377084-37'
+  GA_TRACKER_ID: 'G-MRKGHQ51SQ'
   GTM_TRACKER_ID: 'GTM-NSB9GWK'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -11,7 +11,6 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
   GA_TRACKER_ID: 'G-GK279GHP21'
-  GTM_TRACKER_ID: 'GTM-PNZFWQT'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -10,7 +10,7 @@ data:
   RAILS_SERVE_STATIC_FILES: only-presence-required-to-enable
   GRAPE_SWAGGER_ROOT_URL: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
-  GA_TRACKER_ID: 'UA-37377084-48'
+  GA_TRACKER_ID: 'G-GK279GHP21'
   GTM_TRACKER_ID: 'GTM-PNZFWQT'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'

--- a/app/views/layouts/_analytics.js.haml
+++ b/app/views/layouts/_analytics.js.haml
@@ -1,18 +1,16 @@
-- if adapter == :gtm
-  = javascript_tag nonce: true do
-    :plain
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer',"#{ENV['GTM_TRACKER_ID']}");
+= javascript_tag nonce: true do
+  :plain
+    let googleTrackingID = "#{ENV.fetch('GA_TRACKER_ID', nil)}"
 
-- if adapter == :ga
-  = javascript_tag nonce: true do
-    :plain
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', "#{ENV['GA_TRACKER_ID']}", 'auto');
-      ga('set', 'anonymizeIp', true);
+    const analyticsScriptTag = document.createElement('script')
+    analyticsScriptTag.async = ''
+    analyticsScriptTag.src = `https://www.googletagmanager.com/gtag/js?id=${googleTrackingID}`
+    document.head.appendChild(analyticsScriptTag)
+
+    window.dataLayer = window.dataLayer || []
+
+    function gtag() {
+      dataLayer.push(arguments)
+    }
+    gtag('js', new Date())
+    gtag('config', `${googleTrackingID}`)


### PR DESCRIPTION
#### What

Updates the integration with Google Analytics to use Google Analytics tags instead of legacy Universal Analytics tags.

#### Ticket

[CTSKF-941](https://dsdmoj.atlassian.net/browse/CTSKF-941)

#### Why

We probably should have done it when we moved from UA to GA4 last year 😁 

Using the correct tags will prevent inconsistent data and the potential loss of functionality, and may potentially allow us to take advantage of new features.

#### How

* Updates the `GA_TRACKER_ID` value in the `app-config.yaml` file for all environments.
* Updates the javascript in `_analytics.js.haml` to bring it in line with Google Analytics 4. The tags used by GA4 can be used by both Analytics and Google Tag Manager, which means we can replace the existing javascript code for each of those services with a single snippet which functions for both, and remove redundant `GTM_TRACKER_ID`s. See [here](https://support.google.com/tagmanager/answer/12002338?sjid=1675847859540956513-EU#zippy=%2Cset-up-your-google-tag-in-google-tag-manager-instructions) for the Google guidance for this. The solution was heavily borrowed from the [VCD implementation](https://github.com/ministryofjustice/laa-court-data-ui/blob/1bc627ac2a34bc70d7878a3f2e6f6efb82bc5235/app/views/layouts/_google_analytics.haml).

[CTSKF-941]: https://dsdmoj.atlassian.net/browse/CTSKF-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ