### PR TITLE
[CTSKF-1030] Add new AGFS refuse/reject reasons

### DIFF
--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -26,7 +26,7 @@ class ClaimStateTransitionReason
     end
 
     def reject_reasons_for(claim)
-      reasons = reasons_for('rejected')
+      reasons = reasons_for("rejected_#{claim.agfs? ? 'advocate' : 'litigator'}_claims")
       reasons.insert(6, reasons_for(:disbursement)) if disbursement_only?(claim)
       reasons.flatten
     end

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -56,6 +56,24 @@ en:
       duplicate_claim:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
+      stayed_quashed_indictment:
+        short: &stayed_quashed_indictment_short Second fee for stayed/quashed indictment refused
+        long: &stayed_quashed_indictment_long Second fee not payable for stayed/quashed indictment. More information provided on previous note.
+      predate_rep_order:
+        short: &predate_rep_order_short Hearings not covered by legal aid
+        long: &predate_rep_order_long Hearings predate the rep order so are unable to be paid.
+      paid_elsewhere:
+        short: &paid_elsewhere_short Main hearing paid elsewhere as an uplift
+        long: &paid_elsewhere_long Main hearing was heard concurrently with another case. This case has been paid as an uplift on the separate case.
+      continuation_of_trial:
+        short: &continuation_of_trial_short Continuous trial fees paid
+        long: &continuation_of_trial_long Unable to confirm the matter as a retrial, rather a continuation of first trial, and fees have been added to the first trial
+      prescribed_proceedings:
+        short: &prescribed_proceedings_short Fees should be claimed as prescribed proceedings
+        long: &prescribed_proceedings_long The hearing is payable as prescribed proceedings. Please approach your instructing solicitors to submit on their monthly submission using the code PROH.
+      incorrect_supplemental_case:
+        short: &incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
+        long: &incorrect_supplemental_case_long Supplemental fee claimed under the incorrect case. More information provided on previous note.
       other_refuse:
         short: *other
         long: *blank
@@ -66,6 +84,24 @@ en:
       duplicate_claim:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
+      stayed_quashed_indictment:
+        short: *stayed_quashed_indictment_short
+        long: *stayed_quashed_indictment_long
+      predate_rep_order:
+        short: *predate_rep_order_short
+        long: *predate_rep_order_long
+      paid_elsewhere:
+        short: *paid_elsewhere_short
+        long: *paid_elsewhere_long
+      continuation_of_trial:
+        short: *continuation_of_trial_short
+        long: *continuation_of_trial_long
+      prescribed_proceedings:
+        short: *prescribed_proceedings_short
+        long: *prescribed_proceedings_long
+      incorrect_supplemental_case:
+        short: *incorrect_supplemental_case_short
+        long: *incorrect_supplemental_case_long
       other_refuse:
         short: *other
         long: *blank
@@ -82,6 +118,24 @@ en:
       short_trial:
         short: *short_trial_short
         long: *short_trial_long
+      stayed_quashed_indictment:
+        short: *stayed_quashed_indictment_short
+        long: *stayed_quashed_indictment_long
+      predate_rep_order:
+        short: *predate_rep_order_short
+        long: *predate_rep_order_long
+      paid_elsewhere:
+        short: *paid_elsewhere_short
+        long: *paid_elsewhere_long
+      continuation_of_trial:
+        short: *continuation_of_trial_short
+        long: *continuation_of_trial_long
+      prescribed_proceedings:
+        short: *prescribed_proceedings_short
+        long: *prescribed_proceedings_long
+      incorrect_supplemental_case:
+        short: *incorrect_supplemental_case_short
+        long: *incorrect_supplemental_case_long
       other_refuse:
         short: *other
         long: *blank
@@ -89,6 +143,24 @@ en:
       wrong_ia:
         short: &wrong_ia_short Incorrect trial advocate
         long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
+      stayed_quashed_indictment:
+        short: *stayed_quashed_indictment_short
+        long: *stayed_quashed_indictment_long
+      predate_rep_order:
+        short: *predate_rep_order_short
+        long: *predate_rep_order_long
+      paid_elsewhere:
+        short: *paid_elsewhere_short
+        long: *paid_elsewhere_long
+      continuation_of_trial:
+        short: *continuation_of_trial_short
+        long: *continuation_of_trial_long
+      prescribed_proceedings:
+        short: *prescribed_proceedings_short
+        long: *prescribed_proceedings_long
+      incorrect_supplemental_case:
+        short: *incorrect_supplemental_case_short
+        long: *incorrect_supplemental_case_long
     refused_litigator_claims:
       duplicate_claim:
         short: *duplicate_claim_short

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -20,24 +20,24 @@ en:
         wrong_ia:
           short: &wrong_ia_short Incorrect trial advocate
           long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
