### PR TITLE
[CTSKF-1001] Format injection messages

### DIFF
--- a/app/views/case_workers/_injection_errors.html.haml
+++ b/app/views/case_workers/_injection_errors.html.haml
@@ -1,0 +1,9 @@
+- if claim.injection_error.present? || claim.disk_evidence
+  %div.error-message-container
+    - if claim.injection_error
+      - claim.injection_error do |message|
+        %div.error-message
+          = message
+    - if claim.disk_evidence
+      %div.error-message
+        = t('.disk_evidence')

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -72,16 +72,7 @@
                       = govuk_link_to claim.case_number, case_workers_claim_path(claim), 'aria-label': t('.case_number_label', case_number: claim.case_number)
                       %span.unique-id-small
                         = claim.unique_id
-
-                      - if claim.injection_error.present? || claim.disk_evidence
-                        %div.error-message-container
-                          - if claim.injection_error
-                            - claim.injection_error do |message|
-                              %div.error-message
-                                = message
-                          - if claim.disk_evidence
-                            %div.error-message
-                              = t('.disk_evidence')
+                      = render partial: 'case_workers/injection_errors', locals: { claim: claim }
 
                   = govuk_table_td('data-label': t('.court')) do
                     = claim.court.name

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -60,26 +60,28 @@
           = govuk_table_tbody do
             = collection_check_boxes :allocation, :claim_ids, @claims, :id, :case_number do |b|
               - present(b.object) do |claim|
-                = govuk_table_row(id: dom_id(claim), class: claim.injection_error ? 'error injection-error' : nil) do
+                = govuk_table_row(id: dom_id(claim)) do
                   = govuk_table_td('data-label': t('.select')) do
-                    .govuk-form-group.error-message-container
-                      .govuk-checkboxes.govuk-checkboxes--small{ 'data-module': 'govuk-checkboxes' }
-                        .govuk-checkboxes__item
-                          = b.check_box(class: 'govuk-checkboxes__input')
-                          = b.label(class: 'govuk-label govuk-checkboxes__label'){ t('.choose_label_html', case_number: claim.case_number) }
-
-                      - claim.injection_error do |message|
-                        .error-message
-                          = message
+                    .govuk-checkboxes.govuk-checkboxes--small{ 'data-module': 'govuk-checkboxes' }
+                      .govuk-checkboxes__item
+                        = b.check_box(class: 'govuk-checkboxes__input')
+                        = b.label(class: 'govuk-label govuk-checkboxes__label'){ t('.choose_label_html', case_number: claim.case_number) }
 
                   = govuk_table_td('data-label': t('.case_number')) do
                     %span.js-test-case-number
                       = govuk_link_to claim.case_number, case_workers_claim_path(claim), 'aria-label': t('.case_number_label', case_number: claim.case_number)
                       %span.unique-id-small
                         = claim.unique_id
-                      - if claim.disk_evidence == true
-                        %span.disk-evidence
-                          = t('.disk_evidence')
+
+                      - if claim.injection_error.present? || claim.disk_evidence
+                        %div.error-message-container
+                          - if claim.injection_error
+                            - claim.injection_error do |message|
+                              %div.error-message
+                                = message
+                          - if claim.disk_evidence
+                            %div.error-message
+                              = t('.disk_evidence')
 
                   = govuk_table_td('data-label': t('.court')) do
                     = claim.court.name

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -51,13 +51,9 @@
             = sortable 'last_submitted_at', t('.submission_date'), 'aria-label': t('.last_submitted_at_sort_label'), id: 'last_submitted_at_ms'
 
         - present_collection(claims).each do |claim|
-          = govuk_table_row(class: claim.injection_error ? 'error injection-error' : nil) do
+          = govuk_table_row do
             = govuk_table_td('data-label': t('.type')) do
-              .error-message-container
-                = claim.pretty_type
-                - claim.injection_error do |message|
-                  .error-message
-                    = message
+              = claim.pretty_type
 
             = govuk_table_td('data-label': t('.case_number')) do
               = govuk_link_to claim.case_number,
@@ -65,9 +61,15 @@
                         class: 'js-test-case-number-link',
                         'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
 
