### PR TITLE
API logging when statis is nil

### DIFF
--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -6,9 +6,7 @@ module API
     end
 
     def after
-      return if response_status.nil?
-
-      if response_status.between?(200, 399)
+      if response_status&.between?(200, 399)
         log_api(:info, 'api-response',
                 { status: response_status, claim_id: response_param('claim_id'),
                   case_number: response_param('case_number'), id: response_param('id'), **request_data_log })

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -206,7 +206,7 @@ RSpec.shared_examples 'a claim validate endpoint' do |options|
       end
 
       it { expect_error_response('Creator email is invalid') }
-      it { expect(LogStuff).to have_received(:send).with(:error, hash_including(type: 'api-error')) }
+      it { expect(LogStuff).to have_received(:send).with(:error, hash_including(type: 'api-error')).at_least(:once) }
     end
 
     context 'when user email is invalid' do
@@ -216,7 +216,7 @@ RSpec.shared_examples 'a claim validate endpoint' do |options|
       end
 
       it { expect_error_response("#{claim_user_type} email is invalid") }
-      it { expect(LogStuff).to have_received(:send).with(:error, hash_including(type: 'api-error')) }
+      it { expect(LogStuff).to have_received(:send).with(:error, hash_including(type: 'api-error')).at_least(:once) }
     end
 
     context 'when user email is valid but contains upper case characters' do


### PR DESCRIPTION
#### What

Increase API logging.

#### Ticket

N/A

#### Why

If the status is nil then the 'after' hook was not logging and returning nil. This might result in losing data in the logs. Now it will be logged as an api-error.

#### How

Remove the guard clause and use the safe navigator instead to ensure `response_status.between?` doesn't fail.
