### PR TITLE
Allow the `advocate_email` field for supplementary and interim claims.

### DIFF
--- a/app/interfaces/api/logger.rb
+++ b/app/interfaces/api/logger.rb
@@ -24,6 +24,7 @@ module API
         path:,
         creator_email:,
         user_email:,
+        advocate_email:,
         input_parameters: request_data.keys
       }
     end
@@ -54,6 +55,12 @@ module API
       return if request_data['user_email'].blank?
 
       EmailSanitizerService.new(request_data['user_email']).call
+    end
+
+    def advocate_email
+      return if request_data['advocate_email'].blank?
+
+      EmailSanitizerService.new(request_data['advocate_email']).call
     end
 
     def response_status

--- a/app/interfaces/api/v1/external_users/claims/advocates/interim_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/interim_claim.rb
@@ -24,7 +24,7 @@ module API
               optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
               optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
               optional :apply_vat, type: Boolean, desc: 'OPTIONAL: Include VAT (JSON Boolean data type: true or false)'
-              use :user_email
+              use :legacy_agfs_params
               use :advocate_category_agfs_reform
               optional :main_hearing_date,
                        type: String, desc: 'OPTIONAL: The date of the main hearing of the case (YYYY-MM-DD)',

--- a/app/interfaces/api/v1/external_users/claims/advocates/supplementary_claim.rb
+++ b/app/interfaces/api/v1/external_users/claims/advocates/supplementary_claim.rb
@@ -23,7 +23,7 @@ module API
               optional :cms_number, type: String, desc: 'OPTIONAL: The CMS number'
               optional :additional_information, type: String, desc: 'OPTIONAL: Any additional information'
               optional :apply_vat, type: Boolean, desc: 'OPTIONAL: Include VAT (JSON Boolean data type: true or false)'
-              use :user_email
+              use :legacy_agfs_params
               use :advocate_category_all
               optional :main_hearing_date,
                        type: String,

--- a/spec/api/logger_spec.rb
+++ b/spec/api/logger_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe API::Logger do
           method: nil,
           path: nil,
           creator_email: nil,
+          advocate_email: nil,
           user_email: nil,
           claim_id: nil,
           case_number: nil,
@@ -75,6 +76,7 @@ RSpec.describe API::Logger do
           method: 'GET',
           path: 'valid/path',
           creator_email: 'a******e@e*****e.com',
+          advocate_email: nil,
           user_email: 'a******e@e*****e.com',
           claim_id: '456',
           case_number: '789',
@@ -113,6 +115,7 @@ RSpec.describe API::Logger do
           method: 'GET',
           path: 'valid/path',
           creator_email: 'a******e@e*****e.com',
+          advocate_email: nil,
           user_email: 'a******e@e*****e.com',
           claim_id: '456',
           case_number: '789',
@@ -173,6 +176,7 @@ RSpec.describe API::Logger do
             id: nil,
             creator_email: nil,
             input_parameters: [],
+            advocate_email: nil,
             user_email: nil }
         end
 
@@ -202,6 +206,7 @@ RSpec.describe API::Logger do
             id: '1',
             creator_email: nil,
             input_parameters: [],
+            advocate_email: nil,
             user_email: nil }
         end
 


### PR DESCRIPTION
#### What

Allow the `advocate_email` field for supplementary and interim claims.

#### Ticket

N/A

#### Why

The `advocate_email` field for claims submitted via the API is deprecated in favour of `user_email` but at least one 3rd party client is still using it. It was never enabled for supplementary and interim claims and this causes problems for some providers.

#### How

Replace the `user_email` field with `legacy_agfs_params` in the configuration for these endpoints:

* /api/external_users/claims/advocates/supplementary
* /api/external_users/claims/advocates/supplementary/validate
* /api/external_users/claims/advocates/interim
* /api/external_users/claims/advocates/interim/validate