### PR TITLE
Format summary page with a summary card

### DIFF
--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -25,6 +25,8 @@ class Defendant < ApplicationRecord
 
   accepts_nested_attributes_for :representation_orders, reject_if: :all_blank, allow_destroy: true
 
+  # Do we still need this name method now we are using first name
+  # and last name on the summary page instead?
   def name
     [first_name, last_name].join(' ').gsub('  ', ' ')
   end

--- a/app/models/offence.rb
+++ b/app/models/offence.rb
@@ -113,4 +113,13 @@ class Offence < ApplicationRecord
   def post_agfs_reform?
     fee_schemes.any? { |fs| fs.name == 'AGFS' && fs.version > FeeScheme::NINE }
   end
+
+  def display_offence_band_or_offence_class
+    "ABC"
+    offence_class
+    offence_band
+     # binding.pry
+    # id = offence_class_id
+    # offence_classes.offence_class_id
+  end
 end

--- a/app/views/external_users/claims/offence_details/_default_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_default_summary.html.haml
@@ -15,12 +15,6 @@
 
       .govuk-summary-list__row.summary-page-table-two-row
         %dt.govuk-summary-list__key
-          =(t('offence_band', scope: claim_fields) )
-        %dd.govuk-summary-list__value
-          = claim.offence ? claim.offence.offence_band : t('general.not_provided')
-
-      .govuk-summary-list__row.summary-page-table-two-row
-        %dt.govuk-summary-list__key
-          =( t('offence_class', scope: claim_fields) )
+          =(t('offence_class', scope: claim_fields) )
         %dd.govuk-summary-list__value
           = claim.offence ? claim.offence.offence_class : t('general.not_provided')

--- a/app/views/external_users/claims/offence_details/_default_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_default_summary.html.haml
@@ -1,6 +1,26 @@
 - claim_fields = %i[external_users claims case_details fields]
 
-= govuk_summary_list_row_collection( t('offence_category', scope: claim_fields) ) { claim.offence ? claim.offence.description : t('general.not_provided') }
+.govuk-summary-card
+  .govuk-summary-card__title-wrapper
+    %h2.govuk-summary-card__title
+      =(t('offence_category', scope: claim_fields) )
 
-= govuk_summary_list_row_collection( t('offence_class', scope: claim_fields) ) do
-  = claim.offence ? claim.offence.offence_class : t('general.not_provided')
+  .govuk-summary-card__content
+    %dl.govuk-summary-list
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          =(t('offence_category', scope: claim_fields) )
+        %dd.govuk-summary-list__value
+          = claim.offence ? claim.offence.description : t('general.not_provided')
+
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          =(t('offence_band', scope: claim_fields) )
+        %dd.govuk-summary-list__value
+          = claim.offence ? claim.offence.offence_band : t('general.not_provided')
+
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          =( t('offence_class', scope: claim_fields) )
+        %dd.govuk-summary-list__value
+          = claim.offence ? claim.offence.offence_class : t('general.not_provided')

--- a/app/views/external_users/claims/offence_details/_fee_reform_summary.html.haml
+++ b/app/views/external_users/claims/offence_details/_fee_reform_summary.html.haml
@@ -3,3 +3,31 @@
 = govuk_summary_list_row_collection( t('offence_class', scope: claim_fields) ) { claim.offence&.offence_category ? claim.offence.offence_category.description : t('general.not_provided') }
 = govuk_summary_list_row_collection( t('offence_band', scope: claim_fields) ) { claim.offence&.offence_band ? claim.offence.offence_band.description : t('general.not_provided') }
 = govuk_summary_list_row_collection( t('offence_category', scope: claim_fields) ) { claim.offence ? claim.offence.description : t('general.not_provided') }
+
+
+.govuk-summary-card
+  .govuk-summary-card__title-wrapper
+    %h2.govuk-summary-card__title
+      =(t('offence_category', scope: claim_fields) )
+
+  .govuk-summary-card__content
+    %dl.govuk-summary-list
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          = t('offence_category', scope: claim_fields)
+        %dd.govuk-summary-list__value
+          = claim.offence ? claim.offence.description : t('general.not_provided')
+
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          = t('offence_band', scope: claim_fields)
+        %dd.govuk-summary-list__value
+          = claim.offence&.offence_band ? claim.offence.offence_band.description : t('general.not_provided')
+
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          = t('offence_class', scope: claim_fields)
+        %dd.govuk-summary-list__value
+          = claim.offence&.offence_category ? claim.offence.offence_category.description : t('general.not_provided')
+
+

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -1,6 +1,3 @@
-- if claim.certification.present?
-  = render partial: 'shared/certification', locals: { claim: claim }
-
 .govuk-summary-card
   .govuk-summary-card__title-wrapper
     %h2.govuk-summary-card__title
@@ -29,18 +26,3 @@
     - if claim&.requires_retrial_dates?
       = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
       = render partial: 'shared/main_hearing_date_details', locals: {claim: claim}
-
-- if claim.defendants.any?
-  %h2.govuk-heading-l
-    = t('external_users.claims.defendants.defendant_fields.defendant_details')
-
-  = render partial: 'shared/claim_defendants', locals: { defendants: claim.defendants }
-
-- else
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      %p.govuk-body
-        = t('.no_defendant')
-
-- unless claim.fixed_fee_case?
-  = render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -1,88 +1,40 @@
 - if claim.certification.present?
   = render partial: 'shared/certification', locals: { claim: claim }
 
-%h3.govuk-heading-m
-  = t('.claim_type')
+.govuk-summary-card
+  .govuk-summary-card__title-wrapper
+    %h2.govuk-summary-card__title
+      = t('shared.claim.claim_type')
 
-= govuk_summary_list do
-  - unless claim.providers_ref.blank?
-    = govuk_summary_list_row_collection('Provider reference number') do
-      = claim.providers_ref
+  .govuk-summary-card__content
+    %dl.govuk-summary-list
 
