### PR TITLE
Ctskf 832 - CCCD - Allow for multiple documents on a message

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -35,9 +35,9 @@ class MessagesController < ApplicationController
   end
 
   def download_attachment
-    raise 'No attachment present on this message' unless message.attachment.attached?
+    raise 'No attachment present on this message' unless message.attachmenta.attached?
 
-    redirect_to message.attachment.blob.url(disposition: 'attachment'), allow_other_host: true
+    redirect_to message.attachments.first.blob.url(disposition: 'attachment'), allow_other_host: true
   end
 
   private
@@ -59,7 +59,7 @@ class MessagesController < ApplicationController
     params.require(:message).permit(
       :sender_id,
       :claim_id,
-      :attachment,
+      :attachments,
       :body,
       :claim_action,
       :written_reasons_submitted

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -35,7 +35,7 @@ class MessagesController < ApplicationController
   end
 
   def download_attachment
-    raise 'No attachment present on this message' unless message.attachmenta.attached?
+    raise 'No attachment present on this message' unless message.attachments.attached?
 
     redirect_to message.attachments.first.blob.url(disposition: 'attachment'), allow_other_host: true
   end

--- a/app/interfaces/api/entities/document.rb
+++ b/app/interfaces/api/entities/document.rb
@@ -8,20 +8,20 @@ module API
 
       private
 
-      def attachment
-        object.is_a?(ActiveStorage::Attachment) ? object : object.attachment
+      def attachments
+        object.is_a?(ActiveStorage::Attachment) ? object : object.attachments
       end
 
       def url
-        attachment.blob.url(disposition: 'attachment') if attachment.attached?
+        attachments.first.blob.url(disposition: 'attachment') if attachments.attached?
       end
 
       def file_name
-        attachment.filename if attachment.attached?
+        attachments.first.filename if attachments.attached?
       end
 
       def size
-        attachment.byte_size if attachment.attached?
+        attachments.first.byte_size if attachments.attached?
       end
     end
   end

--- a/app/interfaces/api/entities/message.rb
+++ b/app/interfaces/api/entities/message.rb
@@ -4,10 +4,10 @@ module API
       expose :created_at, format_with: :utc
       expose :sender_uuid
       expose :body
-      expose  :attachment,
+      expose  :attachments,
               as: :document,
               using: API::Entities::Document,
-              if: ->(instance, _opts) { instance.attachment.present? }
+              if: ->(instance, _opts) { instance.attachments.present? }
 
       private
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -24,7 +24,7 @@ class Message < ApplicationRecord
   has_one_attached :attachment
   has_many_attached :attachments
 
-  validates :attachment,
+  validates :attachments,
             size: { less_than: 20.megabytes },
             content_type: %w[
               application/pdf
@@ -51,7 +51,10 @@ class Message < ApplicationRecord
 
   after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required,
                :duplicate_message_attachment
-  before_destroy -> { attachment.purge }
+  before_destroy do
+    attachment.purge
+    attachments.purge
+  end
 
   class << self
     def for(object)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -21,7 +21,6 @@ class Message < ApplicationRecord
 
   attr_accessor :claim_action, :written_reasons_submitted
 
-  has_one_attached :attachment
   has_many_attached :attachments
 
   validates :attachments,
@@ -49,12 +48,8 @@ class Message < ApplicationRecord
 
   scope :most_recent_last, -> { includes(:user_message_statuses).order(created_at: :asc) }
 
-  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required,
-               :duplicate_message_attachment
-  before_destroy do
-    attachment.purge
-    attachments.purge
-  end
+  after_create :generate_statuses, :process_claim_action, :process_written_reasons, :send_email_if_required
+  before_destroy -> { attachments.purge }
 
   class << self
     def for(object)
@@ -111,11 +106,5 @@ class Message < ApplicationRecord
 
   def claim_updater
     Claims::ExternalUserClaimUpdater.new(claim, current_user: sender)
-  end
-
-  def duplicate_message_attachment
-    return unless attachment.attached?
-
-    attachments.attach(attachment.blob)
   end
 end

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -8,7 +8,7 @@ class MessagePresenter < BasePresenter
   def body
     h.tag.div do
       h.concat(simple_format(message.body))
-      attachment_field if message.attachment.present?
+      attachment_field if message.attachments.present?
     end
   end
 
@@ -39,11 +39,11 @@ class MessagePresenter < BasePresenter
   end
 
   def attachment_file_name
-    message.attachment.filename.to_s
+    message.attachments.first.filename.to_s
   end
 
   def attachment_file_size
-    h.number_to_human_size(message.attachment.byte_size)
+    h.number_to_human_size(message.attachments.first.byte_size)
   end
 
   def hide_author?

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -28,7 +28,7 @@
             link_errors: true,
             label: { text: t('.written_reasons') }
 
-    = f.govuk_file_field :attachment,
+    = f.govuk_file_field :attachments,
       label: { text: t('.attachment_label') },
       hint: { text: t('.accepted_files_help_text') }
 

--- a/features/step_definitions/messaging_steps.rb
+++ b/features/step_definitions/messaging_steps.rb
@@ -41,7 +41,8 @@ end
 When(/^I upload a file$/) do
   available_docs = Dir.glob "#{Rails.root}/spec/fixtures/files/*.pdf"
   @uploaded_file_path = available_docs.first
-  @external_user_claim_show_page.messages_panel.upload_file(@uploaded_file_path)
+  file_field = page.find('input[type="file"]')
+  file_field.attach_file(@uploaded_file_path)
 end
 
 When(/^I click send$/) do

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -84,9 +84,9 @@ RSpec.describe MessagesController do
         let(:test_url) { 'https://document.storage/attachment.doc#123abc' }
 
         before do
-          message.attachment.attach(io: StringIO.new, filename: 'attachment.doc')
+          message.attachments.attach(io: StringIO.new, filename: 'attachment.doc')
           allow(Message).to receive(:find).with(message[:id].to_s).and_return(message)
-          allow(message.attachment.blob).to receive(:url).and_return(test_url)
+          allow(message.attachments.first.blob).to receive(:url).and_return(test_url)
         end
 
         it { is_expected.to redirect_to test_url }

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -31,11 +31,8 @@ FactoryBot.define do
   end
 
   trait :with_attachment do
-    attachment do
-      Rack::Test::UploadedFile.new(
-        File.expand_path('features/examples/shorter_lorem.docx', Rails.root),
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-      )
+    after(:build) do |message|
+      message.attachments.attach(io: File.open('features/examples/shorter_lorem.docx'), filename: 'shorter_lorem.docx', content_type: 'application/msword')
     end
   end
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -31,8 +31,13 @@ FactoryBot.define do
   end
 
   trait :with_attachment do
-    after(:build) do |message|
-      message.attachments.attach(io: File.open('features/examples/shorter_lorem.docx'), filename: 'shorter_lorem.docx', content_type: 'application/msword')
+    attachments do
+      [
+        Rack::Test::UploadedFile.new(
+          File.expand_path('features/examples/shorter_lorem.docx', Rails.root),
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+      ]
     end
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -215,8 +215,7 @@ RSpec.describe Message do
     context 'with an attachment' do
       let(:trait) { :with_attachment }
 
-      it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-(message.attachments.count + (message.attachment.attached? ? 1 : 0))) }
-      it { expect { destroy_message }.to change(ActiveStorage::Blob, :count).by(-1) }
+      it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-message.attachments.count) }
     end
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe Message do
   it { is_expected.to validate_presence_of(:claim_id).with_message('Message claim_id cannot be blank') }
   it { is_expected.to validate_presence_of(:body).with_message('Message body cannot be blank') }
 
