### PR TITLE
Ensure emails sanitation works with short emails

### DIFF
--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -68,7 +68,7 @@ module API
 
     def redact(input)
       input[0] +
-        ('*' * (input.length - 2)) +
+        ('*' * [1, input.length - 2].max) +
         input[-1]
     end
 


### PR DESCRIPTION
#### What

Ensure at least one * when redacting an email address for the logs.

#### Ticket

N/A

#### Why

The email sanitation replaces all but the first and last characters of an address with \*. The calculation for this fails if this is only 1 character long as it attemts to multiply the string '*' by a negative number.

#### How

Set a minimum number of '*' to add to the redacted email address.