### PR TITLE
Update brakeman ignore file

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/helpers/application_helper.rb",
-      "line": 78,
+      "line": 79,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.except(:page).merge(:sort => column, :direction => ((\"desc\" or \"asc\")), :anchor => column).permit!",
       "render_path": null,
@@ -20,6 +20,25 @@
       "confidence": "Medium",
       "cwe_id": [
         915
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.0.8.7 ends on 2025-04-01",
+      "file": "Gemfile.lock",
+      "line": 458,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
       ],
       "note": ""
     },
@@ -70,6 +89,6 @@
       "note": "Caseworkers need to identify the downloads correspond to the cases they are processing"
     }
   ],
-  "updated": "2024-04-11 12:12:25 +0100",
-  "brakeman_version": "6.1.2"
+  "updated": "2025-01-31 09:19:56 +0000",
+  "brakeman_version": "6.2.2"
 }


### PR DESCRIPTION
#### What

Add an exception to the brakeman configuration to allow Rails 7.0.

#### Ticket

N/A

#### Why

Brakeman has started flagging the upcoming end of support of Rails 7.0. This needs to be silenced until we have upgraded.

#### How

Update `config/brakeman.ignore`.
