### PR TITLE
Transfer attachment to attachments on claim

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -21,7 +21,7 @@ class Message < ApplicationRecord
 
   attr_accessor :claim_action, :written_reasons_submitted
 
-  # has_one_attached :attachment
+  has_one_attached :attachment
   has_many_attached :attachments
 
   validates :attachments,
@@ -51,6 +51,7 @@ class Message < ApplicationRecord
 
   scope :most_recent_last, -> { includes(:user_message_statuses).order(created_at: :asc) }
 
+  after_initialize :update_attachments
   after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
   before_destroy -> { attachments.purge }
 
@@ -109,5 +110,9 @@ class Message < ApplicationRecord
 
   def claim_updater
     Claims::ExternalUserClaimUpdater.new(claim, current_user: sender)
+  end
+
+  def update_attachments
+    attachments.attach(attachment.blob) if attachment.attached?
   end
 end


### PR DESCRIPTION
#### What

Ensure that attachments that were added to messages are still available with the preparation for the multiple attachments feature.

#### Ticket

[CCCD - Allow for multiple documents on a message](https://dsdmoj.atlassian.net/browse/CTSKF-832)

#### Why

The implementation of multiple attachments will result in the attachments being detached from messages. This is because the name of the relation has changed from 'attachment' to `attachments` and this name is used in the database backing `ActiveStorage::Attachment` to enable [polymorphic associations.](https://guides.rubyonrails.org/association_basics.html#polymorphic-associations)

#### How

`Message.attachment` is reintroduced with `has_one_attached` alongside the new `Message.attachments`.

A new `after_initialize` callback is created to check if `attachment` is attached and, if so, attach it to `attachments`.
