### PR TITLE
Upgrade version of bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -689,9 +689,9 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
-  arm64-darwin-22
   arm64-darwin-23
-  x86_64-linux
+  arm64-darwin-24
+  x86_64-linux-gnu
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.15)
@@ -801,4 +801,4 @@ RUBY VERSION
    ruby 3.3.5p100
 
 BUNDLED WITH
-   2.4.22
+   2.6.2


### PR DESCRIPTION
#### What

Upgrade to the latest version of bundler and the `x86_64` platform.

#### Ticket

N/A

#### Why

The latest version of `nokogiri` splits the linux platforms into gnu and musl and this requires that the platform defined in `Gemfile.lock` to be updated. Also, bundler version >= 2.5.6 is recommended. See [here.](https://github.com/sparklemotion/nokogiri/releases/tag/v1.18.0)

Also, the platform versions for Darwin are updated. 22 (Ventura) is removed and 24 (Sequoia) is added.

#### How

```bash
bundle update --bundler
bundle lock --remove-platform x86_64-linux
bundle lock --add-platform x86_64-linux-gnu
```