-  - unless claim.draft?
-    = govuk_summary_list_row_collection('Claim submitted on') do
-      = claim.submitted_at
+    = render partial: 'shared/claim_and_case_type_details', locals: { claim: claim }
 
-  - if claim.case_workers.any? && current_user_is_caseworker? && current_user.persona.admin?
-    = govuk_summary_list_row_collection(t('.assignee')) do
-      = claim.case_worker_names
+    - if claim.agfs? && claim.case_type.present? && claim.requires_cracked_dates?
+      = render partial: 'shared/claim_cracked_trial_details', locals: { claim: claim }
 
-  - if @claim.lgfs?
-    = govuk_summary_list_row_collection(t('common.external_user.claim_creator')) do
-      = claim.creator.name
+    - if claim.case_type && claim.case_concluded_at
+      = render partial: 'shared/claim_case_concluded_at_details', locals: { claim: claim }
 
-  - if @claim.agfs?
-    = govuk_summary_list_row_collection(t("common.external_user.#{@claim.external_user_type}")) do
-      = claim.external_user.name
-    = govuk_summary_list_row_collection(t("common.external_user.category.#{@claim.external_user_type}")) do
-      = claim.advocate_category
+    - if claim.lgfs? && claim.interim? && !claim.interim_fee.nil?
+      = render partial: 'shared/claim_interim_details', locals: { claim: claim }
 
-  = govuk_summary_list_row_collection(t("common.external_user.account_number.#{@claim.external_user_type}")) do
-    = claim.supplier_number
+    - if claim.transfer?
+      = render partial: 'shared/claim_transfer_details', locals: { claim: claim }
 
-  - if claim.court
-    = govuk_summary_list_row_collection(t('common.crown_court')) do
-      = claim.court.name
+    - if claim&.requires_trial_dates?
+      = render partial: 'shared/claim_trial_details', locals: { claim: claim }
 
-  = govuk_summary_list_row_collection(t('.case_num')) do
-    = claim.case_number
-    %span.unique-id-small
-      = claim.unique_id
-
-  - if claim.transfer_court.present?
-    = govuk_summary_list_row_collection(t('common.transfer_court')) do
-      = claim.transfer_court.name
-    = govuk_summary_list_row_collection(t('common.transfer_case_number')) do
-      = claim.transfer_case_number
-
-  - if claim.case_stage
-    = govuk_summary_list_row_collection(t('.case_stage')) do
-      = claim.case_stage&.description
-
-  - if claim.display_case_type?
-    = govuk_summary_list_row_collection(t('.case_type')) do
-      = claim.case_type&.name
-
-  - if claim.discontinuance?
-    = govuk_summary_list_row_collection(t('common.prosecution_evidence')) do
-      = t(claim.prosecution_evidence?.class)
-
-  - if claim.agfs? && claim.case_type.present? && claim.requires_cracked_dates?
-    = render partial: 'shared/claim_cracked_trial_details', locals: { claim: claim }
-
-  - if claim.case_type && claim.case_concluded_at
-    = render partial: 'shared/claim_case_concluded_at_details', locals: { claim: claim }
-
-  - if claim.lgfs? && claim.interim? && !claim.interim_fee.nil?
-    = render partial: 'shared/claim_interim_details', locals: { claim: claim }
-
-  - if claim.transfer?
-    = render partial: 'shared/claim_transfer_details', locals: { claim: claim }
-
-  - if claim&.requires_trial_dates?
-    = render partial: 'shared/claim_trial_details', locals: { claim: claim }
-
-  - if claim&.requires_retrial_dates?
-    = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
-
-  = govuk_summary_list_row_collection(t('common.main_hearing_date')) do
-    = claim.main_hearing_date&.strftime(Settings.date_format)
+    - if claim&.requires_retrial_dates?
+      = render partial: 'shared/claim_retrial_details', locals: { claim: claim }
+      = render partial: 'shared/main_hearing_date_details', locals: {claim: claim}
 
 - if claim.defendants.any?
   %h2.govuk-heading-l
     = t('external_users.claims.defendants.defendant_fields.defendant_details')
 
-  = render partial: 'shared/claim_defendants', locals: {defendants: claim.defendants }
+  = render partial: 'shared/claim_defendants', locals: { defendants: claim.defendants }
 
 - else
   .govuk-grid-row

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -79,12 +79,10 @@
     = claim.main_hearing_date&.strftime(Settings.date_format)
 
 - if claim.defendants.any?
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      %h3.govuk-heading-m
-        = t('.defendants')
+  %h2.govuk-heading-l
+    = t('external_users.claims.defendants.defendant_fields.defendant_details')
 
-    = render partial: 'shared/claim_defendants', locals: {defendants: claim.defendants }
+  = render partial: 'shared/claim_defendants', locals: {defendants: claim.defendants }
 
 - else
   .govuk-grid-row

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -18,8 +18,27 @@
 
   %h2.govuk-heading-l
     = t('.h2_basic_info')
+
+  - if claim.certification.present?
+    = render partial: 'shared/certification', locals: { claim: claim }
+
   .js-accordion__panel
     = render partial: 'shared/claim', locals: { claim: claim, hide_totals: true }
+
+- if claim.defendants.any?
+  %h2.govuk-heading-l
+    = t('external_users.claims.defendants.defendant_fields.defendant_details')
+
+  = render partial: 'shared/claim_defendants', locals: { defendants: claim.defendants }
+
+- else
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body
+        = t('.no_defendant')
+
+- unless claim.fixed_fee_case?
+  = render partial: 'external_users/claims/offence_details/summary', locals: { claim: claim }
 
   %h2.govuk-heading-l
     = t('.h2_evidence')

