### PR TITLE
[CTSKF-964] Use SecretsManager for managing secrets in the Production environment

### DIFF
--- a/.k8s/bin/secret
+++ b/.k8s/bin/secret
@@ -14,10 +14,10 @@
 # most basic example if current-context is the one you want
 # `kubernetes_deploy/bin/secret -e dev`
 #
-# output base64 decoded cccd-secrets oject to STDOUT
+# output base64 decoded cccd-env-vars oject to STDOUT
 # `kubernetes_deploy/bin/secret -c live -e dev -d`
 #
-# write base64 decoded cccd-secrets oject to a .gitignored temp file
+# write base64 decoded cccd-env-vars oject to a .gitignored temp file
 # `kubernetes_deploy/bin/secret -c live -e dev -dw`
 #
 # query the s3 bucket secrets
@@ -37,7 +37,7 @@ class SecretOptParser
     options.context = `kubectl config current-context`.chomp
     options.decode = false
     options.write = false
-    options.secret = 'cccd-secrets'
+    options.secret = 'cccd-env-vars'
 
     secret_opt_parser = OptionParser.new do |opts|
       opts.banner = "Usage: #{__FILE__} [options]"
@@ -59,7 +59,7 @@ class SecretOptParser
 
       opts.on('-s',
               '--secret [SECRETS_OBJECT]',
-              'Optional: the secret object from which to retrieve key-value pairs (default cccd-secrets)') do |secret|
+              'Optional: the secret object from which to retrieve key-value pairs (default cccd-env-vars)') do |secret|
         options.secret = secret
       end
 

--- a/.k8s/live/cron_jobs/archive_stale.yaml
+++ b/.k8s/live/cron_jobs/archive_stale.yaml
@@ -38,7 +38,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
             env:
             - name: DATABASE_URL

--- a/.k8s/live/cron_jobs/vacuum_db.yaml
+++ b/.k8s/live/cron_jobs/vacuum_db.yaml
@@ -37,7 +37,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
             env:
             - name: DATABASE_URL

--- a/.k8s/live/jobs/migrate.yaml
+++ b/.k8s/live/jobs/migrate.yaml
@@ -29,7 +29,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL

--- a/.k8s/live/jobs/seed.yaml
+++ b/.k8s/live/jobs/seed.yaml
@@ -29,7 +29,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -65,7 +65,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           # secret env vars defined by infrastructure/terraform
           # WHERE env var name does not match key name

--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL

--- a/.k8s/live/production/dump.yaml
+++ b/.k8s/live/production/dump.yaml
@@ -32,7 +32,7 @@ spec:
             - configMapRef:
                 name: cccd-app-config
             - secretRef:
-                name: cccd-secrets
+                name: cccd-env-vars
 
           env:
             - name: DATABASE_URL

--- a/docs/build_and_deploy.md
+++ b/docs/build_and_deploy.md
@@ -1,9 +1,14 @@
 ## Build and Deploy
 
-- [circleCI](#circleci)
-- [Kubernetes](#kubernetes)
-- [Cronjobs](#cronjobs)
-- [Container configuration and secrets](#container-configuration-and-secrets)
+- [Build and Deploy](#build-and-deploy)
+  - [CircleCI](#circleci)
+  - [Kubernetes](#kubernetes)
+    - [Cronjobs](#cronjobs)
+    - [Container configuration and secrets](#container-configuration-and-secrets)
+      - [Secret management](#secret-management)
+      - [Non-secret app configuration](#non-secret-app-configuration)
+      - [Secret app configuration](#secret-app-configuration)
+      - [Secret infrastructure configuration](#secret-infrastructure-configuration)
 
 ### CircleCI
 
@@ -94,7 +99,7 @@ Similar to ConfigMaps, these are handled via sharable k8s [Secrets](https://kube
 # deployment.yaml - example reference for a secret
 envFrom:
   - secretRef:
-      name: cccd-secrets
+      name: cccd-env-vars
 ```
 An environment variable will be created with the name and value defined in the secrets file.
 

--- a/docs/cookie_rotation.md
+++ b/docs/cookie_rotation.md
@@ -42,7 +42,7 @@ To rotate the `secret_key_base` without inconveniencing users you must:
    SECRET_KEY_BASE to hold the new secret.
 
    Note: secret env vars are kept in Kubernetes Secrets on the cluster
-   They can be viewed by running `kubectl -n <namespace> get secrets cccd-secrets -o json`.
+   They can be viewed by running `kubectl -n <namespace> get secrets cccd-env-vars -o json`.
 
 4. Deploy the application, manually [updating](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/add-secrets-to-deployment.html#adding-a-secret-to-an-application) the Secrets in the cluster first. 
 


### PR DESCRIPTION
#### What

Updates the `.k8s/live/production/deployment-worker.yaml`, `.k8s/live/production/deployment.yaml`, and `.k8s/live/production/dump.yaml` files to enable the use of the new `cccd-env-vars` secret in the production environment.

Also updates all remaining uses of the old `cccd-secrets` secret, in various jobs, cron jobs, bin scripts and guidance.

#### Ticket

[CTSKF-964](https://dsdmoj.atlassian.net/browse/CTSKF-964)

#### Why

As part of the move to use SecretsManager for all secrets in all environments


[CTSKF-964]: https://dsdmoj.atlassian.net/browse/CTSKF-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