### PR TITLE
Email sanitation

### DIFF
--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -49,27 +49,13 @@ module API
     def creator_email
       return if request_data['creator_email'].blank?
 
-      sanitised_email(request_data['creator_email'])
+      EmailSanitizerService.new(request_data['creator_email']).call
     end
 
     def user_email
       return if request_data['user_email'].blank?
 
-      sanitised_email(request_data['user_email'])
-    end
-
-    def sanitised_email(email)
-      name, domain, extension = email.split(/[@.]/, 3)
-
-      "#{redact(name)}@#{redact(domain)}.#{extension}"
-    rescue NoMethodError
-      'Invalid email, cannot be redacted'
-    end
-
-    def redact(input)
-      input[0] +
-        ('*' * [1, input.length - 2].max) +
-        input[-1]
+      EmailSanitizerService.new(request_data['user_email']).call
     end
 
     def response_status

--- a/app/services/email_sanitizer_service.rb
+++ b/app/services/email_sanitizer_service.rb
@@ -5,6 +5,8 @@ class EmailSanitizerService
 
   def call
     local, domain = @original_email.split('@')
+    return 'Invalid email, cannot be redacted' if local.nil? || domain.nil?
+
     "#{redact(local)}@#{redact_domain(domain)}"
   end
 

--- a/app/services/email_sanitizer_service.rb
+++ b/app/services/email_sanitizer_service.rb
@@ -5,10 +5,21 @@ class EmailSanitizerService
 
   def call
     local, domain = @original_email.split('@')
-    return "#{local[0]}*#{local[0]}@#{domain}" if local.length == 1
-    return "#{local[0]}*#{local[1]}@#{domain}" if local.length == 2
+    "#{redact(local)}@#{redact_domain(domain)}"
+  end
 
-    sanitized_local = local[0] + ('*' * (local.length - 2)) + local[-1]
-    "#{sanitized_local}@#{domain}"
+  private
+
+  def redact(input)
+    return "#{input[0]}*#{input[0]}" if input.length == 1
+    return "#{input[0]}*#{input[1]}" if input.length == 2
+
+    input[0] + ('*' * (input.length - 2)) + input[-1]
+  end
+
+  def redact_domain(domain)
+    parts = domain.split('.')
+    parts[0..-2] = parts[0..-2].map { |part| redact(part) } if parts.length > 1
+    parts.join('.')
   end
 end

--- a/app/services/email_sanitizer_service.rb
+++ b/app/services/email_sanitizer_service.rb
@@ -1,0 +1,14 @@
+class EmailSanitizerService
+  def initialize(email)
+    @original_email = email
+  end
+
+  def call
+    local, domain = @original_email.split('@')
+    return "#{local[0]}*#{local[0]}@#{domain}" if local.length == 1
+    return "#{local[0]}*#{local[1]}@#{domain}" if local.length == 2
+
+    sanitized_local = local[0] + ('*' * (local.length - 2)) + local[-1]
+    "#{sanitized_local}@#{domain}"
+  end
+end

--- a/spec/services/email_sanitizer_service_spec.rb
+++ b/spec/services/email_sanitizer_service_spec.rb
@@ -54,5 +54,12 @@ RSpec.describe EmailSanitizerService, type: :service do
 
       it { is_expected.to eq(expected_response) }
     end
+
+    context 'when the email is invalid without an @ symbol' do
+      let(:email) { 'invalidemail.com' }
+      let(:expected_response) { 'Invalid email, cannot be redacted' }
+
+      it { is_expected.to eq(expected_response) }
+    end
   end
 end

--- a/spec/services/email_sanitizer_service_spec.rb
+++ b/spec/services/email_sanitizer_service_spec.rb
@@ -6,37 +6,51 @@ RSpec.describe EmailSanitizerService, type: :service do
 
     let(:service) { described_class.new(email) }
 