--- a/app/views/shared/_claim_and_case_type_details.html.haml
+++ b/app/views/shared/_claim_and_case_type_details.html.haml
@@ -1,0 +1,93 @@
+- unless claim.providers_ref.blank?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('shared.claim.provider_reference')
+    %dd.govuk-summary-list__value
+      = claim.providers_ref
+
+- unless claim.draft?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('shared.claim.claim_submitted')
+    %dd.govuk-summary-list__value
+      = claim.submitted_at
+
+- if claim.case_workers.any? && current_user_is_caseworker? && current_user.persona.admin?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('shared.claim.assignee')
+    %dd.govuk-summary-list__value
+      = claim.case_worker_names
+
+- if @claim.lgfs?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('common.external_user.claim_creator')
+    %dd.govuk-summary-list__value
+      = claim.creator.name
+
+- if @claim.agfs?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t("common.external_user.#{@claim.external_user_type}")
+    %dd.govuk-summary-list__value
+      = claim.external_user.name
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t("common.external_user.category.#{@claim.external_user_type}")
+    %dd.govuk-summary-list__value
+      = claim.advocate_category
+
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t("common.external_user.account_number.#{@claim.external_user_type}")
+  %dd.govuk-summary-list__value
+    = claim.supplier_number
+
+- if claim.court
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('common.crown_court')
+    %dd.govuk-summary-list__value
+      = claim.court.name
+
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t('shared.claim.case_num')
+  %dd.govuk-summary-list__value
+    = claim.case_number
+    %span.unique-id-small
+      = claim.unique_id
+
+- if claim.transfer_court.present?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('common.transfer_court')
+    %dd.govuk-summary-list__value
+      = claim.transfer_court.name
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('common.transfer_case_number')
+    %dd.govuk-summary-list__value
+      = claim.transfer_case_number
+
+- if claim.case_stage
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('shared.claim.case_stage')
+    %dd.govuk-summary-list__value
+      = claim.case_stage&.description
+
+- if claim.display_case_type?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('shared.claim.case_type')
+    %dd.govuk-summary-list__value
+      = claim.case_type&.name
+
+- if claim.discontinuance?
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t('common.prosecution_evidence')
+    %dd.govuk-summary-list__value
+      = t(claim.prosecution_evidence?.class)

--- a/app/views/shared/_claim_case_concluded_at_details.html.haml
+++ b/app/views/shared/_claim_case_concluded_at_details.html.haml
@@ -1,4 +1,5 @@
-- cracked_trial_detail_translations = 'external_users.claims.case_details.cracked_trial_fields'
-
-= govuk_summary_list_row_collection(t('external_users.claims.case_details.case_concluded_date.case_concluded_at')) do
-  = claim.case_concluded_at
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t('external_users.claims.case_details.case_concluded_date.case_concluded_at')
+  %dd.govuk-summary-list__value
+    = claim.case_concluded_at

--- a/app/views/shared/_claim_cracked_trial_details.html.haml
+++ b/app/views/shared/_claim_cracked_trial_details.html.haml
@@ -6,14 +6,26 @@
 - else
   - trial_cracked_at_third_key = t("#{cracked_trial_detail_translations}.trial_cracked_at_third.default")
 
-= govuk_summary_list_row_collection(t("#{cracked_trial_detail_translations}.trial_fixed_notice_at")) do
-  = claim.trial_fixed_notice_at.strftime(Settings.date_format) rescue ''
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t("#{cracked_trial_detail_translations}.trial_fixed_notice_at")
+    %dd.govuk-summary-list__value
+      = claim.trial_fixed_notice_at.strftime(Settings.date_format) rescue ''
 
-= govuk_summary_list_row_collection(t("#{cracked_trial_detail_translations}.trial_fixed_at")) do
-  = claim.trial_fixed_at.strftime(Settings.date_format) rescue ''
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t("#{cracked_trial_detail_translations}.trial_fixed_at")
+    %dd.govuk-summary-list__value
+      = claim.trial_fixed_at.strftime(Settings.date_format) rescue ''
 
-= govuk_summary_list_row_collection(t("#{cracked_trial_detail_translations}.trial_cracked_at")) do
-  = claim.trial_cracked_at.strftime(Settings.date_format) rescue ''
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = t("#{cracked_trial_detail_translations}.trial_cracked_at")
+    %dd.govuk-summary-list__value
+      = claim.trial_cracked_at.strftime(Settings.date_format) rescue ''
 
-= govuk_summary_list_row_collection(trial_cracked_at_third_key) do
-  = claim.trial_cracked_at_third.humanize rescue ''
+  .govuk-summary-list__row.summary-page-table-two-row
+    %dt.govuk-summary-list__key
+      = trial_cracked_at_third_key
+    %dd.govuk-summary-list__value
+      = claim.trial_cracked_at_third.humanize rescue ''

--- a/app/views/shared/_claim_defendant_details.html.haml
+++ b/app/views/shared/_claim_defendant_details.html.haml
@@ -1,33 +1,44 @@
-.app-card--defendant
-  %h4.govuk-heading-s
-    = t('.defendant', context: index)
+.govuk-summary-card
+  .govuk-summary-card__title-wrapper
+    %h2.govuk-summary-card__title
+      = t('.defendant', context: index)
 
-  = govuk_summary_list do
-    = govuk_summary_list_row_collection( t('external_users.claims.defendants.defendant_fields.full_name') ) { defendant.name }
+  .govuk-summary-card__content
+    %dl.govuk-summary-list
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          = t('external_users.claims.defendants.defendant_fields.first_name')
+        %dd.govuk-summary-list__value
+          = defendant.first_name
 
-    - if defendant.date_of_birth.present?
-      = govuk_summary_list_row_collection( t('external_users.claims.defendants.defendant_fields.date_of_birth') ) { defendant.date_of_birth.strftime(Settings.date_format) rescue '' }
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          = t('external_users.claims.defendants.defendant_fields.last_name')
+        %dd.govuk-summary-list__value
+          = defendant.last_name
 
