### PR TITLE
Ctskf 473 cccd consolidate evidence table on summary page

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,6 @@
 class Document < ApplicationRecord
   include Duplicable
+  include ActionView::Helpers::NumberHelper
 
   belongs_to :external_user
   belongs_to :creator, class_name: 'ExternalUser'
@@ -61,6 +62,14 @@ class Document < ApplicationRecord
 
   def document_file_size
     document.byte_size if document.attached?
+  end
+
+  def document_file_size_in_kb
+    number_to_human_size(document.byte_size) if document.attached?
+  end
+
+  def document_date_added
+    document.created_at.strftime('%m/%d/%y')
   end
 
   private

--- a/app/validators/representation_order_validator.rb
+++ b/app/validators/representation_order_validator.rb
@@ -87,7 +87,7 @@ class RepresentationOrderValidator < BaseValidator
   end
 
   def earliest_permitted
-    if claim&.lgfs? && claim&.interim?
+    if claim.lgfs? && claim.interim?
       { date: Settings.interim_earliest_permitted_repo_date, error: :not_before_interim_earliest_permitted_date }
     else
       { date: Settings.earliest_permitted_date, error: :not_before_earliest_permitted_date }

--- a/app/views/external_users/claims/supporting_evidence/_summary.html.haml
+++ b/app/views/external_users/claims/supporting_evidence/_summary.html.haml
@@ -5,28 +5,11 @@
   - if local_assigns[:editable]
     = govuk_link_to t('common.change_html', context: t('external_users.claims.supporting_evidence_checklist.summary.header')), edit_polymorphic_path(claim, step: :supporting_evidence, referrer: :summary), class: 'govuk-!-static-margin-bottom-7 link-change'
 
+  - unless @claim.evidence_checklist_ids.empty?
+    = render partial: 'shared/supporting_evidence_checklist', locals: { f: @claim }
+
   - if claim.mandatory_supporting_evidence?
-    = govuk_summary_list do
-      = govuk_summary_list_row_collection( t('shared.summary.disk_evidence') ) { claim.disk_evidence ? t('.answer_yes') : t('.answer_no') }
-      = govuk_summary_list_row_collection( t('shared.summary.disk_evidence_reference') ) { claim.disk_evidence_reference }
-
-      = govuk_summary_list_row_collection( t('shared.summary.supporting_evidence') ) do
-        %ul.govuk-list
-          - claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
-            %li
-              = govuk_link_to document.document_file_name,
-                        download_document_path(document),
-                        class: 'download',
-                        'aria-label': "Download document: #{document.document_file_name}"
-
-      = govuk_summary_list_row_collection( t('shared.summary.supporting_evidence_checklist') ) do
-        %ul.govuk-list
-          - DocType.find_by_ids(claim.evidence_checklist_ids).each do |dt|
-            %li
-              = dt.name
-
-      - if claim.additional_information.present?
-        = govuk_summary_list_row_collection( t('external_users.claims.additional_information.summary.header') ) { format_multiline(claim.additional_information) }
+    = render partial: 'shared/supporting_evidence_uploads', locals: {f: @claim }
 
   - else
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -24,6 +24,7 @@
   %h2.govuk-heading-l
     = t('.h2_evidence')
   .js-accordion__panel
+    = render partial: 'shared/evidence_checklist'
     = render partial: 'shared/evidence_list'
 
   %h2.govuk-heading-l

--- a/app/views/shared/_evidence_checklist.html.haml
+++ b/app/views/shared/_evidence_checklist.html.haml
@@ -1,20 +1,8 @@
-.evidence-checklist-read-only
-  - if @claim.disk_evidence?
+- if @claim.disk_evidence?
+  .evidence-checklist-read-only
     %h3.govuk-heading-m
       = t('.evidence_address')
     = render partial: 'external_users/claims/supporting_documents/laa_address', locals: { f: @claim }
 
-  %h3.govuk-heading-m
-    = t('shared.evidence_checklist.caption')
-  - if current_user.persona.is_a? ExternalUser
-    %p.form-hint
-      = t('.evidence_hint')
-
-  - if @claim.evidence_checklist_ids.empty?
-    %p
-      = t('.no_evidence')
-  - else
-    %ul.govuk-list
-      - DocType.find_by_ids(@claim.evidence_checklist_ids).each do |dt|
-        %li
-          = dt.name
+    - unless @claim.evidence_checklist_ids.empty?
+      = render partial: 'shared/supporting_evidence_checklist', locals: { f: @claim }

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -1,50 +1,10 @@
-= render partial: 'shared/evidence_checklist'
 
 .app-summary-section
-  %h3.govuk-heading-m
-    = t('.existing_evidence')
-
   - if current_user_persona_is?(CaseWorker) && @claim.documents.any?
     = govuk_link_to t('shared.download_all_html', context: t('.existing_evidence')), download_zip_case_workers_claim_path(@claim), class: 'download-all-link'
-
   - if @claim.documents.none?
     %p.govuk-body
-      = t('.no_documents_uploaded')
+      = t('shared.evidence_list.no_supporting_evidence')
 
   - else