-        stayed_quashed_indictment:
-          short: &stayed_quashed_indictment_short Second fee for stayed/quashed indictment refused
-          long: &stayed_quashed_indictment_long Second fee not payable for stayed/quashed indictment. More information provided on previous note.
-        predate_rep_order:
-          short: &predate_rep_order_short Hearings not covered by legal aid
-          long: &predate_rep_order_long Hearings predate the rep order so are unable to be paid.
-        paid_elsewhere:
-          short: &paid_elsewhere_short Main hearing paid elsewhere as an uplift
-          long: &paid_elsewhere_long Main hearing was heard concurrently with another case. This case has been paid as an uplift on the separate case.
-        continuation_of_trial:
-          short: &continuation_of_trial_short Continuous trial fees paid
-          long: &continuation_of_trial_long Unable to confirm the matter as a retrial, rather a continuation of first trial, and fees have been added to the first trial
-        prescribed_proceedings:
-          short: &prescribed_proceedings_short Fees should be claimed as prescribed proceedings
-          long: &prescribed_proceedings_long The hearing is payable as prescribed proceedings. Please approach your instructing solicitors to submit on their monthly submission using the code PROH.
-        incorrect_supplemental_case:
-          short: &incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
-          long: &incorrect_supplemental_case_long Supplemental fee claimed under the incorrect case. More information provided on previous note.
+        agfs_stayed_quashed_indictment:
+          short: &agfs_stayed_quashed_indictment_short Second fee for stayed/quashed indictment refused
+          long: &agfs_stayed_quashed_indictment_long We refused your claim because a second fee is not payable for a stayed/quashed indictment. More information provided on previous note.
+        agfs_predate_rep_order:
+          short: &agfs_predate_rep_order_short Hearings not covered by legal aid
+          long: &agfs_predate_rep_order_long We refused your claim because hearings predate the representation order so are unable to be paid.
+        agfs_paid_elsewhere:
+          short: &agfs_paid_elsewhere_short Main hearing paid elsewhere as an uplift
+          long: &agfs_paid_elsewhere_long We refused your claim because the main hearing was heard concurrently with another case. This case has been paid as an uplift on the separate case.
+        agfs_continuation_of_trial:
+          short: &agfs_continuation_of_trial_short Continuous trial fees paid
+          long: &agfs_continuation_of_trial_long We refused your claim because we are unable to confirm the matter as a retrial, rather a continuation of first trial, and fees have been added to the first trial.
+        agfs_prescribed_proceedings:
+          short: &agfs_prescribed_proceedings_short Fees should be claimed as prescribed proceedings
+          long: &agfs_prescribed_proceedings_long We refused your claim because the hearing is payable as prescribed proceedings. Please approach your instructing solicitors to submit on their monthly submission using the code PROH.
+        agfs_incorrect_supplemental_case:
+          short: &agfs_incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
+          long: &agfs_incorrect_supplemental_case_long We refused your claim because the supplemental fee was claimed under the incorrect case. More information provided on previous note.
       rejected:
         no_indictment:
           short: &no_indictment_short No indictment attached
@@ -60,30 +60,30 @@ en:
         wrong_maat_ref:
           short: &wrong_maat_ref_short Wrong MAAT reference
           long: &wrong_maat_ref_long We rejected your claim because the MAAT reference you provided does not match the defendant records. Check the MAAT reference number for this defendant and submit the claim again.
-        advocate_request:
-          short: &advocate_request_short Rejected at the request of the Advocate
-          long: &advocate_request_long Rejected at the request of the Advocate.
-        rep_order_required:
-          short: &rep_order_required_short A copy of the breach/appeal rep order is required
-          long: &rep_order_required_long A copy of the breach/appeal rep order is required.
-        further_clarification:
-          short: &further_clarification_short Further clarification required to consider basic fee
-          long: &further_clarification_long Further clarification required to consider the basic fee claimed. More information provided on previous note.
-        hardship_requirements:
-          short: &hardship_requirements_short Hardship requirements not satisfied
-          long: &hardship_requirements_long Hardship requirements not satisfied. More information provided on previous note.
-        supplemental_fee:
-          short: &supplemental_fee_short Supplementary claim made prior to main hearing
-          long: &supplemental_fee_long Supplemental fee, but main hearing is yet to be paid. Would need to submit claim for the main hearing first.
-        invalid_supplier_code:
-          short: &invalid_supplier_code_short Supplier account code invalid
-          long: &invalid_supplier_code_long Supplier account code invalid.
-        soft_reject_no_response:
-          short: &soft_reject_no_response_short No response to soft reject
-          long: &soft_reject_no_response_long Soft Reject – not responded to/incorrect content supplied.
-        soft_reject_attendance_notes:
-          short: &soft_reject_attendance_notes_short Main hearing attendance note(s) required
-          long: &soft_reject_attendance_notes_long Soft Reject – No response to request for attendance note to confirm counsel had attended the main hearing/first day of trial.
+        agfs_advocate_request:
+          short: &agfs_advocate_request_short Rejected at the request of the Advocate
+          long: &agfs_advocate_request_long We rejected your claim at your request.
+        agfs_breach_or_appeal:
+          short: &agfs_breach_or_appeal_short A copy of the breach/appeal rep order is required
+          long: &agfs_breach_or_appeal_long We rejected your claim because a copy of the breach/appeal rep order is required.
+        agfs_further_clarification:
+          short: &agfs_further_clarification_short Further clarification required to consider basic fee
+          long: &agfs_further_clarification_long We rejected your claim because further clarification is required to consider the basic fee claimed. More information provided on previous note.
+        agfs_hardship_requirements:
+          short: &agfs_hardship_requirements_short Hardship requirements not satisfied
+          long: &agfs_hardship_requirements_long We rejected your claim because hardship requirements are not satisfied. More information provided on previous note.
+        agfs_supplemental_fee:
+          short: &agfs_supplemental_fee_short Supplementary claim made prior to main hearing
+          long: &agfs_supplemental_fee_long We rejected your claim because this is a supplemental fee, but the main hearing is yet to be paid. You need to submit the claim for the main hearing first.
+        agfs_invalid_supplier_code:
+          short: &agfs_invalid_supplier_code_short Supplier account code invalid
+          long: &agfs_invalid_supplier_code_long We rejected your claim because the supplier account code you provided is invalid.
+        agfs_soft_reject_no_response:
+          short: &agfs_soft_reject_no_response_short No response to soft reject
+          long: &agfs_soft_reject_no_response_long Soft Reject – we rejected your claim because you have not responded to a soft reject, or incorrect content was supplied.
+        agfs_soft_reject_attendance_notes:
+          short: &agfs_soft_reject_attendance_notes_short Main hearing attendance note(s) required
+          long: &agfs_soft_reject_attendance_notes_long Soft Reject – we rejected your claim because you have not responded to our request for an attendance note to confirm counsel had attended the main hearing/first day of trial.
   claim_state_transition_reason:
     disbursement:
       no_prior_authority:
@@ -99,24 +99,24 @@ en:
       duplicate_claim:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