-    - unless @claim.lgfs? && @claim.interim?
-      = govuk_summary_list_row_collection( t('external_users.claims.defendants.defendant_fields.judical_apportionment') ) { defendant.order_for_judicial_apportionment == true ? t('global_yes') : t('global_no') }
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          = t('external_users.claims.defendants.defendant_fields.date_of_birth')
+        %dd.govuk-summary-list__value
+          = defendant.date_of_birth.strftime(Settings.date_format) rescue ''
 
+      .govuk-summary-list__row.summary-page-table-two-row
+        %dt.govuk-summary-list__key
+          = t('external_users.claims.defendants.defendant_fields.order_of_judicial_apportionment')
+        %dd.govuk-summary-list__value
+          = defendant.order_for_judicial_apportionment == true ? t('global_yes') : t('global_no')
 
-  - if defendant.representation_orders.any?
-    = govuk_table do
-      = govuk_table_caption do
-        = t('shared.claim.reporders')
+      - if defendant.representation_orders.any?
+        .govuk-summary-list__row.summary-page-table-two-row
+          %dt.govuk-summary-list__key
+            - defendant.representation_orders.each_with_index do |representation_order, index|
+              = "#{t('shared.claim.reporders')} #{index + 1}"
 
-      = govuk_table_thead_collection [t('.date'),
-      t('external_users.claims.defendants.representation_order_fields.maat_reference_number')]
-
-      = govuk_table_tbody do
-        - defendant.representation_orders.each do | representation_order |
-          = govuk_table_row do
-            = govuk_table_td('data-label': t('.date')) do
-              = representation_order.representation_order_date.strftime(Settings.date_format) rescue ''
-
-            = govuk_table_td('data-label': t('external_users.claims.defendants.representation_order_fields.maat_reference_number')) do
-              = representation_order.maat_reference
-
-  - else
-    = govuk_inset_text(t('.no_reporder'))
+              %dd.govuk-summary-list__value.summary-page-values
+                %span #{representation_order.representation_order_date.strftime(Settings.date_format) rescue ''}
+                %span
+                  = t('external_users.claims.defendants.defendant_fields.maat_reference')
+                  #{representation_order.maat_reference }
+      - else
+        = govuk_inset_text(t('.no_reporder'))

--- a/app/views/shared/_claim_defendants.html.haml
+++ b/app/views/shared/_claim_defendants.html.haml
@@ -1,3 +1,2 @@
 - defendants.each_with_index do | defendant, index |
-  .govuk-grid-column-one-half
     = render partial: 'shared/claim_defendant_details', locals: { defendant: present(defendant, CaseWorkers::DefendantPresenter), index: index += 1 }

--- a/app/views/shared/_claim_interim_details.html.haml
+++ b/app/views/shared/_claim_interim_details.html.haml
@@ -1,42 +1,75 @@
 - fee = present(claim.interim_fee)
 
-= govuk_summary_list_row_collection(t('shared.summary.fee_type')) do
-  = fee.fee_type.description
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t('shared.summary.fee_type')
+  %dd.govuk-summary-list__value
+    = fee.fee_type.description
 
 - if fee.is_interim_warrant?
-  = govuk_summary_list_row_collection(t('shared.summary.warrant_fee.date_issued')) do
-    = fee.warrant_issued_date
+  %dl.govuk-summary-list
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.warrant_fee.date_issued')
+      %dd.govuk-summary-list__value
+        = fee.warrant_issued_date
 
 - if fee.warrant_executed_date.present?
-  = govuk_summary_list_row_collection(t('shared.summary.warrant_fee.date_executed')) do
-    = fee.warrant_executed_date
-
+  %dl.govuk-summary-list
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.warrant_fee.date_executed')
+      %dd.govuk-summary-list__value
+        = fee.warrant_executed_date
 - else
   - unless fee.is_disbursement?
-    = govuk_summary_list_row_collection(t('shared.summary.ppe_total')) do
-      = fee.quantity
-
-    - if fee.is_effective_pcmh?
-      = govuk_summary_list_row_collection(t('shared.summary.effective_pcmh_date')) do
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.ppe_total')
+      %dd.govuk-summary-list__value
+        = fee.quantity
+  - if fee.is_effective_pcmh?
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.effective_pcmh_date')
+      %dd.govuk-summary-list__value
         = fee.effective_pcmh_date
 
-- if fee.is_trial_start?
-  = govuk_summary_list_row_collection(t('shared.summary.trial_start')) do
-    = fee.first_day_of_trial
+  - if fee.is_trial_start?
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.trial_start')
+      %dd.govuk-summary-list__value
+        = fee.first_day_of_trial
 
-  = govuk_summary_list_row_collection(t('shared.summary.estimated_trial_length')) do
-    = fee.estimated_trial_length
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.estimated_trial_length')
+      %dd.govuk-summary-list__value
+        = fee.estimated_trial_length
 
-- if fee.is_retrial_start?
-  = govuk_summary_list_row_collection(t('shared.summary.retrial_start')) do
-    = fee.retrial_started_at
+  - if fee.is_retrial_start?
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.retrial_start')
+      %dd.govuk-summary-list__value
+        = fee.retrial_started_at
 
-  = govuk_summary_list_row_collection(t('shared.summary.estimated_retrial_length')) do
-    = fee.retrial_estimated_length
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.estimated_retrial_length')
+      %dd.govuk-summary-list__value
+        = fee.retrial_estimated_length
 
-- if fee.is_retrial_new_solicitor?
-  = govuk_summary_list_row_collection(t('shared.summary.legal_aid_transfer_date')) do
-    = fee.legal_aid_transfer_date
+  - if fee.is_retrial_new_solicitor?
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.legal_aid_transfer_date')
+      %dd.govuk-summary-list__value
+        = fee.legal_aid_transfer_date
 