-    = govuk_table do
-      = govuk_table_caption(class: 'govuk-visually-hidden') do
-        = t('.caption')
-
-      = govuk_table_thead do
-        = govuk_table_row do
-          = govuk_table_th do
-            = t('.name_of_file')
-
-          = govuk_table_th_numeric do
-            = t('.file_size')
-
-          = govuk_table_th_numeric do
-            = t('.date_added')
-
-          = govuk_table_th_numeric do
-            = t('.actions')
-
-      = govuk_table_tbody do
-        - @claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
-          = govuk_table_row do
-            = govuk_table_td('data-label': t('.name_of_file')) do
-              = document.document_file_name
-
-            = govuk_table_td_numeric('data-label': t('.file_size')) do
-              = number_to_human_size(document.document_file_size)
-
-            = govuk_table_td_numeric('data-label': t('.date_added')) do
-              = document.created_at.strftime(Settings.date_format)
-
-            = govuk_table_td_numeric('data-label': t('.actions')) do
-              .app-link-group
-                - if document.converted_preview_document.present?
-                  = govuk_link_to t('common.view_html', context: "#{document.document_file_name}"), document_path(document)
-
-                = govuk_link_to t('common.download_html', context: "#{document.document_file_name}"), download_document_path(document)
+    = render partial: 'shared/supporting_evidence_uploads', locals: {f: @claim }

--- a/app/views/shared/_supporting_evidence_checklist.html.haml
+++ b/app/views/shared/_supporting_evidence_checklist.html.haml
@@ -1,0 +1,10 @@
+.div.govuk-summary-card
+  .govuk-summary-card__title-wrapper
+    %h2.govuk-summary-card__title= (t('shared.summary.supporting_evidence_checklist'))
+  .govuk-summary-card__content
+    %dl.govuk-summary-list
+      = govuk_summary_list do
+        %ul.remove-margin
+        - DocType.find_by_ids(@claim.evidence_checklist_ids).each do |dt|
+          %li.no-bullets-item.format-supporting-evidence-list
+            = dt.name

--- a/app/views/shared/_supporting_evidence_uploads.html.haml
+++ b/app/views/shared/_supporting_evidence_uploads.html.haml
@@ -1,0 +1,16 @@
+.govuk-summary-card.custom-summary-card
+  .govuk-summary-card__title-wrapper
+    %h2.govuk-summary-card__title= (t('shared.evidence_list.existing_evidence'))
+  .govuk-summary-card__content
+    %dl.govuk-summary-list
+      %div.govuk-summary-list__row
+        %div.govuk-summary-list__key.file-name= (t('shared.evidence_list.file'))
+        %div.govuk-summary-list__key.file-info= (t('shared.evidence_list.file_size'))
+        %div.govuk-summary-list__key.file-info= (t('shared.evidence_list.date_added'))
+
+      - @claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
+        %div.govuk-summary-list__row
+          %div.govuk-summary-list__value.file-name= govuk_link_to document.document_file_name, download_document_path(document)
+          %div.govuk-summary-list__value.file-info= document.document_file_size_in_kb
+          %div.govuk-summary-list__value.file-info= document.document_date_added
+

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -37,6 +37,45 @@
   }
 }
 
+// Formats the row length of the 'Existing evidence' table
+.custom-summary-card .govuk-summary-list__row {
+  display: flex;
+}
+
+.custom-summary-card .govuk-summary-list__key.file-name,
+.custom-summary-card .govuk-summary-list__value.file-name {
+  flex: 3;
+  text-align: left;
+}
+
+.custom-summary-card .govuk-summary-list__key.file-info,
+.custom-summary-card .govuk-summary-list__value.file-info {
+  flex: 1;
+  text-align: right;
+}
+
+.format-supporting-evidence-list {
+  margin-left: 0;
+  padding-top: 0;
+  padding-left: 10px;
+  list-style-type: none;
+}
+
+.download-all-link {
+  display: inline-block;
+  margin-top: 20px;
+  margin-right: 20px;
+  margin-bottom: 10px;
+}
+
+.no-bullets-item {
+  list-style-type: none;
+}
+
+.remove-margin {
+  margin: 0;
+}
+
 #claims-list>li {
   padding: 1rem;
   clear: both;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2171,8 +2171,9 @@ en:
       caption: 'Evidence Provided: A list of uploaded documents'
       summary: 'Note: View and Download links are in 4th column, Actions'
       existing_evidence: Existing evidence
-      no_documents_uploaded: No documents have been uploaded.
-      name_of_file: Name of file
+      download_all: Download all
+      no_supporting_evidence: There is no supporting evidence for this claim
+      file: File
       file_size: File size
       date_added: Date added
       actions: Actions
@@ -2430,7 +2431,7 @@ en:
       additional_information: Additional claim information
       created_by: 'Created by:'
       h2_basic_info: Basic claim information
-      h2_evidence: Evidence
+      h2_evidence: Supporting evidence
       h2_messages: Messages and claim status
       h2_status: Status
       h2_summary: Fees, expenses and more information

--- a/spec/models/claims/cloner_spec.rb
+++ b/spec/models/claims/cloner_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Claims::Cloner do
 
   def representation_orders_for(defendants)
     [].tap do |collection|
-      defendants.each { |d| collection << d.representation_orders }
+      defendants.map { |d| collection << d.representation_orders }
     end.flatten
   end
 end


### PR DESCRIPTION
#### What
Consolidates the three claim summary pages so that the supporting evidence shows the same information in the same format.
Use the updated design ticket. 

[New Designs using summary cards](https://www.figma.com/design/ji0NwMxvla3H2x8XhXT4ZN/CLAIR-Taskforce-s.28-file?node-id=1935-4711&node-type=section&t=GEhm1v3u6gb1nxPH-0)

#### Ticket

[CCCD - Consolidate evidence table on summary page](https://dsdmoj.atlassian.net/browse/CTSKF-473)

#### Why
To make the supporting evidence on all claim summary consistent and remove duplication. 
#### How
[Gov design summary card](https://design-system.service.mod.gov.uk/components/summary-list/)
