### PR TITLE
Fix parsing of request data.

### DIFF
--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -39,7 +39,7 @@ module API
     end
 
     def request_data
-      return env['api.rquest.input'] if env['api.request.input'].present?
+      return JSON.parse(env['api.request.input']) if env['api.request.input'].present?
       return env['rack.request.form_hash'] if env['rack.request.form_hash'].present?
       return env['rack.request.query_hash'] if env['rack.request.query_hash'].present?
 


### PR DESCRIPTION
#### What

env['api.request.input'] is a JSON string so needs to be parsed before it can be used as a hash. Also, fix a typo.
