### PR TITLE
Reinstate one of three time sensitive tests

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -256,12 +256,9 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       let(:refused_at) { 1.week.ago.beginning_of_day + 11.hours + 15.minutes }
       let(:claim) { create(:advocate_final_claim, :authorised) }
 
-      before do
-        pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
-      end
-
       context 'with a completed journey' do
         before do
+          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -279,6 +276,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with an uncompleted journey' do
         before do
+          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -304,6 +302,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       #
       context 'when handling timezones' do
         before do
+          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           create(:advocate_final_claim, :authorised)
         end
 


### PR DESCRIPTION
#### What
Enables MI test which passes during GMT but fails during BST, and vice versa

Note: there are two other similar tests which use claims back-dated 1 week. These will start to fail in a week's time and will need similarly updating.

#### Ticket


N/A

See #5536 