### PR TITLE
[CTSKF-1009] Add injection warning for Additional Prep Fees

### DIFF
--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -40,6 +40,7 @@ module API
         expose :agfs_hardship
         expose :lgfs_hardship
         expose :clar_fees_warning
+        expose :additional_prep_fee_warning
       end
 
       private
@@ -129,6 +130,14 @@ module API
 
       def cav_warning
         (last_injection_attempt_succeeded && contains_conference_and_view).to_i
+      end
+
+      def clar_fees_warning
+        (last_injection_attempt_succeeded && contains_clar_fees).to_i
+      end
+
+      def additional_prep_fee_warning
+        (last_injection_attempt_succeeded && contains_additional_prep_fee).to_i
       end
 
       def supplementary

--- a/app/interfaces/api/helpers/search_result_helpers.rb
+++ b/app/interfaces/api/helpers/search_result_helpers.rb
@@ -98,15 +98,21 @@ module API
         object&.last_injection_succeeded || false
       end
 
-      def clar_fees_warning
-        (last_injection_attempt_succeeded && contains_clar_fees).to_i
-      end
-
       def contains_clar_fees
         fees&.map do |fee|
           [
             fee[2].eql?('Fee::MiscFeeType'),
             fee[1].in?(['Paper heavy case', 'Unused materials (up to 3 hours)', 'Unused materials (over 3 hours)']),
+            fee[0].to_i.positive?
+          ].all?
+        end&.any?
+      end
+
+      def contains_additional_prep_fee
+        fees&.map do |fee|
+          [
+            fee[2].eql?('Fee::MiscFeeType'),
+            fee[1].eql?('Additional preparation fee'),
             fee[0].to_i.positive?
           ].all?
         end&.any?

--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -397,6 +397,10 @@ class Claim::BaseClaimPresenter < BasePresenter
     claim.fees.select { |f| f.fee_type.unique_code.in?(%w[MIPHC MIUMU MIUMO]) }.any? { |x| x.amount&.nonzero? }
   end
 