-  = govuk_summary_list_row_collection(t('shared.summary.trial_concluded_at')) do
-    = fee.trial_concluded_at
+    .govuk-summary-list__row.summary-page-table-two-row
+      %dt.govuk-summary-list__key
+        = t('shared.summary.trial_concluded_at')
+      %dd.govuk-summary-list__value
+        = fee.trial_concluded_at

--- a/app/views/shared/_claim_retrial_details.html.haml
+++ b/app/views/shared/_claim_retrial_details.html.haml
@@ -1,16 +1,32 @@
 - retrial_i18n_scope = %i[external_users claims case_details retrial_detail_fields]
 
-= govuk_summary_list_row_collection(t('retrial_started_at', scope: retrial_i18n_scope)) do
-  = claim&.retrial_started_at&.strftime(Settings.date_format)
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    =t('retrial_started_at', scope: retrial_i18n_scope)
+  %dd.govuk-summary-list__value
+    = claim&.retrial_started_at&.strftime(Settings.date_format)
 
-= govuk_summary_list_row_collection(t('retrial_estimated_length', scope: retrial_i18n_scope)) do
-  = claim&.retrial_estimated_length
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t('retrial_estimated_length', scope: retrial_i18n_scope)
+  %dd.govuk-summary-list__value
+    = claim&.retrial_estimated_length
 
-= govuk_summary_list_row_collection(t('retrial_actual_length', scope: retrial_i18n_scope)) do
-  = claim&.retrial_actual_length
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    =  t('retrial_actual_length', scope: retrial_i18n_scope)
+  %dd.govuk-summary-list__value
+    = claim&.retrial_actual_length
 
-= govuk_summary_list_row_collection(t('retrial_concluded_at', scope: retrial_i18n_scope)) do
-  = claim&.retrial_concluded_at&.strftime(Settings.date_format)
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    =  t('retrial_concluded_at', scope: retrial_i18n_scope)
+  %dd.govuk-summary-list__value
+    = claim&.retrial_concluded_at&.strftime(Settings.date_format)
 
-= govuk_summary_list_row_collection(t('retrial_reduction', scope: retrial_i18n_scope)) do
-  = claim&.retrial_reduction? ? 'Yes' : 'No'
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    =  t('retrial_reduction', scope: retrial_i18n_scope)
+  %dd.govuk-summary-list__value
+    = claim&.retrial_reduction? ? 'Yes' : 'No'
+

--- a/app/views/shared/_claim_trial_details.html.haml
+++ b/app/views/shared/_claim_trial_details.html.haml
@@ -1,13 +1,25 @@
 - trial_detail_translations = 'external_users.claims.case_details.trial_detail_fields'
 
-= govuk_summary_list_row_collection(t("#{trial_detail_translations}.first_day_of_trial")) do
-  = claim.first_day_of_trial.strftime(Settings.date_format) rescue ''
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t("#{trial_detail_translations}.first_day_of_trial")
+  %dd.govuk-summary-list__value
+    = claim.first_day_of_trial.strftime(Settings.date_format) rescue ''
 
-= govuk_summary_list_row_collection(t("#{trial_detail_translations}.estimated_trial_length")) do
-  = claim.estimated_trial_length rescue ''
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t("#{trial_detail_translations}.estimated_trial_length")
+  %dd.govuk-summary-list__value
+    = claim.estimated_trial_length rescue ''
 
-= govuk_summary_list_row_collection(t("#{trial_detail_translations}.actual_trial_length")) do
-  = claim.actual_trial_length rescue ''
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t("#{trial_detail_translations}.actual_trial_length")
+  %dd.govuk-summary-list__value
+    = claim.estimated_trial_length rescue ''
 
-= govuk_summary_list_row_collection(t("#{trial_detail_translations}.trial_concluded_at")) do
-  = claim.trial_concluded_at.strftime(Settings.date_format) rescue ''
+.govuk-summary-list__row.summary-page-table-two-row
+  %dt.govuk-summary-list__key
+    = t("#{trial_detail_translations}.trial_concluded_at")
+  %dd.govuk-summary-list__value
+    = claim.trial_concluded_at.strftime(Settings.date_format) rescue ''

--- a/app/views/shared/_evidence_checklist.html.haml
+++ b/app/views/shared/_evidence_checklist.html.haml
@@ -4,17 +4,14 @@
       = t('.evidence_address')
     = render partial: 'external_users/claims/supporting_documents/laa_address', locals: { f: @claim }
 
-  %h3.govuk-heading-m
-    = t('shared.evidence_checklist.caption')
-  - if current_user.persona.is_a? ExternalUser
-    %p.form-hint
-      = t('.evidence_hint')
-
-  - if @claim.evidence_checklist_ids.empty?
-    %p
-      = t('.no_evidence')
-  - else
-    %ul.govuk-list
-      - DocType.find_by_ids(@claim.evidence_checklist_ids).each do |dt|
-        %li
-          = dt.name
+  - unless @claim.evidence_checklist_ids.empty?
+    .govuk-summary-card
+      .govuk-summary-card__title-wrapper
+        %h2.govuk-summary-card__title= (t('shared.evidence_checklist.caption'))
+      .govuk-summary-card__content
+        %dl.govuk-summary-list
+          = govuk_summary_list do
+            %ul.remove-margin
+            - DocType.find_by_ids(@claim.evidence_checklist_ids).each do |dt|
+              %li.no-bullets-item.format-supporting-evidence-list
+                = dt.name

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -1,50 +1,26 @@
 = render partial: 'shared/evidence_checklist'
 
 .app-summary-section
-  %h3.govuk-heading-m
-    = t('.existing_evidence')
-
   - if current_user_persona_is?(CaseWorker) && @claim.documents.any?
     = govuk_link_to t('shared.download_all_html', context: t('.existing_evidence')), download_zip_case_workers_claim_path(@claim), class: 'download-all-link'
 
   - if @claim.documents.none?
     %p.govuk-body
