### PR TITLE
CTSKF-1002 - CCCD - Task to copy message attachment (singular) to attachments (plural)

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -22,6 +22,7 @@ class Message < ApplicationRecord
   attr_accessor :claim_action, :written_reasons_submitted
 
   has_one_attached :attachment
+  has_many_attached :attachments
 
   validates :attachment,
             size: { less_than: 20.megabytes },
@@ -48,7 +49,7 @@ class Message < ApplicationRecord
 
   scope :most_recent_last, -> { includes(:user_message_statuses).order(created_at: :asc) }
 
-  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
+  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required, :duplicate_message_attachment
   before_destroy -> { attachment.purge }
 
   class << self
@@ -106,5 +107,15 @@ class Message < ApplicationRecord
 
   def claim_updater
     Claims::ExternalUserClaimUpdater.new(claim, current_user: sender)
+  end
+
+  def duplicate_message_attachment
+    if self.attachment.attached?
+      attachment_blob = self.attachment.blob
+      if self.attachments.find_by(blob: attachment_blob)
+      else
+        self.attachments.attach(attachment_blob)
+      end
+    end
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -49,7 +49,8 @@ class Message < ApplicationRecord
 
   scope :most_recent_last, -> { includes(:user_message_statuses).order(created_at: :asc) }
 
-  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required, :duplicate_message_attachment
+  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required,
+               :duplicate_message_attachment
   before_destroy -> { attachment.purge }
 
   class << self
@@ -110,12 +111,9 @@ class Message < ApplicationRecord
   end
 
   def duplicate_message_attachment
-    if self.attachment.attached?
-      attachment_blob = self.attachment.blob
-      if self.attachments.find_by(blob: attachment_blob)
-      else
-        self.attachments.attach(attachment_blob)
-      end
-    end
+    return unless attachment.attached?
+
+    attachment_blob = attachment.blob
+    attachments.attach(attachment_blob) unless attachments.find_by(blob: attachment_blob)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -113,7 +113,6 @@ class Message < ApplicationRecord
   def duplicate_message_attachment
     return unless attachment.attached?
 
-    attachment_blob = attachment.blob
-    attachments.attach(attachment_blob) unless attachments.find_by(blob: attachment_blob)
+    attachments.attach(attachment.blob)
   end
 end

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -1,0 +1,25 @@
+namespace :documents do
+  desc 'Copy all message attachment to message attachments.'
+  task :duplicate_message_attachment => :environment do
+    messages = Message.all
+    puts "There are #{messages.count} messages."
+
+    messages.each do |message|
+      if message.attachment.attached?
+        puts "Duplicating attachment of message ##{message.id}."
+        attachment_blob = message.attachment.blob
+
+        existing_attachment = message.attachments.find_by(blob: attachment_blob)
+        if existing_attachment
+          puts "Attachment #{existing_attachment.blob.filename} is already duplicated in the database with ID #{existing_attachment.id}."
+        else
+          message.attachments.attach(attachment_blob)
+          puts "Attachment #{attachment_blob.filename} is duplicated in the database."
+        end
+      else
+        puts "There is no attachment in message ##{message.id}."
+      end
+    end
+    puts "duplicate_message_attachment done!"
+  end
+end

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -9,13 +9,8 @@ namespace :documents do
         puts "Duplicating attachment of message ##{message.id}."
         attachment_blob = message.attachment.blob
 
-        existing_attachment = message.attachments.find_by(blob: attachment_blob)
-        if existing_attachment
-          puts "Attachment #{existing_attachment.blob.filename} is already duplicated in the database with ID #{existing_attachment.id}."
-        else
-          message.attachments.attach(attachment_blob)
-          puts "Attachment #{attachment_blob.filename} is duplicated in the database."
-        end
+        message.attachments.attach(attachment_blob)
+        puts "Attachment #{attachment_blob.filename} is duplicated in the database."
       else
         puts "There is no attachment in message ##{message.id}."
       end

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -17,4 +17,10 @@ namespace :documents do
     end
     puts "duplicate_message_attachment done!"
   end
+
+  desc'Count blob map.'
+  task :count_blob_map => :environment do
+    blobs = ActiveStorage::Attachment.includes(:blob, blob: :attachments).where(name: 'attachment').map(&:blob)
+    puts blobs.map { |blob| blob.attachments.count }.tally
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Message do
     context 'with an attachment' do
       let(:trait) { :with_attachment }
 
-      it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-1) }
+      it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-2) }
       it { expect { destroy_message }.to change(ActiveStorage::Blob, :count).by(-1) }
     end
   end


### PR DESCRIPTION
#### What

1. Add a new has_many_attached :attachments to the Message model alongside the existing has_one_attached :attachment
2. Add a after_create callback in the Message model to attach an attachment, if it exists, to attachments.
3. Create and run a Rake task to attach attachments on existing messages to attachments.

#### Ticket
https://dsdmoj.atlassian.net/browse/CTSKF-1002

