### PR TITLE
Remove inflection of GOVUK

### DIFF
--- a/app/validators/concerns/govuk_design_system_form_builder_errorable.rb
+++ b/app/validators/concerns/govuk_design_system_form_builder_errorable.rb
@@ -11,7 +11,7 @@
 # NOTE: Once all models are using this module then the method(s)
 # can be promoted to the superclass and this module removed
 #
-module GOVUKDesignSystemFormBuilderErrorable
+module GovukDesignSystemFormBuilderErrorable
   extend ActiveSupport::Concern
 
   included do

--- a/app/validators/supplier_number_sub_model_validator.rb
+++ b/app/validators/supplier_number_sub_model_validator.rb
@@ -1,5 +1,5 @@
 class SupplierNumberSubModelValidator < BaseSubModelValidator
-  include GOVUKDesignSystemFormBuilderErrorable
+  include GovukDesignSystemFormBuilderErrorable
 
   def has_many_association_names
     [:lgfs_supplier_numbers]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,7 +19,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'CLI'
   inflect.acronym 'CPS'
   inflect.acronym 'GA'
-  inflect.acronym 'GOVUK'
   inflect.acronym 'GTM'
   inflect.acronym 'LF1'
   inflect.acronym 'LF2'

--- a/features/page_objects/advocate_interim_claim_form_page.rb
+++ b/features/page_objects/advocate_interim_claim_form_page.rb
@@ -3,6 +3,6 @@ require_relative 'claim_form_page'
 class AdvocateInterimClaimFormPage < ClaimFormPage
   set_url "/advocates/interim_claims/new"
 
-  section :warrant_issued_date, GOVUKDateSection, ".warrant-fee-issued-date-group"
+  section :warrant_issued_date, GovukDateSection, ".warrant-fee-issued-date-group"
   element :warrant_net_amount, '.warrant_fee_attributes_amount'
 end

--- a/features/page_objects/certification_page.rb
+++ b/features/page_objects/certification_page.rb
@@ -3,6 +3,6 @@ class CertificationPage < BasePage
 
   element :attended_main_hearing, "label.govuk-radios__label", text: "I attended the main hearing (1st day of trial)"
   element :certified_by, "input[name='certification[certified_by]']"
-  section :certification_date, GOVUKDateSection, '#certification_date'
+  section :certification_date, GovukDateSection, '#certification_date'
   element :certify_and_submit_claim, 'button.govuk-button', text: 'Certify and submit claim'
 end

--- a/features/page_objects/claim_form_page.rb
+++ b/features/page_objects/claim_form_page.rb
@@ -27,14 +27,14 @@ class ClaimFormPage < BasePage
   section :auto_case_stage, CommonAutocomplete, "#cc-case-stage"
   section :auto_court, CommonAutocomplete, "#cc-court"
   section :auto_offence, CommonAutocomplete, "#cc-offence"
-  section :main_hearing_date, GOVUKDateSection, '#main_hearing_date'
+  section :main_hearing_date, GovukDateSection, '#main_hearing_date'
 
   element :case_number, "input[name='claim[case_number]']"
   element :case_type_dropdown, "#case_type"
 
   section :trial_details, "#trial-dates" do
-    section :first_day_of_trial, GOVUKDateSection, '#first_day_of_trial'
-    section :trial_concluded_on, GOVUKDateSection, '#trial_concluded_at'
+    section :first_day_of_trial, GovukDateSection, '#first_day_of_trial'
+    section :trial_concluded_on, GovukDateSection, '#trial_concluded_at'
     element :actual_trial_length, "input[name='claim[actual_trial_length]']"
     element :estimated_trial_length, "input[name='claim[estimated_trial_length]']"
   end
@@ -46,10 +46,10 @@ class ClaimFormPage < BasePage
     element :first_name, "div.cc-first-name input"
     element :last_name, "div.cc-last-name input"
 
-    section :dob, GOVUKDateSection, 'div.cc-dob'
+    section :dob, GovukDateSection, 'div.cc-dob'
 
     sections :representation_orders, ".cc-ro-details" do
-      section :date, GOVUKDateSection, 'div.cc-ro-date'
+      section :date, GovukDateSection, 'div.cc-ro-date'
       element :maat_reference, "div.cc-maat input"
     end
 

--- a/features/page_objects/litigator_claim_form_page.rb
+++ b/features/page_objects/litigator_claim_form_page.rb
@@ -9,7 +9,7 @@ class LitigatorClaimFormPage < ClaimFormPage
 
   set_url "/litigators/claims/new"
 