+  def has_additional_prep_fee?
+    claim.fees.select { |f| f.fee_type.unique_code.eql?('MIAPF') }.any? { |x| x.amount&.nonzero? }
+  end
+
   def eligible_misc_fee_type_options_for_select
     claim.eligible_misc_fee_types.map do |fee_type|
       [

--- a/app/views/warnings/_injection_warnings_summary.html.haml
+++ b/app/views/warnings/_injection_warnings_summary.html.haml
@@ -15,3 +15,12 @@
 
       %span.form-hint.govuk-error-summary__body
         = t('shared.injection_errors.clar_fees_warning.message')
+
+- if claim&.last_injection_attempt&.succeeded && claim.has_additional_prep_fee?
+  .js-callout-injection-warning
+    .warning-summary.govuk-error-summary{ role: 'group', 'aria-labelledby': 'warning-summary-heading', tabindex: '-1' }
+      %h2.govuk-heading-m.govuk-error-summary__title{ id: 'warning-summary-heading' }
+        = t('shared.injection_errors.additional_prep_fee_warning.header')
+
+      %span.form-hint.govuk-error-summary__body
+        = t('shared.injection_errors.additional_prep_fee_warning.message')

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -74,6 +74,10 @@ moj.Modules.AllocationDataTable = {
         $(row).addClass('injection-warning')
         $('td', row).eq(0).wrapInner('<div class="warning-message-container"></div>')
         $('td .warning-message-container', row).eq(0).append('<div class="warning-message">Paper heavy case or unused materials fees not injected</div>')
+      } else if (data.filter.additional_prep_fee_warning) {
+        $(row).addClass('injection-warning')
+        $('td', row).eq(0).wrapInner('<div class="warning-message-container"></div>')
+        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">Additional prep fee not injected</div>')
       }
 
       return row

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -69,11 +69,11 @@ moj.Modules.AllocationDataTable = {
       } else if (data.filter.cav_warning) {
         $(row).addClass('injection-warning')
         $('td', row).eq(0).wrapInner('<div class="warning-message-container"></div>')
-        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">CAVs not injected</div>')
+        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">Conference fees not injected</div>')
       } else if (data.filter.clar_fees_warning) {
         $(row).addClass('injection-warning')
         $('td', row).eq(0).wrapInner('<div class="warning-message-container"></div>')
-        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">CLAR fees not injected</div>')
+        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">Paper heavy case or unused materials fees not injected</div>')
       }
 
       return row

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -36,7 +36,7 @@ tr {
       .warning-message {
         position: absolute;
         top: -$govuk-gutter;
-        width: 320px;
+        width: 500px;
         color: govuk-colour("orange");
         text-align: left;
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2115,11 +2115,11 @@ en:
       error: Claim not injected
       dismiss: Dismiss this message
       cav_warning:
-        header: 'Warning: conferences and views were not injected'
+        header: 'Warning: Conferences and views were not injected'
         message: 'The provider has claimed conferences and views on this claim, but they have not been injected into CCR. Enter them manually.'
       clar_fees_warning:
-        header: 'Warning: CLAR fees were not injected'
-        message: 'The provider has claimed Criminal Legal Aid Review fees on this claim, but they have not been injected. Please enter them manually.'
+        header: 'Warning: Paper heavy case or unused materials fees were not injected'
+        message: 'The provider has claimed paper heavy case or unused materials fees on this claim, but they have not been injected. Enter them manually.'
 
     message_controls:
       attachment_label: Optionally attach a file

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2120,6 +2120,9 @@ en:
       clar_fees_warning:
         header: 'Warning: Paper heavy case or unused materials fees were not injected'
         message: 'The provider has claimed paper heavy case or unused materials fees on this claim, but they have not been injected. Enter them manually.'
+      additional_prep_fee_warning:
+        header: 'Warning: Additional preparation fee was not injected'
+        message: 'The provider has claimed an additional preparation fee on this claim, but it has not been injected. Enter it manually.'
 
     message_controls:
       attachment_label: Optionally attach a file

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -70,7 +70,8 @@ describe API::Entities::SearchResult do
           supplementary: 0,
           agfs_hardship: 0,
           lgfs_hardship: 0,
-          clar_fees_warning: 0
+          clar_fees_warning: 0,
+          additional_prep_fee_warning: 0
         }
       end
 
@@ -196,6 +197,14 @@ describe API::Entities::SearchResult do
         let(:claim) { OpenStruct.new('id' => '19932', 'uuid' => 'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme' => 'lgfs', 'scheme_type' => 'Final', 'case_number' => 'T20202401', 'state' => 'submitted', 'court_name' => 'Newcastle', 'case_type' => 'Trial', 'total' => '1200.00', 'disk_evidence' => false, 'external_user' => 'Emile Hirsch', 'maat_references' => '5864761', 'defendants' => 'Junius Leschberg', 'fees' => '1001.0~Trial~Fee::GraduatedFeeType,59.59~Unused materials (up to 3 hours)~Fee::MiscFeeType', 'last_submitted_at' => '2020-04-22T07:27:59Z', 'class_letter' => 'B', 'is_fixed_fee' => false, 'fee_type_code' => 'GRTRL', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'allocation_type' => 'Grad', 'injection_errors' => '{"errors":[]}', 'last_injection_succeeded' => 'true') }
 
         before { result.merge!(trial: 1, graduated_fees: 1, clar_fees_warning: 1) }
+
+        include_examples 'returns expected JSON filter values'
+      end
+
+      context 'when passed an advocate claims with an Additional Prep fee and without an injection attempt error' do
+        let(:claim) { OpenStruct.new('id' => '19932', 'uuid' => 'aec3900f-3e82-4c4f-a7cd-498ad45f11f8', 'scheme' => 'agfs', 'scheme_type' => 'Advocate', 'case_number' => 'T20200824', 'state' => 'submitted', 'court_name' => 'Newcastle', 'case_type' => 'Contempt', 'total' => '426.36', 'disk_evidence' => false, 'external_user' => 'Theodore Schumm', 'maat_references' => '2320144', 'defendants' => 'Junius Lesch', 'fees' => '0.0~Daily attendance fee (3 to 40)~Fee::BasicFeeType, 0.0~Daily attendance fee (41 to 50)~Fee::BasicFeeType, 0.0~Daily attendance fee (51+)~Fee::BasicFeeType, 0.0~Standard appearance fee~Fee::BasicFeeType, 0.0~Plea and case management hearing~Fee::BasicFeeType, 0.0~Conferences and views~Fee::BasicFeeType, 0.0~Number of defendants uplift~Fee::BasicFeeType, 0.0~Number of cases uplift~Fee::BasicFeeType, 0.0~Number of prosecution witnesses~Fee::BasicFeeType, 1.0~Basic fee~Fee::BasicFeeType, 1.0~Additional preparation fee~Fee::MiscFeeType', 'last_submitted_at' => '2020-08-01 09:33:30.932017', 'is_fixed_fee' => false, 'fee_type_code' => 'GRRAK', 'graduated_fee_types' => 'GRTRL,GRRTR,GRGLT,GRDIS,GRRAK,GRCBR', 'injection_errors' => '{"errors":[]}', 'last_injection_succeeded' => 'true') }
+
+        before { result.merge!(graduated_fees: 1, additional_prep_fee_warning: 1) }
 
         include_examples 'returns expected JSON filter values'
       end

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -70,7 +70,7 @@ describe('Modules.AllocationDataTable.js', function () {
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">CAVs not injected</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">Conference fees not injected</div></div></td></tr>')
     })
 
     it('...should have a `createdRow` callback defined for CLAR fee warnings', function () {
@@ -82,7 +82,7 @@ describe('Modules.AllocationDataTable.js', function () {
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">CLAR fees not injected</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">Paper heavy case or unused materials fees not injected</div></div></td></tr>')
     })
 
     it('...should have `processing`', function () {

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -85,6 +85,18 @@ describe('Modules.AllocationDataTable.js', function () {
       expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">Paper heavy case or unused materials fees not injected</div></div></td></tr>')
     })
 
+    it('...should have a `createdRow` callback defined for Additional Prep fee warnings', function () {
+      expect(options.createdRow).toBeDefined()
+      const row = $('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"></td></tr>')
+      const data = {
+        filter: {
+          additional_prep_fee_warning: 1
+        }
+      }
+      const output = options.createdRow(row, data)
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">Additional prep fee not injected</div></div></td></tr>')
+    })
+
     it('...should have `processing`', function () {
       expect(options.processing).toEqual(true)
     })

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -378,6 +378,52 @@ RSpec.describe 'case_workers/claims/show.html.haml' do
     end
   end
 
+  context 'fee injection warnings' do
+    before do
+      trial_claim
+      create(:injection_attempt, claim: @claim)
+      create(:misc_fee, fee_type:, claim: @claim, quantity: 1, amount: 100.00)
+      assign(:claim, @claim)
+      render
+    end
+
+    context 'with CLAR fees' do
+      let(:fee_type) { build(:misc_fee_type, :miumu) }
+
+      it 'displays an injection warning' do
+        expect(rendered).to have_css('div.js-callout-injection-warning')
+      end
+
+      it 'displays the expected text' do
+        expect(rendered).to have_text('Warning: Paper heavy case or unused materials fees were not injected')
+      end
+    end
+
+    context 'with CAV fees' do
+      let(:fee_type) { build(:misc_fee_type, :bacav) }
+
+      it 'displays an injection warning' do
+        expect(rendered).to have_css('div.js-callout-injection-warning')
+      end
+
+      it 'displays the expected text' do
+        expect(rendered).to have_text('Warning: Conferences and views were not injected')
+      end
+    end
+
+    context 'with Additional Prep fee' do
+      let(:fee_type) { build(:misc_fee_type, :miapf) }
+
+      it 'displays an injection warning' do
+        expect(rendered).to have_css('div.js-callout-injection-warning')
+      end
+
+      it 'displays the expected text' do
+        expect(rendered).to have_text('Warning: Additional preparation fee was not injected')
+      end
+    end
+  end
+
   def certified_claim
     eu = create(:external_user, :advocate, user: create(:user, first_name: 'Stepriponikas', last_name: 'Bonstart'))
     @claim = create(:allocated_claim, external_user: eu)


### PR DESCRIPTION
#### What

Display warnings on the claim allocation page and summary page for claims with Additional Prep Fees to inform users that the fee has not injected to CCR.

#### Ticket

[CTSKF-1009](https://dsdmoj.atlassian.net/browse/CTSKF-1009)

#### Why

Other fee types which are not injected to CCR (Conferences and Views, CLAR fees) have these warnings. This brings Additional Prep Fees in line with those fees, giving caseworkers additional useful information to help their processing.

#### How

* Rewords existing warnings for Conferences and Views and CLAR fees to remove acronyms and improve clarity.
* Adds a new warning to the allocation page
* Adds a new warning to the claim summary page

#### Screenshots

**Conferences and views:**

Allocation:

<img width="973" alt="image" src="https://github.com/user-attachments/assets/55225fef-f9cd-4edc-ae06-c38b6c2c4c8a" />

Summary:

<img width="981" alt="image" src="https://github.com/user-attachments/assets/898f4e25-47d6-44e8-8276-1679f78300da" />

**CLAR fees:**

Allocation:

<img width="969" alt="image" src="https://github.com/user-attachments/assets/60551dbf-5880-45a2-89d4-b02c948bbff7" />

Summary:

<img width="971" alt="image" src="https://github.com/user-attachments/assets/f12dae18-027a-41d1-a128-2822a3c1b987" />

**Additional prep fees:**

Allocation:

<img width="995" alt="image" src="https://github.com/user-attachments/assets/cc6fadd2-4c25-4189-8986-8c95e3a54a6f" />

Summary:

<img width="971" alt="image" src="https://github.com/user-attachments/assets/45c486fe-da28-4137-b498-73561673aa18" />


[CTSKF-1009]: https://dsdmoj.atlassian.net/browse/CTSKF-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