-              - if claim.disk_evidence == true
-                %span.disk-evidence
-                  = t('.disk_evidence')
+              - if claim.injection_error.present? || claim.disk_evidence
+                %div.error-message-container
+                  - if claim.injection_error
+                    - claim.injection_error do |message|
+                      %div.error-message
+                        = message
+                  - if claim.disk_evidence
+                    %div.error-message
+                      = t('.disk_evidence')
 
             = govuk_table_td('data-label': t('.advocate_litigator')) do
               = claim.external_user.name

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -60,16 +60,7 @@
                         case_workers_claim_path(claim),
                         class: 'js-test-case-number-link',
                         'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
-
-              - if claim.injection_error.present? || claim.disk_evidence
-                %div.error-message-container
-                  - if claim.injection_error
-                    - claim.injection_error do |message|
-                      %div.error-message
-                        = message
-                  - if claim.disk_evidence
-                    %div.error-message
-                      = t('.disk_evidence')
+              = render partial: 'case_workers/injection_errors', locals: { claim: claim }
 
             = govuk_table_td('data-label': t('.advocate_litigator')) do
               = claim.external_user.name

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -62,22 +62,16 @@ moj.Modules.AllocationDataTable = {
 
       $('td', row).addClass('govuk-table__cell')
 
-      if (data.filter.injection_errored) {
-        $(row).addClass('error injection-error')
-        $('td', row).eq(0).wrapInner('<div class="error-message-container"></div>')
-        $('td .error-message-container', row).eq(0).append('<div class="error-message">' + data.injection_errors + '</div>')
-      } else if (data.filter.cav_warning) {
-        $(row).addClass('injection-warning')
-        $('td', row).eq(0).wrapInner('<div class="warning-message-container"></div>')
-        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">Conference fees not injected</div>')
-      } else if (data.filter.clar_fees_warning) {
-        $(row).addClass('injection-warning')
-        $('td', row).eq(0).wrapInner('<div class="warning-message-container"></div>')
-        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">Paper heavy case or unused materials fees not injected</div>')
-      } else if (data.filter.additional_prep_fee_warning) {
-        $(row).addClass('injection-warning')
-        $('td', row).eq(0).wrapInner('<div class="warning-message-container"></div>')
-        $('td .warning-message-container', row).eq(0).append('<div class="warning-message">Additional prep fee not injected</div>')
+      const showWarning = data.filter.injection_errored || data.filter.cav_warning || data.filter.clar_fees_warning || data.filter.additional_prep_fee_warning || data.filter.disk_evidence
+
+      if (showWarning) {
+        $('td', row).eq(1).append('<div class="error-message-container"></div>')
+
+        if (data.filter.injection_errored) { $('td .error-message-container', row).append('<div class="error-message">' + data.injection_errors + '</div>') }
+        if (data.filter.cav_warning) { $('td .error-message-container', row).append('<div class="error-message">Conference fees not injected</div>') }
+        if (data.filter.clar_fees_warning) { $('td .error-message-container', row).append('<div class="error-message">Paper heavy case or unused materials fees not injected</div>') }
+        if (data.filter.additional_prep_fee_warning) { $('td .error-message-container', row).append('<div class="error-message">Additional prep fee not injected</div>') }
+        if (data.filter.disk_evidence) { $('td .error-message-container', row).append('<div class="error-message">Disk evidence</div>') }
       }
 
       return row
@@ -158,7 +152,7 @@ moj.Modules.AllocationDataTable = {
       targets: 1,
       data: null,
       render: function (data, type, full) {
-        return data.filter.disk_evidence ? '<span class="js-test-case-number"><a aria-label="View Claim, Case number: ' + data.case_number + '" href="/case_workers/claims/' + data.id + '">' + data.case_number + '</a><br/><span class="disk-evidence">Disk evidence</span></span>' : '<span class="js-test-case-number"><a aria-label="View Claim, Case number: ' + data.case_number + '" href="/case_workers/claims/' + data.id + '">' + data.case_number + '</a></span>'
+        return '<span class="js-test-case-number"><a aria-label="View Claim, Case number: ' + data.case_number + '" href="/case_workers/claims/' + data.id + '">' + data.case_number + '</a></span>'
       }
 
     }, {

--- a/app/webpack/stylesheets/_shame.scss
+++ b/app/webpack/stylesheets/_shame.scss
@@ -378,11 +378,6 @@ form {
   margin-bottom: $govuk-gutter;
 }
 
-.disk-evidence {
-  display: block;
-  color: $govuk-error-colour;
-}
-
 .js-allocation-page #page-h1 {
   margin-bottom: 0;
 }

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -1,44 +1,22 @@
 // stylelint-disable max-nesting-depth, selector-class-pattern, selector-no-qualifying-type
 
 tr {
-  &.error.injection-error {
-    border-left: 5px solid $govuk-error-colour;
-    color: inherit;
+  td {
+    padding-top: $govuk-gutter;
 
-    td {
-      padding-top: $govuk-gutter;
-
-      .error-message-container {
-        position: relative;
-        padding-left: $gutter-half;
-      }
+    .error-message-container {
+      position: relative;
+      width: 200px;
+      border-left: 3px solid $govuk-error-colour;
+      @include govuk-responsive-margin(2, "top");
+      @include govuk-responsive-margin(2, "bottom");
 
       .error-message {
-        position: absolute;
-        top: -$govuk-gutter;
-        width: 320px;
+        top: $govuk-gutter;
         color: $govuk-error-colour;
         text-align: left;
-      }
-    }
-  }
-
-  &.injection-warning {
-    border-left: 5px solid govuk-colour("orange");
-
-    td {
-      padding-top: $govuk-gutter;
-
-      .warning-message-container {
-        position: relative;
-      }
-
-      .warning-message {
-        position: absolute;
-        top: -$govuk-gutter;
-        width: 500px;
-        color: govuk-colour("orange");
-        text-align: left;
+        @include govuk-responsive-margin(1, "top");
+        @include govuk-responsive-margin(1, "left");
       }
     }
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2598,7 +2598,6 @@ en:
           re_allocate: Re-allocate
           select_all: Select all
           allocated_to: Allocated to
-          disk_evidence: Disk evidence
           no_claims_allocated: There is no claim available for allocation
           number_of_claims: 'Number of claims: %{claim_count}'
           choose_label_html: <span class="govuk-visually-hidden">Select case %{case_number}</span>
@@ -2662,7 +2661,6 @@ en:
         case_type: Case type
         case_type_sort_label: 'Sort by: Case type'
         defendants: Defendants
-        disk_evidence: Disk evidence
         last_submitted_at_sort_label: 'Sort by: Last submitted at date'
         messages: Messages
         none: None
@@ -2717,6 +2715,8 @@ en:
         start_date: Effective start date
         end_date: Effective end date
         contract_number: Contract Number
+    injection_errors:
+      disk_evidence: Disk evidence
   api:
     v1:
       common_params:

--- a/spec/javascripts/Modules.AllocationDataTable_spec.js
+++ b/spec/javascripts/Modules.AllocationDataTable_spec.js
@@ -48,9 +48,9 @@ describe('Modules.AllocationDataTable.js', function () {
       ])
     })
 
-    it('...should have a `createdRow` callback defined', function () {
+    it('...should have a `createdRow` callback defined for injection errors', function () {
       expect(options.createdRow).toBeDefined()
-      const row = $('<tr class="govuk-table__row error injection-error"><td data-label="Select claim" class="govuk-table__cell"></td></tr>')
+      const row = $('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"><td data-label="Case number" class="govuk-table__cell"></td></tr>')
       const data = {
         injection_errors: 'I am an error',
         filter: {
@@ -58,43 +58,57 @@ describe('Modules.AllocationDataTable.js', function () {
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row error injection-error"><td data-label="Select claim" class="govuk-table__cell"><div class="error-message-container"><div class="error-message">I am an error</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"></td><td data-label="Case number" class="govuk-table__cell"><div class="error-message-container"><div class="error-message">I am an error</div></div></td></tr>')
     })
 
     it('...should have a `createdRow` callback defined for CAV warnings', function () {
       expect(options.createdRow).toBeDefined()
-      const row = $('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"></td></tr>')
+      const row = $('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"><td data-label="Case number" class="govuk-table__cell"></td></tr>')
       const data = {
         filter: {
           cav_warning: 1
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">Conference fees not injected</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"></td><td data-label="Case number" class="govuk-table__cell"><div class="error-message-container"><div class="error-message">Conference fees not injected</div></div></td></tr>')
     })
 
     it('...should have a `createdRow` callback defined for CLAR fee warnings', function () {
       expect(options.createdRow).toBeDefined()
-      const row = $('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"></td></tr>')
+      const row = $('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"><td data-label="Case number" class="govuk-table__cell"></td></tr>')
       const data = {
         filter: {
           clar_fees_warning: 1
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">Paper heavy case or unused materials fees not injected</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"></td><td data-label="Case number" class="govuk-table__cell"><div class="error-message-container"><div class="error-message">Paper heavy case or unused materials fees not injected</div></div></td></tr>')
     })
 
     it('...should have a `createdRow` callback defined for Additional Prep fee warnings', function () {
       expect(options.createdRow).toBeDefined()
-      const row = $('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"></td></tr>')
+      const row = $('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"><td data-label="Case number" class="govuk-table__cell"></td></tr>')
       const data = {
         filter: {
           additional_prep_fee_warning: 1
         }
       }
       const output = options.createdRow(row, data)
-      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row injection-warning"><td data-label="Select claim" class="govuk-table__cell"><div class="warning-message-container"><div class="warning-message">Additional prep fee not injected</div></div></td></tr>')
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"></td><td data-label="Case number" class="govuk-table__cell"><div class="error-message-container"><div class="error-message">Additional prep fee not injected</div></div></td></tr>')
+    })
+
+    it('...should have a `createdRow` callback defined for multiple fee warnings', function () {
+      expect(options.createdRow).toBeDefined()
+      const row = $('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"><td data-label="Case number" class="govuk-table__cell"></td></tr>')
+      const data = {
+        filter: {
+          cav_warning: 1,
+          clar_fees_warning: 1,
+          additional_prep_fee_warning: 1
+        }
+      }
+      const output = options.createdRow(row, data)
+      expect(output[0].outerHTML).toEqual('<tr class="govuk-table__row"><td data-label="Select claim" class="govuk-table__cell"></td><td data-label="Case number" class="govuk-table__cell"><div class="error-message-container"><div class="error-message">Conference fees not injected</div><div class="error-message">Paper heavy case or unused materials fees not injected</div><div class="error-message">Additional prep fee not injected</div></div></td></tr>')
     })
 
     it('...should have `processing`', function () {


### PR DESCRIPTION
#### What

Improve the appearance of warnings for failed claim injection, non-injected fees, and disk evidence displayed on the claims tables on the caseworker allocation/reallocation/your claims/archive pages.

#### Ticket

[CTSKF-1001](https://dsdmoj.atlassian.net/browse/CTSKF-1001)

#### Why

The current design is confusing - warnings are displayed in various places with different styling, and when multiple warnings exist for non-injected fees only one is displayed. The new design will give a more consistent and GDS-like experience for users.

#### How

* Updates the styling in `app/webpack/stylesheets/components/_table.scss`. Previously styling for these warnings was split into `error-messages` and `warning-messages`, however the new design unifies the appearance of these and so to simplify the code all messages are now styled as errors.
* Updates the javascript in `app/webpack/javascripts/modules/Modules.AllocationDataTable.js` to change the appearance of errors on the Allocation page.
* Creates a new shared partial (`app/views/case_workers/_injection_errors.html.haml`) and updates the HAML for `app/views/case_workers/claims/_claims_list.html.haml` (which is shared by the Your Claims and  Archive pages) and `app/views/case_workers/admin/allocations/_re_allocation.html.haml` (which creates the Reallocation page) to use this new partial.

NB: the tables on the Your Claims/Archive/Reallocation pages behave slightly differently to the one on the Allocation page. The Allocation table displays details of fees (Conference fees, CLAR fees and Additional Prep fees) that have not been injected into CCR. The tables on the other three pages do not do this - they only display messages about failed injections and disk evidence. This is existing behaviour and hasn't been addressed in this PR. Users are able to open claims from those screens and view the summary, which contains warnings at the top of the page highlighting fees that have not been injected, so users are aware of them.

#### Screenshots

**Allocations:**

Before: 

<img width="988" alt="image" src="https://github.com/user-attachments/assets/36d6ea0a-472b-4d86-a031-c75166aef737" />

<img width="997" alt="image" src="https://github.com/user-attachments/assets/0a0461f1-1ab4-4a81-a24b-2aabaa29e63a" />


After:

<img width="970" alt="image" src="https://github.com/user-attachments/assets/55514c80-2f90-4609-8888-dd358da93c40" />

<img width="963" alt="image" src="https://github.com/user-attachments/assets/afeafa69-a392-4559-8372-e54592a808b1" />

**Your Claims/Archive/Reallocation:** 

Before: 

<img width="978" alt="image" src="https://github.com/user-attachments/assets/8e6fb368-b437-4d99-8e6b-5a149b53a4d2" />

After:

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/5b1abdfd-d218-4321-8677-66b50ca07401" />


[CTSKF-1001]: https://dsdmoj.atlassian.net/browse/CTSKF-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