### PR TITLE
Log request data in response

### DIFF
--- a/spec/api/logger_spec.rb
+++ b/spec/api/logger_spec.rb
@@ -151,7 +151,10 @@ RSpec.describe API::Logger do
             status:,
             claim_id: nil,
             case_number: nil,
-            id: nil }
+            id: nil,
+            creator_email: nil,
+            input_parameters: [],
+            user_email: nil }
         end
 
         it 'returns nil in empty fields' do
@@ -177,7 +180,10 @@ RSpec.describe API::Logger do
             status:,
             claim_id: '456',
             case_number: '789',
-            id: '1' }
+            id: '1',
+            creator_email: nil,
+            input_parameters: [],
+            user_email: nil }
         end
 
         it 'records the required fields and sends to LogStuff' do
@@ -217,9 +223,9 @@ RSpec.describe API::Logger do
 
       it 'logs an error and records it' do
         expect(LogStuff).to have_received(:send).once.with(:error, type: 'api-error',
-                                                                   data: { request_id: '123',
-                                                                           path: 'api/valid/path',
-                                                                           status: 400 },
+                                                                   data: hash_including(request_id: '123',
+                                                                                        path: 'api/valid/path',
+                                                                                        status: 400),
                                                                    error: 'Test error')
       end
     end


### PR DESCRIPTION
#### What

Add request data to API response log.

#### Ticket

N/A

#### Why

When requests are sent to the API using JSON in the body then the data is not available to be logged before the requests is processed. All parameters are added to api.request.input during the processing of the request and this is available for logging after. Therefore, to ensure that the correct data is being logged it is added to the log after the request as well as before.

#### How

Create a hash of data for logging both before and after. Use `env['api.request.input']` for getting request parameters for the log if it exists. Otherwise fall back to `env['rack.request.form_hash']` or `env['rack.request.query_hash']`.
