### PR TITLE
Reintegrate Google Tag Manager

### DIFF
--- a/.k8s/live/production/app-config.yaml
+++ b/.k8s/live/production/app-config.yaml
@@ -11,6 +11,7 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://claim-crown-court-defence.service.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
   GA_TRACKER_ID: 'G-MRKGHQ51SQ'
+  GTM_TRACKER_ID: 'GTM-NSB9GWK'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'

--- a/.k8s/live/staging/app-config.yaml
+++ b/.k8s/live/staging/app-config.yaml
@@ -11,6 +11,7 @@ data:
   GRAPE_SWAGGER_ROOT_URL: 'https://staging.claim-crown-court-defence.service.justice.gov.uk'
   CASEWORKER_API_URL: 'http://cccd-app-service'
   GA_TRACKER_ID: 'G-GK279GHP21'
+  GTM_TRACKER_ID: 'GTM-PNZFWQT'
   MAINTENANCE_MODE: 'false'
   SETTINGS__SLACK__BOT_NAME: 'Injectotron'
   SETTINGS__SLACK__FAIL_ICON: ':katyperry:'

--- a/app/views/layouts/_analytics.js.haml
+++ b/app/views/layouts/_analytics.js.haml
@@ -1,16 +1,25 @@
-= javascript_tag nonce: true do
-  :plain
-    let googleTrackingID = "#{ENV.fetch('GA_TRACKER_ID', nil)}"
+- if adapter == :gtm
+  = javascript_tag nonce: true do
+    :plain
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer',"#{ENV['GTM_TRACKER_ID']}");
+- if adapter == :ga
+  = javascript_tag nonce: true do
+    :plain
+      let googleTrackingID = "#{ENV.fetch('GA_TRACKER_ID', nil)}"
 
-    const analyticsScriptTag = document.createElement('script')
-    analyticsScriptTag.async = ''
-    analyticsScriptTag.src = `https://www.googletagmanager.com/gtag/js?id=${googleTrackingID}`
-    document.head.appendChild(analyticsScriptTag)
+      const analyticsScriptTag = document.createElement('script')
+      analyticsScriptTag.async = ''
+      analyticsScriptTag.src = `https://www.googletagmanager.com/gtag/js?id=${googleTrackingID}`
+      document.head.appendChild(analyticsScriptTag)
 
-    window.dataLayer = window.dataLayer || []
+      window.dataLayer = window.dataLayer || []
 
-    function gtag() {
-      dataLayer.push(arguments)
-    }
-    gtag('js', new Date())
-    gtag('config', `${googleTrackingID}`)
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', `${googleTrackingID}`)


### PR DESCRIPTION
#### What

The use of the Google Tag Manager API (as opposed to Google Analytics) was removed in a previous [PR](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/7598) as it did not seem to be needed (guidance suggested that a single Google Analytics tag could be used for both GA and GTM). 

However GTM is reporting that no data is being received and we have had issues making changes to key events and filters, which might be explained by the lack of GTM tag:

<img width="719" alt="image" src="https://github.com/user-attachments/assets/7c02d7f6-1d01-4cb2-80e6-c702ed5bb276">

This PR reintegrates CCCD with GTM. This has been tested on staging and the warning is resolved. This will hopefully now make it easier to carry out the rest of the GA work.

#### How

* Re-adds javascript to `/app/views/layouts/_analytics.js.haml` to send data to GTM.
* Re-adds GTM tag ids to staging and production `app-config.yaml` files.
