### PR TITLE
Group dotenv dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,17 +34,20 @@ updates:
     aws:
       patterns:
         - "aws-*"
+    dotenv:
+      patterns:
+        - "dotenv*"
+    rails:
+      patterns:
+        - "rails"
+        - "action*"
+        - "active*"
     rubocop:
       patterns:
         - "rubocop*"
     sentry:
       patterns:
         - "sentry-*"
-    rails:
-      patterns:
-        - "rails"
-        - "action*"
-        - "active*"
   open-pull-requests-limit: 5
   rebase-strategy: "disabled"
   allow:


### PR DESCRIPTION
#### What

Group dotenv dependabot updates.

#### Ticket

N/A

#### Why

`dotenv` and `dotenv-rails` have the same version numbers and are updated together. When dependabot creates PRs for them they are usually duplicates of each other.

#### How

Add a new group to the configuration. Also, the groups are now in alphabetical order so that they are easier to manage now that the number is starting to increase.