-      = t('.no_documents_uploaded')
+      = t('shared.evidence_list.no_supporting_evidence')
 
   - else
-    = govuk_table do
-      = govuk_table_caption(class: 'govuk-visually-hidden') do
-        = t('.caption')
+  .govuk-summary-card.custom-summary-card
+    .govuk-summary-card__title-wrapper
+      %h2.govuk-summary-card__title=t('.existing_evidence')
+    .govuk-summary-card__content
+      %dl.govuk-summary-list
+        .govuk-summary-list__row
+          .govuk-summary-list__key.file-name= t('.name_of_file')
+          .govuk-summary-list__key.file-info= t('.file_size')
+          .govuk-summary-list__key.file-info= t('.date_added')
 
-      = govuk_table_thead do
-        = govuk_table_row do
-          = govuk_table_th do
-            = t('.name_of_file')
-
-          = govuk_table_th_numeric do
-            = t('.file_size')
-
-          = govuk_table_th_numeric do
-            = t('.date_added')
-
-          = govuk_table_th_numeric do
-            = t('.actions')
-
-      = govuk_table_tbody do
         - @claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
-          = govuk_table_row do
-            = govuk_table_td('data-label': t('.name_of_file')) do
-              = document.document_file_name
-
-            = govuk_table_td_numeric('data-label': t('.file_size')) do
-              = number_to_human_size(document.document_file_size)
-
-            = govuk_table_td_numeric('data-label': t('.date_added')) do
-              = document.created_at.strftime(Settings.date_format)
-
-            = govuk_table_td_numeric('data-label': t('.actions')) do
-              .app-link-group
-                - if document.converted_preview_document.present?
-                  = govuk_link_to t('common.view_html', context: "#{document.document_file_name}"), document_path(document)
-
-                = govuk_link_to t('common.download_html', context: "#{document.document_file_name}"), download_document_path(document)
+          .govuk-summary-list__row
+            .govuk-summary-list__value.file-name= govuk_link_to document.document_file_name, download_document_path(document)
+            .govuk-summary-list__value.file-info= number_to_human_size(document.document_file_size)
+            .govuk-summary-list__value.file-info= document.created_at.strftime(Settings.date_format)

--- a/app/views/shared/_evidence_list.html.haml
+++ b/app/views/shared/_evidence_list.html.haml
@@ -6,7 +6,7 @@
 
   - if @claim.documents.none?
     %p.govuk-body
-      = t('shared.evidence_list.no_supporting_evidence')
+      = t('.no_supporting_evidence')
 
   - else
   .govuk-summary-card.custom-summary-card

--- a/app/views/shared/_main_hearing_date_details.html.haml
+++ b/app/views/shared/_main_hearing_date_details.html.haml
@@ -1,5 +1,5 @@
 .govuk-summary-list__row.summary-page-table-two-row
   %dt.govuk-summary-list__key
-    = t('common.transfer_detail_summary')
+    = t('common.main_hearing_date')
   %dd.govuk-summary-list__value
