### PR TITLE
[CTSKF-902] Refactor callback actions

### DIFF
--- a/app/controllers/concerns/password_helpers.rb
+++ b/app/controllers/concerns/password_helpers.rb
@@ -1,12 +1,6 @@
 module PasswordHelpers
   extend ActiveSupport::Concern
 
-  included do
-    before_action :set_resource_params, only: %i[create update_password]
-    before_action :set_temporary_password, only: :create
-    before_action :set_user_params, only: :update_password
-  end
-
   def update_password
     user = user_for_controller_action
 
@@ -36,26 +30,25 @@ module PasswordHelpers
   end
 
   def params_with_temporary_password
-    @resource_params['user_attributes']['password'] = @temporary_password
-    @resource_params['user_attributes']['password_confirmation'] = @temporary_password
-    @resource_params
+    resource_params['user_attributes']['password'] = temporary_password
+    resource_params['user_attributes']['password_confirmation'] = temporary_password
+    resource_params
   end
 
   def password_params
-    %i[email first_name last_name].each { |attribute| @user_params[:user_attributes].delete(attribute) }
-    @user_params
+    %i[email first_name last_name].each { |attribute| user_params[:user_attributes].delete(attribute) }
+    user_params
   end
 
-  def set_resource_params
-    resource = controller_name.singularize
-    @resource_params = send((resource + '_params').to_sym)
+  def resource_params
+    @resource_params ||= send(:"#{controller_name.singularize}_params")
   end
 
-  def set_user_params
-    @user_params = @resource_params.slice(:user_attributes)
+  def user_params
+    @user_params ||= resource_params.slice(:user_attributes)
   end
 
-  def set_temporary_password
-    @temporary_password = SecureRandom.uuid
+  def temporary_password
+    @temporary_password ||= SecureRandom.uuid
   end
 end


### PR DESCRIPTION
#### What

Prevent exceptions due to missing callback actions in Rails 7.1.

#### Ticket

[CCCD - Fix missing callback actions](https://dsdmoj.atlassian.net/browse/CTSKF-902)

#### Why

With Rails 7.1 an exception will be raised if a callback in a controller is defined for an action that does not exist. This can happen when a helper is included, and callbacks are defined for actions that may or may not be present. This happens with `PasswordHelper` where callbacks are defined for the `create` action, which is not defined in `SuperAdmins::Admin::SuperAdminsController`.

#### How

The callbacks that are defined in `PasswordHelper` are used to set instance variables related to the parameters of the request. It isn't necessary to manage parameters with callbacks in this way and instead methods (with memoization) can be used instead.

#### ~Note~

~This change is forked off commits that start to install Rails 7.1. These commits should be removed before merging:~

* ~34e517c01f9e9e3caedb651e8eb6da3c571519f5~
* ~2a3298b8058f005d01d0cad261fff013fa43c38f~

~The test failure of `spec/lib/previous_version_of_claim_spec.rb:27` is a known issue with Rails 7.1. See https://dsdmoj.atlassian.net/browse/CTSKF-899~