### PR TITLE
Some pre Rails 7.1 changes

### DIFF
--- a/app/controllers/concerns/provider_admin_concern.rb
+++ b/app/controllers/concerns/provider_admin_concern.rb
@@ -2,7 +2,7 @@ module ProviderAdminConcern
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_provider, only: %i[show edit update regenerate_api_key]
+    before_action :set_provider, only: %i[show edit update]
   end
 
   private

--- a/app/controllers/external_users/admin/providers_controller.rb
+++ b/app/controllers/external_users/admin/providers_controller.rb
@@ -3,6 +3,8 @@ module ExternalUsers
     class ProvidersController < ExternalUsers::Admin::ApplicationController
       include ProviderAdminConcern
 
+      before_action :set_provider, only: :regenerate_api_key
+
       def regenerate_api_key
         @provider.regenerate_api_key!
         redirect_to external_users_admin_provider_path(@provider), notice: t('.notice')

--- a/config/initializers/00_extensions.rb
+++ b/config/initializers/00_extensions.rb
@@ -41,3 +41,11 @@ end
 class FalseClass
   include Extensions::BooleanExtension::False
 end
+
+module ActionView
+  module Helpers
+    class FormBuilder
+      include Extensions::FormBuilderExtension
+    end
+  end
+end

--- a/lib/extensions/form_builder_extension.rb
+++ b/lib/extensions/form_builder_extension.rb
@@ -1,0 +1,15 @@
+# From Rails 7.1 the `logstasher` gem causes a 'stack level too deep' error
+# when an instance of `ActionView::Helpers::FormBuilder` is passed as a
+# parameter to a partial. This is because the `as_json` method is called and
+# the `template` attribute results in a circular reference.
+#
+# See https://github.com/rails/rails/issues/51626
+module Extensions
+  module FormBuilderExtension
+    def as_json(options = {})
+      amended_options = options.tap { |o| o[:except] = options[:except].to_a << :template }
+
+      super(amended_options)
+    end
+  end
+end

--- a/spec/lib/govuk_component/warning_text_helpers_spec.rb
+++ b/spec/lib/govuk_component/warning_text_helpers_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe GovukComponent::WarningTextHelpers, type: :helper do
 
   describe '#govuk_warning_text_description' do
     context 'when called with a block' do
-      subject(:markup) { helper.govuk_warning_text_description { 'You can be fined up to £5,000 if you do not register.' } }
+      subject(:markup) { (helper.govuk_warning_text_description { 'You can be fined up to £5,000 if you do not register.' }).to_s }
 
       it { is_expected.to have_tag(:div, with: { class: 'govuk-warning-text__text govuk-\!-font-weight-regular govuk-\!-margin-top-4' }) }
     end

--- a/spec/services/cleaners/advocate_claim_cleaner_spec.rb
+++ b/spec/services/cleaners/advocate_claim_cleaner_spec.rb
@@ -16,7 +16,7 @@ end
 RSpec.shared_examples 'clear basic fees' do
   it { expect { call_cleaner }.not_to change { claim.basic_fees.size } }
   it { expect { call_cleaner }.to change { claim.basic_fees.flat_map(&:dates_attended).size }.to 0 }
-  it { expect { call_cleaner }.to change { claim.basic_fees.sum(&:amount) }.to 0 }
+  it { expect { call_cleaner }.to change { claim.basic_fees.sum { |fee| fee.amount.to_i } }.to 0 }
 end
 
 RSpec.shared_examples 'does not clear basic fees' do


### PR DESCRIPTION
#### What

Some small changes that can be made in advance of upgrading Rails 7.1.

#### Ticket

[CCCD: Upgrade Rails to 7.1](https://dsdmoj.atlassian.net/browse/CTSKF-769)

#### Why

Make the Rails 7.1 upgrade a little smoother.

#### How

* Explicitly convert `helper.govuk_warning_text_description` to a string in a test.
* Move a before action callback out of a concern as it is only relevant to some controllers.
* Cater for slight differences between the deprecated Rails specific `sum` method and the core Ruby version.
* Monkey patch `ActionView::Helpers::FormBuilder#as_json` to avoid fatal errors caused by `logstasher`.