-      stayed_quashed_indictment:
-        short: *stayed_quashed_indictment_short
-        long: *stayed_quashed_indictment_long
-      predate_rep_order:
-        short: *predate_rep_order_short
-        long: *predate_rep_order_long
-      paid_elsewhere:
-        short: *paid_elsewhere_short
-        long: *paid_elsewhere_long
-      continuation_of_trial:
-        short: *continuation_of_trial_short
-        long: *continuation_of_trial_long
-      prescribed_proceedings:
-        short: *prescribed_proceedings_short
-        long: *prescribed_proceedings_long
-      incorrect_supplemental_case:
-        short: *incorrect_supplemental_case_short
-        long: *incorrect_supplemental_case_long
+      agfs_stayed_quashed_indictment:
+        short: *agfs_stayed_quashed_indictment_short
+        long: *agfs_stayed_quashed_indictment_long
+      agfs_predate_rep_order:
+        short: *agfs_predate_rep_order_short
+        long: *agfs_predate_rep_order_long
+      agfs_paid_elsewhere:
+        short: *agfs_paid_elsewhere_short
+        long: *agfs_paid_elsewhere_long
+      agfs_continuation_of_trial:
+        short: *agfs_continuation_of_trial_short
+        long: *agfs_continuation_of_trial_long
+      agfs_prescribed_proceedings:
+        short: *agfs_prescribed_proceedings_short
+        long: *agfs_prescribed_proceedings_long
+      agfs_incorrect_supplemental_case:
+        short: *agfs_incorrect_supplemental_case_short
+        long: *agfs_incorrect_supplemental_case_long
       other_refuse:
         short: *other
         long: *blank
@@ -127,24 +127,24 @@ en:
       duplicate_claim:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
-      stayed_quashed_indictment:
-        short: *stayed_quashed_indictment_short
-        long: *stayed_quashed_indictment_long
-      predate_rep_order:
-        short: *predate_rep_order_short
-        long: *predate_rep_order_long
-      paid_elsewhere:
-        short: *paid_elsewhere_short
-        long: *paid_elsewhere_long
-      continuation_of_trial:
-        short: *continuation_of_trial_short
-        long: *continuation_of_trial_long
-      prescribed_proceedings:
-        short: *prescribed_proceedings_short
-        long: *prescribed_proceedings_long
-      incorrect_supplemental_case:
-        short: *incorrect_supplemental_case_short
-        long: *incorrect_supplemental_case_long
+      agfs_stayed_quashed_indictment:
+        short: *agfs_stayed_quashed_indictment_short
+        long: *agfs_stayed_quashed_indictment_long
+      agfs_predate_rep_order:
+        short: *agfs_predate_rep_order_short
+        long: *agfs_predate_rep_order_long
+      agfs_paid_elsewhere:
+        short: *agfs_paid_elsewhere_short
+        long: *agfs_paid_elsewhere_long
+      agfs_continuation_of_trial:
+        short: *agfs_continuation_of_trial_short
+        long: *agfs_continuation_of_trial_long
+      agfs_prescribed_proceedings:
+        short: *agfs_prescribed_proceedings_short
+        long: *agfs_prescribed_proceedings_long
+      agfs_incorrect_supplemental_case:
+        short: *agfs_incorrect_supplemental_case_short
+        long: *agfs_incorrect_supplemental_case_long
       other_refuse:
         short: *other
         long: *blank
@@ -161,24 +161,24 @@ en:
       short_trial:
         short: *short_trial_short
         long: *short_trial_long
-      stayed_quashed_indictment:
-        short: *stayed_quashed_indictment_short
-        long: *stayed_quashed_indictment_long
-      predate_rep_order:
-        short: *predate_rep_order_short
-        long: *predate_rep_order_long
-      paid_elsewhere:
-        short: *paid_elsewhere_short
-        long: *paid_elsewhere_long
-      continuation_of_trial:
-        short: *continuation_of_trial_short
-        long: *continuation_of_trial_long
-      prescribed_proceedings:
-        short: *prescribed_proceedings_short
-        long: *prescribed_proceedings_long
-      incorrect_supplemental_case:
-        short: *incorrect_supplemental_case_short
-        long: *incorrect_supplemental_case_long
+      agfs_stayed_quashed_indictment:
+        short: *agfs_stayed_quashed_indictment_short
+        long: *agfs_stayed_quashed_indictment_long
+      agfs_predate_rep_order:
+        short: *agfs_predate_rep_order_short
+        long: *agfs_predate_rep_order_long
+      agfs_paid_elsewhere:
+        short: *agfs_paid_elsewhere_short
+        long: *agfs_paid_elsewhere_long
+      agfs_continuation_of_trial:
+        short: *agfs_continuation_of_trial_short
+        long: *agfs_continuation_of_trial_long
+      agfs_prescribed_proceedings:
+        short: *agfs_prescribed_proceedings_short
+        long: *agfs_prescribed_proceedings_long
+      agfs_incorrect_supplemental_case:
+        short: *agfs_incorrect_supplemental_case_short
+        long: *agfs_incorrect_supplemental_case_long
       other_refuse:
         short: *other
         long: *blank
@@ -186,24 +186,24 @@ en:
       wrong_ia:
         short: *wrong_ia_short
         long: *wrong_ia_long
-      stayed_quashed_indictment:
-        short: *stayed_quashed_indictment_short
-        long: *stayed_quashed_indictment_long
-      predate_rep_order:
-        short: *predate_rep_order_short
-        long: *predate_rep_order_long
-      paid_elsewhere:
-        short: *paid_elsewhere_short
-        long: *paid_elsewhere_long
-      continuation_of_trial:
-        short: *continuation_of_trial_short
-        long: *continuation_of_trial_long
-      prescribed_proceedings:
-        short: *prescribed_proceedings_short
-        long: *prescribed_proceedings_long
-      incorrect_supplemental_case:
-        short: *incorrect_supplemental_case_short
-        long: *incorrect_supplemental_case_long
+      agfs_stayed_quashed_indictment:
+        short: *agfs_stayed_quashed_indictment_short
+        long: *agfs_stayed_quashed_indictment_long
+      agfs_predate_rep_order:
+        short: *agfs_predate_rep_order_short
+        long: *agfs_predate_rep_order_long
+      agfs_paid_elsewhere:
+        short: *agfs_paid_elsewhere_short
+        long: *agfs_paid_elsewhere_long
+      agfs_continuation_of_trial:
+        short: *agfs_continuation_of_trial_short
+        long: *agfs_continuation_of_trial_long
+      agfs_prescribed_proceedings:
+        short: *agfs_prescribed_proceedings_short
+        long: *agfs_prescribed_proceedings_long
+      agfs_incorrect_supplemental_case:
+        short: *agfs_incorrect_supplemental_case_short
+        long: *agfs_incorrect_supplemental_case_long
     refused_litigator_claims:
       duplicate_claim:
         short: *duplicate_claim_short