-    context 'when the email has multiple characters before the @ symbol' do
+    context 'when the local part has multiple characters' do
       let(:email) { 'example@example.com' }
-      let(:expected_response) { 'e*****e@example.com' }
+      let(:expected_response) { 'e*****e@e*****e.com' }
 
       it { is_expected.to eq(expected_response) }
     end
 
-    context 'when the email has a single character before the @ symbol' do
+    context 'when the local part has a single character' do
       let(:email) { 'a@b.com' }
-      let(:expected_response) { 'a*a@b.com' }
+      let(:expected_response) { 'a*a@b*b.com' }
 
       it { is_expected.to eq(expected_response) }
     end
 
-    context 'when the email has two characters before the @ symbol' do
+    context 'when the local part has two characters' do
       let(:email) { 'ab@cd.com' }
-      let(:expected_response) { 'a*b@cd.com' }
+      let(:expected_response) { 'a*b@c*d.com' }
 
       it { is_expected.to eq(expected_response) }
     end
 
-    context 'when the email has a dot (.) before the @ symbol' do
+    context 'when the local part contains a dot (.)' do
       let(:email) { 'first.last@example.com' }
-      let(:expected_response) { 'f********t@example.com' }
+      let(:expected_response) { 'f********t@e*****e.com' }
 
       it { is_expected.to eq(expected_response) }
     end
 
-    context 'when the email has a hyphen before the @ symbol' do
+    context 'when the local part contains a hyphen (-)' do
       let(:email) { 'first-last@example.com' }
-      let(:expected_response) { 'f********t@example.com' }
+      let(:expected_response) { 'f********t@e*****e.com' }
+
+      it { is_expected.to eq(expected_response) }
+    end
+
+    context 'when the domain has multiple parts' do
+      let(:email) { 'user@sub.example.com' }
+      let(:expected_response) { 'u**r@s*b.e*****e.com' }
+
+      it { is_expected.to eq(expected_response) }
+    end
+
+    context 'when the domain has a single character' do
+      let(:email) { 'user@a.com' }
+      let(:expected_response) { 'u**r@a*a.com' }
 
       it { is_expected.to eq(expected_response) }
     end

--- a/spec/services/email_sanitizer_service_spec.rb
+++ b/spec/services/email_sanitizer_service_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe EmailSanitizerService, type: :service do
+  describe '#call' do
+    subject { service.call }
+
+    let(:service) { described_class.new(email) }
+
+    context 'when the email has multiple characters before the @ symbol' do
+      let(:email) { 'example@example.com' }
+      let(:expected_response) { 'e*****e@example.com' }
+
+      it { is_expected.to eq(expected_response) }
+    end
+
+    context 'when the email has a single character before the @ symbol' do
+      let(:email) { 'a@b.com' }
+      let(:expected_response) { 'a*a@b.com' }
+
+      it { is_expected.to eq(expected_response) }
+    end
+
+    context 'when the email has two characters before the @ symbol' do
+      let(:email) { 'ab@cd.com' }
+      let(:expected_response) { 'a*b@cd.com' }
+
+      it { is_expected.to eq(expected_response) }
+    end
+
+    context 'when the email has a dot (.) before the @ symbol' do
+      let(:email) { 'first.last@example.com' }
+      let(:expected_response) { 'f********t@example.com' }
+
+      it { is_expected.to eq(expected_response) }
+    end
+
+    context 'when the email has a hyphen before the @ symbol' do
+      let(:email) { 'first-last@example.com' }
+      let(:expected_response) { 'f********t@example.com' }
+
+      it { is_expected.to eq(expected_response) }
+    end
+  end
+end


### PR DESCRIPTION
#### What

Improve the email address sanitization, including its testing.

#### Ticket

N/A

#### Why

Email addresses are sanitized before adding to logs to avoid unnecessary storage of PII. A bug in this sanitization can cause errors that prevent the service from operating correctly.

#### How

Extract the email sanitization to a separate service that can be tested in isolation from the logger.