### PR TITLE
Roll back uri version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'active_storage_validations'
 gem 'faraday', '~> 2.12'
 gem 'faraday-follow_redirects', '~> 0.3'
 gem 'puma'
+gem 'uri', '< 1.0.0'
 
 group :development, :test do
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -634,7 +634,7 @@ GEM
     tzinfo-data (1.2024.2)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
-    uri (1.0.0)
+    uri (0.13.1)
     utf8-cleaner (1.0.0)
       activesupport
     vcr (6.3.1)
@@ -766,6 +766,7 @@ DEPENDENCIES
   timecop
   tty-spinner
   tzinfo-data
+  uri (< 1.0.0)
   utf8-cleaner (~> 1.0)
   vcr
   webmock


### PR DESCRIPTION
#### What

Rollback the version of the uri gem.

#### Ticket

N/A

#### Why

The document converter job started throwing errors (`uninitialized constant URI::PATTERN (NameError)`) when uri was upgraded to version 1.0.0. Rolling back while investigating.

#### How

Pin `uri` to version < 1.0.0.
