### PR TITLE
Ctskf 984 cccd  tidy up and standardise manage users table

### DIFF
--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -4,7 +4,7 @@
 = render partial: 'layouts/header', locals: { page_heading: t('.page_heading', provider_name: "#{current_user.provider.name}") }
 
 = content_for :search_html_block do
-  .form-group
+  .form-group{ class: 'govuk-!-margin-bottom-6'}
     = govuk_link_to t('.new_user'), new_external_users_admin_external_user_path
 
 = render partial: 'shared/search_form', locals: { search_path: external_users_admin_external_users_path(anchor: 'search-button'), hint_text: t('hint.search_users'), button_text: t('search.users') }

--- a/app/views/external_users/admin/external_users/index.html.haml
+++ b/app/views/external_users/admin/external_users/index.html.haml
@@ -19,6 +19,7 @@
   t('.supplier_number'),
   t('.email'),
   t('.email_confirmation'),
+  t('.status'),
   t('.actions')]
 
   = govuk_table_tbody do
@@ -37,11 +38,11 @@
         = govuk_table_td('data-label': t('.email_confirmation')) do
           = advocate.send_email_notification_of_message? ? t('.option_yes') : t('.option_no')
 
+        = govuk_table_td('data-label': t('.status')) do
+          = govuk_tag_active_user?(advocate)
+
         = govuk_table_td('data-label': t('.actions')) do
           - if advocate.active? && advocate.enabled?
             = render partial: 'edit_delete_links', locals: { advocate: advocate }
           - elsif advocate.active? && !advocate.enabled?
-            Inactive
             = render partial: 'edit_delete_links', locals: { advocate: advocate }
-          - else
-            Inactive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -736,7 +736,7 @@ en:
         index:
           title: 'Manage users'
           page_heading: Manage %{provider_name}'s users
-          actions: Manage details
+          actions: Actions
           advocates: 'Users'
           add_advocate: 'Add User'
           edit: *edit
@@ -753,7 +753,10 @@ en:
           option_yes: *global_yes
           option_no: *global_no
           email_title: Email %{external_user}
-          email_confirmation: Email notifications of messages?
+          email_confirmation: Email notifications?
+          status: Status
+          active: Active
+          inactive: Inactive
           table_caption: "%{provider_name} users"
         edit_delete_links:
           delete_html: Delete<span class="govuk-visually-hidden"> user %{context}</span>

--- a/lib/govuk_component/tag_helpers.rb
+++ b/lib/govuk_component/tag_helpers.rb
@@ -2,7 +2,6 @@
 
 module GovukComponent
   module TagHelpers
-    include SharedHelpers
     def govuk_tag(body = nil, color = nil, **tag_options)
       tag_options = prepend_classes('govuk-tag--' + color, tag_options) if color.present?
       tag_options = prepend_classes('govuk-tag', tag_options)

--- a/lib/govuk_component/tag_helpers.rb
+++ b/lib/govuk_component/tag_helpers.rb
@@ -8,5 +8,12 @@ module GovukComponent
 
       tag.strong(body, **tag_options)
     end
+
+    def govuk_tag_active_user?(user)
+      status = user.active? && user.enabled? ? 'Active' : 'Inactive'
+      tag_class = status == 'Active' ? 'govuk-tag--green' : 'govuk-tag--red'
+
+      content_tag(:strong, status, class: "govuk-tag #{tag_class}")
+    end
   end
 end

--- a/lib/govuk_component/tag_helpers.rb
+++ b/lib/govuk_component/tag_helpers.rb
@@ -2,6 +2,7 @@
 
 module GovukComponent
   module TagHelpers
+    include SharedHelpers
     def govuk_tag(body = nil, color = nil, **tag_options)
       tag_options = prepend_classes('govuk-tag--' + color, tag_options) if color.present?
       tag_options = prepend_classes('govuk-tag', tag_options)
@@ -10,10 +11,7 @@ module GovukComponent
     end
 
     def govuk_tag_active_user?(user)
-      status = user.active? && user.enabled? ? 'Active' : 'Inactive'
-      tag_class = status == 'Active' ? 'govuk-tag--green' : 'govuk-tag--red'
-
-      content_tag(:strong, status, class: "govuk-tag #{tag_class}")
+      user.active? && user.enabled? ? govuk_tag('Active', 'green') : govuk_tag('Inactive', 'red')
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -47,5 +47,13 @@ FactoryBot.define do
     trait :disabled do
       disabled_at { 10.minutes.ago }
     end
+
+    trait :enabled do
+      disabled_at { nil }
+    end
+
+    trait :active do
+      deleted_at { false }
+    end
   end
 end

--- a/spec/lib/govuk_component/tag_helpers_spec.rb
+++ b/spec/lib/govuk_component/tag_helpers_spec.rb
@@ -34,4 +34,31 @@ RSpec.describe GovukComponent::TagHelpers, type: :helper do
       end
     end
   end
+
+  describe '#govuk_tag_active_user?' do
+    it 'responds to govuk_tag_active_user?' do
+      expect(helper).to respond_to(:govuk_tag_active_user?)
+    end
+
+    context 'when external user is inactive' do
+      let(:user) { create(:user, :active, :disabled) }
+
+      it 'displays a red inactive tag' do
+        tag_class = 'govuk-tag govuk-tag--red'
+        tag_text = 'Inactive'
+
+        expect(govuk_tag_active_user?(user)).to have_tag(:strong, with: { class: tag_class }, text: tag_text)
+      end
+    end
+
+    context 'when external user is active' do
+      let(:user) { create(:user, :active, :enabled) }
+
+      it 'displays a green inactive tag' do
+        tag_class = 'govuk-tag govuk-tag--green'
+        tag_text = 'Active'
+        expect(govuk_tag_active_user?(user)).to have_tag(:strong, with: { class: tag_class }, text: tag_text)
+      end
+    end
+  end
 end

--- a/spec/lib/govuk_component/tag_helpers_spec.rb
+++ b/spec/lib/govuk_component/tag_helpers_spec.rb
@@ -41,22 +41,23 @@ RSpec.describe GovukComponent::TagHelpers, type: :helper do
     end
 
     context 'when external user is inactive' do
+      subject { helper.govuk_tag_active_user?(user) }
+
       let(:user) { create(:user, :active, :disabled) }
       let(:tag_class) { 'govuk-tag govuk-tag--red' }
       let(:tag_text) { 'Inactive' }
-      subject { helper.govuk_tag_active_user?(user) }
 
       it { is_expected.to have_tag(:strong, with: { class: tag_class }, text: tag_text) }
     end
 
     context 'when external user is active' do
-      let(:user) { create(:user, :active, :enabled) }
+      subject { helper.govuk_tag_active_user?(user) }
 
-      it 'displays a green inactive tag' do
-        tag_class = 'govuk-tag govuk-tag--green'
-        tag_text = 'Active'
-        expect(govuk_tag_active_user?(user)).to have_tag(:strong, with: { class: tag_class }, text: tag_text)
-      end
+      let(:user) { create(:user, :active, :enabled) }
+      let(:tag_class) { 'govuk-tag govuk-tag--green' }
+      let(:tag_text) { 'Active' }
+
+      it { is_expected.to have_tag(:strong, with: { class: tag_class }, text: tag_text) }
     end
   end
 end

--- a/spec/lib/govuk_component/tag_helpers_spec.rb
+++ b/spec/lib/govuk_component/tag_helpers_spec.rb
@@ -42,13 +42,11 @@ RSpec.describe GovukComponent::TagHelpers, type: :helper do
 
     context 'when external user is inactive' do
       let(:user) { create(:user, :active, :disabled) }
+      let(:tag_class) { 'govuk-tag govuk-tag--red' }
+      let(:tag_text) { 'Inactive' }
+      subject { helper.govuk_tag_active_user?(user) }
 
-      it 'displays a red inactive tag' do
-        tag_class = 'govuk-tag govuk-tag--red'
-        tag_text = 'Inactive'
-
-        expect(govuk_tag_active_user?(user)).to have_tag(:strong, with: { class: tag_class }, text: tag_text)
-      end
+      it { is_expected.to have_tag(:strong, with: { class: tag_class }, text: tag_text) }
     end
 
     context 'when external user is active' do


### PR DESCRIPTION
What
This ticket focuses on updating the CCCD case worker summary page only (other summary pages on the provider side are still waiting for designed) and implementing the gov design summary cards to display the claim information in a more readable way.

While doing this ticket I realised that some of the Caseworker summary page shares some files that display on the summary page with the external users summary page - both in the shared folder as well as in the external folder. This means I was unable to make the changes in isolation. I therefore temporarily duplicated these files to update the caseworker summary page with the new format only. There is a ticket that aims to consolidate these designs - so hopefully that will undo some of the strange file structure and duplication that I have introduced
[Summary cards](https://design-system.service.mod.gov.uk/components/summary-list/)

Ticket
[CCCD - Implement Summary Page accessibility improvements (caseworker) wrap in summary cards.](https://dsdmoj.atlassian.net/browse/CTSKF-993)

Why
The CCCD summary page displays essential information but suffers from poor usability. To improve user experience and accessibility, we will implement a new design pattern developed from other projects.

Additional thoughts
I followed the design in Figma very closely and sometimes it didn't always match up with the ticket description. I did get rid of the sortable arrows in the travel table - but I think I need to go and check this with Kristina.
There were no designs for when there was nothing to display in a section- so if feels like it doesn't match the rest of the design.