-    = t('common.transfer_date')
+    = claim.main_hearing_date&.strftime(Settings.date_format)

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -501,3 +501,28 @@ form {
 .error {
   color: $govuk-error-colour;
 }
+
+
+// Format 'Existing evidence' table
+.custom-summary-card .govuk-summary-list__row {
+  display: flex;
+}
+
+.custom-summary-card .govuk-summary-list__key.file-name,
+.custom-summary-card .govuk-summary-list__value.file-name {
+  flex: 3;
+  text-align: left;
+}
+
+.custom-summary-card .govuk-summary-list__key.file-info,
+.custom-summary-card .govuk-summary-list__value.file-info {
+  flex: 1;
+  text-align: right;
+}
+
+.download-all-link {
+  display: inline-block;
+  margin-top: 20px;
+  margin-right: 20px;
+  margin-bottom: 10px;
+}

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -520,6 +520,11 @@ form {
   text-align: right;
 }
 
+.summary-page-values {
+  display: flex;
+  flex-direction: column;
+}
+
 .download-all-link {
   display: inline-block;
   margin-top: 20px;

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -526,3 +526,11 @@ form {
   margin-right: 20px;
   margin-bottom: 10px;
 }
+
+.no-bullets-item {
+  list-style-type: none;
+}
+
+.remove-margin {
+  margin: 0;
+}

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -534,3 +534,18 @@ form {
 .remove-margin {
   margin: 0;
 }
+
+.summary-page-table-two-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.summary-page-table-two-row .govuk-summary-list__key {
+  flex: 1;
+}
+
+.summary-page-table-two-row .govuk-summary-list__value {
+  text-align: left;
+  flex: 1;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2172,7 +2172,7 @@ en:
       summary: 'Note: View and Download links are in 4th column, Actions'
       existing_evidence: Existing evidence
       no_documents_uploaded: No documents have been uploaded.
-      name_of_file: Name of file
+      name_of_file: File
       file_size: File size
       date_added: Date added
       actions: Actions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2094,6 +2094,8 @@ en:
       case_stage: *case_stage
       case_worker: Case worker
       claim_type: Claim and case type
+      provider_reference: Provider reference number
+      claim_submitted: Claim submitted on
       defendant: Defendant names
       j_a: Judicial apportionment
       no_defendant: No defendant details have been supplied for this claim

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2171,6 +2171,7 @@ en:
       caption: 'Evidence Provided: A list of uploaded documents'
       summary: 'Note: View and Download links are in 4th column, Actions'
       existing_evidence: Existing evidence
+      no_supporting_evidence: "There is no supporting evidence for this claim"
       no_documents_uploaded: No documents have been uploaded.
       name_of_file: File
       file_size: File size

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1175,20 +1175,22 @@ en:
         selected_offence_header: 'You have chosen the following offence details:'
       defendants:
         defendant_fields:
+          defendant_details: Defendant details
           first_name: *first_name
           first_name_html: First name <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           last_name: *last_name
           last_name_html: Last name <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
-          full_name: Full name
           date_of_birth: Date of birth
           date_of_birth_html: Date of birth <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           date_hint: *date_hint
           judical_apportionment: Judicial apportionment
+          order_of_judicial_apportionment: Order for judicial apportionment
           order_for_judicial_apportionment:  Order for judicial apportionment
           order_for_judicial_apportionment_html: Order for judicial apportionment <span class="govuk-visually-hidden">for defendant <span class="fx-numberedList-number"></span></span>
           order_for_judicial_apportionment_help: Judicial apportionment is when the defendant has applied for and received an order confirming they are not required to pay the full amount of their defence costs. If applicable, ensure you upload a copy of the order to your claim.
           add_another_rep_order: 'Add another representation order'
           remove_defendant: 'Remove defendant'
+          maat_reference: 'MAAT reference:'
           defendant: Defendant
           defendant_html: Defendant <span class="fx-numberedList-number"></span>
           remove: Remove
@@ -2093,7 +2095,6 @@ en:
       case_worker: Case worker
       claim_type: Claim and case type
       defendant: Defendant names
-      defendants: Defendants
       j_a: Judicial apportionment
       no_defendant: No defendant details have been supplied for this claim
       offence: Offence
@@ -2431,6 +2432,7 @@ en:
       additional_information: Additional claim information
       created_by: 'Created by:'
       h2_basic_info: Basic claim information
+      h2_defendant_details: Defendant
       h2_evidence: Evidence
       h2_messages: Messages and claim status
       h2_status: Status

--- a/spec/models/defendant_spec.rb
+++ b/spec/models/defendant_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Defendant do
   context 'name presentation methods' do
     let(:claim) { create(:advocate_claim) }
 
+    # Do we still need this now we aren't using it on the summary page?
     describe '#name' do
       it 'joins first name and last name together' do
         defendant = create(:defendant, first_name: 'Roberto', last_name: 'Smith', claim_id: claim.id)

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -350,32 +350,6 @@ RSpec.describe Offence do
     end
   end
 
-  # describe '#display_offence_band_or_offence_class' do
-  #   let(:offence) { create(:offence, band: 'ABC', offence_class: 'Class A') }
-  #
-  #   context 'when an offence band is present' do
-  #     it 'returns the offence band' do
-  #       expect(offence.display_offence_band_or_offence_class).to include(/[A-E]/)
-  #     end
-  #   end
-  #
-  #   context 'when offence band is not present but offence class is' do
-  #     before { offence.update(band: nil) }
-  #
-  #     it 'returns the offence class' do
-  #       expect(offence.display_offence_band_or_offence_class).to eq('Class A')
-  #     end
-  #   end
-  #
-  #   context 'when neither offence band nor offence class is present' do
-  #     before { offence.update(band: nil, offence_class: nil) }
-  #
-  #     it 'returns nil or a fallback value' do
-  #       expect(offence.display_offence_band_or_offence_class).to be_nil
-  #     end
-  #   end
-  # end
-
 
   describe '#display_offence_band_or_offence_class' do
 

--- a/spec/models/offence_spec.rb
+++ b/spec/models/offence_spec.rb
@@ -349,4 +349,51 @@ RSpec.describe Offence do
       it { is_expected.to be_truthy }
     end
   end
+
+  # describe '#display_offence_band_or_offence_class' do
+  #   let(:offence) { create(:offence, band: 'ABC', offence_class: 'Class A') }
+  #
+  #   context 'when an offence band is present' do
+  #     it 'returns the offence band' do
+  #       expect(offence.display_offence_band_or_offence_class).to include(/[A-E]/)
+  #     end
+  #   end
+  #
+  #   context 'when offence band is not present but offence class is' do
+  #     before { offence.update(band: nil) }
+  #
+  #     it 'returns the offence class' do
+  #       expect(offence.display_offence_band_or_offence_class).to eq('Class A')
+  #     end
+  #   end
+  #
+  #   context 'when neither offence band nor offence class is present' do
+  #     before { offence.update(band: nil, offence_class: nil) }
+  #
+  #     it 'returns nil or a fallback value' do
+  #       expect(offence.display_offence_band_or_offence_class).to be_nil
+  #     end
+  #   end
+  # end
+
+
+  describe '#display_offence_band_or_offence_class' do
+
+    context 'when a litigator is submitting a claim - fee scheme 9' do
+      # subject { offence.display_offence_band_or_offence_class }
+      # let(:claim) { create(:litigator_claim, :lgfs_scheme_9) }
+      let(:offence) { create(:offence, :with_lgfs_fee_scheme_nine) }
+
+
+      it 'displays the offence class' do
+        # binding.pry
+        expect(offence.display_offence_band_or_offence_class).to include(/[A-E]/)
+        # expect(offence.display_offence_band_or_offence_class).to include(/[A-E]/)
+      end
+
+      xit 'does not display class' do
+        expect(offence.display_offence_band_or_offence_class).not_to include(/[A-E]/)
+      end
+    end
+  end
 end

--- a/spec/requests/case_workers/case_worker_summary_page_spec.rb
+++ b/spec/requests/case_workers/case_worker_summary_page_spec.rb
@@ -1,68 +1,66 @@
-RSpec.describe 'Caseworker summary page' do
+RSpec.describe 'Caseworker summary page', type: :request do
   describe 'GET /case_workers/claims/12' do
-    describe 'display offence band' do
-
-    context 'when a litigator is submitting a claim - fee scheme 9' do
-      subject(:claim) { create(:litigator_claim, :lgfs_scheme_9) }
-
-      it 'displays the offence band ' do
-        expect(claim.offence.display_offence_band_or_offence_class).to eq('ABC')
+    describe 'Offence details segment' do
+      before do
+        @case_worker = create(:case_worker)
+        sign_in @case_worker.user
+        get case_workers_claim_url(claim.id)
       end
 
-      it 'does not display class' do
-        expect(claim.offence.display_offence_band_or_offence_class).to eq('ABC')
-      end
-    end
-    end
+      let(:offence_class_numbers) { /^[0-9.]*$/ }
+      let(:offence_band_letters) {/^[A-Z]+$/}
 
-    RSpec.describe 'Caseworker summary page', type: :request do
-      describe 'GET /case_workers/claims/:id' do
+      context 'when a litigator has submitted a claim with fee scheme 9' do
         let(:claim) { create(:litigator_claim, :lgfs_scheme_9) }
 
-        context 'when a litigator is submitting a claim - fee scheme 9' do
-          before do
-            get "/case_workers/claims/#{claim.id}"
-          end
+        it 'displays the offence class' do
+          binding.pry
+          expect(response.body).to include(offence_class_numbers)
+        end
 
-          it 'displays the offence band' do
-            expect(response.body).to include('ABC')
-          end
-
-          it 'does not display the offence class' do
-            expect(response.body).not_to include('Offence Class')
-          end
+        it 'does not display offence band' do
+          expect(response.body).not_to include(offence_band_letters)
         end
       end
+
+      context 'when a litigator has submitted a claim with fee scheme 10' do
+        subject(:claim) { create(:litigator_claim, :lgfs_scheme_10) }
+
+        it 'displays the offence class' do
+          expect(response.body).to include(offence_class_numbers)
+        end
+
+        it 'does not display offence band' do
+          expect(response.body).not_to include(offence_band_letters)
+        end
+      end
+
+      context 'when an advocate has submitted a claim with fee scheme 9' do
+        subject(:claim) { create(:advocate_claim, :agfs_scheme_9) }
+
+        it 'displays the offence class' do
+          expect(response.body).to include(offence_class_numbers)
+        end
+
+        it 'does not display offence band' do
+          expect(response.body).not_to include(offence_band_letters)
+        end
+      end
+
+      context 'when an advocate has submitted a claim with fee scheme 10' do
+        subject(:claim) { create(:advocate_claim, :agfs_scheme_10) }
+
+        it 'displays the offence band ' do
+          expect(response.body).to include(offence_band_letters)
+        end
+
+        it 'does not display class' do
+          expect(response.body).not_to include(offence_class_numbers)
+        end
+      end
+
+      # context 'when no band or class has been provided' do
+      # end
     end
-
-
-
-  #
-  #   context 'Advocate is submitting a claim fee scheme 9' do
-  #     let(:offence) {
-  #       create(
-  #         :offence, with_fee_scheme_nine,
-  #         :offence_class, :with_lgfs_offence
-  #       )
-  #     }
-  #   subject(:claim) { create(:advocate_claim, :offence) }
-  #
-  #   end
-  #
-  #   context ' FROM Fee scheme 10 onwards then their will be a band' do
-  #
-  #   end
-  #
-  #   context 'No band has been provided' do
-  #
-  #   end
-  #
-  #   context 'Not offence class has been provided '
-  # end
-  #
-  # describe 'display offence class' do
-  #   # the reverse
-  #   # lgfs and agfs 9 will have a class
-  #   # agfs onwards wont
-  # end
+  end
 end

--- a/spec/requests/case_workers/case_worker_summary_page_spec.rb
+++ b/spec/requests/case_workers/case_worker_summary_page_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe 'Caseworker summary page' do
+  describe 'GET /case_workers/claims/12' do
+    describe 'display offence band' do
+
+    context 'when a litigator is submitting a claim - fee scheme 9' do
+      subject(:claim) { create(:litigator_claim, :lgfs_scheme_9) }
+
+      it 'displays the offence band ' do
+        expect(claim.offence.display_offence_band_or_offence_class).to eq('ABC')
+      end
+
+      it 'does not display class' do
+        expect(claim.offence.display_offence_band_or_offence_class).to eq('ABC')
+      end
+    end
+    end
+
+    RSpec.describe 'Caseworker summary page', type: :request do
+      describe 'GET /case_workers/claims/:id' do
+        let(:claim) { create(:litigator_claim, :lgfs_scheme_9) }
+
+        context 'when a litigator is submitting a claim - fee scheme 9' do
+          before do
+            get "/case_workers/claims/#{claim.id}"
+          end
+
+          it 'displays the offence band' do
+            expect(response.body).to include('ABC')
+          end
+
+          it 'does not display the offence class' do
+            expect(response.body).not_to include('Offence Class')
+          end
+        end
+      end
+    end
+
+
+
+  #
+  #   context 'Advocate is submitting a claim fee scheme 9' do
+  #     let(:offence) {
+  #       create(
+  #         :offence, with_fee_scheme_nine,
+  #         :offence_class, :with_lgfs_offence
+  #       )
+  #     }
+  #   subject(:claim) { create(:advocate_claim, :offence) }
+  #
+  #   end
+  #
+  #   context ' FROM Fee scheme 10 onwards then their will be a band' do
+  #
+  #   end
+  #
+  #   context 'No band has been provided' do
+  #
+  #   end
+  #
+  #   context 'Not offence class has been provided '
+  # end
+  #
+  # describe 'display offence class' do
+  #   # the reverse
+  #   # lgfs and agfs 9 will have a class
+  #   # agfs onwards wont
+  # end
+end


### PR DESCRIPTION
#### What
This ticket focuses on updating the case worker summary page only (other summary pages on the provider side are still waiting for designed. They will need to be consolidated to limit duplication). And implementing the gov design summary cards to display the claim information.

#### Ticket

[CCCD - Implement Summary Page accessibility improvements (caseworker) wrap in summary cards.](https://dsdmoj.atlassian.net/browse/CTSKF-993)

#### Why
The CCCD summary page displays essential information but suffers from poor usability. To improve user experience and accessibility, we will implement a new design pattern developed from other projects.

#### How

--------

