### PR TITLE
Pin the version of concurrent-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,12 @@ gem 'uri', '< 2.0.0'
 
 gem 'laa-cda', git: 'https://github.com/ministryofjustice/laa-cda'
 
+# Version 1.3.5 of concurrent-ruby removes logger and this causes issues with
+# Rails 7.0. It should be possible to remove this restriction when we move to
+# Rails 7.1.
+# See https://github.com/ruby-concurrency/concurrent-ruby/issues/1077
+gem 'concurrent-ruby', '< 1.3.5'
+
 group :development, :test do
   gem 'annotate'
   gem 'brakeman', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -705,6 +705,7 @@ DEPENDENCIES
   capybara-selenium
   chartkick (~> 5.1.2)
   cocoon (~> 1.2.15)
+  concurrent-ruby (< 1.3.5)
   config (~> 5.5)
   cucumber-rails (~> 3.1.0)
   database_cleaner


### PR DESCRIPTION
#### What

Fix the version of the `concurrent-ruby` gem to 1.3.4.

#### Ticket

N/A

#### Why

There is an issue with `concurrent-ruby` version 1.3.5 and Rails 7.0. See https://github.com/ruby-concurrency/concurrent-ruby/issues/1077

#### How

Pin the version of the gem in `Gemfile`.