### PR TITLE
Only allow patch level dependabot updates for Rails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,16 @@ updates:
   rebase-strategy: "disabled"
   allow:
     - dependency-type: "all"
+  ignore:
+    - dependency-name: "rails"
+      versions:
+        - ">= 7.1"
+    - dependency-name: "active*"
+      versions:
+        - ">= 7.1"
+    - dependency-name: "action*"
+      versions:
+        - ">= 7.1"
   reviewers:
   - "mpw5"
   - "jrmhaig"


### PR DESCRIPTION
#### What

Prevent Dependabot from upgrading Rails beyond 7.0.*

#### Ticket

N/A

#### Why

Major and minor level upgrades of Rails (according to semantic version) are major version upgrades and so require a more detailed process rather than simply installing new gems.

#### How

Add Dependabot configuration to ignore any versions of `rails`, `action*` or `active*` greater than or equal to 7.1.