@@ -263,30 +263,30 @@ en:
       wrong_maat_ref:
         short: *wrong_maat_ref_short
         long: *wrong_maat_ref_long
-      advocate_request:
-        short: *advocate_request_short
-        long: *advocate_request_long
-      rep_order_required:
-        short: *rep_order_required_short
-        long: *rep_order_required_long
-      further_clarification:
-        short: *further_clarification_short
-        long: *further_clarification_long
-      hardship_requirements:
-        short: *hardship_requirements_short
-        long: *hardship_requirements_long
-      supplemental_fee:
-        short: *supplemental_fee_short
-        long: *supplemental_fee_long
-      invalid_supplier_code:
-        short: *invalid_supplier_code_short
-        long: *invalid_supplier_code_long
-      soft_reject_no_response:
-        short: *soft_reject_no_response_short
-        long: *soft_reject_no_response_long
-      soft_reject_attendance_notes:
-        short: *soft_reject_attendance_notes_short
-        long: *soft_reject_attendance_notes_long
+      agfs_advocate_request:
+        short: *agfs_advocate_request_short
+        long: *agfs_advocate_request_long
+      agfs_breach_or_appeal:
+        short: *agfs_breach_or_appeal_short
+        long: *agfs_breach_or_appeal_long
+      agfs_further_clarification:
+        short: *agfs_further_clarification_short
+        long: *agfs_further_clarification_long
+      agfs_hardship_requirements:
+        short: *agfs_hardship_requirements_short
+        long: *agfs_hardship_requirements_long
+      agfs_supplemental_fee:
+        short: *agfs_supplemental_fee_short
+        long: *agfs_supplemental_fee_long
+      agfs_invalid_supplier_code:
+        short: *agfs_invalid_supplier_code_short
+        long: *agfs_invalid_supplier_code_long
+      agfs_soft_reject_no_response:
+        short: *agfs_soft_reject_no_response_short
+        long: *agfs_soft_reject_no_response_long
+      agfs_soft_reject_attendance_notes:
+        short: *agfs_soft_reject_attendance_notes_short
+        long: *agfs_soft_reject_attendance_notes_long
       other:
         short: *other
         long: *blank

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -85,6 +85,10 @@ en:
       other_refuse:
         short: *other
         long: *blank
+    refused_advocate_hardship_claims:
+      wrong_ia:
+        short: &wrong_ia_short Incorrect trial advocate
+        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
     refused_litigator_claims:
       duplicate_claim:
         short: *duplicate_claim_short
@@ -115,10 +119,6 @@ en:
       other_refuse:
         short: *other
         long: *blank
-    refused_advocate_hardship_claims:
-      wrong_ia:
-        short: &wrong_ia_short Incorrect trial advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
     refused_litigator_hardship_claims:
       duplicate_claim:
         short: *duplicate_claim_short

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -16,6 +16,27 @@ en:
       short_trial:
         short: &short_trial_short The trial estimate was less than 10 days
         long: &short_trial_long We refused your claim because the trial is estimated to last for less than 10 days, this interim payment can only be claimed where the trial has commenced and is set to last for more than 10 days.
+      wrong_ia:
+        short: &wrong_ia_short Incorrect trial advocate
+        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
+      stayed_quashed_indictment:
+        short: &stayed_quashed_indictment_short Second fee for stayed/quashed indictment refused
+        long: &stayed_quashed_indictment_long Second fee not payable for stayed/quashed indictment. More information provided on previous note.
+      predate_rep_order:
+        short: &predate_rep_order_short Hearings not covered by legal aid
+        long: &predate_rep_order_long Hearings predate the rep order so are unable to be paid.
+      paid_elsewhere:
+        short: &paid_elsewhere_short Main hearing paid elsewhere as an uplift
+        long: &paid_elsewhere_long Main hearing was heard concurrently with another case. This case has been paid as an uplift on the separate case.
+      continuation_of_trial:
+        short: &continuation_of_trial_short Continuous trial fees paid
+        long: &continuation_of_trial_long Unable to confirm the matter as a retrial, rather a continuation of first trial, and fees have been added to the first trial
+      prescribed_proceedings:
+        short: &prescribed_proceedings_short Fees should be claimed as prescribed proceedings
+        long: &prescribed_proceedings_long The hearing is payable as prescribed proceedings. Please approach your instructing solicitors to submit on their monthly submission using the code PROH.
+      incorrect_supplemental_case:
+        short: &incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
+        long: &incorrect_supplemental_case_long Supplemental fee claimed under the incorrect case. More information provided on previous note.
   claim_state_transition_reason:
     rejected:
       no_indictment:
@@ -51,29 +72,29 @@ en:
         long: We rejected your claim because you didn’t attach the final invoice. Submit the claim again with the final invoice clearly stating the breakdown of costs and defendant’s name. We cannot accept estimated costs.
     refused_advocate_claims:
       wrong_ia:
-        short: &wrong_ia_short Incorrect trial advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
+        short: *wrong_ia_short
+        long: *wrong_ia_long
       duplicate_claim:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
       stayed_quashed_indictment:
-        short: &stayed_quashed_indictment_short Second fee for stayed/quashed indictment refused
-        long: &stayed_quashed_indictment_long Second fee not payable for stayed/quashed indictment. More information provided on previous note.
+        short: *stayed_quashed_indictment_short
+        long: *stayed_quashed_indictment_long
       predate_rep_order:
-        short: &predate_rep_order_short Hearings not covered by legal aid
-        long: &predate_rep_order_long Hearings predate the rep order so are unable to be paid.
+        short: *predate_rep_order_short
+        long: *predate_rep_order_long
       paid_elsewhere:
-        short: &paid_elsewhere_short Main hearing paid elsewhere as an uplift
-        long: &paid_elsewhere_long Main hearing was heard concurrently with another case. This case has been paid as an uplift on the separate case.
+        short: *paid_elsewhere_short
+        long: *paid_elsewhere_long
       continuation_of_trial:
-        short: &continuation_of_trial_short Continuous trial fees paid
-        long: &continuation_of_trial_long Unable to confirm the matter as a retrial, rather a continuation of first trial, and fees have been added to the first trial
+        short: *continuation_of_trial_short
+        long: *continuation_of_trial_long
       prescribed_proceedings:
-        short: &prescribed_proceedings_short Fees should be claimed as prescribed proceedings
-        long: &prescribed_proceedings_long The hearing is payable as prescribed proceedings. Please approach your instructing solicitors to submit on their monthly submission using the code PROH.
+        short: *prescribed_proceedings_short
+        long: *prescribed_proceedings_long
       incorrect_supplemental_case:
-        short: &incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
-        long: &incorrect_supplemental_case_long Supplemental fee claimed under the incorrect case. More information provided on previous note.
+        short: *incorrect_supplemental_case_short
+        long: *incorrect_supplemental_case_long
       other_refuse:
         short: *other
         long: *blank
@@ -141,8 +162,8 @@ en:
         long: *blank
     refused_advocate_hardship_claims:
       wrong_ia:
-        short: &wrong_ia_short Incorrect trial advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
+        short: *wrong_ia_short
+        long: *wrong_ia_long
       stayed_quashed_indictment:
         short: *stayed_quashed_indictment_short
         long: *stayed_quashed_indictment_long

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -1,68 +1,90 @@
 en:
   dictionary:
     claim_state_transition_reason:
-      other:
-        short: &other Other
-        long: &blank ''
-      duplicate_claim:
-        short: &duplicate_claim_short Duplicate claim
-        long: &duplicate_claim_long We refused your claim because our records show this bill has already been paid.
-      no_effective_pcmh:
-        short: &no_effective_pcmh_short No effective PCMH has taken place
-        long: &no_effective_pcmh_long We refused your claim because the court records do not show that an effective PCMH has taken place. Check the case details and submit the claim again.The ‘effective PCMH payment can be made at any time after the PCMH has taken place up until the trial conclusion.
-      no_effective_trial:
-        short: &no_effective_trial_short No effective trial start has taken place
-        long: &no_effective_trial_long We refused your claim because the court records do not show that the trial has commenced. Check the case details and submit the claim again.
-      short_trial:
-        short: &short_trial_short The trial estimate was less than 10 days
-        long: &short_trial_long We refused your claim because the trial is estimated to last for less than 10 days, this interim payment can only be claimed where the trial has commenced and is set to last for more than 10 days.
-      wrong_ia:
-        short: &wrong_ia_short Incorrect trial advocate
-        long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
-      stayed_quashed_indictment:
-        short: &stayed_quashed_indictment_short Second fee for stayed/quashed indictment refused
-        long: &stayed_quashed_indictment_long Second fee not payable for stayed/quashed indictment. More information provided on previous note.
-      predate_rep_order:
-        short: &predate_rep_order_short Hearings not covered by legal aid
-        long: &predate_rep_order_long Hearings predate the rep order so are unable to be paid.
-      paid_elsewhere:
-        short: &paid_elsewhere_short Main hearing paid elsewhere as an uplift
-        long: &paid_elsewhere_long Main hearing was heard concurrently with another case. This case has been paid as an uplift on the separate case.
-      continuation_of_trial:
-        short: &continuation_of_trial_short Continuous trial fees paid
-        long: &continuation_of_trial_long Unable to confirm the matter as a retrial, rather a continuation of first trial, and fees have been added to the first trial
-      prescribed_proceedings:
-        short: &prescribed_proceedings_short Fees should be claimed as prescribed proceedings
-        long: &prescribed_proceedings_long The hearing is payable as prescribed proceedings. Please approach your instructing solicitors to submit on their monthly submission using the code PROH.
-      incorrect_supplemental_case:
-        short: &incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
-        long: &incorrect_supplemental_case_long Supplemental fee claimed under the incorrect case. More information provided on previous note.
+      refused:
+        other:
+          short: &other Other
+          long: &blank ''
+        duplicate_claim:
+          short: &duplicate_claim_short Duplicate claim
+          long: &duplicate_claim_long We refused your claim because our records show this bill has already been paid.
+        no_effective_pcmh:
+          short: &no_effective_pcmh_short No effective PCMH has taken place
+          long: &no_effective_pcmh_long We refused your claim because the court records do not show that an effective PCMH has taken place. Check the case details and submit the claim again.The ‘effective PCMH payment can be made at any time after the PCMH has taken place up until the trial conclusion.
+        no_effective_trial:
+          short: &no_effective_trial_short No effective trial start has taken place
+          long: &no_effective_trial_long We refused your claim because the court records do not show that the trial has commenced. Check the case details and submit the claim again.
+        short_trial:
+          short: &short_trial_short The trial estimate was less than 10 days
+          long: &short_trial_long We refused your claim because the trial is estimated to last for less than 10 days, this interim payment can only be claimed where the trial has commenced and is set to last for more than 10 days.
+        wrong_ia:
+          short: &wrong_ia_short Incorrect trial advocate
+          long: &wrong_ia_long We refused your claim because court records show a different advocate was the trial advocate for the case. Submit the claim again with the correct trial advocate details or include evidence to support why you think the court records are wrong.
+        stayed_quashed_indictment:
+          short: &stayed_quashed_indictment_short Second fee for stayed/quashed indictment refused
+          long: &stayed_quashed_indictment_long Second fee not payable for stayed/quashed indictment. More information provided on previous note.
+        predate_rep_order:
+          short: &predate_rep_order_short Hearings not covered by legal aid
+          long: &predate_rep_order_long Hearings predate the rep order so are unable to be paid.
+        paid_elsewhere:
+          short: &paid_elsewhere_short Main hearing paid elsewhere as an uplift
+          long: &paid_elsewhere_long Main hearing was heard concurrently with another case. This case has been paid as an uplift on the separate case.
+        continuation_of_trial:
+          short: &continuation_of_trial_short Continuous trial fees paid
+          long: &continuation_of_trial_long Unable to confirm the matter as a retrial, rather a continuation of first trial, and fees have been added to the first trial
+        prescribed_proceedings:
+          short: &prescribed_proceedings_short Fees should be claimed as prescribed proceedings
+          long: &prescribed_proceedings_long The hearing is payable as prescribed proceedings. Please approach your instructing solicitors to submit on their monthly submission using the code PROH.
+        incorrect_supplemental_case:
+          short: &incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
+          long: &incorrect_supplemental_case_long Supplemental fee claimed under the incorrect case. More information provided on previous note.
+      rejected:
+        no_indictment:
+          short: &no_indictment_short No indictment attached
+          long: &no_indictment_long We rejected your claim because you didn’t attach the indictment. Submit the claim again with the indictment. You can download a copy from the Digital Case System.
+        no_rep_order:
+          short: &no_rep_order_short No Magistrates’ representation order attached (granted before 1/8/2015)
+          long: &no_rep_order_long We rejected your claim because you didn’t attach the representation order. Submit the claim again with the representation order. You can get a copy from the Magistrates’ Court where it was issued.
+        time_elapsed:
+          short: &time_elapsed_short Claim significantly out of time with no explanation
+          long: &time_elapsed_long We rejected your claim because the case ended over 3 months ago. Submit the claim again explaining why it is late.
+        no_amend_rep_order:
+          short: &no_amend_rep_order_short No amending representation order
+          long: &no_amend_rep_order_long We rejected your claim because you didn’t attach the amending representation order – both the original and the amended order confirming a change in representation. Submit the claim again with both representation orders.
+        case_still_live:
+          short: &case_still_live_short Case still live
+          long: &case_still_live_long We rejected your claim because our records show the case hasn’t ended. Submit the claim again when the case has ended, including any hearings for sentencing.
+        wrong_case_no:
+          short: &wrong_case_no_short Incorrect case number
+          long: &wrong_case_no_long We rejected your claim because the case number didn’t match court records for this defendant. Check the case details and submit the claim again.
+        wrong_maat_ref:
+          short: &wrong_maat_ref_short Wrong MAAT reference
+          long: &wrong_maat_ref_long We rejected your claim because the MAAT reference you provided does not match the defendant records. Check the MAAT reference number for this defendant and submit the claim again.
+        advocate_request:
+          short: &advocate_request_short Rejected at the request of the Advocate
+          long: &advocate_request_long Rejected at the request of the Advocate.
+        rep_order_required:
+          short: &rep_order_required_short A copy of the breach/appeal rep order is required
+          long: &rep_order_required_long A copy of the breach/appeal rep order is required.
+        further_clarification:
+          short: &further_clarification_short Further clarification required to consider basic fee
+          long: &further_clarification_long Further clarification required to consider the basic fee claimed. More information provided on previous note.
+        hardship_requirements:
+          short: &hardship_requirements_short Hardship requirements not satisfied
+          long: &hardship_requirements_long Hardship requirements not satisfied. More information provided on previous note.
+        supplemental_fee:
+          short: &supplemental_fee_short Supplementary claim made prior to main hearing
+          long: &supplemental_fee_long Supplemental fee, but main hearing is yet to be paid. Would need to submit claim for the main hearing first.
+        invalid_supplier_code:
+          short: &invalid_supplier_code_short Supplier account code invalid
+          long: &invalid_supplier_code_long Supplier account code invalid.
+        soft_reject_no_response:
+          short: &soft_reject_no_response_short No response to soft reject
+          long: &soft_reject_no_response_long Soft Reject – not responded to/incorrect content supplied.
+        soft_reject_attendance_notes:
+          short: &soft_reject_attendance_notes_short Main hearing attendance note(s) required
+          long: &soft_reject_attendance_notes_long Soft Reject – No response to request for attendance note to confirm counsel had attended the main hearing/first day of trial.
   claim_state_transition_reason:
-    rejected:
-      no_indictment:
-        short: No indictment attached
-        long: We rejected your claim because you didn’t attach the indictment. Submit the claim again with the indictment. You can download a copy from the Digital Case System.
-      no_rep_order:
-        short: No Magistrates’ representation order attached (granted before 1/8/2015)
-        long: We rejected your claim because you didn’t attach the representation order. Submit the claim again with the representation order. You can get a copy from the Magistrates’ Court where it was issued.
-      time_elapsed:
-        short: Claim significantly out of time with no explanation
-        long: We rejected your claim because the case ended over 3 months ago. Submit the claim again explaining why it is late.
-      no_amend_rep_order:
-        short: No amending representation order
-        long: We rejected your claim because you didn’t attach the amending representation order – both the original and the amended order confirming a change in representation. Submit the claim again with both representation orders.
-      case_still_live:
-        short: Case still live
-        long: We rejected your claim because our records show the case hasn’t ended. Submit the claim again when the case has ended, including any hearings for sentencing.
-      wrong_case_no:
-        short: Incorrect case number
-        long: We rejected your claim because the case number didn’t match court records for this defendant. Check the case details and submit the claim again.
-      wrong_maat_ref:
-        short: Wrong MAAT reference
-        long: We rejected your claim because the MAAT reference you provided does not match the defendant records. Check the MAAT reference number for this defendant and submit the claim again.
-      other:
-        short: *other
-        long: *blank
     disbursement:
       no_prior_authority:
         short: No prior authority provided
@@ -217,6 +239,80 @@ en:
         short: *duplicate_claim_short
         long: *duplicate_claim_long
       other_refuse:
+        short: *other
+        long: *blank
+    rejected_advocate_claims:
+      no_indictment:
+        short: *no_indictment_short
+        long: *no_indictment_long
+      no_rep_order:
+        short: *no_rep_order_short
+        long: *no_rep_order_long
+      time_elapsed:
+        short: *time_elapsed_short
+        long: *time_elapsed_long
+      no_amend_rep_order:
+        short: *no_amend_rep_order_short
+        long: *no_amend_rep_order_long
+      case_still_live:
+        short: *case_still_live_short
+        long: *case_still_live_long
+      wrong_case_no:
+        short: *wrong_case_no_short
+        long: *wrong_case_no_long
+      wrong_maat_ref:
+        short: *wrong_maat_ref_short
+        long: *wrong_maat_ref_long
+      advocate_request:
+        short: *advocate_request_short
+        long: *advocate_request_long
+      rep_order_required:
+        short: *rep_order_required_short
+        long: *rep_order_required_long
+      further_clarification:
+        short: *further_clarification_short
+        long: *further_clarification_long
+      hardship_requirements:
+        short: *hardship_requirements_short
+        long: *hardship_requirements_long
+      supplemental_fee:
+        short: *supplemental_fee_short
+        long: *supplemental_fee_long
+      invalid_supplier_code:
+        short: *invalid_supplier_code_short
+        long: *invalid_supplier_code_long
+      soft_reject_no_response:
+        short: *soft_reject_no_response_short
+        long: *soft_reject_no_response_long
+      soft_reject_attendance_notes:
+        short: *soft_reject_attendance_notes_short
+        long: *soft_reject_attendance_notes_long
+      other:
+        short: *other
+        long: *blank
+    rejected_litigator_claims:
+      no_indictment:
+        short: *no_indictment_short
+        long: *no_indictment_long
+      no_rep_order:
+        short: *no_rep_order_short
+        long: *no_rep_order_long
+      time_elapsed:
+        short: *time_elapsed_short
+        long: *time_elapsed_long
+      no_amend_rep_order:
+        short: *no_amend_rep_order_short
+        long: *no_amend_rep_order_long
+      case_still_live:
+        short: *case_still_live_short
+        long: *case_still_live_long
+      wrong_case_no:
+        short: *wrong_case_no_short
+        long: *wrong_case_no_long
+      wrong_maat_ref:
+        short: *wrong_maat_ref_short
+        long: *wrong_maat_ref_long
+      other:
         short: *other
         long: *blank
     global:

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -108,21 +108,42 @@ RSpec.describe ClaimStateTransitionReason do
       let(:basic_fee) { build(:basic_fee, :baf_fee, quantity: 1, amount: 21.01) }
       let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee]) }
 
-      it { is_expected.to match_array %w[wrong_ia duplicate_claim other_refuse] }
+      it {
+        is_expected.to match_array %w[wrong_ia duplicate_claim stayed_quashed_indictment predate_rep_order
+                                      paid_elsewhere continuation_of_trial prescribed_proceedings
+                                      incorrect_supplemental_case other_refuse]
+      }
     end
 
     context 'with an advocate interim claim' do
       let(:claim) { create(:advocate_interim_claim) }
 
-      it do
-        is_expected.to match_array %w[duplicate_claim no_effective_pcmh no_effective_trial short_trial other_refuse]
-      end
+      it {
+        is_expected.to match_array %w[duplicate_claim no_effective_pcmh no_effective_trial short_trial
+                                      stayed_quashed_indictment predate_rep_order paid_elsewhere
+                                      continuation_of_trial prescribed_proceedings
+                                      incorrect_supplemental_case other_refuse]
+      }
     end
 
     context 'with an advocate supplementary claim' do
       let(:claim) { create(:advocate_supplementary_claim) }
 
-      it { is_expected.to match_array %w[wrong_ia duplicate_claim other_refuse] }
+      it {
+        is_expected.to match_array %w[wrong_ia duplicate_claim stayed_quashed_indictment predate_rep_order
+                                      paid_elsewhere continuation_of_trial prescribed_proceedings
+                                      incorrect_supplemental_case other_refuse]
+      }
+    end
+
+    context 'with an advocate hardship claim' do
+      let(:claim) { create(:advocate_hardship_claim) }
+
+      it {
+        is_expected.to match_array %w[wrong_ia stayed_quashed_indictment predate_rep_order paid_elsewhere
+                                      continuation_of_trial prescribed_proceedings
+                                      incorrect_supplemental_case]
+      }
     end
   end
 

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -48,24 +48,30 @@ RSpec.describe ClaimStateTransitionReason do
   describe '.reject_reasons_for' do
     subject(:reject_reasons_for) { described_class.reject_reasons_for(claim) }
 
-    let(:reasons) do
+    let(:agfs_reasons) do
+      %w[no_indictment no_rep_order time_elapsed no_amend_rep_order case_still_live wrong_case_no wrong_maat_ref
+         advocate_request rep_order_required further_clarification hardship_requirements supplemental_fee
+         invalid_supplier_code soft_reject_no_response soft_reject_attendance_notes other]
+    end
+
+    let(:lgfs_reasons) do
       %w[no_indictment no_rep_order time_elapsed no_amend_rep_order case_still_live wrong_case_no wrong_maat_ref other]
     end
 
     let(:disbursement_only_reasons) { %w[no_prior_authority no_invoice] }
-    let(:all_reasons) { (reasons + disbursement_only_reasons) }
 
     context 'with an advocate claim' do
       let(:basic_fee) { build(:basic_fee, :baf_fee, quantity: 1, amount: 21.01) }
       let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee], state: 'refused') }
 
       it 'returns base rejection reasons' do
-        expect(reject_reasons_for.map(&:code)).to match_array(reasons)
+        expect(reject_reasons_for.map(&:code)).to match_array(agfs_reasons)
       end
     end
 
     context 'with a Litigator interim, disbursement only claim' do
       let(:claim) { create(:interim_claim, :disbursement_only_fee, state: 'rejected') }
+      let(:all_reasons) { (lgfs_reasons + disbursement_only_reasons) }
 
       it 'returns base rejection reasons and disbursement specific reasons' do
         expect(reject_reasons_for.map(&:code)).to match_array(all_reasons)
