### PR TITLE
[CTSKF-1000] Add user research panel link to footer

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -22,6 +22,9 @@
             = govuk_footer_link_to t('.feedback'), new_feedback_path
 
           %li.govuk-footer__inline-list-item
+            = govuk_footer_link_to t('.research'), Settings.research_panel_url
+
+          %li.govuk-footer__inline-list-item
             = t('.service_owner_html', link: 'https://mojdigital.blog.gov.uk/')
 
         %svg.govuk-footer__licence-logo{ focusable: 'false', height: '17', 'aria-hidden': 'true', viewbox: '0 0 483.2 195.7', width: '41', xmlns: 'http://www.w3.org/2000/svg' }

--- a/config/locales/en/views/layouts.yml
+++ b/config/locales/en/views/layouts.yml
@@ -22,6 +22,7 @@ en:
       copyright_html: "&copy; Crown copyright"
       feedback: Feedback
       licence_html: All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+      research: Join our research panel
       service_owner_html: <span>Built by</span> <a class="govuk-footer__link" href="%{link}"><abbr title="Ministry of Justice">MOJ Digital Services</abbr></a>
       support_link: Support links
       terms_and_conditions: Terms and Conditions

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -240,3 +240,5 @@ maat_api_oauth_url: <%=ENV['OAUTH_URL']%>
 secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 google_api_key: <%= ENV["GOOGLE_API_KEY"] %>
 survey_monkey_bearer_token: <%= ENV["SURVEY_MONKEY_BEARER_TOKEN"] %>
+
+research_panel_url: https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2BpeqOUlDIpGmeYA_28YLbNUMjJaNVJIMzdQMkRLRUFEM05VVEFNSlpCQS4u


### PR DESCRIPTION
#### What

Add link to research panel form to footer

#### Ticket

[CTSKF-1000](https://dsdmoj.atlassian.net/browse/CTSKF-1000)

#### Why

To allow providers to sign up to be part of the research panel.

#### How

Adds the link to the `app/views/layouts/_footer.html.haml` partial, with the link text and form url defined in `config/locales/en/views/layouts.yml` and `config/settings.yml`.

#### Screenshots

<img width="997" alt="image" src="https://github.com/user-attachments/assets/88f265d8-a9e6-495d-9936-034500515267" />


[CTSKF-1000]: https://dsdmoj.atlassian.net/browse/CTSKF-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