### PR TITLE
CTSKF-962 SecretsManager Staging

### DIFF
--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -65,7 +65,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           # secret env vars defined by infrastructure/terraform
           # WHERE env var name does not match key name

--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL

--- a/.k8s/live/staging/dump.yaml
+++ b/.k8s/live/staging/dump.yaml
@@ -32,7 +32,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
#### What
Switch CCCD Dev environment from manually controlled Kubernetes secret for environment variables to one controlled by AWS SecretsManager

#### Ticket

[CTSKF-962](https://dsdmoj.atlassian.net/browse/CTSKF-962)

#### Why
More secure and easier to use way of backing up and managing our secrets

#### How

Create new secret in AWS Console

Change deployment-worker.yaml, deployment.yaml and dump.yaml to use the new cccd-env-vars secret


[CTSKF-962]: https://dsdmoj.atlassian.net/browse/CTSKF-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