@@ -76,7 +82,7 @@ RSpec.describe ClaimStateTransitionReason do
       let(:claim) { build(:advocate_claim, :without_fees, state: 'rejected') }
 
       it 'returns base rejection reasons' do
-        expect(reject_reasons_for.map(&:code)).to match_array(reasons)
+        expect(reject_reasons_for.map(&:code)).to match_array(agfs_reasons)
       end
     end
   end

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe ClaimStateTransitionReason do
 
     let(:agfs_reasons) do
       %w[no_indictment no_rep_order time_elapsed no_amend_rep_order case_still_live wrong_case_no wrong_maat_ref
-         advocate_request rep_order_required further_clarification hardship_requirements supplemental_fee
-         invalid_supplier_code soft_reject_no_response soft_reject_attendance_notes other]
+         agfs_advocate_request agfs_breach_or_appeal agfs_further_clarification agfs_hardship_requirements
+         agfs_supplemental_fee agfs_invalid_supplier_code agfs_soft_reject_no_response agfs_soft_reject_attendance_notes
+         other]
     end
 
     let(:lgfs_reasons) do
@@ -115,9 +116,9 @@ RSpec.describe ClaimStateTransitionReason do
       let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee]) }
 
       it {
-        is_expected.to match_array %w[wrong_ia duplicate_claim stayed_quashed_indictment predate_rep_order
-                                      paid_elsewhere continuation_of_trial prescribed_proceedings
-                                      incorrect_supplemental_case other_refuse]
+        is_expected.to match_array %w[wrong_ia duplicate_claim agfs_stayed_quashed_indictment agfs_predate_rep_order
+                                      agfs_paid_elsewhere agfs_continuation_of_trial agfs_prescribed_proceedings
+                                      agfs_incorrect_supplemental_case other_refuse]
       }
     end
 
@@ -126,9 +127,9 @@ RSpec.describe ClaimStateTransitionReason do
 
       it {
         is_expected.to match_array %w[duplicate_claim no_effective_pcmh no_effective_trial short_trial
-                                      stayed_quashed_indictment predate_rep_order paid_elsewhere
-                                      continuation_of_trial prescribed_proceedings
-                                      incorrect_supplemental_case other_refuse]
+                                      agfs_stayed_quashed_indictment agfs_predate_rep_order agfs_paid_elsewhere
+                                      agfs_continuation_of_trial agfs_prescribed_proceedings
+                                      agfs_incorrect_supplemental_case other_refuse]
       }
     end
 
@@ -136,9 +137,9 @@ RSpec.describe ClaimStateTransitionReason do
       let(:claim) { create(:advocate_supplementary_claim) }
 
       it {
-        is_expected.to match_array %w[wrong_ia duplicate_claim stayed_quashed_indictment predate_rep_order
-                                      paid_elsewhere continuation_of_trial prescribed_proceedings
-                                      incorrect_supplemental_case other_refuse]
+        is_expected.to match_array %w[wrong_ia duplicate_claim agfs_stayed_quashed_indictment agfs_predate_rep_order
+                                      agfs_paid_elsewhere agfs_continuation_of_trial agfs_prescribed_proceedings
+                                      agfs_incorrect_supplemental_case other_refuse]
       }
     end
 
@@ -146,9 +147,9 @@ RSpec.describe ClaimStateTransitionReason do
       let(:claim) { create(:advocate_hardship_claim) }
 
       it {
-        is_expected.to match_array %w[wrong_ia stayed_quashed_indictment predate_rep_order paid_elsewhere
-                                      continuation_of_trial prescribed_proceedings
-                                      incorrect_supplemental_case]
+        is_expected.to match_array %w[wrong_ia agfs_stayed_quashed_indictment agfs_predate_rep_order agfs_paid_elsewhere
+                                      agfs_continuation_of_trial agfs_prescribed_proceedings
+                                      agfs_incorrect_supplemental_case]
       }
     end
   end


### PR DESCRIPTION
#### What

Add new AGFS refuse/reject reasons

#### Ticket

[CTSKF-1030](https://dsdmoj.atlassian.net/browse/CTSKF-1030)

#### Why

Caseworkers require additional reasons to select when refusing or rejecting an AGFS claim, to reduce the use of the 'Other' option.

#### How

All refuse and reject reasons are held in `config/locales/claim_state_transition_reason.en.yml` with code in `/app/models/claim_state_transition_reason.rb` used to select the appropriate options. For refuse reasons, the current behaviour is to select a list of reasons based on the type claim, while for reject reasons the same list is displayed for all claims, regardless of fee scheme or claim type.

This PR:
* adds the required additional refuse reasons to `config/locales/claim_state_transition_reason.en.yml` for each of the following keys: `refused_advocate_claims`, `refused_advocate_supplementary_claims`, `refused_advocate_interim_claims`, `refused_advocate_hardship_claims`;
* adds the required additional reject reasons to `config/locales/claim_state_transition_reason.en.yml`, introducing the concept of different reasons for AGFS and LGFS claims by defining `rejected_advocate_claims` and `rejected_litigator_claims` keys. `rejected_litigator_claims` contains only the existing rejection reasons, `rejected_agfs_claims` is extended to include the new reasons;
* modifies the `reject_reasons_for` method in `/app/models/claim_state_transition_reason.rb` to select reject reasons based on the fee scheme of the claim;
* does some tidying up of the translation file to make it more readable and maintainable in future. All wordings now defined in `en.dictionary.claim_state_transition_reason`, with aliases to enable them to be referred to elsewhere. `en.claim_state_transition_reason` now defines all the relevant claim types and the reasons that should be displayed for both refusals and rejections, using the aliases defined in the dictionary.

(These changes result in some duplication of data in the translation file. It might be possible to DRY this out, possibly by defining sets of common reasons and adding to them as needed based on case type/fee scheme, however the current approach makes it easier to see and configure which reasons are displayed, and making changes may lead to changes in the order in which the reasons are displayed on screen, which may be disruptive to caseworkers. There are also additional changes still to be made for LGFS claims; it may be worth investigating improvements once those changes have been implemented.)

[CTSKF-1030]: https://dsdmoj.atlassian.net/browse/CTSKF-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