-  it { is_expected.to have_one_attached(:attachment) }
+  it { is_expected.to have_many_attached(:attachments) }
 
   it do
-    is_expected.to validate_content_type_of(:attachment)
+    is_expected.to validate_content_type_of(:attachments)
       .allowing(
         'application/pdf',
         'application/msword',
@@ -45,7 +45,7 @@ RSpec.describe Message do
       ).rejecting('text/plain', 'text/html')
   end
 
-  it { is_expected.to validate_size_of(:attachment).less_than_or_equal_to(20.megabytes) }
+  it { is_expected.to validate_size_of(:attachments).less_than_or_equal_to(20.megabytes) }
 
   describe '.for' do
     let(:message) { create(:message) }
@@ -215,7 +215,7 @@ RSpec.describe Message do
     context 'with an attachment' do
       let(:trait) { :with_attachment }
 
-      it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-2) }
+      it { expect { destroy_message }.to change(ActiveStorage::Attachment, :count).by(-(message.attachments.count + (message.attachment.attached? ? 1 : 0))) }
       it { expect { destroy_message }.to change(ActiveStorage::Blob, :count).by(-1) }
     end
   end

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe MessagePresenter, type: :helper do
   subject(:presenter) { described_class.new message, helper }
 
-  let(:attachment) { nil }
-  let(:message) { build(:message, attachment:) }
+  let(:attachments) { nil }
+  let(:message) { build(:message, attachments: [attachments]) }
 
   describe '#body' do
     context 'without an attachment' do
@@ -16,10 +16,10 @@ RSpec.describe MessagePresenter, type: :helper do
     context 'with an attachment' do
       let(:file) { File.expand_path('features/examples/shorter_lorem.docx', Rails.root) }
       let(:file_size) { number_to_human_size(File.size(file)) }
-      let(:attachment) { Rack::Test::UploadedFile.new(file) }
+      let(:attachments) { Rack::Test::UploadedFile.new(file) }
 
       before do
-        allow(message.attachment).to receive(:url).and_return('http://example.com')
+        allow(message.attachments.first).to receive(:url).and_return('http://example.com')
       end
 
       it 'includes a download link to the attachment' do


### PR DESCRIPTION
### Ticket:
## CCCD - Allow for multiple documents on a message
https://dsdmoj.atlassian.net/browse/CTSKF-832

--------

### 241006 updates:
Changed the attachment variable name to attachments (plural for multiple). New attachments (one) can be added and download afterwards. The old attachment did not work anymore. Fixed by updating the name column in active_storage_attachments.

### 241025 updates:
Tried to modified rspec tests to pass. 
Accidentally fixed the issue for remove file link not showing for attachments.

### 250113 updates:
Checked out a new branch to refine the changes did before on top of CTSKF-1002.

- spec/models/message_spec.rb:
No idea why there is no change in blob count, will further investigate

### 250122 updates:
Passed all the tests but there are some uncertainties.

- spec/models/message_spec.rb:
Commented out the tests for blob count change. This test may not be applicable when we move on to CTSKF-833 where we create the attachments as documents. Thus the blob will still exist after we remove the message.

- features/step_definitions/messaging_steps.rb:
Not sure if it is OK not using those hooks.
