### PR TITLE
Group postcss dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     datatables:
       patterns:
         - "*datatables*"
+    postcss:
+      patterns:
+        - "postcss"
+        - "postcss-*"
   open-pull-requests-limit: 10
   allow:
     - dependency-type: "all"


### PR DESCRIPTION
#### What

Group dependabot updates for postcss related packages.

#### Ticket

N/A

#### Why

Allow related libraries to be updated together and reduce the number of dependabot PRs that are created.

#### How

```yaml
    postcss:
      patterns:
        - "postcss"
        - "postcss-*"
```