-  section :case_concluded_date, GOVUKDateSection, '#case_concluded_at'
+  section :case_concluded_date, GovukDateSection, '#case_concluded_at'
 
   sections :miscellaneous_fees, LGFSMiscFeeSection, "div#misc-fees .misc-fee-group"
   element :add_another_miscellaneous_fee, "div#misc-fees a.add_fields"
@@ -22,7 +22,7 @@ class LitigatorClaimFormPage < ClaimFormPage
 
   element :ppe_total, "input.quantity"
   element :actual_trial_length, ".js-fee-calculator-days"
-  section :graduated_fee_date, GOVUKDateSection, "div.graduated-fee-group"
+  section :graduated_fee_date, GovukDateSection, "div.graduated-fee-group"
 
   def select_supplier_number(number)
     select number, from: "claim_supplier_number", autocomplete: false

--- a/features/page_objects/sections/basic_fee_section.rb
+++ b/features/page_objects/sections/basic_fee_section.rb
@@ -19,5 +19,5 @@ class BasicFeeSection < CheckboxFeeSection
   section :prosecution_witnesses, FeeSection, ".basic-fee-group.number-of-prosecution-witnesses"
   section :pages_of_prosecution_evidence, FeeSection, ".basic-fee-group.pages-of-prosecution-evidence"
 
-  section :basic_fees_checkboxes, GOVUKChecklistSection, '.basic-fees-checklist'
+  section :basic_fees_checkboxes, GovukChecklistSection, '.basic-fees-checklist'
 end

--- a/features/page_objects/sections/cracked_trial_section.rb
+++ b/features/page_objects/sections/cracked_trial_section.rb
@@ -1,9 +1,9 @@
 require_relative 'common_date_section'
 
 class CrackedTrialSection < SitePrism::Section
-  section :trial_fixed_notice_at, GOVUKDateSection, '#trial_fixed_notice_at'
-  section :trial_fixed_at, GOVUKDateSection, '#trial_fixed_at'
-  section :trial_cracked_at, GOVUKDateSection, '#trial_cracked_at'
+  section :trial_fixed_notice_at, GovukDateSection, '#trial_fixed_notice_at'
+  section :trial_fixed_at, GovukDateSection, '#trial_fixed_at'
+  section :trial_cracked_at, GovukDateSection, '#trial_cracked_at'
 
   element :first_third, "label[for='claim_trial_cracked_at_third_first_third']"
   element :second_third, "label[for='claim_trial_cracked_at_third_second_third']"

--- a/features/page_objects/sections/expense_section.rb
+++ b/features/page_objects/sections/expense_section.rb
@@ -11,5 +11,5 @@ class ExpenseSection < SitePrism::Section
   element :mileage_25, ".fx-travel-mileage.fx-travel-mileage-car label:first"
   element :mileage_45, ".fx-travel-mileage.fx-travel-mileage-bike label:last"
 
-  section :expense_date, GOVUKDateSection, ".fx-travel-date"
+  section :expense_date, GovukDateSection, ".fx-travel-date"
 end

--- a/features/page_objects/sections/govuk_checklist_section.rb
+++ b/features/page_objects/sections/govuk_checklist_section.rb
@@ -1,4 +1,4 @@
-class GOVUKChecklistSection < SitePrism::Section
+class GovukChecklistSection < SitePrism::Section
   sections :checklist, '.basic-fees-checklist .govuk-checkboxes__item' do
     element :checkbox, '.govuk-checkboxes__input', visible: false
     element :label, '.govuk-label'

--- a/features/page_objects/sections/govuk_date_section.rb
+++ b/features/page_objects/sections/govuk_date_section.rb
@@ -1,4 +1,4 @@
-class GOVUKDateSection < SitePrism::Section
+class GovukDateSection < SitePrism::Section
   include DateHelper
   element :day, 'div.govuk-date-input div.govuk-date-input__item:nth-child(1) input'
   element :month, 'div.govuk-date-input div.govuk-date-input__item:nth-child(2) input'

--- a/features/page_objects/sections/lgfs_fixed_fee_section.rb
+++ b/features/page_objects/sections/lgfs_fixed_fee_section.rb
@@ -3,5 +3,5 @@ class LGFSFixedFeeSection < SitePrism::Section
   element :quantity_hint, ".quantity_wrapper .govuk-hint"
   element :rate, "input.rate"
   element :total, ".fee-net-amount"
-  section :date, GOVUKDateSection, ".govuk-date-input"
+  section :date, GovukDateSection, ".govuk-date-input"
 end

--- a/features/page_objects/sections/lgfs_interim_fee_section.rb
+++ b/features/page_objects/sections/lgfs_interim_fee_section.rb
@@ -12,23 +12,23 @@ class LGFSInterimFeeSection < SitePrism::Section
   element :amount, ".fee-amount"
 
   # interim effective PCMH fee fields
-  section :effective_pcmh_date, GOVUKDateSection, '#effective-pcmh-date'
+  section :effective_pcmh_date, GovukDateSection, '#effective-pcmh-date'
 
   # interim trial start fee fields
   element :estimated_trial_length, '#estimated_trial_length input'
-  section :first_day_of_trial, GOVUKDateSection, '#first_day_of_trial'
+  section :first_day_of_trial, GovukDateSection, '#first_day_of_trial'
 
   # interim retrial start fee fields
   element :retrial_estimated_length, '#retrial_estimated_length input'
-  section :retrial_started_at, GOVUKDateSection, '#retrial_started_at'
+  section :retrial_started_at, GovukDateSection, '#retrial_started_at'
 
   # interim retrial (new solicitor) fee fields
-  section :legal_aid_transfer_date, GOVUKDateSection, '#legal_aid_transfer_date'
-  section :trial_concluded_at, GOVUKDateSection, '#trial_concluded_at'
+  section :legal_aid_transfer_date, GovukDateSection, '#legal_aid_transfer_date'
+  section :trial_concluded_at, GovukDateSection, '#trial_concluded_at'
 
   # interim warrant fee fields
-  section :warrant_issued_date, GOVUKDateSection, ".warrant-fee-issued-date-group"
-  section :warrant_executed_date, GOVUKDateSection, ".warrant-fee-executed-date-group"
+  section :warrant_issued_date, GovukDateSection, ".warrant-fee-issued-date-group"
+  section :warrant_executed_date, GovukDateSection, ".warrant-fee-executed-date-group"
 
   def select_fee_type(name)
     select name, from: select_container[:id], autocomplete: false

--- a/features/page_objects/sections/lgfs_transfer_detail_section.rb
+++ b/features/page_objects/sections/lgfs_transfer_detail_section.rb
@@ -6,5 +6,5 @@ class LGFSTransferDetailSection < SitePrism::Section
   element :elected_case_yes, "label[for='claim-elected-case-true-field']"
   element :elected_case_no, "label[for='claim-elected-case-false-field']"
 
-  section :transfer_date, GOVUKDateSection, '#cc-transfer_date'
+  section :transfer_date, GovukDateSection, '#cc-transfer_date'
 end

--- a/features/page_objects/sections/retrial_section.rb
+++ b/features/page_objects/sections/retrial_section.rb
@@ -2,8 +2,8 @@ require_relative 'common_date_section'
 require_relative 'govuk_date_section'
 
 class RetrialSection < SitePrism::Section
-  section :retrial_started_at, GOVUKDateSection, '#retrial_started_at'
-  section :retrial_concluded_at, GOVUKDateSection, '#retrial_concluded_at'
+  section :retrial_started_at, GovukDateSection, '#retrial_started_at'
+  section :retrial_concluded_at, GovukDateSection, '#retrial_concluded_at'
 
   element :retrial_actual_length, "input[name='claim[retrial_actual_length]']"
   element :retrial_estimated_length, "input[name='claim[retrial_estimated_length]']"

--- a/features/page_objects/sections/typed_fee_section.rb
+++ b/features/page_objects/sections/typed_fee_section.rb
@@ -12,7 +12,7 @@ class TypedFeeSection < SitePrism::Section
   element :case_numbers_section, ".case_numbers_wrapper"
   element :add_dates, ".dates-wrapper .add_fields"
   element :numbered, ".fx-numberedList-number"
-  section :dates, GOVUKDateSection, ".fee-dates"
+  section :dates, GovukDateSection, ".fee-dates"
 
   # NOTE: the select list is hidden. Selection is done
   # by entering text into the input text field.

--- a/lib/govuk_component.rb
+++ b/lib/govuk_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   require_relative 'govuk_component/railtie' if defined?(Rails)
 end

--- a/lib/govuk_component/button_helpers.rb
+++ b/lib/govuk_component/button_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module ButtonHelpers
     GOVUK_BUTTON_START_SVG_OPTIONS = {
       class: 'govuk-button__start-icon',

--- a/lib/govuk_component/detail_helpers.rb
+++ b/lib/govuk_component/detail_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module DetailHelpers
     def govuk_detail(summary_text = nil, tag_options = {}, &)
       tag_options = prepend_classes('govuk-details', tag_options)

--- a/lib/govuk_component/inset_text_helpers.rb
+++ b/lib/govuk_component/inset_text_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module InsetTextHelpers
     def govuk_inset_text(tag_options = {}, &)
       tag_options = prepend_classes('govuk-inset-text', tag_options)

--- a/lib/govuk_component/link_helpers.rb
+++ b/lib/govuk_component/link_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module LinkHelpers
     def govuk_back_link_to(body = nil, url = nil, tag_options = {})
       tag_options = prepend_classes('govuk-back-link', tag_options)

--- a/lib/govuk_component/notification_banner_helpers.rb
+++ b/lib/govuk_component/notification_banner_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module NotificationBannerHelpers
     def govuk_notification_banner(header = nil, content = nil, tag_options = {}, &)
       govuk_notification_banner_options(tag_options)

--- a/lib/govuk_component/panel_helpers.rb
+++ b/lib/govuk_component/panel_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module PanelHelpers
     def govuk_panel(title = nil, body = nil, tag_options = {})
       tag_options = prepend_classes('govuk-panel govuk-panel--confirmation', tag_options)

--- a/lib/govuk_component/phase_banner_helpers.rb
+++ b/lib/govuk_component/phase_banner_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module PhaseBannerHelpers
     def govuk_phase_banner(phase = nil, body = nil, tag_options = {})
       tag_options = prepend_classes('govuk-phase-banner', tag_options)

--- a/lib/govuk_component/railtie.rb
+++ b/lib/govuk_component/railtie.rb
@@ -2,77 +2,77 @@
 
 require 'rails'
 
-module GOVUKComponent
+module GovukComponent
   class Railtie < Rails::Railtie
     initializer 'govuk_component.shared_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::SharedHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::SharedHelpers }
       end
     end
 
     initializer 'govuk_component.button_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::ButtonHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::ButtonHelpers }
       end
     end
 
     initializer 'govuk_component.detail_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::DetailHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::DetailHelpers }
       end
     end
 
     initializer 'govuk_component.inset_text_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::InsetTextHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::InsetTextHelpers }
       end
     end
 
     initializer 'govuk_component.link_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::LinkHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::LinkHelpers }
       end
     end
 
     initializer 'govuk_component.notification_banner_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::NotificationBannerHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::NotificationBannerHelpers }
       end
     end
 
     initializer 'govuk_component.panel_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::PanelHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::PanelHelpers }
       end
     end
 
     initializer 'govuk_component.phase_banner_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::PhaseBannerHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::PhaseBannerHelpers }
       end
     end
 
     initializer 'govuk_component.summary_list_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::SummaryListHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::SummaryListHelpers }
       end
     end
 
     initializer 'govuk_component.table_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::TableHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::TableHelpers }
       end
     end
 
     initializer 'govuk_component.tag_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::TagHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::TagHelpers }
       end
     end
 
     initializer 'govuk_component.warning_text_helpers' do
       config.after_initialize do
-        ActiveSupport.on_load(:action_view) { include GOVUKComponent::WarningTextHelpers }
+        ActiveSupport.on_load(:action_view) { include GovukComponent::WarningTextHelpers }
       end
     end
   end

--- a/lib/govuk_component/shared_helpers.rb
+++ b/lib/govuk_component/shared_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module SharedHelpers
     private
 

--- a/lib/govuk_component/summary_list_helpers.rb
+++ b/lib/govuk_component/summary_list_helpers.rb
@@ -2,7 +2,7 @@
 
 # Component Reference: https://design-system.service.gov.uk/components/summary-list/
 
-module GOVUKComponent
+module GovukComponent
   module SummaryListHelpers
     def govuk_summary_list(tag_options = {}, &)
       tag_options = prepend_classes('govuk-summary-list', tag_options)

--- a/lib/govuk_component/table_helpers.rb
+++ b/lib/govuk_component/table_helpers.rb
@@ -2,7 +2,7 @@
 
 # Component Reference: https://design-system.service.gov.uk/components/table/
 
-module GOVUKComponent
+module GovukComponent
   module TableHelpers
     def govuk_table(tag_options = {}, &)
       tag_options = prepend_classes('govuk-table app-table--responsive', tag_options)

--- a/lib/govuk_component/tag_helpers.rb
+++ b/lib/govuk_component/tag_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module TagHelpers
     def govuk_tag(body = nil, color = nil, **tag_options)
       tag_options = prepend_classes('govuk-tag--' + color, tag_options) if color.present?

--- a/lib/govuk_component/warning_text_helpers.rb
+++ b/lib/govuk_component/warning_text_helpers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module GOVUKComponent
+module GovukComponent
   module WarningTextHelpers
     def govuk_warning_text(body = nil, assistive_text = t('common.warning'), **tag_options, &)
       tag_options = prepend_classes('govuk-warning-text', tag_options)

--- a/spec/lib/govuk_component/button_helpers_spec.rb
+++ b/spec/lib/govuk_component/button_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::ButtonHelpers, type: :helper do
+RSpec.describe GovukComponent::ButtonHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_button' do

--- a/spec/lib/govuk_component/detail_helpers_spec.rb
+++ b/spec/lib/govuk_component/detail_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::DetailHelpers, type: :helper do
+RSpec.describe GovukComponent::DetailHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_detail' do

--- a/spec/lib/govuk_component/inset_text_helpers_spec.rb
+++ b/spec/lib/govuk_component/inset_text_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::InsetTextHelpers, type: :helper do
+RSpec.describe GovukComponent::InsetTextHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_inset_text' do

--- a/spec/lib/govuk_component/link_helpers_spec.rb
+++ b/spec/lib/govuk_component/link_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::LinkHelpers, type: :helper do
+RSpec.describe GovukComponent::LinkHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_back_link_to' do

--- a/spec/lib/govuk_component/notification_banner_helpers_spec.rb
+++ b/spec/lib/govuk_component/notification_banner_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::NotificationBannerHelpers, type: :helper do
+RSpec.describe GovukComponent::NotificationBannerHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_notification_banner' do

--- a/spec/lib/govuk_component/panel_helpers_spec.rb
+++ b/spec/lib/govuk_component/panel_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::PanelHelpers, type: :helper do
+RSpec.describe GovukComponent::PanelHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_panel' do

--- a/spec/lib/govuk_component/phase_banner_helpers_spec.rb
+++ b/spec/lib/govuk_component/phase_banner_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::PhaseBannerHelpers, type: :helper do
+RSpec.describe GovukComponent::PhaseBannerHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_phase_banner' do

--- a/spec/lib/govuk_component/summary_list_helpers_spec.rb
+++ b/spec/lib/govuk_component/summary_list_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::SummaryListHelpers, type: :helper do
+RSpec.describe GovukComponent::SummaryListHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_summary_list' do

--- a/spec/lib/govuk_component/table_helpers_spec.rb
+++ b/spec/lib/govuk_component/table_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::TableHelpers, type: :helper do
+RSpec.describe GovukComponent::TableHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_table' do

--- a/spec/lib/govuk_component/tag_helpers_spec.rb
+++ b/spec/lib/govuk_component/tag_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::TagHelpers, type: :helper do
+RSpec.describe GovukComponent::TagHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_tag' do

--- a/spec/lib/govuk_component/warning_text_helpers_spec.rb
+++ b/spec/lib/govuk_component/warning_text_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe GOVUKComponent::WarningTextHelpers, type: :helper do
+RSpec.describe GovukComponent::WarningTextHelpers, type: :helper do
   include RSpecHtmlMatchers
 
   describe '#govuk_warning_text' do

--- a/spec/support/capybara_extensions.rb
+++ b/spec/support/capybara_extensions.rb
@@ -4,7 +4,7 @@ require_relative 'capybara_extensions/govuk_component/matchers'
 
 module CapybaraExtensions
   def self.extension_methods
-    (CapybaraExtensions::GOVUKComponent::Matchers.instance_methods - Object.instance_methods).uniq
+    (CapybaraExtensions::GovukComponent::Matchers.instance_methods - Object.instance_methods).uniq
   end
 end
 
@@ -25,6 +25,6 @@ module Capybara
     end
   end
 
-  Node::Base.include CapybaraExtensions::GOVUKComponent::Matchers
-  Node::Simple.include CapybaraExtensions::GOVUKComponent::Matchers
+  Node::Base.include CapybaraExtensions::GovukComponent::Matchers
+  Node::Simple.include CapybaraExtensions::GovukComponent::Matchers
 end

--- a/spec/support/capybara_extensions/govuk_component/matchers.rb
+++ b/spec/support/capybara_extensions/govuk_component/matchers.rb
@@ -2,7 +2,7 @@
 
 # rubocop:disable Naming/PredicateName
 module CapybaraExtensions
-  module GOVUKComponent
+  module GovukComponent
     module Matchers
       def has_govuk_link?(options)
         href = options.delete(:href)


### PR DESCRIPTION
#### What

Previously, inflection had been added to uppercase occurrences of `GOVUK` in the ruby code in CCCD: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/6163

This causes conflicts with the `govuk-components` gem, which uses the format `Govuk`.

To resolve that conflict and allow the use of the gem, this change removes the inflection and updates the capitalisation of all uses of GOVUK in the ruby codebase.
