### PR TITLE
[CTSKF-963] Use SecretsManager for managing secrets in the API Sandbox environment

### DIFF
--- a/.k8s/live/api-sandbox/deployment-worker.yaml
+++ b/.k8s/live/api-sandbox/deployment-worker.yaml
@@ -58,7 +58,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           # secret env vars defined by infrastructure/terraform
           # WHERE env var name does not match key name

--- a/.k8s/live/api-sandbox/deployment.yaml
+++ b/.k8s/live/api-sandbox/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL

--- a/.k8s/live/api-sandbox/dump.yaml
+++ b/.k8s/live/api-sandbox/dump.yaml
@@ -32,7 +32,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
#### What

Updates the `.k8s/live/api-sandbox/deployment-worker.yaml`, `.k8s/live/api-sandbox/deployment.yaml`, and `.k8s/live/api-sandbox/dump.yaml`.

#### Ticket

[CTSKF-963](https://dsdmoj.atlassian.net/browse/CTSKF-963)

#### Why

As part of the move to use SecretsManager for all secrets in all environments


[CTSKF-963]: https://dsdmoj.atlassian.net/browse/CTSKF-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