### PR TITLE
Ctskf 984 cccd   tidy up and standardise 'manage users' table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
@@ -411,8 +410,6 @@ GEM
     net-ssh (7.3.0)
     nio4r (2.7.4)
     nokogiri (1.18.2-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.18.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -689,7 +686,6 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
-  x86_64-darwin-22
   x86_64-linux-gnu
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
@@ -410,6 +411,8 @@ GEM
     net-ssh (7.3.0)
     nio4r (2.7.4)
     nokogiri (1.18.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -686,6 +689,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  x86_64-darwin-22
   x86_64-linux-gnu
 
 DEPENDENCIES

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -4,8 +4,9 @@
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading', provider_name: "#{current_user.provider.name}") }
 
 = content_for :search_html_block do
-  .form-group
-    = govuk_link_to t('.new_user'), new_external_users_admin_external_user_path
+  .div{ class: "govuk-!-margin-bottom-6" }
+    .form-group
+      = govuk_link_to t('.new_user'), new_external_users_admin_external_user_path
 
 = render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'search-button'), hint_text: t('hint.search_users'), button_text: t('search.users') }
 

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -4,9 +4,8 @@
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading', provider_name: "#{current_user.provider.name}") }
 
 = content_for :search_html_block do
-  .div{ class: "govuk-!-margin-bottom-6" }
-    .form-group
-      = govuk_link_to t('.new_user'), new_external_users_admin_external_user_path
+  .form-group{ class: 'govuk-!-margin-bottom-6'}
+    = govuk_link_to t('.new_user'), new_external_users_admin_external_user_path
 
 = render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'search-button'), hint_text: t('hint.search_users'), button_text: t('search.users') }
 

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -19,6 +19,7 @@
   t('.supplier_number'),
   t('.email'),
   t('.email_confirmation'),
+  t('.status'),
   t('.actions')]
 
   = govuk_table_tbody do
@@ -37,11 +38,11 @@
         = govuk_table_td('data-label': t('.email_confirmation')) do
           = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
 
+        = govuk_table_td('data-label': t('.status')) do
+          = govuk_tag_active_user?(advocate)
+
         = govuk_table_td('data-label': t('.actions')) do
           - if advocate.active? && advocate.enabled?
             = render partial: 'edit_delete_links', locals: { advocate: advocate }
           - elsif advocate.active? && !advocate.enabled?
-            Inactive
             = render partial: 'edit_delete_links', locals: { advocate: advocate }
-          - else
-            Inactive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -736,7 +736,7 @@ en:
         index:
           title: 'Manage users'
           page_heading: Manage %{provider_name}'s users
-          actions: Manage details
+          actions: Actions
           advocates: 'Users'
           add_advocate: 'Add User'
           edit: *edit
@@ -753,7 +753,10 @@ en:
           option_yes: *global_yes
           option_no: *global_no
           email_title: Email %{external_user}
-          email_confirmation: Email notifications of messages?
+          email_confirmation: Email notifications?
+          status: Status
+          active: Active
+          inactive: Inactive
           table_caption: "%{provider_name} users"
         edit_delete_links:
           delete_html: Delete<span class="govuk-visually-hidden"> user %{context}</span>

--- a/lib/govuk_component/tag_helpers.rb
+++ b/lib/govuk_component/tag_helpers.rb
@@ -8,5 +8,12 @@ module GovukComponent
 
       tag.strong(body, **tag_options)
     end
+
+    def govuk_tag_active_user?(user)
+      status = user.active? && user.enabled? ? 'Active' : 'Inactive'
+      tag_class = status == 'Active' ? 'govuk-tag--green' : 'govuk-tag--red'
+
+      content_tag(:strong, status, class: "govuk-tag #{tag_class}")
+    end
   end
 end

--- a/lib/govuk_component/tag_helpers.rb
+++ b/lib/govuk_component/tag_helpers.rb
@@ -2,6 +2,7 @@
 
 module GovukComponent
   module TagHelpers
+    include SharedHelpers
     def govuk_tag(body = nil, color = nil, **tag_options)
       tag_options = prepend_classes('govuk-tag--' + color, tag_options) if color.present?
       tag_options = prepend_classes('govuk-tag', tag_options)

--- a/lib/govuk_component/tag_helpers.rb
+++ b/lib/govuk_component/tag_helpers.rb
@@ -10,10 +10,7 @@ module GovukComponent
     end
 
     def govuk_tag_active_user?(user)
-      status = user.active? && user.enabled? ? 'Active' : 'Inactive'
-      tag_class = status == 'Active' ? 'govuk-tag--green' : 'govuk-tag--red'
-
-      content_tag(:strong, status, class: "govuk-tag #{tag_class}")
+      user.active? && user.enabled? ? govuk_tag('Active', 'green') : govuk_tag('Inactive', 'red')
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -47,5 +47,13 @@ FactoryBot.define do
     trait :disabled do
       disabled_at { 10.minutes.ago }
     end
+
+    trait :enabled do
+      disabled_at { nil }
+    end
+
+    trait :active do
+      deleted_at { false }
+    end
   end
 end

--- a/spec/lib/govuk_component/tag_helpers_spec.rb
+++ b/spec/lib/govuk_component/tag_helpers_spec.rb
@@ -34,4 +34,31 @@ RSpec.describe GovukComponent::TagHelpers, type: :helper do
       end
     end
   end
+
+  describe '#govuk_tag_active_user?' do
+    it 'responds to govuk_tag_active_user?' do
+      expect(helper).to respond_to(:govuk_tag_active_user?)
+    end
+
+    context 'when external user is inactive' do
+      let(:user) { create(:user, :active, :disabled) }
+
+      it 'displays a red inactive tag' do
+        tag_class = 'govuk-tag govuk-tag--red'
+        tag_text = 'Inactive'
+
+        expect(govuk_tag_active_user?(user)).to have_tag(:strong, with: { class: tag_class }, text: tag_text)
+      end
+    end
+
+    context 'when external user is active' do
+      let(:user) { create(:user, :active, :enabled) }
+
+      it 'displays a green inactive tag' do
+        tag_class = 'govuk-tag govuk-tag--green'
+        tag_text = 'Active'
+        expect(govuk_tag_active_user?(user)).to have_tag(:strong, with: { class: tag_class }, text: tag_text)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What
Implement GDS styles and styling tweaks to the ‘Manage Users’ page visible to Advocates and Litigators and also the Caseworkers ‘manage caseworkers’ page

- Use [GDS tags](https://design-system.service.gov.uk/components/tag/multiple-tags/) to style inactive/active to make it visually clear which is active or inactive
- Rename ‘Email notifications of messages?’ to ‘Email notifications’
- Rename ‘Manage details’ to ‘Actions' 
- Add govuk-spacing(6); (30px) bottom padding to the ‘create new user’ button as currently there is no space between it and the table

#### How
Adds a govuk_tag helper method to check if the user is active or inactive and then displays the corresponding gov_tag.
#### Ticket

[CCCD - Tidy up and standardise 'Manage Users' table](https://dsdmoj.atlassian.net/browse/CTSKF-984)

#### Why
To make the page more accessible and legible
